### PR TITLE
fix(sync): use WMIC to terminate gateway processes across Windows sessions

### DIFF
--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -733,18 +733,21 @@ function restartGatewayWindows() {
     const logPath = join(getTempDir(), 'openclaw-auto-restart.log');
 
     try {
-        // Kill existing gateway processes first (don't rely on schtasks stop)
+        // Kill existing gateway processes first — taskkill fails across Windows sessions,
+        // use WMIC which can terminate processes regardless of session boundary.
         console.log('   Stopping existing gateway processes...');
         try {
-            const findCmd = "Get-Process -Name 'node' -ErrorAction SilentlyContinue | Where-Object { \$_.CommandLine -like '*openclaw*' } | Select-Object -ExpandProperty Id";
-            const pids = execSync(`powershell -NoProfile -Command "${findCmd}"`, { encoding: 'utf-8' }).trim();
+            const findPids = `Get-NetTCPConnection -LocalPort 18789 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique`;
+            const pids = execSync(`powershell -NoProfile -Command "${findPids}"`, { encoding: 'utf-8' }).trim();
             if (pids) {
-                const pidList = pids.split('\n').filter(p => p.trim());
+                const pidList = pids.split('\n').filter(p => p.trim() && p !== '0');
                 for (const pid of pidList) {
-                    try { execSync(`taskkill /PID ${pid.trim()} /F`, { stdio: 'pipe' }); } catch { /* ignore */ }
+                    const pidTrim = pid.trim();
+                    try {
+                        execSync(`wmic process where "ProcessId=${pidTrim}" call terminate`, { stdio: 'ignore' });
+                    } catch { /* ignore individual failures */ }
                 }
-                // Wait for graceful shutdown
-                execSync('timeout /t 2 /nobreak > nul', { shell: true, stdio: 'ignore' });
+                execSync('timeout /t 3 /nobreak > nul', { shell: true, stdio: 'ignore' });
             }
         } catch { /* no existing processes */ }
 


### PR DESCRIPTION
## Summary
- `taskkill` fails across Windows Session 0/1 boundaries — the OpenClaw Gateway scheduled task runs in a different session than the CLI, so taskkill always returns "Access denied" even as Administrator
- `wmic process where "ProcessId=XXX" call terminate` works across session boundaries
- Also: find gateway PIDs by port (18789) instead of process name to avoid killing unrelated node.exe processes

## Test plan
- [x] `node scripts/sync-plugin.mjs --dev` successfully restarts gateway with no manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)