### PR TITLE
fix(test): use threads pool for better-sqlite3 compatibility + test layering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
         working-directory: packages/openclaw-plugin
         run: npm run build:production
 
-  test-openclaw-plugin:
-    name: Test OpenClaw Plugin
+  test-openclaw-plugin-unit:
+    name: Test OpenClaw Plugin (unit)
     runs-on: ubuntu-latest
     needs: build-openclaw-plugin
     steps:
@@ -89,6 +89,26 @@ jobs:
         working-directory: packages/openclaw-plugin
         run: npm ci --ignore-scripts
 
-      - name: Run tests
+      - name: Run unit tests
         working-directory: packages/openclaw-plugin
-        run: npm test
+        run: npm run test:unit
+
+  test-openclaw-plugin-integration:
+    name: Test OpenClaw Plugin (integration)
+    runs-on: ubuntu-latest
+    needs: build-openclaw-plugin
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        working-directory: packages/openclaw-plugin
+        run: npm ci --ignore-scripts
+
+      - name: Run integration tests
+        working-directory: packages/openclaw-plugin
+        run: npm run test:integration

--- a/.planning/milestones/v1.16-REQUIREMENTS.md
+++ b/.planning/milestones/v1.16-REQUIREMENTS.md
@@ -100,4 +100,4 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 ---
 *Requirements defined: 2026-04-12*
-*Last updated: 2026-04-12 after roadmap creation*
+*Last updated: 2026-04-14 (archived with milestone)*

--- a/.planning/milestones/v1.16-REQUIREMENTS.md
+++ b/.planning/milestones/v1.16-REQUIREMENTS.md
@@ -1,0 +1,103 @@
+# Requirements Archive: v1.16 Trinity Training Trajectory Quality Enhancement
+
+**Archived:** 2026-04-14
+**Status:** SHIPPED
+
+For current requirements, see `.planning/REQUIREMENTS.md`.
+
+---
+
+# Requirements: v1.16 Trinity Training Trajectory Quality Enhancement
+
+**Defined:** 2026-04-12
+**Core Value:** AI agents improve their own behavior through a structured evolution loop. pain -> diagnosis -> principle -> gate -> active -> reflection -> training -> internalization
+
+## v1 Requirements
+
+Requirements for v1.16 milestone. Each maps to roadmap phases.
+
+### Dreamer Candidate Diversity
+
+- [ ] **DIVER-01**: Dreamer prompt includes strategic perspective requirements (conservative_fix / structural_improvement / paradigm_shift) with explicit anti-pattern warnings
+- [ ] **DIVER-02**: DreamerCandidate interface gains optional `riskLevel` ("low"|"medium"|"high") and `strategicPerspective` fields for backward-compatible schema evolution
+- [ ] **DIVER-03**: Post-generation `validateCandidateDiversity()` checks risk level diversity (Set.size >= 2) and keyword overlap similarity (reject at > 0.8)
+- [ ] **DIVER-04**: Diversity validation failures are logged as telemetry warnings with `diversityCheckPassed: false`, not hard gates — pipeline continues with best available candidate
+
+### Runtime Reasoning Derivation
+
+- [ ] **DERIV-01**: `deriveReasoningChain()` extracts thinking content (from `<thinking>` tags), uncertainty markers (3 regex patterns), and confidence signal (high/medium/low) from assistant turns
+- [ ] **DERIV-02**: `deriveDecisionPoints()` extracts before-context (last 500 chars), after-reflection (first 300 chars on failure), and confidence delta per tool call
+- [ ] **DERIV-03**: `deriveContextualFactors()` computes fileStructureKnown, errorHistoryPresent, userGuidanceAvailable, and timePressure from existing snapshot data
+- [ ] **DERIV-04**: Derived reasoning signals are injected into Dreamer prompt builder (reasoning chain + contextual factors) and Scribe prompt builder (decision points)
+
+### Philosopher Multi-Dimension Evaluation
+
+- [ ] **PHILO-01**: Philosopher prompt evaluates candidates across 6 dimensions with calibrated weights: Principle Alignment (0.20), Specificity (0.15), Actionability (0.15), Executability (0.15), Safety Impact (0.20), UX Impact (0.15)
+- [ ] **PHILO-02**: Philosopher output includes risk assessment per candidate: falsePositiveEstimate (0-1), implementationComplexity (low/medium/high), breakingChangeRisk (boolean)
+- [ ] **PHILO-03**: New PhilosopherJudgment fields (scores, risks) are optional — existing tournament scoring in nocturnal-candidate-scoring.ts continues unchanged
+
+### Scribe Contrastive Analysis
+
+- [ ] **SCRIBE-01**: Scribe generates rejectedAnalysis with whyRejected (mental model that led to mistake), warningSignals (observable caution triggers), correctiveThinking (correct reasoning path)
+- [ ] **SCRIBE-02**: Scribe generates chosenJustification with whyChosen (embodied principle), keyInsights (1-3 transferable insights), limitations (when approach doesn't apply)
+- [ ] **SCRIBE-03**: Scribe generates contrastiveAnalysis with criticalDifference (ONE key insight), decisionTrigger ("When X, do Y" pattern), preventionStrategy (systematic avoidance)
+- [ ] **SCRIBE-04**: ContrastiveAnalysis is optional on TrinityDraftArtifact — pre-enhancement artifacts export unchanged, backward compatible
+
+## v2 Requirements
+
+Deferred to future milestone. Tracked but not in current roadmap.
+
+### ORPO Export Integration
+
+- **SCRIBE-05**: ORPO export incorporates contrastive analysis into prompt (decisionTrigger), chosen (keyInsights), rejected (warningSignals), and rationale (criticalDifference) fields
+- **SCRIBE-06**: ORPO export validates contrastive analysis completeness before enrichment, falls back to base narrative gracefully
+
+### Advanced Features
+
+- **EXEC-01**: Execution feasibility validation — simulate whether betterDecision would prevent the observed error
+- **HIST-01**: Historical case retrieval — inject similar past artifacts into Dreamer prompt for pattern-based learning
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Snapshot schema changes | Design decision: runtime derivation preserves backward compatibility |
+| Nocturnal service orchestration changes | Deriver called from Trinity stage builders, not service layer |
+| Arbiter validation rule changes | New fields are optional; arbiter validates existing fields unchanged |
+| Stub implementation changes | New fields only used in real adapter path |
+| ORPO export integration (this milestone) | Deferred to v1.17 after contrastive analysis quality is validated |
+| Execution feasibility validation | P2 — deferred until Phase A/B results validated |
+| Historical case retrieval | P2 — deferred until Phase A/B results validated |
+| LLM prompt A/B testing framework | Valuable but not required for initial implementation |
+| Human feedback loop for artifacts | Valuable but orthogonal to pipeline quality |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| DIVER-01 | Phase 35 | Pending |
+| DIVER-02 | Phase 35 | Pending |
+| DIVER-03 | Phase 35 | Pending |
+| DIVER-04 | Phase 35 | Pending |
+| DERIV-01 | Phase 34 | Pending |
+| DERIV-02 | Phase 34 | Pending |
+| DERIV-03 | Phase 34 | Pending |
+| DERIV-04 | Phase 35 | Pending |
+| PHILO-01 | Phase 36 | Pending |
+| PHILO-02 | Phase 36 | Pending |
+| PHILO-03 | Phase 36 | Pending |
+| SCRIBE-01 | Phase 37 | Pending |
+| SCRIBE-02 | Phase 37 | Pending |
+| SCRIBE-03 | Phase 37 | Pending |
+| SCRIBE-04 | Phase 37 | Pending |
+
+**Coverage:**
+- v1 requirements: 15 total
+- Mapped to phases: 15
+- Unmapped: 0
+
+---
+*Requirements defined: 2026-04-12*
+*Last updated: 2026-04-12 after roadmap creation*

--- a/.planning/milestones/v1.16-ROADMAP.md
+++ b/.planning/milestones/v1.16-ROADMAP.md
@@ -4,7 +4,7 @@
 
 - [x] **v1.9.3** - Remaining lint stabilization (shipped 2026-04-09)
 - [x] **v1.12** - Nocturnal Production Stabilization (Phases 16-18, shipped 2026-04-10)
-- [x] **v1.13** - Boundary Contract Hardening (Phases 19-23, shipped 2026-04-11) - [Archive](milestones/v1.13/v1.13-ROADMAP.md)
+- [x] **v1.13** - Boundary Contract Hardening (Phases 19-23, shipped 2026-04-11) - [Archive](v1.13/v1.13-ROADMAP.md)
 - [x] **v1.14** - Evolution Worker Decomposition & Contract Hardening (Phases 24-29, baseline complete on branch `fix/bugs-231-228` / PR #245)
 - [x] **v1.15** - Runtime & Truth Contract Hardening (Phases 30-33, shipped 2026-04-12)
 - [x] **v1.16** - Trinity Training Trajectory Quality Enhancement (Phases 34-37, shipped 2026-04-13)
@@ -102,7 +102,7 @@ Plans:
 
 Plans:
 - [x] 37-01: TBD
-- [ ] 37-02: TBD
+- [x] 37-02: TBD
 
 ## Progress
 

--- a/.planning/milestones/v1.16-ROADMAP.md
+++ b/.planning/milestones/v1.16-ROADMAP.md
@@ -1,0 +1,119 @@
+# Roadmap: Principles Disciple
+
+## Milestones
+
+- [x] **v1.9.3** - Remaining lint stabilization (shipped 2026-04-09)
+- [x] **v1.12** - Nocturnal Production Stabilization (Phases 16-18, shipped 2026-04-10)
+- [x] **v1.13** - Boundary Contract Hardening (Phases 19-23, shipped 2026-04-11) - [Archive](milestones/v1.13/v1.13-ROADMAP.md)
+- [x] **v1.14** - Evolution Worker Decomposition & Contract Hardening (Phases 24-29, baseline complete on branch `fix/bugs-231-228` / PR #245)
+- [x] **v1.15** - Runtime & Truth Contract Hardening (Phases 30-33, shipped 2026-04-12)
+- [x] **v1.16** - Trinity Training Trajectory Quality Enhancement (Phases 34-37, shipped 2026-04-13)
+- [ ] **v1.10** - Thinking Models page optimization (deferred)
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (30-33): v1.15 Runtime & Truth Contract Hardening (shipped)
+- Integer phases (34-37): v1.16 Trinity Training Trajectory Quality Enhancement (current)
+- Decimal phases: Urgent insertions (marked with INSERTED)
+
+<details>
+<summary>Shipped milestones (Phases 1-33)</summary>
+
+- [x] **Phase 24: Queue Store Extraction** - Extract queue persistence, locking, and migration into EvolutionQueueStore with read/write contracts
+- [x] **Phase 25: Pain Flag Detector Extraction** - Extract pain flag detection into PainFlagDetector with entry-point validation (completed 2026-04-11)
+- [x] **Phase 26: Task Dispatcher Extraction** - Extract task dispatch and execution into EvolutionTaskDispatcher with entry-point validation
+- [x] **Phase 27: Workflow Orchestrator Extraction** - Extract workflow watchdog and lifecycle into WorkflowOrchestrator with entry-point validation
+- [x] **Phase 28: Context Builder + Service Slim + Fallback Audit** - Extract context building, slim the worker, and audit all 16 silent fallback points (completed 2026-04-11)
+- [x] **Phase 29: Integration Verification** - Verify end-to-end flow, public API preservation, test passing, and lifecycle correctness (completed 2026-04-11)
+- [x] **Phase 30: Runtime & Truth Contract Framing** - Create runtime/truth contract matrix, merge-gate checklist, and milestone framing (completed 2026-04-12)
+- [x] **Phase 31: Runtime Adapter Contract Hardening** - Contract embedded runtime invocation, model/provider resolution, fail-fast behavior (completed 2026-04-12)
+- [x] **Phase 32: Evidence-Bound Export and Dataset Hardening** - Harden export/dataset against fabricated facts (completed 2026-04-12)
+- [x] **Phase 33: Production Invariants and Merge-Gate Verification** - Invariant checks, merge-gate audit (completed 2026-04-12, audit=defer)
+
+</details>
+
+### v1.16 Trinity Training Trajectory Quality Enhancement (In Progress)
+
+**Milestone Goal:** Improve Nocturnal Trinity pipeline's training artifact quality through Dreamer diversity, runtime reasoning derivation, Philosopher multi-dimension evaluation, and Scribe contrastive analysis.
+
+- [x] **Phase 34: Reasoning Deriver Module** - Build leaf module for runtime reasoning derivation from existing snapshot data (completed 2026-04-13)
+- [x] **Phase 35: Dreamer Enhancement** - Enhance Dreamer prompt for candidate diversity with deriver integration and soft post-validation (completed 2026-04-13)
+- [x] **Phase 36: Philosopher 6D Evaluation** - Expand Philosopher evaluation to 6 dimensions with risk assessment (completed 2026-04-13)
+- [x] **Phase 37: Scribe Contrastive Analysis** - Add contrastive analysis to Scribe output with backward-compatible optional fields (completed 2026-04-13)
+
+## Phase Details
+
+### Phase 34: Reasoning Deriver Module
+**Goal**: Derived reasoning signals are available to Trinity pipeline stages without any snapshot schema changes
+**Depends on**: Nothing (leaf module, no downstream dependencies)
+**Requirements**: DERIV-01, DERIV-02, DERIV-03
+**Success Criteria** (what must be TRUE):
+  1. `deriveReasoningChain()` extracts thinking content (from `<thinking>` tags), uncertainty markers (3 regex patterns), and confidence signal (high/medium/low) from assistant turns in existing snapshot data
+  2. `deriveDecisionPoints()` extracts before-context (last 500 chars), after-reflection (first 300 chars on failure), and confidence delta per tool call from existing snapshot data
+  3. `deriveContextualFactors()` computes fileStructureKnown, errorHistoryPresent, userGuidanceAvailable, and timePressure from existing snapshot data
+  4. All three functions are pure TypeScript with zero new dependencies and handle edge cases (missing tags, empty turns, missing tool calls) gracefully
+**Plans**: TBD
+
+Plans:
+- [x] 34-01: TBD
+- [x] 34-02: TBD
+
+### Phase 35: Dreamer Enhancement
+**Goal**: Dreamer generates strategically diverse candidates with derived reasoning context, validated by soft diversity checks
+**Depends on**: Phase 34
+**Requirements**: DIVER-01, DIVER-02, DIVER-03, DIVER-04, DERIV-04
+**Success Criteria** (what must be TRUE):
+  1. Dreamer prompt includes strategic perspective requirements (conservative_fix / structural_improvement / paradigm_shift) with explicit anti-pattern warnings
+  2. DreamerCandidate interface has optional `riskLevel` ("low"|"medium"|"high") and `strategicPerspective` fields -- existing candidates without these fields continue to work
+  3. Derived reasoning signals (reasoning chain + contextual factors) are injected into the Dreamer prompt builder from the new deriver module
+  4. `validateCandidateDiversity()` checks risk level diversity (Set.size >= 2) and keyword overlap similarity (reject at > 0.8) on generated candidates
+  5. Diversity validation failures log telemetry warnings with `diversityCheckPassed: false` and do not hard-gate the pipeline -- best available candidate proceeds
+**Plans**: TBD
+
+Plans:
+- [x] 35-01: TBD
+- [x] 35-02: TBD
+
+### Phase 36: Philosopher 6D Evaluation
+**Goal**: Philosopher evaluates candidates across 6 calibrated dimensions with per-candidate risk assessment
+**Depends on**: Phase 35 (Dreamer produces strategic perspectives that Philosopher evaluates)
+**Requirements**: PHILO-01, PHILO-02, PHILO-03
+**Success Criteria** (what must be TRUE):
+  1. Philosopher prompt evaluates candidates across 6 dimensions with calibrated weights: Principle Alignment (0.20), Specificity (0.15), Actionability (0.15), Executability (0.15), Safety Impact (0.20), UX Impact (0.15)
+  2. Philosopher output includes risk assessment per candidate: falsePositiveEstimate (0-1), implementationComplexity (low/medium/high), breakingChangeRisk (boolean)
+  3. New PhilosopherJudgment fields (scores, risks) are optional -- existing tournament scoring in nocturnal-candidate-scoring.ts continues unchanged
+**Plans**: TBD
+
+Plans:
+- [x] 36-01: TBD
+- [x] 36-02: TBD
+
+### Phase 37: Scribe Contrastive Analysis
+**Goal**: Scribe produces contrastive analysis that distinguishes chosen vs rejected reasoning paths, enabling richer training signals
+**Depends on**: Phase 34 (decision points for rejected analysis), Phase 36 (6D judgments inform contrastive depth)
+**Requirements**: SCRIBE-01, SCRIBE-02, SCRIBE-03, SCRIBE-04
+**Success Criteria** (what must be TRUE):
+  1. Scribe generates rejectedAnalysis with whyRejected (mental model that led to mistake), warningSignals (observable caution triggers), and correctiveThinking (correct reasoning path)
+  2. Scribe generates chosenJustification with whyChosen (embodied principle), keyInsights (1-3 transferable insights), and limitations (when approach does not apply)
+  3. Scribe generates contrastiveAnalysis with criticalDifference (ONE key insight), decisionTrigger ("When X, do Y" pattern), and preventionStrategy (systematic avoidance)
+  4. ContrastiveAnalysis is optional on TrinityDraftArtifact -- pre-enhancement artifacts export unchanged and backward compatible
+**Plans**: TBD
+
+Plans:
+- [x] 37-01: TBD
+- [ ] 37-02: TBD
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 34 -> 35 -> 36 -> 37
+
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 34. Reasoning Deriver Module | v1.16 | 2/2 | Complete    | 2026-04-13 |
+| 35. Dreamer Enhancement | v1.16 | 2/2 | Complete    | 2026-04-13 |
+| 36. Philosopher 6D Evaluation | v1.16 | 2/2 | Complete    | 2026-04-13 |
+| 37. Scribe Contrastive Analysis | v1.16 | 1/1 | Complete    | 2026-04-13 |
+
+*Last updated: 2026-04-13*

--- a/packages/openclaw-plugin/.dependency-cruiser.json
+++ b/packages/openclaw-plugin/.dependency-cruiser.json
@@ -1,0 +1,19 @@
+{
+  "forbidden": [
+    {
+      "name": "no-circular",
+      "severity": "error",
+      "comment": "Cycles hurt maintainability and testability.",
+      "from": {},
+      "to": {
+        "circular": true
+      }
+    }
+  ],
+  "options": {
+    "tsPreCompilationDeps": true,
+    "enhancedResolveOptions": {
+      "extensions": [".ts", ".tsx", ".js", ".jsx", ".json"]
+    }
+  }
+}

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -30,10 +30,11 @@
     "build:web": "node scripts/build-web.mjs",
     "build:bundle": "node esbuild.config.js && node scripts/build-web.mjs",
     "build:production": "node esbuild.config.js --production && node scripts/build-web.mjs --production && node scripts/verify-build.mjs",
-    "test": "vitest run",
+    "test": "vitest run --project=unit",
     "test:unit": "vitest run --project=unit",
     "test:integration": "vitest run --project=integration",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --project=unit --coverage",
+    "test:all": "vitest run",
     "lint": "eslint src/",
     "bootstrap-rules": "node scripts/bootstrap-rules.mjs",
     "validate-live-path": "tsx scripts/validate-live-path.ts"

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -31,6 +31,8 @@
     "build:bundle": "node esbuild.config.js && node scripts/build-web.mjs",
     "build:production": "node esbuild.config.js --production && node scripts/build-web.mjs --production && node scripts/verify-build.mjs",
     "test": "vitest run",
+    "test:unit": "vitest run --project=unit",
+    "test:integration": "vitest run --project=integration",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "bootstrap-rules": "node scripts/bootstrap-rules.mjs",

--- a/packages/openclaw-plugin/src/config/defaults/runtime.ts
+++ b/packages/openclaw-plugin/src/config/defaults/runtime.ts
@@ -1,9 +1,51 @@
 /**
  * Centralized Runtime Defaults
- * 
+ *
  * All runtime-related constants that were previously scattered across modules.
  * Centralizing these makes it easier to tune behavior and understand limits.
  */
+
+// ── Time Constants ──────────────────────────────────────────────────────────────
+
+/** Milliseconds per second */
+export const MS_PER_SECOND = 1000;
+
+/** Seconds per minute */
+export const SECONDS_PER_MINUTE = 60;
+
+/** Minutes per hour */
+export const MINUTES_PER_HOUR = 60;
+
+/** Hours per day */
+export const HOURS_PER_DAY = 24;
+
+/** Days per week */
+export const DAYS_PER_WEEK = 7;
+
+/** One minute in milliseconds */
+export const ONE_MINUTE_MS = SECONDS_PER_MINUTE * MS_PER_SECOND;
+
+/** One hour in milliseconds */
+export const ONE_HOUR_MS = MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MS_PER_SECOND;
+
+/** One day in milliseconds */
+export const ONE_DAY_MS = HOURS_PER_DAY * ONE_HOUR_MS;
+
+/** One week in milliseconds */
+export const ONE_WEEK_MS = DAYS_PER_WEEK * ONE_DAY_MS;
+
+// ── Workflow TTL & Timeouts ────────────────────────────────────────────────────
+
+/** Default TTL for helper workflows (5 minutes) */
+export const WORKFLOW_TTL_MS = 5 * ONE_MINUTE_MS;
+
+/** Default workflow timeout (15 minutes) */
+export const WORKFLOW_TIMEOUT_MS = 15 * ONE_MINUTE_MS;
+
+/** Default workflow sweep interval (30 minutes) */
+export const WORKFLOW_SWEEP_MS = 30 * ONE_MINUTE_MS;
+
+// ── Trajectory Gate Block Retry Settings ──────────────────────────────────────
 
 /**
  * Trajectory gate block retry settings
@@ -12,40 +54,56 @@
 export const TRAJECTORY_GATE_BLOCK_RETRY_DELAY_MS = 250;
 export const TRAJECTORY_GATE_BLOCK_MAX_RETRIES = 3;
 
-/**
- * Thinking checkpoint defaults (P-10)
- */
-export const THINKING_CHECKPOINT_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+// ── Thinking Checkpoint Defaults (P-10) ───────────────────────────────────────
+
+export const THINKING_CHECKPOINT_WINDOW_MS = 5 * ONE_MINUTE_MS;
 export const THINKING_CHECKPOINT_DEFAULT_HIGH_RISK_TOOLS = [
   'run_shell_command',
-  'delete_file', 
+  'delete_file',
   'move_file',
 ] as const;
 
-/**
- * Large change threshold for GFI gate adjustments
- */
+// ── GFI Gate Thresholds ───────────────────────────────────────────────────────
+
+/** Large change threshold for GFI gate adjustments */
 export const GFI_LARGE_CHANGE_LINES = 50;
 
-/**
- * Agent spawn GFI threshold (critically high = no spawn)
- */
+/** Agent spawn GFI threshold (critically high = no spawn) */
 export const AGENT_SPAWN_GFI_THRESHOLD = 90;
 
-/**
- * Evolution worker polling intervals
- */
-export const EVOLUTION_WORKER_POLL_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+// ── Evolution Worker Settings ───────────────────────────────────────────────────
+
+/** Evolution worker polling interval (15 minutes) */
+export const EVOLUTION_WORKER_POLL_INTERVAL_MS = 15 * ONE_MINUTE_MS;
+
+/** Evolution queue batch size */
 export const EVOLUTION_QUEUE_BATCH_SIZE = 10;
 
-/**
- * Session tracker settings
- */
-export const SESSION_TOKEN_WARNING_THRESHOLD = 8000;
-export const SESSION_MAX_IDLE_MS = 30 * 60 * 1000; // 30 minutes
+/** Pain queue dedup window (30 minutes) */
+export const PAIN_QUEUE_DEDUP_WINDOW_MS = 30 * ONE_MINUTE_MS;
 
-/**
- * Event log buffer settings
- */
+// ── Session Tracker Settings ───────────────────────────────────────────────────
+
+export const SESSION_TOKEN_WARNING_THRESHOLD = 8000;
+export const SESSION_MAX_IDLE_MS = 30 * ONE_MINUTE_MS;
+
+// ── Event Log Buffer Settings ───────────────────────────────────────────────────
+
 export const EVENT_LOG_BUFFER_SIZE = 20;
-export const EVENT_LOG_FLUSH_INTERVAL_MS = 30 * 1000; // 30 seconds
+export const EVENT_LOG_FLUSH_INTERVAL_MS = 30 * ONE_MINUTE_MS;
+
+// ── Default Busy Timeout ───────────────────────────────────────────────────────
+
+/** Default busy timeout for SQLite operations (5 seconds) */
+export const DEFAULT_BUSY_TIMEOUT_MS = 5 * MS_PER_SECOND;
+
+// ── Nocturnal Runtime Settings ─────────────────────────────────────────────────
+
+/** Idle threshold (30 minutes) */
+export const DEFAULT_IDLE_THRESHOLD_MS = 30 * ONE_MINUTE_MS;
+
+/** Quota window (24 hours) */
+export const DEFAULT_QUOTA_WINDOW_MS = ONE_DAY_MS;
+
+/** Cool down period (30 minutes) */
+export const DEFAULT_COOLDOWN_MS = 30 * ONE_MINUTE_MS;

--- a/packages/openclaw-plugin/src/config/defaults/runtime.ts
+++ b/packages/openclaw-plugin/src/config/defaults/runtime.ts
@@ -107,3 +107,16 @@ export const DEFAULT_QUOTA_WINDOW_MS = ONE_DAY_MS;
 
 /** Cool down period (30 minutes) */
 export const DEFAULT_COOLDOWN_MS = 30 * ONE_MINUTE_MS;
+
+// ── String & Size Limits ────────────────────────────────────────────────────────
+
+/** Max string length for trajectory/event logs */
+export const MAX_STRING_LENGTH = 1000;
+
+/** Default max file size (10MB) */
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+// ── Workflow TTL Settings ───────────────────────────────────────────────────────
+
+/** Deep-reflect workflow TTL (10 minutes) */
+export const DEEP_REFLECT_TTL_MS = 10 * ONE_MINUTE_MS;

--- a/packages/openclaw-plugin/src/config/defaults/runtime.ts
+++ b/packages/openclaw-plugin/src/config/defaults/runtime.ts
@@ -120,3 +120,8 @@ export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
 /** Deep-reflect workflow TTL (10 minutes) */
 export const DEEP_REFLECT_TTL_MS = 10 * ONE_MINUTE_MS;
+
+// ── Time Window Constants ───────────────────────────────────────────────────────
+
+/** Two hours in milliseconds */
+export const TWO_HOURS_MS = 2 * ONE_HOUR_MS;

--- a/packages/openclaw-plugin/src/core/event-log.ts
+++ b/packages/openclaw-plugin/src/core/event-log.ts
@@ -23,30 +23,95 @@ import type { PluginLogger } from '../openclaw-sdk.js';
 
 /**
  * EventLog - Structured event logging with daily statistics aggregation.
+ *
+ * Log files are date-stamped: events_YYYY-MM-DD.jsonl
+ * Old event files are automatically cleaned up based on retention policy.
  */
+
+/**
+ * Event log retention in days.
+ * Files older than this are deleted on cleanup.
+ */
+const EVENT_LOG_RETENTION_DAYS = 7;
+
 export class EventLog {
-  private readonly eventsFile: string;
+  private readonly logsDir: string;
   private readonly statsFile: string;
   private readonly logger?: PluginLogger;
-  
+
   private readonly statsCache: Map<string, DailyStats> = new Map();
   private eventBuffer: EventLogEntry[] = [];
   private readonly maxBufferSize = 20;
   private readonly flushIntervalMs = 30000;
   private flushTimer?: ReturnType<typeof setInterval>;
-  
+
+  // Cached event file path for current date
+  private currentEventsFile: string | undefined;
+  private currentDate: string | undefined;
+
   constructor(stateDir: string, logger?: PluginLogger) {
-    const logsDir = path.join(stateDir, 'logs');
-    if (!fs.existsSync(logsDir)) {
-      fs.mkdirSync(logsDir, { recursive: true });
+    this.logsDir = path.join(stateDir, 'logs');
+    if (!fs.existsSync(this.logsDir)) {
+      fs.mkdirSync(this.logsDir, { recursive: true });
     }
-    
-    this.eventsFile = path.join(logsDir, 'events.jsonl');
-    this.statsFile = path.join(logsDir, 'daily-stats.json');
+
+    this.statsFile = path.join(this.logsDir, 'daily-stats.json');
     this.logger = logger;
-    
+
     this.loadStats();
     this.startFlushTimer();
+  }
+
+  /**
+   * Get the event file path for a given date.
+   */
+  private getEventsFile(date: string): string {
+    return path.join(this.logsDir, `events_${date}.jsonl`);
+  }
+
+  /**
+   * Get today's date string (YYYY-MM-DD).
+   */
+  private getTodayStr(): string {
+    return new Date().toISOString().split('T')[0];
+  }
+
+  /**
+   * Ensure we have the correct events file for today's date.
+   */
+  private ensureEventsFile(): string {
+    const today = this.getTodayStr();
+    if (this.currentDate !== today || !this.currentEventsFile) {
+      this.currentDate = today;
+      this.currentEventsFile = this.getEventsFile(today);
+      // Run cleanup if date changed
+      this.cleanupOldEventFiles(today);
+    }
+    return this.currentEventsFile;
+  }
+
+  /**
+   * Clean up event files older than EVENT_LOG_RETENTION_DAYS.
+   */
+  private cleanupOldEventFiles(today: string): void {
+    if (EVENT_LOG_RETENTION_DAYS <= 0) return;
+
+    try {
+      const cutoffMs = Date.now() - EVENT_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+      const files = fs.readdirSync(this.logsDir);
+
+      for (const file of files) {
+        if (!file.startsWith('events_') || !file.endsWith('.jsonl')) continue;
+
+        const filePath = path.join(this.logsDir, file);
+        const stat = fs.statSync(filePath);
+        if (stat.mtimeMs < cutoffMs) {
+          fs.unlinkSync(filePath);
+        }
+      }
+    } catch {
+      // Silently fail cleanup
+    }
   }
   
   recordToolCall(sessionId: string | undefined, data: ToolCallEventData): void {
@@ -108,7 +173,7 @@ export class EventLog {
   }
   
    
-  // eslint-disable-next-line @typescript-eslint/max-params
+   
   private record(
     type: EventType, 
     category: EventCategory, 
@@ -136,7 +201,7 @@ export class EventLog {
   }
 
    
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private formatDate(date: Date): string {
     return date.toISOString().split('T')[0];
   }
@@ -246,7 +311,7 @@ export class EventLog {
   }
 
    
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- complexity 13, refactor candidate
+     
   private getEventDedupKey(entry: EventLogEntry): string {
     const eventId = typeof (entry.data as { eventId?: unknown } | undefined)?.eventId === 'string'
       ? String((entry.data as { eventId?: string }).eventId)
@@ -268,10 +333,11 @@ export class EventLog {
   }
 
   private readPersistedEvents(): EventLogEntry[] {
-    if (!fs.existsSync(this.eventsFile)) return [];
+    const eventsFile = this.ensureEventsFile();
+    if (!fs.existsSync(eventsFile)) return [];
 
     try {
-      const content = fs.readFileSync(this.eventsFile, 'utf-8');
+      const content = fs.readFileSync(eventsFile, 'utf-8');
       return content
         .trim()
         .split('\n')
@@ -285,7 +351,7 @@ export class EventLog {
         })
         .filter((entry): entry is EventLogEntry => entry !== null);
     } catch (e) {
-      if (this.logger) this.logger.error(`[PD] Failed to read events.jsonl: ${String(e)}`);
+      if (this.logger) this.logger.error(`[PD] Failed to read events file: ${String(e)}`);
       return [];
     }
   }
@@ -300,13 +366,14 @@ export class EventLog {
 
   private flushEvents(): void {
     if (this.eventBuffer.length === 0) return;
-    
+
+    const eventsFile = this.ensureEventsFile();
     const lines = this.eventBuffer.map(e => JSON.stringify(e)).join('\n') + '\n';
     try {
-      fs.appendFileSync(this.eventsFile, lines, 'utf-8');
+      fs.appendFileSync(eventsFile, lines, 'utf-8');
       this.eventBuffer = [];
     } catch (e) {
-      if (this.logger) this.logger.error(`[PD] Failed to flush events.jsonl: ${String(e)}`);
+      if (this.logger) this.logger.error(`[PD] Failed to flush events: ${String(e)}`);
     }
   }
 
@@ -464,7 +531,7 @@ export class EventLog {
    * Returns the rolled back score, or 0 if event not found.
    */
    
-  // eslint-disable-next-line @typescript-eslint/max-params
+   
   rollbackEmpathyEvent(eventId: string, sessionId: string | undefined, reason: string, triggeredBy: 'user_command' | 'natural_language' | 'system'): number {
     const allEvents = this.getMergedEvents();
     let foundEvent: { entry: EventLogEntry; data: PainSignalEventData } | null = null;

--- a/packages/openclaw-plugin/src/core/nocturnal-candidate-scoring.ts
+++ b/packages/openclaw-plugin/src/core/nocturnal-candidate-scoring.ts
@@ -23,7 +23,7 @@
  * PHASE 6 ONLY — No real training, no automatic deployment
  */
 
-import type { DreamerCandidate, PhilosopherJudgment } from './nocturnal-trinity.js';
+import type { DreamerCandidate, PhilosopherJudgment } from './nocturnal-trinity-types.js';
 import type { ThresholdValues } from './adaptive-thresholds.js';
 
 // ---------------------------------------------------------------------------
@@ -293,7 +293,7 @@ export function validateCandidateDiversity(
 
   for (let i = 0; i < candidates.length; i++) {
     for (let j = i + 1; j < candidates.length; j++) {
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+       
       const overlap = computeKeywordOverlap(
         candidates[i].betterDecision ?? '',
         candidates[j].betterDecision ?? '',
@@ -335,9 +335,9 @@ export function validateCandidateDiversity(
  * Returns value between 0 and 1.
  */
 function computeKeywordOverlap(textA: string, textB: string): number {
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+   
   const wordsA = extractKeywords(textA);
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+   
   const wordsB = extractKeywords(textB);
 
   if (wordsA.length === 0 && wordsB.length === 0) return 0;
@@ -376,7 +376,7 @@ function extractKeywords(text: string): string[] {
  * @returns All scored and ranked candidates
  */
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 export function rankCandidates(
   candidates: DreamerCandidate[],
   judgments: PhilosopherJudgment[],
@@ -464,7 +464,7 @@ export function rankCandidates(
  * @returns Tournament result with winner
  */
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 export function runTournament(
   candidates: DreamerCandidate[],
   judgments: PhilosopherJudgment[],

--- a/packages/openclaw-plugin/src/core/nocturnal-trinity-types.ts
+++ b/packages/openclaw-plugin/src/core/nocturnal-trinity-types.ts
@@ -1,0 +1,94 @@
+/**
+ * Nocturnal Trinity Shared Types
+ *
+ * Types shared between nocturnal-trinity.ts and nocturnal-candidate-scoring.ts.
+ * Extracted to break circular dependency.
+ */
+
+// ---------------------------------------------------------------------------
+// Dreamer Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Individual candidate from Dreamer (alternative decision).
+ * Each candidate represents an alternative "better decision" approach.
+ */
+export interface DreamerCandidate {
+  /** Unique index for this candidate within the Dreamer output */
+  candidateIndex: number;
+  /** The bad decision this candidate addresses */
+  badDecision: string;
+  /** The alternative/better decision */
+  betterDecision: string;
+  /** Why this alternative is better (brief) */
+  rationale: string;
+  /** Confidence that this candidate is valid (0-1) */
+  confidence: number;
+  /** Risk level of this candidate's approach -- LLM-judged per D-02 */
+  riskLevel?: "low" | "medium" | "high";
+  /** Which strategic perspective this candidate embodies per D-01 */
+  strategicPerspective?: "conservative_fix" | "structural_improvement" | "paradigm_shift";
+}
+
+export interface DreamerOutput {
+  /** Whether Dreamer succeeded */
+  valid: boolean;
+  /** List of candidate corrections */
+  candidates: DreamerCandidate[];
+  /** Why Dreamer could not generate (if valid === false) */
+  reason?: string;
+  /** Timestamp of generation */
+  generatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Philosopher Types
+// ---------------------------------------------------------------------------
+
+export interface PhilosopherRiskAssessment {
+  /** Estimated probability that this candidate is a false positive (0-1) */
+  falsePositiveEstimate: number;
+  /** How complex is this candidate to implement */
+  implementationComplexity: 'low' | 'medium' | 'high';
+  /** Whether implementing this candidate risks breaking existing functionality */
+  breakingChangeRisk: boolean;
+}
+
+export interface Philosopher6DScores {
+  principleAlignment: number;
+  specificity: number;
+  actionability: number;
+  executability: number;
+  safetyImpact: number;
+  uxImpact: number;
+}
+
+export interface PhilosopherJudgment {
+  /** Index of the judged candidate (references DreamerCandidate.candidateIndex) */
+  candidateIndex: number;
+  /** Principle-grounded critique of this candidate */
+  critique: string;
+  /** Whether this candidate aligns with the target principle */
+  principleAligned: boolean;
+  /** Ranking score (higher = better, 0-1) */
+  score: number;
+  /** Rank among all candidates (1 = best) */
+  rank: number;
+  /** Per-dimension scores (6D evaluation) — informational, not used for tournament ranking */
+  scores?: Philosopher6DScores;
+  /** Risk assessment for this candidate — informational, consumed by Scribe (Phase 37) */
+  risks?: PhilosopherRiskAssessment;
+}
+
+export interface PhilosopherOutput {
+  /** Whether Philosopher succeeded */
+  valid: boolean;
+  /** Judgments for each candidate */
+  judgments: PhilosopherJudgment[];
+  /** Overall assessment of the candidate set */
+  overallAssessment: string;
+  /** Why Philosopher could not judge (if valid === false) */
+  reason?: string;
+  /** Timestamp of generation */
+  generatedAt: string;
+}

--- a/packages/openclaw-plugin/src/core/nocturnal-trinity.ts
+++ b/packages/openclaw-plugin/src/core/nocturnal-trinity.ts
@@ -584,7 +584,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
     this.cleanupStaleTempDirs();
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   isRuntimeAvailable(): boolean {
     return true;
   }
@@ -682,7 +682,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
   /**
    * Extract text from runEmbeddedPiAgent result.
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private extractPayloadText(result: { payloads?: { isError?: boolean; text?: string }[] }): string {
     return (result.payloads ?? [])
       .filter(p => !p.isError)
@@ -692,13 +692,13 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
   }
 
   /** Clamp a value to [0, 1] range — used for LLM-produced scores that may be out of range */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private clamp01(val: unknown, fallback = 0): number {
     if (typeof val !== 'number' || !Number.isFinite(val)) return fallback;
     return Math.min(1, Math.max(0, val));
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private classifyRuntimeError(error: unknown): TrinityRuntimeFailureCode {
     const detail = error instanceof Error ? error.message : String(error);
     return /timeout/i.test(detail) ? 'runtime_timeout' : 'runtime_run_failed';
@@ -797,7 +797,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
   }
 
 
-  // eslint-disable-next-line @typescript-eslint/max-params
+   
   async invokeScribe(
     dreamerOutput: DreamerOutput,
     philosopherOutput: PhilosopherOutput,
@@ -865,7 +865,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
   // ---------------------------------------------------------------------------
 
    
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private buildDreamerPrompt(
     snapshot: NocturnalSessionSnapshot,
     principleId: string,
@@ -962,7 +962,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
   }
 
    
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private buildPhilosopherPrompt(
     dreamerOutput: DreamerOutput,
     principleId: string,
@@ -1048,7 +1048,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
  
 
    
-  // eslint-disable-next-line @typescript-eslint/max-params, @typescript-eslint/class-methods-use-this
+   
   private buildScribePrompt(
     dreamerOutput: DreamerOutput,
     philosopherOutput: PhilosopherOutput,
@@ -1262,7 +1262,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
               implementationComplexity: (risks.implementationComplexity as string) ?? 'medium',
               breakingChangeRisk: Boolean(risks.breakingChangeRisk),
             };
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+             
             if (hasFp) risksObj.falsePositiveEstimate = this.clamp01(fp as number);
             return { risks: risksObj };
           })() : {}),
@@ -1306,7 +1306,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
   }
 
    
-  // eslint-disable-next-line @typescript-eslint/max-params
+   
   private parseScribeOutput(
     text: string,
     snapshot: NocturnalSessionSnapshot,
@@ -1375,7 +1375,7 @@ export class OpenClawTrinityRuntimeAdapter implements TrinityRuntimeAdapter {
    * Extract JSON object from text that may contain markdown code blocks.
    */
    
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+   
   private extractJson(text: string): string | null {
     // Try direct parse first
     try {
@@ -1470,89 +1470,25 @@ export interface TrinityConfig {
 // Trinity Intermediate Contracts
 // ---------------------------------------------------------------------------
 
-/**
- * Dreamer output — multiple candidate corrections.
- * Each candidate represents an alternative "better decision" approach.
- */
-export interface DreamerCandidate {
-  /** Unique index for this candidate within the Dreamer output */
-  candidateIndex: number;
-  /** The bad decision this candidate addresses */
-  badDecision: string;
-  /** The alternative/better decision */
-  betterDecision: string;
-  /** Why this alternative is better (brief) */
-  rationale: string;
-  /** Confidence that this candidate is valid (0-1) */
-  confidence: number;
-  /** Risk level of this candidate's approach -- LLM-judged per D-02 */
-  riskLevel?: "low" | "medium" | "high";
-  /** Which strategic perspective this candidate embodies per D-01 */
-  strategicPerspective?: "conservative_fix" | "structural_improvement" | "paradigm_shift";
-}
+// Forward-exports from shared types module — single source of truth
+export type {
+  DreamerCandidate,
+  DreamerOutput,
+  PhilosopherRiskAssessment,
+  Philosopher6DScores,
+  PhilosopherJudgment,
+  PhilosopherOutput,
+} from './nocturnal-trinity-types.js';
 
-export interface DreamerOutput {
-  /** Whether Dreamer succeeded */
-  valid: boolean;
-  /** List of candidate corrections */
-  candidates: DreamerCandidate[];
-  /** Why Dreamer could not generate (if valid === false) */
-  reason?: string;
-  /** Timestamp of generation */
-  generatedAt: string;
-}
-
-/**
- * Philosopher output — principle-grounded critique and ranking.
- * Philosopher evaluates Dreamer's candidates and ranks them.
- */
-export interface PhilosopherRiskAssessment {
-  /** Estimated probability that this candidate is a false positive (0-1) */
-  falsePositiveEstimate: number;
-  /** How complex is this candidate to implement */
-  implementationComplexity: 'low' | 'medium' | 'high';
-  /** Whether implementing this candidate risks breaking existing functionality */
-  breakingChangeRisk: boolean;
-}
-
-export interface Philosopher6DScores {
-  principleAlignment: number;
-  specificity: number;
-  actionability: number;
-  executability: number;
-  safetyImpact: number;
-  uxImpact: number;
-}
-
-export interface PhilosopherJudgment {
-  /** Index of the judged candidate (references DreamerCandidate.candidateIndex) */
-  candidateIndex: number;
-  /** Principle-grounded critique of this candidate */
-  critique: string;
-  /** Whether this candidate aligns with the target principle */
-  principleAligned: boolean;
-  /** Ranking score (higher = better, 0-1) */
-  score: number;
-  /** Rank among all candidates (1 = best) */
-  rank: number;
-  /** Per-dimension scores (6D evaluation) — informational, not used for tournament ranking */
-  scores?: Philosopher6DScores;
-  /** Risk assessment for this candidate — informational, consumed by Scribe (Phase 37) */
-  risks?: PhilosopherRiskAssessment;
-}
-
-export interface PhilosopherOutput {
-  /** Whether Philosopher succeeded */
-  valid: boolean;
-  /** Judgments for each candidate */
-  judgments: PhilosopherJudgment[];
-  /** Overall assessment of the candidate set */
-  overallAssessment: string;
-  /** Why Philosopher could not judge (if valid === false) */
-  reason?: string;
-  /** Timestamp of generation */
-  generatedAt: string;
-}
+// Import all types for local use in this file
+import type {
+  DreamerCandidate,
+  DreamerOutput,
+  PhilosopherRiskAssessment,
+  Philosopher6DScores,
+  PhilosopherJudgment,
+  PhilosopherOutput,
+} from './nocturnal-trinity-types.js';
 
 /**
  * Analysis of a rejected candidate — why it lost the tournament.
@@ -1912,9 +1848,9 @@ export function invokeStubPhilosopher(
 
     // Deterministic 6D scores based on strategic perspective (Phase 35 D-07 mapping)
     const perspective = candidate.strategicPerspective;
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let sixDScores: Philosopher6DScores;
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let riskAssessment: PhilosopherRiskAssessment;
 
     if (perspective === 'conservative_fix') {
@@ -2014,7 +1950,7 @@ export function invokeStubPhilosopher(
  * The stub uses tournament selection (scoring + thresholds) to pick the winner.
  */
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 export function invokeStubScribe(
   dreamerOutput: DreamerOutput,
   philosopherOutput: PhilosopherOutput,
@@ -2093,7 +2029,7 @@ export function runTrinity(options: RunTrinityOptions): TrinityResult {
   // Stub path: use synchronous stub implementations
   if (config.useStubs) {
      
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+     
     return runTrinityWithStubs(snapshot, principleId, config);
   }
 
@@ -2133,7 +2069,7 @@ export async function runTrinityAsync(options: RunTrinityOptions): Promise<Trini
   if (config.useStubs) {
     // Stub path: use synchronous stubs
      
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+     
     return runTrinityWithStubs(snapshot, principleId, config);
   }
 

--- a/packages/openclaw-plugin/src/core/session-tracker.ts
+++ b/packages/openclaw-plugin/src/core/session-tracker.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import type { PainConfig } from './config.js';
 import { SystemLogger } from './system-logger.js';
+import { TWO_HOURS_MS } from '../config/defaults/runtime.js';
 
 export interface TokenUsage {
     input?: number;
@@ -84,7 +85,7 @@ export function initPersistence(stateDir: string): void {
     
     // Load all existing sessions
      
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+     
     loadAllSessions();
 }
 
@@ -107,7 +108,7 @@ function loadAllSessions(): void {
     try {
         const files = fs.readdirSync(persistDir).filter(f => f.endsWith('.json'));
         const now = Date.now();
-        const twoHoursAgo = now - 2 * 60 * 60 * 1000;
+        const twoHoursAgo = now - TWO_HOURS_MS;
         
         for (const file of files) {
             try {
@@ -182,7 +183,7 @@ export function flushAllSessions(): void {
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 function getOrCreateSession(sessionId: string, workspaceDir?: string, sessionKey?: string, trigger?: string): SessionState {
     let state = sessions.get(sessionId);
     if (!state) {
@@ -245,7 +246,7 @@ export function trackToolRead(sessionId: string, filePath: string, workspaceDir?
 }
 
  
-    // eslint-disable-next-line @typescript-eslint/max-params -- complexity 12, refactor candidate
+     
 export function trackLlmOutput(sessionId: string, usage: TokenUsage | undefined, config?: PainConfig, workspaceDir?: string, sessionKey?: string, trigger?: string): SessionState {
     const state = getOrCreateSession(sessionId, workspaceDir, sessionKey, trigger);
     state.llmTurns += 1;
@@ -285,7 +286,7 @@ export function trackLlmOutput(sessionId: string, usage: TokenUsage | undefined,
  * Tracks physical friction based on tool execution failures.
  */
  
-    // eslint-disable-next-line @typescript-eslint/max-params -- complexity 11, slightly over threshold
+     
 export function trackFriction(
     sessionId: string,
     deltaF: number,
@@ -552,7 +553,7 @@ export function decayGfi(sessionId: string, elapsedMinutes: number): SessionStat
     if (!state || state.currentGfi <= 0 || elapsedMinutes <= 0) return undefined;
     
     // Determine decay rate based on current GFI level (segmented)
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let decayRate: number;
     if (state.currentGfi >= 70) {
       decayRate = 0.03;  // 3%/min for severe friction

--- a/packages/openclaw-plugin/src/core/system-logger.ts
+++ b/packages/openclaw-plugin/src/core/system-logger.ts
@@ -1,35 +1,127 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { resolvePdPath } from './paths.js';
+import { resolvePdPath, PD_FILES } from './paths.js';
 
 /**
  * System Logger for Principles Disciple
- * Writes critical evolutionary events to the project's memory/logs/SYSTEM.log
+ *
+ * Writes critical evolutionary events to date-stamped log files:
+ *   memory/logs/SYSTEM_YYYY-MM-DD.log
+ *
  * Uses asynchronous writing to avoid blocking the Node.js event loop.
+ * Automatically rotates to a new file at midnight.
+ * Old log files are automatically cleaned up based on retention policy.
  */
+
+// Cache for current log file path, invalidated when date changes
+let cachedLogFile: string | undefined;
+let cachedLogDate: string | undefined;
+
+/**
+ * Log retention: delete SYSTEM logs older than this many days.
+ * Set to 0 to disable cleanup.
+ */
+const LOG_RETENTION_DAYS = 7;
+
+/**
+ * Get the system log file path for a given date.
+ * Format: memory/logs/SYSTEM_YYYY-MM-DD.log
+ */
+function getSystemLogPath(workspaceDir: string, date: Date): string {
+    const dateStr = date.toISOString().slice(0, 10); // YYYY-MM-DD
+    const logDir = path.dirname(resolvePdPath(workspaceDir, 'SYSTEM_LOG'));
+    const baseName = path.basename(PD_FILES.SYSTEM_LOG, '.log');
+    return path.join(logDir, `${baseName}_${dateStr}.log`);
+}
+
+/**
+ * Get today's date string (YYYY-MM-DD).
+ */
+function getTodayStr(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Clean up old SYSTEM log files, keeping only LOG_RETENTION_DAYS.
+ * Called automatically on first log write of each day.
+ */
+function cleanupOldLogs(workspaceDir: string): void {
+    if (LOG_RETENTION_DAYS <= 0) return;
+
+    try {
+        const logDir = path.dirname(resolvePdPath(workspaceDir, 'SYSTEM_LOG'));
+        const baseName = path.basename(PD_FILES.SYSTEM_LOG, '.log');
+        const prefix = `${baseName}_`;
+
+        if (!fs.existsSync(logDir)) return;
+
+        const cutoffMs = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+        const files = fs.readdirSync(logDir);
+
+        for (const file of files) {
+            if (!file.startsWith(prefix) || !file.endsWith('.log')) continue;
+
+            const filePath = path.join(logDir, file);
+            const stat = fs.statSync(filePath);
+            if (stat.mtimeMs < cutoffMs) {
+                fs.unlinkSync(filePath);
+            }
+        }
+    } catch {
+        // Silently fail cleanup - don't crash logging for cleanup failures
+    }
+}
+
+// Track if cleanup has run today
+let lastCleanupDate: string | undefined;
+
 export const SystemLogger = {
     log(workspaceDir: string | undefined, eventType: string, message: string): void {
         if (!workspaceDir) return;
-        
+
         try {
-            const logFile = resolvePdPath(workspaceDir, 'SYSTEM_LOG');
-            const logDir = path.dirname(logFile);
-            
-            if (!fs.existsSync(logDir)) {
-                fs.mkdirSync(logDir, { recursive: true });
+            const today = getTodayStr();
+
+            // Check if date changed - invalidate cache and run cleanup
+            if (cachedLogDate !== today) {
+                cachedLogDate = today;
+                cachedLogFile = undefined;
+                // Run cleanup once per day when date changes
+                if (lastCleanupDate !== today) {
+                    lastCleanupDate = today;
+                    cleanupOldLogs(workspaceDir);
+                }
             }
-            
+
+            // Get or create log file path
+            if (!cachedLogFile) {
+                cachedLogFile = getSystemLogPath(workspaceDir, new Date());
+                const logDir = path.dirname(cachedLogFile);
+                if (!fs.existsSync(logDir)) {
+                    fs.mkdirSync(logDir, { recursive: true });
+                }
+            }
+
             const timestamp = new Date().toISOString();
-            
+
             // Format: [YYYY-MM-DDTHH:mm:ss.sssZ] [EVENT_TYPE] Message
             const logEntry = `[${timestamp}] [${eventType.padEnd(15)}] ${message}\n`;
-            
+
             // Use fire-and-forget async append to prevent blocking
-            fs.appendFile(logFile, logEntry, 'utf8', (_err) => {  
+            fs.appendFile(cachedLogFile, logEntry, 'utf8', (_err) => {
                 // Silently drop errors (e.g. disk full) to not crash the gateway
             });
         } catch (e) { // eslint-disable-line @typescript-eslint/no-unused-vars -- Reason: intentionally unused - silently fail if we can't setup the log
             // Silently fail if we can't setup the log
         }
+    },
+
+    /**
+     * Force refresh of the cached log file path.
+     * Call this at midnight or when the date changes to ensure proper rotation.
+     */
+    refreshCache(): void {
+        cachedLogDate = undefined;
+        cachedLogFile = undefined;
     }
 };

--- a/packages/openclaw-plugin/src/core/workspace-dir-service.ts
+++ b/packages/openclaw-plugin/src/core/workspace-dir-service.ts
@@ -1,10 +1,5 @@
 import type { OpenClawPluginApi, PluginLogger } from '../openclaw-sdk.js';
-import { validateWorkspaceDir } from './workspace-dir-validation.js';
-
-export interface WorkspaceResolutionContext {
-  workspaceDir?: string;
-  agentId?: string;
-}
+import { validateWorkspaceDir, type WorkspaceResolutionContext } from './workspace-dir-validation.js';
 
 export interface WorkspaceResolutionOptions {
   source?: string;
@@ -82,4 +77,42 @@ export function resolveRequiredWorkspaceDir(
   options: Omit<WorkspaceResolutionOptions, 'required'> = {},
 ): string {
   return resolveWorkspaceDir(api, ctx, { ...options, required: true }) as string;
+}
+
+// Re-export helpers that live in workspace-dir-validation.ts for API compatibility
+export { validateWorkspaceDir } from './workspace-dir-validation.js';
+
+export function resolveValidWorkspaceDir(
+  ctx: WorkspaceResolutionContext,
+  api: {
+    runtime: { agent: { resolveAgentWorkspaceDir: (config: unknown, agentId: string) => string } };
+    config: unknown;
+    logger: PluginLogger;
+  },
+  options?: { source?: string; fallbackAgentId?: string },
+): string | undefined {
+  return resolveWorkspaceDir(api as never, ctx, {
+    source: options?.source,
+    fallbackAgentId: options?.fallbackAgentId,
+    logger: api.logger,
+  });
+}
+
+export function logWorkspaceDirHealth(
+  ctx: WorkspaceResolutionContext,
+  source: string,
+  api: {
+    runtime: { agent: { resolveAgentWorkspaceDir: (config: unknown, agentId: string) => string } };
+    config: unknown;
+    logger: PluginLogger;
+  },
+): void {
+  const resolved = resolveValidWorkspaceDir(ctx, api, { source, fallbackAgentId: 'main' });
+  const issue = validateWorkspaceDir(resolved);
+
+  if (issue) {
+    api.logger.error(`[PD:health] ${source}: workspaceDir="${resolved}" - ${issue}`);
+  } else {
+    api.logger.info(`[PD:health] ${source}: workspaceDir="${resolved}" OK`);
+  }
 }

--- a/packages/openclaw-plugin/src/core/workspace-dir-service.ts
+++ b/packages/openclaw-plugin/src/core/workspace-dir-service.ts
@@ -81,6 +81,7 @@ export function resolveRequiredWorkspaceDir(
 
 // Re-export helpers that live in workspace-dir-validation.ts for API compatibility
 export { validateWorkspaceDir } from './workspace-dir-validation.js';
+export type { WorkspaceResolutionContext } from './workspace-dir-validation.js';
 
 export function resolveValidWorkspaceDir(
   ctx: WorkspaceResolutionContext,

--- a/packages/openclaw-plugin/src/core/workspace-dir-validation.ts
+++ b/packages/openclaw-plugin/src/core/workspace-dir-validation.ts
@@ -6,8 +6,11 @@
  */
 
 import * as os from 'os';
-import type { PluginLogger } from '../openclaw-sdk.js';
-import { resolveWorkspaceDir, type WorkspaceResolutionContext } from './workspace-dir-service.js';
+
+export interface WorkspaceResolutionContext {
+  workspaceDir?: string;
+  agentId?: string;
+}
 
 export function validateWorkspaceDir(dir: string | undefined): string | null {
   if (!dir) {
@@ -37,39 +40,4 @@ export function validateWorkspaceDir(dir: string | undefined): string | null {
   }
 
   return null;
-}
-
-export function resolveValidWorkspaceDir(
-  ctx: WorkspaceResolutionContext,
-  api: {
-    runtime: { agent: { resolveAgentWorkspaceDir: (config: unknown, agentId: string) => string } };
-    config: unknown;
-    logger: PluginLogger;
-  },
-  options?: { source?: string; fallbackAgentId?: string },
-): string | undefined {
-  return resolveWorkspaceDir(api as never, ctx, {
-    source: options?.source,
-    fallbackAgentId: options?.fallbackAgentId,
-    logger: api.logger,
-  });
-}
-
-export function logWorkspaceDirHealth(
-  ctx: WorkspaceResolutionContext,
-  source: string,
-  api: {
-    runtime: { agent: { resolveAgentWorkspaceDir: (config: unknown, agentId: string) => string } };
-    config: unknown;
-    logger: PluginLogger;
-  },
-): void {
-  const resolved = resolveValidWorkspaceDir(ctx, api, { source, fallbackAgentId: 'main' });
-  const issue = validateWorkspaceDir(resolved);
-
-  if (issue) {
-    api.logger.error(`[PD:health] ${source}: workspaceDir="${resolved}" - ${issue}`);
-  } else {
-    api.logger.info(`[PD:health] ${source}: workspaceDir="${resolved}" OK`);
-  }
 }

--- a/packages/openclaw-plugin/src/hooks/trajectory-collector.ts
+++ b/packages/openclaw-plugin/src/hooks/trajectory-collector.ts
@@ -7,21 +7,21 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { 
-  PluginHookAfterToolCallEvent, 
-  PluginHookToolContext, 
-  PluginHookLlmOutputEvent, 
+import type {
+  PluginHookAfterToolCallEvent,
+  PluginHookToolContext,
+  PluginHookLlmOutputEvent,
   PluginHookAgentContext,
   PluginHookBeforeMessageWriteEvent
 } from '../openclaw-sdk.js';
+import { MAX_STRING_LENGTH } from '../config/defaults/runtime.js';
 
 const TRAJECTORY_DIR = 'memory/trajectories/';
 
 // 敏感字段匹配正则
 const SENSITIVE_KEY_PATTERN = /password|token|authorization|secret|api[_-]?key|credential|cookie|session/i;
 
-// 最大字符串长度
-const MAX_STRING_LENGTH = 1000;
+// 最大结果长度（不同于 MAX_STRING_LENGTH）
 const MAX_RESULT_LENGTH = 500;
 
 /**
@@ -231,7 +231,7 @@ export function handleBeforeMessageWrite(
   if (typeof msg.content === 'string') {
      
     // Reason: msg.content is string | ContentPart[]; destructuring would require renaming in the else branch
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+     
     content = msg.content;
   } else if (Array.isArray(msg.content)) {
     content = msg.content

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -16,9 +16,7 @@ import type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentContext,
 } from './openclaw-sdk.js';
-import * as crypto from 'crypto';
 import * as path from 'path';
-import type { WorkerProfile } from './core/model-deployment-registry.js';
 import { classifyTask } from './core/local-worker-routing.js';
 import { completeShadowObservation, recordShadowRouting } from './core/shadow-observation-registry.js';
 import { getCommandDescription } from './i18n/commands.js';
@@ -59,82 +57,24 @@ import { migrateDirectoryStructure } from './core/migration.js';
 import { SystemLogger } from './core/system-logger.js';
 import { createDeepReflectTool } from './tools/deep-reflect.js';
 import { createWritePainFlagTool } from './tools/write-pain-flag.js';
-import { PathResolver, resolveWorkspaceDirFromApi } from './core/path-resolver.js';
-import { validateWorkspaceDir, type WorkspaceResolutionContext } from './core/workspace-dir-validation.js';
-import { resolveRequiredWorkspaceDir, resolveWorkspaceDir } from './core/workspace-dir-service.js';
+import { PathResolver } from './core/path-resolver.js';
 import { createPrinciplesConsoleRoute } from './http/principles-console-route.js';
 import { extractAgentIdFromSessionKey } from './utils/session-key.js';
+import { resolveCommandWorkspaceDir, resolveToolHookWorkspaceDirSafe } from './utils/workspace-resolver.js';
+import { computeRuntimeShadowTaskFingerprint, PD_LOCAL_PROFILES } from './utils/shadow-fingerprint.js';
+import type { WorkerProfile } from './core/model-deployment-registry.js';
+import { validateWorkspaceDir } from './core/workspace-dir-validation.js';
+import { resolveWorkspaceDirFromApi } from './core/path-resolver.js';
+import { resolveRequiredWorkspaceDir } from './core/workspace-dir-service.js';
 
 // Track initialization to avoid repeated calls
 let workspaceInitialized = false;
 // Track started evolution workers — one per workspace
 const startedWorkspaces = new Set<string>();
 
-/**
- * Resolve workspaceDir for slash commands.
- * Chain: ctx.workspaceDir → resolveWorkspaceDirFromApi (official OpenClaw API + env vars)
- * 
- * CRITICAL: Throws if workspaceDir cannot be resolved. Silent failures are dangerous
- * because commands might operate on the wrong directory.
- */
-function resolveCommandWorkspaceDir(
-  api: OpenClawPluginApi,
-  ctx: { workspaceDir?: string },
-): string {
-  // 1. Direct from command context (most reliable — set by OpenClaw for current session)
-  if (ctx.workspaceDir) {
-    const issue = validateWorkspaceDir(ctx.workspaceDir);
-    if (!issue) return ctx.workspaceDir;
-    api.logger.error(`[PD:Command] ctx.workspaceDir="${ctx.workspaceDir}" is invalid: ${issue}`);
-  }
-
-  // 2. Official OpenClaw API → env vars → config file
-  const resolved = resolveWorkspaceDirFromApi(api);
-  if (resolved) return resolved;
-
-  // CRITICAL FAILURE: Cannot determine workspace directory
-  const errorMsg = `[PD:Command] CRITICAL: Cannot resolve workspace directory. ` +
-    `ctx.workspaceDir="${ctx.workspaceDir}" is invalid, and all fallbacks failed. ` +
-    `Commands will NOT execute to prevent data corruption.`;
-  api.logger.error(errorMsg);
-  
-  throw new Error(errorMsg);
-}
-
 // Map from childSessionKey → shadowObservationId
 // Used to complete shadow observations when subagent ends
 const pendingShadowObservations = new Map<string, string>();
-
-// PD local worker profiles that are managed by the shadow routing policy
-const PD_LOCAL_PROFILES = new Set<WorkerProfile>(['local-reader', 'local-editor']);
-
-function computeRuntimeShadowTaskFingerprint(event: PluginHookSubagentSpawningEvent): string {
-  const payload = {
-    childSessionKey: event.childSessionKey,
-    agentId: event.agentId,
-    label: event.label ?? '',
-    mode: event.mode,
-    threadRequested: event.threadRequested,
-    requesterChannel: event.requester?.channel ?? '',
-    requesterThreadId: event.requester?.threadId ?? '',
-  };
-  return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex').slice(0, 16);
-}
-
-function _resolveCommandWorkspaceDirStrict(
-  api: OpenClawPluginApi,
-  ctx: WorkspaceResolutionContext,
-): string {
-  return resolveRequiredWorkspaceDir(api, ctx, { source: 'command' });
-}
-
-function resolveToolHookWorkspaceDirSafe(
-  ctx: WorkspaceResolutionContext,
-  api: OpenClawPluginApi,
-  source: string,
-): string | undefined {
-  return resolveWorkspaceDir(api, ctx, { source });
-}
 
 const plugin = {
   name: "Principles Disciple",

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -60,8 +60,8 @@ import { SystemLogger } from './core/system-logger.js';
 import { createDeepReflectTool } from './tools/deep-reflect.js';
 import { createWritePainFlagTool } from './tools/write-pain-flag.js';
 import { PathResolver, resolveWorkspaceDirFromApi } from './core/path-resolver.js';
-import { validateWorkspaceDir } from './core/workspace-dir-validation.js';
-import { resolveRequiredWorkspaceDir, resolveWorkspaceDir, type WorkspaceResolutionContext } from './core/workspace-dir-service.js';
+import { validateWorkspaceDir, type WorkspaceResolutionContext } from './core/workspace-dir-validation.js';
+import { resolveRequiredWorkspaceDir, resolveWorkspaceDir } from './core/workspace-dir-service.js';
 import { createPrinciplesConsoleRoute } from './http/principles-console-route.js';
 import { extractAgentIdFromSessionKey } from './utils/session-key.js';
 
@@ -421,7 +421,7 @@ const plugin = {
 
     // ── Slash Commands ──
     // Register command with optional short alias
-    // eslint-disable-next-line @typescript-eslint/max-params, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const registerCommandWithAlias = (name: string, alias: string | null, desc: string, handler: any, opts?: { acceptsArgs?: boolean }) => {
       const base = {
         name,

--- a/packages/openclaw-plugin/src/openclaw-sdk.d.ts
+++ b/packages/openclaw-plugin/src/openclaw-sdk.d.ts
@@ -429,7 +429,7 @@ export interface PluginHookBeforePromptBuildResult {
 
 export interface PluginHookBeforeToolCallEvent {
     toolName: string;
-    params: Record<string, unknown>;
+    params: Record<string, any>;
     runId?: string;
     toolCallId?: string;
 }
@@ -446,7 +446,7 @@ export type PluginApprovalResolution =
     | 'cancelled';
 
 export interface PluginHookBeforeToolCallResult {
-    params?: Record<string, unknown>;
+    params?: Record<string, any>;
     block?: boolean;
     blockReason?: string;
     /**
@@ -471,7 +471,7 @@ export interface PluginHookBeforeToolCallResult {
 
 export interface PluginHookAfterToolCallEvent {
     toolName: string;
-    params: Record<string, unknown>;
+    params: Record<string, any>;
     runId?: string;
     toolCallId?: string;
     result?: unknown;
@@ -496,14 +496,14 @@ export interface PluginHookLlmOutputEvent {
 }
 
 export interface PluginHookBeforeMessageWriteEvent {
-    message: unknown;
+    message: any;
     sessionKey?: string;
     agentId?: string;
 }
 
 export interface PluginHookBeforeMessageWriteResult {
     block?: boolean;
-    message?: unknown;
+    message?: any;
 }
 
 export interface PluginHookSubagentEndedEvent {

--- a/packages/openclaw-plugin/src/openclaw-sdk.d.ts
+++ b/packages/openclaw-plugin/src/openclaw-sdk.d.ts
@@ -429,7 +429,7 @@ export interface PluginHookBeforePromptBuildResult {
 
 export interface PluginHookBeforeToolCallEvent {
     toolName: string;
-    params: Record<string, any>;
+    params: Record<string, unknown>;
     runId?: string;
     toolCallId?: string;
 }
@@ -446,7 +446,7 @@ export type PluginApprovalResolution =
     | 'cancelled';
 
 export interface PluginHookBeforeToolCallResult {
-    params?: Record<string, any>;
+    params?: Record<string, unknown>;
     block?: boolean;
     blockReason?: string;
     /**
@@ -471,7 +471,7 @@ export interface PluginHookBeforeToolCallResult {
 
 export interface PluginHookAfterToolCallEvent {
     toolName: string;
-    params: Record<string, any>;
+    params: Record<string, unknown>;
     runId?: string;
     toolCallId?: string;
     result?: unknown;
@@ -496,14 +496,14 @@ export interface PluginHookLlmOutputEvent {
 }
 
 export interface PluginHookBeforeMessageWriteEvent {
-    message: any;
+    message: unknown;
     sessionKey?: string;
     agentId?: string;
 }
 
 export interface PluginHookBeforeMessageWriteResult {
     block?: boolean;
-    message?: any;
+    message?: unknown;
 }
 
 export interface PluginHookSubagentEndedEvent {

--- a/packages/openclaw-plugin/src/service/central-sync-service.ts
+++ b/packages/openclaw-plugin/src/service/central-sync-service.ts
@@ -7,18 +7,13 @@
 
 import type { OpenClawPluginService, OpenClawPluginServiceContext, PluginLogger } from '../openclaw-sdk.js';
 import { CentralDatabase } from './central-database.js';
+import { WORKFLOW_TTL_MS } from '../config/defaults/runtime.js';
 
 let syncInterval: ReturnType<typeof setInterval> | null = null;
 let logger: PluginLogger | undefined = undefined;
 let centralDb: CentralDatabase | null = null;
 
-/**
- * Default sync interval: 5 minutes.
- * Can be overridden via config: intervals.central_sync_ms
- */
-const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000;
-
-    // eslint-disable-next-line complexity -- complexity 12, refactor candidate
+     
 async function runSyncCycle(): Promise<void> {
   if (!centralDb) {
     logger?.warn?.('[PD:CentralSync] CentralDatabase not initialized, skipping sync');
@@ -51,7 +46,7 @@ export const CentralSyncService: OpenClawPluginService = {
     logger = ctxLogger;
 
     const { intervals } = config as { intervals?: { central_sync_ms?: number } };
-    const intervalMs = intervals?.central_sync_ms ?? DEFAULT_SYNC_INTERVAL_MS;
+    const intervalMs = intervals?.central_sync_ms ?? WORKFLOW_TTL_MS;
 
     // Initialize CentralDatabase
     centralDb = new CentralDatabase();

--- a/packages/openclaw-plugin/src/service/correction-observer-workflow-manager.ts
+++ b/packages/openclaw-plugin/src/service/correction-observer-workflow-manager.ts
@@ -22,11 +22,11 @@ import type {
     CorrectionObserverPayload,
     CorrectionObserverResult,
 } from './correction-observer-types.js';
+import { WORKFLOW_TTL_MS } from '../config/defaults/runtime.js';
 
 const WORKFLOW_SESSION_PREFIX = 'agent:main:subagent:workflow-correction-';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_TTL_MS = 5 * 60 * 1000;
 
 // ── Options ─────────────────────────────────────────────────────────────────
 
@@ -162,7 +162,7 @@ export class CorrectionObserverWorkflowManager extends WorkflowManagerBase {
             workflowType: 'correction_observer',
             sessionPrefix: WORKFLOW_SESSION_PREFIX,
             defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-            defaultTtlMs: DEFAULT_TTL_MS,
+            defaultTtlMs: WORKFLOW_TTL_MS,
         });
     }
 

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -16,6 +16,7 @@ import { getEvolutionLogger } from '../core/evolution-logger.js';
 import type { TaskKind, TaskPriority } from '../core/trajectory-types.js';
 export type { TaskKind, TaskPriority } from '../core/trajectory-types.js';
 import { LockUnavailableError } from '../config/index.js';
+import { PAIN_QUEUE_DEDUP_WINDOW_MS } from '../config/defaults/runtime.js';
 import { checkWorkspaceIdle, checkCooldown } from './nocturnal-runtime.js';
 import { loadNocturnalConfig } from './nocturnal-config.js';
 import { WorkflowStore } from './subagent-workflow/workflow-store.js';
@@ -413,7 +414,6 @@ function buildFallbackNocturnalSnapshot(
     };
 }
 
-const PAIN_QUEUE_DEDUP_WINDOW_MS = 30 * 60 * 1000;
 
 // P0 fix: File lock constants and helper for queue operations (prevents TOCTOU race)
 export const EVOLUTION_QUEUE_LOCK_SUFFIX = '.lock';

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -19,7 +19,7 @@ import { LockUnavailableError } from '../config/index.js';
 import { checkWorkspaceIdle, checkCooldown } from './nocturnal-runtime.js';
 import { loadNocturnalConfig } from './nocturnal-config.js';
 import { WorkflowStore } from './subagent-workflow/workflow-store.js';
-import type { WorkflowRow } from './subagent-workflow/types.js';
+import type { WorkflowRow, RecentPainContext } from './subagent-workflow/types.js';
 import { EmpathyObserverWorkflowManager } from './subagent-workflow/empathy-observer-workflow-manager.js';
 import { DeepReflectWorkflowManager } from './subagent-workflow/deep-reflect-workflow-manager.js';
 import { NocturnalWorkflowManager, nocturnalWorkflowSpec } from './subagent-workflow/nocturnal-workflow-manager.js';
@@ -208,27 +208,6 @@ let timeoutId: NodeJS.Timeout | null = null;
  */
 export type QueueStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'canceled';
 export type TaskResolution = 'marker_detected' | 'auto_completed_timeout' | 'failed_max_retries' | 'runtime_unavailable' | 'canceled' | 'late_marker_principle_created' | 'late_marker_no_principle' | 'stub_fallback' | 'skipped_thin_violation';
-
-/**
- * Recent pain context attached to sleep_reflection tasks.
- * Carries explicit recent pain signal metadata without being a separate task kind.
- * Used by NocturnalTargetSelector for ranking bias and context enrichment.
- */
-export interface RecentPainContext {
-  /** Most recent unresolved pain event */
-  mostRecent: {
-    score: number;
-    source: string;
-    reason: string;
-    timestamp: string;
-    /** Session ID where the pain occurred */
-    sessionId: string;
-  } | null;
-  /** Count of pain events in the recent window (for signal strength) */
-  recentPainCount: number;
-  /** Highest pain score in the recent window */
-  recentMaxPainScore: number;
-}
 
 export interface EvolutionQueueItem {
     // Core identity
@@ -692,7 +671,7 @@ function shouldSkipForDedup(
  * Load and migrate the evolution queue. Returns empty array if file doesn't exist.
  */
 function loadEvolutionQueue(queuePath: string): EvolutionQueueItem[] {
-    // eslint-disable-next-line no-useless-assignment
+     
     let rawQueue: RawQueueItem[] = [];
     try {
         rawQueue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -36,8 +36,7 @@ import type { CorrectionObserverPayload } from './correction-observer-types.js';
 import { KeywordOptimizationService } from './keyword-optimization-service.js';
 import { TrajectoryRegistry } from '../core/trajectory.js';
 import { CorrectionCueLearner } from '../core/correction-cue-learner.js';
-
-const WORKFLOW_TTL_MS = 5 * 60 * 1000; // 5 minutes default TTL for helper workflows
+import { WORKFLOW_TTL_MS } from '../config/defaults/runtime.js';
 import { OpenClawTrinityRuntimeAdapter } from '../core/nocturnal-trinity.js';
 
 /**
@@ -1993,10 +1992,14 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                     };
 
                     // Dispatch LLM subagent via CorrectionObserverWorkflowManager
+                    const subagent = api?.runtime?.subagent;
+                    if (!subagent) {
+                        throw new Error('[PD:EvolutionWorker] subagent runtime not available for keyword_optimization');
+                    }
                     const manager = new CorrectionObserverWorkflowManager({
                         workspaceDir: wctx.workspaceDir,
                         logger,
-                        subagent: api?.runtime?.subagent!,
+                        subagent,
                         agentSession: api?.runtime?.agent?.session,
                     });
 
@@ -2010,7 +2013,11 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                         workflowId = handle.workflowId;
                         koTask.resultRef = workflowId;
                     } else {
-                        workflowId = koTask.resultRef!;
+                        // isPolling implies resultRef exists (checked above)
+                        workflowId = koTask.resultRef;
+                        if (!workflowId) {
+                            throw new Error(`[PD:EvolutionWorker] keyword_optimization task ${koTask.id} has no resultRef in polling mode`);
+                        }
                     }
 
                     // Poll workflow state

--- a/packages/openclaw-plugin/src/service/nocturnal-service.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-service.ts
@@ -32,6 +32,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import type { RecentPainContext } from './subagent-workflow/types.js';
+import type { PluginLogger } from '../openclaw-sdk.js';
 import {
   createNocturnalTrajectoryExtractor,
   computeThinkingModelDelta,
@@ -268,6 +269,12 @@ export interface NocturnalServiceOptions {
    * When omitted, a deterministic local candidate is synthesized.
    */
   artificerOutputOverride?: string;
+
+  /**
+   * Logger for diagnostic output.
+   * When provided, warnings are logged via logger.warn instead of console.warn.
+   */
+  logger?: PluginLogger;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/openclaw-plugin/src/service/nocturnal-service.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-service.ts
@@ -31,7 +31,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import type { RecentPainContext } from './evolution-worker.js';
+import type { RecentPainContext } from './subagent-workflow/types.js';
 import {
   createNocturnalTrajectoryExtractor,
   computeThinkingModelDelta,
@@ -299,16 +299,16 @@ function invokeStubReflector(
   const hasPain = snapshot.stats.totalPainEvents > 0;
   const hasFailures = (snapshot.stats.failureCount ?? 0) > 0;
 
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let badDecision: string;
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let betterDecision: string;
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let rationale: string;
 
   if (hasGateBlocks && snapshot.gateBlocks.length > 0) {
     // Use actual gate block content
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+     
     const block = snapshot.gateBlocks[0];
     const tool = block.toolName ?? 'a tool';
     const file = block.filePath ? ` on ${block.filePath}` : '';
@@ -317,7 +317,7 @@ function invokeStubReflector(
     rationale = `Gate blocks exist for a reason — bypassing them without understanding the underlying constraint risks unintended consequences. The block on ${tool}${file} indicates the operation exceeded allowed thresholds for the current evolution tier.`;
   } else if (hasPain && snapshot.painEvents.length > 0) {
     // Use actual pain event content
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+     
     const pain = snapshot.painEvents[0];
     const painSource = pain.source ?? 'unknown';
     const painReason = pain.reason ? `: ${pain.reason}` : '';
@@ -413,7 +413,7 @@ function buildGateBlockRefs(snapshot: NocturnalSessionSnapshot): string[] {
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 function buildDefaultArtificerOutput(
   ruleId: string,
   artifact: NocturnalArtifact,
@@ -463,7 +463,7 @@ function buildDefaultArtificerOutput(
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 function persistCodeCandidate(
   workspaceDir: string,
   stateDir: string,
@@ -560,7 +560,7 @@ function persistCodeCandidate(
 }
 
  
-// eslint-disable-next-line @typescript-eslint/max-params
+ 
 function maybePersistArtificerCandidate(
   workspaceDir: string,
   stateDir: string,
@@ -804,11 +804,11 @@ export function executeNocturnalReflection(
   // Step 5: Artifact generation (Trinity or single-reflector)
   // -------------------------------------------------------------------------
    
-  // eslint-disable-next-line no-useless-assignment
+   
   let trinityArtifact: TrinityDraftArtifact | null = null;
   let trinityResult: TrinityResult | null = null;
    
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let rawJson: string;
 
   if (options.skipReflector) {
@@ -1033,7 +1033,7 @@ export function executeNocturnalReflection(
   };
 
    
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let persistedPath: string;
   try {
     persistedPath = persistArtifact(workspaceDir, artifactWithBoundedAction);
@@ -1161,7 +1161,7 @@ export async function executeNocturnalReflectionAsync(
   // If runtime adapter is provided, use async Trinity path
   if (options.runtimeAdapter) {
      
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+     
     return executeNocturnalReflectionWithAdapter(workspaceDir, stateDir, options);
   }
 
@@ -1219,13 +1219,13 @@ async function executeNocturnalReflectionWithAdapter(
 
   // Step 2: Target selection (or use override to skip)
    
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let selectedPrincipleId: string | undefined;
    
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let selectedSessionId: string | undefined;
    
-  // eslint-disable-next-line no-useless-assignment
+   
   let snapshot: NocturnalSessionSnapshot | null = null;
 
   if (options.principleIdOverride && options.snapshotOverride) {
@@ -1248,7 +1248,7 @@ async function executeNocturnalReflectionWithAdapter(
     // Skip Selector: use provided principleId and snapshot directly
     selectedPrincipleId = options.principleIdOverride;
     selectedSessionId = snapshotValidation.snapshot.sessionId;
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+     
     snapshot = snapshotValidation.snapshot;
     // Calculate violation density from snapshot stats for meaningful diagnostics
     const snapStats = snapshotValidation.snapshot.stats;
@@ -1305,10 +1305,10 @@ async function executeNocturnalReflectionWithAdapter(
     }
 
      
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+     
     selectedPrincipleId = selection.selectedPrincipleId;
      
-    // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+     
     selectedSessionId = selection.selectedSessionId;
 
     if (!selectedPrincipleId || !selectedSessionId) {
@@ -1343,11 +1343,11 @@ async function executeNocturnalReflectionWithAdapter(
 
   // Step 4: Trinity execution via adapter (async)
    
-  // eslint-disable-next-line no-useless-assignment
+   
   let trinityArtifact: TrinityDraftArtifact | null = null;
   let trinityResult: TrinityResult | null = null;
    
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let rawJson: string;
 
   if (options.skipReflector) {
@@ -1454,7 +1454,7 @@ async function executeNocturnalReflectionWithAdapter(
   // Step 7: Persist artifact
   const artifactWithBoundedAction = { ...arbiterResult.artifact, boundedAction: execResult.boundedAction };
    
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let persistedPath: string;
   try {
     persistedPath = persistArtifact(workspaceDir, artifactWithBoundedAction);

--- a/packages/openclaw-plugin/src/service/nocturnal-service.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-service.ts
@@ -123,6 +123,7 @@ function incrementGeneratedSampleCount(stateDir: string, principleId: string): v
     state.generatedSampleCount += 1;
     setPrincipleState(stateDir, state);
   } catch (err) {
+    // eslint-disable-next-line no-console -- Non-critical warning in helper function
     console.warn(`[nocturnal-service] Failed to sync generatedSampleCount for ${principleId}:`, err instanceof Error ? err.stack : err);
   }
 }
@@ -528,6 +529,7 @@ function persistCodeCandidate(
     try {
       refreshPrincipleLifecycle(workspaceDir, stateDir);
     } catch (err) {
+      // eslint-disable-next-line no-console -- Non-critical warning in helper function
       console.warn('[nocturnal-service] Lifecycle refresh failed after code candidate persistence:', err instanceof Error ? err.stack : err);
     }
     return {
@@ -705,6 +707,11 @@ export function executeNocturnalReflection(
   stateDir: string,
   options: NocturnalServiceOptions = {}
 ): NocturnalRunResult {
+  // Use provided logger or fallback to console
+  const logger = options.logger;
+  // eslint-disable-next-line no-console -- Intentional console fallback when no logger provided
+  const warn = logger?.warn?.bind(logger) ?? console.warn.bind(console);
+
   const diagnostics: NocturnalRunDiagnostics = {
     preflight: null,
     selection: null,
@@ -804,7 +811,7 @@ export function executeNocturnalReflection(
   // The async version would be used in real worker integration
   const config = loadNocturnalConfig(stateDir);
   void recordRunStart(stateDir, selectedPrincipleId, config.cooldown_ms).catch((err) => {
-    console.warn(`[nocturnal-service] Failed to record run start: ${String(err)}`);
+    warn(`[nocturnal-service] Failed to record run start: ${String(err)}`);
   });
 
   // -------------------------------------------------------------------------
@@ -841,7 +848,7 @@ export function executeNocturnalReflection(
       // Trinity failed — fail closed (same semantics as production)
       const failures = trinityResult.failures.map((f) => `${f.stage}: ${f.reason}`);
       void recordRunEnd(stateDir, 'failed', { reason: `Trinity override failed: ${failures.join('; ')}` }).catch((err) => {
-        console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+        warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
       });
       // Emit threshold signals: malformed Trinity override is a strong signal
       adjustThresholdsFromSignals(stateDir, {
@@ -864,7 +871,7 @@ export function executeNocturnalReflection(
       if (!draftValidation.valid) {
         const {failures} = draftValidation;
         void recordRunEnd(stateDir, 'failed', { reason: `Trinity draft invalid: ${failures.join('; ')}` }).catch((err) => {
-          console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+          warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
         });
         // Emit threshold signals: malformed draft content is a strong signal
         adjustThresholdsFromSignals(stateDir, {
@@ -915,7 +922,7 @@ export function executeNocturnalReflection(
           // Trinity draft invalid — fail closed
           const {failures} = draftValidation;
           void recordRunEnd(stateDir, 'failed', { reason: `Trinity draft invalid: ${failures.join('; ')}` }).catch((err) => {
-            console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+            warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
           });
           // Emit threshold signals: malformed draft content is a strong signal
           adjustThresholdsFromSignals(stateDir, {
@@ -942,7 +949,7 @@ export function executeNocturnalReflection(
         // Phase 6 requirement: malformed Trinity stage output fails closed
         const failures = trinityResult.failures.map((f) => `${f.stage}: ${f.reason}`);
         void recordRunEnd(stateDir, 'failed', { reason: `Trinity chain failed: ${failures.join('; ')}` }).catch((err) => {
-          console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+          warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
         });
         // Emit threshold signals: malformed Trinity is the strongest signal for tightening schema threshold
         adjustThresholdsFromSignals(stateDir, {
@@ -986,7 +993,7 @@ export function executeNocturnalReflection(
   if (!arbiterResult.passed || !arbiterResult.artifact) {
     const failures = arbiterResult.failures.map((f) => f.reason);
     void recordRunEnd(stateDir, 'failed', { reason: failures.join('; ') }).catch((err) => {
-      console.warn(`[nocturnal-service] Failed to record run end (arbiter failed): ${String(err)}`);
+      warn(`[nocturnal-service] Failed to record run end (arbiter failed): ${String(err)}`);
     });
     // Emit threshold signals: arbiter rejection indicates principle alignment issues
     adjustThresholdsFromSignals(stateDir, {
@@ -1012,7 +1019,7 @@ export function executeNocturnalReflection(
   if (!execResult.executable) {
     const failures = execResult.failures.map((f) => f.reason);
     void recordRunEnd(stateDir, 'failed', { reason: failures.join('; ') }).catch((err) => {
-      console.warn(`[nocturnal-service] Failed to record run end (executability failed): ${String(err)}`);
+      warn(`[nocturnal-service] Failed to record run end (executability failed): ${String(err)}`);
     });
     // Emit threshold signals: executability rejection indicates action quality issues
     adjustThresholdsFromSignals(stateDir, {
@@ -1048,7 +1055,7 @@ export function executeNocturnalReflection(
     diagnostics.persistedPath = persistedPath;
   } catch (err) {
     void recordRunEnd(stateDir, 'failed', { reason: `persistence error: ${String(err)}` }).catch((e) => {
-      console.warn(`[nocturnal-service] Failed to record run end (persistence failed): ${String(e)}`);
+      warn(`[nocturnal-service] Failed to record run end (persistence failed): ${String(e)}`);
     });
     return {
       success: false,
@@ -1073,7 +1080,7 @@ export function executeNocturnalReflection(
   } catch (err) {
     // Non-fatal: artifact is persisted, registry is secondary.
     // Log but don't fail the run.
-    console.warn(`[nocturnal-service] Failed to register sample in dataset registry: ${String(err)}`);
+    warn(`[nocturnal-service] Failed to register sample in dataset registry: ${String(err)}`);
   }
 
   try {
@@ -1091,7 +1098,7 @@ export function executeNocturnalReflection(
       createdAt: arbiterResult.artifact.createdAt,
     });
   } catch (err) {
-    console.warn(`[nocturnal-service] Failed to append behavioral artifact lineage: ${String(err)}`);
+    warn(`[nocturnal-service] Failed to append behavioral artifact lineage: ${String(err)}`);
   }
 
   diagnostics.artificer = maybePersistArtificerCandidate(
@@ -1108,7 +1115,7 @@ export function executeNocturnalReflection(
   // Step 9: Record run success
   // -------------------------------------------------------------------------
   void recordRunEnd(stateDir, 'success', { sampleCount: 1 }).catch((err) => {
-    console.warn(`[nocturnal-service] Failed to record run end (success): ${String(err)}`);
+    warn(`[nocturnal-service] Failed to record run end (success): ${String(err)}`);
   });
 
   // -------------------------------------------------------------------------
@@ -1185,6 +1192,11 @@ async function executeNocturnalReflectionWithAdapter(
   stateDir: string,
   options: NocturnalServiceOptions
 ): Promise<NocturnalRunResult> {
+  // Use provided logger or fallback to console
+  const logger = options.logger;
+  // eslint-disable-next-line no-console -- Intentional console fallback when no logger provided
+  const warn = logger?.warn?.bind(logger) ?? console.warn.bind(console);
+
   const diagnostics: NocturnalRunDiagnostics = {
     preflight: null,
     selection: null,
@@ -1345,7 +1357,7 @@ async function executeNocturnalReflectionWithAdapter(
   // Step 3: Record run start
   const config = loadNocturnalConfig(stateDir);
   void recordRunStart(stateDir, selectedPrincipleId, config.cooldown_ms).catch((err) => {
-    console.warn(`[nocturnal-service] Failed to record run start: ${String(err)}`);
+    warn(`[nocturnal-service] Failed to record run start: ${String(err)}`);
   });
 
   // Step 4: Trinity execution via adapter (async)
@@ -1377,7 +1389,7 @@ async function executeNocturnalReflectionWithAdapter(
     if (!trinityResult.success) {
       const failures = trinityResult.failures.map((f) => `${f.stage}: ${f.reason}`);
       void recordRunEnd(stateDir, 'failed', { reason: `Trinity override failed: ${failures.join('; ')}` }).catch((err) => {
-        console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+        warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
       });
       adjustThresholdsFromSignals(stateDir, { malformedRate: 1.0, arbiterRejectRate: 0.0, executabilityRejectRate: 0.0, qualityDelta: 0.0 });
       return { success: false, noTargetSelected: false, validationFailed: true, validationFailures: [`Trinity override failed: ${failures.join('; ')}`], snapshot, diagnostics };
@@ -1404,7 +1416,7 @@ async function executeNocturnalReflectionWithAdapter(
         if (!draftValidation.valid) {
           const {failures} = draftValidation;
           void recordRunEnd(stateDir, 'failed', { reason: `Trinity draft invalid: ${failures.join('; ')}` }).catch((err) => {
-            console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+            warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
           });
           adjustThresholdsFromSignals(stateDir, { malformedRate: 1.0, arbiterRejectRate: 0.0, executabilityRejectRate: 0.0, qualityDelta: 0.0 });
           return { success: false, noTargetSelected: false, validationFailed: true, validationFailures: failures, snapshot, diagnostics };
@@ -1415,7 +1427,7 @@ async function executeNocturnalReflectionWithAdapter(
       } else {
         const failures = trinityResult.failures.map((f) => `${f.stage}: ${f.reason}`);
         void recordRunEnd(stateDir, 'failed', { reason: `Trinity chain failed: ${failures.join('; ')}` }).catch((err) => {
-          console.warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
+          warn(`[nocturnal-service] Failed to record run end: ${String(err)}`);
         });
         adjustThresholdsFromSignals(stateDir, { malformedRate: 1.0, arbiterRejectRate: 0.0, executabilityRejectRate: 0.0, qualityDelta: 0.0 });
         return { success: false, noTargetSelected: false, validationFailed: true, validationFailures: [`Trinity chain failed: ${failures.join('; ')}`], snapshot, diagnostics };
@@ -1440,7 +1452,7 @@ async function executeNocturnalReflectionWithAdapter(
   if (!arbiterResult.passed || !arbiterResult.artifact) {
     const failures = arbiterResult.failures.map((f) => f.reason);
     void recordRunEnd(stateDir, 'failed', { reason: failures.join('; ') }).catch((err) => {
-      console.warn(`[nocturnal-service] Failed to record run end (arbiter failed): ${String(err)}`);
+      warn(`[nocturnal-service] Failed to record run end (arbiter failed): ${String(err)}`);
     });
     adjustThresholdsFromSignals(stateDir, { malformedRate: 0.0, arbiterRejectRate: 1.0, executabilityRejectRate: 0.0, qualityDelta: 0.0 });
     return { success: false, noTargetSelected: false, validationFailed: true, validationFailures: failures, diagnostics };
@@ -1451,7 +1463,7 @@ async function executeNocturnalReflectionWithAdapter(
   if (!execResult.executable) {
     const failures = execResult.failures.map((f) => f.reason);
     void recordRunEnd(stateDir, 'failed', { reason: failures.join('; ') }).catch((err) => {
-      console.warn(`[nocturnal-service] Failed to record run end (executability failed): ${String(err)}`);
+      warn(`[nocturnal-service] Failed to record run end (executability failed): ${String(err)}`);
     });
     adjustThresholdsFromSignals(stateDir, { malformedRate: 0.0, arbiterRejectRate: 0.0, executabilityRejectRate: 1.0, qualityDelta: 0.0 });
     return { success: false, noTargetSelected: false, validationFailed: true, validationFailures: failures, diagnostics };
@@ -1469,7 +1481,7 @@ async function executeNocturnalReflectionWithAdapter(
     diagnostics.persistedPath = persistedPath;
   } catch (err) {
     void recordRunEnd(stateDir, 'failed', { reason: `persistence error: ${String(err)}` }).catch((e) => {
-      console.warn(`[nocturnal-service] Failed to record run end (persistence failed): ${String(e)}`);
+      warn(`[nocturnal-service] Failed to record run end (persistence failed): ${String(e)}`);
     });
     return { success: false, noTargetSelected: false, validationFailed: true, validationFailures: [`Failed to persist artifact: ${String(err)}`], snapshot, diagnostics };
   }
@@ -1481,7 +1493,7 @@ async function executeNocturnalReflectionWithAdapter(
       incrementGeneratedSampleCount(stateDir, arbiterResult.artifact.principleId);
     }
   } catch (err) {
-    console.warn(`[nocturnal-service] Failed to register sample in dataset registry: ${String(err)}`);
+    warn(`[nocturnal-service] Failed to register sample in dataset registry: ${String(err)}`);
   }
 
   try {
@@ -1499,7 +1511,7 @@ async function executeNocturnalReflectionWithAdapter(
       createdAt: arbiterResult.artifact.createdAt,
     });
   } catch (err) {
-    console.warn(`[nocturnal-service] Failed to append behavioral artifact lineage: ${String(err)}`);
+    warn(`[nocturnal-service] Failed to append behavioral artifact lineage: ${String(err)}`);
   }
 
   diagnostics.artificer = maybePersistArtificerCandidate(
@@ -1514,7 +1526,7 @@ async function executeNocturnalReflectionWithAdapter(
 
   // Step 9: Record run success
   void recordRunEnd(stateDir, 'success', { sampleCount: 1 }).catch((err) => {
-    console.warn(`[nocturnal-service] Failed to record run end (success): ${String(err)}`);
+    warn(`[nocturnal-service] Failed to record run end (success): ${String(err)}`);
   });
 
   // Step 10: Adaptive threshold adjustment

--- a/packages/openclaw-plugin/src/service/subagent-workflow/deep-reflect-workflow-manager.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/deep-reflect-workflow-manager.ts
@@ -98,7 +98,7 @@ export const deepReflectWorkflowSpec: SubagentWorkflowSpec<DeepReflectResult> = 
     workflowType: 'deep-reflect',
     transport: 'runtime_direct',
     timeoutMs: 60_000,
-    ttlMs: 10 * 60 * 1000,
+    ttlMs: DEEP_REFLECT_TTL_MS,
     shouldDeleteSessionAfterFinalize: true,
 
     buildPrompt(taskInput: unknown, ctx: DeepReflectBuildPromptContext): string {

--- a/packages/openclaw-plugin/src/service/subagent-workflow/deep-reflect-workflow-manager.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/deep-reflect-workflow-manager.ts
@@ -13,11 +13,11 @@ import type { RuntimeDirectDriver } from './runtime-direct-driver.js';
 import { isSubagentRuntimeAvailable } from '../../utils/subagent-probe.js';
 import { buildCritiquePromptV2 } from '../../tools/critique-prompt.js';
 import { WorkflowManagerBase } from './workflow-manager-base.js';
+import { DEEP_REFLECT_TTL_MS } from '../../config/defaults/runtime.js';
 
 const WORKFLOW_SESSION_PREFIX = 'agent:main:subagent:workflow-';
 
 const DEFAULT_TIMEOUT_MS = 60_000; // Deep-reflect needs more time than empathy
-const DEFAULT_TTL_MS = 10 * 60 * 1000;
 
 export interface DeepReflectWorkflowOptions {
     workspaceDir: string;
@@ -37,7 +37,7 @@ export class DeepReflectWorkflowManager extends WorkflowManagerBase {
             workflowType: 'deep-reflect',
             sessionPrefix: WORKFLOW_SESSION_PREFIX,
             defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-            defaultTtlMs: DEFAULT_TTL_MS,
+            defaultTtlMs: DEEP_REFLECT_TTL_MS,
         });
     }
 
@@ -70,7 +70,7 @@ export class DeepReflectWorkflowManager extends WorkflowManagerBase {
     }
 
      
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+     
     protected override generateWorkflowId(): string {
         return `wf_dr_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
     }

--- a/packages/openclaw-plugin/src/service/subagent-workflow/empathy-observer-workflow-manager.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/empathy-observer-workflow-manager.ts
@@ -14,11 +14,11 @@ import { trackFriction } from '../../core/session-tracker.js';
 import { isSubagentRuntimeAvailable } from '../../utils/subagent-probe.js';
 import { WorkflowManagerBase } from './workflow-manager-base.js';
 import { normalizeSeverity } from '../../core/empathy-types.js';
+import { WORKFLOW_TTL_MS } from '../../config/defaults/runtime.js';
 
 const WORKFLOW_SESSION_PREFIX = 'agent:main:subagent:workflow-';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_TTL_MS = 5 * 60 * 1000;
 
 export interface EmpathyObserverWorkflowOptions {
     workspaceDir: string;
@@ -38,7 +38,7 @@ export class EmpathyObserverWorkflowManager extends WorkflowManagerBase {
             workflowType: 'empathy-observer',
             sessionPrefix: WORKFLOW_SESSION_PREFIX,
             defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-            defaultTtlMs: DEFAULT_TTL_MS,
+            defaultTtlMs: WORKFLOW_TTL_MS,
         });
     }
 
@@ -71,7 +71,7 @@ export class EmpathyObserverWorkflowManager extends WorkflowManagerBase {
     }
 
      
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+     
     protected override createWorkflowMetadata<TResult>(
         spec: SubagentWorkflowSpec<TResult>,
         options: {
@@ -105,7 +105,7 @@ export class EmpathyObserverWorkflowManager extends WorkflowManagerBase {
     }
 
      
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+     
     protected override generateWorkflowId(): string {
         return `wf_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
     }

--- a/packages/openclaw-plugin/src/service/subagent-workflow/nocturnal-workflow-manager.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/nocturnal-workflow-manager.ts
@@ -36,7 +36,7 @@ import {
 } from '../nocturnal-service.js';
 import { type TrinityStageFailure, type TrinityResult } from '../../core/nocturnal-trinity.js';
 import type { TrinityRuntimeAdapter } from '../../core/nocturnal-trinity.js';
-import type { RecentPainContext } from '../evolution-worker.js';
+import type { RecentPainContext } from './types.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { validateNocturnalSnapshotIngress } from '../../core/nocturnal-snapshot-contract.js';
@@ -394,7 +394,7 @@ export class NocturnalWorkflowManager implements WorkflowManager {
     }
 
      
-    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+     
     async notifyLifecycleEvent(
          
         _workflowId: string,

--- a/packages/openclaw-plugin/src/service/subagent-workflow/types.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/types.ts
@@ -367,6 +367,27 @@ export type { PluginLogger } from '../../openclaw-sdk.js';
 // ── Nocturnal Workflow Types ───────────────────────────────────────────────────
 
 /**
+ * Recent pain context for sleep_reflection tasks.
+ * Used by target selector for ranking bias and context enrichment.
+ * Originally from evolution-worker.ts, moved here to break circular dependency.
+ */
+export interface RecentPainContext {
+    /** Most recent unresolved pain event */
+    mostRecent: {
+        score: number;
+        source: string;
+        reason: string;
+        timestamp: string;
+        /** Session ID where the pain occurred */
+        sessionId: string;
+    } | null;
+    /** Count of pain events in the recent window (for signal strength) */
+    recentPainCount: number;
+    /** Highest pain score in the recent window */
+    recentMaxPainScore: number;
+}
+
+/**
  * Nocturnal workflow result type.
  * Mirrors NocturnalRunResult from nocturnal-service.ts (per D-02).
  */

--- a/packages/openclaw-plugin/src/service/subagent-workflow/types.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/types.ts
@@ -11,6 +11,7 @@
 
 import type {
     NocturnalArtifact,
+    ArbiterResult,
 } from '../../core/nocturnal-arbiter.js';
 import type {
     BoundedAction,
@@ -19,11 +20,15 @@ import type {
     NocturnalSessionSnapshot,
 } from '../../core/nocturnal-trajectory-extractor.js';
 import type {
-    NocturnalRunDiagnostics,
-} from '../nocturnal-service.js';
-import type {
     TrinityResult,
 } from '../../core/nocturnal-trinity.js';
+import type {
+    IdleCheckResult,
+    PreflightCheckResult,
+} from '../nocturnal-runtime.js';
+import type {
+    NocturnalSelectionResult,
+} from '../nocturnal-target-selector.js';
 
 // ── Workflow Transport ────────────────────────────────────────────────────────
 
@@ -402,3 +407,43 @@ export type NocturnalResult = {
     diagnostics: NocturnalRunDiagnostics;
     trinityTelemetry?: TrinityResult['telemetry'];
 };
+
+/**
+ * Diagnostics from each pipeline stage.
+ * Duplicated from nocturnal-service.ts to break circular dependency.
+ */
+export interface NocturnalRunDiagnostics {
+    /** Pre-flight check result */
+    preflight: PreflightCheckResult | null;
+    /** Selection result */
+    selection: NocturnalSelectionResult | null;
+    /** Idle check result */
+    idle: IdleCheckResult | null;
+    /** Whether Trinity chain was attempted */
+    trinityAttempted: boolean;
+    /** Trinity result (if trinityAttempted === true) */
+    trinityResult: TrinityResult | null;
+    /** Which chain mode was used */
+    chainModeUsed: 'trinity' | 'single-reflector' | null;
+    /** Arbiter validation result */
+    arbiterResult: ArbiterResult | null;
+    /** Executability validation result (if arbiter passed) */
+    executabilityResult: { executable: boolean; failures: string[] } | null;
+    /** Whether artifact was persisted */
+    persisted: boolean;
+    /** Persistence path (if persisted) */
+    persistedPath?: string;
+    /** Code-candidate sidecar diagnostics */
+    artificer: NocturnalArtificerDiagnostics;
+}
+
+export interface NocturnalArtificerDiagnostics {
+    status: 'skipped' | 'validation_failed' | 'persisted_candidate';
+    reason?:
+        | 'behavioral_artifact_unavailable'
+        | 'no_deterministic_rule'
+        | 'persistence_failed'
+        | 'cancelled';
+    validationErrors?: string[];
+    persistedPath?: string;
+}

--- a/packages/openclaw-plugin/src/utils/shadow-fingerprint.ts
+++ b/packages/openclaw-plugin/src/utils/shadow-fingerprint.ts
@@ -10,7 +10,17 @@ import type { PluginHookSubagentSpawningEvent } from '../openclaw-sdk.js';
 /**
  * PD local worker profiles that are managed by the shadow routing policy.
  */
-export const PD_LOCAL_PROFILES = new Set(['local-reader', 'local-editor']);
+const _pdLocalProfiles = new Set(['local-reader', 'local-editor']);
+export const PD_LOCAL_PROFILES: ReadonlySet<string> = _pdLocalProfiles;
+
+/**
+ * Check if a profile is a local PD profile.
+ */
+export function isLocalProfile(profile: string): boolean {
+  return _pdLocalProfiles.has(profile);
+}
+
+const RUNTIME_SHADOW_FINGERPRINT_HEX_LENGTH = 16;
 
 /**
  * Compute a fingerprint for runtime shadow task tracking.
@@ -28,5 +38,5 @@ export function computeRuntimeShadowTaskFingerprint(
     requesterChannel: event.requester?.channel ?? '',
     requesterThreadId: event.requester?.threadId ?? '',
   };
-  return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex').slice(0, 16);
+  return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex').slice(0, RUNTIME_SHADOW_FINGERPRINT_HEX_LENGTH);
 }

--- a/packages/openclaw-plugin/src/utils/shadow-fingerprint.ts
+++ b/packages/openclaw-plugin/src/utils/shadow-fingerprint.ts
@@ -1,0 +1,32 @@
+/**
+ * Shadow Observation Fingerprint Utilities
+ *
+ * Computes fingerprints for shadow task routing and tracking.
+ */
+
+import * as crypto from 'crypto';
+import type { PluginHookSubagentSpawningEvent } from '../openclaw-sdk.js';
+
+/**
+ * PD local worker profiles that are managed by the shadow routing policy.
+ */
+export const PD_LOCAL_PROFILES = new Set(['local-reader', 'local-editor']);
+
+/**
+ * Compute a fingerprint for runtime shadow task tracking.
+ * Used to correlate shadow routing decisions with subagent lifecycle events.
+ */
+export function computeRuntimeShadowTaskFingerprint(
+  event: PluginHookSubagentSpawningEvent,
+): string {
+  const payload = {
+    childSessionKey: event.childSessionKey,
+    agentId: event.agentId,
+    label: event.label ?? '',
+    mode: event.mode,
+    threadRequested: event.threadRequested,
+    requesterChannel: event.requester?.channel ?? '',
+    requesterThreadId: event.requester?.threadId ?? '',
+  };
+  return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex').slice(0, 16);
+}

--- a/packages/openclaw-plugin/src/utils/workspace-resolver.ts
+++ b/packages/openclaw-plugin/src/utils/workspace-resolver.ts
@@ -1,0 +1,54 @@
+/**
+ * Workspace Directory Resolution Utilities
+ *
+ * Shared helpers for resolving workspace directories across commands and hooks.
+ */
+
+import type { OpenClawPluginApi } from '../openclaw-sdk.js';
+import { validateWorkspaceDir, type WorkspaceResolutionContext } from '../core/workspace-dir-validation.js';
+import { resolveWorkspaceDir } from '../core/workspace-dir-service.js';
+import { resolveWorkspaceDirFromApi } from '../core/path-resolver.js';
+
+/**
+ * Resolve workspace directory for command execution.
+ *
+ * Chain: ctx.workspaceDir → resolveWorkspaceDirFromApi (official OpenClaw API + env vars)
+ *
+ * CRITICAL: Throws if workspaceDir cannot be resolved. Silent failures are dangerous
+ * because commands might operate on the wrong directory.
+ */
+export function resolveCommandWorkspaceDir(
+  api: OpenClawPluginApi,
+  ctx: { workspaceDir?: string },
+): string {
+  // 1. Direct from command context (most reliable — set by OpenClaw for current session)
+  if (ctx.workspaceDir) {
+    const issue = validateWorkspaceDir(ctx.workspaceDir);
+    if (!issue) return ctx.workspaceDir;
+    api.logger.error(`[PD:Command] ctx.workspaceDir="${ctx.workspaceDir}" is invalid: ${issue}`);
+  }
+
+  // 2. Official OpenClaw API → env vars → config file
+  const resolved = resolveWorkspaceDirFromApi(api);
+  if (resolved) return resolved;
+
+  // CRITICAL FAILURE: Cannot determine workspace directory
+  const errorMsg = `[PD:Command] CRITICAL: Cannot resolve workspace directory. ` +
+    `ctx.workspaceDir="${ctx.workspaceDir}" is invalid, and all fallbacks failed. ` +
+    `Commands will NOT execute to prevent data corruption.`;
+  api.logger.error(errorMsg);
+
+  throw new Error(errorMsg);
+}
+
+/**
+ * Resolve workspace directory for tool hook execution (safe version).
+ * Returns undefined instead of throwing if resolution fails.
+ */
+export function resolveToolHookWorkspaceDirSafe(
+  ctx: WorkspaceResolutionContext,
+  api: OpenClawPluginApi,
+  source: string,
+): string | undefined {
+  return resolveWorkspaceDir(api, ctx, { source });
+}

--- a/packages/openclaw-plugin/tests/core/workspace-dir-validation.test.ts
+++ b/packages/openclaw-plugin/tests/core/workspace-dir-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as os from 'os';
-import { validateWorkspaceDir, resolveValidWorkspaceDir, logWorkspaceDirHealth } from '../../src/core/workspace-dir-validation.js';
+import { validateWorkspaceDir, resolveValidWorkspaceDir, logWorkspaceDirHealth } from '../../src/core/workspace-dir-service.js';
 
 const homeDir = os.homedir();
 

--- a/packages/openclaw-plugin/tests/integration/tool-hooks-workspace-dir.e2e.test.ts
+++ b/packages/openclaw-plugin/tests/integration/tool-hooks-workspace-dir.e2e.test.ts
@@ -65,7 +65,7 @@ describe('E2E: Tool Hooks workspaceDir Resolution', () => {
 
   describe('Scenario 2: ctx.workspaceDir is undefined (current OpenClaw behavior)', () => {
     it('should fallback to agentId resolution', async () => {
-      const { resolveValidWorkspaceDir } = await import('../../src/core/workspace-dir-validation.js');
+      const { resolveValidWorkspaceDir } = await import('../../src/core/workspace-dir-service.js');
       
       const mockApi = createMockApi(testWorkspaceDir);
       const ctx = { 
@@ -80,7 +80,7 @@ describe('E2E: Tool Hooks workspaceDir Resolution', () => {
     });
 
     it('should refuse to guess a workspace when agentId is also undefined', async () => {
-      const { resolveValidWorkspaceDir } = await import('../../src/core/workspace-dir-validation.js');
+      const { resolveValidWorkspaceDir } = await import('../../src/core/workspace-dir-service.js');
       
       const mockApi = createMockApi(testWorkspaceDir);
       const ctx = { 
@@ -131,7 +131,7 @@ describe('E2E: Tool Hooks workspaceDir Resolution', () => {
 
   describe('Scenario 4: Invalid workspace candidates are rejected', () => {
     it('should return undefined when all workspace resolution candidates are invalid', async () => {
-      const { resolveValidWorkspaceDir } = await import('../../src/core/workspace-dir-validation.js');
+      const { resolveValidWorkspaceDir } = await import('../../src/core/workspace-dir-service.js');
       
       const mockApi = createMockApi(os.homedir());
       mockApi.runtime.agent.resolveAgentWorkspaceDir.mockReturnValue(os.homedir());

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -26,6 +26,7 @@ const integrationTests = [
   'tests/core/replay-engine.test.ts',
   'tests/core/trajectory.test.ts',
   'tests/integration/**/*.test.ts',
+  'tests/integration/**/*.test.tsx',
   'tests/service/nocturnal-service-code-candidate.test.ts',
   'tests/service/nocturnal-target-selector.test.ts',
 ];

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -1,12 +1,40 @@
 import { defineConfig } from 'vitest/config';
 
+/**
+ * Vitest configuration with test layering
+ *
+ * LAYERS:
+ * - unit: Mock-based tests, no real DB (fast, parallel)
+ * - integration: Tests using real SQLite DB (requires threads pool)
+ *
+ * USAGE:
+ * - npm test              → run all tests
+ * - npm run test:unit     → run unit tests only (fast)
+ * - npm run test:integration → run integration tests only
+ *
+ * WHY threads pool?
+ * better-sqlite3 native handles don't clean up properly in fork subprocesses,
+ * causing teardown hangs. Threads pool handles this correctly.
+ */
+
+// Integration tests: use real SQLite database
+const integrationTests = [
+  'tests/core/control-ui-db.test.ts',
+  'tests/core/evolution-logger.test.ts',
+  'tests/core/nocturnal-e2e.test.ts',
+  'tests/core/nocturnal-trajectory-extractor.test.ts',
+  'tests/core/replay-engine.test.ts',
+  'tests/core/trajectory.test.ts',
+  'tests/integration/**/*.test.ts',
+  'tests/service/nocturnal-service-code-candidate.test.ts',
+  'tests/service/nocturnal-target-selector.test.ts',
+];
+
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
-    // vitest 4: pool: 'forks' 默认启用隔离，每个测试文件在独立进程中运行
-    pool: 'forks',
-    // 确保测试完成后进程能正常退出
+    pool: 'threads',
     teardownTimeout: 15000,
     coverage: {
       provider: 'v8',
@@ -18,6 +46,24 @@ export default defineConfig({
         branches: 60,
         statements: 70,
       },
-    }
-  }
+    },
+    // Workspace projects for layered testing
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+          exclude: integrationTests,
+          pool: 'threads',
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          include: integrationTests,
+          pool: 'threads',
+        },
+      },
+    ],
+  },
 });


### PR DESCRIPTION
## Summary

- **Fix teardown hang**: Change vitest pool from `forks` to `threads` to resolve better-sqlite3 native module handle leak
- **Test layering**: Add unit/integration separation with dedicated npm scripts
- **Config consolidation**: Remove duplicate root vitest.config.ts

## Root Cause

better-sqlite3's native SQLite handles don't clean up properly in fork subprocesses even after `db.close()`. Worker threads handle native module cleanup correctly.

## Changes

| File | Change |
|------|--------|
| `vitest.config.ts` | pool: `forks` → `threads`, add test projects for layering |
| `package.json` | Add `test:unit`, `test:integration` scripts |
| Root `vitest.config.ts` | Removed (duplicate, not used) |

## Test Results

- Integration tests (with real SQLite): 11 files, 108 tests, 8.68s ✅
- Unit tests (mock): Run separately with `npm run test:unit` ✅
- No more teardown hangs ✅

## 5-Why Analysis

1. **Why tests hung?** → better-sqlite3 handles in fork subprocesses
2. **Why fork pool?** → Default pool setting, no review
3. **Why hard to debug?** → Config split across 2 files, misleading symptoms
4. **Why 127 tests mixed?** → No test layering strategy
5. **Root cause** → Test architecture lacked governance

## Other Changes

- workspace-dir-service/validation refactoring
- nocturnal-workflow-manager improvements  
- v1.16 planning milestones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新特性**
  * 日志文件现已按日期自动分割，每日单独保存
  * 事件和系统日志添加了自动保留策略（保留7天）
  * 系统日志新增缓存刷新功能

* **测试**
  * 新增独立的 `test:unit` 和 `test:integration` 测试脚本
  * Vitest 配置优化，支持并行运行单元和集成测试

* **文档**
  * 添加 v1.16 "Trinity Training Trajectory Quality Enhancement" 里程碑需求与路线图
<!-- end of auto-generated comment: release notes by coderabbit.ai -->