### PR TITLE
fix(install): clean target dir before sync + version check + unify bundle

### DIFF
--- a/packages/create-principles-disciple/scripts/bundle-plugin.mjs
+++ b/packages/create-principles-disciple/scripts/bundle-plugin.mjs
@@ -2,6 +2,7 @@
 /**
  * Bundle plugin for npm publishing.
  * Copies pre-built plugin files from openclaw-plugin to plugin/ directory.
+ * MUST produce identical output to what sync-plugin.mjs syncs.
  */
 
 import { existsSync, mkdirSync, rmSync, cpSync } from 'fs';
@@ -14,6 +15,16 @@ const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..', '..', '..');
 const PLUGIN_SRC = join(ROOT_DIR, 'openclaw-plugin');
 const PLUGIN_DEST = join(__dirname, '..', 'plugin');
+
+// Files to bundle — MUST match SYNC_ITEMS in sync-plugin.mjs
+const SYNC_ITEMS = [
+  'dist',
+  'templates',
+  'scripts',
+  'docs',
+  'openclaw.plugin.json',
+  'package.json',
+];
 
 console.log('📦 Bundling plugin for npm publish...\n');
 
@@ -33,23 +44,21 @@ if (existsSync(PLUGIN_DEST)) {
 
 mkdirSync(PLUGIN_DEST, { recursive: true });
 
-// Copy dist
-console.log('  Copying dist/...');
-cpSync(distDir, join(PLUGIN_DEST, 'dist'), { recursive: true });
-
-// Copy openclaw.plugin.json
-console.log('  Copying openclaw.plugin.json...');
-cpSync(
-  join(PLUGIN_SRC, 'openclaw.plugin.json'),
-  join(PLUGIN_DEST, 'openclaw.plugin.json')
-);
-
-// Copy package.json
-console.log('  Copying package.json...');
-cpSync(
-  join(PLUGIN_SRC, 'package.json'),
-  join(PLUGIN_DEST, 'package.json')
-);
+// Copy each item — same as sync-plugin.mjs
+for (const item of SYNC_ITEMS) {
+  const src = join(PLUGIN_SRC, item);
+  if (!existsSync(src)) {
+    console.log(`  ⚠️  Skipping ${item} (not found in source)`);
+    continue;
+  }
+  console.log(`  Copying ${item}...`);
+  try {
+    cpSync(src, join(PLUGIN_DEST, item), { recursive: true });
+  } catch {
+    // File copy for regular files
+    cpSync(src, join(PLUGIN_DEST, item));
+  }
+}
 
 console.log('\n✅ Plugin bundled successfully!');
 console.log(`   Location: ${PLUGIN_DEST}`);

--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -33,7 +33,6 @@ const INSTALL_DIR = join(OPENCLAW_DIR, 'extensions', 'principles-disciple');
 const SYNC_ITEMS = [
     'dist',
     'templates',
-    'agents',
     'scripts',
     'docs',
     'openclaw.plugin.json',
@@ -264,6 +263,31 @@ function verifyBuild() {
 }
 
 /**
+ * Remove existing installation directory (clean slate)
+ * This ensures no stale files remain from old versions.
+ */
+function cleanTargetDir(force) {
+    if (!existsSync(INSTALL_DIR)) {
+        return;
+    }
+
+    if (!force) {
+        const installedVersion = getVersion(INSTALL_DIR);
+        if (installedVersion && installedVersion !== getVersion(SOURCE_DIR)) {
+            console.error(`\n❌ VERSION CONFLICT:`);
+            console.error(`   Installed: v${installedVersion}`);
+            console.error(`   Source:    v${getVersion(SOURCE_DIR)}`);
+            console.error(`   Run with --force to overwrite, or uninstall first.`);
+            process.exit(1);
+        }
+    }
+
+    console.log('\n🗑️  Removing existing installation...');
+    rmSync(INSTALL_DIR, { recursive: true, force: true });
+    console.log(`   Removed: ${INSTALL_DIR}`);
+}
+
+/**
  * Ensure installation directory exists
  */
 function ensureInstallDir() {
@@ -399,16 +423,11 @@ function main() {
         verifyBuild();
     }
 
-    // Step 4: Ensure installation directory exists
-    ensureInstallDir();
+    // Step 4: Clean existing installation (must happen after build so we know what's current)
+    cleanTargetDir(args.force);
 
-    // Step 5: Check existing installation
-    if (existsSync(join(INSTALL_DIR, 'package.json'))) {
-        const installedVersion = getVersion(INSTALL_DIR);
-        if (installedVersion) {
-            console.log(`\n📦 Existing installation: v${installedVersion}`);
-        }
-    }
+    // Step 5: Ensure installation directory exists
+    ensureInstallDir();
 
     // Step 6: Sync files
     console.log('\n📦 Syncing files to OpenClaw...');


### PR DESCRIPTION
## Summary
- **sync-plugin.mjs**: cleanTargetDir() removes existing install before sync (prevents stale files from old versions)
- **sync-plugin.mjs**: abort on version mismatch unless --force is set
- **sync-plugin.mjs**: remove agents from SYNC_ITEMS (build artifact, not source)
- **bundle-plugin.mjs**: use same SYNC_ITEMS as sync-plugin.mjs so both install paths produce identical output

## Root Cause
Previous installation chaos: two install paths produced different output, sync-plugin.mjs did not clean target dir so stale files persisted.

## Testing
Local test passed: node scripts/sync-plugin.mjs — version 1.7.8, clean install, no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了插件同步和安装过程的错误处理机制，确保缺失文件不会导致整个过程失败
  * 添加了版本冲突检测，防止不兼容版本的意外覆盖安装

* **Refactor**
  * 优化了插件打包和同步脚本的配置结构，提高了可维护性和可靠性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->