### PR TITLE
fix: write_pain_flag records pain event to trajectory DB before flag file

### DIFF
--- a/packages/openclaw-plugin/src/tools/write-pain-flag.ts
+++ b/packages/openclaw-plugin/src/tools/write-pain-flag.ts
@@ -1,8 +1,9 @@
 import type { OpenClawPluginApi } from '../openclaw-sdk.js';
 import { Type } from '@sinclair/typebox';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { buildPainFlag, writePainFlag } from '../core/pain.js';
+import { buildPainFlag } from '../core/pain.js';
 import { resolveWorkspaceDirFromApi } from '../core/path-resolver.js';
+import { TrajectoryRegistry } from '../core/trajectory.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { atomicWriteFileSync } from '../utils/io.js';
@@ -116,6 +117,29 @@ export function createWritePainFlagTool(api: OpenClawPluginApi) {
             }
 
             try {
+                // ── Record pain event to trajectory DB first (before flag file) ──
+                // This ensures we have a real AUTOINCREMENT ID that flows through
+                // the entire pain→principle→compile chain (painEventId propagation).
+                let painEventId: number | undefined;
+                try {
+                    const trajectory = TrajectoryRegistry.get(workspaceDir);
+                    painEventId = trajectory.recordPainEvent({
+                        sessionId: sessionId || 'unknown',
+                        source,
+                        score,
+                        reason,
+                        severity: null,
+                        origin: 'manual',
+                        confidence: null,
+                        text: undefined,
+                    });
+                } catch (trajErr) {
+                    // If trajectory write fails, log but continue — the pain flag
+                    // itself is still valid and should be processed. The pain event
+                    // ID simply won't be available for the compiler's exact matching.
+                    api.logger?.warn?.(`[PD:write_pain_flag] Failed to record pain event to trajectory: ${String(trajErr)}`);
+                }
+
                 // ── Build pain flag data (KV format) ──
                 const painData = buildPainFlag({
                     source,
@@ -123,6 +147,7 @@ export function createWritePainFlagTool(api: OpenClawPluginApi) {
                     reason,
                     session_id: sessionId,
                     is_risky: isRisky,
+                    pain_event_id: painEventId !== undefined ? String(painEventId) : undefined,
                 });
 
                 // ── Validate contract compliance ──


### PR DESCRIPTION
## Summary

Fix pain ID chain断裂 bug：`write_pain_flag` 工具现在在写入 pain flag 文件**之前**先向 `trajectory.db` 写入 pain event，确保有真实的 AUTOINCREMENT ID 通过完整链路。

**问题：** `write_pain_flag` 只写 flag 文件不写 trajectory.db → `painEventId = undefined` → `derivedFromPainIds` 存 task ID 字符串 → compiler exact match 失败 → `evaluability` 回退到 `manual_only`

**修复：** `write_pain_flag` 先调用 `TrajectoryRegistry.get(workspaceDir).recordPainEvent()`，把返回的 AUTOINCREMENT ID 传给 `buildPainFlag({ pain_event_id: String(id) })`

**相关 Issue:** #341

## Test Plan

- [x] `npm run test:unit` — 1852 tests pass
- [x] Build clean (tsc)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **Bug Fixes**
  * 增强了痛点事件的记录机制，现在可在数据库中跟踪事件标识符
  * 改进了错误处理，确保记录失败时系统仍能继续运行，同时记录警告信息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->