### PR TITLE
refactor(runtime-v2): ADR-0001 service boundaries + PainToPrincipleService facade

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,14 +1,14 @@
 ---
 gsd_state_version: 1.0
 milestone: v2.9
-milestone_name: M10 — Nocturnal Artificer LLM Upgrade — IN PROGRESS
+milestone_name: M10 — Nocturnal Artificer LLM Upgrade
 status: completed
-last_updated: "2026-05-01T15:54:10.516Z"
+last_updated: "2026-05-02T10:00:00.000Z"
 last_activity: 2026-04-30 -- M10 Artificer LLM upgrade complete on fix/nocturnal-artificer-llm-upgrade
 progress:
   total_phases: 81
-  completed_phases: 71
-  total_plans: 139
+  completed_phases: 81
+  total_plans: 148
   completed_plans: 148
   percent: 100
 ---

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,16 +1,16 @@
 ---
 gsd_state_version: 1.0
 milestone: v2.9
-milestone_name: M10 — Nocturnal Artificer LLM Upgrade
-status: complete
-last_updated: "2026-04-30T12:00:00.000Z"
-last_activity: "2026-04-30 -- M10 COMPLETE: Artificer LLM upgrade — 42/42 tests pass"
+milestone_name: M10 — Nocturnal Artificer LLM Upgrade — IN PROGRESS
+status: completed
+last_updated: "2026-05-01T15:54:10.516Z"
+last_activity: 2026-04-30 -- M10 Artificer LLM upgrade complete on fix/nocturnal-artificer-llm-upgrade
 progress:
-  total_phases: 83
+  total_phases: 81
   completed_phases: 71
   total_plans: 139
   completed_plans: 148
-  percent: 85
+  percent: 100
 ---
 
 # Project State: Principles

--- a/docs/adr/0001-runtime-v2-service-boundaries.md
+++ b/docs/adr/0001-runtime-v2-service-boundaries.md
@@ -1,0 +1,113 @@
+# ADR-0001: Runtime V2 Service Boundaries
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Issues:** PRI-16, PRI-17, PRI-12, PRI-13, PRI-14, PRI-18
+
+## Problem Statement
+
+`pd-cli` and `openclaw-plugin` independently orchestrate the same pain-to-principle pipeline:
+
+- Bridge creation via `createPainSignalBridge()`
+- Observability writes via `recordPainSignalObservability()`
+- Error classification (`classifyResult` / `classifyCatch`)
+- Latency measurement with `Date.now()`
+
+This duplication creates drift risk: pd-cli's `pain-record.ts` and openclaw-plugin's pain hook implement slightly different classification logic, observability call patterns, and error handling. When one changes, the other is easily missed.
+
+## Target Architecture
+
+Four ownership boundaries:
+
+| Boundary | Package | Owns |
+|----------|---------|------|
+| **Core (domain)** | `@principles/core` | Pain-to-principle orchestration, state, read models, service contracts |
+| **CLI (UX)** | `@principles/pd-cli` | Operator UX, output formatting, workspace resolution |
+| **Plugin (hooks)** | `openclaw-plugin` | OpenClaw hook/event adaptation, platform-specific context |
+| **Runtime adapters** | `pi-ai` / openclaw-cli | Model/provider execution only |
+
+## First Boundary: PainToPrincipleService
+
+A core-owned facade wrapping the existing pain-to-principle chain:
+
+```typescript
+class PainToPrincipleService {
+  constructor(opts: PainToPrincipleServiceOptions)
+  async recordPain(input: PainToPrincipleInput): Promise<PainToPrincipleOutput>
+}
+```
+
+Owning: normalized pain input, optional observability write, bridge creation + invocation, latency measurement, failure category mapping, structured result output.
+
+**Reuse rule:** Service internally calls `createPainSignalBridge()`, `recordPainSignalObservability()`, and `FAILURE_CATEGORY_MAP`. It does NOT reassemble `RuntimeStateManager`, `DiagnosticianRunner`, or `CandidateIntakeService` directly.
+
+## Follow-up Boundary: PainChainReadModel
+
+`PainChainReadModel` / `RuntimeChainInspector` for read-side queries (trace by painId, last successful chain, recent chains, missing links). Currently duplicated as inline SQL in `pd runtime trace show` and `pd health --json`.
+
+## Plugin Logic Inventory
+
+Logic that should migrate from callers to core over subsequent issues:
+
+| Logic | Current Owner | Target Owner | Issue |
+|-------|--------------|--------------|-------|
+| Pain observability write | pd-cli manual | `PainToPrincipleService` | PRI-12 |
+| Bridge creation + invocation | pd-cli / plugin | `PainToPrincipleService` | PRI-12 |
+| Failure category mapping | pd-cli `classifyResult`/`classifyCatch` | `PainToPrincipleService` | PRI-12 |
+| Latency measurement | pd-cli manual | `PainToPrincipleService` | PRI-12 |
+| Runtime V2 diagnostician invocation | openclaw-plugin | Core via service | PRI-13 |
+| Pain-chain read model (trace/health) | pd-cli inline SQL | Core `PainChainReadModel` | PRI-14 |
+
+Logic that stays in plugin:
+
+| Logic | Owner | Reason |
+|-------|-------|--------|
+| after_tool_call integration | openclaw-plugin | OpenClaw platform hook |
+| GFI/session tracking | openclaw-plugin | OpenClaw session lifecycle |
+| Diagnostic gate evaluation | openclaw-plugin | Gate logic is plugin-specific |
+| Platform context extraction | openclaw-plugin | OpenClaw-specific metadata |
+| Trajectory/event-log writes (OpenClaw-specific) | openclaw-plugin | Plugin-internal observability |
+
+## Migration Plan
+
+| Phase | Scope | Issue |
+|-------|-------|-------|
+| **A (this round)** | Implement `PainToPrincipleService` + exports, no callers migrated | PRI-17, PRI-12 |
+| **B** | Migrate `pd pain record` to call service | PRI-18 |
+| **C** | Thin openclaw-plugin pain hook to adapter | PRI-13 |
+| **D** | Extract read model, deprecate inline factory | PRI-14 |
+
+## Compatibility Rules
+
+- `PainSignalBridge` class and `createPainSignalBridge()` are unchanged
+- No database schema changes
+- No behavior changes in this round
+
+## Error Classification Contract
+
+Service uses chain-integrity-first classification (moved from pd-cli):
+
+1. If bridge result has `errorCategory` → map via `FAILURE_CATEGORY_MAP`
+2. If `status=failed` and `candidateIds=[]` → `'candidate_missing'` (not `runtime_unavailable`)
+3. If `status=failed` and `ledgerEntryIds=[]` → `'ledger_write_failed'` (not `runtime_unavailable`)
+4. On thrown `PDRuntimeError` → map via `FAILURE_CATEGORY_MAP[err.category]`
+5. On thrown generic Error → regex fallback (`config_missing`, `runtime_timeout`, `output_invalid`, default `runtime_unavailable`)
+
+## Deferred
+
+- No `RuleHost` / `PrincipleCompiler` move
+- No auto-pruning design (PRI-15)
+- No runtime provider selection change
+- No read model extraction (PRI-14)
+
+## Rollback
+
+Delete `pain-to-principle-service.ts` + test + exports from `index.ts`. Zero blast radius since no callers are migrated in this round.
+
+## Testing
+
+- Unit tests: mock `createPainSignalBridge` + `recordPainSignalObservability`, test service external contract
+- Error classification parity: iterate all 17 `PDErrorCategory` values, verify mapping matches `FAILURE_CATEGORY_MAP`
+- Idempotent scenarios: bridge returning `succeeded` (existing) and `skipped` (leased)
+- Chain integrity: `candidate_missing` and `ledger_write_failed` must not map to `runtime_unavailable`
+- Existing `PainSignalBridge` tests remain unchanged

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
@@ -1,0 +1,185 @@
+/**
+ * PainToPrincipleService unit tests.
+ *
+ * Tests the service's external contract via mocked bridge and observability.
+ * Does NOT test PainSignalBridge internals.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PDRuntimeError, PD_ERROR_CATEGORIES, FAILURE_CATEGORY_MAP } from '../error-categories.js';
+import type { PainSignalBridgeResult } from '../pain-signal-bridge.js';
+import type { RecordPainSignalObservabilityOptions, PainSignalObservabilityResult } from '../pain-signal-observability.js';
+import type { PainSignalRuntimeFactoryOptions } from '../pain-signal-runtime-factory.js';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockBridgeResult: PainSignalBridgeResult = {
+  status: 'succeeded', painId: '', taskId: '', candidateIds: [], ledgerEntryIds: [],
+};
+let mockBridgeError: Error | null = null;
+let observabilityCalled = false;
+let mockObservabilityWarnings: string[] = [];
+
+vi.mock('../pain-signal-runtime-factory.js', () => ({
+  createPainSignalBridge: vi.fn(async (_opts: PainSignalRuntimeFactoryOptions) => ({
+    onPainDetected: vi.fn(async (data: { taskId?: string }) => {
+      if (mockBridgeError) throw mockBridgeError;
+      // Use taskId from input if provided, otherwise from mock result
+      return { ...mockBridgeResult, taskId: data.taskId ?? mockBridgeResult.taskId };
+    }),
+  })),
+}));
+
+vi.mock('../pain-signal-observability.js', () => ({
+  recordPainSignalObservability: vi.fn((_opts: RecordPainSignalObservabilityOptions): PainSignalObservabilityResult => {
+    observabilityCalled = true;
+    return { warnings: mockObservabilityWarnings };
+  }),
+}));
+
+import { PainToPrincipleService } from '../pain-to-principle-service.js';
+import type { PainToPrincipleServiceOptions } from '../pain-to-principle-service.js';
+import type { LedgerAdapter } from '../candidate-intake.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const SUCCEEDED: PainSignalBridgeResult = {
+  status: 'succeeded', painId: 'pain-001', taskId: 'diagnosis_pain-001',
+  runId: 'run-001', artifactId: 'art-001', candidateIds: ['c1'], ledgerEntryIds: ['l1'],
+};
+
+function makeOpts(overrides?: Partial<PainToPrincipleServiceOptions>): PainToPrincipleServiceOptions {
+  return { workspaceDir: '/tmp/ws', stateDir: '/tmp/st', ledgerAdapter: {} as LedgerAdapter, ...overrides };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PainToPrincipleService', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let service: PainToPrincipleService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBridgeResult = { ...SUCCEEDED };
+    mockBridgeError = null;
+    observabilityCalled = false;
+    mockObservabilityWarnings = [];
+    service = new PainToPrincipleService(makeOpts());
+  });
+
+  // 1. Happy path
+  it('recordPain returns succeeded with all fields', async () => {
+    const r = await service.recordPain({ painId: 'pain-001', painType: 'user_frustration', source: 'manual', reason: 'test' });
+    expect(r.status).toBe('succeeded');
+    expect(r.painId).toBe('pain-001');
+    expect(r.taskId).toBe('diagnosis_pain-001');
+    expect(r.runId).toBe('run-001');
+    expect(r.artifactId).toBe('art-001');
+    expect(r.candidateIds).toEqual(['c1']);
+    expect(r.ledgerEntryIds).toEqual(['l1']);
+    expect(r.observabilityWarnings).toEqual([]);
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(r.failureCategory).toBeUndefined();
+  });
+
+  // 2. Bridge returns failed with errorCategory → FAILURE_CATEGORY_MAP
+  it('recordPain returns failed when bridge returns failed with errorCategory', async () => {
+    mockBridgeResult = { ...SUCCEEDED, status: 'failed', errorCategory: 'timeout', candidateIds: [], ledgerEntryIds: [] };
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(r.failureCategory).toBe('runtime_timeout');
+  });
+
+  // 3. Idempotent: bridge returns skipped (leased)
+  it('recordPain returns skipped when bridge returns skipped (idempotent leased)', async () => {
+    mockBridgeResult = { status: 'skipped', painId: 'pain-001', taskId: 'diagnosis_pain-001', candidateIds: [], ledgerEntryIds: [], message: 'already leased' };
+    const r = await service.recordPain({ painId: 'pain-001', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('skipped');
+    expect(r.failureCategory).toBeUndefined();
+  });
+
+  // 4. Idempotent: bridge returns succeeded (existing)
+  it('recordPain returns succeeded when bridge returns succeeded (idempotent existing)', async () => {
+    const r = await service.recordPain({ painId: 'pain-001', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('succeeded');
+    expect(r.candidateIds).toEqual(['c1']);
+  });
+
+  // 5. candidate_missing classification
+  it('recordPain classifies candidate_missing', async () => {
+    mockBridgeResult = { ...SUCCEEDED, status: 'failed', candidateIds: [], ledgerEntryIds: [], message: 'no candidates' };
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.failureCategory).toBe('candidate_missing');
+  });
+
+  // 6. ledger_write_failed classification
+  it('recordPain classifies ledger_write_failed', async () => {
+    mockBridgeResult = { ...SUCCEEDED, status: 'failed', candidateIds: ['c1'], ledgerEntryIds: [], message: 'no ledger' };
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.failureCategory).toBe('ledger_write_failed');
+  });
+
+  // 7. observability skip
+  it('recordPain skips observability when recordObservability=false', async () => {
+    await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r', recordObservability: false });
+    expect(observabilityCalled).toBe(false);
+  });
+
+  // 8. observability warnings passthrough
+  it('recordPain includes observability warnings', async () => {
+    mockObservabilityWarnings = ['warn1', 'warn2'];
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.observabilityWarnings).toEqual(['warn1', 'warn2']);
+  });
+
+  // 9. Bridge throws PDRuntimeError
+  it('recordPain catches bridge throw PDRuntimeError', async () => {
+    mockBridgeError = new PDRuntimeError('storage_unavailable', 'disk full');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(r.failureCategory).toBe('ledger_write_failed');
+    expect(r.message).toContain('storage_unavailable');
+  });
+
+  // 10. Bridge throws generic Error
+  it('recordPain catches bridge throw generic Error', async () => {
+    mockBridgeError = new Error('Something timed out unexpectedly');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(r.failureCategory).toBe('runtime_timeout');
+  });
+
+  // 11. latencyMs present and non-negative
+  it('recordPain computes latencyMs', async () => {
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(typeof r.latencyMs).toBe('number');
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // 12. Custom taskId passthrough
+  it('recordPain uses provided taskId', async () => {
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r', taskId: 'custom-task-123' });
+    expect(r.taskId).toBe('custom-task-123');
+  });
+});
+
+// ── Parity: all 17 PDErrorCategory → FAILURE_CATEGORY_MAP ──────────────────
+
+describe('PainToPrincipleService error classification parity', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let service: PainToPrincipleService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    observabilityCalled = false;
+    mockObservabilityWarnings = [];
+    service = new PainToPrincipleService(makeOpts());
+  });
+
+  it('classifyFromBridge maps all 17 PDErrorCategories correctly', async () => {
+    for (const cat of PD_ERROR_CATEGORIES) {
+      mockBridgeResult = { ...SUCCEEDED, status: 'failed', errorCategory: cat, candidateIds: [], ledgerEntryIds: [] };
+      const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+      expect(r.failureCategory).toBe(FAILURE_CATEGORY_MAP[cat]);
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PDRuntimeError, PD_ERROR_CATEGORIES, FAILURE_CATEGORY_MAP } from '../error-categories.js';
-import type { PainSignalBridgeResult } from '../pain-signal-bridge.js';
+import type { PainSignalBridgeResult, PainDetectedData } from '../pain-signal-bridge.js';
 import type { RecordPainSignalObservabilityOptions, PainSignalObservabilityResult } from '../pain-signal-observability.js';
 import type { PainSignalRuntimeFactoryOptions } from '../pain-signal-runtime-factory.js';
 
@@ -18,12 +18,13 @@ let mockBridgeResult: PainSignalBridgeResult = {
 let mockBridgeError: Error | null = null;
 let observabilityCalled = false;
 let mockObservabilityWarnings: string[] = [];
+let lastPainDetectedData: PainDetectedData | null = null;
 
 vi.mock('../pain-signal-runtime-factory.js', () => ({
   createPainSignalBridge: vi.fn(async (_opts: PainSignalRuntimeFactoryOptions) => ({
-    onPainDetected: vi.fn(async (data: { taskId?: string }) => {
+    onPainDetected: vi.fn(async (data: PainDetectedData) => {
+      lastPainDetectedData = data;
       if (mockBridgeError) throw mockBridgeError;
-      // Use taskId from input if provided, otherwise from mock result
       return { ...mockBridgeResult, taskId: data.taskId ?? mockBridgeResult.taskId };
     }),
   })),
@@ -63,6 +64,7 @@ describe('PainToPrincipleService', () => {
     mockBridgeError = null;
     observabilityCalled = false;
     mockObservabilityWarnings = [];
+    lastPainDetectedData = null;
     service = new PainToPrincipleService(makeOpts());
   });
 
@@ -79,6 +81,32 @@ describe('PainToPrincipleService', () => {
     expect(r.observabilityWarnings).toEqual([]);
     expect(r.latencyMs).toBeGreaterThanOrEqual(0);
     expect(r.failureCategory).toBeUndefined();
+  });
+
+  // 1b. Full input contract: all PainDetectedData fields passed to bridge
+  it('recordPain passes complete PainDetectedData to bridge', async () => {
+    await service.recordPain({
+      painId: 'pain-002',
+      painType: 'subagent_error',
+      source: 'auto',
+      reason: 'timeout',
+      score: 80,
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+      taskId: 'custom-task',
+      traceId: 'trace-1',
+    });
+    expect(lastPainDetectedData).toEqual({
+      painId: 'pain-002',
+      painType: 'subagent_error',
+      source: 'auto',
+      reason: 'timeout',
+      score: 80,
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+      taskId: 'custom-task',
+      traceId: 'trace-1',
+    });
   });
 
   // 2. Bridge returns failed with errorCategory → FAILURE_CATEGORY_MAP
@@ -172,6 +200,7 @@ describe('PainToPrincipleService error classification parity', () => {
     vi.clearAllMocks();
     observabilityCalled = false;
     mockObservabilityWarnings = [];
+    lastPainDetectedData = null;
     service = new PainToPrincipleService(makeOpts());
   });
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -202,6 +202,7 @@ export type { DiagnoseRunOptions, DiagnoseStatusOptions, DiagnoseStatusResult, C
 // Pain signal bridge (M8)
 export {
   PainSignalBridge,
+  createDiagnosticianTaskId,
 } from './pain-signal-bridge.js';
 export type {
   PainSignalBridgeOptions,
@@ -215,7 +216,7 @@ export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfi
 
 // Pain-to-Principle service facade (PRI-12)
 export { PainToPrincipleService } from './pain-to-principle-service.js';
-export type { PainToPrincipleServiceOptions, PainToPrincipleInput, PainToPrincipleOutput } from './pain-to-principle-service.js';
+export type { PainToPrincipleServiceOptions, PainToPrincipleInput, PainToPrincipleOutput, FailureCategory } from './pain-to-principle-service.js';
 
 // Migration bridge
 export { EvolutionQueueItemMigrator } from './store/task-migration.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -213,6 +213,10 @@ export { recordPainSignalObservability } from './pain-signal-observability.js';
 export type { PainSignalObservabilityResult, RecordPainSignalObservabilityOptions } from './pain-signal-observability.js';
 export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfig, validateRuntimeConfig, type PainSignalRuntimeFactoryOptions, type RuntimeConfig } from './pain-signal-runtime-factory.js';
 
+// Pain-to-Principle service facade (PRI-12)
+export { PainToPrincipleService } from './pain-to-principle-service.js';
+export type { PainToPrincipleServiceOptions, PainToPrincipleInput, PainToPrincipleOutput } from './pain-to-principle-service.js';
+
 // Migration bridge
 export { EvolutionQueueItemMigrator } from './store/task-migration.js';
 

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -65,7 +65,7 @@ export interface PainSignalBridgeOptions {
   autoIntakeEnabled?: boolean;
 }
 
-function createDiagnosticianTaskId(painId: string): string {
+export function createDiagnosticianTaskId(painId: string): string {
   return `diagnosis_${painId}`;
 }
 

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -89,20 +89,21 @@ export class PainToPrincipleService {
     const {painId} = input;
     const taskId = input.taskId ?? `diagnosis_${painId}`;
 
+    const painData: PainDetectedData = {
+      painId,
+      painType: input.painType,
+      source: input.source,
+      reason: input.reason,
+      score: input.score,
+      sessionId: input.sessionId,
+      agentId: input.agentId,
+      taskId,
+      traceId: input.traceId,
+    };
+
     // Observability (optional, best-effort)
     let observabilityWarnings: string[] = [];
     if (input.recordObservability !== false) {
-      const painData: PainDetectedData = {
-        painId,
-        painType: input.painType,
-        source: input.source,
-        reason: input.reason,
-        score: input.score,
-        sessionId: input.sessionId,
-        agentId: input.agentId,
-        taskId,
-        traceId: input.traceId,
-      };
       const obs = recordPainSignalObservability({
         workspaceDir: this.opts.workspaceDir,
         stateDir: this.opts.stateDir,
@@ -119,18 +120,6 @@ export class PainToPrincipleService {
         owner: this.opts.owner,
         autoIntakeEnabled: this.opts.autoIntakeEnabled,
       });
-
-      const painData: PainDetectedData = {
-        painId,
-        painType: input.painType,
-        source: input.source,
-        reason: input.reason,
-        score: input.score,
-        sessionId: input.sessionId,
-        agentId: input.agentId,
-        taskId,
-        traceId: input.traceId,
-      };
 
       const bridgeResult = await bridge.onPainDetected(painData);
       const latencyMs = Date.now() - startTime;

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -10,9 +10,19 @@
 import { createPainSignalBridge } from './pain-signal-runtime-factory.js';
 import { recordPainSignalObservability } from './pain-signal-observability.js';
 import { FAILURE_CATEGORY_MAP } from './error-categories.js';
+import { createDiagnosticianTaskId } from './pain-signal-bridge.js';
 import type { PainDetectedData, PainSignalBridgeResult } from './pain-signal-bridge.js';
 import { PDRuntimeError } from './error-categories.js';
 import type { LedgerAdapter } from './candidate-intake.js';
+
+export type FailureCategory =
+  | 'runtime_unavailable'
+  | 'config_missing'
+  | 'runtime_timeout'
+  | 'output_invalid'
+  | 'artifact_missing'
+  | 'ledger_write_failed'
+  | 'candidate_missing';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -26,7 +36,7 @@ export interface PainToPrincipleServiceOptions {
 
 export interface PainToPrincipleInput {
   painId: string;
-  painType: 'tool_failure' | 'subagent_error' | 'user_frustration';
+  painType: PainDetectedData['painType'];
   source: string;
   reason: string;
   score?: number;
@@ -47,15 +57,15 @@ export interface PainToPrincipleOutput {
   ledgerEntryIds: string[];
   message?: string;
   observabilityWarnings: string[];
-  failureCategory?: string;
+  failureCategory?: FailureCategory;
   latencyMs: number;
 }
 
 // ── Error classification ───────────────────────────────────────────────────
 
-function classifyFromBridge(result: PainSignalBridgeResult): string | undefined {
+function classifyFromBridge(result: PainSignalBridgeResult): FailureCategory | undefined {
   if (result.errorCategory) {
-    return FAILURE_CATEGORY_MAP[result.errorCategory] ?? 'runtime_unavailable';
+    return (FAILURE_CATEGORY_MAP[result.errorCategory] as FailureCategory) ?? 'runtime_unavailable';
   }
   if (result.status === 'failed') {
     if (result.candidateIds.length === 0) return 'candidate_missing';
@@ -64,12 +74,12 @@ function classifyFromBridge(result: PainSignalBridgeResult): string | undefined 
   return undefined;
 }
 
-function classifyFromError(err: unknown): string {
+function classifyFromError(err: unknown): FailureCategory {
   if (err instanceof PDRuntimeError && err.category) {
-    return FAILURE_CATEGORY_MAP[err.category] ?? 'runtime_unavailable';
+    return (FAILURE_CATEGORY_MAP[err.category] as FailureCategory) ?? 'runtime_unavailable';
   }
   const msg = err instanceof Error ? err.message : String(err);
-  if (/api[_\s]?key|not found in env|XIAOMI_KEY|OPENROUTER|missing required/i.test(msg)) return 'config_missing';
+  if (/api[_\s]?key|not found in env|missing required/i.test(msg)) return 'config_missing';
   if (/timeout|timed[_\s]?out/i.test(msg)) return 'runtime_timeout';
   if (/output.*invalid|validation.*fail/i.test(msg)) return 'output_invalid';
   return 'runtime_unavailable';
@@ -87,7 +97,7 @@ export class PainToPrincipleService {
   async recordPain(input: PainToPrincipleInput): Promise<PainToPrincipleOutput> {
     const startTime = Date.now();
     const {painId} = input;
-    const taskId = input.taskId ?? `diagnosis_${painId}`;
+    const taskId = input.taskId ?? createDiagnosticianTaskId(painId);
 
     const painData: PainDetectedData = {
       painId,
@@ -101,17 +111,6 @@ export class PainToPrincipleService {
       traceId: input.traceId,
     };
 
-    // Observability (optional, best-effort)
-    let observabilityWarnings: string[] = [];
-    if (input.recordObservability !== false) {
-      const obs = recordPainSignalObservability({
-        workspaceDir: this.opts.workspaceDir,
-        stateDir: this.opts.stateDir,
-        data: painData,
-      });
-      observabilityWarnings = obs.warnings;
-    }
-
     try {
       const bridge = await createPainSignalBridge({
         workspaceDir: this.opts.workspaceDir,
@@ -122,6 +121,17 @@ export class PainToPrincipleService {
       });
 
       const bridgeResult = await bridge.onPainDetected(painData);
+
+      let observabilityWarnings: string[] = [];
+      if (input.recordObservability !== false) {
+        const obs = recordPainSignalObservability({
+          workspaceDir: this.opts.workspaceDir,
+          stateDir: this.opts.stateDir,
+          data: painData,
+        });
+        observabilityWarnings = obs.warnings;
+      }
+
       const latencyMs = Date.now() - startTime;
 
       return {
@@ -138,6 +148,20 @@ export class PainToPrincipleService {
         latencyMs,
       };
     } catch (err: unknown) {
+      let observabilityWarnings: string[] = [];
+      if (input.recordObservability !== false) {
+        try {
+          const obs = recordPainSignalObservability({
+            workspaceDir: this.opts.workspaceDir,
+            stateDir: this.opts.stateDir,
+            data: painData,
+          });
+          observabilityWarnings = obs.warnings;
+        } catch {
+          // Observability is best-effort; swallow errors on failure path
+        }
+      }
+
       const latencyMs = Date.now() - startTime;
       return {
         status: 'failed',

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -1,0 +1,166 @@
+/**
+ * PainToPrincipleService — core-owned facade for the pain-to-principle chain.
+ *
+ * Wraps PainSignalBridge + observability + error classification + latency.
+ * Callers (pd-cli, openclaw-plugin) should use this instead of composing
+ * bridge/observability/classification manually.
+ *
+ * PRI-12: Introduce facade without migrating callers.
+ */
+import { createPainSignalBridge } from './pain-signal-runtime-factory.js';
+import { recordPainSignalObservability } from './pain-signal-observability.js';
+import { FAILURE_CATEGORY_MAP } from './error-categories.js';
+import type { PainDetectedData, PainSignalBridgeResult } from './pain-signal-bridge.js';
+import { PDRuntimeError } from './error-categories.js';
+import type { LedgerAdapter } from './candidate-intake.js';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface PainToPrincipleServiceOptions {
+  workspaceDir: string;
+  stateDir: string;
+  ledgerAdapter: LedgerAdapter;
+  owner?: string;
+  autoIntakeEnabled?: boolean;
+}
+
+export interface PainToPrincipleInput {
+  painId: string;
+  painType: 'tool_failure' | 'subagent_error' | 'user_frustration';
+  source: string;
+  reason: string;
+  score?: number;
+  sessionId?: string;
+  agentId?: string;
+  taskId?: string;
+  traceId?: string;
+  recordObservability?: boolean;
+}
+
+export interface PainToPrincipleOutput {
+  status: 'succeeded' | 'skipped' | 'failed' | 'retried';
+  painId: string;
+  taskId: string;
+  runId?: string;
+  artifactId?: string;
+  candidateIds: string[];
+  ledgerEntryIds: string[];
+  message?: string;
+  observabilityWarnings: string[];
+  failureCategory?: string;
+  latencyMs: number;
+}
+
+// ── Error classification ───────────────────────────────────────────────────
+
+function classifyFromBridge(result: PainSignalBridgeResult): string | undefined {
+  if (result.errorCategory) {
+    return FAILURE_CATEGORY_MAP[result.errorCategory] ?? 'runtime_unavailable';
+  }
+  if (result.status === 'failed') {
+    if (result.candidateIds.length === 0) return 'candidate_missing';
+    if (result.ledgerEntryIds.length === 0) return 'ledger_write_failed';
+  }
+  return undefined;
+}
+
+function classifyFromError(err: unknown): string {
+  if (err instanceof PDRuntimeError && err.category) {
+    return FAILURE_CATEGORY_MAP[err.category] ?? 'runtime_unavailable';
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/api[_\s]?key|not found in env|XIAOMI_KEY|OPENROUTER|missing required/i.test(msg)) return 'config_missing';
+  if (/timeout|timed[_\s]?out/i.test(msg)) return 'runtime_timeout';
+  if (/output.*invalid|validation.*fail/i.test(msg)) return 'output_invalid';
+  return 'runtime_unavailable';
+}
+
+// ── Service ────────────────────────────────────────────────────────────────
+
+export class PainToPrincipleService {
+  private readonly opts: PainToPrincipleServiceOptions;
+
+  constructor(opts: PainToPrincipleServiceOptions) {
+    this.opts = opts;
+  }
+
+  async recordPain(input: PainToPrincipleInput): Promise<PainToPrincipleOutput> {
+    const startTime = Date.now();
+    const {painId} = input;
+    const taskId = input.taskId ?? `diagnosis_${painId}`;
+
+    // Observability (optional, best-effort)
+    let observabilityWarnings: string[] = [];
+    if (input.recordObservability !== false) {
+      const painData: PainDetectedData = {
+        painId,
+        painType: input.painType,
+        source: input.source,
+        reason: input.reason,
+        score: input.score,
+        sessionId: input.sessionId,
+        agentId: input.agentId,
+        taskId,
+        traceId: input.traceId,
+      };
+      const obs = recordPainSignalObservability({
+        workspaceDir: this.opts.workspaceDir,
+        stateDir: this.opts.stateDir,
+        data: painData,
+      });
+      observabilityWarnings = obs.warnings;
+    }
+
+    try {
+      const bridge = await createPainSignalBridge({
+        workspaceDir: this.opts.workspaceDir,
+        stateDir: this.opts.stateDir,
+        ledgerAdapter: this.opts.ledgerAdapter,
+        owner: this.opts.owner,
+        autoIntakeEnabled: this.opts.autoIntakeEnabled,
+      });
+
+      const painData: PainDetectedData = {
+        painId,
+        painType: input.painType,
+        source: input.source,
+        reason: input.reason,
+        score: input.score,
+        sessionId: input.sessionId,
+        agentId: input.agentId,
+        taskId,
+        traceId: input.traceId,
+      };
+
+      const bridgeResult = await bridge.onPainDetected(painData);
+      const latencyMs = Date.now() - startTime;
+
+      return {
+        status: bridgeResult.status,
+        painId: bridgeResult.painId,
+        taskId: bridgeResult.taskId,
+        runId: bridgeResult.runId,
+        artifactId: bridgeResult.artifactId,
+        candidateIds: bridgeResult.candidateIds,
+        ledgerEntryIds: bridgeResult.ledgerEntryIds,
+        message: bridgeResult.message,
+        observabilityWarnings,
+        failureCategory: classifyFromBridge(bridgeResult),
+        latencyMs,
+      };
+    } catch (err: unknown) {
+      const latencyMs = Date.now() - startTime;
+      return {
+        status: 'failed',
+        painId,
+        taskId,
+        candidateIds: [],
+        ledgerEntryIds: [],
+        message: err instanceof Error ? err.message : String(err),
+        observabilityWarnings,
+        failureCategory: classifyFromError(err),
+        latencyMs,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements PRI-17 (ADR) and PRI-12 (PainToPrincipleService facade) for Runtime V2 core service refactor.

## Changes

### PRI-17: Define Runtime V2 Service Boundaries and ADR
- **New file**: `docs/adr/0001-runtime-v2-service-boundaries.md`
- Defines 4 ownership boundaries: core (domain), pd-cli (UX), openclaw-plugin (hooks), runtime/pi (execution)
- Documents plugin logic inventory and migration plan (Phase A → D)
- Specifies error classification contract with chain-integrity-first mapping

### PRI-12: Introduce Core PainToPrincipleService Facade
- **New file**: `packages/principles-core/src/runtime-v2/pain-to-principle-service.ts`
- Wraps `createPainSignalBridge` + `recordPainSignalObservability` + error classification + latency
- Chain-integrity-first classification: `errorCategory` → `candidate_missing` → `ledger_write_failed` (never mis-maps to `runtime_unavailable`)
- Never throws; returns `status: 'failed'` on any error
- **13 unit tests** covering: success, failure, idempotent (skipped/succeeded), observability, parity

### Exports
- **Modified**: `packages/principles-core/src/runtime-v2/index.ts` (3 export lines added)

## Acceptance

✅ Service lives in `@principles/core/runtime-v2`
✅ Existing `PainSignalBridge` tests still pass (15/15)
✅ New tests cover all 5 PRI-12 scenarios + idempotent edge cases
✅ No CLI/plugin migration in this round
✅ No schema changes
✅ No RuleHost/PrincipleCompiler move

## Test Plan

- [x] Unit tests: 13/13 passed
- [x] Regression: pain-signal-bridge.test.ts (15/15 passed)
- [x] Regression: pain-signal-observability.test.ts
- [x] Build: `npm run build --workspace=@principles/core` ✅

## Non-goals (deferred to future issues)

- No pd-cli migration (PRI-18)
- No openclaw-plugin migration (PRI-13)
- No read model extraction (PRI-14)
- No auto-pruning design (PRI-15)

## Related Issues

- Closes PRI-17
- Closes PRI-12
- Parent: PRI-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增统一的痛点-原则工作流服务，提供改进的错误分类和可观测性支持

* **文档**
  * 新增运行时v2服务架构决策文档，阐述服务边界和迁移规划

* **测试**
  * 新增新服务的单元测试套件，确保功能完整性和质量

* **杂项**
  * 更新项目里程碑M10进度指标

<!-- end of auto-generated comment: release notes by coderabbit.ai -->