### PR TITLE
fix(nocturnal): start one EvolutionWorker per workspace

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,22 +1,50 @@
 # 项目记忆 — Principles Disciple
 
-## 当前状态 (2026-04-08)
-- **版本**: v1.8.2 (PR #178 已合并到 main)
-- **分支**: main 包含 Issues #177-#190 全部修复
-- **下一版本**: v1.9.0 (PR #191 principle tree ledger + rule host + replay engine)
+## 当前状态 (2026-04-13)
+- **版本**: v1.10.x
+- **OpenClaw 版本**: 2026.4.11
+- **OpenClaw 源码**: `/home/csuzngjh/code/openclaw/`
 
-## 待处理
-- PR #191 代码评审发现 16 个问题（3 Critical, 8 Major, 4 Minor）
-- PR #191 merge 状态为 CONFLICTING — 需要 rebase 到 main
+## 核心架构事实
+
+### 多智能体工作目录
+- 每个 agent 有**独立**的工作目录和独立的心跳任务
+- 配置来源：`~/.openclaw/openclaw.json` → `agents.list`
+- 8 个 agent：main、builder、pm、hr、repair、verification、research、resource-scout
+- 每个 agent 的 workspace 由 `agents.list[].workspace` 指定
+- 子代理复用主代理的工作目录
+
+### 插件加载机制（关键）
+- OpenClaw 的插件是**懒加载**的：`register()` 在第一次 `before_prompt_build` 时才触发
+- `startPluginServices()` 在 Gateway 启动时只调用一次，此时我们的插件还没注册
+- **`before_prompt_build` hook 按 agent 触发**，每个 agent 心跳时都会调用
+- hook 的 `ctx.workspaceDir` 是**当前 agent 的工作目录**
+
+### EvolutionWorker 正确设计
+- **每个 workspace 启动一个独立的 EvolutionWorker**
+- 在 `before_prompt_build` 中，当 hook 触发时为该 workspace 启动 Worker
+- 用 `startedWorkspaces: Set<string>` 去重（index.ts 模块级）
+- 用 `EvolutionWorkerService._startedWorkspaces: Set<string>` 去重（evolution-worker.ts 服务级）
+- 每个 Worker 只处理自己 workspace 的 `.pain_flag` 和 `evolution_queue.json`
+
+### 调试时的教训
+1. **不要假设 `api.logger` 写到 SYSTEM.log** — 它写到 OpenClaw 的 `[plugins]` 子系统日志，用 `journalctl --user -u openclaw-gateway` 查看
+2. **bundle.js 缓存问题** — `sync-plugin.mjs` 可能使用旧 dist/，验证时直接 `grep` 检查 bundle 内容
+3. **查看 OpenClaw 源码是必须的** — 不读 `server-startup-post-attach.ts` 和 `services.ts` 就无法理解插件加载时序
+4. **不要写死 agent ID 或路径** — 始终通过 hook 的 `ctx.workspaceDir` 或 `api.config.agents` 获取
+5. **部署后必须验证 bundle 内容** — `grep "新代码特征" dist/bundle.js`，确认 md5 匹配
 
 ## 部署
 - `cd packages/openclaw-plugin && node scripts/sync-plugin.mjs --dev` 构建、同步、重启
-- `--bump/-b` 标志自动检测未提交变更并 bump 版本号
+- 验证部署：`grep "EvolutionWorker started for workspace:" ~/.openclaw/extensions/principles-disciple/dist/bundle.js`
+- 查看运行时日志：`journalctl --user -u openclaw-gateway --since "5 min ago" | grep "PD:"`
 - `npx tsx scripts/pipeline-health.ts --workspace ~/.openclaw/workspace-main` 健康检查
 
 ## 关键文件位置
 - 插件源码: `packages/openclaw-plugin/src/`
 - 测试: `packages/openclaw-plugin/tests/`
-- OpenClaw 源码: `../openclaw/` (核实框架行为时必须查阅)
-- 状态文件: `~/.openclaw/workspace-main/.state/`
+- OpenClaw 源码: `/home/csuzngjh/code/openclaw/`
+- 插件配置: `~/.openclaw/openclaw.json`
+- 状态文件: `~/.openclaw/workspace-*/.state/`
+- 故障排查文档: `docs/troubleshooting/evolution-worker-start.md`
 - Cron jobs: `~/.openclaw/cron/jobs.json`

--- a/docs/troubleshooting/evolution-worker-start.md
+++ b/docs/troubleshooting/evolution-worker-start.md
@@ -1,0 +1,51 @@
+# EvolutionWorker 启动问题排查手册
+
+## 问题描述
+
+EvolutionWorker 的 `start()` 方法从未被调用，导致 pain flag 检测不到、诊断任务不被处理、Nocturnal 管道瘫痪。
+
+## 根因
+
+OpenClaw 的 `startPluginServices()` 在 Gateway 启动时只调用一次，但我们的插件是**懒加载**的（`register()` 在第一次 `before_prompt_build` 时才触发）。当 `register()` 执行时，`startPluginServices()` 已经执行完毕。
+
+## 修复
+
+在 `before_prompt_build` 第一次执行时手动调用 `EvolutionWorkerService.start()`，使用 `resolveWorkspaceDirFromApi(api, 'main')` 获取默认 agent 的工作目录。
+
+## 验证方法
+
+```bash
+# 查看 EvolutionWorker 是否启动
+journalctl --user -u openclaw-gateway --since "5 min ago" --no-pager | grep "EvolutionWorker"
+
+# 测试 pain flag
+cat > ~/.openclaw/workspace-main/.state/.pain_flag << 'EOF'
+source: manual
+score: 75
+time: 2026-04-13T15:11:00.000Z
+reason: Test
+EOF
+
+# 等待心跳周期，查看日志
+journalctl --user -u openclaw-gateway --since "1 min ago" --no-pager | grep -i "EvolutionWorker\|pain\|enqueued"
+```
+
+## 常见陷阱
+
+1. **bundle.js 缓存**：`sync-plugin.mjs` 可能使用旧 dist/，直接编译更可靠
+2. **api.logger 写到子系统日志**：用 `journalctl` 查看，不在 SYSTEM.log
+3. **/tmp 在沙箱中不可写**：调试日志不要依赖 /tmp
+4. **心跳被 requests-in-flight 阻止**：等心跳周期自动触发
+
+## 正常链路的日志证据
+
+```
+[PD:EvolutionWorker] Starting with workspaceDir=~/.openclaw/workspace-main, stateDir=~/.openclaw/workspace-main/.state
+[PD:EvolutionWorker] Detected pain flag (score: 75, source: manual). Enqueueing evolution task.
+[PD:EvolutionWorker] Enqueued pain task XXXX (score=75)
+[PD:EvolutionWorker] Wrote diagnostician task to diagnostician_tasks.json for task XXXX
+```
+
+## 历史
+- 发现时间：2026-04-13
+- 修复 PR：#290

--- a/packages/openclaw-plugin/src/core/nocturnal-trajectory-extractor.ts
+++ b/packages/openclaw-plugin/src/core/nocturnal-trajectory-extractor.ts
@@ -96,6 +96,14 @@ export interface NocturnalGateBlock {
 }
 
 /**
+ * User correction sample for nocturnal snapshot.
+ * #268: Wire correction_samples into nocturnal pipeline.
+ */
+export interface NocturnalUserCorrection {
+  correctionCue: string | null;
+}
+
+/**
  * A structured nocturnal session snapshot.
  * Contains all information needed for a reflector to generate decision-point samples.
  *
@@ -114,6 +122,8 @@ export interface NocturnalSessionSnapshot {
   toolCalls: NocturnalToolCall[];
   painEvents: NocturnalPainEvent[];
   gateBlocks: NocturnalGateBlock[];
+  /** #268: User corrections from correction_samples table */
+  userCorrections: NocturnalUserCorrection[];
   /**
    * Summary statistics for quick triage.
    * #246: All fields are now number (never null).
@@ -281,6 +291,8 @@ export class NocturnalTrajectoryExtractor {
     const toolCalls = this.trajectory.listToolCallsForSession(sessionId);
     const painEvents = this.trajectory.listPainEventsForSession(sessionId);
     const gateBlocks = this.trajectory.listGateBlocksForSession(sessionId);
+    // #268: Fetch correction samples for this session
+    const correctionSamples = this.trajectory.listCorrectionSamplesForSession(sessionId);
 
     // Map to sanitized structures
     // SECURITY: Only sanitizedText from assistant turns
@@ -346,6 +358,10 @@ export class NocturnalTrajectoryExtractor {
       toolCalls: nocturnalToolCalls,
       painEvents: nocturnalPainEvents,
       gateBlocks: nocturnalGateBlocks,
+      // #268: Map correction samples to nocturnal format
+      userCorrections: correctionSamples.map((cs: { correctionCue: string | null }) => ({
+        correctionCue: cs.correctionCue,
+      })),
       stats: {
         totalAssistantTurns: sanitizedAssistantTurns.length,
         totalToolCalls: nocturnalToolCalls.length,

--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -935,6 +935,25 @@ export class TrajectoryDatabase {
     }));
   }
 
+  /**
+   * List correction samples for a specific session.
+   * Returns minimal fields for nocturnal use — correction cue only.
+   * #268: Wire correction_samples into nocturnal pipeline.
+   */
+  listCorrectionSamplesForSession(sessionId: string): { correctionCue: string | null }[] {
+    const rows = this.db.prepare(`
+      SELECT cs.sample_id, ut.correction_cue
+      FROM correction_samples cs
+      LEFT JOIN user_turns ut ON ut.id = cs.user_correction_turn_id
+      WHERE cs.session_id = ?
+      ORDER BY cs.created_at DESC
+    `).all(sessionId) as Record<string, unknown>[];
+
+    return rows.map((row) => ({
+      correctionCue: row.correction_cue ? String(row.correction_cue) : null,
+    }));
+  }
+
   reviewCorrectionSample(sampleId: string, status: Exclude<CorrectionSampleReviewStatus, 'pending'>, note?: string): CorrectionSampleRecord {
     const updatedAt = nowIso();
     const updated = this.withWrite(() => {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -170,8 +170,9 @@ const plugin = {
             // OpenClaw calls startPluginServices() only once during Gateway startup.
             // Our plugin is lazy-loaded (register() fires on first before_prompt_build),
             // so EvolutionWorkerService.start() was never called automatically.
-            // Manually start it here using the default agent's workspaceDir.
-            const defaultWorkspaceDir = resolveWorkspaceDirFromApi(api, 'main');
+            // Manually start it here using the configured default agent's workspaceDir.
+            const agentsConfig = (api.config as any)?.agents;
+            const defaultWorkspaceDir = agentsConfig?.defaults?.workspace;
             if (defaultWorkspaceDir) {
               EvolutionWorkerService.api = api;
               EvolutionWorkerService.start({
@@ -181,7 +182,7 @@ const plugin = {
                 logger: api.logger,
               });
             } else {
-              api.logger.error('[PD] EvolutionWorkerService.start skipped: default workspaceDir unavailable');
+              api.logger.error('[PD] EvolutionWorkerService.start skipped: agents.defaults.workspace not configured');
             }
 
             migrateDirectoryStructure(api, workspaceDir);

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -166,9 +166,27 @@ const plugin = {
         if (!workspaceDir) return;
         try {
           if (!workspaceInitialized) {
+            // ── Start Evolution Worker service ──
+            // OpenClaw calls startPluginServices() only once during Gateway startup.
+            // Our plugin is lazy-loaded (register() fires on first before_prompt_build),
+            // so EvolutionWorkerService.start() was never called automatically.
+            // Manually start it here using the default agent's workspaceDir.
+            const defaultWorkspaceDir = resolveWorkspaceDirFromApi(api, 'main');
+            if (defaultWorkspaceDir) {
+              EvolutionWorkerService.api = api;
+              EvolutionWorkerService.start({
+                config: api.config,
+                workspaceDir: defaultWorkspaceDir,
+                stateDir: path.join(defaultWorkspaceDir, '.state'),
+                logger: api.logger,
+              });
+            } else {
+              api.logger.error('[PD] EvolutionWorkerService.start skipped: default workspaceDir unavailable');
+            }
+
             migrateDirectoryStructure(api, workspaceDir);
             ensureWorkspaceTemplates(api, workspaceDir, language);
-            SystemLogger.log(workspaceDir, 'SYSTEM_BOOT', `Principles Disciple online. Language: ${language}`);
+            SystemLogger.log(workspaceDir, 'SYSTEM_BOOT', `Principles Disciple online. Language: ${language}. defaultWorkspaceDir=${defaultWorkspaceDir || '(unknown)'}`);
             workspaceInitialized = true;
           }
           const result = await handleBeforePromptBuild(event, { ...ctx, api, workspaceDir });

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -66,6 +66,8 @@ import { extractAgentIdFromSessionKey } from './utils/session-key.js';
 
 // Track initialization to avoid repeated calls
 let workspaceInitialized = false;
+// Track started evolution workers — one per workspace
+const startedWorkspaces = new Set<string>();
 
 /**
  * Resolve workspaceDir for slash commands.
@@ -166,30 +168,28 @@ const plugin = {
         if (!workspaceDir) return;
         try {
           if (!workspaceInitialized) {
-            // ── Start Evolution Worker service ──
-            // OpenClaw calls startPluginServices() only once during Gateway startup.
-            // Our plugin is lazy-loaded (register() fires on first before_prompt_build),
-            // so EvolutionWorkerService.start() was never called automatically.
-            // Manually start it here using the configured default agent's workspaceDir.
-            const agentsConfig = (api.config as any)?.agents;
-            const defaultWorkspaceDir = agentsConfig?.defaults?.workspace;
-            if (defaultWorkspaceDir) {
-              EvolutionWorkerService.api = api;
-              EvolutionWorkerService.start({
-                config: api.config,
-                workspaceDir: defaultWorkspaceDir,
-                stateDir: path.join(defaultWorkspaceDir, '.state'),
-                logger: api.logger,
-              });
-            } else {
-              api.logger.error('[PD] EvolutionWorkerService.start skipped: agents.defaults.workspace not configured');
-            }
-
             migrateDirectoryStructure(api, workspaceDir);
             ensureWorkspaceTemplates(api, workspaceDir, language);
-            SystemLogger.log(workspaceDir, 'SYSTEM_BOOT', `Principles Disciple online. Language: ${language}. defaultWorkspaceDir=${defaultWorkspaceDir || '(unknown)'}`);
+            SystemLogger.log(workspaceDir, 'SYSTEM_BOOT', `Principles Disciple online. Language: ${language}`);
             workspaceInitialized = true;
           }
+
+          // ── Start EvolutionWorker for THIS workspace ──
+          // Each agent has its own heartbeat task. When before_prompt_build fires,
+          // it fires for the current agent's workspaceDir. Start one EvolutionWorker
+          // per workspace so each agent's pain signals are processed independently.
+          if (!startedWorkspaces.has(workspaceDir)) {
+            startedWorkspaces.add(workspaceDir);
+            EvolutionWorkerService.api = api;
+            EvolutionWorkerService.start({
+              config: api.config,
+              workspaceDir,
+              stateDir: path.join(workspaceDir, '.state'),
+              logger: api.logger,
+            });
+            api.logger.info(`[PD] EvolutionWorker started for workspace: ${workspaceDir}`);
+          }
+
           const result = await handleBeforePromptBuild(event, { ...ctx, api, workspaceDir });
           
           // Record success

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -2085,24 +2085,27 @@ async function processEvolutionQueueWithResult(
 export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
     id: 'principles-evolution-worker',
     api: null,
+    _startedWorkspaces: new Set<string>(),
 
     start(ctx: OpenClawPluginServiceContext): void {
-        // Guard: prevent duplicate starts (e.g., from health check + before_prompt_build race)
-        const existing = (EvolutionWorkerService as any)._started;
-        if (existing) {
-            ctx?.logger?.info?.(`[PD:EvolutionWorker] Already started, skipping duplicate call`);
+        const workspaceDir = ctx?.workspaceDir;
+
+        // Guard: prevent duplicate starts for the SAME workspace
+        const started = EvolutionWorkerService._startedWorkspaces;
+        if (started.has(workspaceDir)) {
+            ctx?.logger?.info?.(`[PD:EvolutionWorker] Already started for ${workspaceDir}, skipping`);
             return;
         }
-        (EvolutionWorkerService as any)._started = true;
 
         const logger = ctx?.logger || console;
         const {api} = this;
-        const workspaceDir = ctx?.workspaceDir;
 
         if (!workspaceDir) {
             if (logger) logger.warn('[PD:EvolutionWorker] workspaceDir not found in service config. Evolution cycle disabled.');
             return;
         }
+
+        started.add(workspaceDir);
 
         const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });
         if (logger) logger.info(`[PD:EvolutionWorker] Starting with workspaceDir=${wctx.workspaceDir}, stateDir=${wctx.stateDir}`);

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -17,6 +17,7 @@ import type { TaskKind, TaskPriority } from '../core/trajectory-types.js';
 export type { TaskKind, TaskPriority } from '../core/trajectory-types.js';
 import { LockUnavailableError } from '../config/index.js';
 import { checkWorkspaceIdle, checkCooldown } from './nocturnal-runtime.js';
+import { loadNocturnalConfig } from './nocturnal-config.js';
 import { WorkflowStore } from './subagent-workflow/workflow-store.js';
 import type { WorkflowRow } from './subagent-workflow/types.js';
 import { EmpathyObserverWorkflowManager } from './subagent-workflow/empathy-observer-workflow-manager.js';
@@ -407,6 +408,8 @@ function buildFallbackNocturnalSnapshot(
         toolCalls: [],
         painEvents: fallbackPainEvents,
         gateBlocks: [],
+        // #268: Empty corrections in fallback path (no trajectory data available)
+        userCorrections: [],
         stats: {
             totalAssistantTurns: realStats?.totalAssistantTurns ?? 0,
             totalToolCalls: realStats?.totalToolCalls ?? 0,
@@ -2120,12 +2123,16 @@ export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
         const initialDelay = 5000;
         const interval = config.get('intervals.worker_poll_ms') || (15 * 60 * 1000);
 
+        // Periodic trigger tracking
+        let heartbeatCounter = 0;
+
         async function runCycle(): Promise<void> {
             const cycleStart = Date.now();
+            heartbeatCounter++;
 
             // ──── DEBUG: Verify subagent availability in heartbeat context ────
             const hbSubagent = api?.runtime?.subagent;
-            logger?.info?.(`[PD:DEBUG:SubagentCheck:Heartbeat] api_exists=${!!api}, subagent_exists=${!!hbSubagent}, subagent.run_exists=${!!hbSubagent?.run}`);
+            logger?.info?.(`[PD:DEBUG:SubagentCheck:Heartbeat] api_exists=${!!api}, subagent_exists=${!!hbSubagent}, subagent.run_exists=${!!hbSubagent?.run}, heartbeatCounter=${heartbeatCounter}`);
             if (hbSubagent?.run) {
                 logger?.info?.('[PD:DEBUG:SubagentCheck:Heartbeat] run entrypoint is callable');
             }
@@ -2146,18 +2153,45 @@ export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
             };
 
             try {
+                // Load config on each cycle (supports runtime updates)
+                const sleepConfig = loadNocturnalConfig(wctx.stateDir);
+
                 const idleResult = checkWorkspaceIdle(wctx.workspaceDir, {});
-                logger?.info?.(`[PD:EvolutionWorker] HEARTBEAT cycle=${new Date().toISOString()} idle=${idleResult.isIdle} idleForMs=${idleResult.idleForMs} userActiveSessions=${idleResult.userActiveSessions} abandonedSessions=${idleResult.abandonedSessionIds.length} lastActivityEpoch=${idleResult.mostRecentActivityAt}`);
-                if (idleResult.isIdle) {
-                    logger?.debug?.(`[PD:EvolutionWorker] Workspace idle (${idleResult.idleForMs}ms since last activity)`);
-                    const cooldown = checkCooldown(wctx.stateDir);
+                logger?.info?.(`[PD:EvolutionWorker] HEARTBEAT cycle=${new Date().toISOString()} idle=${idleResult.isIdle} idleForMs=${idleResult.idleForMs} userActiveSessions=${idleResult.userActiveSessions} abandonedSessions=${idleResult.abandonedSessionIds.length} lastActivityEpoch=${idleResult.mostRecentActivityAt} triggerMode=${sleepConfig.trigger_mode}`);
+
+                let shouldTrySleepReflection = false;
+
+                // Path 1: Idle-based trigger (default mode)
+                if (idleResult.isIdle && sleepConfig.trigger_mode === 'idle') {
+                    logger?.info?.(`[PD:EvolutionWorker] Workspace idle (${idleResult.idleForMs}ms since last activity)`);
+                    shouldTrySleepReflection = true;
+                }
+
+                // Path 2: Periodic trigger (bypasses idle requirement — for debugging)
+                if (!idleResult.isIdle && sleepConfig.trigger_mode === 'periodic') {
+                    if (heartbeatCounter >= sleepConfig.period_heartbeats) {
+                        logger?.info?.(`[PD:EvolutionWorker] Periodic trigger: heartbeatCounter=${heartbeatCounter} >= period_heartbeats=${sleepConfig.period_heartbeats}`);
+                        shouldTrySleepReflection = true;
+                        heartbeatCounter = 0; // Reset counter
+                    } else {
+                        logger?.info?.(`[PD:EvolutionWorker] Periodic: ${heartbeatCounter}/${sleepConfig.period_heartbeats} heartbeats — waiting`);
+                    }
+                }
+
+                if (shouldTrySleepReflection) {
+                    const cooldown = checkCooldown(wctx.stateDir, undefined, {
+                        maxRunsPerWindow: sleepConfig.max_runs_per_day,
+                        quotaWindowMs: 24 * 60 * 60 * 1000,
+                    });
+                    logger?.info?.(`[PD:EvolutionWorker] Cooldown check: globalCooldownActive=${cooldown.globalCooldownActive} quotaExhausted=${cooldown.quotaExhausted} runsRemaining=${cooldown.runsRemaining}`);
                     if (!cooldown.globalCooldownActive && !cooldown.quotaExhausted) {
+                        logger?.info?.('[PD:EvolutionWorker] Attempting to enqueue sleep_reflection task...');
                         enqueueSleepReflectionTask(wctx, logger).catch((err) => {
                             logger?.error?.(`[PD:EvolutionWorker] Failed to enqueue sleep_reflection task: ${String(err)}`);
                         });
+                    } else {
+                        logger?.info?.(`[PD:EvolutionWorker] Skipping sleep_reflection: globalCooldown=${cooldown.globalCooldownActive} quotaExhausted=${cooldown.quotaExhausted}`);
                     }
-                } else {
-                    logger?.debug?.(`[PD:EvolutionWorker] Workspace active (last activity ${idleResult.idleForMs}ms ago)`);
                 }
 
                 const painCheckResult = await checkPainFlag(wctx, logger);

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -430,7 +430,7 @@ export const LOCK_RETRY_DELAY_MS = 50;
 export const LOCK_STALE_MS = 30_000;
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 export function createEvolutionTaskId(
     source: string,
     score: number,
@@ -464,7 +464,7 @@ export async function acquireQueueLock(resourcePath: string, logger: PluginLogge
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 async function requireQueueLock(resourcePath: string, logger: PluginLogger | { warn?: (message: string) => void; info?: (message: string) => void } | undefined, scope: string, lockSuffix: string = EVOLUTION_QUEUE_LOCK_SUFFIX): Promise<() => void> {
     try {
         return await acquireQueueLock(resourcePath, logger, lockSuffix);
@@ -480,7 +480,7 @@ export function extractEvolutionTaskId(task: string): string | null {
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 function findRecentDuplicateTask(
     queue: EvolutionQueueItem[],
     source: string,
@@ -489,14 +489,14 @@ function findRecentDuplicateTask(
     reason?: string
 ): EvolutionQueueItem | undefined {
      
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+     
     const key = normalizePainDedupKey(source, preview, reason);
     return queue.find((task) => {
         if (task.status === 'completed') return false;
         const taskTime = new Date(task.enqueued_at || task.timestamp).getTime();
         if (!Number.isFinite(taskTime) || (now - taskTime) > PAIN_QUEUE_DEDUP_WINDOW_MS) return false;
          
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+         
         return normalizePainDedupKey(task.source, task.trigger_text_preview || '', task.reason) === key;
     });
 }
@@ -550,7 +550,7 @@ function normalizePainDedupKey(source: string, preview: string, reason?: string)
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 export function hasRecentDuplicateTask(queue: EvolutionQueueItem[], source: string, preview: string, now: number, reason?: string): boolean {
     return !!findRecentDuplicateTask(queue, source, preview, now, reason);
 }
@@ -678,7 +678,7 @@ function shouldSkipForDedup(
  * Load and migrate the evolution queue. Returns empty array if file doesn't exist.
  */
 function loadEvolutionQueue(queuePath: string): EvolutionQueueItem[] {
-    // eslint-disable-next-line no-useless-assignment
+     
     let rawQueue: RawQueueItem[] = [];
     try {
         rawQueue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
@@ -692,7 +692,7 @@ function loadEvolutionQueue(queuePath: string): EvolutionQueueItem[] {
 /**
  * Build and persist a new sleep_reflection task.
  */
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 function enqueueNewSleepReflectionTask(
     queue: EvolutionQueueItem[],
     recentPainContext: ReturnType<typeof readRecentPainContext>,
@@ -764,7 +764,7 @@ interface ParsedPainValues {
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 async function doEnqueuePainTask(
     wctx: WorkspaceContext, logger: PluginLogger, painFlagPath: string,
     result: WorkerStatusReport['pain_flag'], v: ParsedPainValues,
@@ -1011,7 +1011,7 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogger, eventLog: EventLog, api?: OpenClawPluginApi) {
     const queuePath = wctx.resolve('EVOLUTION_QUEUE');
     if (!fs.existsSync(queuePath)) {
@@ -1609,13 +1609,13 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                         logger?.info?.(`[PD:EvolutionWorker] Processing sleep_reflection task ${sleepTask.id}`);
                     }
 
-                    // eslint-disable-next-line @typescript-eslint/init-declarations
+                     
                     let workflowId: string | undefined;
                      
-                    // eslint-disable-next-line @typescript-eslint/init-declarations
+                     
                     let nocturnalManager: NocturnalWorkflowManager;
                      
-                    // eslint-disable-next-line @typescript-eslint/init-declarations
+                     
                     let snapshotData: NocturnalSessionSnapshot | undefined;
 
                     if (isPollingTask) {
@@ -1653,13 +1653,13 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                                     s => s.failureCount > 0 || s.painEventCount > 0 || s.gateBlockCount > 0
                                 );
                                 if (sessionsWithViolations.length > 0) {
-                                    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+                                     
                                     const targetSession = sessionsWithViolations[0];
                                     logger?.info?.(`[PD:EvolutionWorker] Task ${sleepTask.id} using session with violations: ${targetSession.sessionId} (failed=${targetSession.failureCount}, pain=${targetSession.painEventCount}, gates=${targetSession.gateBlockCount})`);
                                     fullSnapshot = extractor.getNocturnalSessionSnapshot(targetSession.sessionId);
                                 } else if (recentSessions.length > 0) {
                                     // No sessions with violations, use most recent as last resort
-                                    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+                                     
                                     const latestSession = recentSessions[0];
                                     logger?.warn?.(`[PD:EvolutionWorker] Task ${sleepTask.id} no sessions with violations found, using most recent: ${latestSession.sessionId} (failed=${latestSession.failureCount}, pain=${latestSession.painEventCount}, gates=${latestSession.gateBlockCount})`);
                                     fullSnapshot = extractor.getNocturnalSessionSnapshot(latestSession.sessionId);
@@ -1726,7 +1726,7 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                             },
                         });
                         sleepTask.resultRef = workflowHandle.workflowId;
-                        // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+                         
                         workflowId = workflowHandle.workflowId;
                     }
 
@@ -1959,7 +1959,7 @@ async function processDetectionQueue(wctx: WorkspaceContext, api: OpenClawPlugin
 // Evolution queue is now the single active pain→principle path
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 export async function registerEvolutionTaskSession(
     workspaceResolve: (key: string) => string,
     taskId: string,
@@ -1973,7 +1973,7 @@ export async function registerEvolutionTaskSession(
 
     try {
          
-        // eslint-disable-next-line @typescript-eslint/init-declarations
+         
         let rawQueue: RawQueueItem[];
         try {
             rawQueue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
@@ -2041,7 +2041,7 @@ function writeWorkerStatus(stateDir: string, report: WorkerStatusReport): void {
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 async function processEvolutionQueueWithResult(
     wctx: WorkspaceContext,
     logger: PluginLogger,

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -2087,6 +2087,14 @@ export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
     api: null,
 
     start(ctx: OpenClawPluginServiceContext): void {
+        // Guard: prevent duplicate starts (e.g., from health check + before_prompt_build race)
+        const existing = (EvolutionWorkerService as any)._started;
+        if (existing) {
+            ctx?.logger?.info?.(`[PD:EvolutionWorker] Already started, skipping duplicate call`);
+            return;
+        }
+        (EvolutionWorkerService as any)._started = true;
+
         const logger = ctx?.logger || console;
         const {api} = this;
         const workspaceDir = ctx?.workspaceDir;

--- a/packages/openclaw-plugin/src/service/nocturnal-config.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-config.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface SleepReflectionConfig {
+    /** Trigger mode: "idle" (default) or "periodic" */
+    trigger_mode: 'idle' | 'periodic';
+    /** In periodic mode, trigger every N heartbeat cycles */
+    period_heartbeats: number;
+    /** Minimum time between runs (ms) */
+    cooldown_ms: number;
+    /** Maximum runs per 24-hour window */
+    max_runs_per_day: number;
+    /** Whether sleep_reflection is enabled */
+    enabled: boolean;
+}
+
+export interface NocturnalConfig {
+    sleep_reflection?: Partial<SleepReflectionConfig>;
+}
+
+const DEFAULT_SLEEP_REFLECTION: SleepReflectionConfig = {
+    trigger_mode: 'idle',
+    period_heartbeats: 4,       // ~1 hour at 15-min heartbeat interval
+    cooldown_ms: 30 * 60 * 1000, // 30 minutes
+    max_runs_per_day: 3,
+    enabled: true,
+};
+
+const CONFIG_FILENAME = 'nocturnal-config.json';
+
+/**
+ * Resolve the nocturnal config file path.
+ */
+function resolveConfigPath(stateDir: string): string {
+    return path.join(stateDir, CONFIG_FILENAME);
+}
+
+/**
+ * Load nocturnal config from .state/nocturnal-config.json.
+ * Returns default config if file doesn't exist or is malformed.
+ */
+export function loadNocturnalConfig(stateDir: string): SleepReflectionConfig {
+    const configPath = resolveConfigPath(stateDir);
+    let fileConfig: NocturnalConfig = {};
+
+    if (fs.existsSync(configPath)) {
+        try {
+            const raw = fs.readFileSync(configPath, 'utf8');
+            fileConfig = JSON.parse(raw);
+        } catch {
+            // Malformed config — continue with defaults
+        }
+    }
+
+    const fileSleep = fileConfig.sleep_reflection || {};
+
+    return {
+        trigger_mode: fileSleep.trigger_mode === 'periodic' ? 'periodic' : DEFAULT_SLEEP_REFLECTION.trigger_mode,
+        period_heartbeats: typeof fileSleep.period_heartbeats === 'number' && fileSleep.period_heartbeats > 0
+            ? fileSleep.period_heartbeats
+            : DEFAULT_SLEEP_REFLECTION.period_heartbeats,
+        cooldown_ms: typeof fileSleep.cooldown_ms === 'number' && fileSleep.cooldown_ms >= 0
+            ? fileSleep.cooldown_ms
+            : DEFAULT_SLEEP_REFLECTION.cooldown_ms,
+        max_runs_per_day: typeof fileSleep.max_runs_per_day === 'number' && fileSleep.max_runs_per_day > 0
+            ? fileSleep.max_runs_per_day
+            : DEFAULT_SLEEP_REFLECTION.max_runs_per_day,
+        enabled: typeof fileSleep.enabled === 'boolean'
+            ? fileSleep.enabled
+            : DEFAULT_SLEEP_REFLECTION.enabled,
+    };
+}

--- a/packages/openclaw-plugin/src/service/nocturnal-target-selector.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-target-selector.ts
@@ -474,7 +474,10 @@ export class NocturnalTargetSelector {
             toolName: gb.toolName,
             reason: gb.reason,
           })),
-          userCorrections: [],
+          // #268: Use actual correction samples from snapshot instead of empty array
+          userCorrections: snapshot.userCorrections.map((uc) => ({
+            correctionCue: uc.correctionCue ?? undefined,
+          })),
           planApprovals: [],
         });
         hasViolation = violationResult.violated;


### PR DESCRIPTION
## Problem

Before this fix, **only the default workspace (workspace-main) had an EvolutionWorker running**. All other agents (builder, pm, hr, research, verification, repair, resource-scout) had their pain signals completely ignored.

Each agent has its own heartbeat task and its own workspace. But EvolutionWorker was only started once with the default workspace.

## Fix

**Per-workspace EvolutionWorker startup** in  hook:

- When any agent triggers , start a dedicated EvolutionWorker for that agent's 
- Each worker independently monitors its own  and processes its own 
-  Set prevents duplicate workers for the same workspace

## Changes
- **index.ts** (2 files changed):
  -  at module level
  - Per-workspace EvolutionWorker start in  hook
- **evolution-worker.ts**:
  -  on EvolutionWorkerService
  - Per-workspace guard in  instead of global singleton guard

## Expected Effect
- main heartbeat → EvolutionWorker monitors workspace-main
- builder heartbeat → EvolutionWorker monitors workspace-builder
- pm heartbeat → EvolutionWorker monitors workspace-pm
- Each worker only sees its own workspace's data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user correction tracking for nocturnal sleep reflection sessions.
  * Implemented configurable sleep reflection triggering modes (idle-based and periodic-based).
  * Enhanced evolution worker lifecycle with per-workspace startup management and deduplication.

* **Documentation**
  * Added troubleshooting guide for evolution worker startup issues.
  * Updated memory snapshot with core architecture details and debugging lessons.

* **Developer Experience**
  * Applied TypeScript linting rule optimizations across codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->