### PR TITLE
fix(pipeline-health): TS compilation errors + principle count regex

### DIFF
--- a/scripts/pipeline-health.ts
+++ b/scripts/pipeline-health.ts
@@ -159,7 +159,7 @@ function parseKvLines(text: string): Record<string, string> {
 }
 
 function countPrinciplesInMarkdown(text: string): number {
-  const matches = text.match(/^### P-\d+/gm);
+  const matches = text.match(/^### P[_-]\d+/gm);
   return matches ? matches.length : 0;
 }
 
@@ -828,7 +828,7 @@ function generateMarkdown(report: HealthReport, prevReport: HealthReport | null)
     const prevStages = prevReport.stages;
     const currStages = report.stages;
 
-    const trends: string[][] = [];
+    const trends: Array<[string, string|number, string|number]> = [];
 
     // Pain events
     const currPain = (currStages.pain_signal as any)?.trajectory_db;
@@ -863,7 +863,7 @@ function generateMarkdown(report: HealthReport, prevReport: HealthReport | null)
     }
 
     for (const [label, curr, prev] of trends) {
-      const diff = (curr as number) - (prev as number);
+      const diff = Number(curr) - Number(prev);
       const arrow = diff > 0 ? '↑' : diff < 0 ? '↓' : '→';
       lines.push(`- **${label}**: ${curr} ${arrow} (上次: ${prev})`);
     }
@@ -985,7 +985,7 @@ function runSingleWorkspace(workspace: string, prevReport: HealthReport | null):
   const timestamp = now.toISOString();
 
   const scan = carpetScan(stateDir);
-  const painSignal = collectPainSignal(stateDir);
+  const painSignal = collectPainSignal(stateDir, workspace);
   const evolutionQueue = collectEvolutionQueue(stateDir);
   const diagnostician = collectDiagnostician(stateDir);
   const principles = collectPrinciples(stateDir, workspace);
@@ -1011,6 +1011,7 @@ function runSingleWorkspace(workspace: string, prevReport: HealthReport | null):
     },
     unknown_files: scan.unknown,
     anomalies: [],
+    inferred_breakpoints: [],
   };
 
   report.anomalies = detectAnomalies(report);


### PR DESCRIPTION
## 修复内容

1. **countPrinciplesInMarkdown 正则**: `/P-\d+/` → `/P[_-]\d+/`，匹配 P_060 格式（之前只匹配 P-XX，导致原则数量始终报 0）
2. **trends 数组类型**: `string[][]` → `Array<[string, string|number, string|number]>`
3. **collectPainSignal 缺参**: 补充第 2 个参数 `workspace`
4. **HealthReport 缺字段**: 初始化时包含 `inferred_breakpoints: []`

## 验证
修复前: `Principles: 0 in PRINCIPLES.md`
修复后: `Principles: 5 in PRINCIPLES.md` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 改进了内部管道健康监测系统，包括更准确的趋势计算、增强的工作空间支持和优化的报告生成功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->