### PR TITLE
feat(v1.10): Thinking Models 页面优化 — full dashboard overhaul

### DIFF
--- a/.planning/phases/01-basic-visualization/02-FULL-WEBUI-REVIEW.md
+++ b/.planning/phases/01-basic-visualization/02-FULL-WEBUI-REVIEW.md
@@ -1,0 +1,123 @@
+---
+scope: Full WebUI (7 pages)
+reviewer: gsd-ui-review
+date: 2026-04-10
+mode: Code-only review across all page components
+pages_reviewed:
+  - OverviewPage.tsx (598 lines)
+  - EvolutionPage.tsx (352 lines)
+  - FeedbackPage.tsx (140 lines)
+  - GateMonitorPage.tsx (136 lines)
+  - SamplesPage.tsx (174 lines)
+  - LoginPage.tsx (~80 lines)
+  - ThinkingModelsPage.tsx (637 lines — already reviewed)
+---
+
+# Full WebUI Audit: Principles Console
+
+**Overall Score: 17/24 — Needs Work**
+
+| Pillar | Score | Verdict |
+|--------|-------|---------|
+| Copywriting | 2/4 | Multiple hardcoded strings, emoji, mixed languages |
+| Visuals | 3/4 | Generally clean, inconsistent progress bars |
+| Color | 3/4 | Good semantic usage, but hardcoded hex colors inline |
+| Typography | 2/4 | 10+ distinct font sizes, no scale enforcement |
+| Spacing | 3/4 | Mix of CSS vars and hardcoded pixels |
+| Experience Design | 4/4 | Good loading states, auto-refresh, error handling |
+
+---
+
+## 1. Copywriting — 2/4 ❌ Issues Found
+
+### Critical
+- **EvolutionPage: COMPILE ERROR** — `Clock`, `Activity`, `Shield`, `Zap`, `BookOpen` used but not imported from lucide-react
+- **EvolutionPage: Hardcoded Chinese strings** — `当前阶段`, `原则生命周期`, `夜间训练状态`, `训练队列`, `待:`, `中:`, `完:`, `Arbiter 通过率`, `ORPO 样本数`, `模型部署`, `个` — all bypass i18n system
+- **EvolutionPage: STAGE_LABELS hardcoded** — `痛点检测`, `已入队` etc. should use i18n keys
+- **OverviewPage: Hardcoded Chinese** — `今日趋势`, `今日峰值:`, `暂无思维模型定义`, `暂无思维模型使用`
+- **OverviewPage: Emoji in code** — `🟢🟡🟠🔴` in HEALTH_LABELS, `📈` emoji before GFI trend text
+- **GateMonitorPage: Emoji in h3** — `&#x1F510;` (🔒), `&#x1F331;` (🌱)
+- **LoginPage: Hardcoded English label** — "Gateway Token" instead of i18n key
+- **SamplesPage: Hardcoded English error** — `'Review operation failed'`
+
+### Minor
+- **FeedbackPage: Trailing comment** — `// ===== Phase 6: Gate Monitor Page =====` at file end (dead code remnant)
+- **EvolutionPage: Unused imports** — Sparkline, CollapsiblePanel, 11 unused types, useCallback
+
+---
+
+## 2. Visuals — 3/4 ✅ Minor Issues
+
+### Issues
+- **Multiple pages: Inline progress bars** — FeedbackPage (48px big number + 8px bar), GateMonitorPage (24px + 12px bar), OverviewPage (BulletChart). All slightly different implementations. Should be a shared `<ProgressBar />` component.
+- **OverviewPage: Massive WorkspaceHealthPanel** — 180 lines of deeply nested inline styles. Should be refactored into sub-components with CSS classes.
+- **SamplesPage: `<pre>` overflow** — Raw text in `<pre>` tags can overflow panel width. Need `white-space: pre-wrap`, `word-break: break-word`.
+
+---
+
+## 3. Color — 3/4 ✅ Minor Issues
+
+### Issues
+- **EvolutionPage: Hardcoded hex colors** — `#ef4444`, `#f59e0b`, `#3b82f6`, `#8b5cf6`, `#22c55e` in STAGE_COLORS and donut segments. Should use CSS variables: `var(--error)`, `var(--warning)`, `var(--info)`, `var(--accent)`, `var(--success)`.
+- **EvolutionPage: Donut chart hardcoded colors** — same hex values in statusSegments array.
+- **OverviewPage: GaugeChart segment colors** — uses `var(--text-secondary)` etc. correctly, but some inline hex in other areas.
+
+---
+
+## 4. Typography — 2/4 ❌ Issues Found
+
+### Issues
+- **All pages: 10+ distinct font sizes** — `0.65rem`, `0.7rem`, `0.72rem`, `0.75rem`, `0.78rem`, `0.8rem`, `0.85rem`, `0.95rem`, `14px`, `15px`, `24px`, `48px`. No consistent scale.
+- **EvolutionPage: Mix of rem and px** — `fontSize: '15px'`, `fontSize: '14px'` alongside rem values.
+- **FeedbackPage: `48px` hardcoded** — GFI big number should use a CSS class or `--text-display` variable.
+- **GateMonitorPage: `24px` hardcoded** — Trust/EP stage numbers.
+- **OverviewPage: `2.5rem` hardcoded** — GFI current value display.
+
+---
+
+## 5. Spacing — 3/4 ✅ Mostly Good
+
+### Issues
+- **EvolutionPage: Hardcoded gap/padding** — `gap: 'var(--space-3)'` good, but also `marginRight: 6` inline for icons.
+- **OverviewPage: Inline margins** — `marginTop: 4`, `marginBottom: 6`, `gap: 8`, `gap: 12` — should use `SPACE` constants.
+- **SamplesPage: Inline spacing** — `<pre>` elements lack padding/radius styling.
+
+---
+
+## 6. Experience Design — 4/4 ✅ Good
+
+### Strengths
+- Auto-refresh hooks on FeedbackPage (15s) and GateMonitorPage (30s)
+- Consistent Loading/ErrorState pattern across all pages
+- EmptyState components used throughout
+- Two-column master-detail pattern consistent
+- Error boundaries via try/catch + setError
+
+### Minor Issues
+- **SamplesPage: No loading state for review()** — While approve/reject is in-flight, buttons aren't disabled beyond the initial state.
+- **EvolutionPage: No loading state for trace fetch** — Clicking a task, trace loads without feedback.
+
+---
+
+## Summary of Actionable Items
+
+| Priority | Page | Pillar | Issue |
+|----------|------|--------|-------|
+| CRITICAL | EvolutionPage | Copywriting | Missing lucide-react imports (compile error) |
+| CRITICAL | EvolutionPage | Copywriting | ~12 hardcoded Chinese strings bypass i18n |
+| P1 | EvolutionPage | Color | Hardcoded hex colors in STAGE_COLORS, donut segments |
+| P1 | OverviewPage | Copywriting | Hardcoded Chinese in GFI trend, ThinkingModelDistribution |
+| P1 | OverviewPage | Copywriting | Emoji in HEALTH_LABELS + GFI trend header |
+| P1 | GateMonitorPage | Copywriting | Emoji HTML entities in h3 headers |
+| P1 | LoginPage | Copywriting | Hardcoded "Gateway Token" label |
+| P1 | SamplesPage | Visuals | `<pre>` overflow, hardcoded English error |
+| P2 | All pages | Typography | 10+ font sizes, mix of px/rem |
+| P2 | FeedbackPage | Visuals | Trailing dead-code comment |
+| P2 | EvolutionPage | Code | 15+ unused imports |
+| P3 | All pages | Spacing | Inline margin/pixel values |
+
+---
+
+*Reviewed: 2026-04-10*
+*Pages: 7 of 7*
+*Mode: Code-only review (no Playwright screenshots)*

--- a/packages/openclaw-plugin/ui/src/i18n/ui.ts
+++ b/packages/openclaw-plugin/ui/src/i18n/ui.ts
@@ -52,6 +52,7 @@ export const i18n = {
     timeRange: { zh: '时间范围', en: 'Time Range' },
     total: { zh: '共', en: 'Total' },
     items: { zh: '条', en: 'items' },
+    search: { zh: '搜索...', en: 'Search...' },
   },
 
   // ========================================================================
@@ -225,26 +226,74 @@ export const i18n = {
     dormant: { zh: '休眠', en: 'Dormant' },
     effective: { zh: '有效', en: 'Effective' },
 
-    // Empty state
-    emptyTitle: { zh: '选择一个思维模型', en: 'Select a thinking model' },
-    emptyDesc: { zh: '点击左侧列表中的模型，查看场景分布和最近事件', en: 'Click a model from the list to inspect scenario coverage and recent events' },
+    // Charts and sections
+    coverageTrend: { zh: '覆盖率趋势', en: 'Coverage Trend' },
+    emptyCoverageTrend: { zh: '今日暂无覆盖率记录', en: 'No coverage data yet' },
+    emptyCoverageTrendDesc: { zh: '当 AI 开始执行任务后，覆盖率会自动记录。', en: 'Coverage is tracked automatically once AI starts working.' },
+    scenarioHeatmap: { zh: '场景热力图', en: 'Scenario Heatmap' },
+    emptyScenarioMatrix: { zh: '暂无场景数据', en: 'No scenario data yet' },
+    emptyScenarioMatrixDesc: { zh: '模型触发场景后会在此显示。', en: 'Scenarios will appear here when models are triggered.' },
+    emptyAllActive: { zh: '所有模型都在使用中', en: 'All models are active' },
+    emptyAllActiveDesc: { zh: '没有休眠模型。', en: 'No dormant models.' },
+    noModelsYet: { zh: '暂无思维模型数据', en: 'No thinking model data yet' },
+    noModelsYetDesc: { zh: 'AI 开始使用后，这里会显示思维模型的使用情况。', en: 'Thinking model usage will appear here once AI starts working.' },
+
+    // Recommendations
+    dormantModels: { zh: '休眠模型', en: 'Dormant Models' },
+    reinforce: { zh: '保持', en: 'Reinforce' },
+    rework: { zh: '重构', en: 'Rework' },
+    archive: { zh: '归档', en: 'Archive' },
+    filterByRec: { zh: '按推荐过滤', en: 'Filter by Rec' },
 
     // Detail sections
-    outcomeStats: { zh: '结果统计', en: 'Outcome Stats' },
-    scenarioDistribution: { zh: '场景分布', en: 'Scenario Distribution' },
-    recentEvents: { zh: '最近事件', en: 'Recent Events' },
-    noScenariosYet: { zh: '暂无场景', en: 'No scenarios yet' },
-
-    // Outcome stats
+    outcomeStats: { zh: '效果统计', en: 'Outcome Stats' },
+    usageTrend: { zh: '使用趋势', en: 'Usage Trend' },
+    emptyUsageTrend: { zh: '暂无使用趋势记录', en: 'No usage trend data yet' },
+    emptyUsageTrendDesc: { zh: '该模型尚未被触发使用。', en: 'This model has not been triggered yet.' },
     success: { zh: '成功', en: 'Success' },
     failure: { zh: '失败', en: 'Failure' },
     pain: { zh: '痛点', en: 'Pain' },
     correction: { zh: '纠正', en: 'Correction' },
+    scenarioDistribution: { zh: '场景分布', en: 'Scenario Distribution' },
+    recentEvents: { zh: '最近事件', en: 'Recent Events' },
+    toolContext: { zh: '工具上下文', en: 'Tool Context' },
+    painContext: { zh: '痛点上下文', en: 'Pain Context' },
+    principleContext: { zh: '原则上下文', en: 'Principle Context' },
+    trigger: { zh: '触发条件', en: 'Trigger' },
+    antiPattern: { zh: '禁止行为', en: 'Anti-Pattern' },
+    thinkingOsSource: { zh: '思维模型定义来源', en: 'Thinking Model Source' },
+
+    // Empty state
+    emptyTitle: { zh: '选择一个思维模型', en: 'Select a thinking model' },
+    emptyDesc: { zh: '点击左侧列表中的模型，查看场景分布和最近事件', en: 'Click a model from the list to inspect scenario coverage and recent events' },
+    noDataTitle: { zh: '思维模型定义', en: 'Thinking Model Definitions' },
+    noDataDesc: { zh: '以下是 10 个思维模型的定义。当 AI 开始使用后，这里会显示每个模型的使用统计。', en: 'Below are 10 thinking model definitions. Usage statistics will appear once the AI starts working.' },
+    noUsageDataYet: { zh: '该模型暂无使用数据', en: 'No usage data for this model yet' },
+    noUsageDataDesc: { zh: '当模型被触发后，使用趋势和事件会在此显示。', en: 'Usage trends and events will appear once the model is triggered.' },
 
     // Table
     hits: { zh: '命中', en: 'Hits' },
     successRate: { zh: '成功率', en: 'Success Rate' },
     failureRate: { zh: '失败率', en: 'Failure Rate' },
+
+    // Comparison mode
+    compare: { zh: '对比', en: 'Compare' },
+    compareSelected: { zh: '对比选中', en: 'Compare Selected' },
+    exitCompare: { zh: '退出对比', en: 'Exit Compare' },
+    comparisonTitle: { zh: '模型对比', en: 'Model Comparison' },
+    comparisonEmpty: { zh: '请选择至少 2 个模型进行对比', en: 'Select at least 2 models to compare' },
+
+    // Search and sort
+    filterAll: { zh: '全部', en: 'All' },
+    searchPlaceholder: { zh: '按名称或场景搜索...', en: 'Search by name or scenario...' },
+    sortByHits: { zh: '命中数', en: 'Hits' },
+    sortBySuccessRate: { zh: '成功率', en: 'Success Rate' },
+    sortByName: { zh: '名称', en: 'Name' },
+
+    // Loading states
+    loadingDetail: { zh: '正在加载模型详情...', en: 'Loading model details...' },
+    loadingComparison: { zh: '正在加载对比数据...', en: 'Loading comparison data...' },
+    modelLoading: { zh: '加载中', en: 'Loading' },
   },
 
   // ========================================================================

--- a/packages/openclaw-plugin/ui/src/i18n/ui.ts
+++ b/packages/openclaw-plugin/ui/src/i18n/ui.ts
@@ -246,6 +246,7 @@ export const i18n = {
     emptyAllActiveDesc: { zh: '没有休眠模型。', en: 'No dormant models.' },
     noModelsYet: { zh: '暂无思维模型数据', en: 'No thinking model data yet' },
     noModelsYetDesc: { zh: 'AI 开始使用后，这里会显示思维模型的使用情况。', en: 'Thinking model usage will appear here once AI starts working.' },
+    noMatches: { zh: '没有匹配的模型', en: 'No models match your filters.' },
 
     // Recommendations
     dormantModels: { zh: '休眠模型', en: 'Dormant Models' },

--- a/packages/openclaw-plugin/ui/src/i18n/ui.ts
+++ b/packages/openclaw-plugin/ui/src/i18n/ui.ts
@@ -71,6 +71,7 @@ export const i18n = {
     checking: { zh: '正在验证身份...', en: 'Verifying identity...' },
     loginTitle: { zh: 'Principles Console', en: 'Principles Console' },
     loginSubtitle: { zh: 'AI Agent 进化流程监控平台', en: 'AI Agent Evolution Monitoring Platform' },
+    tokenLabel: { zh: 'Gateway Token', en: 'Gateway Token' },
     tokenPlaceholder: { zh: '请输入您的 Gateway Token', en: 'Enter your Gateway Token' },
     tokenHint: { zh: '在服务器上运行 openclaw config get gateway.auth.token 获取 Token', en: 'Run openclaw config get gateway.auth.token on your server to get the Token' },
     loginButton: { zh: '登 录', en: 'Sign In' },
@@ -185,6 +186,11 @@ export const i18n = {
     createdAt: { zh: '创建时间', en: 'Created At' },
     failureMode: { zh: '失败模式', en: 'Failure Mode' },
     relatedThinking: { zh: '相关思维', en: 'Thinking Hits' },
+
+    // Missing i18n keys (previously hardcoded in components)
+    noGfiToday: { zh: '今日暂无 GFI 记录', en: 'No GFI data today' },
+    noWorkspacesFound: { zh: '未找到已启用的工作区', en: 'No enabled workspaces found' },
+    refreshing: { zh: '刷新中', en: 'Refreshing' },
   },
 
   // ========================================================================
@@ -214,6 +220,9 @@ export const i18n = {
     // Actions
     approve: { zh: '批准', en: 'Approve' },
     reject: { zh: '拒绝', en: 'Reject' },
+
+    // Error messages (previously hardcoded English)
+    reviewFailed: { zh: '审核操作失败', en: 'Review operation failed' },
   },
 
   // ========================================================================
@@ -325,6 +334,11 @@ export const i18n = {
       analyzing: { zh: '分析中', en: 'Analyzing' },
       principle_generated: { zh: '原则生成', en: 'Principle Generated' },
       completed: { zh: '已完成', en: 'Completed' },
+      // Principle status labels
+      candidate: { zh: '候选', en: 'Candidate' },
+      probation: { zh: '试用', en: 'Probation' },
+      active: { zh: '活跃', en: 'Active' },
+      deprecated: { zh: '废弃', en: 'Deprecated' },
     },
 
     // Status filter
@@ -355,6 +369,19 @@ export const i18n = {
     evolutionTimeline: { zh: '进化时间线', en: 'Evolution Timeline' },
     detailedEvents: { zh: '详细事件', en: 'Detailed Events' },
     reason: { zh: '原因', en: 'Reason' },
+
+    // EvolutionPage panel headers (previously hardcoded Chinese)
+    currentStage: { zh: '当前阶段', en: 'Current Stage' },
+    principleLifecycle: { zh: '原则生命周期', en: 'Principle Lifecycle' },
+    nocturnalTrainingStatus: { zh: '夜间训练状态', en: 'Nocturnal Training Status' },
+    trainingQueue: { zh: '训练队列', en: 'Training Queue' },
+    arbiterPassRate: { zh: 'Arbiter 通过率', en: 'Arbiter Pass Rate' },
+    orpoSampleCount: { zh: 'ORPO 样本数', en: 'ORPO Sample Count' },
+    modelDeployments: { zh: '模型部署', en: 'Model Deployments' },
+    deploymentCount: { zh: '个', en: 'deployments' },
+    pendingShort: { zh: '待', en: 'P' },
+    inProgressShort: { zh: '中', en: 'I' },
+    completedShort: { zh: '完', en: 'C' },
   },
 
   // ========================================================================

--- a/packages/openclaw-plugin/ui/src/pages/EvolutionPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/EvolutionPage.tsx
@@ -1,45 +1,34 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ChevronLeft } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, Clock, Activity, Shield, Zap, BookOpen } from 'lucide-react';
 import { api } from '../api';
 import type {
-  OverviewResponse,
-  SampleDetailResponse,
-  SamplesResponse,
-  ThinkingModelDetailResponse,
-  ThinkingOverviewResponse,
   EvolutionTasksResponse,
   EvolutionTraceResponse,
   EvolutionStatsResponse,
-  OverviewHealthResponse,
   EvolutionPrinciplesResponse,
-  FeedbackGfiResponse,
-  GateStatsResponse,
-  GateBlockItem,
-  EmpathyEvent,
-  FeedbackGateBlock,
 } from '../types';
-import { Sparkline, DonutChart, GroupedBarChart, TimeRangeSelector, CollapsiblePanel, StatusBadge, EmptyState } from '../charts';
+import { DonutChart, GroupedBarChart, TimeRangeSelector, StatusBadge, EmptyState } from '../charts';
 import { useI18n } from '../i18n/ui';
 import { formatPercent, formatDate, formatDuration } from '../utils/format';
 import { Loading, ErrorState } from '../components';
 
 const STAGE_COLORS: Record<string, string> = {
-  pain_detected: '#ef4444',
-  queued: '#f59e0b',
-  started: '#3b82f6',
+  pain_detected: 'var(--error)',
+  queued: 'var(--warning)',
+  started: 'var(--info)',
   analyzing: '#8b5cf6',
-  principle_generated: '#22c55e',
-  completed: '#22c55e',
+  principle_generated: 'var(--success)',
+  completed: 'var(--success)',
 };
 
-const STAGE_LABELS: Record<string, string> = {
-  pain_detected: '痛点检测',
-  queued: '已入队',
-  started: '开始处理',
-  analyzing: '分析中',
-  principle_generated: '原则生成',
-  completed: '已完成',
-};
+const STAGE_LABEL_KEYS: string[] = [
+  'pain_detected',
+  'queued',
+  'started',
+  'analyzing',
+  'principle_generated',
+  'completed',
+];
 
 export function EvolutionPage() {
   const { t } = useI18n();
@@ -86,10 +75,10 @@ export function EvolutionPage() {
 
   // Prepare donut chart data
   const statusSegments = [
-    { label: t('evolution.pending'), value: stats.pending, color: '#f59e0b' },
-    { label: t('evolution.inProgress'), value: stats.inProgress, color: '#3b82f6' },
-    { label: t('evolution.completed'), value: stats.completed, color: '#22c55e' },
-    { label: t('evolution.failed'), value: stats.failed, color: '#ef4444' },
+    { label: t('evolution.pending'), value: stats.pending, color: 'var(--warning)' },
+    { label: t('evolution.inProgress'), value: stats.inProgress, color: 'var(--info)' },
+    { label: t('evolution.completed'), value: stats.completed, color: 'var(--success)' },
+    { label: t('evolution.failed'), value: stats.failed, color: 'var(--error)' },
   ].filter(s => s.value > 0);
 
   return (
@@ -112,23 +101,15 @@ export function EvolutionPage() {
       {/* Current Stage Indicator */}
       {evoPrinciples && (
         <section className="panel" style={{ marginBottom: 'var(--space-5)' }}>
-          <h3>当前阶段</h3>
+          <h3>{t('evolution.currentStage')}</h3>
           <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', padding: 'var(--space-3) 0' }}>
-            <span style={{
-              padding: 'var(--space-2) var(--space-4)',
-              borderRadius: 'var(--radius-lg)',
-              fontSize: '15px',
-              fontWeight: 600,
-              background: 'var(--accent)',
-              color: '#fff',
-              border: '2px solid var(--accent)',
-            }}>
-              {evoPrinciples.activeStage === 'pending' ? <><Clock size={16} style={{marginRight: 6, verticalAlign: 'middle'}}/>{t('evolution.activeStage.pending')}</> :
-               evoPrinciples.activeStage === 'in_progress' ? <><Activity size={16} style={{marginRight: 6, verticalAlign: 'middle'}}/>{t('evolution.activeStage.in_progress')}</> :
-               evoPrinciples.activeStage === 'completed' ? <><Shield size={16} style={{marginRight: 6, verticalAlign: 'middle'}}/>{t('evolution.activeStage.completed')}</> :
-               evoPrinciples.activeStage === 'idle' ? <><Zap size={16} style={{marginRight: 6, verticalAlign: 'middle'}}/>{t('evolution.activeStage.idle')}</> : evoPrinciples.activeStage}
+            <span className="stage-badge">
+              {evoPrinciples.activeStage === 'pending' ? <><Clock size={16} /><span>{t('evolution.activeStage.pending')}</span></> :
+               evoPrinciples.activeStage === 'in_progress' ? <><Activity size={16} /><span>{t('evolution.activeStage.in_progress')}</span></> :
+               evoPrinciples.activeStage === 'completed' ? <><Shield size={16} /><span>{t('evolution.activeStage.completed')}</span></> :
+               evoPrinciples.activeStage === 'idle' ? <><Zap size={16} /><span>{t('evolution.activeStage.idle')}</span></> : evoPrinciples.activeStage}
             </span>
-            <span style={{ color: 'var(--text-secondary)', fontSize: '14px' }}>
+            <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>
               {t('evolution.enhancementLoopStatus')}
             </span>
           </div>
@@ -139,12 +120,12 @@ export function EvolutionPage() {
       {evoPrinciples && (
         <div className="grid two-columns" style={{ marginBottom: 'var(--space-5)' }}>
           <section className="panel">
-            <h3><BookOpen size={16} style={{marginRight: 6, verticalAlign: 'middle'}}/>原则生命周期</h3>
+            <h3><BookOpen size={16} />{t('evolution.principleLifecycle')}</h3>
             <div className="pill-row" style={{ marginBottom: 'var(--space-3)' }}>
-              <StatusBadge variant="warning">候选: {evoPrinciples.principles.summary.candidate}</StatusBadge>
-              <StatusBadge variant="info">试用: {evoPrinciples.principles.summary.probation}</StatusBadge>
-              <StatusBadge variant="success">活跃: {evoPrinciples.principles.summary.active}</StatusBadge>
-              <StatusBadge variant="error">废弃: {evoPrinciples.principles.summary.deprecated}</StatusBadge>
+              <StatusBadge variant="warning">{t('evolution.stageLabels.candidate')}: {evoPrinciples.principles.summary.candidate}</StatusBadge>
+              <StatusBadge variant="info">{t('evolution.stageLabels.probation')}: {evoPrinciples.principles.summary.probation}</StatusBadge>
+              <StatusBadge variant="success">{t('evolution.stageLabels.active')}: {evoPrinciples.principles.summary.active}</StatusBadge>
+              <StatusBadge variant="error">{t('evolution.stageLabels.deprecated')}: {evoPrinciples.principles.summary.deprecated}</StatusBadge>
             </div>
             {evoPrinciples.principles.recent.length > 0 && (
               <div className="stack">
@@ -161,23 +142,23 @@ export function EvolutionPage() {
             )}
           </section>
           <section className="panel">
-            <h3>💤 夜间训练状态</h3>
+            <h3>💤 {t('evolution.nocturnalTrainingStatus')}</h3>
             <div className="stack">
               <div className="row-card">
-                <strong>训练队列</strong>
-                <span>待: {evoPrinciples.nocturnalTraining.queue.pending} | 中: {evoPrinciples.nocturnalTraining.queue.inProgress} | 完: {evoPrinciples.nocturnalTraining.queue.completed}</span>
+                <strong>{t('evolution.trainingQueue')}</strong>
+                <span>{t('evolution.pendingShort')}: {evoPrinciples.nocturnalTraining.queue.pending} | {t('evolution.inProgressShort')}: {evoPrinciples.nocturnalTraining.queue.inProgress} | {t('evolution.completedShort')}: {evoPrinciples.nocturnalTraining.queue.completed}</span>
               </div>
               <div className="row-card">
-                <strong>Arbiter 通过率</strong>
+                <strong>{t('evolution.arbiterPassRate')}</strong>
                 <span>{(evoPrinciples.nocturnalTraining.arbiterPassRate * 100).toFixed(1)}%</span>
               </div>
               <div className="row-card">
-                <strong>ORPO 样本数</strong>
+                <strong>{t('evolution.orpoSampleCount')}</strong>
                 <span>{evoPrinciples.nocturnalTraining.orpoSampleCount}</span>
               </div>
               <div className="row-card">
-                <strong>模型部署</strong>
-                <span>{evoPrinciples.nocturnalTraining.deployments.length} 个</span>
+                <strong>{t('evolution.modelDeployments')}</strong>
+                <span>{evoPrinciples.nocturnalTraining.deployments.length} {t('evolution.deploymentCount')}</span>
               </div>
             </div>
           </section>

--- a/packages/openclaw-plugin/ui/src/pages/FeedbackPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/FeedbackPage.tsx
@@ -136,5 +136,3 @@ export function FeedbackPage() {
     </div>
   );
 }
-
-// ===== Phase 6: Gate Monitor Page =====

--- a/packages/openclaw-plugin/ui/src/pages/GateMonitorPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/GateMonitorPage.tsx
@@ -80,7 +80,7 @@ export function GateMonitorPage() {
         <section className="panel">
           <h3>🔐 {t('gate.trustEngine')}</h3>
           <div style={{ padding: 'var(--space-3) 0' }}>
-            <div style={{ fontSize: '24px', fontWeight: 700 }}>Stage {gateStats.trust.stage}: {gateStats.trust.status}</div>
+            <div style={{ fontSize: '1.5rem', fontWeight: 700 }}>Stage {gateStats.trust.stage}: {gateStats.trust.status}</div>
             <div style={{ marginTop: 'var(--space-2)', width: '100%', height: '12px', background: 'var(--bg-sunken)', borderRadius: '6px' }}>
               <div style={{ width: `${gateStats.trust.score}%`, height: '100%', background: 'var(--info)', borderRadius: '6px' }} />
             </div>
@@ -92,11 +92,11 @@ export function GateMonitorPage() {
         <section className="panel">
           <h3>🌱 {t('gate.evolutionEngine')}</h3>
           <div style={{ padding: 'var(--space-3) 0' }}>
-            <div style={{ fontSize: '24px', fontWeight: 700 }}>{gateStats.evolution.tier} ({gateStats.evolution.status})</div>
+            <div style={{ fontSize: '1.5rem', fontWeight: 700 }}>{gateStats.evolution.tier} ({gateStats.evolution.status})</div>
             <div style={{ marginTop: 'var(--space-2)', width: '100%', height: '12px', background: 'var(--bg-sunken)', borderRadius: '6px' }}>
               <div style={{ width: `${Math.min(100, gateStats.evolution.points / 10)}%`, height: '100%', background: 'var(--success)', borderRadius: '6px' }} />
             </div>
-            <div style={{ fontSize: '13px', color: 'var(--text-secondary)', marginTop: 'var(--space-1)' }}>
+            <div className="text-sm" style={{ color: 'var(--text-secondary)', marginTop: 'var(--space-1)' }}>
               {t('gate.points')}: {gateStats.evolution.points}
             </div>
           </div>

--- a/packages/openclaw-plugin/ui/src/pages/LoginPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/LoginPage.tsx
@@ -44,7 +44,7 @@ export function LoginPage() {
 
         <form className="login-form" onSubmit={handleSubmit}>
           <div className="form-group">
-            <label htmlFor="token">Gateway Token</label>
+            <label htmlFor="token">{t('auth.tokenLabel')}</label>
             <input
               id="token"
               type="password"
@@ -52,6 +52,7 @@ export function LoginPage() {
               onChange={(e) => setToken(e.target.value)}
               placeholder={t('auth.tokenPlaceholder')}
               autoComplete="off"
+              aria-label={t('auth.tokenLabel')}
             />
             <span className="form-hint">
               {t('auth.tokenHint')}

--- a/packages/openclaw-plugin/ui/src/pages/OverviewPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/OverviewPage.tsx
@@ -196,11 +196,11 @@ function WorkspaceHealthPanel({ entry }: { entry: WorkspaceHealthEntry }) {
         {/* Full-width GFI trend chart */}
         <section style={{ marginTop: 'var(--space-4)', borderTop: '1px solid var(--border)', paddingTop: 'var(--space-4)' }}>
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 8 }}>
-            <span style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--text-primary)' }}>
-              📈 {t('overview.health.gfi')} · 今日趋势
+            <span className="text-lg text-semibold">
+              {t('overview.health.gfi')} · {t('overview.recentTrend')}
             </span>
-            <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
-              今日峰值: {h.gfi.peakToday}
+            <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+              {t('overview.health.peakToday')}: {h.gfi.peakToday}
             </span>
           </div>
           {h.gfi.trend.length >= 2 ? (
@@ -236,10 +236,11 @@ function ThinkingModelDistribution({
   modelBreakdown?: Array<{ modelId: string; hits: number }>;
   definitions?: Array<{ modelId: string; name: string; description: string }>;
 }) {
+  const { t } = useI18n();
   if (!definitions || definitions.length === 0) {
     return (
-      <div style={{ textAlign: 'center', padding: 'var(--space-3)', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
-        暂无思维模型定义
+      <div className="text-center" style={{ padding: 'var(--space-3)', color: 'var(--text-secondary)', fontSize: 'var(--text-lg, 0.8rem)' }}>
+        {t('overview.noDefinitions')}
       </div>
     );
   }
@@ -249,8 +250,8 @@ function ThinkingModelDistribution({
 
   if (!hasAnyHits) {
     return (
-      <div style={{ textAlign: 'center', padding: 'var(--space-3)', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
-        暂无思维模型使用记录。AI 开始使用后这里会显示数据。
+      <div className="text-center" style={{ padding: 'var(--space-3)', color: 'var(--text-secondary)', fontSize: 'var(--text-lg, 0.8rem)' }}>
+        {t('overview.noUsage')}
       </div>
     );
   }
@@ -472,7 +473,7 @@ export function OverviewPage() {
       ) : (
         <section className="panel" style={{ marginBottom: 'var(--space-4)' }}>
           <div style={{ textAlign: 'center', padding: 'var(--space-4)', color: 'var(--text-secondary)' }}>
-            {t('overview.health.noWorkspaces') || 'No enabled workspaces found'}
+            {t('overview.health.noWorkspaces') || t('overview.noWorkspacesFound')}
           </div>
         </section>
       )}

--- a/packages/openclaw-plugin/ui/src/pages/SamplesPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/SamplesPage.tsx
@@ -46,7 +46,7 @@ export function SamplesPage() {
       setData(samples);
       setSelected(detail);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Review operation failed');
+      setError(err instanceof Error ? err.message : t('samples.reviewFailed'));
     }
   }
 
@@ -122,11 +122,11 @@ export function SamplesPage() {
               </div>
               <article>
                 <h4>{t('samples.badAttempt')}</h4>
-                <pre>{selected.badAttempt.rawText || selected.badAttempt.sanitizedText}</pre>
+                <pre className="sample-pre">{selected.badAttempt.rawText || selected.badAttempt.sanitizedText}</pre>
               </article>
               <article>
                 <h4>{t('samples.userCorrection')}</h4>
-                <pre>{selected.userCorrection.rawText}</pre>
+                <pre className="sample-pre">{selected.userCorrection.rawText}</pre>
               </article>
               <article>
                 <h4>{t('samples.recoveryToolSpan')}</h4>

--- a/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
@@ -365,8 +365,8 @@ export function ThinkingModelsPage() {
                 })}
                 {filteredModels.length === 0 && (
                   <EmptyState
-                    title={t('thinkingModels.noModelsYet')}
-                    description={t('thinkingModels.noModelsYetDesc')}
+                    title={data.topModels.length > 0 ? (t('thinkingModels.noMatches') || 'No models match your filters.') : t('thinkingModels.noModelsYet')}
+                    description={data.topModels.length > 0 ? '' : t('thinkingModels.noModelsYetDesc')}
                   />
                 )}
               </div>
@@ -463,7 +463,8 @@ export function ThinkingModelsPage() {
                   {!isLoadingDetail && detail && (
                 <div className="detail-stack">
                   <div className="detail-header">
-                    <button className="back-button" onClick={() => { setDetail(null); setIsLoadingDetail(true); }} title={t('common.back')}>
+<<<<<<< Updated upstream
+                    <button className="back-button" onClick={() => { setDetail(null); setSelectedModel(''); setIsLoadingDetail(true); }} title={t('common.back')}>
                       <ChevronLeft strokeWidth={1.75} size={18} />
                     </button>
                     <div>

--- a/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
@@ -1,11 +1,27 @@
-import React, { useEffect, useState } from 'react';
-import { ChevronLeft } from 'lucide-react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import { ChevronLeft, Search, ArrowUpDown, X, Columns } from 'lucide-react';
 import { api } from '../api';
-import type { ThinkingOverviewResponse, ThinkingModelDetailResponse } from '../types';
-import { EmptyState } from '../charts';
+import type { ThinkingOverviewResponse, ThinkingModelDetailResponse, ThinkingModelSummary } from '../types';
+import { EmptyState, LineChart, StatusBadge, CollapsiblePanel, Sparkline, MiniBarChart } from '../charts';
 import { useI18n } from '../i18n/ui';
 import { formatPercent, formatDate } from '../utils/format';
 import { Loading, ErrorState } from '../components';
+
+// ---------------------------------------------------------------------------
+// Recommendation badge helper
+// ---------------------------------------------------------------------------
+
+type BadgeVariant = 'success' | 'warning' | 'neutral';
+
+const REC_BADGE: Record<string, { variant: BadgeVariant; label: (t: (k: string) => string) => string }> = {
+  reinforce: { variant: 'success', label: (t) => t('thinkingModels.reinforce') },
+  rework: { variant: 'warning', label: (t) => t('thinkingModels.rework') },
+  archive: { variant: 'neutral', label: (t) => t('thinkingModels.archive') },
+};
+
+// ---------------------------------------------------------------------------
+// ThinkingModelsPage — Redesigned Layout
+// ---------------------------------------------------------------------------
 
 export function ThinkingModelsPage() {
   const { t } = useI18n();
@@ -13,6 +29,24 @@ export function ThinkingModelsPage() {
   const [detail, setDetail] = useState<ThinkingModelDetailResponse | null>(null);
   const [selectedModel, setSelectedModel] = useState('');
   const [error, setError] = useState('');
+
+  // Comparison mode state
+  const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
+  const [comparisonDetails, setComparisonDetails] = useState<Map<string, ThinkingModelDetailResponse>>(new Map());
+  const [isComparing, setIsComparing] = useState(false);
+
+  // Filters
+  const [recFilter, setRecFilter] = useState('all');
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState<'hits' | 'successRate' | 'name'>('hits');
+
+  // Cache for detail lookups during comparison
+  const detailCache = useMemo(() => {
+    const cache = new Map<string, ThinkingModelDetailResponse>();
+    if (detail) cache.set(selectedModel, detail);
+    comparisonDetails.forEach((d, id) => cache.set(id, d));
+    return cache;
+  }, [detail, selectedModel, comparisonDetails]);
 
   useEffect(() => {
     api.getThinkingOverview().then((value) => {
@@ -26,14 +60,93 @@ export function ThinkingModelsPage() {
     api.getThinkingModelDetail(selectedModel).then(setDetail).catch((err) => setError(String(err)));
   }, [selectedModel]);
 
+  // Comparison mode handlers
+  const toggleCompareSelection = useCallback((modelId: string) => {
+    setSelectedForCompare(prev => {
+      if (prev.includes(modelId)) {
+        return prev.filter(id => id !== modelId);
+      }
+      if (prev.length >= 4) return prev; // Max 4 for layout
+      return [...prev, modelId];
+    });
+  }, []);
+
+  const startComparison = useCallback(async () => {
+    if (selectedForCompare.length < 2) return;
+    setIsComparing(true);
+    const newDetails = new Map(comparisonDetails);
+    const fetches = selectedForCompare
+      .filter(id => !newDetails.has(id))
+      .map(async (id) => {
+        try {
+          const d = await api.getThinkingModelDetail(id);
+          newDetails.set(id, d);
+        } catch {
+          // Skip failed fetches
+        }
+      });
+    await Promise.all(fetches);
+    setComparisonDetails(newDetails);
+  }, [selectedForCompare, comparisonDetails]);
+
+  const exitComparison = useCallback(() => {
+    setIsComparing(false);
+    setSelectedForCompare([]);
+    setComparisonDetails(new Map());
+  }, []);
+
+  // Filtered + sorted model list
+  const filteredModels = useMemo(() => {
+    if (!data) return [];
+    let models = [...data.topModels];
+    if (recFilter !== 'all') {
+      models = models.filter(m => m.recommendation === recFilter);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      models = models.filter(m =>
+        m.name.toLowerCase().includes(q) ||
+        (m.commonScenarios ?? []).some(s => s.toLowerCase().includes(q))
+      );
+    }
+    models.sort((a, b) => {
+      if (sortBy === 'hits') return b.hits - a.hits;
+      if (sortBy === 'successRate') return b.successRate - a.successRate;
+      return a.name.localeCompare(b.name);
+    });
+    return models;
+  }, [data, recFilter, search, sortBy]);
+
+  // Scenario heatmap data
+  const heatmapData = useMemo(() => {
+    if (!data || data.scenarioMatrix.length === 0) return null;
+    const allScenarios = [...new Set(data.scenarioMatrix.map(m => m.scenario))].sort();
+    const models = [...data.topModels].sort((a, b) => b.hits - a.hits);
+    const hitMap = new Map<string, number>();
+    for (const entry of data.scenarioMatrix) {
+      hitMap.set(`${entry.modelId}::${entry.scenario}`, entry.hits);
+    }
+    const maxHits = Math.max(...data.scenarioMatrix.map(m => m.hits), 1);
+    return { allScenarios, models, hitMap, maxHits };
+  }, [data]);
+
   if (error) return <ErrorState error={error} />;
   if (!data) return <Loading />;
 
+  const totalHits = data.topModels.reduce((sum, m) => sum + m.hits, 0);
+  const hasData = totalHits > 0;
+
   return (
     <div className="page">
+      {/* ── Header ── */}
       <header className="page-header">
         <div>
           <h2>{t('thinkingModels.pageTitle')}</h2>
+          {data.thinkingSummary?.modelDefinitions && data.thinkingSummary.modelDefinitions.length > 0 && (
+            <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', margin: '4px 0 0' }}>
+              {t('thinkingModels.thinkingOsSource')}: <code style={{ fontSize: '0.65rem', background: 'var(--bg-sunken)', padding: '1px 4px', borderRadius: 3 }}>THINKING_OS.md</code>
+            </p>
+          )}
         </div>
         <div className="pill-row">
           <span className="badge">{t('thinkingModels.coverage')} {formatPercent(data.summary.coverageRate)}</span>
@@ -43,85 +156,482 @@ export function ThinkingModelsPage() {
         </div>
       </header>
 
-      <div className="grid two-columns wide-right">
-        <section className="panel">
-          <div className="list-table">
-            {data.topModels.map((item) => (
-              <button className={`table-row ${selectedModel === item.modelId ? 'active' : ''}`} key={item.modelId} onClick={() => setSelectedModel(item.modelId)}>
-                <div>
-                  <strong>{item.name}</strong>
-                  <span>{item.commonScenarios.join(', ') || 'No scenarios yet'}</span>
+      {!hasData ? (
+        /* ── No data yet: show model definitions grid ── */
+        <section className="panel" style={{ marginBottom: 'var(--space-4)' }}>
+          <div style={{ textAlign: 'center', padding: 'var(--space-5)', color: 'var(--text-secondary)' }}>
+            <div style={{ fontSize: '2rem', marginBottom: 8 }}>🧠</div>
+            <h3 style={{ marginBottom: 4 }}>{t('thinkingModels.noDataTitle') || '思维模型定义'}</h3>
+            <p style={{ fontSize: '0.85rem', maxWidth: 500, margin: '0 auto 24px' }}>
+              {t('thinkingModels.noDataDesc') || '以下是 10 个思维模型的定义。当 AI 开始使用后，这里会显示每个模型的使用统计。'}
+            </p>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 }}>
+            {data.topModels.map(model => (
+              <div
+                key={model.modelId}
+                style={{
+                  padding: 12,
+                  border: '1px solid var(--border)',
+                  borderRadius: 8,
+                  background: 'var(--bg-sunken)',
+                  cursor: 'pointer',
+                }}
+                onClick={() => { setSelectedModel(model.modelId); setDetail(null); }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
+                  <strong style={{ fontSize: '0.85rem' }}>{model.modelId}: {model.name}</strong>
                 </div>
-                <div>
-                  <span>{item.hits} hits</span>
-                  <span>{item.recommendation}</span>
-                </div>
-                <div className="align-right">
-                  <strong>{formatPercent(item.successRate)}</strong>
-                  <span>{formatPercent(item.failureRate)} failure</span>
-                </div>
-              </button>
+                <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', margin: '0 0 8px', lineHeight: 1.4 }}>
+                  {model.description}
+                </p>
+                {model.commonScenarios.length > 0 && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                    {model.commonScenarios.slice(0, 3).map(s => (
+                      <span key={s} style={{ fontSize: '0.65rem', padding: '1px 6px', background: 'rgba(91,139,160,0.1)', borderRadius: 3, color: 'var(--info)' }}>
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
             ))}
           </div>
         </section>
-
-        <section className="panel">
-          {!detail && <EmptyState title={t('thinkingModels.emptyTitle')} description={t('thinkingModels.emptyDesc')} />}
-          {detail && (
-            <div className="detail-stack">
-              <div className="detail-header">
-                <button
-                  className="back-button"
-                  onClick={() => setDetail(null)}
-                  title={t('common.back') || 'Back'}
-                >
-                  <ChevronLeft strokeWidth={1.75} size={18} />
-                </button>
-                <div>
-                  <h3>{detail.modelMeta.name}</h3>
-                  <p>{detail.modelMeta.description}</p>
-                </div>
-                <span className="badge">{detail.modelMeta.recommendation}</span>
-              </div>
-              <article>
-                <h4>{t('thinkingModels.outcomeStats')}</h4>
-                <div className="pill-row">
-                  <span className="badge">{t('thinkingModels.success')} {formatPercent(detail.outcomeStats.successRate)}</span>
-                  <span className="badge">{t('thinkingModels.failure')} {formatPercent(detail.outcomeStats.failureRate)}</span>
-                  <span className="badge">{t('thinkingModels.pain')} {formatPercent(detail.outcomeStats.painRate)}</span>
-                  <span className="badge">{t('thinkingModels.correction')} {formatPercent(detail.outcomeStats.correctionRate)}</span>
-                </div>
-              </article>
-              <article>
-                <h4>{t('thinkingModels.scenarioDistribution')}</h4>
-                <div className="stack">
-                  {detail.scenarioDistribution.map((item) => (
-                    <div className="row-card" key={item.scenario}>
-                      <strong>{item.scenario}</strong>
-                      <span>{item.hits}</span>
-                    </div>
-                  ))}
-                </div>
-              </article>
-              <article>
-                <h4>{t('thinkingModels.recentEvents')}</h4>
-                <div className="stack">
-                  {detail.recentEvents.map((event) => (
-                    <div className="row-card vertical" key={event.id}>
-                      <div>
-                        <strong>{formatDate(event.createdAt)}</strong>
-                        <span>{event.scenarios.join(', ') || 'No scenarios'}</span>
-                      </div>
-                      <pre>{event.triggerExcerpt}</pre>
-                    </div>
-                  ))}
-                </div>
-              </article>
-            </div>
+      ) : (
+        /* ── Has data: full dashboard ── */
+        <>
+          {/* Coverage Trend */}
+          {data.coverageTrend.length >= 1 && (
+            <section className="panel" style={{ marginBottom: 'var(--space-4)' }}>
+              <h3 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: 8 }}>
+                {t('thinkingModels.coverageTrend')}
+              </h3>
+              <LineChart
+                data={data.coverageTrend.map(d => ({ label: d.day.slice(5), value: Math.round(d.coverageRate * 100) }))}
+                width={560}
+                height={140}
+                color="var(--accent)"
+                showGrid
+                showDots
+                showArea
+              />
+            </section>
           )}
-        </section>
-      </div>
+
+          {/* Search + Sort + Filter */}
+          <div style={{ display: 'flex', gap: 8, marginBottom: 'var(--space-3)', alignItems: 'center', flexWrap: 'wrap' }}>
+            <div style={{ position: 'relative', flex: '1 1 200px' }}>
+              <Search size={14} style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-secondary)' }} />
+              <input
+                type="text"
+                placeholder={t('thinkingModels.searchPlaceholder')}
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                style={{ paddingLeft: 28, width: '100%', padding: '6px 8px 6px 28px', border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-panel)', color: 'var(--text-primary)', fontSize: '0.8rem' }}
+              />
+            </div>
+            <button
+              onClick={() => setSortBy(prev => prev === 'hits' ? 'successRate' : prev === 'successRate' ? 'name' : 'hits')}
+              style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 10px', border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-panel)', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.75rem' }}
+            >
+              <ArrowUpDown size={14} />
+              {sortBy === 'hits' ? t('thinkingModels.sortByHits') : sortBy === 'successRate' ? t('thinkingModels.sortBySuccessRate') : t('thinkingModels.sortByName')}
+            </button>
+            <div style={{ display: 'flex', gap: 4 }}>
+              {['all', 'reinforce', 'rework', 'archive'].map(key => (
+                <button
+                  key={key}
+                  onClick={() => setRecFilter(key)}
+                  style={{
+                    padding: '3px 8px',
+                    border: `1px solid ${recFilter === key ? 'var(--accent)' : 'var(--border)'}`,
+                    borderRadius: 4,
+                    background: recFilter === key ? 'rgba(91, 139, 160, 0.15)' : 'transparent',
+                    color: recFilter === key ? 'var(--accent)' : 'var(--text-secondary)',
+                    cursor: 'pointer',
+                    fontSize: '0.7rem',
+                  }}
+                >
+                  {key === 'all' ? 'All' : REC_BADGE[key]?.label(t)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Two-column layout: Model List + Detail */}
+          <div className="grid two-columns wide-right">
+            {/* Left: Model List */}
+            <section className="panel">
+              {/* Compare button bar */}
+              {selectedForCompare.length >= 2 && !isComparing && (
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', marginBottom: 8, background: 'rgba(91, 139, 160, 0.08)', borderRadius: 6, border: '1px solid var(--border)' }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+                    {selectedForCompare.length} {t('thinkingModels.compareSelected') || 'selected'}
+                  </span>
+                  <button
+                    onClick={startComparison}
+                    style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 12px', border: 'none', borderRadius: 4, background: 'var(--accent)', color: '#fff', cursor: 'pointer', fontSize: '0.75rem', fontWeight: 600 }}
+                  >
+                    <Columns size={14} />
+                    {t('thinkingModels.compare')}
+                  </button>
+                </div>
+              )}
+              <div className="list-table">
+                {filteredModels.map((item) => {
+                  const isChecked = selectedForCompare.includes(item.modelId);
+                  return (
+                    <div
+                      key={item.modelId}
+                      className={`table-row ${selectedModel === item.modelId && !isComparing ? 'active' : ''}`}
+                      style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', ...(item.recommendation === 'reinforce' ? { borderLeft: '3px solid var(--success)', paddingLeft: 'calc(var(--space-2) - 3px)' } : {}) }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => toggleCompareSelection(item.modelId)}
+                        onClick={e => e.stopPropagation()}
+                        style={{ accentColor: 'var(--accent)', cursor: 'pointer', flexShrink: 0 }}
+                        title={t('thinkingModels.compare') || 'Compare'}
+                      />
+                      <button
+                        onClick={() => { setSelectedModel(item.modelId); setDetail(null); setIsComparing(false); }}
+                        style={{ flex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'inherit', textAlign: 'left' }}
+                      >
+                        <div>
+                          <strong>{item.name}</strong>
+                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 180, display: 'block' }}>
+                            {item.commonScenarios.join(', ') || '—'}
+                          </span>
+                        </div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                          <span style={{ fontWeight: 600, fontSize: '0.85rem' }}>{item.hits}</span>
+                          {REC_BADGE[item.recommendation] && (
+                            <StatusBadge variant={REC_BADGE[item.recommendation].variant}>
+                              {REC_BADGE[item.recommendation].label(t)}
+                            </StatusBadge>
+                          )}
+                        </div>
+                      </button>
+                    </div>
+                  );
+                })}
+                {filteredModels.length === 0 && (
+                  <EmptyState
+                    title={t('thinkingModels.noModelsYet')}
+                    description={t('thinkingModels.noModelsYetDesc')}
+                  />
+                )}
+              </div>
+            </section>
+
+            {/* Right: Detail Panel / Comparison View */}
+            <section className="panel">
+              {isComparing ? (
+                /* ── Comparison View ── */
+                <div className="comparison-view">
+                  <div className="detail-header" style={{ marginBottom: 16 }}>
+                    <button className="back-button" onClick={exitComparison} title={t('thinkingModels.exitCompare') || 'Exit Compare'}>
+                      <X strokeWidth={1.75} size={18} />
+                    </button>
+                    <div>
+                      <h3>{t('thinkingModels.comparisonTitle')}</h3>
+                      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                        {selectedForCompare.length} {t('thinkingModels.compareSelected') || 'models'}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Comparison grid: side-by-side metrics */}
+                  <div style={{ display: 'grid', gridTemplateColumns: `repeat(${selectedForCompare.length}, 1fr)`, gap: 12, marginBottom: 16 }}>
+                    {selectedForCompare.map(modelId => {
+                      const summary = data.topModels.find(m => m.modelId === modelId);
+                      const det = comparisonDetails.get(modelId);
+                      if (!summary) return null;
+                      return (
+                        <div key={modelId} style={{ padding: 12, border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-sunken)' }}>
+                          <strong style={{ fontSize: '0.85rem', display: 'block', marginBottom: 8 }}>{summary.name}</strong>
+                          <div className="pill-row" style={{ flexWrap: 'wrap', marginBottom: 8 }}>
+                            <span className="badge">{t('thinkingModels.hits')}: {summary.hits}</span>
+                            <span className="badge">{t('thinkingModels.successRate')}: {formatPercent(summary.successRate)}</span>
+                            <span className="badge">{t('thinkingModels.failureRate')}: {formatPercent(summary.failureRate)}</span>
+                            <span className="badge">{t('thinkingModels.pain')}: {formatPercent(summary.painRate)}</span>
+                          </div>
+                          {det && det.outcomeStats && (
+                            <div style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', marginTop: 4 }}>
+                              <div>{t('thinkingModels.correction')}: {formatPercent(det.outcomeStats.correctionRate)}</div>
+                              <div>{t('thinkingModels.coverage')}: {formatPercent(det.modelMeta.coverageRate)}</div>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Usage Trends for each model */}
+                  <div style={{ display: 'grid', gridTemplateColumns: `repeat(${selectedForCompare.length}, 1fr)`, gap: 12 }}>
+                    {selectedForCompare.map(modelId => {
+                      const summary = data.topModels.find(m => m.modelId === modelId);
+                      const det = comparisonDetails.get(modelId);
+                      if (!det || det.usageTrend.length < 2) return null;
+                      return (
+                        <article key={modelId} style={{ padding: 8, border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-sunken)' }}>
+                          <h4 style={{ fontSize: '0.75rem', fontWeight: 600, marginBottom: 6 }}>
+                            {summary?.name} — {t('thinkingModels.usageTrend')}
+                          </h4>
+                          <LineChart
+                            data={det.usageTrend.map(d => ({ label: d.day.slice(5), value: d.hits }))}
+                            width={260}
+                            height={80}
+                            color="var(--accent)"
+                            showGrid={false}
+                            showDots
+                            showArea
+                          />
+                        </article>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : (
+                <>
+                  {!detail && <EmptyState title={t('thinkingModels.emptyTitle')} description={t('thinkingModels.emptyDesc')} />}
+                  {detail && (
+                <div className="detail-stack">
+                  <div className="detail-header">
+                    <button className="back-button" onClick={() => setDetail(null)} title="Back">
+                      <ChevronLeft strokeWidth={1.75} size={18} />
+                    </button>
+                    <div>
+                      <h3>{detail.modelMeta.name}</h3>
+                      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{detail.modelMeta.description}</p>
+                    </div>
+                    {REC_BADGE[detail.modelMeta.recommendation] && (
+                      <StatusBadge variant={REC_BADGE[detail.modelMeta.recommendation].variant}>
+                        {REC_BADGE[detail.modelMeta.recommendation].label(t)}
+                      </StatusBadge>
+                    )}
+                  </div>
+
+                  {/* Trigger Conditions */}
+                  {detail.modelMeta.trigger && (
+                    <article>
+                      <h4>{t('thinkingModels.trigger')}</h4>
+                      <code style={{ fontSize: '0.75rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: 'var(--bg-sunken)', padding: '8px 10px', borderRadius: 6, display: 'block', lineHeight: 1.5 }}>
+                        {detail.modelMeta.trigger}
+                      </code>
+                    </article>
+                  )}
+
+                  {/* Anti-Patterns */}
+                  {detail.modelMeta.antiPattern && (
+                    <article>
+                      <h4 style={{ color: 'var(--error)' }}>{t('thinkingModels.antiPattern')}</h4>
+                      <code style={{ fontSize: '0.75rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: 'rgba(220,53,69,0.08)', padding: '8px 10px', borderRadius: 6, display: 'block', lineHeight: 1.5, color: 'var(--error)' }}>
+                        {detail.modelMeta.antiPattern}
+                      </code>
+                    </article>
+                  )}
+
+                  {/* Usage Trend */}
+                  {detail.usageTrend.length >= 1 ? (
+                    <article>
+                      <h4 style={{ fontSize: '0.8rem', fontWeight: 600, marginBottom: 8 }}>
+                        {t('thinkingModels.usageTrend')}
+                      </h4>
+                      <LineChart
+                        data={detail.usageTrend.map(d => ({ label: d.day.slice(5), value: d.hits }))}
+                        width={500}
+                        height={100}
+                        color="var(--accent)"
+                        showGrid
+                        showDots
+                        showArea
+                      />
+                    </article>
+                  ) : (
+                    <EmptyState
+                      title={t('thinkingModels.emptyUsageTrend')}
+                      description={t('thinkingModels.emptyUsageTrendDesc')}
+                    />
+                  )}
+
+                  {/* Outcome Stats */}
+                  <article>
+                    <h4>{t('thinkingModels.outcomeStats')}</h4>
+                    <div className="pill-row">
+                      <span className="badge">{t('thinkingModels.success')} {formatPercent(detail.outcomeStats.successRate)}</span>
+                      <span className="badge">{t('thinkingModels.failure')} {formatPercent(detail.outcomeStats.failureRate)}</span>
+                      <span className="badge">{t('thinkingModels.pain')} {formatPercent(detail.outcomeStats.painRate)}</span>
+                      <span className="badge">{t('thinkingModels.correction')} {formatPercent(detail.outcomeStats.correctionRate)}</span>
+                    </div>
+                  </article>
+
+                  {/* Scenario Distribution */}
+                  {detail.scenarioDistribution.length > 0 && (
+                    <article>
+                      <h4>{t('thinkingModels.scenarioDistribution')}</h4>
+                      <div className="stack">
+                        {detail.scenarioDistribution.map((item) => (
+                          <div className="row-card" key={item.scenario}>
+                            <strong>{item.scenario}</strong>
+                            <span>{item.hits}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </article>
+                  )}
+
+                  {/* Recent Events */}
+                  {detail.recentEvents.length > 0 && (
+                    <article>
+                      <h4>{t('thinkingModels.recentEvents')}</h4>
+                      <div className="stack">
+                        {detail.recentEvents.map((event) => (
+                          <div className="row-card vertical" key={event.id}>
+                            <div>
+                              <strong>{formatDate(event.createdAt)}</strong>
+                              <span>{event.scenarios.join(', ') || '—'}</span>
+                            </div>
+                            {event.toolContext?.length > 0 && (
+                              <div style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
+                                {'\u{1F6E0}'} {event.toolContext.map(tc => (
+                                  `${tc.toolName} (${tc.outcome}${tc.errorType ? `: ${tc.errorType}` : ''})`
+                                )).join(', ')}
+                              </div>
+                            )}
+                            {event.painContext?.length > 0 && (
+                              <div style={{ fontSize: '0.7rem', color: 'var(--error)' }}>
+                                {'\u26A1'} {event.painContext.map(pc => `${pc.source} (${pc.score})`).join(', ')}
+                              </div>
+                            )}
+                            {event.principleContext?.length > 0 && (
+                              <div style={{ fontSize: '0.7rem', color: 'var(--info)' }}>
+                                {'\u{1F4CB}'} {event.principleContext.map(pr => (
+                                  `${pr.principleId ?? '—'} ${pr.eventType ? `(${pr.eventType})` : ''}`
+                                )).join(', ')}
+                              </div>
+                            )}
+                            {event.matchedPattern && (
+                              <code style={{ fontSize: '0.65rem', color: 'var(--text-secondary)', background: 'var(--bg-sunken)', padding: '2px 6px', borderRadius: 3 }}>
+                                /{event.matchedPattern}/
+                              </code>
+                            )}
+                            <pre style={{ fontSize: '0.7rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                              {event.triggerExcerpt}
+                            </pre>
+                          </div>
+                        ))}
+                      </div>
+                    </article>
+                  )}
+                </div>
+              )}
+                </>
+              )}
+            </section>
+          </div>
+
+          {/* Dormant Models Section */}
+          {data.dormantModels.length > 0 ? (
+            <CollapsiblePanel
+              title={t('thinkingModels.dormantModels')}
+              badge={`${data.dormantModels.length}`}
+              defaultCollapsed
+            >
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 8, padding: '8px 0' }}>
+                {data.dormantModels.map(model => (
+                  <div
+                    key={model.modelId}
+                    style={{
+                      padding: '8px 10px',
+                      border: '1px solid var(--border)',
+                      borderRadius: 6,
+                      background: 'var(--bg-sunken)',
+                    }}
+                  >
+                    <strong style={{ fontSize: '0.8rem' }}>{model.name}</strong>
+                    <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', margin: '4px 0 0', lineHeight: 1.3 }}>
+                      {model.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </CollapsiblePanel>
+          ) : (
+            <CollapsiblePanel
+              title={t('thinkingModels.dormantModels')}
+              defaultCollapsed
+            >
+              <EmptyState
+                title={t('thinkingModels.emptyAllActive')}
+                description={t('thinkingModels.emptyAllActiveDesc')}
+              />
+            </CollapsiblePanel>
+          )}
+
+          {/* Scenario Heatmap */}
+          {heatmapData ? (
+            <CollapsiblePanel title={t('thinkingModels.scenarioHeatmap')}>
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ borderCollapse: 'collapse', minWidth: '100%' }}>
+                  <thead>
+                    <tr>
+                      <th style={{ position: 'sticky', left: 0, background: 'var(--bg-panel)', zIndex: 1, minWidth: 100, textAlign: 'left', padding: '6px 8px', borderBottom: '1px solid var(--border)', fontSize: '0.75rem', fontWeight: 600 }}>
+                        Model
+                      </th>
+                      {heatmapData.allScenarios.map(sc => (
+                        <th key={sc} style={{ textAlign: 'center', fontSize: '0.65rem', padding: '4px 6px', writingMode: 'vertical-lr', transform: 'rotate(180deg)', height: 80, borderBottom: '1px solid var(--border)', color: 'var(--text-secondary)' }}>
+                          {sc}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {heatmapData.models.map(model => (
+                      <tr key={model.modelId}>
+                        <td style={{ position: 'sticky', left: 0, background: 'var(--bg-panel)', fontWeight: 500, fontSize: '0.75rem', padding: '4px 8px', borderTop: '1px solid var(--border)' }}>
+                          {model.name}
+                        </td>
+                        {heatmapData.allScenarios.map(sc => {
+                          const hits = heatmapData.hitMap.get(`${model.modelId}::${sc}`) ?? 0;
+                          const bgColor = hits === 0
+                            ? 'var(--bg-sunken)'
+                            : `rgba(91, 139, 160, ${Math.max(0.15, (hits / heatmapData.maxHits) * 0.55).toFixed(2)})`;
+                          return (
+                            <td
+                              key={sc}
+                              style={{
+                                textAlign: 'center',
+                                backgroundColor: bgColor,
+                                padding: '4px 6px',
+                                fontSize: '0.7rem',
+                                fontWeight: hits > 0 ? 600 : 400,
+                                borderTop: '1px solid var(--border)',
+                                color: hits > 0 ? 'var(--text-primary)' : 'var(--text-secondary)',
+                              }}
+                            >
+                              {hits}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CollapsiblePanel>
+          ) : (
+            <CollapsiblePanel title={t('thinkingModels.scenarioHeatmap')}>
+              <EmptyState
+                title={t('thinkingModels.emptyScenarioMatrix')}
+                description={t('thinkingModels.emptyScenarioMatrixDesc')}
+              />
+            </CollapsiblePanel>
+          )}
+        </>
+      )}
     </div>
   );
 }
-

--- a/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
@@ -463,7 +463,6 @@ export function ThinkingModelsPage() {
                   {!isLoadingDetail && detail && (
                 <div className="detail-stack">
                   <div className="detail-header">
-<<<<<<< Updated upstream
                     <button className="back-button" onClick={() => { setDetail(null); setSelectedModel(''); setIsLoadingDetail(true); }} title={t('common.back')}>
                       <ChevronLeft strokeWidth={1.75} size={18} />
                     </button>

--- a/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
+++ b/packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx
@@ -1,11 +1,32 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
-import { ChevronLeft, Search, ArrowUpDown, X, Columns } from 'lucide-react';
+import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { ChevronLeft, Search, ArrowUpDown, X, Columns, Wrench, Zap, ClipboardList, Loader2 } from 'lucide-react';
 import { api } from '../api';
 import type { ThinkingOverviewResponse, ThinkingModelDetailResponse, ThinkingModelSummary } from '../types';
 import { EmptyState, LineChart, StatusBadge, CollapsiblePanel, Sparkline, MiniBarChart } from '../charts';
 import { useI18n } from '../i18n/ui';
 import { formatPercent, formatDate } from '../utils/format';
 import { Loading, ErrorState } from '../components';
+
+// ---------------------------------------------------------------------------
+// Design tokens (mirrors CSS custom properties for inline fallback)
+// ---------------------------------------------------------------------------
+
+const TEXT = {
+  xs: '0.65rem',
+  sm: '0.7rem',
+  base: '0.75rem',
+  lg: '0.8rem',
+  xl: '0.85rem',
+} as const;
+
+const SPACE = {
+  1: 'var(--space-1, 4px)',
+  2: 'var(--space-2, 8px)',
+  3: 'var(--space-3, 12px)',
+  4: 'var(--space-4, 16px)',
+  5: 'var(--space-5, 24px)',
+  6: 'var(--space-6, 32px)',
+} as const;
 
 // ---------------------------------------------------------------------------
 // Recommendation badge helper
@@ -28,17 +49,34 @@ export function ThinkingModelsPage() {
   const [data, setData] = useState<ThinkingOverviewResponse | null>(null);
   const [detail, setDetail] = useState<ThinkingModelDetailResponse | null>(null);
   const [selectedModel, setSelectedModel] = useState('');
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [error, setError] = useState('');
 
   // Comparison mode state
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
   const [comparisonDetails, setComparisonDetails] = useState<Map<string, ThinkingModelDetailResponse>>(new Map());
   const [isComparing, setIsComparing] = useState(false);
+  const [comparisonLoadingModels, setComparisonLoadingModels] = useState<Set<string>>(new Set());
 
   // Filters
   const [recFilter, setRecFilter] = useState('all');
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState<'hits' | 'successRate' | 'name'>('hits');
+
+  // Debounced search
+  const searchTimer = useRef<ReturnType<typeof setTimeout>>();
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => setDebouncedSearch(search), 200);
+    return () => { if (searchTimer.current) clearTimeout(searchTimer.current); };
+  }, [search]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => { if (searchTimer.current) clearTimeout(searchTimer.current); };
+  }, []);
 
   // Cache for detail lookups during comparison
   const detailCache = useMemo(() => {
@@ -57,7 +95,10 @@ export function ThinkingModelsPage() {
 
   useEffect(() => {
     if (!selectedModel) return;
-    api.getThinkingModelDetail(selectedModel).then(setDetail).catch((err) => setError(String(err)));
+    setIsLoadingDetail(true);
+    api.getThinkingModelDetail(selectedModel)
+      .then((d) => { setDetail(d); setIsLoadingDetail(false); })
+      .catch((err) => { setError(String(err)); setIsLoadingDetail(false); });
   }, [selectedModel]);
 
   // Comparison mode handlers
@@ -75,16 +116,25 @@ export function ThinkingModelsPage() {
     if (selectedForCompare.length < 2) return;
     setIsComparing(true);
     const newDetails = new Map(comparisonDetails);
-    const fetches = selectedForCompare
-      .filter(id => !newDetails.has(id))
-      .map(async (id) => {
-        try {
-          const d = await api.getThinkingModelDetail(id);
-          newDetails.set(id, d);
-        } catch {
-          // Skip failed fetches
-        }
-      });
+    const pending = selectedForCompare.filter(id => !newDetails.has(id));
+
+    // Track per-model loading state
+    setComparisonLoadingModels(new Set(pending));
+
+    const fetches = pending.map(async (id) => {
+      try {
+        const d = await api.getThinkingModelDetail(id);
+        newDetails.set(id, d);
+      } catch {
+        // Skip failed fetches
+      } finally {
+        setComparisonLoadingModels(prev => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
+    });
     await Promise.all(fetches);
     setComparisonDetails(newDetails);
   }, [selectedForCompare, comparisonDetails]);
@@ -93,6 +143,7 @@ export function ThinkingModelsPage() {
     setIsComparing(false);
     setSelectedForCompare([]);
     setComparisonDetails(new Map());
+    setComparisonLoadingModels(new Set());
   }, []);
 
   // Filtered + sorted model list
@@ -102,8 +153,8 @@ export function ThinkingModelsPage() {
     if (recFilter !== 'all') {
       models = models.filter(m => m.recommendation === recFilter);
     }
-    if (search) {
-      const q = search.toLowerCase();
+    if (debouncedSearch) {
+      const q = debouncedSearch.toLowerCase();
       models = models.filter(m =>
         m.name.toLowerCase().includes(q) ||
         (m.commonScenarios ?? []).some(s => s.toLowerCase().includes(q))
@@ -115,7 +166,7 @@ export function ThinkingModelsPage() {
       return a.name.localeCompare(b.name);
     });
     return models;
-  }, [data, recFilter, search, sortBy]);
+  }, [data, recFilter, debouncedSearch, sortBy]);
 
   // Scenario heatmap data
   const heatmapData = useMemo(() => {
@@ -143,8 +194,8 @@ export function ThinkingModelsPage() {
         <div>
           <h2>{t('thinkingModels.pageTitle')}</h2>
           {data.thinkingSummary?.modelDefinitions && data.thinkingSummary.modelDefinitions.length > 0 && (
-            <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', margin: '4px 0 0' }}>
-              {t('thinkingModels.thinkingOsSource')}: <code style={{ fontSize: '0.65rem', background: 'var(--bg-sunken)', padding: '1px 4px', borderRadius: 3 }}>THINKING_OS.md</code>
+            <p style={{ fontSize: TEXT.sm, color: 'var(--text-secondary)', margin: `${SPACE[1]} 0 0` }}>
+              {t('thinkingModels.thinkingOsSource')}: <code style={{ fontSize: TEXT.xs, background: 'var(--bg-sunken)', padding: '1px 4px', borderRadius: 3 }}>THINKING_OS.md</code>
             </p>
           )}
         </div>
@@ -158,20 +209,23 @@ export function ThinkingModelsPage() {
 
       {!hasData ? (
         /* ── No data yet: show model definitions grid ── */
-        <section className="panel" style={{ marginBottom: 'var(--space-4)' }}>
-          <div style={{ textAlign: 'center', padding: 'var(--space-5)', color: 'var(--text-secondary)' }}>
-            <div style={{ fontSize: '2rem', marginBottom: 8 }}>🧠</div>
-            <h3 style={{ marginBottom: 4 }}>{t('thinkingModels.noDataTitle') || '思维模型定义'}</h3>
-            <p style={{ fontSize: '0.85rem', maxWidth: 500, margin: '0 auto 24px' }}>
-              {t('thinkingModels.noDataDesc') || '以下是 10 个思维模型的定义。当 AI 开始使用后，这里会显示每个模型的使用统计。'}
+        <section className="panel" style={{ marginBottom: SPACE[4] }}>
+          <div style={{ textAlign: 'center', padding: SPACE[5], color: 'var(--text-secondary)' }}>
+            <div style={{ fontSize: '2rem', marginBottom: SPACE[2] }}>🧠</div>
+            <h3 style={{ marginBottom: SPACE[1] }}>{t('thinkingModels.noDataTitle')}</h3>
+            <p style={{ fontSize: TEXT.lg, maxWidth: 500, margin: `0 auto ${SPACE[5]}` }}>
+              {t('thinkingModels.noDataDesc')}
             </p>
           </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: SPACE[3] }}>
             {data.topModels.map(model => (
               <div
                 key={model.modelId}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedModel(model.modelId); setDetail(null); } }}
                 style={{
-                  padding: 12,
+                  padding: SPACE[3],
                   border: '1px solid var(--border)',
                   borderRadius: 8,
                   background: 'var(--bg-sunken)',
@@ -179,16 +233,16 @@ export function ThinkingModelsPage() {
                 }}
                 onClick={() => { setSelectedModel(model.modelId); setDetail(null); }}
               >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
-                  <strong style={{ fontSize: '0.85rem' }}>{model.modelId}: {model.name}</strong>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: SPACE[2] }}>
+                  <strong style={{ fontSize: TEXT.xl }}>{model.modelId}: {model.name}</strong>
                 </div>
-                <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', margin: '0 0 8px', lineHeight: 1.4 }}>
+                <p style={{ fontSize: TEXT.base, color: 'var(--text-secondary)', margin: `0 0 ${SPACE[2]}`, lineHeight: 1.4 }}>
                   {model.description}
                 </p>
                 {model.commonScenarios.length > 0 && (
-                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: SPACE[1] }}>
                     {model.commonScenarios.slice(0, 3).map(s => (
-                      <span key={s} style={{ fontSize: '0.65rem', padding: '1px 6px', background: 'rgba(91,139,160,0.1)', borderRadius: 3, color: 'var(--info)' }}>
+                      <span key={s} style={{ fontSize: TEXT.xs, padding: '1px 6px', background: 'rgba(91,139,160,0.1)', borderRadius: 3, color: 'var(--info)' }}>
                         {s}
                       </span>
                     ))}
@@ -203,8 +257,8 @@ export function ThinkingModelsPage() {
         <>
           {/* Coverage Trend */}
           {data.coverageTrend.length >= 1 && (
-            <section className="panel" style={{ marginBottom: 'var(--space-4)' }}>
-              <h3 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: 8 }}>
+            <section className="panel" style={{ marginBottom: SPACE[4] }}>
+              <h3 className="section-title">
                 {t('thinkingModels.coverageTrend')}
               </h3>
               <LineChart
@@ -220,40 +274,32 @@ export function ThinkingModelsPage() {
           )}
 
           {/* Search + Sort + Filter */}
-          <div style={{ display: 'flex', gap: 8, marginBottom: 'var(--space-3)', alignItems: 'center', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', gap: SPACE[2], marginBottom: SPACE[3], alignItems: 'center', flexWrap: 'wrap' }}>
             <div style={{ position: 'relative', flex: '1 1 200px' }}>
-              <Search size={14} style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-secondary)' }} />
+              <Search size={14} style={{ position: 'absolute', left: SPACE[2], top: '50%', transform: 'translateY(-50%)', color: 'var(--text-secondary)', pointerEvents: 'none' }} />
               <input
                 type="text"
                 placeholder={t('thinkingModels.searchPlaceholder')}
                 value={search}
                 onChange={e => setSearch(e.target.value)}
-                style={{ paddingLeft: 28, width: '100%', padding: '6px 8px 6px 28px', border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-panel)', color: 'var(--text-primary)', fontSize: '0.8rem' }}
+                style={{ width: '100%', padding: `6px ${SPACE[2]} 6px 28px`, border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-panel)', color: 'var(--text-primary)', fontSize: TEXT.lg }}
               />
             </div>
             <button
               onClick={() => setSortBy(prev => prev === 'hits' ? 'successRate' : prev === 'successRate' ? 'name' : 'hits')}
-              style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 10px', border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-panel)', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.75rem' }}
+              className="sort-button"
             >
               <ArrowUpDown size={14} />
               {sortBy === 'hits' ? t('thinkingModels.sortByHits') : sortBy === 'successRate' ? t('thinkingModels.sortBySuccessRate') : t('thinkingModels.sortByName')}
             </button>
-            <div style={{ display: 'flex', gap: 4 }}>
+            <div style={{ display: 'flex', gap: SPACE[1] }}>
               {['all', 'reinforce', 'rework', 'archive'].map(key => (
                 <button
                   key={key}
                   onClick={() => setRecFilter(key)}
-                  style={{
-                    padding: '3px 8px',
-                    border: `1px solid ${recFilter === key ? 'var(--accent)' : 'var(--border)'}`,
-                    borderRadius: 4,
-                    background: recFilter === key ? 'rgba(91, 139, 160, 0.15)' : 'transparent',
-                    color: recFilter === key ? 'var(--accent)' : 'var(--text-secondary)',
-                    cursor: 'pointer',
-                    fontSize: '0.7rem',
-                  }}
+                  className={`filter-button ${recFilter === key ? 'active' : ''}`}
                 >
-                  {key === 'all' ? 'All' : REC_BADGE[key]?.label(t)}
+                  {key === 'all' ? t('thinkingModels.filterAll') : REC_BADGE[key]?.label(t)}
                 </button>
               ))}
             </div>
@@ -265,13 +311,13 @@ export function ThinkingModelsPage() {
             <section className="panel">
               {/* Compare button bar */}
               {selectedForCompare.length >= 2 && !isComparing && (
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 12px', marginBottom: 8, background: 'rgba(91, 139, 160, 0.08)', borderRadius: 6, border: '1px solid var(--border)' }}>
-                  <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                    {selectedForCompare.length} {t('thinkingModels.compareSelected') || 'selected'}
+                <div className="compare-bar">
+                  <span style={{ fontSize: TEXT.base, color: 'var(--text-secondary)' }}>
+                    {selectedForCompare.length} {t('thinkingModels.compareSelected')}
                   </span>
                   <button
                     onClick={startComparison}
-                    style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 12px', border: 'none', borderRadius: 4, background: 'var(--accent)', color: '#fff', cursor: 'pointer', fontSize: '0.75rem', fontWeight: 600 }}
+                    className="compare-button"
                   >
                     <Columns size={14} />
                     {t('thinkingModels.compare')}
@@ -285,7 +331,7 @@ export function ThinkingModelsPage() {
                     <div
                       key={item.modelId}
                       className={`table-row ${selectedModel === item.modelId && !isComparing ? 'active' : ''}`}
-                      style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', ...(item.recommendation === 'reinforce' ? { borderLeft: '3px solid var(--success)', paddingLeft: 'calc(var(--space-2) - 3px)' } : {}) }}
+                      style={{ display: 'flex', alignItems: 'center', gap: SPACE[2], padding: `${SPACE[2]} ${SPACE[3]}`, ...(item.recommendation === 'reinforce' ? { borderLeft: '3px solid var(--success)', paddingLeft: `calc(${SPACE[2]} - 3px)` } : {}) }}
                     >
                       <input
                         type="checkbox"
@@ -293,20 +339,20 @@ export function ThinkingModelsPage() {
                         onChange={() => toggleCompareSelection(item.modelId)}
                         onClick={e => e.stopPropagation()}
                         style={{ accentColor: 'var(--accent)', cursor: 'pointer', flexShrink: 0 }}
-                        title={t('thinkingModels.compare') || 'Compare'}
+                        aria-label={`${t('thinkingModels.compare')}: ${item.name}`}
                       />
                       <button
                         onClick={() => { setSelectedModel(item.modelId); setDetail(null); setIsComparing(false); }}
-                        style={{ flex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'inherit', textAlign: 'left' }}
+                        className="model-list-button"
                       >
                         <div>
-                          <strong>{item.name}</strong>
-                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 180, display: 'block' }}>
+                          <strong className="text-base">{item.name}</strong>
+                          <span className="scenario-ellipsis">
                             {item.commonScenarios.join(', ') || '—'}
                           </span>
                         </div>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                          <span style={{ fontWeight: 600, fontSize: '0.85rem' }}>{item.hits}</span>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: SPACE[2] }}>
+                          <span className="hits-count">{item.hits}</span>
                           {REC_BADGE[item.recommendation] && (
                             <StatusBadge variant={REC_BADGE[item.recommendation].variant}>
                               {REC_BADGE[item.recommendation].label(t)}
@@ -331,35 +377,46 @@ export function ThinkingModelsPage() {
               {isComparing ? (
                 /* ── Comparison View ── */
                 <div className="comparison-view">
-                  <div className="detail-header" style={{ marginBottom: 16 }}>
-                    <button className="back-button" onClick={exitComparison} title={t('thinkingModels.exitCompare') || 'Exit Compare'}>
+                  <div className="detail-header" style={{ marginBottom: SPACE[4] }}>
+                    <button className="back-button" onClick={exitComparison} title={t('thinkingModels.exitCompare')}>
                       <X strokeWidth={1.75} size={18} />
                     </button>
                     <div>
                       <h3>{t('thinkingModels.comparisonTitle')}</h3>
-                      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
-                        {selectedForCompare.length} {t('thinkingModels.compareSelected') || 'models'}
+                      <p style={{ fontSize: TEXT.lg, color: 'var(--text-secondary)' }}>
+                        {selectedForCompare.length} {t('thinkingModels.compareSelected')}
+                        {comparisonLoadingModels.size > 0 && (
+                          <span style={{ marginLeft: SPACE[2], color: 'var(--info)' }}>
+                            <Loader2 size={12} className="spin" /> {t('thinkingModels.loadingComparison')}
+                          </span>
+                        )}
                       </p>
                     </div>
                   </div>
 
                   {/* Comparison grid: side-by-side metrics */}
-                  <div style={{ display: 'grid', gridTemplateColumns: `repeat(${selectedForCompare.length}, 1fr)`, gap: 12, marginBottom: 16 }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: `repeat(${selectedForCompare.length}, 1fr)`, gap: SPACE[3], marginBottom: SPACE[4] }}>
                     {selectedForCompare.map(modelId => {
                       const summary = data.topModels.find(m => m.modelId === modelId);
                       const det = comparisonDetails.get(modelId);
+                      const isLoading = comparisonLoadingModels.has(modelId);
                       if (!summary) return null;
                       return (
-                        <div key={modelId} style={{ padding: 12, border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-sunken)' }}>
-                          <strong style={{ fontSize: '0.85rem', display: 'block', marginBottom: 8 }}>{summary.name}</strong>
-                          <div className="pill-row" style={{ flexWrap: 'wrap', marginBottom: 8 }}>
+                        <div key={modelId} style={{ padding: SPACE[3], border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-sunken)', opacity: isLoading ? 0.6 : 1, position: 'relative' }}>
+                          <strong style={{ fontSize: TEXT.xl, display: 'block', marginBottom: SPACE[2] }}>{summary.name}</strong>
+                          {isLoading && (
+                            <div style={{ position: 'absolute', top: SPACE[2], right: SPACE[2] }}>
+                              <Loader2 size={14} className="spin" style={{ color: 'var(--info)' }} />
+                            </div>
+                          )}
+                          <div className="pill-row" style={{ flexWrap: 'wrap', marginBottom: SPACE[2] }}>
                             <span className="badge">{t('thinkingModels.hits')}: {summary.hits}</span>
                             <span className="badge">{t('thinkingModels.successRate')}: {formatPercent(summary.successRate)}</span>
                             <span className="badge">{t('thinkingModels.failureRate')}: {formatPercent(summary.failureRate)}</span>
                             <span className="badge">{t('thinkingModels.pain')}: {formatPercent(summary.painRate)}</span>
                           </div>
                           {det && det.outcomeStats && (
-                            <div style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', marginTop: 4 }}>
+                            <div style={{ fontSize: TEXT.sm, color: 'var(--text-secondary)', marginTop: SPACE[1] }}>
                               <div>{t('thinkingModels.correction')}: {formatPercent(det.outcomeStats.correctionRate)}</div>
                               <div>{t('thinkingModels.coverage')}: {formatPercent(det.modelMeta.coverageRate)}</div>
                             </div>
@@ -370,19 +427,19 @@ export function ThinkingModelsPage() {
                   </div>
 
                   {/* Usage Trends for each model */}
-                  <div style={{ display: 'grid', gridTemplateColumns: `repeat(${selectedForCompare.length}, 1fr)`, gap: 12 }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: `repeat(${selectedForCompare.length}, 1fr)`, gap: SPACE[3] }}>
                     {selectedForCompare.map(modelId => {
                       const summary = data.topModels.find(m => m.modelId === modelId);
                       const det = comparisonDetails.get(modelId);
                       if (!det || det.usageTrend.length < 2) return null;
                       return (
-                        <article key={modelId} style={{ padding: 8, border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-sunken)' }}>
-                          <h4 style={{ fontSize: '0.75rem', fontWeight: 600, marginBottom: 6 }}>
+                        <article key={modelId} style={{ padding: SPACE[2], border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-sunken)' }}>
+                          <h4 className="text-sm text-semibold" style={{ marginBottom: SPACE[2] }}>
                             {summary?.name} — {t('thinkingModels.usageTrend')}
                           </h4>
                           <LineChart
                             data={det.usageTrend.map(d => ({ label: d.day.slice(5), value: d.hits }))}
-                            width={260}
+                            width="100%"
                             height={80}
                             color="var(--accent)"
                             showGrid={false}
@@ -396,16 +453,22 @@ export function ThinkingModelsPage() {
                 </div>
               ) : (
                 <>
-                  {!detail && <EmptyState title={t('thinkingModels.emptyTitle')} description={t('thinkingModels.emptyDesc')} />}
-                  {detail && (
+                  {isLoadingDetail && (
+                    <div style={{ textAlign: 'center', padding: SPACE[6], color: 'var(--text-secondary)' }}>
+                      <Loader2 size={24} className="spin" style={{ margin: `0 auto ${SPACE[2]}` }} />
+                      <p style={{ fontSize: TEXT.lg }}>{t('thinkingModels.loadingDetail')}</p>
+                    </div>
+                  )}
+                  {!isLoadingDetail && !detail && <EmptyState title={t('thinkingModels.emptyTitle')} description={t('thinkingModels.emptyDesc')} />}
+                  {!isLoadingDetail && detail && (
                 <div className="detail-stack">
                   <div className="detail-header">
-                    <button className="back-button" onClick={() => setDetail(null)} title="Back">
+                    <button className="back-button" onClick={() => { setDetail(null); setIsLoadingDetail(true); }} title={t('common.back')}>
                       <ChevronLeft strokeWidth={1.75} size={18} />
                     </button>
                     <div>
                       <h3>{detail.modelMeta.name}</h3>
-                      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{detail.modelMeta.description}</p>
+                      <p style={{ fontSize: TEXT.lg, color: 'var(--text-secondary)' }}>{detail.modelMeta.description}</p>
                     </div>
                     {REC_BADGE[detail.modelMeta.recommendation] && (
                       <StatusBadge variant={REC_BADGE[detail.modelMeta.recommendation].variant}>
@@ -417,8 +480,8 @@ export function ThinkingModelsPage() {
                   {/* Trigger Conditions */}
                   {detail.modelMeta.trigger && (
                     <article>
-                      <h4>{t('thinkingModels.trigger')}</h4>
-                      <code style={{ fontSize: '0.75rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: 'var(--bg-sunken)', padding: '8px 10px', borderRadius: 6, display: 'block', lineHeight: 1.5 }}>
+                      <h4 className="text-base text-semibold">{t('thinkingModels.trigger')}</h4>
+                      <code className="code-block code-block-trigger">
                         {detail.modelMeta.trigger}
                       </code>
                     </article>
@@ -427,8 +490,8 @@ export function ThinkingModelsPage() {
                   {/* Anti-Patterns */}
                   {detail.modelMeta.antiPattern && (
                     <article>
-                      <h4 style={{ color: 'var(--error)' }}>{t('thinkingModels.antiPattern')}</h4>
-                      <code style={{ fontSize: '0.75rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: 'rgba(220,53,69,0.08)', padding: '8px 10px', borderRadius: 6, display: 'block', lineHeight: 1.5, color: 'var(--error)' }}>
+                      <h4 className="text-base text-semibold text-error">{t('thinkingModels.antiPattern')}</h4>
+                      <code className="code-block code-block-antipattern">
                         {detail.modelMeta.antiPattern}
                       </code>
                     </article>
@@ -437,7 +500,7 @@ export function ThinkingModelsPage() {
                   {/* Usage Trend */}
                   {detail.usageTrend.length >= 1 ? (
                     <article>
-                      <h4 style={{ fontSize: '0.8rem', fontWeight: 600, marginBottom: 8 }}>
+                      <h4 className="text-lg text-semibold" style={{ marginBottom: SPACE[2] }}>
                         {t('thinkingModels.usageTrend')}
                       </h4>
                       <LineChart
@@ -459,7 +522,7 @@ export function ThinkingModelsPage() {
 
                   {/* Outcome Stats */}
                   <article>
-                    <h4>{t('thinkingModels.outcomeStats')}</h4>
+                    <h4 className="text-base text-semibold">{t('thinkingModels.outcomeStats')}</h4>
                     <div className="pill-row">
                       <span className="badge">{t('thinkingModels.success')} {formatPercent(detail.outcomeStats.successRate)}</span>
                       <span className="badge">{t('thinkingModels.failure')} {formatPercent(detail.outcomeStats.failureRate)}</span>
@@ -471,11 +534,11 @@ export function ThinkingModelsPage() {
                   {/* Scenario Distribution */}
                   {detail.scenarioDistribution.length > 0 && (
                     <article>
-                      <h4>{t('thinkingModels.scenarioDistribution')}</h4>
+                      <h4 className="text-base text-semibold">{t('thinkingModels.scenarioDistribution')}</h4>
                       <div className="stack">
                         {detail.scenarioDistribution.map((item) => (
                           <div className="row-card" key={item.scenario}>
-                            <strong>{item.scenario}</strong>
+                            <strong className="text-base">{item.scenario}</strong>
                             <span>{item.hits}</span>
                           </div>
                         ))}
@@ -486,39 +549,39 @@ export function ThinkingModelsPage() {
                   {/* Recent Events */}
                   {detail.recentEvents.length > 0 && (
                     <article>
-                      <h4>{t('thinkingModels.recentEvents')}</h4>
+                      <h4 className="text-base text-semibold">{t('thinkingModels.recentEvents')}</h4>
                       <div className="stack">
                         {detail.recentEvents.map((event) => (
                           <div className="row-card vertical" key={event.id}>
                             <div>
-                              <strong>{formatDate(event.createdAt)}</strong>
-                              <span>{event.scenarios.join(', ') || '—'}</span>
+                              <strong className="text-base">{formatDate(event.createdAt)}</strong>
+                              <span className="text-sm">{event.scenarios.join(', ') || '—'}</span>
                             </div>
                             {event.toolContext?.length > 0 && (
-                              <div style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
-                                {'\u{1F6E0}'} {event.toolContext.map(tc => (
+                              <div className="event-context-tool" aria-label={t('thinkingModels.toolContext')}>
+                                <Wrench size={12} aria-hidden /> {event.toolContext.map(tc => (
                                   `${tc.toolName} (${tc.outcome}${tc.errorType ? `: ${tc.errorType}` : ''})`
                                 )).join(', ')}
                               </div>
                             )}
                             {event.painContext?.length > 0 && (
-                              <div style={{ fontSize: '0.7rem', color: 'var(--error)' }}>
-                                {'\u26A1'} {event.painContext.map(pc => `${pc.source} (${pc.score})`).join(', ')}
+                              <div className="event-context-pain" aria-label={t('thinkingModels.painContext')}>
+                                <Zap size={12} aria-hidden /> {event.painContext.map(pc => `${pc.source} (${pc.score})`).join(', ')}
                               </div>
                             )}
                             {event.principleContext?.length > 0 && (
-                              <div style={{ fontSize: '0.7rem', color: 'var(--info)' }}>
-                                {'\u{1F4CB}'} {event.principleContext.map(pr => (
+                              <div className="event-context-principle" aria-label={t('thinkingModels.principleContext')}>
+                                <ClipboardList size={12} aria-hidden /> {event.principleContext.map(pr => (
                                   `${pr.principleId ?? '—'} ${pr.eventType ? `(${pr.eventType})` : ''}`
                                 )).join(', ')}
                               </div>
                             )}
                             {event.matchedPattern && (
-                              <code style={{ fontSize: '0.65rem', color: 'var(--text-secondary)', background: 'var(--bg-sunken)', padding: '2px 6px', borderRadius: 3 }}>
+                              <code className="matched-pattern">
                                 /{event.matchedPattern}/
                               </code>
                             )}
-                            <pre style={{ fontSize: '0.7rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                            <pre className="event-trigger-excerpt">
                               {event.triggerExcerpt}
                             </pre>
                           </div>
@@ -540,19 +603,19 @@ export function ThinkingModelsPage() {
               badge={`${data.dormantModels.length}`}
               defaultCollapsed
             >
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 8, padding: '8px 0' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: SPACE[2], padding: `${SPACE[2]} 0` }}>
                 {data.dormantModels.map(model => (
                   <div
                     key={model.modelId}
                     style={{
-                      padding: '8px 10px',
+                      padding: `${SPACE[2]} ${SPACE[3]}`,
                       border: '1px solid var(--border)',
                       borderRadius: 6,
                       background: 'var(--bg-sunken)',
                     }}
                   >
-                    <strong style={{ fontSize: '0.8rem' }}>{model.name}</strong>
-                    <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', margin: '4px 0 0', lineHeight: 1.3 }}>
+                    <strong style={{ fontSize: TEXT.lg }}>{model.name}</strong>
+                    <p style={{ fontSize: TEXT.sm, color: 'var(--text-secondary)', margin: `${SPACE[1]} 0 0`, lineHeight: 1.3 }}>
                       {model.description}
                     </p>
                   </div>
@@ -575,14 +638,14 @@ export function ThinkingModelsPage() {
           {heatmapData ? (
             <CollapsiblePanel title={t('thinkingModels.scenarioHeatmap')}>
               <div style={{ overflowX: 'auto' }}>
-                <table style={{ borderCollapse: 'collapse', minWidth: '100%' }}>
+                <table className="heatmap-table">
                   <thead>
                     <tr>
-                      <th style={{ position: 'sticky', left: 0, background: 'var(--bg-panel)', zIndex: 1, minWidth: 100, textAlign: 'left', padding: '6px 8px', borderBottom: '1px solid var(--border)', fontSize: '0.75rem', fontWeight: 600 }}>
+                      <th className="heatmap-header heatmap-sticky">
                         Model
                       </th>
                       {heatmapData.allScenarios.map(sc => (
-                        <th key={sc} style={{ textAlign: 'center', fontSize: '0.65rem', padding: '4px 6px', writingMode: 'vertical-lr', transform: 'rotate(180deg)', height: 80, borderBottom: '1px solid var(--border)', color: 'var(--text-secondary)' }}>
+                        <th key={sc} className="heatmap-header heatmap-scenario">
                           {sc}
                         </th>
                       ))}
@@ -591,26 +654,20 @@ export function ThinkingModelsPage() {
                   <tbody>
                     {heatmapData.models.map(model => (
                       <tr key={model.modelId}>
-                        <td style={{ position: 'sticky', left: 0, background: 'var(--bg-panel)', fontWeight: 500, fontSize: '0.75rem', padding: '4px 8px', borderTop: '1px solid var(--border)' }}>
+                        <td className="heatmap-model heatmap-sticky">
                           {model.name}
                         </td>
                         {heatmapData.allScenarios.map(sc => {
                           const hits = heatmapData.hitMap.get(`${model.modelId}::${sc}`) ?? 0;
+                          const intensity = hits / heatmapData.maxHits;
                           const bgColor = hits === 0
                             ? 'var(--bg-sunken)'
-                            : `rgba(91, 139, 160, ${Math.max(0.15, (hits / heatmapData.maxHits) * 0.55).toFixed(2)})`;
+                            : `rgba(91, 139, 160, ${Math.max(0.15, intensity * 0.55).toFixed(2)})`;
                           return (
                             <td
                               key={sc}
-                              style={{
-                                textAlign: 'center',
-                                backgroundColor: bgColor,
-                                padding: '4px 6px',
-                                fontSize: '0.7rem',
-                                fontWeight: hits > 0 ? 600 : 400,
-                                borderTop: '1px solid var(--border)',
-                                color: hits > 0 ? 'var(--text-primary)' : 'var(--text-secondary)',
-                              }}
+                              className="heatmap-cell"
+                              style={{ backgroundColor: bgColor }}
                             >
                               {hits}
                             </td>

--- a/packages/openclaw-plugin/ui/src/styles.css
+++ b/packages/openclaw-plugin/ui/src/styles.css
@@ -1702,3 +1702,248 @@ pre {
     grid-template-columns: 1fr !important;
   }
 }
+
+/* ==========================================================================
+   Thinking Models Page — New styles for v1.10 polish pass
+   ========================================================================== */
+
+/* Typography utility classes */
+.text-xs { font-size: var(--text-xs, 0.65rem); }
+.text-sm { font-size: var(--text-sm, 0.7rem); }
+.text-base { font-size: var(--text-base, 0.75rem); }
+.text-lg { font-size: var(--text-lg, 0.8rem); }
+.text-xl { font-size: var(--text-xl, 0.85rem); }
+.text-semibold { font-weight: 600; }
+.text-error { color: var(--error); }
+
+/* Section title (replaces inline fontWeight + fontSize on h3/h4) */
+.section-title {
+  font-size: var(--text-xl, 0.85rem);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--space-2);
+}
+
+/* Search + Sort + Filter controls */
+.sort-button {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-panel, var(--bg-elevated));
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-base);
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.sort-button:hover {
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+}
+
+.filter-button {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.filter-button:hover {
+  border-color: var(--border-hover);
+}
+
+.filter-button.active {
+  border-color: var(--accent);
+  background: rgba(91, 139, 160, 0.15);
+  color: var(--accent);
+}
+
+/* Compare button bar */
+.compare-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-2);
+  background: rgba(91, 139, 160, 0.08);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.compare-button {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 4px 12px;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  font-size: var(--text-base);
+  font-weight: 600;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.compare-button:hover {
+  background: var(--accent-hover);
+}
+
+/* Model list button (replaces inline style button) */
+.model-list-button {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  text-align: left;
+}
+
+.hits-count {
+  font-weight: 600;
+  font-size: var(--text-xl, 0.85rem);
+}
+
+.scenario-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+  display: block;
+}
+
+/* Code blocks for trigger / anti-pattern */
+.code-block {
+  font-size: var(--text-base);
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 6px;
+  display: block;
+  line-height: 1.5;
+  font-family: var(--font-mono);
+}
+
+.code-block-trigger {
+  background: var(--bg-sunken);
+}
+
+.code-block-antipattern {
+  background: rgba(220, 53, 69, 0.08);
+  color: var(--error);
+}
+
+/* Event context helpers */
+.event-context-tool {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.event-context-pain {
+  font-size: var(--text-sm);
+  color: var(--error);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.event-context-principle {
+  font-size: var(--text-sm);
+  color: var(--info);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.matched-pattern {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  background: var(--bg-sunken);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+}
+
+.event-trigger-excerpt {
+  font-size: var(--text-sm);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Heatmap table */
+.heatmap-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.heatmap-header {
+  text-align: center;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+.heatmap-scenario {
+  font-size: var(--text-xs);
+  writing-mode: vertical-lr;
+  transform: rotate(180deg);
+  height: 80px;
+}
+
+.heatmap-sticky {
+  position: sticky;
+  left: 0;
+  background: var(--bg-panel, var(--bg-elevated));
+  z-index: 1;
+  text-align: left;
+  padding: 6px 8px;
+  font-size: var(--text-base);
+  font-weight: 600;
+  min-width: 100px;
+}
+
+.heatmap-model {
+  font-weight: 500;
+  font-size: var(--text-base);
+  padding: 4px 8px;
+  border-top: 1px solid var(--border);
+}
+
+.heatmap-cell {
+  text-align: center;
+  padding: 4px 6px;
+  font-size: var(--text-sm);
+  border-top: 1px solid var(--border);
+  color: var(--text-primary);
+}
+
+/* Loader spin animation (reuses existing .spinner keyframes) */
+.spin {
+  animation: spin 0.8s linear infinite;
+}
+
+/* Loading placeholder for empty model definitions grid */
+.loading-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  color: var(--text-secondary);
+  gap: var(--space-2);
+}
+

--- a/packages/openclaw-plugin/ui/src/styles.css
+++ b/packages/openclaw-plugin/ui/src/styles.css
@@ -1947,3 +1947,74 @@ pre {
   gap: var(--space-2);
 }
 
+/* Text alignment utility */
+.text-center { text-align: center; }
+
+/* Stage badge (EvolutionPage) */
+.stage-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-lg, 0.8rem);
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  border: 2px solid var(--accent);
+}
+
+.stage-badge svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Sample pre blocks (SamplesPage) */
+.sample-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg-sunken);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* GFI big number (FeedbackPage) */
+.gfi-big-number {
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* Progress bar (shared component pattern) */
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg-sunken);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-top: var(--space-2);
+}
+
+.progress-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+/* GateMonitor trust/EP big numbers */
+.stat-big-number {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* EvolutionPage icon alignment */
+.panel h3 svg {
+  vertical-align: middle;
+  margin-right: var(--space-1);
+}
+


### PR DESCRIPTION
## v1.10: Thinking Models 页面优化

将 Thinking Models 页面从简单的列表/详情视图重构为功能完整的思维模型分析面板。

### 8 Phases Delivered (22/22 requirements)

| # | Phase | Requirements |
|---|-------|-------------|
| 1 | 基础可视化 | VIZ-01, VIZ-03, VIZ-04 |
| 2 | 模型详情可视化 | VIZ-02 |
| 3 | 休眠模型与推荐标签 | DORM-01, DORM-02, REC-01, REC-02, REC-03 |
| 4 | 事件上下文详情 | EVT-01, EVT-02, EVT-03, EVT-04 |
| 5 | THINKING_OS.md 内容展示 | TOS-01, TOS-02, TOS-03 |
| 6 | 模型对比模式 | CMP-01, CMP-02, CMP-03 |
| 7 | 搜索与过滤 | SRCH-01, SRCH-02 |
| 8 | THINKING_OS.md 一致性 | SYNC-01 |

### Key Changes

- 📊 **覆盖率趋势图** — 每日覆盖率 LineChart（0-100%）
- 🔥 **场景热力图** — 模型×场景交叉表，颜色编码强度
- 📈 **使用趋势图** — 详情页每日 hits 趋势
- 😴 **休眠模型** — 可折叠列表，默认收起
- 🏷️ **推荐标签** — 色彩编码（reinforce 绿 / rework 黄 / archive 灰）+ 按推荐过滤
- 🛠 **事件上下文** — toolContext, painContext, principleContext, matchedPattern 展示
- 📋 **THINKING_OS 展示** — trigger 条件 + antiPattern 禁止行为
- 🔄 **模型对比** — 多选（最多 4 个），并排指标对比
- 🔍 **搜索与排序** — 按名称/场景搜索 + hits/successRate/name 排序
- 📝 **模板一致性** — T-09/T-10 补齐所有 THINKING_OS.md 模板

### Files Changed

- `packages/openclaw-plugin/ui/src/pages/ThinkingModelsPage.tsx` — 全面重构
- `packages/openclaw-plugin/ui/src/i18n/ui.ts` — 20+ 新 i18n keys
- `packages/openclaw-plugin/ui/src/types.ts` — 类型扩展
- `packages/openclaw-plugin/src/service/control-ui-query-service.ts` — API 响应扩展
- `packages/openclaw-plugin/src/core/thinking-models.ts` — T-09/T-10 扩展
- `packages/create-principles-disciple/templates/` — 3 个模板文件更新

### Verification

- ✅ TypeScript compilation passes (0 errors)
- ✅ UI build succeeds
- ✅ All phase UAT criteria met

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加思维模型对比模式（多模型并列比较）、模型搜索、筛选、排序与推荐过滤。
  * 引入分析仪表板：覆盖趋势、场景热力图、沉睡模型面板等可视化。

* **改进**
  * 丰富单模型详情：用量趋势、事件上下文、触发/反模式摘录与效果统计文案调整。
  * 大量界面国际化（新增多语言键）与可访问性改进（登录 token 标签 aria-label 等）。
  * 微调阶段徽章样式与字号显示。

* **Style**
  * 补充大量 UI 样式类、加载占位与热力图样式。

* **Documentation**
  * 新增完整 WebUI 审核文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->