### PR TITLE
fix: atomic queue writes to prevent data loss on crash

### DIFF
--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -35,6 +35,15 @@ import { readPainFlagContract } from '../core/pain.js';
 const WORKFLOW_TTL_MS = 5 * 60 * 1000; // 5 minutes default TTL for helper workflows
 import { OpenClawTrinityRuntimeAdapter } from '../core/nocturnal-trinity.js';
 
+/**
+ * Atomic file write — write to temp then rename to prevent partial writes on crash.
+ */
+function atomicWriteFileSync(filePath: string, data: string): void {
+  const tmpPath = filePath + '.tmp';
+  fs.writeFileSync(tmpPath, data, 'utf8');
+  fs.renameSync(tmpPath, filePath);
+}
+
 // ── Workflow Watchdog ────────────────────────────────────────────────────────
 // Detects stale/orphaned workflows, invalid results, and cleanup failures.
 // Runs every heartbeat cycle, catching bugs like:
@@ -492,7 +501,7 @@ function findRecentDuplicateTask(
     const key = normalizePainDedupKey(source, preview, reason);
     return queue.find((task) => {
         if (task.status === 'completed') return false;
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+         
         const taskTime = new Date(task.enqueued_at || task.timestamp).getTime();
         if (!Number.isFinite(taskTime) || (now - taskTime) > PAIN_QUEUE_DEDUP_WINDOW_MS) return false;
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -678,7 +687,7 @@ function shouldSkipForDedup(
  * Load and migrate the evolution queue. Returns empty array if file doesn't exist.
  */
 function loadEvolutionQueue(queuePath: string): EvolutionQueueItem[] {
-    // eslint-disable-next-line @typescript-eslint/init-declarations, no-useless-assignment
+    // eslint-disable-next-line no-useless-assignment
     let rawQueue: RawQueueItem[] = [];
     try {
         rawQueue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
@@ -720,7 +729,7 @@ function enqueueNewSleepReflectionTask(
         recentPainContext,
     });
 
-    fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2), 'utf8');
+    atomicWriteFileSync(queuePath, JSON.stringify(queue, null, 2));
     logger?.info?.(`[PD:EvolutionWorker] Enqueued sleep_reflection task ${taskId}`);
 }
 
@@ -811,7 +820,7 @@ async function doEnqueuePainTask(
             retryCount: 0, maxRetries: 3,
         });
 
-        fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2), 'utf8');
+        atomicWriteFileSync(queuePath, JSON.stringify(queue, null, 2));
         fs.appendFileSync(painFlagPath, `\nstatus: queued\ntask_id: ${taskId}\n`, 'utf8');
         result.enqueued = true;
 
@@ -1595,7 +1604,7 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
 
             // Write claimed state (includes any pain changes from above) and release lock
             if (queueChanged) {
-                fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2), 'utf8');
+                atomicWriteFileSync(queuePath, JSON.stringify(queue, null, 2));
             }
             releaseLock();
             for (const sleepTask of sleepReflectionTasks) {
@@ -1847,7 +1856,7 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                             freshQueue[idx] = sleepTask;
                         }
                     }
-                    fs.writeFileSync(queuePath, JSON.stringify(freshQueue, null, 2), 'utf8');
+                    atomicWriteFileSync(queuePath, JSON.stringify(freshQueue, null, 2));
 
                     // Log completions to EvolutionLogger
                     for (const sleepTask of sleepReflectionTasks) {
@@ -1879,7 +1888,7 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
         }
 
         if (queueChanged) {
-            fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2), 'utf8');
+            atomicWriteFileSync(queuePath, JSON.stringify(queue, null, 2));
         }
 
         // Pipeline observability: log stage-level summary at end of cycle
@@ -1997,7 +2006,7 @@ export async function registerEvolutionTaskSession(
         if (!task.started_at) {
             task.started_at = new Date().toISOString();
         }
-        fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2), 'utf8');
+        atomicWriteFileSync(queuePath, JSON.stringify(queue, null, 2));
         return true;
     } finally {
         releaseLock();
@@ -2037,7 +2046,7 @@ interface WorkerStatusReport {
 function writeWorkerStatus(stateDir: string, report: WorkerStatusReport): void {
     try {
         const statusPath = path.join(stateDir, 'worker-status.json');
-        fs.writeFileSync(statusPath, JSON.stringify(report, null, 2), 'utf8');
+        atomicWriteFileSync(statusPath, JSON.stringify(report, null, 2));
     } catch {
         // Non-critical: worker-status.json is for monitoring, failure is acceptable
     }
@@ -2066,7 +2075,7 @@ async function processEvolutionQueueWithResult(
         const purgeResult = purgeStaleFailedTasks(queue, logger);
         if (purgeResult.purged > 0) {
             // Write back the cleaned queue
-            fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2), 'utf8');
+            atomicWriteFileSync(queuePath, JSON.stringify(queue, null, 2));
         }
 
         queueResult.total = queue.length;

--- a/packages/openclaw-plugin/src/service/nocturnal-service.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-service.ts
@@ -103,6 +103,15 @@ import { getPrincipleState, setPrincipleState } from '../core/principle-training
 import type { Implementation } from '../types/principle-tree-schema.js';
 import { validateNocturnalSnapshotIngress } from '../core/nocturnal-snapshot-contract.js';
 
+/**
+ * Atomic file write — write to temp then rename to prevent partial writes on crash.
+ */
+function atomicWriteFileSync(filePath: string, data: string): void {
+  const tmpPath = filePath + '.tmp';
+  fs.writeFileSync(tmpPath, data, 'utf8');
+  fs.renameSync(tmpPath, filePath);
+}
+
 // ---------------------------------------------------------------------------
 // #251: Sync trainingStore sample counts after registration
 // ---------------------------------------------------------------------------
@@ -385,7 +394,7 @@ function persistArtifact(
     fs.mkdirSync(dir, { recursive: true });
   }
 
-  fs.writeFileSync(artifactPath, JSON.stringify(sampleRecord, null, 2), 'utf-8');
+  atomicWriteFileSync(artifactPath, JSON.stringify(sampleRecord, null, 2));
   return artifactPath;
 }
 


### PR DESCRIPTION
## Summary

**Problem**: `evolution-worker.ts` had 7 `fs.writeFileSync` calls writing EVOLUTION_QUEUE directly. On crash (OOM/SIGKILL) the JSON file gets partially written → empty queue on next startup → silent data loss of all pending tasks.

**Fix**: Replace all queue/status writes with atomic pattern:
```typescript
const tmpPath = filePath + '.tmp';
fs.writeFileSync(tmpPath, data, 'utf8');
fs.renameSync(tmpPath, filePath);
```

**Files changed**:
- `packages/openclaw-plugin/src/service/evolution-worker.ts` — 8 atomic replacements (7× queuePath + 1× statusPath)
- `packages/openclaw-plugin/src/service/nocturnal-service.ts` — 1 atomic replacement (artifact write)

**Verification**: `npx tsc --noEmit` → source files 0 errors ✅

Closes #293