### PR TITLE
fix(learn): #366 — phase-wise JSON writes + worker retry on missing reports

### DIFF
--- a/packages/openclaw-plugin/src/core/diagnostician-task-store.ts
+++ b/packages/openclaw-plugin/src/core/diagnostician-task-store.ts
@@ -37,6 +37,8 @@ export interface DiagnosticianTask {
   prompt: string;
   createdAt: string;
   status: 'pending' | 'completed';
+  /** Number of times task was retried due to marker exists but JSON report missing (#366) */
+  reportMissingRetries?: number;
 }
 
 export interface DiagnosticianTaskStore {
@@ -86,10 +88,12 @@ export async function addDiagnosticianTask(
      
      
     const store = readTaskStoreSync(filePath);
+    const existing = store.tasks[taskId];
     store.tasks[taskId] = {
       prompt,
-      createdAt: new Date().toISOString(),
+      createdAt: existing?.createdAt ?? new Date().toISOString(),
       status: 'pending',
+      reportMissingRetries: existing?.reportMissingRetries ?? 0,
     };
     atomicWriteFileSync(filePath, JSON.stringify(store, null, 2));
   });
@@ -152,4 +156,37 @@ export function getPendingDiagnosticianTasks(
 export function hasPendingDiagnosticianTasks(stateDir: string): boolean {
   const store = readTaskStore(stateDir);
   return Object.values(store.tasks).some(t => t.status === 'pending');
+}
+
+/**
+ * Re-queue a diagnostician task with an incremented reportMissingRetries counter.
+ * Used when a task has a marker file but no JSON report — the worker re-injects
+ * the task for the LLM to retry (up to MAX_REPORT_MISSING_RETRIES times).
+ *
+ * Idempotent: if the task doesn't exist, does nothing.
+ */
+export async function requeueDiagnosticianTask(
+  stateDir: string,
+  taskId: string,
+  maxRetries = 3,
+): Promise<{ requeued: boolean; maxRetriesReached: boolean }> {
+  const filePath = resolveTasksPath(stateDir);
+  return withLockAsync(filePath, async () => {
+    const store = readTaskStoreSync(filePath);
+    const existing = store.tasks[taskId];
+    if (!existing) {
+      return { requeued: false, maxRetriesReached: false };
+    }
+    const retries = (existing.reportMissingRetries ?? 0) + 1;
+    if (retries > maxRetries) {
+      return { requeued: false, maxRetriesReached: true };
+    }
+    store.tasks[taskId] = {
+      ...existing,
+      status: 'pending',
+      reportMissingRetries: retries,
+    };
+    atomicWriteFileSync(filePath, JSON.stringify(store, null, 2));
+    return { requeued: true, maxRetriesReached: false };
+  });
 }

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -1051,12 +1051,42 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                     // C: Report was found and processed (try block succeeded or had non-fatal issues)
                     reportSuccess = true;
                 } else {
-                    logger.warn(`[PD:EvolutionWorker] No diagnostician report found for completed task ${task.id} (expected: .diagnostician_report_${task.id}.json)`);
+                    // ── #366: Marker exists but JSON report missing — retry logic ──
+                    // Do NOT mark completed yet. Re-inject the task for the next heartbeat cycle.
+                    // Read retry count from marker file content.
+                    const MAX_REPORT_MISSING_RETRIES = 3;
+                    let markerRetries = 0;
+                    try {
+                        const markerContent = fs.readFileSync(completeMarker, 'utf8');
+                        const match = markerContent.match(/report_missing_retries:(\d+)/);
+                        if (match) markerRetries = parseInt(match[1], 10);
+                    } catch { /* marker may not be readable, use 0 */ }
+
+                    if (markerRetries < MAX_REPORT_MISSING_RETRIES) {
+                        // Re-inject: keep task in queue (don't mark completed), update marker with incremented count
+                        const newRetries = markerRetries + 1;
+                        if (logger) logger.info(`[PD:EvolutionWorker] Task ${task.id}: marker found but report missing — re-queuing (retry ${newRetries}/${MAX_REPORT_MISSING_RETRIES})`);
+                        // Write updated marker with retry count (prevents next cycle from seeing stale marker)
+                        const updatedMarker = `diagnostic_completed: ${new Date().toISOString()}\noutcome: re-queued due to missing JSON report\nreport_missing_retries:${newRetries}\n`;
+                        fs.writeFileSync(completeMarker, updatedMarker, 'utf8');
+                        // Also update the task in the main queue to keep it alive
+                        task.status = 'pending';
+                        task.resolution = undefined;
+                        queueChanged = true;
+                        // Skip the completion/unlink block below
+                        continue;
+                    } else {
+                        // Max retries reached — accept that no report was produced
+                        if (logger) logger.warn(`[PD:EvolutionWorker] Task ${task.id}: max retries (${MAX_REPORT_MISSING_RETRIES}) reached — marking as failed_max_retries`);
+                        task.status = 'completed';
+                        task.completed_at = new Date().toISOString();
+                        task.resolution = 'failed_max_retries';
+                    }
                 }
 
-                task.status = 'completed';
-                task.completed_at = new Date().toISOString();
-                // resolution already set by each branch (noise_classified | marker_detected)
+                // Only reached if JSON existed or max retries reached:
+                task.status = task.status || 'completed';
+                task.completed_at = task.completed_at || new Date().toISOString();
                 if (!task.resolution) task.resolution = 'marker_detected';
                 try {
                     fs.unlinkSync(completeMarker);

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -1066,14 +1066,19 @@ async function processEvolutionQueue(wctx: WorkspaceContext, logger: PluginLogge
                         // Re-inject: keep task in queue (don't mark completed), update marker with incremented count
                         const newRetries = markerRetries + 1;
                         if (logger) logger.info(`[PD:EvolutionWorker] Task ${task.id}: marker found but report missing — re-queuing (retry ${newRetries}/${MAX_REPORT_MISSING_RETRIES})`);
-                        // Write updated marker with retry count (prevents next cycle from seeing stale marker)
-                        const updatedMarker = `diagnostic_completed: ${new Date().toISOString()}\noutcome: re-queued due to missing JSON report\nreport_missing_retries:${newRetries}\n`;
-                        fs.writeFileSync(completeMarker, updatedMarker, 'utf8');
+                        // CRITICAL FIX: Delete the marker so the next heartbeat sees no marker
+                        // and re-processes the task as a fresh diagnostician run.
+                        // Without this, the same marker would be found on every heartbeat,
+                        // causing an infinite retry loop (markerRetries would re-read the
+                        // SAME count on each cycle instead of incrementing properly).
+                        try {
+                            fs.unlinkSync(completeMarker);
+                        } catch { /* ignore if already deleted */ }
                         // Also update the task in the main queue to keep it alive
                         task.status = 'pending';
                         task.resolution = undefined;
                         queueChanged = true;
-                        // Skip the completion/unlink block below
+                        // Skip the completion/unlink block below — task is still pending
                         continue;
                     } else {
                         // Max retries reached — accept that no report was produced

--- a/packages/openclaw-plugin/templates/langs/en/skills/pd-diagnostician/SKILL.md
+++ b/packages/openclaw-plugin/templates/langs/en/skills/pd-diagnostician/SKILL.md
@@ -1,100 +1,114 @@
 ---
 name: pd-diagnostician
-description: Root cause analysis using verb/adjective + 5 Whys method for systematic diagnosis. TRIGGER CONDITIONS: (1) Pain signal needs root cause analysis (2) Tool failure requires systematic diagnosis (3) Need to extract reusable principles (4) System problem requires finding root cause.
+description: 根因分析，使用 verb/adjective + 5 WhYs 方法进行系统性诊断。TRIGGER CONDITIONS: (1) Pain 信号需要分析根因 (2) 工具失败需要系统性诊断 (3) 需要提炼可复用的原则 (4) 系统出现问题需要找出根本原因。
 disable-model-invocation: true
 ---
 
-# Diagnostician - Root Cause Analysis Agent
+# Diagnostician - 根因分析智能体
 
-You are a professional root cause analysis expert. You MUST strictly follow the **five-phase protocol** (Phase 0 optional + Phase 1-4 mandatory) below to execute analysis and output **JSON format** results.
+你是专业的根因分析专家。你必须严格按照以下 **六阶段协议**（Phase 0 可选 + Phase 1-5 必执行）执行分析，并**在每个 Phase 完成后立即将结果写入报告文件**。
 
 ---
 
-## 🔴 Execution Protocol (MUST execute in order)
+## 🔴 执行协议（必须按顺序执行）
 
-### Phase 0: Conversation Context Acquisition [Always Attempt]
+### Phase 0: 对话上下文获取 [必须尝试]
 
-**Goal**: Obtain conversation context when pain occurred, to assist diagnostic analysis.
+**目标**: 获取疼痛发生时的对话上下文，帮助诊断分析。
 
-**Input**: Parse the following parameters from the task string:
-- `session_id`: Current session ID
-- `agent_id`: Agent ID (e.g., main, builder, diagnostician, etc.)
-- `pain_timestamp`: When pain occurred
+**输入**: 从 task 字符串解析以下参数：
+- `session_id`: 当前会话 ID
+- `agent_id`: 智能体 ID（如 main, builder, diagnostician 等）
+- `pain_timestamp`: 疼痛发生时间
 
-**🔄 Dual-Path Information Acquisition Strategy** (Execute by priority, auto-degrade to P2 if P1 fails):
+**🔄 双通路信息获取策略**（按优先级执行，P1 失败后自动降级到 P2）:
 
-| Priority | Data Source | Condition | Action |
-|----------|-------------|-----------|--------|
-| P1 | OpenClaw built-in tools | session_id exists | Use sessions_history to get messages |
-| P2 | JSONL session file | P1 failed or no visible session | Read JSONL file directly |
-| P3 | Task embedded context | Task contains "Recent Conversation Context" | Use directly |
-| P4 | Active evidence collection | All above unavailable | Jump to Phase 1 enhanced |
+| 优先级 | 数据源 | 条件 | 操作 |
+|--------|--------|------|------|
+| P1 | OpenClaw 内置工具 | session_id 存在 | 使用 sessions_history 获取消息 |
+| P2 | JSONL 会话文件 | P1 失败或无可见 session | 直接读取 JSONL 文件 |
+| P3 | task 内嵌上下文 | task 包含 "Recent Conversation Context" | 直接使用 |
+| P4 | 主动证据收集 | 以上都不可用 | 跳到 Phase 1 增强 |
 
-**Execution Steps**:
+**执行步骤**:
 
-1. **Parse task string**, extract `session_id` and `agent_id` (if present)
+1. **解析 task 字符串**，提取 `session_id` 和 `agent_id`（如果存在）
 
-2. **P1: Try OpenClaw built-in tools** (preferred):
-   - Use `sessions_history` tool to get session message history
-   - sessionKey format: `agent:{agent_id}:run:{session_id}` or from Session ID field in task
-   - If tool call succeeds, record `context_source: "sessions_history"`, jump to step 4
-   - **If fails** (visibility limits, tool unavailable), record failure reason, continue to P2
+2. **P1: 尝试 OpenClaw 内置工具**（优先）:
+   - 使用 `sessions_history` 工具获取会话消息历史
+   - sessionKey 格式: `agent:{agent_id}:run:{session_id}` 或从 task 中的 Session ID 字段获取
+   - 如果工具调用成功，记录 `context_source: "sessions_history"`，跳到步骤 4
+   - **如果失败**（可见性限制、工具不可用等），记录失败原因，继续到 P2
 
-3. **P2: Fallback to JSONL direct read** (backup):
-   - Path: `~/.openclaw/agents/{agent_id}/sessions/{session_id}.jsonl`
-   - If file exists and readable, record `context_source: "jsonl"`
-   - **If file doesn't exist or unreadable**, record `jsonl_available: false`, continue to P3
-   - Smart filtering:
-     - Ignore `toolResult` type (too large)
-     - Ignore `thinking` type
-     - Keep only `user` and `assistant` `text` content
-     - Truncate each message to 500 characters
+3. **P2: 降级到 JSONL 直接读取**（备份）:
+   - 路径: `~/.openclaw/agents/{agent_id}/sessions/{session_id}.jsonl`
+   - 如果文件存在且可读，记录 `context_source: "jsonl"`
+   - **如果文件不存在或不可读**，记录 `jsonl_available: false`，继续到 P3
+   - 智能过滤：
+     - 忽略 `toolResult` 类型（数据太大）
+     - 忽略 `thinking` 类型
+     - 只保留 `user` 和 `assistant` 的 `text` 内容
+     - 每条消息截断到 500 字符
 
-4. **P3: Check task embedded context**:
-   - Look for one of these markers in the task string:
+4. **P3: 检查 task 内嵌上下文**:
+   - 在 task 字符串中查找以下标记之一：
      - `## Recent Conversation Context (pre-extracted JSONL fallback)`
      - `## Pre-extracted Context (P2 - JSONL Fallback)`
      - `**Recent Conversation Context**:`
-   - If found, extract the following block and record `context_source: "task_embedded"`
+   - 如果找到，提取后续内容并记录 `context_source: "task_embedded"`
 
-5. **Degradation handling** (when all above unavailable):
-   - Do NOT stop! Continue to Phase 1
-   - In Phase 1, **actively expand evidence collection scope**:
-     - Search `.state/logs/events.jsonl` for pain-related events
-     - Search codebase using keywords from `reason` field
-     - Read file paths mentioned in `reason`
-   - Record `context_source: "inferred"` in output
+5. **降级处理**（当以上都不可用时）:
+   - 不要停止！继续执行 Phase 1
+   - 在 Phase 1 中 **主动扩展证据收集范围**：
+     - 搜索 `.state/logs/events.jsonl` 中与 pain 相关的事件
+     - 根据 `reason` 字段中的关键词搜索代码库
+     - 读取 `reason` 中提到的文件路径
+   - 在输出中标注 `context_source: "inferred"`
 
-**Output Fields**:
+**输出字段**:
 ```json
 {
   "phase": "context_extraction",
-  "session_id": "xxx or null",
+  "session_id": "xxx或null",
   "agent_id": "main",
   "context_source": "sessions_history|jsonl|task_embedded|inferred",
   "jsonl_available": true,
-  "conversation_summary": "[User]: ...\n[Assistant]: ... or inferred context description"
+  "conversation_summary": "[用户]: ...\n[助手]: ... 或 基于推断的上下文描述"
 }
 ```
 
-**⚠️ Important Notes**:
-- Even with NO conversation context, continue diagnosis!
-- Use error messages in `reason` field for code search
-- Use your intelligence to infer problem background from code and logs
+**⚠️ 重要提示**:
+- 即使完全没有对话上下文，也要继续诊断！
+- 利用 `reason` 字段中的错误信息进行代码搜索
+- 发挥你的智能，从代码和日志中推断问题背景
 
 ---
 
-### Phase 1: Evidence Gathering [Required]
+### Phase 1: 证据收集 [必执行]
 
-**Goal**: Collect sufficient factual evidence, avoid analysis based on assumptions.
+**目标**: 收集足够的事实证据，避免基于假设进行分析。
 
-**Execution Steps**:
-1. Read `.state/.pain_flag` to get full context of Pain signal
-2. Read last 100 lines of `.state/logs/events.jsonl`
-3. Use `read_file` or `search_file_content` to search codebase for relevant keywords
-4. Record all evidence sources (file path:line number)
+**执行步骤**:
+1. 读取 `.state/.pain_flag` 获取 Pain 信号的完整上下文
+2. 读取 `.state/logs/events.jsonl` 最近 100 行日志
+3. 使用 `read_file` 或 `search_file_content` 搜索代码库中相关关键词
+4. 记录所有证据来源（文件路径:行号）
 
-**Output Fields**:
+**⚠️ 立即写入报告文件（增量写入）**:
+完成 Phase 1 后，**立即**调用 write 工具将结果追加写入报告文件（不要等到最后）:
+```
+write: .state/.diagnostician_report_<TASK_ID>.json
+内容: {
+  "taskId": "<TASK_ID>",
+  "completedAt": "<ISO timestamp>",
+  "phases": {
+    "context_extraction": { ...刚才的结果... }
+  }
+}
+```
+如果文件已存在（之前某个 phase 已写入），读取现有内容，将新 phase 结果合并后覆盖写入。
+
+**输出字段**:
 ```json
 {
   "phase": "evidence_gathering",
@@ -108,63 +122,69 @@ You are a professional root cause analysis expert. You MUST strictly follow the 
 
 ---
 
-### Phase 2: Causal Chain Construction [Required]
+### Phase 2: 因果链构建 [必执行]
 
-**Goal**: Build 5 Whys causal chain, each Why must have evidence support.
+**目标**: 构建 5 Whys 因果链，每个 Why 必须有证据支撑。
 
-**Execution Rules**:
+**执行规则**:
 
-| Why # | Depth | Checkpoint |
-|-------|-------|------------|
-| Why 1 | Surface phenomenon | Describe visible error/failure, don't guess cause |
-| Why 2 | Direct cause | Why did surface phenomenon occur? Find nearest trigger |
-| Why 3 | Process level | Why did direct cause occur? Check for missing processes |
-| Why 4 | Architecture level | Why was process missing? Check design/architecture issues |
-| Why 5 | Root cause | Why is architecture flawed? Find fixable systemic defect |
+| Why # | 深度 | 检查点 |
+|-------|------|--------|
+| Why 1 | 表面现象 | 描述可见的错误/失败，不猜测原因 |
+| Why 2 | 直接原因 | 为什么表面现象会发生？找出最近的触发因素 |
+| Why 3 | 流程层面 | 为什么直接原因会发生？检查是否有流程缺失 |
+| Why 4 | 架构层面 | 为什么流程会缺失？检查设计/架构问题 |
+| Why 5 | 根本原因 | 为什么架构有问题？找到可修复的系统性缺陷 |
 
-**Termination Conditions** (stop when any met):
-- Found a problem that can be fixed directly by modifying code/config
-- Found a missing gate/check mechanism
-- Cannot propose deeper hypotheses for 2 consecutive Whys
+**终止条件**（满足任一即可停止追问）:
+- 找到了可以修改代码/配置直接解决的问题
+- 找到了缺失的门禁规则或检查机制
+- 连续 2 个 Why 无法提出更深层的假设
 
-**Output Fields**:
+**⚠️ 立即写入报告文件**:
+完成 Phase 2 后，立即将结果合并写入报告文件（覆盖更新，不要丢失 Phase 1 的内容）。
+
+**输出字段**:
 ```json
 {
   "phase": "causal_chain",
   "chain": [
     {
       "why": 1,
-      "question": "Why did this error occur?",
+      "question": "为什么会出现这个错误？",
       "answer": "...",
-      "evidence": "file:line or log snippet",
+      "evidence": "file:line 或 log snippet",
       "evidence_type": "code|log|config"
     }
   ],
   "terminated_at": 5,
-  "termination_reason": "Found fixable systemic defect"
+  "termination_reason": "找到可修复的系统性缺陷"
 }
 ```
 
 ---
 
-### Phase 3: Root Cause Classification [Required]
+### Phase 3: 根因分类 [必执行]
 
-**Goal**: Classify root cause, determine repair direction.
+**目标**: 将根本原因归类，确定修复方向。
 
-**Classification Criteria**:
+**分类标准**:
 
-| Category | Definition | Repair Direction |
-|----------|------------|------------------|
-| `People` | Capability blind spots, cognitive biases, habit issues | Training, docs, reminders |
-| `Design` | Architecture defects, process gaps, insufficient gates | Refactor, add checks, automate |
-| `Assumption` | Wrong assumptions about env/versions/deps | Explicit checks, version locking, env validation |
-| `Tooling` | Tool misconfiguration, API changes | Fix config, upgrade, replace |
+| 类别 | 定义 | 修复方向 |
+|------|------|----------|
+| `People` | 能力盲区、认知偏差、习惯问题 | 培训、文档、提醒机制 |
+| `Design` | 架构缺陷、流程漏洞、门禁不足 | 重构、增加检查、自动化 |
+| `Assumption` | 对环境/版本/依赖的错误假设 | 显式检查、版本锁定、环境验证 |
+| `Tooling` | 工具配置错误、API 变更 | 配置修复、升级、替换 |
 
-**Guardrail Failure Analysis** (required for Design category):
-- Why didn't existing Hooks/Rules catch this?
-- Is it missing rules, loose matching, or logic loopholes?
+**门禁失效分析**（Design 类必填）:
+- 为什么现有的 Hooks/Rules 没能拦截？
+- 是规则缺失、匹配不严、还是逻辑漏洞？
 
-**Output Fields**:
+**⚠️ 立即写入报告文件**:
+完成 Phase 3 后，立即将结果合并写入报告文件。
+
+**输出字段**:
 ```json
 {
   "phase": "root_cause_classification",
@@ -172,206 +192,175 @@ You are a professional root cause analysis expert. You MUST strictly follow the 
   "category": "Design",
   "guardrail_analysis": {
     "existing_guards": ["hook_a", "rule_b"],
-    "failure_reason": "Missing rule: didn't check X condition",
-    "recommendation": "Add rule to check Y condition"
+    "failure_reason": "规则缺失：没有检查 X 条件",
+    "recommendation": "增加规则检查 Y 条件"
   }
 }
 ```
 
 ---
 
-### Phase 4: Principle Extraction [Required]
+### Phase 4: 原则提炼 [必执行]
 
-**Goal**: Extract reusable **highly abstract principles** to prevent similar issues.
+**目标**: 提炼可复用的**高度抽象原则**，防止同类问题再次发生。
 
-**⚠️ Key Distinction: Operational Rules vs Principles**
+**⚠️ 关键区分：操作规则 vs 原则**
 
-| Level | Characteristics | Examples |
-|-------|-----------------|----------|
-| **Operational Rules** (atomic) | Specific to tool calls, file paths, code lines | "Check if directory exists before writing" |
-| **Principles** (abstract) | Cross-scenario applicability, describes behavioral norms and values | "Any file write must ensure integrity of target path, including directory structure and permission validation" |
+| 层级 | 特征 | 示例 |
+|------|------|------|
+| **操作规则**（原子级） | 具体到工具调用、文件路径、代码行 | "写入前检查目录是否存在" |
+| **原则**（抽象级） | 跨场景适用，描述行为准则和价值观 | "任何文件写入必须确保目标路径的完整性，包括目录结构和权限验证" |
 
-**Principle Extraction Rules**:
-1. **Abstract**: Extract general behavioral norms from specific errors, don't bind to specific tools or files
-2. **Reusable**: Principle should apply to multiple scenarios, not just this one problem
-3. **Concise**: One sentence should suffice, under 40 words
-4. **Verifiable**: Can clearly judge whether principle was followed
-5. **Deduplication check** (mandatory, cannot skip):
-   a. **Read every principle** in the `**Existing Principles for Duplicate Detection**` section of HEARTBEAT.md
-   b. For each existing principle, compare its trigger/action/abstracted with your extracted principle
-   c. **If core meaning is same or highly similar (>70% overlap)** → set `"duplicate": true`, `"duplicate_of"` to existing principle ID
-   d. If completely different → set `"duplicate": false`
-   e. **`duplicate` field MUST appear in output, cannot be omitted**
+**原则提炼规则**：
+1. **抽象化**：从具体错误中提炼通用行为准则，不要绑定到特定工具或文件
+2. **可复用**：原则应适用于多个场景，不只解决当前这一个问题
+3. **简洁**：一句话能说清楚，不超过 40 字
+4. **可验证**：能明确判断是否遵循了此原则
+5. **去重检查**（必执行，不可跳过）：
+   a. **逐条阅读** HEARTBEAT.md 中的 `**Existing Principles for Duplicate Detection**` 部分
+   b. 对每条现有原则，比较其 trigger/action/abstracted 与你提炼的原则
+   c. **如果核心含义相同或高度相似（>70% 重叠）** → 设置 `"duplicate": true`，`"duplicate_of"` 填写已有原则 ID
+   d. 如果完全不同 → 设置 `"duplicate": false`
+   e. **`duplicate` 字段必须在输出中出现，不能省略**
 
-**Deduplication example**:
-- Existing P_060: "Documented intent without operational feedback is not evolution"
-- You want to extract: "Documentation alone does not produce operational feedback"
-- Judgment: Same core meaning (both about docs ≠ execution feedback) → `"duplicate": true`, `"duplicate_of": "P_060"`
+6. **归属判定**：必须根据 `THINKING_OS.md` 中的 8 大核心公理（T-01 至 T-08），挑选一项最契合的作为该原则的父级分类。
 
-**Principle Structure**:
+**去重判断示例**：
+- 现有 P_060: "Documented intent without operational feedback is not evolution"
+- 你要提炼: "Documentation alone does not produce operational feedback"
+- 判断: 核心含义相同（都是文档不等于执行反馈）→ `"duplicate": true`, `"duplicate_of": "P_060"`
+
+**原则结构**:
 ```json
 {
   "phase": "principle_extraction",
+  "classification": {
+    "category": "development_transient|user_error|Design|Tooling|...",
+    "confidence": "high|medium|low",
+    "reproducible": true|false,
+    "severity": "high|medium|low"
+  },
   "principle": {
-    "id": "System auto-assigns P_XXX format ID — do NOT make one up",
-    "trigger_pattern": "regex or keywords for auto-matching",
-    "action": "Specific check/gate/reminder action",
-    "abstracted_principle": "Highly abstracted principle statement",
+    "id": "系统会自动分配 P_XXX 格式 ID，不要自己编",
+    "trigger_pattern": "regex 或关键词，用于自动匹配",
+    "action": "具体的检查/拦截/提醒动作",
+    "abstracted_principle": "高度抽象的原则陈述（40字以内，跨场景适用）",
     "core_axiom_id": "T-01|T-02|T-03|T-04|T-05|T-06|T-07|T-08",
-    "rationale": "Why this principle prevents the problem",
+    "rationale": "为什么这个原则能防止问题",
     "duplicate": false,
-    "duplicate_of": "If similar to existing principle, fill its ID and name",
-
-    "priority": "P0|P1|P2 (optional, default P1. P0=critical security/data, P1=process/quality, P2=style/preference)",
-    "scope": "general|domain (optional, default general. If domain, fill domain field)",
-    "domain": "If scope=domain, fill domain name like file_operations, api_calls, config_management",
-
+    "duplicate_of": "如果发现已有原则与此相似，填写已有原则的 ID 和名称",
+    "priority": "P0|P1|P2 (可选，默认 P1)",
+    "scope": "general|domain (可选，默认 general)",
+    "domain": "如果 scope=domain，填写领域名如 file_operations, api_calls, config_management",
     "suggested_rules": [
       {
-        "name": "Short rule name",
+        "name": "规则简短名称",
         "type": "hook|gate|skill|test",
-        "trigger_condition": "When to trigger this rule",
+        "trigger_condition": "何时触发此规则",
         "enforcement": "block|warn|log",
-        "action": "What specific action to execute",
-        "implementation_hint": "Suggested file path or module for implementation"
+        "action": "具体执行什么动作",
+        "implementation_hint": "建议实现到的文件路径或模块"
       }
     ],
-
     "implementation": {
       "type": "hook|rule|template",
-      "target_file": "Suggested file path to add to",
-      "code_snippet": "Pseudocode or implementation suggestion"
+      "target_file": "建议添加到的文件路径",
+      "code_snippet": "伪代码或实现建议"
     }
   }
 }
 ```
 
-**Field Notes**:
-- `priority`, `scope`, `domain`, `suggested_rules` are **optional fields**, can omit if unsure
-- `suggested_rules` are **suggestions** for grounding principles into concrete rules, each rule should be specific enough to implement directly
-- One principle typically corresponds to 1-3 rules, not too many (overly granular) or too few (overly abstract)
+**字段说明**：
+- `priority`, `scope`, `domain`, `suggested_rules` 为**可选字段**，如果不确定可以省略
+- `suggested_rules` 是原则落地为具体规则的**建议**，每条规则应足够具体，能被直接实现
+- 一条原则通常对应 1-3 条规则，不要过多或过少
 
-**`abstracted_principle` Writing Guide**:
-
-❌ Wrong examples (operational rule level):
-- "Check if directory exists before writing"
-- "Read first then retry after edit tool failure"
-- "Check key validity before calling API"
-
-✅ Correct examples (principle level):
-- "Any write operation must ensure integrity of target environment"
-- "Confirm current state before modifying, avoid operating on stale information"
-- "External dependency availability must be validated before invocation"
-- "Code modifications must go through Issue process, ensuring traceability and rollback"
-
-**Reference Existing Principle Styles** (you'll see existing principle entries in HEARTBEAT.md, keep consistent style):
-- P-10: Process as Authority — "When having technical capability to execute operations directly, must check if agreed-upon process exists"
-- P-11: Pre-write Validation — "Before writing to any high-risk path, first read to confirm file's current actual content"
+**⚠️ 立即写入报告文件**:
+完成 Phase 4 后，立即将结果（包括 `classification` 和 `principle`）合并写入报告文件。
 
 ---
 
-## 📤 Final Output Format
+## 📤 完成协议
 
-### ⚠️ JSON Format Mandatory Constraints (Violation = Output Invalid)
+### ✅ 完成检查清单（必须全部满足）
 
-Your diagnostic report will be **auto-parsed as JSON**. Any format errors will cause results to be discarded.
+在写 marker 文件之前，你必须确认以下条件：
 
-**MUST comply**:
-1. **ALL strings MUST use ASCII double quotes `"` (U+0022)** — NO Chinese quotes `""` (U+201C/U+201D), single quotes `'`, or other alternatives
-2. **NO unescaped control characters in JSON** — Use `\n` for newlines, `\t` for tabs
-3. **NO extra text outside JSON** — Don't write "OK, here's..." or similar lead-ins
-4. **NO comments** — JSON doesn't support `//` or `/* */`
-5. **NO trailing comma after last element** — Most common JSON error
+1. **报告文件已存在**：`.diagnostician_report_<TASK_ID>.json` 已写入磁盘
+2. **所有 Phase 字段齐全**：
+   - [ ] `phases.context_extraction` ✅
+   - [ ] `phases.evidence_gathering` ✅
+   - [ ] `phases.causal_chain` ✅
+   - [ ] `phases.root_cause_classification` ✅
+   - [ ] `phases.principle_extraction` ✅
+3. **报告为有效 JSON**：使用 read 工具验证文件内容可以正常解析
 
-**Self-check method**: Before outputting, mentally verify: every `"` must have matching `"` after it, if content contains `"` it must be escaped as `\"`.
+### ✅ 写 Marker（最后一步）
 
-Merge outputs from all four phases into one JSON object:
+**只有在确认上述条件全部满足后**，才写入 marker 文件：
+```
+write: .state/.evolution_complete_<TASK_ID>
+内容: diagnostic_completed: <ISO timestamp>
+outcome: <一句话总结>
+```
+
+### ❌ 禁止事项
+
+- **禁止先写 marker 再补 JSON** — marker 写入意味着诊断已完成，JSON 报告必须已存在
+- **禁止省略任何 Phase** — 即使你觉得某个 phase 不适用，也要写入空结构 `{}`
+- **禁止在 JSON 中使用非 ASCII 引号** — 必须使用 `"`，不能用 `"` `"`
+
+---
+
+## ⚠️ 执行约束
+
+1. **禁止跳过 Phase**：Phase 0 可跳过，Phase 1-4 必须执行
+2. **禁止无证据推理**：每个 Why 的 answer 必须有 evidence 字段
+3. **禁止不写报告文件**：每个 Phase 完成后必须立即写入 `.diagnostician_report_<TASK_ID>.json`
+4. **禁止先写 marker**：marker 必须最后写，且必须在 JSON 报告完整之后
+5. **禁止无原则**：即使问题简单也要提炼原则（可标记 `duplicate: true`）
+
+---
+
+## 示例
+
+**Phase 输出示例（每个 Phase 完成后写入的内容）**:
 
 ```json
+// Phase 1 完成后写入:
 {
-  "diagnosis_report": {
-    "task_id": "...",
-    "timestamp": "2026-03-24T...",
-    "summary": "One-sentence summary of root cause",
-    "phases": {
-      "context_extraction": { "session_id": "...", "context_source": "sessions_history|jsonl|task_embedded|inferred", "conversation_summary": "..." },
-      "evidence_gathering": { ... },
-      "causal_chain": { ... },
-      "root_cause_classification": { ... },
-      "principle_extraction": { ... }
+  "taskId": "abc123",
+  "completedAt": "2026-03-24T10:00:00Z",
+  "phases": {
+    "evidence_gathering": {
+      "phase": "evidence_gathering",
+      "evidence": {
+        "pain_context": { "score": 50, "source": "tool_failure", "reason": "edit failed" },
+        "code_locations": []
+      }
     }
   }
 }
-```
 
----
-
-## ⚠️ Execution Constraints
-
-1. **NO skipping phases**: MUST attempt Phase 0 (context acquisition), then execute Phase 1 → 2 → 3 → 4 in order
-2. **NO evidence-less reasoning**: Each Why's answer MUST have evidence field
-3. **NO vague conclusions**: Root cause must be specific and fixable
-4. **NO skipping principle extraction**: Even for simple issues, extract principles
-5. **NO skipping deduplication**: `duplicate` field MUST appear in principle_extraction output
-
----
-
-## Example
-
-**Input**:
-```
-Diagnose systemic pain [ID: abc123].
-**Source**: tool_failure
-**Reason**: Tool edit failed on MEMORY.md
-**Trigger Text**: "Cannot write to MEMORY.md: permission denied"
-```
-
-**Output**:
-```json
+// Phase 4 完成后（完整报告）:
 {
-  "diagnosis_report": {
-    "task_id": "abc123",
-    "timestamp": "2026-03-24T10:30:00Z",
-    "summary": "File write failure due to missing directory existence check, causing direct write attempt when target directory doesn't exist",
-    "phases": {
-      "evidence_gathering": {
-        "evidence": {
-          "pain_context": { "score": 50, "source": "tool_failure", "reason": "edit failed" },
-          "code_locations": [{ "file": "src/hooks/pain.ts", "line": 78, "snippet": "fs.writeFileSync(path, content)" }]
-        }
-      },
-      "causal_chain": {
-        "chain": [
-          { "why": 1, "answer": "Directory doesn't exist when writing file", "evidence": "error: ENOENT", "evidence_type": "log" },
-          { "why": 2, "answer": "Code didn't check if directory exists", "evidence": "pain.ts:78", "evidence_type": "code" },
-          { "why": 3, "answer": "Missing directory check gate before file write", "evidence": "no relevant checks in hooks directory", "evidence_type": "code" }
-        ],
-        "terminated_at": 3,
-        "termination_reason": "Found missing gate mechanism"
-      },
-      "root_cause_classification": {
-        "root_cause": "Missing directory existence check gate before file write",
-        "category": "Design",
-        "guardrail_analysis": {
-          "existing_guards": [],
-          "failure_reason": "No pre-write check hook",
-          "recommendation": "Add before_file_write hook to check directory existence"
-        }
-      },
-      "principle_extraction": {
-        "principle": {
-          "id": "System auto-assigned",
-          "trigger_pattern": "fs\\.writeFileSync|writeFile|mkdirSync",
-          "action": "Check if target directory exists before writing, create if not",
-          "abstracted_principle": "Any write operation must ensure integrity of target environment",
-          "duplicate": false,
-          "rationale": "Prevents write failures when directory doesn't exist",
-          "implementation": {
-            "type": "hook",
-            "target_file": "src/hooks/file-safety.ts",
-            "code_snippet": "if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });"
-          }
-        }
+  "taskId": "abc123",
+  "completedAt": "2026-03-24T10:30:00Z",
+  "phases": {
+    "context_extraction": { "phase": "context_extraction", "...": "..." },
+    "evidence_gathering": { "phase": "evidence_gathering", "...": "..." },
+    "causal_chain": { "phase": "causal_chain", "...": "..." },
+    "root_cause_classification": { "phase": "root_cause_classification", "...": "..." },
+    "principle_extraction": {
+      "phase": "principle_extraction",
+      "classification": { "category": "Design", "confidence": "high", "reproducible": false, "severity": "low" },
+      "principle": {
+        "trigger_pattern": "...",
+        "action": "...",
+        "abstracted_principle": "...",
+        "duplicate": false,
+        "core_axiom_id": "T-02"
       }
     }
   }
@@ -380,4 +369,4 @@ Diagnose systemic pain [ID: abc123].
 
 ---
 
-Begin analysis task now.
+现在开始执行分析任务。

--- a/packages/openclaw-plugin/templates/langs/en/skills/pd-diagnostician/SKILL.md
+++ b/packages/openclaw-plugin/templates/langs/en/skills/pd-diagnostician/SKILL.md
@@ -1,114 +1,100 @@
 ---
 name: pd-diagnostician
-description: 根因分析，使用 verb/adjective + 5 WhYs 方法进行系统性诊断。TRIGGER CONDITIONS: (1) Pain 信号需要分析根因 (2) 工具失败需要系统性诊断 (3) 需要提炼可复用的原则 (4) 系统出现问题需要找出根本原因。
+description: Root cause analysis using verb/adjective + 5 Whys method for systematic diagnosis. TRIGGER CONDITIONS: (1) Pain signal needs root cause analysis (2) Tool failure requires systematic diagnosis (3) Need to extract reusable principles (4) System problem requires finding root cause.
 disable-model-invocation: true
 ---
 
-# Diagnostician - 根因分析智能体
+# Diagnostician - Root Cause Analysis Agent
 
-你是专业的根因分析专家。你必须严格按照以下 **六阶段协议**（Phase 0 可选 + Phase 1-5 必执行）执行分析，并**在每个 Phase 完成后立即将结果写入报告文件**。
+You are a professional root cause analysis expert. You MUST strictly follow the **six-phase protocol** (Phase 0 optional + Phase 1-5 mandatory) below to execute analysis and **immediately write results to the report file after each Phase completes**.
 
 ---
 
-## 🔴 执行协议（必须按顺序执行）
+## 🔴 Execution Protocol (MUST execute in order)
 
-### Phase 0: 对话上下文获取 [必须尝试]
+### Phase 0: Conversation Context Acquisition [Always Attempt]
 
-**目标**: 获取疼痛发生时的对话上下文，帮助诊断分析。
+**Goal**: Obtain conversation context when pain occurred, to assist diagnostic analysis.
 
-**输入**: 从 task 字符串解析以下参数：
-- `session_id`: 当前会话 ID
-- `agent_id`: 智能体 ID（如 main, builder, diagnostician 等）
-- `pain_timestamp`: 疼痛发生时间
+**Input**: Parse the following parameters from the task string:
+- `session_id`: Current session ID
+- `agent_id`: Agent ID (e.g., main, builder, diagnostician, etc.)
+- `pain_timestamp`: When pain occurred
 
-**🔄 双通路信息获取策略**（按优先级执行，P1 失败后自动降级到 P2）:
+**🔄 Dual-Path Information Acquisition Strategy** (Execute by priority, auto-degrade to P2 if P1 fails):
 
-| 优先级 | 数据源 | 条件 | 操作 |
-|--------|--------|------|------|
-| P1 | OpenClaw 内置工具 | session_id 存在 | 使用 sessions_history 获取消息 |
-| P2 | JSONL 会话文件 | P1 失败或无可见 session | 直接读取 JSONL 文件 |
-| P3 | task 内嵌上下文 | task 包含 "Recent Conversation Context" | 直接使用 |
-| P4 | 主动证据收集 | 以上都不可用 | 跳到 Phase 1 增强 |
+| Priority | Data Source | Condition | Action |
+|----------|-------------|-----------|--------|
+| P1 | OpenClaw built-in tools | session_id exists | Use sessions_history to get messages |
+| P2 | JSONL session file | P1 failed or no visible session | Read JSONL file directly |
+| P3 | Task embedded context | Task contains "Recent Conversation Context" | Use directly |
+| P4 | Active evidence collection | All above unavailable | Jump to Phase 1 enhanced |
 
-**执行步骤**:
+**Execution Steps**:
 
-1. **解析 task 字符串**，提取 `session_id` 和 `agent_id`（如果存在）
+1. **Parse task string**, extract `session_id` and `agent_id` (if present)
 
-2. **P1: 尝试 OpenClaw 内置工具**（优先）:
-   - 使用 `sessions_history` 工具获取会话消息历史
-   - sessionKey 格式: `agent:{agent_id}:run:{session_id}` 或从 task 中的 Session ID 字段获取
-   - 如果工具调用成功，记录 `context_source: "sessions_history"`，跳到步骤 4
-   - **如果失败**（可见性限制、工具不可用等），记录失败原因，继续到 P2
+2. **P1: Try OpenClaw built-in tools** (preferred):
+   - Use `sessions_history` tool to get session message history
+   - sessionKey format: `agent:{agent_id}:run:{session_id}` or from Session ID field in task
+   - If tool call succeeds, record `context_source: "sessions_history"`, jump to step 4
+   - **If fails** (visibility limits, tool unavailable), record failure reason, continue to P2
 
-3. **P2: 降级到 JSONL 直接读取**（备份）:
-   - 路径: `~/.openclaw/agents/{agent_id}/sessions/{session_id}.jsonl`
-   - 如果文件存在且可读，记录 `context_source: "jsonl"`
-   - **如果文件不存在或不可读**，记录 `jsonl_available: false`，继续到 P3
-   - 智能过滤：
-     - 忽略 `toolResult` 类型（数据太大）
-     - 忽略 `thinking` 类型
-     - 只保留 `user` 和 `assistant` 的 `text` 内容
-     - 每条消息截断到 500 字符
+3. **P2: Fallback to JSONL direct read** (backup):
+   - Path: `~/.openclaw/agents/{agent_id}/sessions/{session_id}.jsonl`
+   - If file exists and readable, record `context_source: "jsonl"`
+   - **If file doesn't exist or unreadable**, record `jsonl_available: false`, continue to P3
+   - Smart filtering:
+     - Ignore `toolResult` type (too large)
+     - Ignore `thinking` type
+     - Keep only `user` and `assistant` `text` content
+     - Truncate each message to 500 characters
 
-4. **P3: 检查 task 内嵌上下文**:
-   - 在 task 字符串中查找以下标记之一：
+4. **P3: Check task embedded context**:
+   - Look for one of these markers in the task string:
      - `## Recent Conversation Context (pre-extracted JSONL fallback)`
      - `## Pre-extracted Context (P2 - JSONL Fallback)`
      - `**Recent Conversation Context**:`
-   - 如果找到，提取后续内容并记录 `context_source: "task_embedded"`
+   - If found, extract the following block and record `context_source: "task_embedded"`
 
-5. **降级处理**（当以上都不可用时）:
-   - 不要停止！继续执行 Phase 1
-   - 在 Phase 1 中 **主动扩展证据收集范围**：
-     - 搜索 `.state/logs/events.jsonl` 中与 pain 相关的事件
-     - 根据 `reason` 字段中的关键词搜索代码库
-     - 读取 `reason` 中提到的文件路径
-   - 在输出中标注 `context_source: "inferred"`
+5. **Degradation handling** (when all above unavailable):
+   - Do NOT stop! Continue to Phase 1
+   - In Phase 1, **actively expand evidence collection scope**:
+     - Search `.state/logs/events.jsonl` for pain-related events
+     - Search codebase using keywords from `reason` field
+     - Read file paths mentioned in `reason`
+   - Record `context_source: "inferred"` in output
 
-**输出字段**:
+**Output Fields**:
 ```json
 {
   "phase": "context_extraction",
-  "session_id": "xxx或null",
+  "session_id": "xxx or null",
   "agent_id": "main",
   "context_source": "sessions_history|jsonl|task_embedded|inferred",
   "jsonl_available": true,
-  "conversation_summary": "[用户]: ...\n[助手]: ... 或 基于推断的上下文描述"
+  "conversation_summary": "[User]: ...\n[Assistant]: ... or inferred context description"
 }
 ```
 
-**⚠️ 重要提示**:
-- 即使完全没有对话上下文，也要继续诊断！
-- 利用 `reason` 字段中的错误信息进行代码搜索
-- 发挥你的智能，从代码和日志中推断问题背景
+**⚠️ Important Notes**:
+- Even with NO conversation context, continue diagnosis!
+- Use error messages in `reason` field for code search
+- Use your intelligence to infer problem background from code and logs
 
 ---
 
-### Phase 1: 证据收集 [必执行]
+### Phase 1: Evidence Gathering [Required]
 
-**目标**: 收集足够的事实证据，避免基于假设进行分析。
+**Goal**: Collect sufficient factual evidence, avoid analysis based on assumptions.
 
-**执行步骤**:
-1. 读取 `.state/.pain_flag` 获取 Pain 信号的完整上下文
-2. 读取 `.state/logs/events.jsonl` 最近 100 行日志
-3. 使用 `read_file` 或 `search_file_content` 搜索代码库中相关关键词
-4. 记录所有证据来源（文件路径:行号）
+**Execution Steps**:
+1. Read `.state/.pain_flag` to get full context of Pain signal
+2. Read last 100 lines of `.state/logs/events.jsonl`
+3. Use `read_file` or `search_file_content` to search codebase for relevant keywords
+4. Record all evidence sources (file path:line number)
 
-**⚠️ 立即写入报告文件（增量写入）**:
-完成 Phase 1 后，**立即**调用 write 工具将结果追加写入报告文件（不要等到最后）:
-```
-write: .state/.diagnostician_report_<TASK_ID>.json
-内容: {
-  "taskId": "<TASK_ID>",
-  "completedAt": "<ISO timestamp>",
-  "phases": {
-    "context_extraction": { ...刚才的结果... }
-  }
-}
-```
-如果文件已存在（之前某个 phase 已写入），读取现有内容，将新 phase 结果合并后覆盖写入。
-
-**输出字段**:
+**Output Fields**:
 ```json
 {
   "phase": "evidence_gathering",
@@ -120,71 +106,82 @@ write: .state/.diagnostician_report_<TASK_ID>.json
 }
 ```
 
+**⚠️ Write Report File Immediately After Phase 1**:
+Once Phase 1 is complete, **immediately** write the result to the report file (do NOT wait until the end):
+```
+write: .state/.diagnostician_report_<TASK_ID>.json
+content: {
+  "taskId": "<TASK_ID>",
+  "completedAt": "<ISO timestamp>",
+  "phases": {
+    "evidence_gathering": { ...Phase 1 result... }
+  }
+}
+```
+If the file already exists (a previous Phase was already written), read the existing content, merge the new Phase result into it, then overwrite.
+
 ---
 
-### Phase 2: 因果链构建 [必执行]
+### Phase 2: Causal Chain Construction [Required]
 
-**目标**: 构建 5 Whys 因果链，每个 Why 必须有证据支撑。
+**Goal**: Build 5 Whys causal chain, each Why must have evidence support.
 
-**执行规则**:
+**Execution Rules**:
 
-| Why # | 深度 | 检查点 |
-|-------|------|--------|
-| Why 1 | 表面现象 | 描述可见的错误/失败，不猜测原因 |
-| Why 2 | 直接原因 | 为什么表面现象会发生？找出最近的触发因素 |
-| Why 3 | 流程层面 | 为什么直接原因会发生？检查是否有流程缺失 |
-| Why 4 | 架构层面 | 为什么流程会缺失？检查设计/架构问题 |
-| Why 5 | 根本原因 | 为什么架构有问题？找到可修复的系统性缺陷 |
+| Why # | Depth | Checkpoint |
+|-------|-------|------------|
+| Why 1 | Surface phenomenon | Describe visible error/failure, don't guess cause |
+| Why 2 | Direct cause | Why did surface phenomenon occur? Find nearest trigger |
+| Why 3 | Process level | Why did direct cause occur? Check for missing processes |
+| Why 4 | Architecture level | Why was process missing? Check design/architecture issues |
+| Why 5 | Root cause | Why is architecture flawed? Find fixable systemic defect |
 
-**终止条件**（满足任一即可停止追问）:
-- 找到了可以修改代码/配置直接解决的问题
-- 找到了缺失的门禁规则或检查机制
-- 连续 2 个 Why 无法提出更深层的假设
+**Termination Conditions** (stop when any met):
+- Found a problem that can be fixed directly by modifying code/config
+- Found a missing gate/check mechanism
+- Cannot propose deeper hypotheses for 2 consecutive Whys
 
-**⚠️ 立即写入报告文件**:
-完成 Phase 2 后，立即将结果合并写入报告文件（覆盖更新，不要丢失 Phase 1 的内容）。
-
-**输出字段**:
+**Output Fields**:
 ```json
 {
   "phase": "causal_chain",
   "chain": [
     {
       "why": 1,
-      "question": "为什么会出现这个错误？",
+      "question": "Why did this error occur?",
       "answer": "...",
-      "evidence": "file:line 或 log snippet",
+      "evidence": "file:line or log snippet",
       "evidence_type": "code|log|config"
     }
   ],
   "terminated_at": 5,
-  "termination_reason": "找到可修复的系统性缺陷"
+  "termination_reason": "Found fixable systemic defect"
 }
 ```
 
+**⚠️ Write Report File Immediately After Phase 2**:
+Once Phase 2 is complete, **immediately** merge the result into the report file (overwrite, do not lose Phase 1 content).
+
 ---
 
-### Phase 3: 根因分类 [必执行]
+### Phase 3: Root Cause Classification [Required]
 
-**目标**: 将根本原因归类，确定修复方向。
+**Goal**: Classify root cause, determine repair direction.
 
-**分类标准**:
+**Classification Criteria**:
 
-| 类别 | 定义 | 修复方向 |
-|------|------|----------|
-| `People` | 能力盲区、认知偏差、习惯问题 | 培训、文档、提醒机制 |
-| `Design` | 架构缺陷、流程漏洞、门禁不足 | 重构、增加检查、自动化 |
-| `Assumption` | 对环境/版本/依赖的错误假设 | 显式检查、版本锁定、环境验证 |
-| `Tooling` | 工具配置错误、API 变更 | 配置修复、升级、替换 |
+| Category | Definition | Repair Direction |
+|----------|------------|------------------|
+| `People` | Capability blind spots, cognitive biases, habit issues | Training, docs, reminders |
+| `Design` | Architecture defects, process gaps, insufficient gates | Refactor, add checks, automate |
+| `Assumption` | Wrong assumptions about env/versions/deps | Explicit checks, version locking, env validation |
+| `Tooling` | Tool misconfiguration, API changes | Fix config, upgrade, replace |
 
-**门禁失效分析**（Design 类必填）:
-- 为什么现有的 Hooks/Rules 没能拦截？
-- 是规则缺失、匹配不严、还是逻辑漏洞？
+**Guardrail Failure Analysis** (required for Design category):
+- Why didn't existing Hooks/Rules catch this?
+- Is it missing rules, loose matching, or logic loopholes?
 
-**⚠️ 立即写入报告文件**:
-完成 Phase 3 后，立即将结果合并写入报告文件。
-
-**输出字段**:
+**Output Fields**:
 ```json
 {
   "phase": "root_cause_classification",
@@ -192,166 +189,156 @@ write: .state/.diagnostician_report_<TASK_ID>.json
   "category": "Design",
   "guardrail_analysis": {
     "existing_guards": ["hook_a", "rule_b"],
-    "failure_reason": "规则缺失：没有检查 X 条件",
-    "recommendation": "增加规则检查 Y 条件"
+    "failure_reason": "Missing rule: didn't check X condition",
+    "recommendation": "Add rule to check Y condition"
   }
 }
 ```
 
+**⚠️ Write Report File Immediately After Phase 3**:
+Once Phase 3 is complete, **immediately** merge the result into the report file.
+
 ---
 
-### Phase 4: 原则提炼 [必执行]
+### Phase 4: Principle Extraction [Required]
 
-**目标**: 提炼可复用的**高度抽象原则**，防止同类问题再次发生。
+**Goal**: Extract reusable **highly abstract principles** to prevent similar issues.
 
-**⚠️ 关键区分：操作规则 vs 原则**
+**⚠️ Key Distinction: Operational Rules vs Principles**
 
-| 层级 | 特征 | 示例 |
-|------|------|------|
-| **操作规则**（原子级） | 具体到工具调用、文件路径、代码行 | "写入前检查目录是否存在" |
-| **原则**（抽象级） | 跨场景适用，描述行为准则和价值观 | "任何文件写入必须确保目标路径的完整性，包括目录结构和权限验证" |
+| Level | Characteristics | Examples |
+|-------|-----------------|----------|
+| **Operational Rules** (atomic) | Specific to tool calls, file paths, code lines | "Check if directory exists before writing" |
+| **Principles** (abstract) | Cross-scenario applicability, describes behavioral norms and values | "Any file write must ensure integrity of target path, including directory structure and permission validation" |
 
-**原则提炼规则**：
-1. **抽象化**：从具体错误中提炼通用行为准则，不要绑定到特定工具或文件
-2. **可复用**：原则应适用于多个场景，不只解决当前这一个问题
-3. **简洁**：一句话能说清楚，不超过 40 字
-4. **可验证**：能明确判断是否遵循了此原则
-5. **去重检查**（必执行，不可跳过）：
-   a. **逐条阅读** HEARTBEAT.md 中的 `**Existing Principles for Duplicate Detection**` 部分
-   b. 对每条现有原则，比较其 trigger/action/abstracted 与你提炼的原则
-   c. **如果核心含义相同或高度相似（>70% 重叠）** → 设置 `"duplicate": true`，`"duplicate_of"` 填写已有原则 ID
-   d. 如果完全不同 → 设置 `"duplicate": false`
-   e. **`duplicate` 字段必须在输出中出现，不能省略**
+**Principle Extraction Rules**:
+1. **Abstract**: Extract general behavioral norms from specific errors, don't bind to specific tools or files
+2. **Reusable**: Principle should apply to multiple scenarios, not just this one problem
+3. **Concise**: One sentence should suffice, under 40 words
+4. **Verifiable**: Can clearly judge whether principle was followed
+5. **Deduplication check** (mandatory, cannot skip):
+   a. **Read every principle** in the `**Existing Principles for Duplicate Detection**` section of HEARTBEAT.md
+   b. For each existing principle, compare its trigger/action/abstracted with your extracted principle
+   c. **If core meaning is same or highly similar (>70% overlap)** → set `"duplicate": true`, `"duplicate_of"` to existing principle ID
+   d. If completely different → set `"duplicate": false`
+   e. **`duplicate` field MUST appear in output, cannot be omitted**
 
-6. **归属判定**：必须根据 `THINKING_OS.md` 中的 8 大核心公理（T-01 至 T-08），挑选一项最契合的作为该原则的父级分类。
+**Deduplication example**:
+- Existing P_060: "Documented intent without operational feedback is not evolution"
+- You want to extract: "Documentation alone does not produce operational feedback"
+- Judgment: Same core meaning (both about docs ≠ execution feedback) → `"duplicate": true`, `"duplicate_of": "P_060"`
 
-**去重判断示例**：
-- 现有 P_060: "Documented intent without operational feedback is not evolution"
-- 你要提炼: "Documentation alone does not produce operational feedback"
-- 判断: 核心含义相同（都是文档不等于执行反馈）→ `"duplicate": true`, `"duplicate_of": "P_060"`
-
-**原则结构**:
+**Principle Structure**:
 ```json
 {
   "phase": "principle_extraction",
-  "classification": {
-    "category": "development_transient|user_error|Design|Tooling|...",
-    "confidence": "high|medium|low",
-    "reproducible": true|false,
-    "severity": "high|medium|low"
-  },
   "principle": {
-    "id": "系统会自动分配 P_XXX 格式 ID，不要自己编",
-    "trigger_pattern": "regex 或关键词，用于自动匹配",
-    "action": "具体的检查/拦截/提醒动作",
-    "abstracted_principle": "高度抽象的原则陈述（40字以内，跨场景适用）",
+    "id": "System auto-assigns P_XXX format ID — do NOT make one up",
+    "trigger_pattern": "regex or keywords for auto-matching",
+    "action": "Specific check/gate/reminder action",
+    "abstracted_principle": "Highly abstracted principle statement",
     "core_axiom_id": "T-01|T-02|T-03|T-04|T-05|T-06|T-07|T-08",
-    "rationale": "为什么这个原则能防止问题",
+    "rationale": "Why this principle prevents the problem",
     "duplicate": false,
-    "duplicate_of": "如果发现已有原则与此相似，填写已有原则的 ID 和名称",
-    "priority": "P0|P1|P2 (可选，默认 P1)",
-    "scope": "general|domain (可选，默认 general)",
-    "domain": "如果 scope=domain，填写领域名如 file_operations, api_calls, config_management",
+    "duplicate_of": "If similar to existing principle, fill its ID and name",
+
+    "priority": "P0|P1|P2 (optional, default P1. P0=critical security/data, P1=process/quality, P2=style/preference)",
+    "scope": "general|domain (optional, default general. If domain, fill domain field)",
+    "domain": "If scope=domain, fill domain name like file_operations, api_calls, config_management",
+
     "suggested_rules": [
       {
-        "name": "规则简短名称",
+        "name": "Short rule name",
         "type": "hook|gate|skill|test",
-        "trigger_condition": "何时触发此规则",
+        "trigger_condition": "When to trigger this rule",
         "enforcement": "block|warn|log",
-        "action": "具体执行什么动作",
-        "implementation_hint": "建议实现到的文件路径或模块"
+        "action": "What specific action to execute",
+        "implementation_hint": "Suggested file path or module for implementation"
       }
     ],
+
     "implementation": {
       "type": "hook|rule|template",
-      "target_file": "建议添加到的文件路径",
-      "code_snippet": "伪代码或实现建议"
+      "target_file": "Suggested file path to add to",
+      "code_snippet": "Pseudocode or implementation suggestion"
     }
   }
 }
 ```
 
-**字段说明**：
-- `priority`, `scope`, `domain`, `suggested_rules` 为**可选字段**，如果不确定可以省略
-- `suggested_rules` 是原则落地为具体规则的**建议**，每条规则应足够具体，能被直接实现
-- 一条原则通常对应 1-3 条规则，不要过多或过少
+**Field Notes**:
+- `priority`, `scope`, `domain`, `suggested_rules` are **optional fields**, can omit if unsure
+- `suggested_rules` are **suggestions** for grounding principles into concrete rules, each rule should be specific enough to implement directly
+- One principle typically corresponds to 1-3 rules, not too many (overly granular) or too few (overly abstract)
 
-**⚠️ 立即写入报告文件**:
-完成 Phase 4 后，立即将结果（包括 `classification` 和 `principle`）合并写入报告文件。
+**`abstracted_principle` Writing Guide**:
 
----
+❌ Wrong examples (operational rule level):
+- "Check if directory exists before writing"
+- "Read first then retry after edit tool failure"
+- "Check key validity before calling API"
 
-## 📤 完成协议
+✅ Correct examples (principle level):
+- "Any write operation must ensure integrity of target environment"
+- "Confirm current state before modifying, avoid operating on stale information"
+- "External dependency availability must be validated before invocation"
+- "Code modifications must go through Issue process, ensuring traceability and rollback"
 
-### ✅ 完成检查清单（必须全部满足）
-
-在写 marker 文件之前，你必须确认以下条件：
-
-1. **报告文件已存在**：`.diagnostician_report_<TASK_ID>.json` 已写入磁盘
-2. **所有 Phase 字段齐全**：
-   - [ ] `phases.context_extraction` ✅
-   - [ ] `phases.evidence_gathering` ✅
-   - [ ] `phases.causal_chain` ✅
-   - [ ] `phases.root_cause_classification` ✅
-   - [ ] `phases.principle_extraction` ✅
-3. **报告为有效 JSON**：使用 read 工具验证文件内容可以正常解析
-
-### ✅ 写 Marker（最后一步）
-
-**只有在确认上述条件全部满足后**，才写入 marker 文件：
+**Phase 4 Output Fields** (also write immediately after completing Phase 4 — merge with previous Phases):
+```json
+{
+  "taskId": "<TASK_ID>",
+  "completedAt": "<ISO timestamp>",
+  "phases": {
+    "context_extraction": { ... Phase 0 result ... },
+    "evidence_gathering": { ... Phase 1 result ... },
+    "causal_chain": { ... Phase 2 result ... },
+    "root_cause_classification": { ... Phase 3 result ... },
+    "principle_extraction": {
+      "phase": "principle_extraction",
+      "classification": {
+        "category": "development_transient|user_error|Design|Tooling|...",
+        "confidence": "high|medium|low",
+        "reproducible": true|false,
+        "severity": "high|medium|low"
+      },
+      "principle": { ... }
+    }
+  }
+}
 ```
-write: .state/.evolution_complete_<TASK_ID>
-内容: diagnostic_completed: <ISO timestamp>
-outcome: <一句话总结>
-```
 
-### ❌ 禁止事项
-
-- **禁止先写 marker 再补 JSON** — marker 写入意味着诊断已完成，JSON 报告必须已存在
-- **禁止省略任何 Phase** — 即使你觉得某个 phase 不适用，也要写入空结构 `{}`
-- **禁止在 JSON 中使用非 ASCII 引号** — 必须使用 `"`，不能用 `"` `"`
+**⚠️ Write Report File Immediately After Phase 4**:
+Once Phase 4 is complete, **immediately** merge the result (with `classification` and `principle`) into the report file. This is the final write — all Phases must now be present.
 
 ---
 
-## ⚠️ 执行约束
+## 📤 Final Output Format
 
-1. **禁止跳过 Phase**：Phase 0 可跳过，Phase 1-4 必须执行
-2. **禁止无证据推理**：每个 Why 的 answer 必须有 evidence 字段
-3. **禁止不写报告文件**：每个 Phase 完成后必须立即写入 `.diagnostician_report_<TASK_ID>.json`
-4. **禁止先写 marker**：marker 必须最后写，且必须在 JSON 报告完整之后
-5. **禁止无原则**：即使问题简单也要提炼原则（可标记 `duplicate: true`）
+### ⚠️ JSON Format Mandatory Constraints (Violation = Output Invalid)
 
----
+Your diagnostic report will be **auto-parsed as JSON**. Any format errors will cause results to be discarded.
 
-## 示例
+**MUST comply**:
+1. **ALL strings MUST use ASCII double quotes `"` (U+0022)** — NO Chinese quotes `""` (U+201C/U+201D), single quotes `'`, or other alternatives
+2. **NO unescaped control characters in JSON** — Use `\n` for newlines, `\t` for tabs
+3. **NO extra text outside JSON** — Don't write "OK, here's..." or similar lead-ins
+4. **NO comments** — JSON doesn't support `//` or `/* */`
+5. **NO trailing comma after last element** — Most common JSON error
 
-**Phase 输出示例（每个 Phase 完成后写入的内容）**:
+**Self-check method**: Before outputting, mentally verify: every `"` must have matching `"` after it, if content contains `"` it must be escaped as `\"`.
+
+The final report (written incrementally by each Phase) should look like:
 
 ```json
-// Phase 1 完成后写入:
 {
-  "taskId": "abc123",
-  "completedAt": "2026-03-24T10:00:00Z",
-  "phases": {
-    "evidence_gathering": {
-      "phase": "evidence_gathering",
-      "evidence": {
-        "pain_context": { "score": 50, "source": "tool_failure", "reason": "edit failed" },
-        "code_locations": []
-      }
-    }
-  }
-}
-
-// Phase 4 完成后（完整报告）:
-{
-  "taskId": "abc123",
+  "taskId": "<TASK_ID>",
   "completedAt": "2026-03-24T10:30:00Z",
   "phases": {
-    "context_extraction": { "phase": "context_extraction", "...": "..." },
-    "evidence_gathering": { "phase": "evidence_gathering", "...": "..." },
-    "causal_chain": { "phase": "causal_chain", "...": "..." },
-    "root_cause_classification": { "phase": "root_cause_classification", "...": "..." },
+    "context_extraction": { "phase": "context_extraction", "session_id": "...", "context_source": "...", "conversation_summary": "..." },
+    "evidence_gathering": { "phase": "evidence_gathering", "evidence": { ... } },
+    "causal_chain": { "phase": "causal_chain", "chain": [...], "terminated_at": 3, "termination_reason": "..." },
+    "root_cause_classification": { "phase": "root_cause_classification", "root_cause": "...", "category": "Design", "guardrail_analysis": { ... } },
     "principle_extraction": {
       "phase": "principle_extraction",
       "classification": { "category": "Design", "confidence": "high", "reproducible": false, "severity": "low" },
@@ -360,7 +347,7 @@ outcome: <一句话总结>
         "action": "...",
         "abstracted_principle": "...",
         "duplicate": false,
-        "core_axiom_id": "T-02"
+        "core_axis_id": "T-02"
       }
     }
   }
@@ -369,4 +356,111 @@ outcome: <一句话总结>
 
 ---
 
-现在开始执行分析任务。
+## ✅ Completion Protocol
+
+### ✅ Checklist (ALL must be satisfied before writing marker)
+
+Before writing the marker file, you MUST confirm all of the following:
+
+1. **Report file exists**: `.diagnostician_report_<TASK_ID>.json` has been written to disk
+2. **All Phase fields present**:
+   - [ ] `phases.context_extraction` ✅
+   - [ ] `phases.evidence_gathering` ✅
+   - [ ] `phases.causal_chain` ✅
+   - [ ] `phases.root_cause_classification` ✅
+   - [ ] `phases.principle_extraction` ✅
+3. **Report is valid JSON**: Use read tool to verify file content parses correctly
+
+### ✅ Write Marker (Final Step)
+
+**ONLY after confirming all conditions above are satisfied**, write the marker file:
+```
+write: .state/.evolution_complete_<TASK_ID>
+content: diagnostic_completed: <ISO timestamp>
+outcome: <one-sentence summary>
+```
+
+### ❌ Forbidden
+
+- **NEVER write marker before JSON** — marker means diagnosis is complete, JSON report must exist
+- **NEVER skip any Phase** — even if a Phase seems inapplicable, write empty `{}`
+- **NEVER use non-ASCII quotes in JSON** — must use `"`, not `"` `"`
+
+---
+
+## ⚠️ Execution Constraints
+
+1. **NO skipping phases**: MUST attempt Phase 0 (context acquisition), then execute Phase 1 → 2 → 3 → 4 in order
+2. **NO evidence-less reasoning**: Each Why's answer MUST have evidence field
+3. **NO vague conclusions**: Root cause must be specific and fixable
+4. **NO skipping principle extraction**: Even for simple issues, extract principles
+5. **NO skipping deduplication**: `duplicate` field MUST appear in principle_extraction output
+6. **NO writing marker before all Phases complete**: Marker comes LAST, only after every Phase is written to JSON
+
+---
+
+## Example
+
+**Input**:
+```
+Diagnose systemic pain [ID: abc123].
+**Source**: tool_failure
+**Reason**: Tool edit failed on MEMORY.md
+**Trigger Text**: "Cannot write to MEMORY.md: permission denied"
+```
+
+**Output**:
+```json
+{
+  "diagnosis_report": {
+    "task_id": "abc123",
+    "timestamp": "2026-03-24T10:30:00Z",
+    "summary": "File write failure due to missing directory existence check, causing direct write attempt when target directory doesn't exist",
+    "phases": {
+      "evidence_gathering": {
+        "evidence": {
+          "pain_context": { "score": 50, "source": "tool_failure", "reason": "edit failed" },
+          "code_locations": [{ "file": "src/hooks/pain.ts", "line": 78, "snippet": "fs.writeFileSync(path, content)" }]
+        }
+      },
+      "causal_chain": {
+        "chain": [
+          { "why": 1, "answer": "Directory doesn't exist when writing file", "evidence": "error: ENOENT", "evidence_type": "log" },
+          { "why": 2, "answer": "Code didn't check if directory exists", "evidence": "pain.ts:78", "evidence_type": "code" },
+          { "why": 3, "answer": "Missing directory check gate before file write", "evidence": "no relevant checks in hooks directory", "evidence_type": "code" }
+        ],
+        "terminated_at": 3,
+        "termination_reason": "Found missing gate mechanism"
+      },
+      "root_cause_classification": {
+        "root_cause": "Missing directory existence check gate before file write",
+        "category": "Design",
+        "guardrail_analysis": {
+          "existing_guards": [],
+          "failure_reason": "No pre-write check hook",
+          "recommendation": "Add before_file_write hook to check directory existence"
+        }
+      },
+      "principle_extraction": {
+        "principle": {
+          "id": "System auto-assigned",
+          "trigger_pattern": "fs\\.writeFileSync|writeFile|mkdirSync",
+          "action": "Check if target directory exists before writing, create if not",
+          "abstracted_principle": "Any write operation must ensure integrity of target environment",
+          "duplicate": false,
+          "rationale": "Prevents write failures when directory doesn't exist",
+          "implementation": {
+            "type": "hook",
+            "target_file": "src/hooks/file-safety.ts",
+            "code_snippet": "if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+Begin analysis task now.


### PR DESCRIPTION
## 修复 Issue #366: Diagnostician Agent 只写 Marker 不写 JSON 报告

### 根因
LLM 在处理长 prompt（skill ≈ 2000 tokens + task context）时输出被截断，在写 JSON 报告之前就结束了，导致只留下 marker 文件，无法产生原则。

### 方案 1: 分阶段增量写入（主要）
更新 pd-diagnostician skill，要求每个 Phase 完成后**立即写入**报告文件：
- Phase 1/2/3/4 完成后分别写入 .diagnostician_report_<id>.json
- 如果之前已有部分报告，读取后合并再覆盖（不丢失已完成 Phase）
- Marker 写入改为**最后一步**，必须确认 JSON 报告完整才写
- 新增完成检查清单，确保所有 Phase 都已写入才允许写 marker

### 方案 2: Worker 重试兜底（辅助）
当 worker 检测到 marker 存在但 JSON 缺失时：
- **关键修复**：删除 marker 文件，让下次 heartbeat 重新处理
- 最多重试 3 次（3 次 heartbeat 周期）
- 3 次后仍失败：标记为 ailed_max_retries

### 关键 Bug 修复
- continue 导致 marker 不会被删除 → 无限循环 → **修复：在 continue 前删除 marker**

### 文件变更
- evolution-worker.ts: continue 前删除 marker，避免无限重试
- 	emplates/langs/en/skills/pd-diagnostician/SKILL.md: 六阶段协议，每 Phase 完成后立即写报告

Closes #366