### PR TITLE
chore: update MEMORY.md for v1.10.40 + M10 shipped

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,10 +1,9 @@
 # 项目记忆 — Principles Disciple
 
-## 当前状态 (2026-04-14)
-- **版本**: v1.10.x (PR #290 已合并)
+## 当前状态 (2026-04-30)
+- **版本**: v1.10.40 (PR #414 已合并)
 - **OpenClaw 版本**: 2026.4.11
-- **OpenClaw 源码**: `/home/csuzngjh/code/openclaw/`
-- **Agent worktree**: `/home/csuzngjh/code/principles/agent-worktree` (分支 `agent-worktree`)
+- **当前里程碑**: v2.9 M10 (Nocturnal Artificer LLM Upgrade) 已 SHIPPED，m10-03 deferred to v2.10
 
 ## 核心架构事实
 
@@ -43,18 +42,17 @@
 6. **代码操作纪律**：commit 前必须验证 staged 文件；写代码前必须 grep 确认 API 存在；修复后必须读回验证
 
 ## 部署
-- `cd packages/openclaw-plugin && node scripts/sync-plugin.mjs --dev` 构建、同步、重启
+- 插件同步：`node packages/openclaw-plugin/scripts/sync-plugin.mjs`
 - 验证部署：`grep "EvolutionWorker started for workspace:" ~/.openclaw/extensions/principles-disciple/dist/bundle.js`
-- 查看运行时日志：`journalctl --user -u openclaw-gateway --since "5 min ago" | grep "PD:"`
-- `npx tsx scripts/pipeline-health.ts --workspace ~/.openclaw/workspace-main` 健康检查
+- Windows 运行时日志：`Get-Content $env:USERPROFILE/.openclaw/logs/plugin.log -Tail 100 -Wait`
+- 健康检查：`npx tsx scripts/pipeline-health.ts --workspace ~/.openclaw/workspace-main`
 
 ## 关键文件位置
 - 插件源码: `packages/openclaw-plugin/src/`
 - 测试: `packages/openclaw-plugin/tests/`
-- OpenClaw 源码: `/home/csuzngjh/code/openclaw/`
+- OpenClaw 源码: `C:/Users/Administrator/.openclaw/` 或自定义路径
 - 插件配置: `~/.openclaw/openclaw.json`
 - 状态文件: `~/.openclaw/workspace-*/.state/`
-- 故障排查文档: `docs/troubleshooting/evolution-worker-start.md`
 - Cron jobs: `~/.openclaw/cron/jobs.json`
 
 ## 已验证通的链路
@@ -72,6 +70,18 @@
 - quota 默认只有 3 次/天（已通过配置改为 20）
 - idle 检测依赖无活跃会话，开发中很难触发（已通过 periodic 模式绕过）
 - 所有 sleep_reflection 相关日志已从 debug 改为 info 级别
+
+## Runtime v2 当前事实 (2026-04-30)
+- M9 已合并 (2026-04-29)：PiAiRuntimeAdapter 作为默认 Diagnostician Runtime，ledger probation entry = 成功标准
+- M10 已合并 (2026-04-30, PR #414)：Artificer LLM Upgrade 替换 hardcoded stub
+  - m10-01 ✅: runArtificerAsync + parseArtificerOutput + buildArtificerPrompt
+  - m10-02 ✅: Pipeline Integration，LLM 失败返回 `skipped`（DD-04: no candidate > bad candidate）
+  - m10-03 ❌: Dynamic Pruning & E2E Validation — **deferred to v2.10**
+- LOCKED-04 ✅: Artificer 使用与 Diagnostician 相同的 runtimeAdapter 配置
+- LOCKED-05 ✅: 静态验证（validateRuleImplementationCandidate）是强制门控
+- LOCKED-06 ⚠️: Dynamic Pruning 可验证性 — m10-03 deferred，无 adherence-based lifecycle
+- 重要修复：sessions 表 schema 与 OpenClaw trajectory 对齐（`updated_at` 而非 `last_seen_at`）
+- 重要修复：parseArtificerOutput 使用 extractJsonOrPlaintext 支持 markdown/fenced JSON
 
 ## Runtime v2 重构事实 (2026-04-26)
 - 当前方向：PD Runtime v2 已完成 M1-M5，M6 正在接入 `openclaw-cli` 作为第一个真实生产 runtime adapter。目标是摆脱 OpenClaw 插件 API / heartbeat / prompt hook / sessions_spawn / marker file，改成 `pd diagnose run --runtime openclaw-cli` 的显式执行链。

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -44,13 +44,13 @@
 ## 部署
 - 插件同步：`node packages/openclaw-plugin/scripts/sync-plugin.mjs`
 - 验证部署：`grep "EvolutionWorker started for workspace:" ~/.openclaw/extensions/principles-disciple/dist/bundle.js`
-- Windows 运行时日志：`Get-Content $env:USERPROFILE/.openclaw/logs/plugin.log -Tail 100 -Wait`
+- Windows 运行时日志（PowerShell）：`Get-Content $env:USERPROFILE/.openclaw/logs/plugin.log -Tail 100 -Wait`
 - 健康检查：`npx tsx scripts/pipeline-health.ts --workspace ~/.openclaw/workspace-main`
 
 ## 关键文件位置
 - 插件源码: `packages/openclaw-plugin/src/`
 - 测试: `packages/openclaw-plugin/tests/`
-- OpenClaw 源码: `C:/Users/Administrator/.openclaw/` 或自定义路径
+- OpenClaw 源码: `~/.openclaw/`（Windows: `C:/Users/Administrator/.openclaw/`）
 - 插件配置: `~/.openclaw/openclaw.json`
 - 状态文件: `~/.openclaw/workspace-*/.state/`
 - Cron jobs: `~/.openclaw/cron/jobs.json`

--- a/packages/openclaw-plugin/src/commands/nocturnal-train.ts
+++ b/packages/openclaw-plugin/src/commands/nocturnal-train.ts
@@ -347,8 +347,8 @@ Hardware tiers:
                     try {
                       resolve(JSON.parse(trimmed));
                       return;
-                    } catch {
-                      // fall through to result file
+                    } catch (_parseErr) {
+                      // stdout was not valid JSON — fall through to result file
                     }
                   }
                   // Fallback to result file

--- a/packages/openclaw-plugin/src/commands/nocturnal-train.ts
+++ b/packages/openclaw-plugin/src/commands/nocturnal-train.ts
@@ -347,7 +347,7 @@ Hardware tiers:
                     try {
                       resolve(JSON.parse(trimmed));
                       return;
-                    } catch (_parseErr) {
+                    } catch {
                       // stdout was not valid JSON — fall through to result file
                     }
                   }

--- a/packages/openclaw-plugin/src/hooks/prompt.ts
+++ b/packages/openclaw-plugin/src/hooks/prompt.ts
@@ -753,7 +753,7 @@ ${heartbeatChecklist}
 
   // 0. Behavioral Constraints (empathy observer coordination)
   // Injected here (appendSystemContext) instead of prependContext to hide from WebUI users.
-  // See: https://github.com/csuzngjh/principles/issues/XXX
+  // Behavioral constraints: empathy observer coordination
   if (shouldInjectBehavioralConstraints) {
     appendParts.push(`<behavioral_constraints>
 ${empathySilenceConstraint}

--- a/packages/openclaw-plugin/tests/service/nocturnal-workflow-manager.test.ts
+++ b/packages/openclaw-plugin/tests/service/nocturnal-workflow-manager.test.ts
@@ -1,0 +1,583 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { WorkflowRow, WorkflowEventRow } from '../../src/service/subagent-workflow/types.js';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockStoreMethods = {
+  createWorkflow: vi.fn(),
+  recordEvent: vi.fn(),
+  updateWorkflowState: vi.fn(),
+  getWorkflow: vi.fn(),
+  getEvents: vi.fn().mockReturnValue([]),
+  getExpiredWorkflows: vi.fn().mockReturnValue([]),
+  dispose: vi.fn(),
+};
+
+vi.mock('../../src/service/subagent-workflow/workflow-store.js', () => ({
+  WorkflowStore: class MockWorkflowStore {
+    createWorkflow = mockStoreMethods.createWorkflow;
+    recordEvent = mockStoreMethods.recordEvent;
+    updateWorkflowState = mockStoreMethods.updateWorkflowState;
+    getWorkflow = mockStoreMethods.getWorkflow;
+    getEvents = mockStoreMethods.getEvents;
+    getExpiredWorkflows = mockStoreMethods.getExpiredWorkflows;
+    dispose = mockStoreMethods.dispose;
+  },
+}));
+
+vi.mock('../../src/service/nocturnal-service.js', () => ({
+  executeNocturnalReflectionAsync: vi.fn(),
+}));
+
+vi.mock('../../src/utils/subagent-probe.js', () => ({
+  isSubagentRuntimeAvailable: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../src/core/nocturnal-snapshot-contract.js', () => ({
+  validateNocturnalSnapshotIngress: vi.fn().mockReturnValue({
+    status: 'valid',
+    snapshot: { sessionId: 'test-session', artifacts: [] },
+    reasons: [],
+  }),
+}));
+
+vi.mock('../../src/core/nocturnal-paths.js', () => ({
+  resolveNocturnalDir: vi.fn().mockReturnValue('/tmp/nocturnal/samples'),
+}));
+
+vi.mock('../../src/core/event-log.js', () => ({
+  EventLogService: {
+    get: vi.fn().mockReturnValue({
+      recordNocturnalDreamerCompleted: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readdirSync: vi.fn().mockReturnValue([]),
+    unlinkSync: vi.fn(),
+  };
+});
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import {
+  NocturnalWorkflowManager,
+  nocturnalWorkflowSpec,
+  type NocturnalWorkflowOptions,
+} from '../../src/service/subagent-workflow/nocturnal-workflow-manager.js';
+import { WorkflowStore } from '../../src/service/subagent-workflow/workflow-store.js';
+import { executeNocturnalReflectionAsync } from '../../src/service/nocturnal-service.js';
+import { isSubagentRuntimeAvailable } from '../../src/utils/subagent-probe.js';
+import { validateNocturnalSnapshotIngress } from '../../src/core/nocturnal-snapshot-contract.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function createMockRuntimeAdapter() {
+  return {
+    execute: vi.fn(),
+    isRuntimeAvailable: vi.fn().mockReturnValue(true),
+  };
+}
+
+let mockLogger: ReturnType<typeof createMockLogger>;
+
+function createManager(overrides?: Partial<NocturnalWorkflowOptions>) {
+  mockLogger = createMockLogger();
+  const defaults: NocturnalWorkflowOptions = {
+    workspaceDir: '/tmp/test-workspace',
+    stateDir: '/tmp/test-workspace/.state',
+    logger: mockLogger as any,
+    runtimeAdapter: createMockRuntimeAdapter() as any,
+    subagent: { run: vi.fn() },
+  };
+  return new NocturnalWorkflowManager({ ...defaults, ...overrides });
+}
+
+function getMockStore() {
+  return mockStoreMethods;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('nocturnalWorkflowSpec', () => {
+  test('has correct constants', () => {
+    expect(nocturnalWorkflowSpec.workflowType).toBe('nocturnal');
+    expect(nocturnalWorkflowSpec.transport).toBe('runtime_direct');
+    expect(nocturnalWorkflowSpec.timeoutMs).toBe(15 * 60 * 1000);
+    expect(nocturnalWorkflowSpec.ttlMs).toBe(30 * 60 * 1000);
+    expect(nocturnalWorkflowSpec.shouldDeleteSessionAfterFinalize).toBe(false);
+  });
+
+  test('buildPrompt returns empty string', () => {
+    expect(nocturnalWorkflowSpec.buildPrompt({}, {} as any)).toBe('');
+  });
+
+  test('parseResult extracts nocturnalResult from metadata', async () => {
+    const result = await nocturnalWorkflowSpec.parseResult({
+      metadata: { nocturnalResult: { success: true } },
+    } as any);
+    expect(result).toEqual({ success: true });
+  });
+
+  test('parseResult returns null when no nocturnalResult', async () => {
+    const result = await nocturnalWorkflowSpec.parseResult({
+      metadata: {},
+    } as any);
+    expect(result).toBeNull();
+  });
+
+  test('shouldFinalizeOnWaitStatus returns true only for ok', () => {
+    expect(nocturnalWorkflowSpec.shouldFinalizeOnWaitStatus('ok')).toBe(true);
+    expect(nocturnalWorkflowSpec.shouldFinalizeOnWaitStatus('error')).toBe(false);
+    expect(nocturnalWorkflowSpec.shouldFinalizeOnWaitStatus('timeout')).toBe(false);
+  });
+});
+
+describe('NocturnalWorkflowManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isSubagentRuntimeAvailable).mockReturnValue(true);
+    vi.mocked(validateNocturnalSnapshotIngress).mockReturnValue({
+      status: 'valid',
+      snapshot: { sessionId: 'test-session', artifacts: [] },
+      reasons: [],
+    } as any);
+  });
+
+  // ── startWorkflow ────────────────────────────────────────────────────────
+
+  describe('startWorkflow', () => {
+    test('throws when subagent runtime is unavailable', async () => {
+      vi.mocked(isSubagentRuntimeAvailable).mockReturnValue(false);
+      const manager = createManager();
+
+      await expect(
+        manager.startWorkflow(nocturnalWorkflowSpec as any, {
+          parentSessionId: 'sess-1',
+          taskInput: {},
+        })
+      ).rejects.toThrow('subagent runtime unavailable');
+    });
+
+    test('returns terminal_error when snapshot is invalid', async () => {
+      vi.mocked(validateNocturnalSnapshotIngress).mockReturnValue({
+        status: 'invalid',
+        snapshot: null,
+        reasons: ['missing snapshot'],
+      } as any);
+      const manager = createManager();
+
+      const handle = await manager.startWorkflow(nocturnalWorkflowSpec as any, {
+        parentSessionId: 'sess-1',
+        taskInput: {},
+        metadata: {},
+      });
+
+      expect(handle.state).toBe('terminal_error');
+      expect(handle.workflowId).toMatch(/^wf_/);
+    });
+
+    test('returns active handle and launches async pipeline on valid input', async () => {
+      vi.mocked(validateNocturnalSnapshotIngress).mockReturnValue({
+        status: 'valid',
+        snapshot: { sessionId: 'test-session', artifacts: [] },
+        reasons: [],
+      } as any);
+      vi.mocked(executeNocturnalReflectionAsync).mockResolvedValue({
+        success: true,
+        artifact: { principleId: 'p-1' },
+        diagnostics: { persistedPath: '/tmp/artifact.json' },
+      } as any);
+
+      const manager = createManager();
+      const handle = await manager.startWorkflow(nocturnalWorkflowSpec as any, {
+        parentSessionId: 'sess-1',
+        taskInput: {},
+        metadata: { snapshot: { sessionId: 'test-session' } },
+      });
+
+      expect(handle.state).toBe('active');
+      expect(handle.workflowId).toMatch(/^wf_/);
+      expect(handle.childSessionKey).toContain('nocturnal:internal:');
+
+      // Async pipeline runs after startWorkflow returns
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    test('records nocturnal_failed when async pipeline throws', async () => {
+      vi.mocked(validateNocturnalSnapshotIngress).mockReturnValue({
+        status: 'valid',
+        snapshot: { sessionId: 'test-session', artifacts: [] },
+        reasons: [],
+      } as any);
+      vi.mocked(executeNocturnalReflectionAsync).mockRejectedValue(
+        new Error('pipeline exploded')
+      );
+
+      const manager = createManager();
+      const handle = await manager.startWorkflow(nocturnalWorkflowSpec as any, {
+        parentSessionId: 'sess-1',
+        taskInput: {},
+        metadata: { snapshot: { sessionId: 'test-session' } },
+      });
+
+      expect(handle.state).toBe('active');
+
+      // Wait for async pipeline to fail
+      await new Promise((r) => setTimeout(r, 100));
+      const store = getMockStore();
+      expect(store.recordEvent).toHaveBeenCalledWith(
+        handle.workflowId,
+        'nocturnal_failed',
+        null,
+        'terminal_error',
+        expect.stringContaining('pipeline exploded'),
+        expect.anything()
+      );
+    });
+
+    test('passes idleCheckOverride when skipPreflightGates includes idle', async () => {
+      vi.mocked(validateNocturnalSnapshotIngress).mockReturnValue({
+        status: 'valid',
+        snapshot: { sessionId: 'test-session', artifacts: [] },
+        reasons: [],
+      } as any);
+      vi.mocked(executeNocturnalReflectionAsync).mockResolvedValue({
+        success: true,
+        artifact: { principleId: 'p-1' },
+        diagnostics: {},
+      } as any);
+
+      const manager = createManager();
+      await manager.startWorkflow(nocturnalWorkflowSpec as any, {
+        parentSessionId: 'sess-1',
+        taskInput: {},
+        metadata: {
+          snapshot: { sessionId: 'test-session' },
+          skipPreflightGates: ['idle'],
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(executeNocturnalReflectionAsync).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          idleCheckOverride: expect.objectContaining({
+            isIdle: true,
+            reason: 'skipPreflightGates override',
+          }),
+        })
+      );
+    });
+
+    test('passes principleIdOverride when principleId and snapshot provided', async () => {
+      vi.mocked(validateNocturnalSnapshotIngress).mockReturnValue({
+        status: 'valid',
+        snapshot: { sessionId: 'test-session', artifacts: [] },
+        reasons: [],
+      } as any);
+      vi.mocked(executeNocturnalReflectionAsync).mockResolvedValue({
+        success: true,
+        artifact: { principleId: 'p-1' },
+        diagnostics: {},
+      } as any);
+
+      const manager = createManager();
+      await manager.startWorkflow(nocturnalWorkflowSpec as any, {
+        parentSessionId: 'sess-1',
+        taskInput: {},
+        metadata: {
+          snapshot: { sessionId: 'test-session' },
+          principleId: 'p-123',
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(executeNocturnalReflectionAsync).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          principleIdOverride: 'p-123',
+          snapshotOverride: expect.anything(),
+        })
+      );
+    });
+  });
+
+  // ── notifyWaitResult ─────────────────────────────────────────────────────
+
+  describe('notifyWaitResult', () => {
+    test('warns when workflow not found', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue(undefined);
+
+      await manager.notifyWaitResult('missing-id', 'ok');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('workflow not found')
+      );
+    });
+
+    test('skips when workflow is not active', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue({
+        workflow_id: 'wf-1',
+        state: 'completed',
+      });
+
+      await manager.notifyWaitResult('wf-1', 'ok');
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('not in active state')
+      );
+    });
+
+    test('transitions to completed on ok status', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue({
+        workflow_id: 'wf-1',
+        state: 'active',
+      });
+
+      await manager.notifyWaitResult('wf-1', 'ok');
+
+      expect(store.updateWorkflowState).toHaveBeenCalledWith('wf-1', 'finalizing');
+      expect(store.updateWorkflowState).toHaveBeenCalledWith('wf-1', 'completed');
+      expect(store.recordEvent).toHaveBeenCalledWith(
+        'wf-1',
+        'trinity_completed',
+        'active',
+        'finalizing',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    test('transitions to terminal_error on error status', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue({
+        workflow_id: 'wf-1',
+        state: 'active',
+      });
+
+      await manager.notifyWaitResult('wf-1', 'error', 'stage failed');
+
+      expect(store.updateWorkflowState).toHaveBeenCalledWith('wf-1', 'terminal_error');
+      expect(store.recordEvent).toHaveBeenCalledWith(
+        'wf-1',
+        'nocturnal_failed',
+        'active',
+        'terminal_error',
+        'stage failed',
+        expect.anything()
+      );
+    });
+  });
+
+  // ── finalizeOnce ─────────────────────────────────────────────────────────
+
+  describe('finalizeOnce', () => {
+    test('warns when workflow not found', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue(undefined);
+
+      await manager.finalizeOnce('missing-id');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('workflow not found')
+      );
+    });
+
+    test('skips when already completed', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue({
+        workflow_id: 'wf-1',
+        state: 'completed',
+      });
+      // Mark as completed internally
+      manager['completedWorkflows'].set('wf-1', Date.now());
+
+      await manager.finalizeOnce('wf-1');
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('already completed')
+      );
+    });
+
+    test('marks completed for non-completed workflow', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue({
+        workflow_id: 'wf-1',
+        state: 'terminal_error',
+      });
+
+      await manager.finalizeOnce('wf-1');
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('already in terminal state')
+      );
+    });
+  });
+
+  // ── expireWorkflow ───────────────────────────────────────────────────────
+
+  describe('expireWorkflow', () => {
+    test('marks workflow as expired', () => {
+      const manager = createManager();
+      const store = getMockStore();
+
+      manager.expireWorkflow('wf-1', 'timeout');
+
+      expect(store.updateWorkflowState).toHaveBeenCalledWith('wf-1', 'expired');
+      expect(store.recordEvent).toHaveBeenCalledWith(
+        'wf-1',
+        'nocturnal_expired',
+        'active',
+        'expired',
+        'timeout',
+        { reason: 'timeout' }
+      );
+    });
+  });
+
+  // ── sweepExpiredWorkflows ────────────────────────────────────────────────
+
+  describe('sweepExpiredWorkflows', () => {
+    test('returns 0 when no expired workflows', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getExpiredWorkflows.mockReturnValue([]);
+
+      const count = await manager.sweepExpiredWorkflows();
+      expect(count).toBe(0);
+    });
+
+    test('sweeps expired workflows and records events', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getExpiredWorkflows.mockReturnValue([
+        {
+          workflow_id: 'wf-old',
+          state: 'active',
+          child_session_key: 'nocturnal:internal:wf-old',
+        },
+      ]);
+
+      const count = await manager.sweepExpiredWorkflows();
+
+      expect(count).toBe(1);
+      expect(store.updateWorkflowState).toHaveBeenCalledWith('wf-old', 'expired');
+      expect(store.recordEvent).toHaveBeenCalledWith(
+        'wf-old',
+        'nocturnal_expired',
+        'active',
+        'expired',
+        'TTL expired',
+        expect.anything()
+      );
+    });
+
+    test('cleans up completedWorkflows map entries older than 1 minute', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getExpiredWorkflows.mockReturnValue([]);
+
+      // Add an old entry
+      manager['completedWorkflows'].set('wf-old', Date.now() - 120_000);
+      manager['completedWorkflows'].set('wf-recent', Date.now());
+
+      await manager.sweepExpiredWorkflows();
+
+      expect(manager['completedWorkflows'].has('wf-old')).toBe(false);
+      expect(manager['completedWorkflows'].has('wf-recent')).toBe(true);
+    });
+  });
+
+  // ── getWorkflowDebugSummary ──────────────────────────────────────────────
+
+  describe('getWorkflowDebugSummary', () => {
+    test('returns null when workflow not found', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue(undefined);
+
+      const summary = await manager.getWorkflowDebugSummary('missing-id');
+      expect(summary).toBeNull();
+    });
+
+    test('returns debug summary with events', async () => {
+      const manager = createManager();
+      const store = getMockStore();
+      store.getWorkflow.mockReturnValue({
+        workflow_id: 'wf-1',
+        workflow_type: 'nocturnal',
+        transport: 'runtime_direct',
+        parent_session_id: 'sess-1',
+        child_session_key: 'nocturnal:internal:wf-1',
+        run_id: null,
+        state: 'completed',
+        cleanup_state: 'none',
+        last_observed_at: null,
+        metadata_json: '{"parentSessionId":"sess-1"}',
+      });
+      store.getEvents.mockReturnValue([
+        {
+          event_type: 'nocturnal_started',
+          from_state: null,
+          to_state: 'active',
+          reason: 'started',
+          created_at: Date.now(),
+          payload_json: '{}',
+        },
+      ] as WorkflowEventRow[]);
+
+      const summary = await manager.getWorkflowDebugSummary('wf-1', 5);
+
+      expect(summary).not.toBeNull();
+      expect(summary!.workflowId).toBe('wf-1');
+      expect(summary!.state).toBe('completed');
+      expect(summary!.recentEvents).toHaveLength(1);
+      expect(summary!.recentEvents[0].eventType).toBe('nocturnal_started');
+    });
+  });
+
+  // ── notifyLifecycleEvent ─────────────────────────────────────────────────
+
+  describe('notifyLifecycleEvent', () => {
+    test('is a no-op', async () => {
+      const manager = createManager();
+      // Should not throw
+      await manager.notifyLifecycleEvent('wf-1', 'subagent_spawned');
+      await manager.notifyLifecycleEvent('wf-1', 'subagent_ended');
+    });
+  });
+
+  // ── dispose ──────────────────────────────────────────────────────────────
+
+  describe('dispose', () => {
+    test('disposes the store', () => {
+      const manager = createManager();
+      const store = getMockStore();
+
+      manager.dispose();
+      expect(store.dispose).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/utils/session-key.test.ts
+++ b/packages/openclaw-plugin/tests/utils/session-key.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'vitest';
+import { extractAgentIdFromSessionKey } from '../../src/utils/session-key';
+
+describe('extractAgentIdFromSessionKey', () => {
+  test('returns undefined for undefined input', () => {
+    expect(extractAgentIdFromSessionKey(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for empty string', () => {
+    expect(extractAgentIdFromSessionKey('')).toBeUndefined();
+  });
+
+  test('returns agentId from 3-part key (agent:{id}:{type}:{uuid})', () => {
+    expect(extractAgentIdFromSessionKey('agent:main:session:abc-123')).toBe('main');
+  });
+
+  test('returns agentId from 2-part key (agent:{id}:{uuid})', () => {
+    expect(extractAgentIdFromSessionKey('agent:worker-1:def-456')).toBe('worker-1');
+  });
+
+  test('returns undefined for non-matching format', () => {
+    expect(extractAgentIdFromSessionKey('user:main:session:abc')).toBeUndefined();
+    expect(extractAgentIdFromSessionKey('session:abc-123')).toBeUndefined();
+    expect(extractAgentIdFromSessionKey('random-string')).toBeUndefined();
+  });
+
+  test('trims whitespace from agentId', () => {
+    expect(extractAgentIdFromSessionKey('agent: main :session:abc')).toBe('main');
+  });
+
+  test('returns undefined when agentId is whitespace-only', () => {
+    expect(extractAgentIdFromSessionKey('agent:  :session:abc')).toBeUndefined();
+  });
+
+  test('handles agentId with special characters', () => {
+    expect(extractAgentIdFromSessionKey('agent:my-agent_v2:session:abc')).toBe('my-agent_v2');
+  });
+});

--- a/packages/openclaw-plugin/tests/utils/session-key.test.ts
+++ b/packages/openclaw-plugin/tests/utils/session-key.test.ts
@@ -35,4 +35,18 @@ describe('extractAgentIdFromSessionKey', () => {
   test('handles agentId with special characters', () => {
     expect(extractAgentIdFromSessionKey('agent:my-agent_v2:session:abc')).toBe('my-agent_v2');
   });
+
+  test('returns undefined for whitespace-only agentId', () => {
+    // String.trim() removes ASCII whitespace (\\t, \\n, \\r, space) AND fullwidth space \\u3000 from edges
+    expect(extractAgentIdFromSessionKey('agent:\t:session:abc')).toBeUndefined(); // tab → empty after trim
+    expect(extractAgentIdFromSessionKey('agent:\r:session:abc')).toBeUndefined(); // CR → empty after trim
+    expect(extractAgentIdFromSessionKey('agent:\u3000:session:abc')).toBeUndefined(); // fullwidth space trimmed → empty
+  });
+
+  test('handles mixed whitespace within agentId parts', () => {
+    // Tab is internal (not at trim edge), so 'a\tb'.trim() → 'a\tb' (tab preserved in middle)
+    expect(extractAgentIdFromSessionKey('agent:a\tb:session:abc')).toBe('a\tb');
+    // CR\\n is internal, not at edge, so 'a\r\nb'.trim() → 'a\r\nb'
+    expect(extractAgentIdFromSessionKey('agent:a\r\nb:session:abc')).toBe('a\r\nb');
+  });
 });

--- a/packages/openclaw-plugin/tests/utils/subagent-probe.test.ts
+++ b/packages/openclaw-plugin/tests/utils/subagent-probe.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   getSubagentRuntimeAvailability,
   isSubagentRuntimeAvailable,
+  getAvailableSubagentRuntime,
 } from '../../src/utils/subagent-probe.js';
 
 describe('subagent-probe', () => {
@@ -27,6 +28,47 @@ describe('subagent-probe', () => {
     expect(getSubagentRuntimeAvailability({})).toEqual({
       available: false,
       reason: 'missing_run',
+    });
+  });
+});
+
+describe('getAvailableSubagentRuntime', () => {
+  const validRuntime = { run: () => Promise.resolve({ runId: 'run-1' }) };
+
+  it('returns the passed subagent when it is available', () => {
+    expect(getAvailableSubagentRuntime(validRuntime)).toBe(validRuntime);
+  });
+
+  it('returns undefined when passed undefined and no global gateway exists', () => {
+    expect(getAvailableSubagentRuntime(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when passed unavailable subagent and no global gateway', () => {
+    expect(getAvailableSubagentRuntime({} as any)).toBeUndefined();
+  });
+
+  describe('with global gateway fallback', () => {
+    const symbol = Symbol.for('openclaw.plugin.gatewaySubagentRuntime');
+
+    beforeEach(() => {
+      (globalThis as any)[symbol] = { subagent: validRuntime };
+    });
+
+    afterEach(() => {
+      delete (globalThis as any)[symbol];
+    });
+
+    it('falls back to global gateway when passed subagent is unavailable', () => {
+      expect(getAvailableSubagentRuntime(undefined)).toBe(validRuntime);
+    });
+
+    it('falls back to global gateway when passed subagent has no run', () => {
+      expect(getAvailableSubagentRuntime({} as any)).toBe(validRuntime);
+    });
+
+    it('prefers passed subagent over global gateway when both available', () => {
+      const localRuntime = { run: () => Promise.resolve({ runId: 'local' }) };
+      expect(getAvailableSubagentRuntime(localRuntime)).toBe(localRuntime);
     });
   });
 });

--- a/packages/openclaw-plugin/tests/utils/subagent-probe.test.ts
+++ b/packages/openclaw-plugin/tests/utils/subagent-probe.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from 'vitest';
 import {
   getSubagentRuntimeAvailability,
   isSubagentRuntimeAvailable,
@@ -55,6 +55,11 @@ describe('getAvailableSubagentRuntime', () => {
     });
 
     afterEach(() => {
+      delete (globalThis as any)[symbol];
+    });
+
+    afterAll(() => {
+      // Safety net: ensure cleanup even if a test crashes before afterEach
       delete (globalThis as any)[symbol];
     });
 


### PR DESCRIPTION
## Summary
- Update version to v1.10.40 (PR #414 merged)
- Add Runtime v2 M10 current facts (Artificer LLM Upgrade shipped, m10-03 deferred to v2.10)
- Fix Windows runtime log path, plugin sync path
- Improve JSON parse error context in nocturnal-train.ts
- Improve behavioral constraints comment in prompt.ts
- Add tests for getAvailableSubagentRuntime with global gateway fallback
- Add nocturnal-workflow-manager.test.ts and session-key.test.ts

## Testing
- Lint: 1 warning only (_parseErr unused var, intentional)
- Build: all workspaces pass
- Typecheck: openclaw-plugin clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新版本信息与里程碑记录（v1.10.40 和 v2.9 M10）
  * 调整部署和运行命令，优化日志检查方式

* **错误处理改进**
  * 改进训练流程中的 JSON 解析错误捕获

* **测试**
  * 新增工作流管理器核心功能测试套件
  * 扩展会话密钥提取和运行时选择逻辑的测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->