### PR TITLE
fix(gate): mark active .principles/PROFILE.json as risky path

### DIFF
--- a/packages/openclaw-plugin/templates/workspace/.principles/PROFILE.json
+++ b/packages/openclaw-plugin/templates/workspace/.principles/PROFILE.json
@@ -6,6 +6,7 @@
     "IDENTITY.md",
     "USER.md",
     "docs/PRINCIPLES.md",
+    ".principles/PROFILE.json",
     "docs/PROFILE.json"
   ],
   "gate": {
@@ -22,6 +23,7 @@
         "IDENTITY.md",
         "USER.md",
         "docs/PRINCIPLES.md",
+        ".principles/PROFILE.json",
         "docs/PROFILE.json",
         "docs/okr/**"
       ],


### PR DESCRIPTION
### Motivation
- The gate now loads the active profile from `.principles/PROFILE.json`, but the shipped workspace template did not mark that file as a risky path, allowing low-trust agents to edit the live profile and weaken guardrails.

### Description
- Added `".principles/PROFILE.json"` to `risk_paths` in `packages/openclaw-plugin/templates/workspace/.principles/PROFILE.json` so edits to the active profile are treated as risky by default.
- Added `".principles/PROFILE.json"` to `progressive_gate.plan_approvals.allowed_patterns` in the same file so plan-approval rules also cover live profile edits.
- Change is minimal and limited to the workspace profile template to preserve existing functionality while closing the gating gap.

### Testing
- Ran `python -m json.tool packages/openclaw-plugin/templates/workspace/.principles/PROFILE.json` to validate JSON formatting, which succeeded.
- Verified the change with `git diff -- packages/openclaw-plugin/templates/workspace/.principles/PROFILE.json`, which showed only the two added entries and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b81928125c832ea4d6bcd285920387)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **配置更新**
  * 扩展了系统配置跟踪范围，新增对配置文件的审计风险监控。
  * 更新了审批流程的允许模式配置，确保完整的变更控制覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->