### PR TITLE
feat(gate): P-16 Core Governance Files exemption from all blocking

### DIFF
--- a/packages/openclaw-plugin/src/hooks/progressive-trust-gate.ts
+++ b/packages/openclaw-plugin/src/hooks/progressive-trust-gate.ts
@@ -24,6 +24,50 @@ import { assessRiskLevel, estimateLineChanges } from '../core/risk-calculator.js
 import { checkEvolutionGate } from '../core/evolution-engine.js';
 import { recordGateBlockAndReturn } from './gate-block-helper.js';
 
+// ═══ P-16: Core Governance Files — Exempt from all Blocking ═══
+// 这些文件是团队协作的基础，必须始终放行，不受 GFI 和 Risk Path 限制
+// 可通过 PROFILE.core_governance_files 扩展（merge 而非覆盖）
+const DEFAULT_CORE_GOVERNANCE_PATTERNS = [
+  'PLAN.md',
+  'AGENTS.md',
+  'VERSION.md',
+  '.team/',
+  'MEMORY.md',
+  'SOUL.md',
+  'IDENTITY.md',
+  'USER.md',
+  'HEARTBEAT.md',
+  'BOOTSTRAP.md',
+  'PRINCIPLES.md',
+  'TEAM_ROLE.md',
+  'REPAIR_OPERATING_PROMPT.md',
+];
+
+/**
+ * Get effective core governance patterns from PROFILE config, merged with defaults.
+ * PROFILE.core_governance_files extends (not replaces) the default list.
+ */
+function getCoreGovernancePatterns(profile?: { core_governance_files?: string[] }): string[] {
+  const base = DEFAULT_CORE_GOVERNANCE_PATTERNS;
+  const extra = profile?.core_governance_files ?? [];
+  return [...new Set([...base, ...extra])];
+}
+
+/**
+ * Check if a file path matches a core governance pattern.
+ * Core governance files are exempt from all gate blocking (P-16).
+ */
+function isCoreGovernanceFile(filePath?: string, corePatterns?: string[]): boolean {
+  if (!filePath) return false;
+  const patterns = corePatterns ?? DEFAULT_CORE_GOVERNANCE_PATTERNS;
+  const normalized = filePath.replace(/\\/g, '/');
+  return patterns.some(pattern =>
+    pattern.endsWith('/')
+      ? normalized.includes(pattern)
+      : normalized.endsWith(pattern) || normalized.includes(`/${pattern}`)
+  );
+}
+
 /**
  * Configuration for progressive gate behavior
  */
@@ -111,8 +155,15 @@ export function checkProgressiveTrustGate(
   lineChanges: number,
   logger: { warn?: (message: string) => void; error?: (message: string) => void; info?: (message: string) => void },
   ctx: { workspaceDir?: string; sessionId?: string },
-  profile?: { risk_paths: string[]; progressive_gate?: { enabled?: boolean; plan_approvals?: any } }
+  profile?: { risk_paths: string[]; progressive_gate?: { enabled?: boolean; plan_approvals?: any }; core_governance_files?: string[] }
 ): PluginHookBeforeToolCallResult | void {
+  // P-16: Core governance files are exempt from all gate blocking
+  const corePatterns = getCoreGovernancePatterns(profile);
+  if (isCoreGovernanceFile(relPath, corePatterns)) {
+    logger.info?.(`[PD_GATE:P-16] Core governance file exempt — bypass all gates: ${relPath}`);
+    return; // Always allow core governance files
+  }
+
   // Check if progressive gate is disabled
   if (profile?.progressive_gate?.enabled === false) {
     return;

--- a/packages/openclaw-plugin/src/openclaw-sdk.d.ts
+++ b/packages/openclaw-plugin/src/openclaw-sdk.d.ts
@@ -229,7 +229,7 @@ export type PluginHookName =
     | 'llm_input' | 'llm_output' | 'agent_end'
     | 'before_compaction' | 'after_compaction' | 'before_reset'
     | 'message_received' | 'message_sending' | 'message_sent'
-    | 'before_tool_call' | 'after_tool_call' | 'tool_result_persist' | 'before_message_write'
+    | 'before_tool_call' | 'after_tool_call' | 'tool_result_persist' | 'before_message_write' | 'session_start' | 'session_end'
     | 'session_start' | 'session_end'
     | 'subagent_spawning' | 'subagent_delivery_target' | 'subagent_spawned' | 'subagent_ended'
     | 'gateway_start' | 'gateway_stop';
@@ -305,6 +305,26 @@ export type PluginHookAfterToolCallEvent = {
     result?: any;
     error?: string;
     durationMs?: number;
+};
+
+export type PluginHookToolResultPersistContext = {
+    agentId?: string;
+    sessionKey?: string;
+    toolName?: string;
+    toolCallId?: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PluginHookToolResultPersistEvent<TMessage = any> = {
+    toolName?: string;
+    toolCallId?: string;
+    /** The toolResult message about to be written to the session transcript. */
+    message: TMessage;
+    isSynthetic?: boolean;
+};
+
+export type PluginHookToolResultPersistResult<TMessage = any> = {
+    message?: TMessage;
 };
 
 export type PluginHookLlmOutputEvent = {
@@ -460,5 +480,6 @@ export type PluginHookHandlerMap = {
     before_compaction: (event: PluginHookBeforeCompactionEvent, ctx: PluginHookAgentContext) => any;
     after_compaction: (event: PluginHookAfterCompactionEvent, ctx: PluginHookAgentContext) => any;
     before_message_write: (event: PluginHookBeforeMessageWriteEvent, ctx: PluginHookSessionContext) => any;
+    tool_result_persist: (event: PluginHookToolResultPersistEvent, ctx: PluginHookToolResultPersistContext) => PluginHookToolResultPersistResult | void;
     [key: string]: (...args: any[]) => any;
 };


### PR DESCRIPTION
- Add DEFAULT_CORE_GOVERNANCE_PATTERNS list (PLAN.md, AGENTS.md, VERSION.md, .team/, etc.)
- Add isCoreGovernanceFile() check at entry of before_tool_call gate
- Core governance files bypass all GFI and Risk Path restrictions
- Add core_governance_files to PROFILE config (merge with defaults)

Source: stash@{2} from fix/team-okr-path-20260329 (WIP before merge)

## 🧬 PR 描述

### 变更内容
<!-- 简要描述这个 PR 做了什么 -->

### 变更类型
- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 测试情况
- [ ] 所有现有测试通过 (`npm test`)
- [ ] 新增测试覆盖新功能
- [ ] 测试覆盖率 > 60%

### 检查清单
- [ ] 代码符合项目风格
- [ ] 文档已更新
- [ ] 无破坏性变更（或已标记为 breaking change）
- [ ] 通过 Thinking OS 检查（T-01/T-04/T-05）

### 相关 Issue
<!-- 关闭的 issue：Closes #XX -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * P-16 核心治理文件现已豁免进度信任门检查，确保关键文件的优先级处理。
  * 新增工具结果持久化钩子和会话生命周期管理（会话开始/结束事件），增强插件扩展能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->