### PR TITLE
docs: add architecture governance baseline

### DIFF
--- a/docs/architecture-governance/ARCHITECTURE_GUARDRAILS.md
+++ b/docs/architecture-governance/ARCHITECTURE_GUARDRAILS.md
@@ -1,0 +1,234 @@
+# Architecture Guardrails
+
+## Purpose
+
+The primary risk in this project is no longer isolated bugs. The larger risk is systemic hidden failure:
+
+- one business concept implemented in multiple places
+- workflow steps split across hooks, services, prompts, runtime APIs, and state files
+- string-based protocols drifting silently
+- state written to multiple storage layers without a declared authority
+- unit tests proving local correctness while system integrity still fails
+
+This document defines the guardrails that prevent those failures from continuing to accumulate.
+
+---
+
+## Core Rules
+
+### 1. One Domain Concept, One Authoritative Writer
+
+Every important business concept must have exactly one authoritative write path.
+
+Examples:
+
+- a specific pain signal source
+- rule match emission
+- workflow completion state
+- subagent cleanup markers
+- promoted principles
+- routing decisions
+
+Other modules may request or observe. They may not write directly unless they are the declared owner.
+
+### 2. One Workflow, One Owner
+
+Every critical workflow must have one owner module.
+
+The owner is responsible for:
+
+- trigger entry
+- protocol validation
+- state transitions
+- persistence
+- cleanup
+- retry policy
+- terminal state handling
+
+If a workflow spans many files, ownership still has to be explicit.
+
+### 3. No Hidden String Protocols
+
+Strings may not serve as hidden APIs by default.
+
+If logic depends on:
+
+- session key formats
+- event `source`
+- event `origin`
+- workflow state values
+- file naming conventions used as control logic
+- prompt tags consumed by runtime hooks
+
+then that protocol must be wrapped in a helper, codec, validator, enum, or schema.
+
+### 4. Truth Source Must Be Declared
+
+Every business concept must declare its authoritative storage layer.
+
+Possible truth sources include:
+
+- SQLite tables
+- JSON state files
+- event logs
+- in-memory state
+
+Logs, summaries, caches, and derived analytics are not authoritative unless declared.
+
+### 5. Invariants Are Mandatory
+
+Each critical workflow must define:
+
+- what must always happen
+- what must never happen
+- what terminal states are valid
+- what cleanup is required
+- what overlapping implementations are forbidden
+
+These invariants must be testable and auditable.
+
+---
+
+## Failure Modes We Must Prevent
+
+### A. Duplicate Writers
+
+Multiple files write the same concept independently.
+
+Typical outcome:
+
+- duplicate state
+- contradictory analytics
+- partial fixes that do not actually retire the old path
+
+### B. Split Workflow Ownership
+
+One chain is spread across hooks, services, files, and prompt instructions with no single owner.
+
+Typical outcome:
+
+- hidden breakpoints
+- cleanup omitted
+- retries added in one place but not another
+
+### C. Protocol Drift
+
+Two files assume the same string format but interpret it differently.
+
+Typical outcome:
+
+- session matching failures
+- wrong branch selection
+- stale cleanup
+- silent workflow misrouting
+
+### D. Competing Truth Sources
+
+Multiple stores claim to describe the same business fact.
+
+Typical outcome:
+
+- stale UI
+- recovery logic using wrong state
+- tests passing while runtime behavior is inconsistent
+
+### E. Local Tests, Broken System
+
+Unit tests validate helpers but not workflow integrity.
+
+Typical outcome:
+
+- orphan sessions
+- unclosed lifecycle loops
+- illegal source/origin combinations
+- hidden overlap between old and new paths
+
+---
+
+## Required Governance Mechanisms
+
+### 1. Domain Ownership Map
+
+We maintain a living map of:
+
+- domain concept
+- authoritative writer
+- authoritative storage
+- known readers
+- known competing paths
+
+### 2. Workflow Registry
+
+We maintain a registry of important workflows, each with:
+
+- workflow id
+- owner module
+- trigger
+- outputs
+- terminal states
+- cleanup requirements
+- forbidden overlaps
+- key invariants
+
+### 3. Audit Scripts
+
+We gradually add scripts that detect:
+
+- duplicate writers
+- orphan workflows
+- invariant violations
+- stale legacy paths
+
+At first these scripts warn only. They should not block development until the signal quality is proven.
+
+### 4. Retirement Policy
+
+When a new path replaces an old path, the old path must be marked explicitly as one of:
+
+- shadow
+- deprecated
+- disabled
+- removed
+
+No path may remain silently active forever.
+
+### 5. Boundary And Invariant Tests
+
+For workflow-heavy code, unit tests are not enough.
+
+We need:
+
+- boundary tests for owner modules
+- invariant tests for forbidden conditions
+- cleanup tests for terminal states
+
+---
+
+## Rules For Future Changes
+
+Any architecture-sensitive PR must answer:
+
+1. What concept is being written?
+2. Who is the single owner?
+3. What is the authoritative truth source?
+4. Is this adding a second path?
+5. What cleanup is required?
+6. What invariant protects this flow?
+7. What old path is being retired?
+
+If these answers are missing, the change is incomplete.
+
+---
+
+## Immediate Strategy
+
+We will not fix this project through one giant refactor.
+
+We will proceed in four stages:
+
+1. Document and observe.
+2. Add audit-only tooling.
+3. Introduce shadow governance around one workflow at a time.
+4. Retire duplicate paths gradually.
+
+The operating plan for that work lives in `GRADUAL_ROADMAP.md`.

--- a/docs/architecture-governance/DOMAIN_OWNERSHIP_BOOTSTRAP.md
+++ b/docs/architecture-governance/DOMAIN_OWNERSHIP_BOOTSTRAP.md
@@ -1,0 +1,46 @@
+# Domain Ownership Bootstrap
+
+This is a first-pass ownership map. It is intentionally incomplete, but it should be concrete enough to reveal where risk is concentrated today.
+
+## High-Risk Concepts
+
+| Concept | Current Authoritative Writer | Current Authoritative Storage | Known Readers | Known Competing Paths | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `pain signal` (generic) | unclear / split across hooks | event log + trajectory + state files | status commands, UI, recovery flows | `hooks/pain.ts`, `hooks/llm.ts`, service flows | High | Core concept currently spans multiple entrypoints. |
+| `user_empathy` | currently intended to be observer-only | event log + trajectory + friction/session state | rollback, summaries, runtime UI | recently conflicted between `hooks/llm.ts` and `service/empathy-observer-manager.ts` | High | This is the clearest example of duplicate writer risk. |
+| `rule_match` | `DetectionService` via `hooks/llm.ts` | event log | evolution systems, analytics | implicit contamination from audit payloads | High | Owner is clearer than others, but funnel contamination remains a recurring class of risk. |
+| `trust change` | split by hook/flow | event log + trust/session state | trust command, UI, policy logic | tool hooks and other system flows | Medium | Ownership is conceptually one domain but physically spread. |
+| `pain_flag` lifecycle | split | state file + event log relationship | recovery worker, commands | `hooks/llm.ts`, `hooks/pain.ts`, `hooks/subagent.ts` cleanup paths | High | High risk because cleanup and creation are separated. |
+| `subagent session lifecycle` | unclear / split | runtime session state + queue state + logs | subagent hooks, workflow services | `hooks/subagent.ts`, direct runtime usage in services/tools | High | Strong candidate for first consolidation. |
+| `evolution task completion` | `hooks/subagent.ts` for diagnostician path | evolution queue + trajectory task outcomes | evolution worker, status commands | placeholder assignment patterns, retry paths | High | Ownership exists in practice but is tightly coupled to session conventions. |
+| `workflow cleanup` | split per workflow | runtime sessions, files, queue state | operators, services | ad hoc `deleteSession`, `unlinkSync`, queue clearing | High | Cleanup is a cross-cutting concern with no shared enforcement. |
+| `routing shadow evidence` | appears centered in runtime hook layer | registry/state files | routing analysis, rollout logic | prompt guidance vs runtime observation | Medium | Promising structure, but ownership should be made explicit. |
+| `promoted principle / rule creation` | split between reducer and upstream workflows | reducer state + dictionaries | prompt injection, evolution reporting | diagnostician output, other future flows | High | Creation paths should be constrained tightly. |
+| `rollback of user-facing signals` | commands + llm rollback cues | event log + friction/session state | operator commands, runtime logic | command path vs natural language trigger path | Medium | Needs a declared owner for rollback semantics. |
+| `nocturnal subagent lifecycle` | service-level orchestration | runtime sessions + experiment/checkpoint state | nocturnal commands, services | multiple runtime use sites in nocturnal modules | High | Another strong candidate for a future workflow-owner module. |
+
+## Immediate Interpretation
+
+### Most Dangerous Ownership Gaps
+
+1. `subagent session lifecycle`
+2. `pain signal`
+3. `workflow cleanup`
+4. `promoted principle / rule creation`
+
+### Why These Matter
+
+- they cross module boundaries
+- they are stateful
+- they rely on runtime side effects
+- they are hard to fully cover with unit tests
+- failures can remain silent for a long time
+
+## Next Step
+
+This bootstrap map should be refined alongside `WORKFLOW_REGISTRY_BOOTSTRAP.md`. The next revision should attach:
+
+- exact owner proposals
+- exact files
+- exact forbidden writers
+- migration order

--- a/docs/architecture-governance/GRADUAL_ROADMAP.md
+++ b/docs/architecture-governance/GRADUAL_ROADMAP.md
@@ -1,0 +1,203 @@
+# Gradual Roadmap
+
+## Why This Must Be Gradual
+
+This project already contains many active workflows. A broad refactor that tries to centralize all ownership at once is more likely to create outages than remove risk.
+
+The correct strategy is:
+
+1. make hidden structure visible
+2. stop adding new uncontrolled complexity
+3. validate governance in shadow mode
+4. retire duplicate paths one workflow at a time
+
+---
+
+## Stage 0: Stop Complexity From Growing
+
+### Goal
+
+Prevent new hidden workflow duplication from entering the codebase.
+
+### Allowed Changes
+
+- governance documents
+- review checklists
+- ownership notes
+- workflow mapping
+
+### Forbidden Changes
+
+- broad ownership rewrites
+- forced facade adoption across the whole codebase
+- changing multiple runtime workflows at once
+
+### Exit Criteria
+
+- architecture governance docs exist
+- PR checklist exists
+- new workflow work can be reviewed against explicit criteria
+
+---
+
+## Stage 1: Audit-Only Visibility
+
+### Goal
+
+Detect hidden structural risk without changing behavior.
+
+### Work
+
+- add duplicate writer scanner
+- add workflow orphan scanner
+- add invariant violation scanner
+- run scanners manually first
+
+### Operating Mode
+
+- report only
+- no automatic fixes
+- no CI blocking
+- warning-only if connected to CI
+
+### Exit Criteria
+
+- we can produce a repeatable architecture audit report
+- we can name the highest-risk duplicate writers
+- we can name the highest-risk orphan workflows
+
+---
+
+## Stage 2: Shadow Governance
+
+### Goal
+
+Introduce governance mechanisms without taking control away from existing runtime behavior.
+
+### Work
+
+- define workflow owners
+- define truth sources
+- define invariants
+- add provenance tags where missing
+- add shadow state tracking for selected workflows
+
+### Operating Mode
+
+- audit-only or shadow-only
+- no authoritative rerouting yet
+- no legacy path removal yet
+
+### Exit Criteria
+
+- one workflow can be observed end-to-end using shadow state
+- invariants are machine-checkable for that workflow
+- cleanup gaps become visible before they become outages
+
+---
+
+## Stage 3: Pilot Workflow Consolidation
+
+### Goal
+
+Use one workflow cluster as the proving ground for the governance model.
+
+### Candidate Order
+
+1. subagent session lifecycle
+2. pain/event writes
+3. routing shadow observation
+4. rollback workflow
+5. nocturnal session cleanup
+
+### Selection Criteria
+
+- clear boundary
+- high operational risk
+- small enough scope to revert quickly
+- visible success criteria
+
+### Required Safety Controls
+
+- kill switch
+- old path retained in shadow temporarily
+- boundary test
+- invariant test
+- rollback plan
+
+### Exit Criteria
+
+- selected workflow has one owner
+- duplicate write paths are retired or explicitly shadowed
+- cleanup is guaranteed
+- runtime behavior is verified
+
+---
+
+## Stage 4: Incremental Retirement
+
+### Goal
+
+Replace hidden overlap with explicit ownership across the project, one cluster at a time.
+
+### Rules
+
+- never retire two unrelated high-risk workflows in one PR
+- never remove legacy path before shadow validation completes
+- every retired path must be documented
+- every new owner path must have tests and invariants
+
+### Exit Criteria
+
+- major workflow clusters have explicit owners
+- duplicate writers are reduced to known, temporary exceptions only
+- architecture audit can fail CI for proven high-confidence violations
+
+---
+
+## First 90-Day Focus
+
+### Wave 1
+
+- publish governance docs
+- add architecture audit scripts
+- produce first audit report
+
+### Wave 2
+
+- map domain ownership for pain, workflow lifecycle, routing, and nocturnal cleanup
+- choose pilot workflow
+
+### Wave 3
+
+- implement shadow governance for pilot workflow
+- validate against real runtime behavior
+
+### Wave 4
+
+- retire first duplicate path
+- update docs and checklist with lessons learned
+
+---
+
+## What We Must Not Do
+
+- do not attempt a repo-wide facade rewrite
+- do not convert all hooks into one framework in one step
+- do not let audit scripts auto-fix state
+- do not make CI blocking before false-positive rate is understood
+- do not keep old and new paths permanently active
+
+---
+
+## Review Rhythm
+
+We should revisit this directory on a regular cadence.
+
+Recommended cadence:
+
+- weekly: read latest audit output
+- biweekly: choose one workflow or concept to clarify
+- monthly: retire or downgrade one duplicate path
+
+This keeps the project moving without destabilizing production behavior.

--- a/docs/architecture-governance/PR_ARCHITECTURE_CHECKLIST.md
+++ b/docs/architecture-governance/PR_ARCHITECTURE_CHECKLIST.md
@@ -1,0 +1,52 @@
+# PR Architecture Checklist
+
+Use this checklist for any pull request that touches:
+
+- hooks
+- prompts
+- runtime subagent APIs
+- event logging
+- trajectory writes
+- state files
+- cleanup flows
+- routing
+- promotion / reducer flows
+
+## Required Questions
+
+- [ ] What business concept is being written?
+- [ ] Who is the single authoritative writer for that concept?
+- [ ] Is this PR adding a second path for an existing concept?
+- [ ] What is the authoritative truth source?
+- [ ] Does this PR depend on a string protocol? If yes, is that protocol now explicit?
+- [ ] What are the valid terminal states for the workflow being changed?
+- [ ] What cleanup must happen?
+- [ ] How is cleanup guaranteed?
+- [ ] What old path is being retired, shadowed, or explicitly left active?
+- [ ] Does this PR introduce any new direct state write that bypasses the intended owner?
+- [ ] Is there a boundary test for the workflow owner?
+- [ ] Is there an invariant test for the new forbidden condition?
+
+## Red Flags
+
+If any of the following is true, the PR needs deeper review:
+
+- [ ] The same `source` or domain concept is now written from multiple files
+- [ ] Session key parsing logic exists in more than one place
+- [ ] Prompt text is being used as a hidden control protocol
+- [ ] Cleanup is best-effort but not observable
+- [ ] Runtime behavior changed but only unit tests were added
+- [ ] New path added, old path not retired
+- [ ] State is written to multiple stores without declared authority
+
+## Outcome Labels
+
+At review time, classify the PR as one of:
+
+- `safe-local-change`
+- `workflow-change`
+- `ownership-change`
+- `protocol-change`
+- `truth-source-change`
+
+Anything beyond `safe-local-change` should also update the documents in `docs/architecture-governance/`.

--- a/docs/architecture-governance/README.md
+++ b/docs/architecture-governance/README.md
@@ -1,0 +1,48 @@
+# Architecture Governance
+
+This directory contains the project-level governance documents for reducing hidden workflow breakage, duplicate implementations, implicit protocol drift, and multi-source state conflicts.
+
+These documents are intentionally incremental. They are not a mandate for a single large refactor. They exist to let the project move from:
+
+- hidden workflow ownership
+- duplicated write paths
+- string-based implicit contracts
+- weak runtime observability
+
+to:
+
+- explicit ownership
+- workflow registries
+- machine-checkable invariants
+- gradual retirement of duplicate paths
+
+## Documents
+
+- `ARCHITECTURE_GUARDRAILS.md`
+  The top-level architectural rules for workflow-heavy code.
+- `GRADUAL_ROADMAP.md`
+  The incremental adoption plan. This is the main operational document for periodic follow-up.
+- `DOMAIN_OWNERSHIP_BOOTSTRAP.md`
+  A first-pass ownership map for the current codebase, focused on high-risk concepts.
+- `WORKFLOW_REGISTRY_BOOTSTRAP.md`
+  A first-pass registry of workflow clusters that currently exist in the project.
+- `PR_ARCHITECTURE_CHECKLIST.md`
+  Review checklist for architecture-sensitive pull requests.
+
+## How To Use This Directory
+
+1. Start with `GRADUAL_ROADMAP.md`.
+2. Use `DOMAIN_OWNERSHIP_BOOTSTRAP.md` to identify duplicated writers.
+3. Use `WORKFLOW_REGISTRY_BOOTSTRAP.md` to identify unclear workflow ownership.
+4. Use `PR_ARCHITECTURE_CHECKLIST.md` for every PR that touches hooks, runtime workflows, state writes, routing, or cleanup.
+5. Update these docs gradually as workflows are clarified and old paths are retired.
+
+## Non-Goals
+
+These documents do not require:
+
+- a full-project rewrite
+- immediate replacement of all legacy paths
+- instant adoption of new facades or state machines
+
+The first goal is visibility and control. Consolidation comes later, one workflow at a time.

--- a/docs/architecture-governance/WORKFLOW_REGISTRY_BOOTSTRAP.md
+++ b/docs/architecture-governance/WORKFLOW_REGISTRY_BOOTSTRAP.md
@@ -1,0 +1,54 @@
+# Workflow Registry Bootstrap
+
+This is a first-pass workflow registry for the current codebase. It is meant to expose where ownership is explicit, where it is split, and which workflows should be prioritized for gradual consolidation.
+
+| Workflow ID | Current Owner | Trigger | Primary Outputs | Authoritative State | Terminal States | Cleanup Required | Forbidden Overlaps | Ownership Status |
+|---|---|---|---|---|---|---|---|---|
+| `wf.empathy_observer` | partially `service/empathy-observer-manager.ts` | `before_prompt_build` -> runtime subagent -> `subagent_ended` | `user_empathy`, friction, event log, trajectory record | runtime session + event log + trajectory | spawn_failed, no_damage, persisted, cleaned | yes | main-model self-report empathy | Partially clear |
+| `wf.llm_pain_detection` | `hooks/llm.ts` + `DetectionService` | `llm_output` | rule match, pain signal, pain flag | event log + pain flag + trajectory side effects | detected, ignored, rolled_back | sometimes | audit payloads, duplicate semantic funnels | Partially clear |
+| `wf.manual_pain` | `hooks/pain.ts` | command/tool outcomes | pain signal, trajectory pain event | event log + trajectory + session/friction | applied, reset | no explicit cleanup | other direct pain writers | Split |
+| `wf.subagent_completion.diagnostician` | `hooks/subagent.ts` | `subagent_ended` | queue completion, task outcome, principle creation | evolution queue + trajectory + reducer | completed, retried, unmatched, failed | yes | non-diagnostician subagent flows | Partially clear |
+| `wf.rollback.user_empathy` | commands + `llm.ts` rollback cue | rollback command or rollback marker in output | event rollback + friction reset | event log + session/friction state | rolled_back, skipped | no | multiple empathy write paths | Split |
+| `wf.routing.shadow_observation` | runtime hook layer + shadow registry | runtime subagent spawning/ending | shadow routing evidence | registry/state files | recorded, completed, dropped | yes | prompt-only routing hints pretending to be evidence | Partially clear |
+| `wf.nocturnal.training_eval` | nocturnal services/core modules | commands + service orchestration | experiment state, checkpoints, eval outputs | nocturnal state + runtime subagent session + files | success, timeout, failed, cleaned | yes | generic subagent lifecycle rules not reused | Split |
+| `wf.pain_flag_lifecycle` | unclear | llm detection, pain hook, subagent cleanup | `.pain_flag` create/update/delete | state file | created, queued, cleared, stale | yes | independent cleanup branches | Unclear |
+| `wf.principle_creation` | reducer plus upstream callers | diagnostician and other evolution paths | principle state mutation | reducer state / dictionaries | created, rejected, probation, promoted | no special cleanup | multiple creation entrypoints | Split |
+
+## Priority Candidates For Governance Trial
+
+### Candidate 1: `wf.subagent_completion.diagnostician`
+
+Why:
+
+- bounded enough to isolate
+- strongly stateful
+- relies on runtime completion and cleanup
+- already has observable terminal events
+
+### Candidate 2: `wf.empathy_observer`
+
+Why:
+
+- compact workflow
+- clearly demonstrates duplicate-path risk
+- cleanup requirement is obvious
+
+### Candidate 3: `wf.pain_flag_lifecycle`
+
+Why:
+
+- high operational impact
+- multiple modules can indirectly affect it
+- stale state can distort downstream recovery
+
+## Immediate Recommendation
+
+Do not attempt to centralize all workflows at once.
+
+Use this order:
+
+1. subagent lifecycle and completion
+2. observer-like bounded workflows
+3. pain flag lifecycle
+4. principle creation paths
+5. nocturnal runtime lifecycle


### PR DESCRIPTION
## Summary
- add a dedicated `docs/architecture-governance/` directory for architecture governance work
- document project guardrails, a gradual rollout roadmap, and an architecture-sensitive PR checklist
- bootstrap first-pass domain ownership and workflow registry docs so future governance work can proceed incrementally

## Notes
- docs-only PR
- intended as the baseline for recurring architecture governance reviews and follow-up improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **文档**
  * 新增架构治理文档目录，包含守护原则、域所有权引导、逐步推进路线图、拉取请求架构检查清单和工作流注册表。这些文档建立了系统治理框架，旨在防止隐藏的工作流故障、重复实现和状态冲突，通过明确所有权和可验证的不变量提升系统可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->