### PR TITLE
fix(ci): remove tsbuildinfo before typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
 
       - name: TypeScript Check
         working-directory: packages/openclaw-plugin
-        run: npx tsc --noEmit
+        run: |
+          rm -f ../principles-core/tsconfig.tsbuildinfo
+          npx tsc --noEmit
 
       - name: Production Build & Verify
         working-directory: packages/openclaw-plugin


### PR DESCRIPTION
## Summary\n\n- CI typecheck 前删除 tsbuildinfo，防止增量缓存掩盖真实类型错误\n- 本地 dev 保留 incremental build\n- Fixes #294\n\n## Test plan\n\n- [x] CI verify:merge passes\n- [x] npm run build --workspace=@principles/core\n- [x] npx tsc --noEmit (openclaw-plugin)