### PR TITLE
fix: install all plugin dependencies including native modules like better-sqlite3

### DIFF
--- a/packages/create-principles-disciple/src/installer.ts
+++ b/packages/create-principles-disciple/src/installer.ts
@@ -139,24 +139,101 @@ async function installPlugin(pluginDir: string): Promise<void> {
   logger.success('插件安装成功');
 }
 
-/**
- * 安装插件依赖
- */
+function verifyNativeModule(modulePath: string): boolean {
+  try {
+    require(modulePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function installPluginDependencies(): Promise<void> {
   const extDir = getPluginExtDir();
-  const micromatchPath = path.join(extDir, 'node_modules', 'micromatch');
-  
-  // 检查关键依赖是否存在
-  if (!existsSync(micromatchPath)) {
-    logger.step('安装插件运行时依赖');
-    try {
-      const execOpts = getExecOptions(extDir);
-      execSync('npm install --silent micromatch@^4.0.8 @sinclair/typebox@^0.34.48', execOpts);
-      logger.success('插件依赖安装完成');
-    } catch (error) {
-      logger.warn('依赖安装失败，插件可能无法正常工作');
-      logger.info('手动修复: cd ~/.openclaw/extensions/principles-disciple && npm install micromatch @sinclair/typebox');
+  const packageJsonPath = path.join(extDir, 'package.json');
+  const nodeModulesPath = path.join(extDir, 'node_modules');
+  const nativeModules = ['better-sqlite3'];
+
+  if (!existsSync(packageJsonPath)) {
+    logger.warn('插件 package.json 不存在，跳过依赖安装');
+    return;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  const allDeps = Object.keys({ ...packageJson.dependencies, ...packageJson.devDependencies });
+
+  let needsInstall = !existsSync(nodeModulesPath);
+
+  if (!needsInstall) {
+    for (const dep of allDeps) {
+      if (!existsSync(path.join(extDir, 'node_modules', dep))) {
+        needsInstall = true;
+        break;
+      }
     }
+    if (!needsInstall) {
+      for (const mod of nativeModules) {
+        const modPath = path.join(extDir, 'node_modules', mod);
+        if (existsSync(modPath) && !verifyNativeModule(mod)) {
+          logger.warn(`原生模块 ${mod} 验证失败，需要重新编译`);
+          needsInstall = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!needsInstall) {
+    logger.success('插件依赖已安装');
+    return;
+  }
+
+  logger.step('安装插件运行时依赖');
+  try {
+    const execOpts = getExecOptions(extDir);
+    logger.info('下载并安装 npm 依赖...');
+    execSync('npm install --ignore-scripts', execOpts);
+
+    for (const mod of nativeModules) {
+      const modPath = path.join(extDir, 'node_modules', mod);
+      if (existsSync(modPath)) {
+        logger.info(`编译原生模块 ${mod}...`);
+        try {
+          execSync(`npm rebuild ${mod}`, execOpts);
+        } catch (e) {
+          logger.warn(`原生模块 ${mod} 编译失败: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+    }
+
+    let nativeModulesOk = true;
+    for (const nativeMod of nativeModules) {
+      const nativeModPath = path.join(extDir, 'node_modules', nativeMod);
+      if (existsSync(nativeModPath)) {
+        if (verifyNativeModule(nativeMod)) {
+          logger.success(`原生模块 ${nativeMod} 验证通过`);
+        } else {
+          logger.warn(`原生模块 ${nativeMod} 验证失败`);
+          nativeModulesOk = false;
+        }
+      }
+    }
+
+    if (nativeModulesOk) {
+      logger.success('插件依赖安装完成');
+    } else {
+      logger.warn('部分原生模块可能无法正常工作');
+      logger.info('如果遇到问题，运行: cd ~/.openclaw/extensions/principles-disciple && npm rebuild');
+    }
+  } catch (error) {
+    logger.error('依赖安装失败');
+    logger.error(`错误: ${error instanceof Error ? error.message : String(error)}`);
+    logger.info('');
+    logger.info('手动修复步骤:');
+    logger.info(`  cd ${extDir}`);
+    logger.info('  npm install --ignore-scripts');
+    logger.info('  npm rebuild better-sqlite3');
+    // 不退出，让安装继续，可能基本功能还能用
   }
 }
 


### PR DESCRIPTION
## Summary

修复 `create-principles-disciple` 安装器漏掉 `better-sqlite3` 原生模块的问题。

## Problem

原 `installPluginDependencies()` 只安装了 `micromatch` 和 `@sinclair/typebox`，漏掉了 `better-sqlite3`，导致插件加载失败：

```
Error: Cannot find module 'better-sqlite3'
Require stack:
- /home/csuzngjh/.openclaw/extensions/principles-disciple/dist/core/trajectory.js
```

## Solution

- 从 `package.json` 读取所有依赖，不再硬编码
- 添加原生模块检测和 `npm rebuild` 步骤
- 验证原生模块可加载后再完成安装

## Testing

- `npm run build` ✅
- `tsc --noEmit` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了依赖安装逻辑，提高了插件扩展的安装可靠性。

* **Bug 修复**
  * 增强了原生模块检测机制，改进了安装失败时的错误提示。
  * 优化了故障排查流程，提供更详细的手动修复步骤。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->