### PR TITLE
fix(event-log): count legacy {success:false} events in diagnosticianReportsWritten

### DIFF
--- a/packages/openclaw-plugin/src/core/event-log.ts
+++ b/packages/openclaw-plugin/src/core/event-log.ts
@@ -416,12 +416,10 @@ export class EventLog {
         }
       } else if (Object.prototype.hasOwnProperty.call(raw, 'success')) {
         // Legacy format: { success: boolean }
-        // Apply agreed default semantics: treat as 'success' if true, 'missing_json' if false
-        if (raw['success']) {
-          stats.evolution.diagnosticianReportsWritten++;
-        }
-        // Note: legacy 'false' entries are not counted in any sub-counter since
-        // the old system had no such breakdown; they are invisible in sub-stats.
+        // Agreed fix: count ALL legacy events in diagnosticianReportsWritten (+1 for both true and false).
+        // Sub-counters (reportsMissingJson/reportsIncompleteFields) stay untouched because
+        // legacy events lack enough information to distinguish sub-category — preserve total, don't fake breakdown.
+        stats.evolution.diagnosticianReportsWritten++;
       }
     } else if (entry.type === 'principle_candidate') {
       stats.evolution.principleCandidatesCreated++;


### PR DESCRIPTION
## Summary

Fix legacy backward compatibility bug where `{ success: false }` persisted diagnostician_report events were not being counted in `diagnosticianReportsWritten`.

## Fix

Changed the legacy compat branch in `updateStats()` from conditional (`if (raw['success'])`) to unconditional `diagnosticianReportsWritten++` for all legacy `{success:boolean}` events.

Sub-counters (`reportsMissingJson`/`reportsIncompleteFields`) remain untouched — legacy events lack category information, so we preserve the total without faking a breakdown.

## Finding Addressed

- **Finding 1/3** (legacy compat): Real, Fixed — `diagnosticianReportsWritten` now correctly counts all legacy `success:boolean` events (true and false)
- **Finding 2/4** (incomplete_fields double-count): Stale — confirmed no double-count; `continue` at line 977 prevents the second `recordDiagnosticianReport` at line 1166

## Test Results

```
Test Files: 1 passed (1)
Tests: 15 passed (15)
```

## Files Changed

- `packages/openclaw-plugin/src/core/event-log.ts` — legacy compat fix