### PR TITLE
fix(pain-diagnosis): 30min timeout + diagnostician_timeout resolution + 4 unit tests

### DIFF
--- a/PAIN_DIAGNOSIS_FIX_PLAN.md
+++ b/PAIN_DIAGNOSIS_FIX_PLAN.md
@@ -101,8 +101,12 @@ if (painCheckResult.enqueued) {
 
 ## 验证清单
 
-- [ ] P1: 超时清理生效，30 分钟后的卡住任务被标记为 failed
-- [ ] P2: 双 store 状态一致，不再有分裂
-- [ ] P3: agent 繁忙时 wake layer 自动重试，诊断任务最终被执行
-- [ ] CI: tsc-plugin + Lint 全部通过
-- [ ] E2E: 创建 PR 并合并到 main
+- [x] P1: 超时清理生效，30 分钟后的卡住任务被标记为 completed + `diagnostician_timeout`
+- [x] P1: `.diagnostician_report_*.json` 文件在超时时被自动清理
+- [x] P1: sleep_reflection 超时保持 60 分钟默认值，resolution = `failed_max_retries`
+- [x] P1: 单元测试 4 个用例全部通过 (evolution-worker.timeout.test.ts)
+- [x] P3: `requestHeartbeatNow` 替代 `runHeartbeatOnce`，日志确认 `available: true` + `Heartbeat wake requested`
+- [x] Watchdog 重构为 3 个子函数 (CheckStale, CheckUncleared, CheckNocturnal)
+- [x] CI: tsc-plugin + Lint 全部通过 (0 errors)
+- [x] E2E: 运行时注入 61 分钟陈旧任务，确认超时机制正确触发
+- [ ] P2: 统一状态源（待后续实现 — 双 store 分裂根治）

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,7 +16,7 @@
 
 ---
 
-# Principles Disciple: 进化智能体框架 (v1.10.27)
+# Principles Disciple: 进化智能体框架 (v1.10.28)
 
 > **可进化编程智能体框架 (Evolutionary Programming Agent Framework)**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "principles-disciple-monorepo",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "principles-disciple-monorepo",
-      "version": "1.10.27",
+      "version": "1.10.28",
       "workspaces": [
         "packages/*"
       ],
@@ -12837,7 +12837,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "principles-disciple",
-      "version": "1.10.27",
+      "version": "1.10.28",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "principles-disciple-monorepo",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "description": "Principles Disciple - OpenClaw Plugin Monorepo",
   "private": true,
   "type": "module",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "principles-disciple",
   "name": "Principles Disciple",
   "description": "Evolutionary programming agent framework with strategic guardrails and reflection loops.",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "skills": [
     "./skills"
   ],
@@ -76,8 +76,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "15c19a4dc3f2",
-    "bundleMd5": "684e47fd5c521d722150a93813fddd02",
-    "builtAt": "2026-04-14T03:01:11.396Z"
+    "gitSha": "cab0dbd8e6e7",
+    "bundleMd5": "1505a7119addd2ee24059f2473cdb1ca",
+    "builtAt": "2026-04-14T10:58:07.896Z"
   }
 }

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "principles-disciple",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "description": "Native OpenClaw plugin for Principles Disciple",
   "type": "module",
   "main": "./dist/bundle.js",

--- a/packages/openclaw-plugin/src/core/evolution-logger.ts
+++ b/packages/openclaw-plugin/src/core/evolution-logger.ts
@@ -260,16 +260,16 @@ export class EvolutionLogger {
   logCompleted(params: {
     traceId: string;
     taskId: string;
-    resolution: 'marker_detected' | 'auto_completed_timeout' | 'manual' | 'late_marker_principle_created' | 'late_marker_no_principle';
+    resolution: 'marker_detected' | 'auto_completed_timeout' | 'manual' | 'late_marker_principle_created' | 'late_marker_no_principle' | 'diagnostician_timeout';
     durationMs?: number;
     principlesGenerated?: number;
   }): void {
      
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let summary: string;
     if (params.resolution === 'marker_detected' || params.resolution === 'late_marker_principle_created') {
       summary = `任务 ${params.taskId} 完成，已生成 ${params.principlesGenerated || 0} 条原则`;
-    } else if (params.resolution === 'auto_completed_timeout' || params.resolution === 'late_marker_no_principle') {
+    } else if (params.resolution === 'auto_completed_timeout' || params.resolution === 'diagnostician_timeout' || params.resolution === 'late_marker_no_principle') {
       summary = `任务 ${params.taskId} 超时自动完成`;
     } else {
       summary = `任务 ${params.taskId} 已完成`;

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -56,7 +56,7 @@ interface WatchdogResult {
   details: string[];
 }
 
-// eslint-disable-next-line complexity
+ 
 async function runWorkflowWatchdog(
   wctx: WorkspaceContext,
   api: OpenClawPluginApi | null,
@@ -98,7 +98,7 @@ async function runWorkflowWatchdog(
 
 // ── Watchdog helpers (extracted from runWorkflowWatchdog for complexity) ──
 
-// eslint-disable-next-line complexity
+ 
 async function cleanupStaleWorkflowSession(
   wf: WorkflowRow,
   subagentRuntime: { deleteSession: (opts: { sessionKey: string; deleteTranscript: boolean }) => Promise<void> } | undefined,
@@ -174,7 +174,7 @@ function runWorkflowWatchdogCheckUncleared(allWorkflows: WorkflowRow[], details:
   }
 }
 
-// eslint-disable-next-line complexity
+ 
 function runWorkflowWatchdogCheckNocturnal(allWorkflows: WorkflowRow[], details: string[]): void {
   for (const wf of allWorkflows) {
     if (wf.workflow_type !== 'nocturnal' || wf.state !== 'completed') continue;
@@ -208,7 +208,12 @@ let timeoutId: NodeJS.Timeout | null = null;
  * Old queue items (without taskKind) are migrated to pain_diagnosis for compatibility.
  */
 export type QueueStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'canceled';
-export type TaskResolution = 'marker_detected' | 'auto_completed_timeout' | 'failed_max_retries' | 'runtime_unavailable' | 'canceled' | 'late_marker_principle_created' | 'late_marker_no_principle' | 'stub_fallback' | 'skipped_thin_violation';
+export type TaskResolution = 'marker_detected' | 'auto_completed_timeout' | 'failed_max_retries' | 'runtime_unavailable' | 'canceled' | 'late_marker_principle_created' | 'late_marker_no_principle' | 'stub_fallback' | 'skipped_thin_violation' | 'diagnostician_timeout';
+
+/** Timeout for pain_diagnosis tasks (30 min) — separate from sleep_reflection timeout.
+ *  Pain diagnostics run via HEARTBEAT (main session LLM), not as a subagent.
+ *  If the agent is persistently busy, we don't want the task to starve indefinitely. */
+const PAIN_DIAGNOSIS_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Recent pain context attached to sleep_reflection tasks.
@@ -370,7 +375,7 @@ function isSessionAtOrBeforeTriggerTime(
     return true;
 }
 
-// eslint-disable-next-line complexity
+ 
 function buildFallbackNocturnalSnapshot(
     sleepTask: EvolutionQueueItem,
     extractor?: ReturnType<typeof createNocturnalTrajectoryExtractor> | null,
@@ -782,7 +787,7 @@ interface ParsedPainValues {
 
  
  
-// eslint-disable-next-line complexity
+ 
 async function doEnqueuePainTask(
     wctx: WorkspaceContext, logger: PluginLogger, painFlagPath: string,
     result: WorkerStatusReport['pain_flag'], v: ParsedPainValues,
@@ -856,7 +861,7 @@ async function doEnqueuePainTask(
     return result;
 }
 
-// eslint-disable-next-line complexity
+ 
 async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Promise<WorkerStatusReport['pain_flag']> {
     const result: WorkerStatusReport['pain_flag'] = { exists: false, score: null, source: null, enqueued: false, skipped_reason: null };
     try {
@@ -1031,7 +1036,7 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
 
  
  
-// eslint-disable-next-line complexity
+ 
 async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogger, eventLog: EventLog, api?: OpenClawPluginApi) {
     const queuePath = wctx.resolve('EVOLUTION_QUEUE');
     if (!fs.existsSync(queuePath)) {
@@ -1309,8 +1314,8 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
             }
 
             const age = Date.now() - startedAt.getTime();
-            if (age > timeout) {
-                const timeoutMinutes = Math.round(timeout / 60000);
+            if (age > PAIN_DIAGNOSIS_TIMEOUT_MS) {
+                const timeoutMinutes = Math.round(PAIN_DIAGNOSIS_TIMEOUT_MS / 60000);
 
                 const timeoutCompleteMarker = path.join(wctx.stateDir, `.evolution_complete_${task.id}`);
                 const timeoutReportPath = path.join(wctx.stateDir, `.diagnostician_report_${task.id}.json`);
@@ -1358,13 +1363,13 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                     } catch { /* report may not exist, not critical */ }
                     task.resolution = principleCreated ? 'late_marker_principle_created' : 'late_marker_no_principle';
                 } else {
-                    if (logger) logger.info(`[PD:EvolutionWorker] Task ${task.id} auto-completed after ${timeoutMinutes} minute timeout`);
+                    if (logger) logger.info(`[PD:EvolutionWorker] Pain diagnosis task ${task.id} timed out after ${timeoutMinutes} minutes`);
                     // #190: Clean up diagnostician report file even on timeout (may have been written late)
                     try {
                         const autoTimeoutReportPath = path.join(wctx.stateDir, `.diagnostician_report_${task.id}.json`);
                         if (fs.existsSync(autoTimeoutReportPath)) fs.unlinkSync(autoTimeoutReportPath);
                     } catch { /* report may not exist, not critical */ }
-                    task.resolution = 'auto_completed_timeout';
+                    task.resolution = 'diagnostician_timeout';
                 }
 
                 // Critical: mark task as completed so it doesn't get re-processed
@@ -1390,7 +1395,7 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                     sessionId: task.assigned_session_key || 'heartbeat:diagnostician',
                     taskId: task.id,
                     outcome: 'timeout',
-                    summary: `Task ${task.id} auto-completed after ${timeoutMinutes} minute timeout.`
+                    summary: `Pain diagnosis task ${task.id} timed out after ${timeoutMinutes} minutes.`
                 });
                 queueChanged = true;
             }
@@ -1925,7 +1930,7 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
 }
 
      
-// eslint-disable-next-line complexity
+ 
 async function processDetectionQueue(wctx: WorkspaceContext, api: OpenClawPluginApi, eventLog: EventLog) {
     const {logger} = api;
     try {
@@ -2113,7 +2118,7 @@ export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
     api: null,
     _startedWorkspaces: new Set<string>(),
 
-    // eslint-disable-next-line complexity
+     
     start(ctx: OpenClawPluginServiceContext): void {
         const workspaceDir = ctx?.workspaceDir;
         const logger = ctx?.logger || console;
@@ -2150,7 +2155,7 @@ export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
         // Periodic trigger tracking
         let heartbeatCounter = 0;
 
-        // eslint-disable-next-line complexity
+         
         async function runCycle(): Promise<void> {
             const cycleStart = Date.now();
             heartbeatCounter++;

--- a/packages/openclaw-plugin/tests/service/evolution-worker.timeout.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-worker.timeout.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('../../src/core/dictionary-service.js', () => ({
+  DictionaryService: {
+    get: vi.fn(() => ({ flush: vi.fn() })),
+  },
+}));
+
+vi.mock('../../src/core/session-tracker.js', () => ({
+  initPersistence: vi.fn(),
+  flushAllSessions: vi.fn(),
+  listSessions: vi.fn(() => []),
+}));
+
+const { mockStartWorkflow, mockGetWorkflowDebugSummary } = vi.hoisted(() => ({
+  mockStartWorkflow: vi.fn(),
+  mockGetWorkflowDebugSummary: vi.fn(),
+}));
+
+vi.mock('../../src/service/subagent-workflow/nocturnal-workflow-manager.js', () => ({
+  NocturnalWorkflowManager: class {
+    startWorkflow = mockStartWorkflow;
+    getWorkflowDebugSummary = mockGetWorkflowDebugSummary;
+  },
+  nocturnalWorkflowSpec: {
+    workflowType: 'nocturnal',
+    transport: 'runtime_direct',
+    timeoutMs: 15 * 60 * 1000,
+    ttlMs: 30 * 60 * 1000,
+  },
+}));
+
+const { mockGetNocturnalSessionSnapshot, mockListRecentNocturnalCandidateSessions } = vi.hoisted(() => ({
+  mockGetNocturnalSessionSnapshot: vi.fn(),
+  mockListRecentNocturnalCandidateSessions: vi.fn(() => []),
+}));
+
+vi.mock('../../src/core/nocturnal-trajectory-extractor.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/core/nocturnal-trajectory-extractor.js')>(
+    '../../src/core/nocturnal-trajectory-extractor.js'
+  );
+  return {
+    ...actual,
+    createNocturnalTrajectoryExtractor: vi.fn(() => ({
+      getNocturnalSessionSnapshot: mockGetNocturnalSessionSnapshot,
+      listRecentNocturnalCandidateSessions: mockListRecentNocturnalCandidateSessions,
+    })),
+  };
+});
+
+import { EvolutionWorkerService } from '../../src/service/evolution-worker.js';
+import { safeRmDir } from '../test-utils.js';
+
+function createMockApi() {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    runtime: {
+      agent: { runEmbeddedPiAgent: vi.fn() },
+      system: {
+        requestHeartbeatNow: vi.fn(),
+        runHeartbeatOnce: vi.fn(),
+      },
+    },
+  } as any;
+}
+
+// Poll every 100ms for fast test execution
+const fastPollConfig = { get: (k: string) => k === 'intervals.worker_poll_ms' ? 100 : undefined };
+
+function readQueue(stateDir: string) {
+  return JSON.parse(fs.readFileSync(path.join(stateDir, 'evolution_queue.json'), 'utf8'));
+}
+
+describe('EvolutionWorkerService timeout mechanisms', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    EvolutionWorkerService.api = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    EvolutionWorkerService.api = null;
+  });
+
+  // ── Pain diagnosis timeout (30 min) ──
+
+  it('times out pain_diagnosis task after 30 minutes → resolution = diagnostician_timeout', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-timeout-pain-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    // Create an in_progress pain_diagnosis task that started 31 minutes ago
+    const startedAt = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      path.join(stateDir, 'evolution_queue.json'),
+      JSON.stringify([
+        {
+          id: 'timeout-test-30min',
+          taskKind: 'pain_diagnosis',
+          priority: 'high',
+          score: 90,
+          source: 'tool_failure',
+          reason: 'Test timeout mechanism',
+          timestamp: startedAt,
+          enqueued_at: startedAt,
+          status: 'in_progress',
+          session_id: 'test',
+          agent_id: 'main',
+          started_at: startedAt,
+          assigned_session_key: 'heartbeat:diagnostician:timeout-test-30min',
+          retryCount: 0,
+          maxRetries: 3,
+          task: 'Diagnose systemic pain [ID: timeout-test-30min]',
+        },
+      ], null, 2),
+      'utf8'
+    );
+
+    const mockApi = createMockApi();
+    EvolutionWorkerService.api = mockApi;
+
+    try {
+      EvolutionWorkerService.start({
+        workspaceDir,
+        stateDir,
+        logger: mockApi.logger,
+        config: fastPollConfig,
+        api: mockApi,
+      } as any);
+
+      // Wait for the worker to process
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const queue = readQueue(stateDir);
+      const task = queue.find((t: any) => t.id === 'timeout-test-30min');
+
+      expect(task.status).toBe('completed');
+      expect(task.resolution).toBe('diagnostician_timeout');
+      expect(task.completed_at).toBeDefined();
+    } finally {
+      EvolutionWorkerService.stop!({ workspaceDir, stateDir, logger: console } as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  it('does not timeout pain_diagnosis task under 30 minutes', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-no-timeout-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    // Create an in_progress pain_diagnosis task that started 10 minutes ago
+    const startedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      path.join(stateDir, 'evolution_queue.json'),
+      JSON.stringify([
+        {
+          id: 'no-timeout-10min',
+          taskKind: 'pain_diagnosis',
+          priority: 'high',
+          score: 80,
+          source: 'human_intervention',
+          reason: 'Should not timeout yet',
+          timestamp: startedAt,
+          enqueued_at: startedAt,
+          status: 'in_progress',
+          session_id: 'test',
+          agent_id: 'main',
+          started_at: startedAt,
+          assigned_session_key: 'heartbeat:diagnostician:no-timeout-10min',
+          retryCount: 0,
+          maxRetries: 3,
+          task: 'Diagnose systemic pain [ID: no-timeout-10min]',
+        },
+      ], null, 2),
+      'utf8'
+    );
+
+    const mockApi = createMockApi();
+    EvolutionWorkerService.api = mockApi;
+
+    try {
+      EvolutionWorkerService.start({
+        workspaceDir,
+        stateDir,
+        logger: mockApi.logger,
+        config: fastPollConfig,
+        api: mockApi,
+      } as any);
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const queue = readQueue(stateDir);
+      const task = queue.find((t: any) => t.id === 'no-timeout-10min');
+
+      // Task should still be in_progress — not yet timed out
+      expect(task.status).toBe('in_progress');
+      expect(task.resolution).toBeUndefined();
+    } finally {
+      EvolutionWorkerService.stop!({ workspaceDir, stateDir, logger: console } as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  // ── Sleep reflection timeout (60 min default) ──
+
+  it('times out sleep_reflection task after 60 minutes → resolution = failed_max_retries', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-timeout-sleep-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(path.join(stateDir, 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+
+    // Create an in_progress sleep_reflection task that started 61 minutes ago
+    const startedAt = new Date(Date.now() - 61 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      path.join(stateDir, 'evolution_queue.json'),
+      JSON.stringify([
+        {
+          id: 'sleep-timeout-60min',
+          taskKind: 'sleep_reflection',
+          priority: 'medium',
+          score: 50,
+          source: 'nocturnal',
+          reason: 'Test sleep reflection timeout',
+          timestamp: startedAt,
+          enqueued_at: startedAt,
+          status: 'in_progress',
+          session_id: 'test',
+          agent_id: 'main',
+          started_at: startedAt,
+          resultRef: 'wf-sleep-timeout',
+          retryCount: 0,
+          maxRetries: 1,
+          recentPainContext: {
+            mostRecent: null,
+            recentPainCount: 0,
+            recentMaxPainScore: 0,
+          },
+        },
+      ], null, 2),
+      'utf8'
+    );
+
+    mockStartWorkflow.mockResolvedValue({
+      workflowId: 'wf-sleep-timeout',
+      childSessionKey: 'child-sleep',
+      state: 'terminal_error',
+    });
+    mockGetWorkflowDebugSummary.mockResolvedValue({
+      state: 'terminal_error',
+      metadata: {},
+      recentEvents: [{ reason: 'Test: simulating stuck sleep reflection', payload: {} }],
+    });
+
+    const mockApi = createMockApi();
+    EvolutionWorkerService.api = mockApi;
+
+    try {
+      EvolutionWorkerService.start({
+        workspaceDir,
+        stateDir,
+        logger: mockApi.logger,
+        config: fastPollConfig,
+        api: mockApi,
+      } as any);
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const queue = readQueue(stateDir);
+      const task = queue.find((t: any) => t.id === 'sleep-timeout-60min');
+
+      expect(task.status).toBe('failed');
+      expect(task.resolution).toBe('failed_max_retries');
+      expect(task.completed_at).toBeDefined();
+    } finally {
+      EvolutionWorkerService.stop!({ workspaceDir, stateDir, logger: console } as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  // ── Report file cleanup on timeout ──
+
+  it('cleans up .diagnostician_report_*.json file on pain_diagnosis timeout', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-timeout-cleanup-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    // Create a stale diagnostician report file
+    const reportPath = path.join(stateDir, '.diagnostician_report_timeout-cleanup.json');
+    fs.writeFileSync(reportPath, JSON.stringify({ test: 'stale report' }), 'utf8');
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    // Create an in_progress pain_diagnosis task that started 31 minutes ago
+    const startedAt = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      path.join(stateDir, 'evolution_queue.json'),
+      JSON.stringify([
+        {
+          id: 'timeout-cleanup',
+          taskKind: 'pain_diagnosis',
+          priority: 'high',
+          score: 70,
+          source: 'tool_failure',
+          reason: 'Test report cleanup on timeout',
+          timestamp: startedAt,
+          enqueued_at: startedAt,
+          status: 'in_progress',
+          session_id: 'test',
+          agent_id: 'main',
+          started_at: startedAt,
+          assigned_session_key: 'heartbeat:diagnostician:timeout-cleanup',
+          retryCount: 0,
+          maxRetries: 3,
+          task: 'Diagnose systemic pain [ID: timeout-cleanup]',
+        },
+      ], null, 2),
+      'utf8'
+    );
+
+    const mockApi = createMockApi();
+    EvolutionWorkerService.api = mockApi;
+
+    try {
+      EvolutionWorkerService.start({
+        workspaceDir,
+        stateDir,
+        logger: mockApi.logger,
+        config: fastPollConfig,
+        api: mockApi,
+      } as any);
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Verify the report file was cleaned up
+      expect(fs.existsSync(reportPath)).toBe(false);
+
+      // Verify the task was marked as completed with timeout resolution
+      const queue = readQueue(stateDir);
+      const task = queue.find((t: any) => t.id === 'timeout-cleanup');
+      expect(task.status).toBe('completed');
+      expect(task.resolution).toBe('diagnostician_timeout');
+    } finally {
+      EvolutionWorkerService.stop!({ workspaceDir, stateDir, logger: console } as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+});


### PR DESCRIPTION
## 问题

PR #305 的 P1 修复方案指定 pain_diagnosis 任务使用 **30 分钟**超时 + `resolution: 'diagnostician_timeout'`，但实际实现使用了 **60 分钟**共享超时 + `resolution: 'auto_completed_timeout'`。

## 改动

### 核心修复
- 新增 `PAIN_DIAGNOSIS_TIMEOUT_MS = 30 * 60 * 1000` 独立常量
- pain_diagnosis 超时判断改用专属常量，不再与 sleep_reflection 共用
- resolution 改为 `'diagnostician_timeout'`，提升可观测性
- evolution-logger.ts 类型定义同步更新

### 测试覆盖 (新建 evolution-worker.timeout.test.ts)
| # | 测试用例 | 验证目标 |
|---|---------|---------|
| 1 | pain_diagnosis 30 分钟超时 → diagnostician_timeout | 核心修复 |
| 2 | pain_diagnosis <30 分钟不超时 | 不误杀正常任务 |
| 3 | sleep_reflection 60 分钟超时 → failed_max_retries | 回归验证 |
| 4 | 超时自动清理 .diagnostician_report_*.json | 资源泄漏防护 |

### 验证
- ✅ tsc: 0 errors
- ✅ lint: 0 errors (仅已有 warning)
- ✅ tests: 4/4 通过 + 18/18 回归通过
- ✅ E2E: 运行时注入 61 分钟陈旧任务，超时机制正确触发