### PR TITLE
chore(release): bump version to 1.7.8

### DIFF
--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,7 +16,7 @@
 
 ---
 
-# Principles Disciple: 进化智能体框架 (v1.6.0)
+# Principles Disciple: 进化智能体框架 (v1.7.8)
 
 > **可进化编程智能体框架 (Evolutionary Programming Agent Framework)**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "principles-disciple-monorepo",
-  "version": "1.7.5",
+  "version": "1.7.8",
   "description": "Principles Disciple - OpenClaw Plugin Monorepo",
   "private": true,
   "scripts": {

--- a/packages/create-principles-disciple/package-lock.json
+++ b/packages/create-principles-disciple/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-principles-disciple",
-  "version": "1.7.1",
+  "version": "1.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-principles-disciple",
-      "version": "1.7.1",
+      "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.3.0",

--- a/packages/create-principles-disciple/package.json
+++ b/packages/create-principles-disciple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-principles-disciple",
-  "version": "1.7.2",
+  "version": "1.7.8",
   "description": "Interactive CLI installer for Principles Disciple OpenClaw plugin",
   "type": "module",
   "bin": {

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "principles-disciple",
   "name": "Principles Disciple",
   "description": "Evolutionary programming agent framework with strategic guardrails and reflection loops.",
-  "version": "1.7.5",
+  "version": "1.7.8",
   "skills": [
     "./skills"
   ],

--- a/packages/openclaw-plugin/package-lock.json
+++ b/packages/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "principles-disciple",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "principles-disciple",
-      "version": "1.7.7",
+      "version": "1.7.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "principles-disciple",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Native OpenClaw plugin for Principles Disciple",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 版本发布 v1.7.8

### 变更内容
- PR #124: fix(ci): add continue-on-error to Run tests step
- PR #123: fix(ci): add timeout to Run tests step in publish-npm workflow

### 版本同步
- packages/openclaw-plugin/package.json
- packages/openclaw-plugin/openclaw.plugin.json
- packages/create-principles-disciple/package.json
- package.json (monorepo)
- README.md
- README_ZH.md

合并后将自动发布到 NPM。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 版本号统一更新至 1.7.8，涉及主项目及其子包（create-principles-disciple、openclaw-plugin 等）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->