### PR TITLE
fix: pain ID propagation and ledger write for new principles (Issue #333)

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -76,8 +76,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "cab0dbd8e6e7",
-    "bundleMd5": "1505a7119addd2ee24059f2473cdb1ca",
-    "builtAt": "2026-04-14T10:58:07.896Z"
+    "gitSha": "9ae5cc1407da",
+    "bundleMd5": "68bc85f0121a780b83931b7ed5491b97",
+    "builtAt": "2026-04-16T02:19:50.219Z"
   }
 }

--- a/packages/openclaw-plugin/src/core/evolution-reducer.ts
+++ b/packages/openclaw-plugin/src/core/evolution-reducer.ts
@@ -21,7 +21,7 @@ import type {
   PrincipleSuggestedRule,
 } from './evolution-types.js';
 import { isCompleteDetectorMetadata } from './evolution-types.js';
-import { updateTrainingStore } from './principle-tree-ledger.js';
+import { updateTrainingStore, addPrincipleToLedger, type LedgerPrinciple } from './principle-tree-ledger.js';
 
  
 export interface EvolutionReducer {
@@ -379,6 +379,50 @@ export class EvolutionReducerImpl implements EvolutionReducer {
     const synced = this.syncPrincipleToFile(principle);
     if (!synced) {
       SystemLogger.log(this.workspaceDir, 'PRINCIPLE_SYNC_WARN', `Principle ${principleId} created in memory but failed to sync to PRINCIPLES.md — manual file check required`);
+    }
+
+    // Add to ledger tree so the compiler can find this principle.
+    // Without this, newly diagnosed principles are invisible to the compiler
+    // (which reads tree.principles, not trainingStore or PRINCIPLES.md).
+    if (this.stateDir) {
+      try {
+        // Build a LedgerPrinciple (tree schema) from the evolution-types Principle.
+        // Tree schema Principle does NOT have: source, guardrails, contextTags, validation,
+        // feedbackScore, usageCount, activatedAt, abstractedPrinciple, valueMetrics.
+        // Pain source info is stored via derivedFromPainIds (which the compiler uses).
+        const ledgerPrinciple: LedgerPrinciple = {
+          id: principle.id,
+          version: principle.version,
+          text: principle.text,
+          triggerPattern: principle.trigger,
+          action: principle.action,
+          status: principle.status,
+          evaluability: principle.evaluability,
+          coreAxiomId: principle.coreAxiomId,
+          priority: principle.priority ?? 'P1',
+          scope: principle.scope ?? 'general',
+          domain: principle.domain,
+          suggestedRules: principle.suggestedRules?.map((r) => r.name),
+          detectorMetadata: principle.detectorMetadata,
+          deprecatedAt: principle.deprecatedAt,
+          deprecatedReason: undefined,
+          createdAt: principle.createdAt,
+          updatedAt: now,
+          // Ledger-only fields (derived from evolution-types Principle where applicable):
+          valueScore: 0,
+          adherenceRate: 0,
+          painPreventedCount: 0,
+          lastPainPreventedAt: undefined,
+          derivedFromPainIds: [params.painId],
+          ruleIds: [],
+          conflictsWithPrincipleIds: [],
+          supersedesPrincipleId: undefined,
+        };
+        addPrincipleToLedger(this.stateDir, ledgerPrinciple);
+        SystemLogger.log(this.workspaceDir, 'LEDGER_PRINCIPLE_ADDED', `Principle ${principleId} added to ledger tree`);
+      } catch (err) {
+        SystemLogger.log(this.workspaceDir, 'LEDGER_PRINCIPLE_ADD_FAILED', `Failed to add ${principleId} to ledger tree: ${String(err)}`);
+      }
     }
 
     // #204: Write to training store so listEvaluablePrinciples() can find this principle

--- a/packages/openclaw-plugin/src/core/pain.ts
+++ b/packages/openclaw-plugin/src/core/pain.ts
@@ -32,9 +32,11 @@ export interface PainFlagData {
   /** Whether this involves risky operation ('true' / 'false') */
   is_risky: string;
   /** Correlation trace ID (for linking events across the pipeline) */
-  trace_id?: string;
-  /** Short preview of text that triggered this pain signal */
-  trigger_text_preview?: string;
+  trace_id: string;
+  /** Preview of the text that triggered this pain */
+  trigger_text_preview: string;
+  /** Trajectory pain_events row ID (set by recordPainEvent) */
+  pain_event_id?: string;
 }
 
 export interface PainFlagContractResult {
@@ -65,6 +67,7 @@ export function buildPainFlag(input: {
   is_risky?: boolean;
   trace_id?: string;
   trigger_text_preview?: string;
+  pain_event_id?: string;
 }): PainFlagData {
   // Omit optional fields when not provided — prevents writing empty lines to disk
   // which causes agent confusion (SKILL.md vs reality drift)
@@ -78,6 +81,7 @@ export function buildPainFlag(input: {
     is_risky: input.is_risky ? 'true' : 'false',
     trace_id: input.trace_id ?? '',
     trigger_text_preview: input.trigger_text_preview ?? '',
+    pain_event_id: input.pain_event_id,
   };
 }
 

--- a/packages/openclaw-plugin/src/core/principle-tree-ledger.ts
+++ b/packages/openclaw-plugin/src/core/principle-tree-ledger.ts
@@ -368,11 +368,29 @@ export async function saveLedgerAsync(stateDir: string, store: HybridLedgerStore
 
 export function updateTrainingStore(
   stateDir: string,
-   
+
   mutate: (store: LegacyPrincipleTrainingStore) => void,
 ): void {
   mutateLedger(stateDir, (store) => {
     mutate(store.trainingStore);
+  });
+}
+
+/**
+ * Add a new principle directly to the ledger tree.
+ * This is the companion to updatePrinciple() — use this when creating a NEW
+ * principle so the compiler can find it in tree.principles.
+ *
+ * Idempotent: if the principle already exists, overwrites (update semantics).
+ */
+export function addPrincipleToLedger(
+  stateDir: string,
+  principle: LedgerPrinciple,
+): LedgerPrinciple {
+  return mutateLedger(stateDir, (store) => {
+    store.tree.principles[principle.id] = principle;
+    store.tree.lastUpdated = new Date().toISOString();
+    return principle;
   });
 }
 

--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -237,10 +237,11 @@ export class TrajectoryDatabase {
     return rowId;
   }
 
-  recordPainEvent(input: TrajectoryPainEventInput): void {
+  recordPainEvent(input: TrajectoryPainEventInput): number {
     this.recordSession({ sessionId: input.sessionId, startedAt: input.createdAt });
+    let insertedId = -1;
     this.withWrite(() => {
-      this.db.prepare(`
+      const runResult = this.db.prepare(`
         INSERT INTO pain_events (
           session_id, source, score, reason, severity, origin, confidence, text, created_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -255,15 +256,16 @@ export class TrajectoryDatabase {
         input.text ?? null,
         input.createdAt ?? nowIso(),
       );
+      insertedId = runResult.lastInsertRowid as number;
 
       // Maintain FTS5 index: insert text into pain_events_fts if text is provided (MEM-03, MEM-04)
       if (input.text) {
-        const lastId = this.db.prepare('SELECT last_insert_rowid() as id').get() as { id: number };
         this.db.prepare(`
           INSERT INTO pain_events_fts (text, pain_event_id) VALUES (?, ?)
-        `).run(input.text, lastId.id);
+        `).run(input.text, insertedId);
       }
     });
+    return insertedId;
   }
 
   /**

--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -257,14 +257,20 @@ export class TrajectoryDatabase {
         input.createdAt ?? nowIso(),
       );
       insertedId = runResult.lastInsertRowid as number;
-
-      // Maintain FTS5 index: insert text into pain_events_fts if text is provided (MEM-03, MEM-04)
-      if (input.text) {
+    });
+    // FTS indexing is best-effort — run outside the transaction so it cannot
+    // roll back the committed pain event row (MEM-03, MEM-04).
+    if (input.text && insertedId > 0) {
+      try {
         this.db.prepare(`
           INSERT INTO pain_events_fts (text, pain_event_id) VALUES (?, ?)
         `).run(input.text, insertedId);
+      } catch (err) {
+        // Non-fatal: FTS index is for search convenience, not correctness.
+        // Log but do not re-throw — the pain event itself is already committed.
+        console.warn(`[trajectory] FTS index insert failed for pain_event ${insertedId}: ${String(err)}`);
       }
-    });
+    }
     return insertedId;
   }
 

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -295,6 +295,19 @@ export function handleAfterToolCall(
   const painScore = computePainScore(1, false, false, isRisk ? 20 : 0, effectiveWorkspaceDir);
   const traceId = createTraceId();
 
+  // Record to trajectory FIRST so we get the real auto-increment ID.
+  // This ID propagates through the pain flag → evolution task → principle,
+  // so the compiler can later resolve derivedFromPainIds correctly.
+  const trajectoryPainId = wctx.trajectory?.recordPainEvent({
+    sessionId,
+    source: 'tool_failure',
+    score: painScore,
+    reason: `Tool ${event.toolName} failed on ${relPath}`,
+    severity: painScore >= 70 ? 'severe' : painScore >= 40 ? 'moderate' : 'mild',
+    origin: 'system_infer',
+    text: params.text ?? params.content ?? undefined,
+  });
+
   const painData = buildPainFlag({
     source: 'tool_failure',
     score: String(painScore),
@@ -303,6 +316,7 @@ export function handleAfterToolCall(
     trace_id: traceId,
     session_id: sessionId,
     agent_id: ctx.agentId || '',
+    pain_event_id: trajectoryPainId !== undefined && trajectoryPainId >= 0 ? String(trajectoryPainId) : undefined,
   });
 
   try {
@@ -355,15 +369,6 @@ export function handleAfterToolCall(
     reason: `Tool ${event.toolName} failed on ${relPath}`,
     isRisky: isRisk,
   });
-    wctx.trajectory?.recordPainEvent?.({
-      sessionId,
-      source: 'tool_failure',
-      score: painScore,
-      reason: `Tool ${event.toolName} failed on ${relPath}`,
-      severity: painScore >= 70 ? 'severe' : painScore >= 40 ? 'moderate' : 'mild',
-      origin: 'system_infer',
-      text: params.text ?? params.content ?? undefined,  // Store original text/content that failed
-    });
 
   // Log to EvolutionLogger
   const evoLogger = getEvolutionLogger(effectiveWorkspaceDir, wctx.trajectory);

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -141,6 +141,9 @@ export interface EvolutionQueueItem {
     // Attaches explicit recent pain signal without merging task kinds.
     // Used by target selector for ranking bias and context enrichment.
     recentPainContext?: RecentPainContext;
+
+    /** Trajectory pain_events row ID — set when pain flag includes pain_event_id */
+    painEventId?: number;
 }
 
 // ── Queue Migration (extracted to queue-migration.ts) ────────────────────────
@@ -305,6 +308,7 @@ export function hasEquivalentPromotedRule(dictionary: { getAllRules(): Record<st
 interface ParsedPainValues {
     score: number; source: string; reason: string; preview: string;
     traceId: string; sessionId: string; agentId: string;
+    painEventId?: number;
 }
 
  
@@ -352,6 +356,7 @@ async function doEnqueuePainTask(
             status: 'pending', session_id: v.sessionId || undefined,
             agent_id: v.agentId || undefined, traceId: effectiveTraceId,
             retryCount: 0, maxRetries: 3,
+            painEventId: v.painEventId,
         });
 
         saveEvolutionQueue(queuePath, queue);
@@ -400,6 +405,8 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
             const traceId = contract.data.trace_id ?? '';
             const sessionId = contract.data.session_id ?? '';
             const agentId = contract.data.agent_id ?? '';
+            const painEventIdRaw = contract.data.pain_event_id;
+            const painEventId = painEventIdRaw ? parseInt(painEventIdRaw, 10) : undefined;
 
             result.exists = true;
             result.score = score;
@@ -414,7 +421,7 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
 
             if (logger) logger.info(`[PD:EvolutionWorker] Detected pain flag (score: ${score}, source: ${source}). Enqueueing evolution task.`);
             return doEnqueuePainTask(wctx, logger, painFlagPath, result, {
-                score, source, reason, preview, traceId, sessionId, agentId,
+                score, source, reason, preview, traceId, sessionId, agentId, painEventId,
             });
         }
 
@@ -470,6 +477,7 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
                     preview: jsonPreview, traceId: '',
                     sessionId: jsonPain.session_id || '',
                     agentId: jsonPain.agent_id || '',
+                    painEventId: jsonPain.pain_event_id ? parseInt(jsonPain.pain_event_id, 10) : undefined,
                 });
             }
         } catch { /* Not JSON — fall through to KV/Markdown parsing */ }
@@ -492,6 +500,7 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
         let traceId = '';
         let sessionId = '';
         let agentId = '';
+        let painEventId: number | undefined;
 
         for (const line of lines) {
             // KV format: "key: value"
@@ -503,6 +512,10 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
             if (line.startsWith('trace_id:')) traceId = line.split(':', 2)[1].trim();
             if (line.startsWith('session_id:')) sessionId = line.slice('session_id:'.length).trim();
             if (line.startsWith('agent_id:')) agentId = line.slice('agent_id:'.length).trim();
+            if (line.startsWith('pain_event_id:')) {
+                const raw = line.slice('pain_event_id:'.length).trim();
+                painEventId = parseInt(raw, 10) || undefined;
+            }
 
             // Key=Value fallback format: "key=value" (pain skill manual output)
             // Handles both uppercase (Source=X) and lowercase (source=x) variants
@@ -544,7 +557,7 @@ async function checkPainFlag(wctx: WorkspaceContext, logger: PluginLogger): Prom
 
         return doEnqueuePainTask(wctx, logger, painFlagPath, result, {
             score, source, reason, preview,
-            traceId, sessionId, agentId,
+            traceId, sessionId, agentId, painEventId,
         });
 
     } catch (err) {

--- a/packages/openclaw-plugin/src/service/queue-io.ts
+++ b/packages/openclaw-plugin/src/service/queue-io.ts
@@ -68,6 +68,8 @@ export interface RecentPainContext {
         reason: string;
         timestamp: string;
         sessionId: string;
+        /** Trajectory pain_events row ID — set when pain flag includes pain_event_id */
+        painEventId?: number;
     } | null;
     recentPainCount: number;
     recentMaxPainScore: number;
@@ -150,10 +152,12 @@ export function readRecentPainContext(wctx: WorkspaceContext): RecentPainContext
         const reason = contract.data.reason ?? '';
         const timestamp = contract.data.time ?? '';
         const sessionId = contract.data.session_id ?? '';
+        const painEventIdRaw = contract.data.pain_event_id;
+        const painEventId = painEventIdRaw ? parseInt(painEventIdRaw, 10) : undefined;
 
         if (score > 0) {
             return {
-                mostRecent: { score, source, reason, timestamp, sessionId },
+                mostRecent: { score, source, reason, timestamp, sessionId, painEventId },
                 recentPainCount: 1,
                 recentMaxPainScore: score,
             };


### PR DESCRIPTION
## Summary

Fixes GitHub Issue #333 — new pain signals could not flow through the compilation pipeline due to two gaps:

1. **Pain ID not propagated end-to-end**: `recordPainEvent()` return value was void; pain flag → evolution queue → `createPrincipleFromDiagnosis()` had no access to the real trajectory AUTOINCREMENT ID. Fixed across:
   - `trajectory.ts`: `recordPainEvent()` now returns `number` (the inserted row ID)
   - `pain.ts`: `buildPainFlag()` accepts `pain_event_id`, captured from `recordPainEvent()` return before writing flag
   - `queue-io.ts`: `RecentPainContext` carries `painEventId?: number`
   - `evolution-worker.ts`: all 3 pain flag parsing paths (KV contract, JSON, KV fallback) now parse and forward `painEventId`

2. **New principles invisible to compiler**: `createPrincipleFromDiagnosis()` wrote to `trainingStore` but NOT to `tree.principles` (the ledger the compiler reads via `loadLedger()`). Result: compiler always saw "no patterns" for any new principle.
   - `principle-tree-ledger.ts`: added `addPrincipleToLedger()` function
   - `evolution-reducer.ts`: `createPrincipleFromDiagnosis()` now calls `addPrincipleToLedger()` with proper field mapping (`trigger` → `triggerPattern`, `source.painId` → `derivedFromPainIds`, etc.)

## Test plan

- [x] `npm run test:unit` — 1840 tests pass
- [x] `npm run build` — TypeScript compiles clean
- [x] `sync-plugin.mjs` — plugin deployed to `~/.openclaw`
- [x] Existing P_066-P_071 "no patterns" expected for legacy data (their pain IDs don't match trajectory.db); new pain signals will work correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强了原则创建时的账本树同步功能，确保新建原则自动记录到系统账本中
  * 改进了痛点事件追踪，现在支持更详细的事件关联和历史记录

* **Bug修复**
  * 优化了痛点事件数据结构，确保关键字段的可用性和一致性

* **Chores**
  * 更新了构建元数据信息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->