### PR TITLE
fix(dedup): server-side principle dedup guard + strengthen SKILL.md dedup instructions

### DIFF
--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -744,24 +744,77 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                                 task.completed_at = new Date().toISOString();
                                 task.resolution = 'marker_detected';
                             } else {
-                                logger.info(`[PD:EvolutionWorker] Creating principle from report for task ${task.id}`);
-                                const principleId = wctx.evolutionReducer.createPrincipleFromDiagnosis({
-                                    painId: task.id,
-                                    painType: task.source === 'Human Intervention' ? 'user_frustration' : 'tool_failure',
-                                    triggerPattern: principle.trigger_pattern,
-                                    action: principle.action,
-                                    source: task.source || 'heartbeat_diagnostician',
-                                    evaluability: principle.evaluability || 'manual_only',
-                                    abstractedPrinciple: principle.abstracted_principle,
-                                });
-                                if (principleId) {
-                                    logger.info(`[PD:EvolutionWorker] Created principle ${principleId} from marker fallback for task ${task.id}`);
-                                } else {
-                                    logger.warn(`[PD:EvolutionWorker] createPrincipleFromDiagnosis returned null for task ${task.id} (may be duplicate or blacklisted)`);
+                                // ── Server-side dedup guard (defense against LLM ignoring duplicate check) ──
+                                const existingPrinciples = wctx.evolutionReducer.getActivePrinciples();
+                                let serverDuplicate: string | null = null;
+                                if (existingPrinciples.length > 0) {
+                                    const newTrigger = (principle.trigger_pattern || '').toLowerCase();
+                                    const newAction = (principle.action || '').toLowerCase();
+                                    const newAbstracted = (principle.abstracted_principle || '').toLowerCase();
+                                    for (const ep of existingPrinciples) {
+                                        const epTrigger = (ep.trigger || '').toLowerCase();
+                                        const epAction = (ep.action || '').toLowerCase();
+                                        const epAbstracted = (ep.abstractedPrinciple || '').toLowerCase();
+                                        const epText = (ep.text || '').toLowerCase();
+
+                                        // Check 1: abstracted principle overlap (>70% keyword match)
+                                        const newKeywords = newAbstracted.split(/\s+/).filter((w: string) => w.length > 3);
+                                        const epKeywords = epAbstracted.split(/\s+/).filter((w: string) => w.length > 3);
+                                        if (newKeywords.length > 0 && epKeywords.length > 0) {
+                                            const overlap = newKeywords.filter((k: string) => epKeywords.includes(k)).length;
+                                            const overlapRatio = overlap / Math.max(newKeywords.length, epKeywords.length);
+                                            if (overlapRatio > 0.7) {
+                                                serverDuplicate = ep.id;
+                                                break;
+                                            }
+                                        }
+
+                                        // Check 2: trigger pattern contains same key terms
+                                        if (newTrigger.length > 10 && epTrigger.length > 10) {
+                                            const sharedTerms = newTrigger.split(/[\s|\\.+*?()[\]{}^$-]+/).filter((t: string) => t.length > 3);
+                                            if (sharedTerms.length > 0 && sharedTerms.every((t: string) => epTrigger.includes(t))) {
+                                                serverDuplicate = ep.id;
+                                                break;
+                                            }
+                                        }
+
+                                        // Check 3: text overlap (LLM often reuses text from existing principle)
+                                        if (epText.length > 20 && newTrigger.length > 20) {
+                                            const sharedPhrases = epText.split(/\s+/).filter(w => w.length > 5);
+                                            const matchCount = sharedPhrases.filter(w => newTrigger.includes(w)).length;
+                                            if (matchCount >= 3) {
+                                                serverDuplicate = ep.id;
+                                                break;
+                                            }
+                                        }
+                                    }
                                 }
-                                task.status = 'completed';
-                                task.completed_at = new Date().toISOString();
-                                task.resolution = 'marker_detected';
+
+                                if (serverDuplicate) {
+                                    logger.info(`[PD:EvolutionWorker] Server-side dedup: new principle overlaps with existing ${serverDuplicate} — skipping creation for task ${task.id}`);
+                                    task.status = 'completed';
+                                    task.completed_at = new Date().toISOString();
+                                    task.resolution = 'marker_detected';
+                                } else {
+                                    logger.info(`[PD:EvolutionWorker] Creating principle from report for task ${task.id}`);
+                                    const principleId = wctx.evolutionReducer.createPrincipleFromDiagnosis({
+                                        painId: task.id,
+                                        painType: task.source === 'Human Intervention' ? 'user_frustration' : 'tool_failure',
+                                        triggerPattern: principle.trigger_pattern,
+                                        action: principle.action,
+                                        source: task.source || 'heartbeat_diagnostician',
+                                        evaluability: principle.evaluability || 'manual_only',
+                                        abstractedPrinciple: principle.abstracted_principle,
+                                    });
+                                    if (principleId) {
+                                        logger.info(`[PD:EvolutionWorker] Created principle ${principleId} from marker fallback for task ${task.id}`);
+                                    } else {
+                                        logger.warn(`[PD:EvolutionWorker] createPrincipleFromDiagnosis returned null for task ${task.id} (may be duplicate or blacklisted)`);
+                                    }
+                                    task.status = 'completed';
+                                    task.completed_at = new Date().toISOString();
+                                    task.resolution = 'marker_detected';
+                                }
                             }
                         } else {
                             logger.warn(`[PD:EvolutionWorker] Diagnostician report for task ${task.id} missing principle fields — diagnostician did not produce a principle`);

--- a/packages/openclaw-plugin/templates/langs/en/skills/pd-diagnostician/SKILL.md
+++ b/packages/openclaw-plugin/templates/langs/en/skills/pd-diagnostician/SKILL.md
@@ -196,14 +196,24 @@ You are a professional root cause analysis expert. You MUST strictly follow the 
 2. **Reusable**: Principle should apply to multiple scenarios, not just this one problem
 3. **Concise**: One sentence should suffice, under 40 words
 4. **Verifiable**: Can clearly judge whether principle was followed
-5. **Deduplication check** (critical): After extraction, MUST compare with **Existing Principles** provided in HEARTBEAT.md. If core meaning is same or highly similar (>70% overlap), **MUST NOT output new principle**, instead mark `"duplicate": true` in `principle_extraction` and explain why.
+5. **Deduplication check** (mandatory, cannot skip):
+   a. **Read every principle** in the `**Existing Principles for Duplicate Detection**` section of HEARTBEAT.md
+   b. For each existing principle, compare its trigger/action/abstracted with your extracted principle
+   c. **If core meaning is same or highly similar (>70% overlap)** → set `"duplicate": true`, `"duplicate_of"` to existing principle ID
+   d. If completely different → set `"duplicate": false`
+   e. **`duplicate` field MUST appear in output, cannot be omitted**
+
+**Deduplication example**:
+- Existing P_060: "Documented intent without operational feedback is not evolution"
+- You want to extract: "Documentation alone does not produce operational feedback"
+- Judgment: Same core meaning (both about docs ≠ execution feedback) → `"duplicate": true`, `"duplicate_of": "P_060"`
 
 **Principle Structure**:
 ```json
 {
   "phase": "principle_extraction",
   "principle": {
-    "id": "P_YYYYMMDD_HASH",
+    "id": "System auto-assigns P_XXX format ID — do NOT make one up",
     "trigger_pattern": "regex or keywords for auto-matching",
     "action": "Specific check/gate/reminder action",
     "abstracted_principle": "Highly abstract principle statement (under 40 words, cross-scenario)",
@@ -297,10 +307,11 @@ Merge outputs from all four phases into one JSON object:
 
 ## ⚠️ Execution Constraints
 
-1. **NO skipping phases**: MUST attempt Phase 0, then execute Phase 1 → 2 → 3 → 4 in order
+1. **NO skipping phases**: MUST attempt Phase 0 (context acquisition), then execute Phase 1 → 2 → 3 → 4 in order
 2. **NO evidence-less reasoning**: Each Why's answer MUST have evidence field
 3. **NO vague conclusions**: Root cause must be specific and fixable
 4. **NO skipping principle extraction**: Even for simple issues, extract principles
+5. **NO skipping deduplication**: `duplicate` field MUST appear in principle_extraction output
 
 ---
 
@@ -348,10 +359,11 @@ Diagnose systemic pain [ID: abc123].
       },
       "principle_extraction": {
         "principle": {
-          "id": "P_20260324_dircheck",
+          "id": "System auto-assigned",
           "trigger_pattern": "fs\\.writeFileSync|writeFile|mkdirSync",
           "action": "Check if target directory exists before writing, create if not",
           "abstracted_principle": "Any write operation must ensure integrity of target environment",
+          "duplicate": false,
           "rationale": "Prevents write failures when directory doesn't exist",
           "implementation": {
             "type": "hook",

--- a/packages/openclaw-plugin/templates/langs/zh/skills/pd-diagnostician/SKILL.md
+++ b/packages/openclaw-plugin/templates/langs/zh/skills/pd-diagnostician/SKILL.md
@@ -196,14 +196,24 @@ disable-model-invocation: true
 2. **可复用**：原则应适用于多个场景，不只解决当前这一个问题
 3. **简洁**：一句话能说清楚，不超过 40 字
 4. **可验证**：能明确判断是否遵循了此原则
-5. **去重检查**（关键）：提炼后必须与 HEARTBEAT.md 中提供的 **Existing Principles** 对比。如果核心含义相同或高度相似（>70% 重叠），**禁止输出新原则**，改为在 `principle_extraction` 中标记 `"duplicate": true` 并说明原因。
+5. **去重检查**（必执行，不可跳过）：
+   a. **逐条阅读** HEARTBEAT.md 中的 `**Existing Principles for Duplicate Detection**` 部分
+   b. 对每条现有原则，比较其 trigger/action/abstracted 与你提炼的原则
+   c. **如果核心含义相同或高度相似（>70% 重叠）** → 设置 `"duplicate": true`，`"duplicate_of"` 填写已有原则 ID
+   d. 如果完全不同 → 设置 `"duplicate": false`
+   e. **`duplicate` 字段必须在输出中出现，不能省略**
+
+**去重判断示例**：
+- 现有 P_060: "Documented intent without operational feedback is not evolution"
+- 你要提炼: "Documentation alone does not produce operational feedback"
+- 判断: 核心含义相同（都是文档不等于执行反馈）→ `"duplicate": true`, `"duplicate_of": "P_060"`
 
 **原则结构**:
 ```json
 {
   "phase": "principle_extraction",
   "principle": {
-    "id": "P_YYYYMMDD_HASH",
+    "id": "系统会自动分配 P_XXX 格式 ID，不要自己编",
     "trigger_pattern": "regex 或关键词，用于自动匹配",
     "action": "具体的检查/拦截/提醒动作",
     "abstracted_principle": "高度抽象的原则陈述（40字以内，跨场景适用）",
@@ -297,10 +307,11 @@ disable-model-invocation: true
 
 ## ⚠️ 执行约束
 
-1. **禁止跳过阶段**: 必须尝试 Phase 0，然后按 Phase 1 → 2 → 3 → 4 顺序执行
+1. **禁止跳过阶段**: 必须尝试 Phase 0（上下文获取），然后按 Phase 1 → 2 → 3 → 4 顺序执行
 2. **禁止无证据推理**: 每个 Why 的 answer 必须有 evidence 字段
 3. **禁止模糊结论**: 根因必须是具体的、可修复的
 4. **禁止遗漏原则提炼**: 即使问题很简单，也要提炼原则
+5. **禁止遗漏去重检查**: `duplicate` 字段必须在 principle_extraction 输出中出现，不能省略
 
 ---
 
@@ -348,10 +359,11 @@ Diagnose systemic pain [ID: abc123].
       },
       "principle_extraction": {
         "principle": {
-          "id": "P_20260324_dircheck",
+          "id": "系统会自动分配",
           "trigger_pattern": "fs\\.writeFileSync|writeFile|mkdirSync",
           "action": "写入前检查目标目录是否存在，不存在则先创建",
           "abstracted_principle": "任何写入操作必须确保目标环境的完整性",
+          "duplicate": false,
           "rationale": "防止在目录不存在时写入失败",
           "implementation": {
             "type": "hook",


### PR DESCRIPTION
## Summary
Server-side dedup guard to prevent LLM from creating duplicate principles.

### Code Changes (evolution-worker.ts)
- Added 3-layer dedup check before principle creation:
  1. **Keyword overlap >70%** on abstracted principle text
  2. **Trigger term containment** - all key terms from new trigger exist in existing trigger
  3. **Text phrase overlap** - 3+ shared long words between existing text and new trigger
- Logs dedup decision and skips principle creation on match

### SKILL.md Changes (zh + en)
- **ID format**: `P_YYYYMMDD_HASH` → system-assigned P_XXX (match actual `nextPrincipleId()`)
- **Dedup steps**: Changed from optional suggestion → mandatory 5-step process (a-e)
- **Concrete example**: Added P_060 dedup case showing how to compare
- **Execution constraints**: Added rule 5 - duplicate field MUST appear in output

### Why This Fix
Discovered during end-to-end test: LLM ignored SKILL.md dedup instructions, created P_063 which collided with existing P_063 (completely different content). Now both code and prompts defend against this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能优化**
  * 增强了原则去重检测机制，通过多重启发式算法识别潜在重复项，防止创建冗余原则。

* **文档**
  * 更新了原则提炼阶段的去重要求，提供更详细的逐步指导。
  * 明确了去重字段在输出中的强制要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->