### PR TITLE
test(nocturnal-workflow-manager): verify async pipeline was actually called

### DIFF
--- a/packages/openclaw-plugin/tests/service/nocturnal-workflow-manager.test.ts
+++ b/packages/openclaw-plugin/tests/service/nocturnal-workflow-manager.test.ts
@@ -216,6 +216,7 @@ describe('NocturnalWorkflowManager', () => {
 
       // Async pipeline runs after startWorkflow returns
       await new Promise((r) => setTimeout(r, 50));
+      expect(executeNocturnalReflectionAsync).toHaveBeenCalled();
     });
 
     test('records nocturnal_failed when async pipeline throws', async () => {


### PR DESCRIPTION
## Summary

Add `expect(executeNocturnalReflectionAsync).toHaveBeenCalled()` assertion
after the setTimeout in the async-launch test. Previously the test only
checked the returned handle state but never verified the mock was invoked.

## Test plan

- [x] `npx vitest run` passes (26 tests)
- [x] CI passes (lint + build + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)