### PR TITLE
fix: prevent legacy docs from seeding trust and gate state

### DIFF
--- a/packages/openclaw-plugin/src/core/migration.ts
+++ b/packages/openclaw-plugin/src/core/migration.ts
@@ -15,14 +15,12 @@ export function migrateDirectoryStructure(api: OpenClawPluginApi, workspaceDir: 
         // Comprehensive migration map covering ALL legacy locations
         const migrationMap: Array<{ legacy: string; newKey: keyof typeof PD_FILES }> = [
             // From docs/
-            { legacy: path.join(legacyDocsDir, 'PROFILE.json'), newKey: 'PROFILE' },
             { legacy: path.join(legacyDocsDir, 'PRINCIPLES.md'), newKey: 'PRINCIPLES' },
             { legacy: path.join(legacyDocsDir, 'THINKING_OS.md'), newKey: 'THINKING_OS' },
             { legacy: path.join(legacyDocsDir, '00-kernel.md'), newKey: 'KERNEL' },
             { legacy: path.join(legacyDocsDir, 'DECISION_POLICY.json'), newKey: 'DECISION_POLICY' },
             { legacy: path.join(legacyDocsDir, 'PLAN.md'), newKey: 'PLAN' },
             { legacy: path.join(legacyDocsDir, 'evolution_queue.json'), newKey: 'EVOLUTION_QUEUE' },
-            { legacy: path.join(legacyDocsDir, 'AGENT_SCORECARD.json'), newKey: 'AGENT_SCORECARD' },
             { legacy: path.join(legacyDocsDir, '.pain_flag'), newKey: 'PAIN_FLAG' },
             { legacy: path.join(legacyDocsDir, 'SYSTEM_CAPABILITIES.json'), newKey: 'SYSTEM_CAPABILITIES' },
             { legacy: path.join(legacyDocsDir, 'SYSTEM.log'), newKey: 'SYSTEM_LOG' },

--- a/packages/openclaw-plugin/tests/core/migration.test.ts
+++ b/packages/openclaw-plugin/tests/core/migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { migrateDirectoryStructure } from '../../src/core/migration.js';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -18,32 +18,22 @@ describe('Directory Structure Migration', () => {
         vi.clearAllMocks();
     });
 
-    it('should move files from docs/ to new locations', () => {
-        const legacyProfile = path.join(workspaceDir, 'docs', 'PROFILE.json');
-        const newProfile = path.join(workspaceDir, '.principles', 'PROFILE.json');
+    it('should move non-security files from docs/ to new locations', () => {
         const legacyPlan = path.join(workspaceDir, 'docs', 'PLAN.md');
         const newPlan = path.join(workspaceDir, 'PLAN.md');
 
         vi.mocked(fs.existsSync).mockImplementation((p) => {
             const pathStr = p.toString();
             if (pathStr === path.join(workspaceDir, 'docs')) return true;
-            if (pathStr === legacyProfile) return true;
             if (pathStr === legacyPlan) return true;
             // Destination directories don't exist yet
             if (pathStr === path.join(workspaceDir, '.principles')) return false;
             // Destination files don't exist yet
-            if (pathStr === newProfile) return false;
             if (pathStr === newPlan) return false;
             return false;
         });
 
         migrateDirectoryStructure(mockApi, workspaceDir);
-
-        // Verify it tried to create .principles/
-        expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(workspaceDir, '.principles'), expect.anything());
-
-        // Verify it moved PROFILE.json
-        expect(fs.renameSync).toHaveBeenCalledWith(legacyProfile, newProfile);
 
         // Verify it moved PLAN.md to root
         expect(fs.renameSync).toHaveBeenCalledWith(legacyPlan, newPlan);
@@ -51,21 +41,25 @@ describe('Directory Structure Migration', () => {
         expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully migrated'));
     });
 
-    it('should not overwrite existing files at destination', () => {
+    it('should not migrate security-sensitive docs files', () => {
         const legacyProfile = path.join(workspaceDir, 'docs', 'PROFILE.json');
+        const legacyScorecard = path.join(workspaceDir, 'docs', 'AGENT_SCORECARD.json');
         const newProfile = path.join(workspaceDir, '.principles', 'PROFILE.json');
+        const newScorecard = path.join(workspaceDir, '.principles', '.state', 'AGENT_SCORECARD.json');
 
         vi.mocked(fs.existsSync).mockImplementation((p) => {
             const pathStr = p.toString();
             if (pathStr === path.join(workspaceDir, 'docs')) return true;
             if (pathStr === legacyProfile) return true;
-            if (pathStr === newProfile) return true; // DESTINATION EXISTS
+            if (pathStr === legacyScorecard) return true;
+            if (pathStr === newProfile) return false;
+            if (pathStr === newScorecard) return false;
             return false;
         });
 
         migrateDirectoryStructure(mockApi, workspaceDir);
 
         expect(fs.renameSync).not.toHaveBeenCalledWith(legacyProfile, newProfile);
-        expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('already exists at destination'));
+        expect(fs.renameSync).not.toHaveBeenCalledWith(legacyScorecard, newScorecard);
     });
 });


### PR DESCRIPTION
### Motivation
- Boot-time migration promoted `docs/PROFILE.json` and `docs/AGENT_SCORECARD.json` into authoritative hidden state, allowing an untrusted repo to seed gate and trust configuration and bypass tool restrictions.
- The change prevents silent, unaudited import of security-sensitive files while preserving helpful migration for non-sensitive legacy content.

### Description
- Removed `docs/PROFILE.json` and `docs/AGENT_SCORECARD.json` entries from the migration map in `packages/openclaw-plugin/src/core/migration.ts` so they are no longer promoted into `.principles`/`.state` during boot.
- Kept migration behavior for non-security legacy files (e.g. `PLAN.md`) to preserve compatibility.
- Updated `packages/openclaw-plugin/tests/core/migration.test.ts` to assert that security-sensitive docs files are not migrated and to retain coverage for regular migrations.

### Testing
- Ran the focused unit tests with `npm test -- migration.test.ts` and both migration tests passed.
- Ran `npm run build` in `packages/openclaw-plugin` and TypeScript compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b814e3b6b8832eb87815a07d4ffbc6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug修复**
  * 移除了对遗留配置文件的自动迁移
  * 增强了安全敏感文件在迁移过程中的保护机制

* **测试**
  * 更新了测试用例以验证改进后的迁移行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->