### PR TITLE
feat(gate): P-16 Core Governance Files exemption from all blocking

### DIFF
--- a/packages/openclaw-plugin/src/hooks/progressive-trust-gate.ts
+++ b/packages/openclaw-plugin/src/hooks/progressive-trust-gate.ts
@@ -27,6 +27,52 @@ import { normalizePath } from '../utils/io.js';
 import { checkEvolutionGate } from '../core/evolution-engine.js';
 import { recordGateBlockAndReturn } from './gate-block-helper.js';
 
+// ═══ P-16: Core Governance Files — Exempt from all Blocking ═══
+// 这些文件是团队协作的基础，必须始终放行，不受 GFI 和 Risk Path 限制
+// 可通过 PROFILE.core_governance_files 扩展（merge 而非覆盖）
+const DEFAULT_CORE_GOVERNANCE_PATTERNS = [
+  'PLAN.md',
+  'AGENTS.md',
+  'VERSION.md',
+  '.team/',
+  'MEMORY.md',
+  'SOUL.md',
+  'IDENTITY.md',
+  'USER.md',
+  'HEARTBEAT.md',
+  'BOOTSTRAP.md',
+  'PRINCIPLES.md',
+  'TEAM_ROLE.md',
+  'REPAIR_OPERATING_PROMPT.md',
+];
+
+/**
+ * Get effective core governance patterns from PROFILE config, merged with defaults.
+ * PROFILE.core_governance_files extends (not replaces) the default list.
+ */
+function getCoreGovernancePatterns(profile?: { core_governance_files?: string[] }): string[] {
+  const base = DEFAULT_CORE_GOVERNANCE_PATTERNS;
+  const extra = profile?.core_governance_files ?? [];
+  return Array.from(new Set([...base, ...extra]));
+}
+
+/**
+ * Check if a file path matches a core governance pattern.
+ * Core governance files are exempt from all gate blocking (P-16).
+ */
+function isCoreGovernanceFile(filePath?: string, corePatterns?: string[]): boolean {
+  if (!filePath) return false;
+  const patterns = corePatterns ?? DEFAULT_CORE_GOVERNANCE_PATTERNS;
+  const normalized = filePath.replace(/\\/g, '/');
+  return patterns.some(pattern =>
+    pattern.endsWith('/')
+      ? normalized.includes(pattern)
+      : normalized.endsWith(pattern) || normalized.includes(`/${pattern}`)
+  );
+}
+
+
+
 /**
  * Build EP gate rejection reason
  */
@@ -79,8 +125,14 @@ export function checkProgressiveTrustGate(
   lineChanges: number,
   logger: { warn?: (message: string) => void; error?: (message: string) => void; info?: (message: string) => void },
   ctx: { workspaceDir?: string; sessionId?: string },
-  profile?: { risk_paths: string[] }
+  profile?: { risk_paths: string[]; core_governance_files?: string[] }
 ): PluginHookBeforeToolCallResult | void {
+  // P-16: Core governance files are exempt from all gate blocking
+  if (isCoreGovernanceFile(relPath, getCoreGovernancePatterns(profile))) {
+    logger.info?.(`[PD_GATE:P-16] Core governance file exempt — bypass all gates: ${relPath}`);
+    return;
+  }
+
   // EP is the only gate now - use actual gate decision
   if (!ctx.workspaceDir) {
     logger.warn?.('[PD_GATE] No workspaceDir, skipping EP gate check');


### PR DESCRIPTION
- Add DEFAULT_CORE_GOVERNANCE_PATTERNS list (PLAN.md, AGENTS.md, VERSION.md, .team/, etc.)
- Add isCoreGovernanceFile() check at entry of before_tool_call gate
- Core governance files bypass all EP gate restrictions
- Add core_governance_files to PROFILE config (merge with defaults)
- Fix Set iteration TS issue with Array.from()

Source: stash@{2} from fix/team-okr-path-20260329 (WIP before merge)

## 🧬 PR 描述

### 变更内容
<!-- 简要描述这个 PR 做了什么 -->

### 变更类型
- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 测试情况
- [ ] 所有现有测试通过 (`npm test`)
- [ ] 新增测试覆盖新功能
- [ ] 测试覆盖率 > 60%

### 检查清单
- [ ] 代码符合项目风格
- [ ] 文档已更新
- [ ] 无破坏性变更（或已标记为 breaking change）
- [ ] 通过 Thinking OS 检查（T-01/T-04/T-05）

### 相关 Issue
<!-- 关闭的 issue：Closes #XX -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 新增核心治理文件豁免机制：系统现支持对指定的核心治理文件进行豁免处理，使其无需通过信任验证检查。用户可配置自定义的核心治理文件匹配模式，灵活管理豁免规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->