### PR TITLE
fix(sync-plugin): update bundle verification for post-#159 empathy architecture

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -76,8 +76,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "2336eb1cf1f6",
-    "bundleMd5": "d8c434beb38609aaab50efb64c410a7b",
-    "builtAt": "2026-04-04T02:52:53.588Z"
+    "gitSha": "a953e2e8db14",
+    "bundleMd5": "244d2be8a726bfbb86dc5f77e2916af3",
+    "builtAt": "2026-04-04T14:53:59.479Z"
   }
 }

--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -224,9 +224,9 @@ function installDependencies() {
 
 /**
  * Build the plugin.
- * Always runs build:production to ensure dist/bundle.js (the actual shipped artifact)
+ * Always runs build:production to ensure dist/bundle.mjs (the actual shipped artifact)
  * is always fresh. We no longer compare timestamps because:
- *   1. tsc alone updates index.js without updating bundle.js
+ *   1. tsc alone updates index.js without updating bundle.mjs
  *   2. Comparing index.js vs src files falsely claims "up to date"
  *   3. The cost of a extra ~10s build is far cheaper than shipping stale bundles
  *
@@ -246,7 +246,7 @@ function buildPlugin() {
         process.exit(1);
     }
 
-    // Post-build verification: ensure critical symbols made it into bundle.js
+    // Post-build verification: ensure critical symbols made it into bundle.mjs
     verifyBundleContents();
 }
 
@@ -255,24 +255,22 @@ function buildPlugin() {
  * This catches build failures where tsc succeeds but esbuild/bundling silently drops code.
  */
 function verifyBundleContents() {
-    const bundleJs = join(SOURCE_DIR, 'dist', 'bundle.js');
-    if (!existsSync(bundleJs)) {
-        console.error('❌ dist/bundle.js missing after build.');
+    const bundleMjs = join(SOURCE_DIR, 'dist', 'bundle.mjs');
+    if (!existsSync(bundleMjs)) {
+        console.error('❌ dist/bundle.mjs missing after build.');
         process.exit(1);
     }
 
-    const content = readFileSync(bundleJs, 'utf-8');
+    const content = readFileSync(bundleMjs, 'utf-8');
 
-    // Critical symbols that must exist in the bundled plugin.
-    // These are functions/classes that were previously silently dropped from the bundle.
-    // NOTE: esbuild minifies class names (EmpathyObserverManager -> EmpathyObserver) and
-    // inlines const values (OBSERVER_SESSION_PREFIX -> "empathy-obs-"), so check for
-    // the actual bundled forms, not the source-level names.
+    // Critical symbols that must exist in the bundled plugin (post #159 empathy migration).
+    // The new empathy system uses EmpathyObserverWorkflowManager + workflow spec pattern.
+    // NOTE: esbuild may minify class names, so check for the actual bundled forms.
     const requiredSymbols = [
-        { name: 'finalizeRun',       reason: 'main empathy observer回收链路 (waitForRun驱动)' },
-        { name: 'reapBySession',      reason: '统一回收入口 (reap + deleteSession + 清理状态)' },
-        { name: 'EmpathyObserver',    reason: 'EmpathyObserverManager class (minified name in bundle)' },
-        { name: 'empathy-obs-',       reason: 'OBSERVER_SESSION_PREFIX value (inlined by esbuild)' },
+        { name: 'empathy-observer-workflow-manager', reason: 'EmpathyObserverWorkflowManager (bundle filename)' },
+        { name: 'empathyObserverWorkflowSpec',       reason: 'empathy workflow spec definition' },
+        { name: 'empathyManager',                      reason: 'empathy manager instance' },
+        { name: 'empathySignalJson',                    reason: 'empathy signal JSON serialization' },
     ];
 
     const missing = [];
@@ -301,7 +299,7 @@ function verifyBundleContents() {
  * This allows post-install verification to detect stale installations.
  */
 function writeBuildFingerprint() {
-    const bundleJs = join(SOURCE_DIR, 'dist', 'bundle.js');
+    const bundleMjs = join(SOURCE_DIR, 'dist', 'bundle.mjs');
     const manifestSrc = join(SOURCE_DIR, 'openclaw.plugin.json');
     const manifestDist = join(SOURCE_DIR, 'dist', 'openclaw.plugin.json');
 
@@ -317,10 +315,10 @@ function writeBuildFingerprint() {
         console.warn('⚠️  Could not get git SHA, fingerprint will be incomplete');
     }
 
-    // Compute MD5 of bundle.js
+    // Compute MD5 of bundle.mjs
     let bundleMd5 = 'unknown';
     try {
-        const bundleContent = readFileSyncRaw(bundleJs);
+        const bundleContent = readFileSyncRaw(bundleMjs);
         bundleMd5 = createHash('md5').update(bundleContent).digest('hex');
     } catch {
         console.warn('⚠️  Could not compute bundle MD5, fingerprint will be incomplete');
@@ -441,7 +439,7 @@ function verifyInstalledFingerprint() {
 function verifyBuild() {
     const distDir = join(SOURCE_DIR, 'dist');
     const indexJs = join(distDir, 'index.js');
-    const bundleJs = join(distDir, 'bundle.js');
+    const bundleMjs = join(distDir, 'bundle.mjs');
 
     if (!existsSync(distDir)) {
         console.error('❌ dist/ directory not found.');
@@ -449,8 +447,8 @@ function verifyBuild() {
         process.exit(1);
     }
 
-    if (!existsSync(indexJs) && !existsSync(bundleJs)) {
-        console.error('❌ dist/index.js or dist/bundle.js not found.');
+    if (!existsSync(indexJs) && !existsSync(bundleMjs)) {
+        console.error('❌ dist/index.js or dist/bundle.mjs not found.');
         console.error('   Run without --skip-build to build automatically.');
         process.exit(1);
     }


### PR DESCRIPTION
## 修复内容

**问题**：sync-plugin.mjs 的 verifyBundleContents() 检查的是旧版 empathy 架构的符号（finalizeRun、reapBySession、empathy-obs-），但 PR #159 已将 empathy 迁移到 EmpathyObserverWorkflowManager，这些符号已不存在，导致验证误报失败。

**修复**：
1. 验证对象从 bundle.js 改为 bundle.mjs（实际部署用的现代模型 bundle）
2. requiredSymbols 更新为新架构符号：
   - empathy-observer-workflow-manager
   - empathyObserverWorkflowSpec
   - empathyManager
   - empathySignalJson
3. writeBuildFingerprint() 同步改为使用 bundle.mjs MD5

**验证**：本地 npm run build:production + sync-plugin.mjs --force 均通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了插件包的构建和验证流程以支持新的模块格式并改进错误提示。
  * 调整了构建产物的内容校验规则以匹配新的运行时符号集合。
  * 刷新并更新了构建指纹与元数据（哈希与构建时间），以反映最新构建。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->