### PR TITLE
chore: mark v1.16 milestone shipped in planning docs

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,14 +7,14 @@
 - [x] **v1.13** - Boundary Contract Hardening (Phases 19-23, shipped 2026-04-11) - [Archive](milestones/v1.13/v1.13-ROADMAP.md)
 - [x] **v1.14** - Evolution Worker Decomposition & Contract Hardening (Phases 24-29, baseline complete on branch `fix/bugs-231-228` / PR #245)
 - [x] **v1.15** - Runtime & Truth Contract Hardening (Phases 30-33, shipped 2026-04-12)
-- [x] **v1.16** - Trinity Training Trajectory Quality Enhancement (Phases 34-37, shipped 2026-04-13)
+- [x] **v1.16** - Trinity Training Trajectory Quality Enhancement (Phases 34-37, shipped 2026-04-14)
 - [ ] **v1.10** - Thinking Models page optimization (deferred)
 
 ## Phases
 
 **Phase Numbering:**
 - Integer phases (30-33): v1.15 Runtime & Truth Contract Hardening (shipped)
-- Integer phases (34-37): v1.16 Trinity Training Trajectory Quality Enhancement (current)
+- Integer phases (34-37): v1.16 Trinity Training Trajectory Quality Enhancement (shipped 2026-04-14)
 - Decimal phases: Urgent insertions (marked with INSERTED)
 
 <details>
@@ -33,14 +33,14 @@
 
 </details>
 
-### v1.16 Trinity Training Trajectory Quality Enhancement (In Progress)
+### v1.16 Trinity Training Trajectory Quality Enhancement (SHIPPED 2026-04-14)
 
 **Milestone Goal:** Improve Nocturnal Trinity pipeline's training artifact quality through Dreamer diversity, runtime reasoning derivation, Philosopher multi-dimension evaluation, and Scribe contrastive analysis.
 
-- [x] **Phase 34: Reasoning Deriver Module** - Build leaf module for runtime reasoning derivation from existing snapshot data (completed 2026-04-13)
-- [x] **Phase 35: Dreamer Enhancement** - Enhance Dreamer prompt for candidate diversity with deriver integration and soft post-validation (completed 2026-04-13)
-- [x] **Phase 36: Philosopher 6D Evaluation** - Expand Philosopher evaluation to 6 dimensions with risk assessment (completed 2026-04-13)
-- [x] **Phase 37: Scribe Contrastive Analysis** - Add contrastive analysis to Scribe output with backward-compatible optional fields (completed 2026-04-13)
+- [x] **Phase 34: Reasoning Deriver Module** - Build leaf module for runtime reasoning derivation from existing snapshot data (completed 2026-04-14)
+- [x] **Phase 35: Dreamer Enhancement** - Enhance Dreamer prompt for candidate diversity with deriver integration and soft post-validation (completed 2026-04-14)
+- [x] **Phase 36: Philosopher 6D Evaluation** - Expand Philosopher evaluation to 6 dimensions with risk assessment (completed 2026-04-14)
+- [x] **Phase 37: Scribe Contrastive Analysis** - Add contrastive analysis to Scribe output with backward-compatible optional fields (completed 2026-04-14)
 
 ## Phase Details
 
@@ -111,9 +111,9 @@ Phases execute in numeric order: 34 -> 35 -> 36 -> 37
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 34. Reasoning Deriver Module | v1.16 | 2/2 | Complete    | 2026-04-13 |
-| 35. Dreamer Enhancement | v1.16 | 2/2 | Complete    | 2026-04-13 |
-| 36. Philosopher 6D Evaluation | v1.16 | 2/2 | Complete    | 2026-04-13 |
-| 37. Scribe Contrastive Analysis | v1.16 | 1/1 | Complete    | 2026-04-13 |
+| 34. Reasoning Deriver Module | v1.16 | 2/2 | Complete    | 2026-04-14 |
+| 35. Dreamer Enhancement | v1.16 | 2/2 | Complete    | 2026-04-14 |
+| 36. Philosopher 6D Evaluation | v1.16 | 2/2 | Complete    | 2026-04-14 |
+| 37. Scribe Contrastive Analysis | v1.16 | 1/1 | Complete    | 2026-04-14 |
 
-*Last updated: 2026-04-13*
+*Last updated: 2026-04-14*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,19 +1,19 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.14
-milestone_name: Keyword Learning Engine
-status: defining_requirements
+milestone: v1.16
+milestone_name: Trinity Training Trajectory Quality Enhancement
+status: shipped
 last_updated: "2026-04-14"
-last_activity: 2026-04-14
+last_activity: 2026-04-14 — Milestone v1.16 shipped
 progress:
-  total_phases: 0
-  completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
-  percent: 0
+  total_phases: 4
+  completed_phases: 4
+  total_plans: 7
+  completed_plans: 7
+  percent: 100
 ---
 
-# State: v1.14 Keyword Learning Engine
+# State: v1.16 Trinity Training Trajectory Quality Enhancement
 
 ## Project Reference
 
@@ -21,25 +21,26 @@ See `.planning/PROJECT.md` (updated 2026-04-14)
 
 **Core Value:** AI agents improve their own behavior through a structured evolution loop
 
-**Current Focus:** Defining requirements for v1.14
+**Current Focus:** Awaiting next milestone definition
 
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-04-14 — Milestone v1.14 started
+Milestone v1.16 shipped. All phases complete (4/4 phases, 7/7 plans).
 
-Progress: [░░░░░░░░░░] 0%
+Progress: [████████████████████] 100%
 
-## Accumulated Context
+## Accomplishments
 
-### Decisions
+- Reasoning Deriver Module (Phase 34): deriveReasoningChain, deriveDecisionPoints, deriveContextualFactors
+- Dreamer Enhancement (Phase 35): strategic perspectives, riskLevel, validateCandidateDiversity
+- Philosopher 6D Evaluation (Phase 36): 6-dimension scoring, risk assessment, backward compatibility
+- Scribe Contrastive Analysis (Phase 37): rejectedAnalysis, chosenJustification, contrastiveAnalysis
+- Keyword Learning Engine (PR #313): correction-cue-learner, CorrectionObserverWorkflow, trajectoryHistory
 
-Decisions are logged in PROJECT.md Key Decisions table.
+## Pending Todos
 
-### Pending Todos
+Next milestone not yet defined. Run `/gsd-new-milestone` to start.
 
-### Blockers/Concerns
+## Blockers/Concerns
 
-None for v1.14 scope
+None


### PR DESCRIPTION
## Summary

- ROADMAP.md: v1.16 shipped date corrected to 2026-04-14
- STATE.md: milestone status updated to shipped, progress 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档更新

* **Chores**
  * 更新v1.16里程碑状态为已发布（2026-04-14）
  * 记录完成的4个阶段（34-37）和7个计划
  * 更新项目状态文档至最新进度信息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->