### PR TITLE
fix(nocturnal): resolve issues #249, #250, #251

### DIFF
--- a/packages/openclaw-plugin/src/commands/archive-impl.ts
+++ b/packages/openclaw-plugin/src/commands/archive-impl.ts
@@ -129,7 +129,7 @@ function _handleArchiveImpl(
   try {
     refreshPrincipleLifecycle(workspaceDir, stateDir);
   } catch (err) {
-    console.warn(`[archive-impl] Lifecycle refresh failed: ${String(err)}`);
+    console.warn('[archive-impl] Lifecycle refresh failed:', err instanceof Error ? err.stack : err);
   }
 
   return {

--- a/packages/openclaw-plugin/src/commands/archive-impl.ts
+++ b/packages/openclaw-plugin/src/commands/archive-impl.ts
@@ -126,7 +126,11 @@ function _handleArchiveImpl(
   updateImplementation(stateDir, implId, {
     archivedAt: new Date().toISOString(),
   });
-  refreshPrincipleLifecycle(workspaceDir, stateDir);
+  try {
+    refreshPrincipleLifecycle(workspaceDir, stateDir);
+  } catch (err) {
+    console.warn(`[archive-impl] Lifecycle refresh failed: ${String(err)}`);
+  }
 
   return {
     text: isZh

--- a/packages/openclaw-plugin/src/commands/disable-impl.ts
+++ b/packages/openclaw-plugin/src/commands/disable-impl.ts
@@ -112,7 +112,7 @@ function _handleDisableImpl(
   try {
     refreshPrincipleLifecycle(workspaceDir, stateDir);
   } catch (err) {
-    console.warn(`[disable-impl] Lifecycle refresh failed: ${String(err)}`);
+    console.warn('[disable-impl] Lifecycle refresh failed:', err instanceof Error ? err.stack : err);
   }
 
   return {

--- a/packages/openclaw-plugin/src/commands/disable-impl.ts
+++ b/packages/openclaw-plugin/src/commands/disable-impl.ts
@@ -109,7 +109,11 @@ function _handleDisableImpl(
     disabledBy: sessionId || 'manual',
     disabledReason: reasonText,
   });
-  refreshPrincipleLifecycle(workspaceDir, stateDir);
+  try {
+    refreshPrincipleLifecycle(workspaceDir, stateDir);
+  } catch (err) {
+    console.warn(`[disable-impl] Lifecycle refresh failed: ${String(err)}`);
+  }
 
   return {
     text: isZh

--- a/packages/openclaw-plugin/src/commands/nocturnal-review.ts
+++ b/packages/openclaw-plugin/src/commands/nocturnal-review.ts
@@ -22,6 +22,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import {
   listDatasetRecords,
   getDatasetRecord,
@@ -31,6 +32,7 @@ import {
   type NocturnalDatasetRecord,
   type NocturnalReviewStatus,
 } from '../core/nocturnal-dataset.js';
+import { getPrincipleState, setPrincipleState } from '../core/principle-training-state.js';
 import type { PluginCommandContext, PluginCommandResult } from '../openclaw-sdk.js';
 
 function isZh(ctx: PluginCommandContext): boolean {
@@ -193,6 +195,16 @@ export function handleNocturnalReviewCommand(ctx: PluginCommandContext): PluginC
       }
 
       const updated = updateReviewStatus(workspaceDir, fingerprint, 'approved_for_training', reason);
+
+      // #251: Sync approvedSampleCount in training store
+      try {
+        const stateDir = path.join(workspaceDir, '.state');
+        const state = getPrincipleState(stateDir, updated.principleId);
+        state.approvedSampleCount += 1;
+        setPrincipleState(stateDir, state);
+      } catch (err) {
+        console.warn(`[nocturnal-review] Failed to sync approvedSampleCount for ${updated.principleId}: ${String(err)}`);
+      }
 
       return {
         text: zh

--- a/packages/openclaw-plugin/src/commands/nocturnal-review.ts
+++ b/packages/openclaw-plugin/src/commands/nocturnal-review.ts
@@ -203,7 +203,7 @@ export function handleNocturnalReviewCommand(ctx: PluginCommandContext): PluginC
         state.approvedSampleCount += 1;
         setPrincipleState(stateDir, state);
       } catch (err) {
-        console.warn(`[nocturnal-review] Failed to sync approvedSampleCount for ${updated.principleId}: ${String(err)}`);
+        console.warn(`[nocturnal-review] Failed to sync approvedSampleCount for ${updated.principleId}:`, err instanceof Error ? err.stack : err);
       }
 
       return {

--- a/packages/openclaw-plugin/src/commands/promote-impl.ts
+++ b/packages/openclaw-plugin/src/commands/promote-impl.ts
@@ -172,7 +172,11 @@ function _handlePromoteImpl(options: PromoteImplOptions): PluginCommandResult {
       disabledBy: undefined,
       disabledReason: undefined,
     });
-    refreshPrincipleLifecycle(workspaceDir, stateDir);
+    try {
+      refreshPrincipleLifecycle(workspaceDir, stateDir);
+    } catch (err) {
+      console.warn(`[promote-impl] Lifecycle refresh failed (re-enable): ${String(err)}`);
+    }
 
     output += isZh
       ? `\n✅ 实现已重新启用: ${implId}\n   状态: disabled -> active`
@@ -225,7 +229,11 @@ function _handlePromoteImpl(options: PromoteImplOptions): PluginCommandResult {
   withLock(eventPath, () => {
     fs.writeFileSync(eventPath, JSON.stringify(promotionEvent, null, 2), 'utf-8');
   });
-  refreshPrincipleLifecycle(workspaceDir, stateDir);
+  try {
+    refreshPrincipleLifecycle(workspaceDir, stateDir);
+  } catch (err) {
+    console.warn(`[promote-impl] Lifecycle refresh failed (promotion): ${String(err)}`);
+  }
 
   output += isZh
     ? `\n\n✅ 实现已晋升: ${implId}\n   状态: candidate -> active`

--- a/packages/openclaw-plugin/src/commands/promote-impl.ts
+++ b/packages/openclaw-plugin/src/commands/promote-impl.ts
@@ -175,7 +175,7 @@ function _handlePromoteImpl(options: PromoteImplOptions): PluginCommandResult {
     try {
       refreshPrincipleLifecycle(workspaceDir, stateDir);
     } catch (err) {
-      console.warn(`[promote-impl] Lifecycle refresh failed (re-enable): ${String(err)}`);
+      console.warn('[promote-impl] Lifecycle refresh failed (re-enable):', err instanceof Error ? err.stack : err);
     }
 
     output += isZh
@@ -232,7 +232,7 @@ function _handlePromoteImpl(options: PromoteImplOptions): PluginCommandResult {
   try {
     refreshPrincipleLifecycle(workspaceDir, stateDir);
   } catch (err) {
-    console.warn(`[promote-impl] Lifecycle refresh failed (promotion): ${String(err)}`);
+    console.warn('[promote-impl] Lifecycle refresh failed (promotion):', err instanceof Error ? err.stack : err);
   }
 
   output += isZh

--- a/packages/openclaw-plugin/src/commands/rollback-impl.ts
+++ b/packages/openclaw-plugin/src/commands/rollback-impl.ts
@@ -188,7 +188,7 @@ function _handleRollbackImpl(
   try {
     refreshPrincipleLifecycle(workspaceDir, stateDir);
   } catch (err) {
-    console.warn(`[rollback-impl] Lifecycle refresh failed: ${String(err)}`);
+    console.warn('[rollback-impl] Lifecycle refresh failed:', err instanceof Error ? err.stack : err);
   }
 
   let output = isZh

--- a/packages/openclaw-plugin/src/commands/rollback-impl.ts
+++ b/packages/openclaw-plugin/src/commands/rollback-impl.ts
@@ -185,7 +185,11 @@ function _handleRollbackImpl(
   withLock(rollbackPath, () => {
     fs.writeFileSync(rollbackPath, JSON.stringify(rollbackRecord, null, 2), 'utf-8');
   });
-  refreshPrincipleLifecycle(workspaceDir, stateDir);
+  try {
+    refreshPrincipleLifecycle(workspaceDir, stateDir);
+  } catch (err) {
+    console.warn(`[rollback-impl] Lifecycle refresh failed: ${String(err)}`);
+  }
 
   let output = isZh
     ? `\n\u2705 \u56de\u6eda\u5b8c\u6210: ${implId}\n   \u72b6\u6001: active -> disabled\n   \u539f\u56e0: ${reasonText}`

--- a/packages/openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts
+++ b/packages/openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts
@@ -121,14 +121,14 @@ export function recommendInternalizationRoute(
     principle.summary.repeatedErrorSignal === 0;
 
   if (principle.rules.length === 0) {
-    reasonCodes.push('no_material_rules');
+    reasonCodes.push('insufficient_data', 'no_material_rules');
     return {
       principleId: principle.principle.id,
       route: 'defer',
-      confidence: 95,
+      confidence: 50,
       reasonCodes,
       evidenceSummary,
-      nextAction: 'Define at least one concrete rule before choosing an internalization route.',
+      nextAction: 'No rules defined for this principle. Create at least one rule via pain→principle→rule pipeline before internalization routing can produce meaningful recommendations.',
     };
   }
 

--- a/packages/openclaw-plugin/src/core/principle-internalization/lifecycle-metrics.ts
+++ b/packages/openclaw-plugin/src/core/principle-internalization/lifecycle-metrics.ts
@@ -11,6 +11,8 @@ export interface RuleMetricResult {
 }
 
 export interface PrincipleAdherenceResult {
+  /** True when no rules exist — all numeric fields are defaults, not computed values */
+  insufficientData?: boolean;
   adherenceRate: number;
   averageRuleCoverage: number;
   averageFalsePositiveRate: number;
@@ -108,6 +110,7 @@ export function computePrincipleAdherence(
 
   if (principle.rules.length === 0) {
     return {
+      insufficientData: true,
       adherenceRate: 0,
       averageRuleCoverage: 0,
       averageFalsePositiveRate: 0,

--- a/packages/openclaw-plugin/src/service/nocturnal-service.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-service.ts
@@ -98,8 +98,23 @@ import {
 } from './nocturnal-runtime.js';
 import { NocturnalPathResolver } from '../core/nocturnal-paths.js';
 import { registerSample } from '../core/nocturnal-dataset.js';
+import { getPrincipleState, setPrincipleState } from '../core/principle-training-state.js';
 import type { Implementation } from '../types/principle-tree-schema.js';
 import { validateNocturnalSnapshotIngress } from '../core/nocturnal-snapshot-contract.js';
+
+// ---------------------------------------------------------------------------
+// #251: Sync trainingStore sample counts after registration
+// ---------------------------------------------------------------------------
+
+function incrementGeneratedSampleCount(stateDir: string, principleId: string): void {
+  try {
+    const state = getPrincipleState(stateDir, principleId);
+    state.generatedSampleCount += 1;
+    setPrincipleState(stateDir, state);
+  } catch (err) {
+    console.warn(`[nocturnal-service] Failed to sync generatedSampleCount for ${principleId}: ${String(err)}`);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -467,7 +482,11 @@ function persistCodeCandidate(
       implementationId,
       createdAt: now,
     });
-    refreshPrincipleLifecycle(workspaceDir, stateDir);
+    try {
+      refreshPrincipleLifecycle(workspaceDir, stateDir);
+    } catch (err) {
+      console.warn(`[nocturnal-service] Lifecycle refresh failed after code candidate persistence: ${String(err)}`);
+    }
     return {
       status: 'persisted_candidate',
       ruleResolution: {
@@ -993,7 +1012,10 @@ export function executeNocturnalReflection(
   // Approved artifacts must enter the dataset registry so they can be reviewed
   // before export. Without this, new samples never appear in the review queue.
   try {
-    registerSample(workspaceDir, arbiterResult.artifact, persistedPath, null);
+    const regResult = registerSample(workspaceDir, arbiterResult.artifact, persistedPath, null);
+    if (regResult.isNew) {
+      incrementGeneratedSampleCount(stateDir, arbiterResult.artifact.principleId);
+    }
   } catch (err) {
     // Non-fatal: artifact is persisted, registry is secondary.
     // Log but don't fail the run.
@@ -1380,7 +1402,10 @@ async function executeNocturnalReflectionWithAdapter(
 
   // Step 8: Register in dataset lineage
   try {
-    registerSample(workspaceDir, arbiterResult.artifact, persistedPath, null);
+    const regResult = registerSample(workspaceDir, arbiterResult.artifact, persistedPath, null);
+    if (regResult.isNew) {
+      incrementGeneratedSampleCount(stateDir, arbiterResult.artifact.principleId);
+    }
   } catch (err) {
     console.warn(`[nocturnal-service] Failed to register sample in dataset registry: ${String(err)}`);
   }

--- a/packages/openclaw-plugin/src/service/nocturnal-service.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-service.ts
@@ -112,7 +112,7 @@ function incrementGeneratedSampleCount(stateDir: string, principleId: string): v
     state.generatedSampleCount += 1;
     setPrincipleState(stateDir, state);
   } catch (err) {
-    console.warn(`[nocturnal-service] Failed to sync generatedSampleCount for ${principleId}: ${String(err)}`);
+    console.warn(`[nocturnal-service] Failed to sync generatedSampleCount for ${principleId}:`, err instanceof Error ? err.stack : err);
   }
 }
 
@@ -485,7 +485,7 @@ function persistCodeCandidate(
     try {
       refreshPrincipleLifecycle(workspaceDir, stateDir);
     } catch (err) {
-      console.warn(`[nocturnal-service] Lifecycle refresh failed after code candidate persistence: ${String(err)}`);
+      console.warn('[nocturnal-service] Lifecycle refresh failed after code candidate persistence:', err instanceof Error ? err.stack : err);
     }
     return {
       status: 'persisted_candidate',


### PR DESCRIPTION
## Summary

- **#249**: Wrap all `refreshPrincipleLifecycle` call sites (6 locations across nocturnal-service, disable-impl, promote-impl, archive-impl, rollback-impl) in dedicated try/catch blocks to prevent silent failures and miscategorized `persistence_failed` errors
- **#251**: Sync `generatedSampleCount` after `registerSample()` in both Trinity and single-reflector paths of nocturnal-service; sync `approvedSampleCount` after review approval in nocturnal-review command
- **#250**: Add `insufficientData` flag to `PrincipleAdherenceResult` for principles without rules; reduce confidence from 95→50 and add `insufficient_data` reason code in `recommendInternalizationRoute`

## Changes (8 files, +71 / -11)

| File | Change |
|------|--------|
| `nocturnal-service.ts` | Dedicated try/catch around lifecycle refresh; `incrementGeneratedSampleCount` helper + sync at 2 registerSample call sites |
| `disable-impl.ts` | try/catch around `refreshPrincipleLifecycle` |
| `promote-impl.ts` | try/catch around 2 `refreshPrincipleLifecycle` calls |
| `archive-impl.ts` | try/catch around `refreshPrincipleLifecycle` |
| `rollback-impl.ts` | try/catch around `refreshPrincipleLifecycle` |
| `nocturnal-review.ts` | Sync `approvedSampleCount` after approve action |
| `lifecycle-metrics.ts` | Add `insufficientData?: boolean` to `PrincipleAdherenceResult` |
| `internalization-routing-policy.ts` | Lower confidence, improve reason codes and nextAction for no-rule principles |

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [x] All 13 principle-internalization tests pass
- [x] nocturnal-review tests pass (29/30, 1 pre-existing failure unrelated to this PR)
- [ ] Manual: run nocturnal reflection, verify `generatedSampleCount` increments in training store
- [ ] Manual: approve a sample via `/pd-nocturnal-review approve`, verify `approvedSampleCount` increments
- [ ] Manual: verify `refreshPrincipleLifecycle` failures log warnings without crashing commands

Closes #249, Closes #250, Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发行说明

* **Bug Fixes**
  * 多个命令在执行生命周期刷新时改为记录警告而非抛出异常，提升操作稳定性并避免中断用户流程。

* **New Features**
  * 增加对已批准/生成样本数量的计数与持久化同步，跟踪训练样本生成与批准情况。

* **Improvements**
  * 在原理建议中对“规则缺失”情形提供更明确理由与更低置信度，改进用户指导。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->