### PR TITLE
fix(uat): use MINIMAX_CN_API_KEY instead of XIAOMI_KEY

### DIFF
--- a/scripts/uat/runtime-v2-chain-uat.mjs
+++ b/scripts/uat/runtime-v2-chain-uat.mjs
@@ -106,11 +106,11 @@ async function main() {
   log('');
 
   // 1. Check environment
-  if (!process.env.XIAOMI_KEY) {
-    error('XIAOMI_KEY environment variable not set');
+  if (!process.env.MINIMAX_CN_API_KEY) {
+    error('MINIMAX_CN_API_KEY environment variable not set');
     process.exit(1);
   }
-  log('✓ XIAOMI_KEY is set');
+  log('✓ MINIMAX_CN_API_KEY is set');
 
   // 2. Runtime probe
   log('Probing runtime...');


### PR DESCRIPTION
## Summary

UAT 脚本 `scripts/uat/runtime-v2-chain-uat.mjs` 之前检查 `XIAOMI_KEY` 环境变量，但实际运行时使用的是 `MINIMAX_CN_API_KEY`（在 `workflows.yaml` 中配置）。

## Changes

- `scripts/uat/runtime-v2-chain-uat.mjs`: 环境变量检查从 `XIAOMI_KEY` 改为 `MINIMAX_CN_API_KEY`

## Test plan

- [x] UAT 脚本在正确设置 `MINIMAX_CN_API_KEY` 后成功运行 3 次
- [x] `pd runtime probe` 正确读取 `MINIMAX_CN_API_KEY`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **更新事项**
  * 更新了环境变量验证配置，优化了启动环境检查流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->