### PR TITLE
feat(pd-cli): candidate intake/audit/repair + pd health fix

### DIFF
--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -9,7 +9,6 @@
  *   pd candidate repair --candidate-id <id> --workspace <path> [--json]
  */
 import { randomUUID } from 'crypto';
-import * as fs from 'fs';
 import * as path from 'path';
 import {
   RuntimeStateManager,
@@ -17,6 +16,8 @@ import {
   candidateShow,
   CandidateIntakeService,
   CandidateIntakeError,
+  loadLedger,
+  getLedgerFilePathPublic,
   type LedgerPrincipleEntry,
 } from '@principles/core/runtime-v2';
 import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
@@ -131,7 +132,7 @@ export async function handleCandidateShow(opts: CandidateShowOptions): Promise<v
   try {
     await stateManager.initialize();
 
-    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: workspaceDir });
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: path.join(workspaceDir, '.state') });
 
     const result = await candidateShow({
       candidateId: opts.candidateId,
@@ -184,7 +185,7 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
   try {
     await stateManager.initialize();
 
-    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: workspaceDir });
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: path.join(workspaceDir, '.state') });
     const service = new CandidateIntakeService({ stateManager, ledgerAdapter });
 
     if (opts.dryRun) {
@@ -285,14 +286,14 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
   }
 }
 
-// ── Audit ───────────────────────────────────────────────────────────────────────
+// ── Audit ─────────────────────────────────────────────────────────────────────
 
 /**
  * pd candidate audit --workspace <path> [--json]
  *
  * Reads workspace/.pd/state.db principle_candidates and
- * workspace/.state/principle_training_state.json.
- * Checks each consumed candidate has a ledger sourceRef = candidate://<id>.
+ * the workspace ledger (same file used by OpenClaw plugin).
+ * Checks each consumed candidate has a ledger entry.
  * Exits non-zero if any consumed candidate is missing from ledger.
  */
 export async function handleCandidateAudit(opts: CandidateAuditOptions): Promise<void> {
@@ -304,7 +305,8 @@ export async function handleCandidateAudit(opts: CandidateAuditOptions): Promise
 
     // Load all candidates from DB
     const dbPath = path.join(workspaceDir, '.pd', 'state.db');
-    const ledgerPath = path.join(workspaceDir, '.state', 'principle_training_state.json');
+    const ledgerStateDir = path.join(workspaceDir, '.state');
+    const ledgerPath = getLedgerFilePathPublic(ledgerStateDir);
 
     const db = stateManager.connection;
     const consumedRows = db.getDb().prepare(
@@ -313,27 +315,16 @@ export async function handleCandidateAudit(opts: CandidateAuditOptions): Promise
 
     const consumedIds = consumedRows.map(r => r.candidate_id);
 
-    // Load ledger
-    let ledgerPrinciples: Record<string, unknown> = {};
-    if (fs.existsSync(ledgerPath)) {
-      try {
-        const ledgerContent = fs.readFileSync(ledgerPath, 'utf8');
-        const ledger = JSON.parse(ledgerContent);
-        ledgerPrinciples = ledger._tree?.principles || {};
-      } catch {
-        // ignore parse errors
-      }
-    }
+    // Load ledger using core's loadLedger (same format as plugin)
+    const ledger = loadLedger(ledgerStateDir);
+    const ledgerPrinciples = ledger.tree.principles;
 
     // Check each consumed candidate has ledger entry
     const missingLedgerEntryIds: string[] = [];
     for (const candidateId of consumedIds) {
-      const sourceRef = `candidate://${candidateId}`;
-      const found = Object.values(ledgerPrinciples).some((p: unknown) => {
-        const principle = p as { sourceRef?: string; derivedFromPainIds?: string[] };
-        return principle.sourceRef === sourceRef ||
-          (principle.derivedFromPainIds && principle.derivedFromPainIds.includes(candidateId));
-      });
+      const found = Object.values(ledgerPrinciples).some((p) =>
+        p.derivedFromPainIds.includes(candidateId),
+      );
       if (!found) {
         missingLedgerEntryIds.push(candidateId);
       }
@@ -343,7 +334,7 @@ export async function handleCandidateAudit(opts: CandidateAuditOptions): Promise
       status: missingLedgerEntryIds.length === 0 ? 'ok' : 'degraded',
       consumedCount: consumedIds.length,
       missingLedgerEntryIds,
-      missingCandidates: [], // not applicable in V2 audit
+      missingCandidates: [],
       checkedLedgerPath: ledgerPath,
       checkedDbPath: dbPath,
     };
@@ -401,7 +392,7 @@ export async function handleCandidateRepair(opts: CandidateRepairOptions): Promi
       process.exit(1);
     }
 
-    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: workspaceDir });
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: path.join(workspaceDir, '.state') });
     const service = new CandidateIntakeService({ stateManager, ledgerAdapter });
 
     // Check if already in ledger

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -1,11 +1,16 @@
 /**
- * pd candidate list/show commands — Principle candidate inspection.
+ * pd candidate commands — Principle candidate inspection, intake, audit, repair.
  *
  * Usage:
  *   pd candidate list --task-id <taskId> --workspace <path> [--json]
  *   pd candidate show <candidateId> --workspace <path> [--json]
+ *   pd candidate intake --candidate-id <id> [--workspace <path>] [--json] [--dry-run]
+ *   pd candidate audit --workspace <path> [--json]
+ *   pd candidate repair --candidate-id <id> --workspace <path> [--json]
  */
 import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   RuntimeStateManager,
   candidateList,
@@ -16,6 +21,8 @@ import {
 } from '@principles/core/runtime-v2';
 import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+// ── Interfaces ────────────────────────────────────────────────────────────────
 
 interface CandidateListOptions {
   taskId: string;
@@ -29,13 +36,52 @@ interface CandidateShowOptions {
   json?: boolean;
 }
 
-/* v8 ignore start */
-/**
- * pd candidate list --task-id <taskId> [--workspace <path>] [--json]
- *
- * Lists all principle candidates for a task, including candidateId, artifactId,
- * taskId, title, description, confidence, status, sourceRunId.
- */
+interface CandidateIntakeOptions {
+  candidateId: string;
+  workspace?: string;
+  json?: boolean;
+  dryRun?: boolean;
+}
+
+interface CandidateAuditOptions {
+  workspace?: string;
+  json?: boolean;
+}
+
+interface CandidateRepairOptions {
+  candidateId: string;
+  workspace?: string;
+  json?: boolean;
+}
+
+interface AuditResult {
+  status: 'ok' | 'degraded';
+  consumedCount: number;
+  missingLedgerEntryIds: string[];
+  missingCandidates: string[];
+  checkedLedgerPath: string;
+  checkedDbPath: string;
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+/** Update candidate status. Sets consumed_at when status='consumed'. */
+async function updateCandidateStatus(stateManager: RuntimeStateManager, candidateId: string, status: string): Promise<void> {
+  const db = stateManager.connection;
+  const now = new Date().toISOString();
+  if (status === 'consumed') {
+    db.getDb().prepare(
+      'UPDATE principle_candidates SET status = ?, consumed_at = ? WHERE candidate_id = ?'
+    ).run(status, now, candidateId);
+  } else {
+    db.getDb().prepare(
+      'UPDATE principle_candidates SET status = ? WHERE candidate_id = ?'
+    ).run(status, candidateId);
+  }
+}
+
+// ── List ───────────────────────────────────────────────────────────────────────
+
 export async function handleCandidateList(opts: CandidateListOptions): Promise<void> {
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
   const stateManager = new RuntimeStateManager({ workspaceDir });
@@ -58,7 +104,7 @@ export async function handleCandidateList(opts: CandidateListOptions): Promise<v
       return;
     }
 
-    console.log(`\nPrinciple Candidates for Task: ${result.taskId}\n`);
+    console.log(`\nPrinciple Candidates for Task: ${opts.taskId}\n`);
     console.log(`  Total: ${result.candidates.length}\n`);
 
     for (const candidate of result.candidates) {
@@ -76,13 +122,8 @@ export async function handleCandidateList(opts: CandidateListOptions): Promise<v
   }
 }
 
-/**
- * pd candidate show <candidateId> [--workspace <path>] [--json]
- *
- * Shows full detail for a single principle candidate.
- * Returns: candidateId, artifactId, taskId, title, description,
- * confidence, sourceRunId, status, createdAt.
- */
+// ── Show ───────────────────────────────────────────────────────────────────────
+
 export async function handleCandidateShow(opts: CandidateShowOptions): Promise<void> {
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
   const stateManager = new RuntimeStateManager({ workspaceDir });
@@ -126,29 +167,15 @@ export async function handleCandidateShow(opts: CandidateShowOptions): Promise<v
   }
 }
 
-interface CandidateIntakeOptions {
-  candidateId: string;
-  workspace?: string;
-  json?: boolean;
-  dryRun?: boolean;
-}
-
-/**
- * Update candidate status to 'consumed' via direct SQL.
- * RuntimeStateManager doesn't expose this method, so we access the DB directly.
- */
-async function updateCandidateStatus(stateManager: RuntimeStateManager, candidateId: string, status: string): Promise<void> {
-  const db = stateManager.connection;
-  db.getDb().prepare('UPDATE principle_candidates SET status = ? WHERE candidate_id = ?').run(status, candidateId);
-}
-/* v8 ignore stop */
+// ── Intake ────────────────────────────────────────────────────────────────────
 
 /**
  * pd candidate intake --candidate-id <id> [--workspace <path>] [--json] [--dry-run]
  *
  * Intakes a principle candidate into the ledger.
  * Wires together CandidateIntakeService + PrincipleTreeLedgerAdapter.
- * Updates candidate status to 'consumed' after successful ledger write.
+ * Updates candidate status to 'consumed' (with consumed_at) after successful ledger write.
+ * If ledger write succeeds but DB update fails, exits non-zero with clear error.
  */
 export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promise<void> {
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
@@ -161,7 +188,6 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
     const service = new CandidateIntakeService({ stateManager, ledgerAdapter });
 
     if (opts.dryRun) {
-      // Dry-run: build complete 11-field entry without writing (CLI-02)
       const candidate = await stateManager.getCandidate(opts.candidateId);
       if (!candidate) {
         console.error(`Candidate not found: ${opts.candidateId}`);
@@ -172,7 +198,6 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
         console.error(`Artifact not found for candidate: ${opts.candidateId}`);
         process.exit(1);
       }
-      // Parse artifact to extract recommendation
       let recommendation: { title?: string; text?: string; triggerPattern?: string; action?: string } = {};
       try {
         const parsed = JSON.parse(artifact.contentJson || '{}');
@@ -180,7 +205,6 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
       } catch (err) {
         console.warn(`Warning: could not parse artifact content as JSON — using defaults. ${err instanceof Error ? err.message : String(err)}`);
       }
-      // Build complete 11-field LedgerPrincipleEntry (same as CandidateIntakeService)
       const entry: LedgerPrincipleEntry = {
         id: randomUUID(),
         title: recommendation.title || candidate.title,
@@ -194,7 +218,6 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
         taskRef: candidate.taskId ? `task://${candidate.taskId}` : undefined,
         createdAt: new Date().toISOString(),
       };
-      // Output
       if (opts.json) {
         console.log(JSON.stringify(entry, null, 2));
       } else {
@@ -204,13 +227,12 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
       return;
     }
 
-    // Normal intake (CLI-01: ledger write first, then update status)
+    // Normal intake: ledger write first
     const entry = await service.intake(opts.candidateId);
 
-    // Check if candidate was already consumed (idempotent return per CLI-04)
+    // Check if already consumed before this call
     const candidate = await stateManager.getCandidate(opts.candidateId);
     if (candidate?.status === 'consumed') {
-      // Already consumed before this call - output info message
       const infoMessage = `Candidate ${opts.candidateId} was already consumed. Ledger entry: ${entry.id}`;
       if (opts.json) {
         console.log(JSON.stringify({
@@ -225,10 +247,16 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
       return;
     }
 
-    // Update candidate status to 'consumed' (CLI-01)
-    await updateCandidateStatus(stateManager, opts.candidateId, 'consumed');
+    // Update DB status — this must succeed; if it fails, exit non-zero
+    try {
+      await updateCandidateStatus(stateManager, opts.candidateId, 'consumed');
+    } catch (err) {
+      const msg = `Ledger write succeeded (entry ${entry.id}) but DB status update failed: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Candidate ${opts.candidateId} may be in inconsistent state.`;
+      console.error(`ERROR: ${msg}`);
+      process.exit(1);
+    }
 
-    // Output success
     const result = {
       candidateId: opts.candidateId,
       ledgerEntryId: entry.id,
@@ -245,13 +273,186 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
       console.log('Intake complete.\n');
     }
   } catch (err) {
-    // Error handling (CLI-04)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (err instanceof CandidateIntakeError || (err as any).name === 'CandidateIntakeError') {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      console.error(`Intake failed [${(err as any).code}]: ${(err as any).message}`);
+    if (err instanceof CandidateIntakeError || (err as { name?: string }).name === 'CandidateIntakeError') {
+      const e = err as { code?: string; message: string };
+      console.error(`Intake failed [${e.code ?? 'unknown'}]: ${e.message}`);
     } else {
       console.error(`Intake failed: ${String(err)}`);
+    }
+    process.exit(1);
+  } finally {
+    await stateManager.close();
+  }
+}
+
+// ── Audit ───────────────────────────────────────────────────────────────────────
+
+/**
+ * pd candidate audit --workspace <path> [--json]
+ *
+ * Reads workspace/.pd/state.db principle_candidates and
+ * workspace/.state/principle_training_state.json.
+ * Checks each consumed candidate has a ledger sourceRef = candidate://<id>.
+ * Exits non-zero if any consumed candidate is missing from ledger.
+ */
+export async function handleCandidateAudit(opts: CandidateAuditOptions): Promise<void> {
+  const workspaceDir = resolveWorkspaceDir(opts.workspace);
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+
+  try {
+    await stateManager.initialize();
+
+    // Load all candidates from DB
+    const dbPath = path.join(workspaceDir, '.pd', 'state.db');
+    const ledgerPath = path.join(workspaceDir, '.state', 'principle_training_state.json');
+
+    const db = stateManager.connection;
+    const consumedRows = db.getDb().prepare(
+      "SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'"
+    ).all() as { candidate_id: string }[];
+
+    const consumedIds = consumedRows.map(r => r.candidate_id);
+
+    // Load ledger
+    let ledgerPrinciples: Record<string, unknown> = {};
+    if (fs.existsSync(ledgerPath)) {
+      try {
+        const ledgerContent = fs.readFileSync(ledgerPath, 'utf8');
+        const ledger = JSON.parse(ledgerContent);
+        ledgerPrinciples = ledger._tree?.principles || {};
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    // Check each consumed candidate has ledger entry
+    const missingLedgerEntryIds: string[] = [];
+    for (const candidateId of consumedIds) {
+      const sourceRef = `candidate://${candidateId}`;
+      const found = Object.values(ledgerPrinciples).some((p: unknown) => {
+        const principle = p as { sourceRef?: string; derivedFromPainIds?: string[] };
+        return principle.sourceRef === sourceRef ||
+          (principle.derivedFromPainIds && principle.derivedFromPainIds.includes(candidateId));
+      });
+      if (!found) {
+        missingLedgerEntryIds.push(candidateId);
+      }
+    }
+
+    const result: AuditResult = {
+      status: missingLedgerEntryIds.length === 0 ? 'ok' : 'degraded',
+      consumedCount: consumedIds.length,
+      missingLedgerEntryIds,
+      missingCandidates: [], // not applicable in V2 audit
+      checkedLedgerPath: ledgerPath,
+      checkedDbPath: dbPath,
+    };
+
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`\nCandidate Audit Results\n`);
+      console.log(`  consumedCount: ${result.consumedCount}`);
+      console.log(`  checkedLedgerPath: ${result.checkedLedgerPath}`);
+      console.log(`  checkedDbPath: ${result.checkedDbPath}`);
+      console.log(`  status: ${result.status}`);
+      if (result.missingLedgerEntryIds.length > 0) {
+        console.log(`\n  MISSING LEDGER ENTRIES (${result.missingLedgerEntryIds.length}):`);
+        result.missingLedgerEntryIds.forEach(id => console.log(`    - ${id}`));
+      } else {
+        console.log(`\n  All consumed candidates have ledger entries.`);
+      }
+      console.log('');
+    }
+
+    if (result.status === 'degraded') {
+      process.exit(1);
+    }
+  } finally {
+    await stateManager.close();
+  }
+}
+
+// ── Repair ─────────────────────────────────────────────────────────────────────
+
+/**
+ * pd candidate repair --candidate-id <id> --workspace <path> [--json]
+ *
+ * Handles consumed but missing ledger entries.
+ * Re-calls CandidateIntakeService.intake() to write ledger entry.
+ * Does not regenerate candidate; does not update status (already consumed).
+ * Fills consumed_at if empty.
+ */
+export async function handleCandidateRepair(opts: CandidateRepairOptions): Promise<void> {
+  const workspaceDir = resolveWorkspaceDir(opts.workspace);
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+
+  try {
+    await stateManager.initialize();
+
+    // Verify candidate exists and is consumed
+    const candidate = await stateManager.getCandidate(opts.candidateId);
+    if (!candidate) {
+      console.error(`Candidate not found: ${opts.candidateId}`);
+      process.exit(1);
+    }
+    if (candidate.status !== 'consumed') {
+      console.error(`Candidate ${opts.candidateId} is not consumed (status=${candidate.status}). Repair only handles consumed candidates.`);
+      process.exit(1);
+    }
+
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: workspaceDir });
+    const service = new CandidateIntakeService({ stateManager, ledgerAdapter });
+
+    // Check if already in ledger
+    const existing = ledgerAdapter.existsForCandidate(opts.candidateId);
+    if (existing) {
+      const result = {
+        candidateId: opts.candidateId,
+        status: 'already_consistent',
+        message: `Candidate ${opts.candidateId} already has ledger entry.`,
+        ledgerEntryId: existing.id,
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`\nCandidate ${opts.candidateId} already has ledger entry: ${existing.id}\n`);
+        console.log('No repair needed.\n');
+      }
+      return;
+    }
+
+    // Re-intake to restore ledger entry
+    const entry = await service.intake(opts.candidateId);
+
+    // Ensure consumed_at is set (belt-and-suspenders)
+    const db = stateManager.connection;
+    const row = db.getDb().prepare('SELECT consumed_at FROM principle_candidates WHERE candidate_id = ?').get(opts.candidateId) as { consumed_at: string | null } | undefined;
+    if (!row?.consumed_at) {
+      const now = new Date().toISOString();
+      db.getDb().prepare('UPDATE principle_candidates SET consumed_at = ? WHERE candidate_id = ?').run(now, opts.candidateId);
+    }
+
+    const result = {
+      candidateId: opts.candidateId,
+      status: 'repaired',
+      ledgerEntryId: entry.id,
+      message: `Ledger entry restored for consumed candidate ${opts.candidateId}.`,
+    };
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`\nCandidate Repair: ${opts.candidateId}\n`);
+      console.log(`  Status:        repaired`);
+      console.log(`  Ledger Entry:   ${entry.id}\n`);
+      console.log('Repair complete.\n');
+    }
+  } catch (err) {
+    if (err instanceof CandidateIntakeError || (err as { name?: string }).name === 'CandidateIntakeError') {
+      const e = err as { code?: string; message: string };
+      console.error(`Repair failed [${e.code ?? 'unknown'}]: ${e.message}`);
+    } else {
+      console.error(`Repair failed: ${String(err)}`);
     }
     process.exit(1);
   } finally {

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -80,6 +80,20 @@ async function updateCandidateStatus(stateManager: RuntimeStateManager, candidat
   }
 }
 
+/**
+ * Ensure consumed_at is set for a consumed candidate.
+ * Returns the consumed_at value (existing or newly written), or null if candidate not found.
+ */
+async function ensureConsumedAt(stateManager: RuntimeStateManager, candidateId: string): Promise<string | null> {
+  const db = stateManager.connection;
+  const row = db.getDb().prepare('SELECT consumed_at FROM principle_candidates WHERE candidate_id = ?').get(candidateId) as { consumed_at: string | null } | undefined;
+  if (!row) return null;
+  if (row.consumed_at) return row.consumed_at;
+  const now = new Date().toISOString();
+  db.getDb().prepare('UPDATE principle_candidates SET consumed_at = ? WHERE candidate_id = ?').run(now, candidateId);
+  return now;
+}
+
 // ── List ───────────────────────────────────────────────────────────────────────
 
 export async function handleCandidateList(opts: CandidateListOptions): Promise<void> {
@@ -396,11 +410,13 @@ export async function handleCandidateRepair(opts: CandidateRepairOptions): Promi
     // Check if already in ledger
     const existing = ledgerAdapter.existsForCandidate(opts.candidateId);
     if (existing) {
+      const consumedAt = await ensureConsumedAt(stateManager, opts.candidateId);
       const result = {
         candidateId: opts.candidateId,
         status: 'already_consistent',
         message: `Candidate ${opts.candidateId} already has ledger entry.`,
         ledgerEntryId: existing.id,
+        consumedAt,
       };
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
@@ -413,19 +429,13 @@ export async function handleCandidateRepair(opts: CandidateRepairOptions): Promi
 
     // Re-intake to restore ledger entry
     const entry = await service.intake(opts.candidateId);
-
-    // Ensure consumed_at is set (belt-and-suspenders)
-    const db = stateManager.connection;
-    const row = db.getDb().prepare('SELECT consumed_at FROM principle_candidates WHERE candidate_id = ?').get(opts.candidateId) as { consumed_at: string | null } | undefined;
-    if (!row?.consumed_at) {
-      const now = new Date().toISOString();
-      db.getDb().prepare('UPDATE principle_candidates SET consumed_at = ? WHERE candidate_id = ?').run(now, opts.candidateId);
-    }
+    const consumedAt = await ensureConsumedAt(stateManager, opts.candidateId);
 
     const result = {
       candidateId: opts.candidateId,
       status: 'repaired',
       ledgerEntryId: entry.id,
+      consumedAt,
       message: `Ledger entry restored for consumed candidate ${opts.candidateId}.`,
     };
     if (opts.json) {

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -59,7 +59,6 @@ interface AuditResult {
   status: 'ok' | 'degraded';
   consumedCount: number;
   missingLedgerEntryIds: string[];
-  missingCandidates: string[];
   checkedLedgerPath: string;
   checkedDbPath: string;
 }
@@ -334,7 +333,6 @@ export async function handleCandidateAudit(opts: CandidateAuditOptions): Promise
       status: missingLedgerEntryIds.length === 0 ? 'ok' : 'degraded',
       consumedCount: consumedIds.length,
       missingLedgerEntryIds,
-      missingCandidates: [],
       checkedLedgerPath: ledgerPath,
       checkedDbPath: dbPath,
     };

--- a/packages/pd-cli/src/commands/health.ts
+++ b/packages/pd-cli/src/commands/health.ts
@@ -1,82 +1,158 @@
 /**
- * pd health command implementation.
+ * pd health command implementation — Runtime V2 edition.
  *
- * Usage: pd health
+ * Usage: pd health [--workspace <path>] [--json]
  *
- * Queries CentralHealthService.getAllWorkspaceHealth() and displays
- * verbose diagnostic output for all enabled workspaces.
+ * Reads workspace/.pd/state.db and workspace/.state/principle_training_state.json
+ * to provide Runtime V2 health diagnostics.
+ * Does NOT depend on openclaw-plugin source paths.
  */
 
-async function loadCentralHealthService(): Promise<{ CentralHealthService: new () => {
-  getAllWorkspaceHealth(): {
-    generatedAt: string;
-    workspaces: {
-      workspaceName: string;
-      health: {
-        activeStage: string;
-        gfi: { current: unknown; peakToday: unknown; threshold: unknown; trend: unknown };
-        trust: { stage: unknown; stageLabel: unknown; score: unknown };
-        evolution: { tier: unknown; points: unknown };
-        painFlag: { active: unknown; source?: unknown; score?: unknown };
-        principles: { candidate: unknown; probation: unknown; active: unknown; deprecated: unknown };
-        queue: { pending: unknown; inProgress: unknown; completed: unknown };
-      };
-    }[];
-  };
-} }> {
-  const importModule = Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<{
-    CentralHealthService: new () => {
-      getAllWorkspaceHealth(): ReturnType<Awaited<ReturnType<typeof loadCentralHealthService>>['CentralHealthService']['prototype']['getAllWorkspaceHealth']>;
-    };
-  }>;
-  return importModule('../../../openclaw-plugin/src/service/central-health-service.js');
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface WorkspaceHealth {
+  generatedAt: string;
+  workspace: string;
+  pdStateDb: { path: string; exists: boolean };
+  ledger: { path: string; exists: boolean; totalPrinciples: number; byStatus: Record<string, number> };
+  candidates: { total: number; consumed: number; pending: number };
+  tasks: { total: number; byStatus: Record<string, number> };
+  candidateLedgerConsistency: { status: 'ok' | 'degraded'; missing: number };
+}
+
+function loadLedger(ledgerPath: string): { principles: Record<string, unknown> } {
+  if (!fs.existsSync(ledgerPath)) return { principles: {} };
+  try {
+    const content = fs.readFileSync(ledgerPath, 'utf8').trim();
+    if (!content) return { principles: {} };
+    const parsed = JSON.parse(content);
+    return { principles: parsed._tree?.principles || {} };
+  } catch {
+    return { principles: {} };
+  }
 }
 
 export async function handleHealth(): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/init-declarations
-  let service: Awaited<ReturnType<typeof loadCentralHealthService>>['CentralHealthService']['prototype'];
-  try {
-    const { CentralHealthService } = await loadCentralHealthService();
-    service = new CentralHealthService();
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`Error: Health check failed — ${message}`);
-    process.exit(1);
-  }
-  const result = service.getAllWorkspaceHealth();
+  const workspaceDir = (() => {
+    try {
+      return resolveWorkspaceDir();
+    } catch {
+      console.error('Error: No workspace directory configured. Set --workspace <path>, PD_WORKSPACE_DIR, or run from initialized workspace.');
+      process.exit(1);
+      return ''; // unreachable
+    }
+  })();
 
-  if (result.workspaces.length === 0) {
-    console.log('No workspaces found.');
-    return;
+  const generatedAt = new Date().toISOString();
+  const pdDbPath = path.join(workspaceDir, '.pd', 'state.db');
+  const ledgerPath = path.join(workspaceDir, '.state', 'principle_training_state.json');
+
+  // Load ledger
+  const { principles: ledgerPrinciples } = loadLedger(ledgerPath);
+  const principleEntries = Object.values(ledgerPrinciples);
+
+  // Count by status in ledger
+  const ledgerByStatus: Record<string, number> = {};
+  for (const p of principleEntries) {
+    const status = (p as { status?: string }).status || 'unknown';
+    ledgerByStatus[status] = (ledgerByStatus[status] || 0) + 1;
   }
 
-  console.log(`generatedAt: ${result.generatedAt}`);
-  console.log(`workspaceCount: ${result.workspaces.length}`);
+  // Load PD state.db metrics (SQLite)
+  let candidatesTotal = 0, candidatesConsumed = 0, candidatesPending = 0;
+  let tasksTotal = 0;
+  const tasksByStatus: Record<string, number> = {};
+  let pdDbExists = false;
+
+  if (fs.existsSync(pdDbPath)) {
+    pdDbExists = true;
+    try {
+      const db = Database(pdDbPath, { readonly: true });
+
+      const cRow = db.prepare('SELECT COUNT(*) as total, status FROM principle_candidates GROUP BY status').all() as { total: number; status: string }[];
+      for (const r of cRow) {
+        candidatesTotal += r.total;
+        if (r.status === 'consumed') candidatesConsumed = r.total;
+        if (r.status === 'pending') candidatesPending = r.total;
+      }
+
+      const tRows = db.prepare('SELECT COUNT(*) as total, status FROM tasks GROUP BY status').all() as { total: number; status: string }[];
+      for (const r of tRows) {
+        tasksTotal += r.total;
+        tasksByStatus[r.status] = r.total;
+      }
+
+      db.close();
+    } catch {
+      // DB accessible but query failed — continue with partial data
+    }
+  }
+
+  // Check candidate/ledger consistency
+  let missingLedgerCount = 0;
+  if (pdDbExists) {
+    try {
+      const db = Database(pdDbPath, { readonly: true });
+      const consumedRows = db.prepare("SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'").all() as { candidate_id: string }[];
+      for (const r of consumedRows) {
+        const sourceRef = `candidate://${r.candidate_id}`;
+        const found = principleEntries.some((p: unknown) => {
+          const principle = p as { sourceRef?: string; derivedFromPainIds?: string[] };
+          return principle.sourceRef === sourceRef ||
+            (principle.derivedFromPainIds && principle.derivedFromPainIds.includes(r.candidate_id));
+        });
+        if (!found) missingLedgerCount++;
+      }
+      db.close();
+    } catch {
+      // ignore
+    }
+  }
+
+  const health: WorkspaceHealth = {
+    generatedAt,
+    workspace: workspaceDir,
+    pdStateDb: { path: pdDbPath, exists: pdDbExists },
+    ledger: {
+      path: ledgerPath,
+      exists: fs.existsSync(ledgerPath),
+      totalPrinciples: principleEntries.length,
+      byStatus: ledgerByStatus,
+    },
+    candidates: {
+      total: candidatesTotal,
+      consumed: candidatesConsumed,
+      pending: candidatesPending,
+    },
+    tasks: { total: tasksTotal, byStatus: tasksByStatus },
+    candidateLedgerConsistency: {
+      status: missingLedgerCount === 0 ? 'ok' : 'degraded',
+      missing: missingLedgerCount,
+    },
+  };
+
+  console.log(`generatedAt: ${health.generatedAt}`);
+  console.log(`workspace: ${health.workspace}`);
+  console.log(`pdStateDb.exists: ${health.pdStateDb.exists}`);
+  console.log(`pdStateDb.path: ${health.pdStateDb.path}`);
+  console.log(`ledger.exists: ${health.ledger.exists}`);
+  console.log(`ledger.path: ${health.ledger.path}`);
+  console.log(`ledger.totalPrinciples: ${health.ledger.totalPrinciples}`);
+  console.log(`ledger.byStatus: ${JSON.stringify(health.ledger.byStatus)}`);
+  console.log(`candidates.total: ${health.candidates.total}`);
+  console.log(`candidates.consumed: ${health.candidates.consumed}`);
+  console.log(`candidates.pending: ${health.candidates.pending}`);
+  console.log(`tasks.total: ${health.tasks.total}`);
+  console.log(`tasks.byStatus: ${JSON.stringify(health.tasks.byStatus)}`);
+  console.log(`candidateLedgerConsistency.status: ${health.candidateLedgerConsistency.status}`);
+  console.log(`candidateLedgerConsistency.missing: ${health.candidateLedgerConsistency.missing}`);
   console.log('');
 
-  for (const ws of result.workspaces) {
-    console.log(`[${ws.workspaceName}]`);
-    const h = ws.health;
-    console.log(`activeStage: ${h.activeStage}`);
-    console.log(`gfi.current: ${h.gfi.current}`);
-    console.log(`gfi.peakToday: ${h.gfi.peakToday}`);
-    console.log(`gfi.threshold: ${h.gfi.threshold}`);
-    console.log(`gfi.trend: ${JSON.stringify(h.gfi.trend)}`);
-    console.log(`trust.stage: ${h.trust.stage}`);
-    console.log(`trust.stageLabel: ${h.trust.stageLabel}`);
-    console.log(`trust.score: ${h.trust.score}`);
-    console.log(`evolution.tier: ${h.evolution.tier}`);
-    console.log(`evolution.points: ${h.evolution.points}`);
-    console.log(`painFlag.active: ${h.painFlag.active}`);
-    console.log(`painFlag.source: ${h.painFlag.source ?? 'null'}`);
-    console.log(`painFlag.score: ${h.painFlag.score ?? 'null'}`);
-    console.log(`principles.candidate: ${h.principles.candidate}`);
-    console.log(`principles.probation: ${h.principles.probation}`);
-    console.log(`principles.active: ${h.principles.active}`);
-    console.log(`principles.deprecated: ${h.principles.deprecated}`);
-    console.log(`queue.pending: ${h.queue.pending}`);
-    console.log(`queue.inProgress: ${h.queue.inProgress}`);
-    console.log(`queue.completed: ${h.queue.completed}`);
-    console.log('');
+  if (health.candidateLedgerConsistency.status === 'degraded') {
+    console.warn('⚠️  Candidate/ledger consistency is DEGRADED. Run: pd candidate audit --workspace "' + workspaceDir + '" --json');
+    console.warn('   To repair missing entries: pd candidate repair --candidate-id <id> --workspace "' + workspaceDir + '" --json');
   }
 }

--- a/packages/pd-cli/src/commands/health.ts
+++ b/packages/pd-cli/src/commands/health.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import { loadLedger, getLedgerFilePathPublic } from '@principles/core/runtime-v2';
 
 interface WorkspaceHealth {
   generatedAt: string;
@@ -23,36 +24,24 @@ interface WorkspaceHealth {
   candidateLedgerConsistency: { status: 'ok' | 'degraded'; missing: number };
 }
 
-function loadLedger(ledgerPath: string): { principles: Record<string, unknown> } {
-  if (!fs.existsSync(ledgerPath)) return { principles: {} };
-  try {
-    const content = fs.readFileSync(ledgerPath, 'utf8').trim();
-    if (!content) return { principles: {} };
-    const parsed = JSON.parse(content);
-    return { principles: parsed._tree?.principles || {} };
-  } catch {
-    return { principles: {} };
-  }
+interface HealthOptions {
+  workspace?: string;
+  json?: boolean;
 }
 
-export async function handleHealth(): Promise<void> {
-  const workspaceDir = (() => {
-    try {
-      return resolveWorkspaceDir();
-    } catch {
-      console.error('Error: No workspace directory configured. Set --workspace <path>, PD_WORKSPACE_DIR, or run from initialized workspace.');
-      process.exit(1);
-      return ''; // unreachable
-    }
-  })();
+export async function handleHealth(opts: HealthOptions = {}): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
 
   const generatedAt = new Date().toISOString();
   const pdDbPath = path.join(workspaceDir, '.pd', 'state.db');
-  const ledgerPath = path.join(workspaceDir, '.state', 'principle_training_state.json');
+  const ledgerStateDir = path.join(workspaceDir, '.state');
+  const ledgerPath = getLedgerFilePathPublic(ledgerStateDir);
 
-  // Load ledger
-  const { principles: ledgerPrinciples } = loadLedger(ledgerPath);
-  const principleEntries = Object.values(ledgerPrinciples);
+  // Load ledger using core's loadLedger (same HybridLedgerStore format as plugin)
+  const ledger = loadLedger(ledgerStateDir);
+  const principleEntries = Object.values(ledger.tree.principles);
 
   // Count by status in ledger
   const ledgerByStatus: Record<string, number> = {};
@@ -61,17 +50,17 @@ export async function handleHealth(): Promise<void> {
     ledgerByStatus[status] = (ledgerByStatus[status] || 0) + 1;
   }
 
-  // Load PD state.db metrics (SQLite)
+  // Load PD state.db metrics (SQLite) — single connection
   let candidatesTotal = 0, candidatesConsumed = 0, candidatesPending = 0;
   let tasksTotal = 0;
   const tasksByStatus: Record<string, number> = {};
   let pdDbExists = false;
+  let missingLedgerCount = 0;
 
   if (fs.existsSync(pdDbPath)) {
     pdDbExists = true;
+    const db = Database(pdDbPath, { readonly: true });
     try {
-      const db = Database(pdDbPath, { readonly: true });
-
       const cRow = db.prepare('SELECT COUNT(*) as total, status FROM principle_candidates GROUP BY status').all() as { total: number; status: string }[];
       for (const r of cRow) {
         candidatesTotal += r.total;
@@ -85,30 +74,19 @@ export async function handleHealth(): Promise<void> {
         tasksByStatus[r.status] = r.total;
       }
 
-      db.close();
-    } catch {
-      // DB accessible but query failed — continue with partial data
-    }
-  }
-
-  // Check candidate/ledger consistency
-  let missingLedgerCount = 0;
-  if (pdDbExists) {
-    try {
-      const db = Database(pdDbPath, { readonly: true });
+      // Check candidate/ledger consistency
       const consumedRows = db.prepare("SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'").all() as { candidate_id: string }[];
       for (const r of consumedRows) {
-        const sourceRef = `candidate://${r.candidate_id}`;
         const found = principleEntries.some((p: unknown) => {
-          const principle = p as { sourceRef?: string; derivedFromPainIds?: string[] };
-          return principle.sourceRef === sourceRef ||
-            (principle.derivedFromPainIds && principle.derivedFromPainIds.includes(r.candidate_id));
+          const principle = p as { derivedFromPainIds?: string[] };
+          return principle.derivedFromPainIds?.includes(r.candidate_id);
         });
         if (!found) missingLedgerCount++;
       }
-      db.close();
     } catch {
-      // ignore
+      // DB accessible but query failed — continue with partial data
+    } finally {
+      db.close();
     }
   }
 
@@ -134,6 +112,14 @@ export async function handleHealth(): Promise<void> {
     },
   };
 
+  if (opts.json) {
+    console.log(JSON.stringify(health, null, 2));
+    if (health.candidateLedgerConsistency.status === 'degraded') {
+      process.exit(1);
+    }
+    return;
+  }
+
   console.log(`generatedAt: ${health.generatedAt}`);
   console.log(`workspace: ${health.workspace}`);
   console.log(`pdStateDb.exists: ${health.pdStateDb.exists}`);
@@ -154,5 +140,6 @@ export async function handleHealth(): Promise<void> {
   if (health.candidateLedgerConsistency.status === 'degraded') {
     console.warn('⚠️  Candidate/ledger consistency is DEGRADED. Run: pd candidate audit --workspace "' + workspaceDir + '" --json');
     console.warn('   To repair missing entries: pd candidate repair --candidate-id <id> --workspace "' + workspaceDir + '" --json');
+    process.exit(1);
   }
 }

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -106,9 +106,10 @@ tasksCmd
 program
   .command('health')
   .description('Show health diagnostics for all workspaces')
-  .option('-w, --workspace <path>', 'Workspace directory (required for trajectory/history/context commands)')
-  .action(async (_opts) => {
-    await handleHealth();
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleHealth(opts);
   });
 
 const centralCmd = program

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -24,7 +24,7 @@ import { handleLegacyCleanup } from './commands/legacy-cleanup.js';
 import { handleDiagnoseStatus, handleDiagnoseRun } from './commands/diagnose.js';
 import { handleRuntimeProbe } from './commands/runtime.js';
 import { handleFlowShow } from './commands/flow.js';
-import { handleCandidateList, handleCandidateShow, handleCandidateIntake } from './commands/candidate.js';
+import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
 const program = new Command();
@@ -338,6 +338,25 @@ candidateCmd
   .option('--dry-run', 'Show what would be written without writing')
   .action(async (opts) => {
     await handleCandidateIntake(opts);
+  });
+
+candidateCmd
+  .command('audit')
+  .description('Audit candidate/ledger consistency for Runtime v2')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output as JSON')
+  .action(async (opts) => {
+    await handleCandidateAudit(opts);
+  });
+
+candidateCmd
+  .command('repair')
+  .description('Repair consumed candidate with missing ledger entry')
+  .requiredOption('--candidate-id <id>', 'Candidate ID to repair')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output as JSON')
+  .action(async (opts) => {
+    await handleCandidateRepair(opts);
   });
 
 // ── Artifact inspection commands ────────────────────────────────────────────

--- a/packages/pd-cli/src/principle-tree-ledger-adapter.ts
+++ b/packages/pd-cli/src/principle-tree-ledger-adapter.ts
@@ -1,87 +1,13 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join, basename } from 'node:path';
-import {
-  CandidateIntakeError,
-  INTAKE_ERROR_CODES,
-  type LedgerAdapter,
-  type LedgerPrincipleEntry,
-} from '@principles/core/runtime-v2';
-
-interface LedgerFile {
-  principles: LedgerPrincipleEntry[];
-}
-
-function resolveLedgerPath(stateDir: string): string {
-  const pdDir = basename(stateDir) === '.pd' ? stateDir : join(stateDir, '.pd');
-  return join(pdDir, 'principle-tree-ledger.json');
-}
-
-function extractCandidateId(sourceRef: string): string {
-  return sourceRef.startsWith('candidate://')
-    ? sourceRef.slice('candidate://'.length)
-    : sourceRef;
-}
-
-function isNotFound(err: unknown): boolean {
-  return typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT';
-}
-
 /**
- * Minimal file-backed ledger adapter for pd-cli candidate intake.
+ * Re-exports the canonical PrincipleTreeLedgerAdapter from @principles/core/runtime-v2.
  *
- * This intentionally depends only on @principles/core runtime-v2 contracts.
- * The OpenClaw plugin can provide a richer adapter later, but the operator CLI
- * must not import the plugin package just to intake candidates.
+ * This adapter uses @principles/core's addPrincipleToLedger/loadLedger, which write to
+ * <stateDir>/principle_training_state.json (HybridLedgerStore format), matching the ledger
+ * format used by the OpenClaw plugin's pain-signal-bridge.
+ *
+ * audit/repair commands use this adapter — it ensures consistency between
+ * what intake writes and what audit/repair read back.
  */
-export class PrincipleTreeLedgerAdapter implements LedgerAdapter {
-  readonly #ledgerPath: string;
-
-  constructor(opts: { stateDir: string }) {
-    this.#ledgerPath = resolveLedgerPath(opts.stateDir);
-  }
-
-  writeProbationEntry(entry: LedgerPrincipleEntry): LedgerPrincipleEntry {
-    const candidateId = extractCandidateId(entry.sourceRef);
-    const existing = this.existsForCandidate(candidateId);
-    if (existing) {
-      return existing;
-    }
-
-    try {
-      const ledger = this.#readLedger();
-      ledger.principles.push(entry);
-      this.#writeLedger(ledger);
-      return entry;
-    } catch (err) {
-      throw new CandidateIntakeError(
-        INTAKE_ERROR_CODES.LEDGER_WRITE_FAILED,
-        `Failed to write ledger entry for candidate ${candidateId}`,
-        { candidateId, cause: err },
-      );
-    }
-  }
-
-  existsForCandidate(candidateId: string): LedgerPrincipleEntry | null {
-    const sourceRef = `candidate://${candidateId}`;
-    const ledger = this.#readLedger();
-    return ledger.principles.find((entry) => entry.sourceRef === sourceRef) ?? null;
-  }
-
-  #readLedger(): LedgerFile {
-    try {
-      const raw = readFileSync(this.#ledgerPath, 'utf8');
-      const parsed = JSON.parse(raw) as Partial<LedgerFile>;
-      return { principles: Array.isArray(parsed.principles) ? parsed.principles : [] };
-    } catch (err) {
-      if (isNotFound(err)) {
-        return { principles: [] };
-      }
-      throw err;
-    }
-  }
-
-  #writeLedger(ledger: LedgerFile): void {
-    mkdirSync(dirname(this.#ledgerPath), { recursive: true });
-    writeFileSync(this.#ledgerPath, `${JSON.stringify(ledger, null, 2)}\n`, 'utf8');
-  }
-}
+export {
+  PrincipleTreeLedgerAdapter,
+} from '@principles/core/runtime-v2';

--- a/packages/pd-cli/tests/commands/candidate-audit-repair.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-audit-repair.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleCandidateAudit, handleCandidateRepair } from '../../src/commands/candidate.js';
+
+// Use vi.hoisted to define mocks
+const { mockStateManager, mockAdapter, mockService, mockDb, mockLoadLedger, mockGetLedgerFilePath, MockRuntimeStateManager, MockCandidateIntakeService, MockPrincipleTreeLedgerAdapter } = vi.hoisted(() => {
+  const mockDbRows: Record<string, unknown[]> = {};
+
+  const mockDb = {
+    getDb: () => ({
+      prepare: (sql: string) => {
+        // Return rows based on SQL pattern
+        const key = sql.trim();
+        const rows = mockDbRows[key] ?? [];
+        return {
+          get: (..._args: unknown[]) => rows[0] ?? undefined,
+          all: () => rows,
+          run: vi.fn(),
+        };
+      },
+    }),
+    setRows: (sql: string, rows: unknown[]) => {
+      mockDbRows[sql.trim()] = rows;
+    },
+    clearRows: () => {
+      for (const key of Object.keys(mockDbRows)) {
+        delete mockDbRows[key];
+      }
+    },
+  };
+
+  const mockStateManager = {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getCandidate: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    connection: mockDb,
+  };
+
+  const mockAdapter = {
+    writeProbationEntry: vi.fn(),
+    existsForCandidate: vi.fn().mockReturnValue(null),
+  };
+
+  const mockService = {
+    intake: vi.fn(),
+  };
+
+  function MockRuntimeStateManager(this: unknown) {
+    return mockStateManager;
+  }
+  MockRuntimeStateManager.prototype = {};
+
+  function MockCandidateIntakeService(this: unknown) {
+    return mockService;
+  }
+  MockCandidateIntakeService.prototype = {};
+
+  function MockPrincipleTreeLedgerAdapter(this: unknown) {
+    return mockAdapter;
+  }
+  MockPrincipleTreeLedgerAdapter.prototype = {};
+
+  const mockLoadLedger = vi.fn();
+  const mockGetLedgerFilePath = vi.fn().mockReturnValue('/tmp/test-workspace/.state/principle_training_state.json');
+
+  return {
+    mockStateManager,
+    mockAdapter,
+    mockService,
+    mockDb,
+    mockLoadLedger,
+    mockGetLedgerFilePath,
+    MockRuntimeStateManager,
+    MockCandidateIntakeService,
+    MockPrincipleTreeLedgerAdapter,
+  };
+});
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  CandidateIntakeService: MockCandidateIntakeService,
+  CandidateIntakeError: class CandidateIntakeError extends Error {
+    code: string;
+    constructor(message: string, code: string) {
+      super(message);
+      this.name = 'CandidateIntakeError';
+      this.code = code;
+    }
+  },
+  RuntimeStateManager: MockRuntimeStateManager,
+  loadLedger: mockLoadLedger,
+  getLedgerFilePathPublic: mockGetLedgerFilePath,
+}));
+
+vi.mock('../../src/principle-tree-ledger-adapter.js', () => ({
+  PrincipleTreeLedgerAdapter: MockPrincipleTreeLedgerAdapter,
+}));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/test-workspace'),
+}));
+
+describe('pd candidate audit', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStateManager.initialize.mockResolvedValue(undefined);
+    mockStateManager.close.mockResolvedValue(undefined);
+    mockLoadLedger.mockReset();
+    mockGetLedgerFilePath.mockReturnValue('/tmp/test-workspace/.state/principle_training_state.json');
+    mockDb.clearRows();
+
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('audit ok: all consumed candidates have ledger entries', async () => {
+    // DB returns one consumed candidate
+    mockDb.setRows(
+      "SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'",
+      [{ candidate_id: 'c1' }],
+    );
+
+    // Ledger contains a principle with derivedFromPainIds matching c1
+    mockLoadLedger.mockReturnValue({
+      tree: {
+        principles: {
+          p1: { id: 'p1', derivedFromPainIds: ['c1'] },
+        },
+      },
+    });
+
+    await handleCandidateAudit({ workspace: '/tmp/test-workspace', json: true });
+
+    const jsonOutput = consoleLogSpy.mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.status === 'ok';
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.status).toBe('ok');
+    expect(parsed.consumedCount).toBe(1);
+    expect(parsed.missingLedgerEntryIds).toEqual([]);
+
+    // ok audit should NOT call process.exit(1)
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+  });
+
+  it('audit degraded: consumed candidate missing from ledger exits 1', async () => {
+    mockDb.setRows(
+      "SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'",
+      [{ candidate_id: 'c1' }],
+    );
+
+    // Ledger has no matching derivedFromPainIds
+    mockLoadLedger.mockReturnValue({
+      tree: {
+        principles: {
+          p1: { id: 'p1', derivedFromPainIds: ['other-candidate'] },
+        },
+      },
+    });
+
+    await handleCandidateAudit({ workspace: '/tmp/test-workspace', json: true });
+
+    const jsonOutput = consoleLogSpy.mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.status === 'degraded';
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.status).toBe('degraded');
+    expect(parsed.missingLedgerEntryIds).toEqual(['c1']);
+
+    // degraded audit must exit 1
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('pd candidate repair', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStateManager.initialize.mockResolvedValue(undefined);
+    mockStateManager.close.mockResolvedValue(undefined);
+    mockStateManager.getCandidate.mockReset();
+    mockAdapter.existsForCandidate.mockReset();
+    mockService.intake.mockReset();
+    mockDb.clearRows();
+
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('repair already_consistent with null consumed_at: sets consumed_at', async () => {
+    mockStateManager.getCandidate.mockResolvedValue({
+      candidateId: 'c1',
+      status: 'consumed',
+      artifactId: 'a1',
+      title: 'Test',
+      description: 'desc',
+    });
+
+    // Ledger entry exists
+    mockAdapter.existsForCandidate.mockReturnValue({ id: 'ledger-1', derivedFromPainIds: ['c1'] });
+
+    // consumed_at is null in DB
+    mockDb.setRows(
+      'SELECT consumed_at FROM principle_candidates WHERE candidate_id = ?',
+      [{ consumed_at: null }],
+    );
+
+    await handleCandidateRepair({ candidateId: 'c1', workspace: '/tmp/test-workspace', json: true });
+
+    const jsonOutput = consoleLogSpy.mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.status === 'already_consistent';
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.status).toBe('already_consistent');
+    expect(parsed.ledgerEntryId).toBe('ledger-1');
+    // consumedAt should be a freshly written ISO timestamp
+    expect(parsed.consumedAt).toBeDefined();
+    expect(typeof parsed.consumedAt).toBe('string');
+    // Should not exit 1
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+  });
+
+  it('repair missing ledger: re-intakes and sets consumed_at', async () => {
+    mockStateManager.getCandidate.mockResolvedValue({
+      candidateId: 'c2',
+      status: 'consumed',
+      artifactId: 'a2',
+      title: 'Test 2',
+      description: 'desc 2',
+    });
+
+    // No ledger entry exists
+    mockAdapter.existsForCandidate.mockReturnValue(null);
+
+    // intake returns new entry
+    mockService.intake.mockResolvedValue({
+      id: 'new-ledger-entry',
+      title: 'Test 2',
+      text: 'text',
+      status: 'probation',
+    });
+
+    // consumed_at is null
+    mockDb.setRows(
+      'SELECT consumed_at FROM principle_candidates WHERE candidate_id = ?',
+      [{ consumed_at: null }],
+    );
+
+    await handleCandidateRepair({ candidateId: 'c2', workspace: '/tmp/test-workspace', json: true });
+
+    // intake was called to restore ledger
+    expect(mockService.intake).toHaveBeenCalledWith('c2');
+
+    const jsonOutput = consoleLogSpy.mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.status === 'repaired';
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.status).toBe('repaired');
+    expect(parsed.ledgerEntryId).toBe('new-ledger-entry');
+    expect(parsed.consumedAt).toBeDefined();
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+  });
+
+  it('repair non-consumed candidate exits 1', async () => {
+    mockStateManager.getCandidate.mockResolvedValue({
+      candidateId: 'c3',
+      status: 'pending',
+      artifactId: 'a3',
+      title: 'Test 3',
+      description: 'desc 3',
+    });
+
+    await handleCandidateRepair({ candidateId: 'c3', workspace: '/tmp/test-workspace', json: true });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('is not consumed'),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/pd-cli/tests/commands/candidate-audit-repair.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-audit-repair.test.ts
@@ -4,17 +4,20 @@ import { handleCandidateAudit, handleCandidateRepair } from '../../src/commands/
 // Use vi.hoisted to define mocks
 const { mockStateManager, mockAdapter, mockService, mockDb, mockLoadLedger, mockGetLedgerFilePath, MockRuntimeStateManager, MockCandidateIntakeService, MockPrincipleTreeLedgerAdapter } = vi.hoisted(() => {
   const mockDbRows: Record<string, unknown[]> = {};
+  // Track all run() calls: { sql, args }[]
+  const runCalls: { sql: string; args: unknown[] }[] = [];
 
   const mockDb = {
     getDb: () => ({
       prepare: (sql: string) => {
-        // Return rows based on SQL pattern
         const key = sql.trim();
         const rows = mockDbRows[key] ?? [];
         return {
           get: (..._args: unknown[]) => rows[0] ?? undefined,
           all: () => rows,
-          run: vi.fn(),
+          run: (...args: unknown[]) => {
+            runCalls.push({ sql: key, args });
+          },
         };
       },
     }),
@@ -25,7 +28,9 @@ const { mockStateManager, mockAdapter, mockService, mockDb, mockLoadLedger, mock
       for (const key of Object.keys(mockDbRows)) {
         delete mockDbRows[key];
       }
+      runCalls.length = 0;
     },
+    runCalls,
   };
 
   const mockStateManager = {
@@ -253,6 +258,11 @@ describe('pd candidate repair', () => {
     // consumedAt should be a freshly written ISO timestamp
     expect(parsed.consumedAt).toBeDefined();
     expect(typeof parsed.consumedAt).toBe('string');
+    // Directly assert SQL UPDATE was executed
+    const updateCall = mockDb.runCalls.find((c) => c.sql.startsWith('UPDATE principle_candidates SET consumed_at'));
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.args[0]).toBe(parsed.consumedAt); // timestamp arg
+    expect(updateCall!.args[1]).toBe('c1'); // candidate_id arg
     // Should not exit 1
     expect(exitSpy).not.toHaveBeenCalledWith(1);
   });
@@ -301,6 +311,11 @@ describe('pd candidate repair', () => {
     expect(parsed.status).toBe('repaired');
     expect(parsed.ledgerEntryId).toBe('new-ledger-entry');
     expect(parsed.consumedAt).toBeDefined();
+    // Directly assert SQL UPDATE was executed
+    const updateCall = mockDb.runCalls.find((c) => c.sql.startsWith('UPDATE principle_candidates SET consumed_at'));
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.args[0]).toBe(parsed.consumedAt);
+    expect(updateCall!.args[1]).toBe('c2');
     expect(exitSpy).not.toHaveBeenCalledWith(1);
   });
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -215,3 +215,6 @@ export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfi
 
 // Migration bridge
 export { EvolutionQueueItemMigrator } from './store/task-migration.js';
+
+// Ledger file utilities (for audit/consistency checks)
+export { loadLedger, getLedgerFilePathPublic } from '../principle-tree-ledger.js';


### PR DESCRIPTION
## Summary
- **feat(pd-cli)**: `pd candidate intake` — consumes a candidate and writes ledger entry idempotently
- **feat(pd-cli)**: `pd candidate audit` — checks all consumed candidates have ledger entries; exits non-zero if degraded
- **feat(pd-cli)**: `pd candidate repair` — re-intakes consumed-but-missing-ledger candidates via `CandidateIntakeService.intake()`
- **fix**: `updateCandidateStatus` now writes `consumed_at` when status='consumed'
- **fix**: intake fails non-zero if ledger write succeeds but DB update fails (consistent state guarantee)
- **fix**: `pd health` rewritten to use direct `better-sqlite3` import (not dynamic import) — no longer depends on openclaw-plugin source paths after install
- **feat**: `pd health` now includes `candidateLedgerConsistency: { status, missing }` check

## Test plan
- [x] `npm run verify:merge` passes
- [x] Candidate tests pass (17 tests)
- [x] Build succeeds (tsc for core, pd-cli, openclaw-plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增候选项摄入（intake）、审计（audit）和修复（repair）命令，用于处理缺失或不一致的已消费候选项
  * health 命令支持按工作区检查并可输出 JSON

* **改进**
  * 候选项摄入与状态更新的错误处理更明确，遇错会返回非零退出码
  * 健康检查增加基于本地状态与账本的一致性校验并在不一致时提示
  * 统一并改进了账本加载/导出相关行为，提升审计与修复一致性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->