### PR TITLE
fix: ensure empathy_keywords.json exists for new users on plugin init

### DIFF
--- a/packages/openclaw-plugin/src/core/init.ts
+++ b/packages/openclaw-plugin/src/core/init.ts
@@ -6,6 +6,7 @@ import { PD_DIRS } from './paths.js';
 import { defaultContextConfig } from '../types.js';
 import { loadStore, setPrincipleState, type PrincipleTrainingState } from './principle-training-state.js';
 import { atomicWriteFileSync } from '../utils/io.js';
+import { createDefaultKeywordStore, saveKeywordStore } from './empathy-keyword-matcher.js';
 
 /**
  * Default PROFILE.json content
@@ -244,6 +245,17 @@ export function ensureStateTemplates(ctx: { logger: PluginLogger }, stateDir: st
         if (!fs.existsSync(dictDest) && fs.existsSync(dictTemplate)) {
             fs.copyFileSync(dictTemplate, dictDest);
             ctx.logger.info(`[PD] Initialized pain dictionary in stateDir: ${dictDest} (Lang: ${language})`);
+        }
+
+        // 3. Initialize empathy keyword store for new users
+        // loadKeywordStore() creates the file if missing, but we call it explicitly
+        // here so the file exists before any agent/workflow tries to read it
+        const empathyFile = path.join(stateDir, 'empathy_keywords.json');
+        if (!fs.existsSync(empathyFile)) {
+            const lang = language === 'zh' || language === 'en' ? language : 'en';
+            const store = createDefaultKeywordStore(lang);
+            saveKeywordStore(stateDir, store);
+            ctx.logger.info(`[PD] Initialized empathy keyword store in stateDir: ${empathyFile}`);
         }
     } catch (err) {
         ctx.logger.error(`[PD] Failed to initialize state templates: ${String(err)}`);


### PR DESCRIPTION
## Summary

New OpenClaw users get error: `[tools] read failed: ENOENT: ... empathy_keywords.json`

Root cause: `empathy_keywords.json` was only created lazily on first user message (via `loadKeywordStore()` in the prompt hook). If any tool/workflow tries to read the file before the first conversation, ENOENT occurs.

Fix: Initialize the empathy keyword store in `ensureStateTemplates()` during plugin startup, ensuring the file exists for new workspaces.

## Changes

- `packages/openclaw-plugin/src/core/init.ts`: Added initialization of `empathy_keywords.json` in `ensureStateTemplates()` — creates the file with default keyword store if it doesn't exist yet.

## Test plan

- [x] TypeScript clean
- [x] Unit tests pass (1853 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增同理心关键词初始化功能，为新用户自动创建和保存相关配置文件。
  * 支持多语言设置，自动根据系统语言（中文或英文）初始化对应的关键词存储库。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->