### PR TITLE
refactor(runtime-v2): pd pain record uses PainToPrincipleService

### DIFF
--- a/packages/openclaw-plugin/tests/integration/runtime-v2-pain-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/runtime-v2-pain-guard.test.ts
@@ -56,11 +56,11 @@ describe('Runtime V2 pain entrypoint guard', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('pd pain record enters PainSignalBridge directly', () => {
+  it('pd pain record uses PainToPrincipleService', () => {
     const source = read('packages/pd-cli/src/commands/pain-record.ts');
 
-    expect(source).toMatch(/createPainSignalBridge/);
-    expect(source).toMatch(/bridge\.onPainDetected/);
+    expect(source).toMatch(/PainToPrincipleService/);
+    expect(source).toMatch(/service\.recordPain/);
     expect(source).not.toMatch(/\.pain_flag|PAIN_FLAG|writePainFlag/);
   });
 

--- a/packages/pd-cli/src/commands/pain-record.ts
+++ b/packages/pd-cli/src/commands/pain-record.ts
@@ -4,26 +4,16 @@
  * Usage:
  *   pd pain record --reason <text> [--score N] [--source manual] [--workspace <path>] [--json]
  *
- * Flow:
- *   PainDetectedData → PainSignalBridge.onPainDetected()
- *   → DiagnosticianRunner.run() → CandidateIntakeService.intake()
- *   → PrincipleTreeLedger probation entry
- *
- * Output:
- *   JSON: { painId, taskId, runId, artifactId, candidateIds, ledgerEntryIds }
- *   Text: Human-readable summary
- *   Exit: non-0 on failure
+ * Delegates to PainToPrincipleService (core) for bridge creation, observability,
+ * error classification, and latency measurement.
  */
 
 import {
-  createPainSignalBridge,
+  PainToPrincipleService,
   PrincipleTreeLedgerAdapter,
-  recordPainSignalObservability,
   resolveRuntimeConfig,
-  FAILURE_CATEGORY_MAP,
 } from '@principles/core/runtime-v2';
-import { PDRuntimeError } from '@principles/core/runtime-v2';
-import type { PainSignalBridgeResult } from '@principles/core/runtime-v2';
+import type { PainToPrincipleOutput } from '@principles/core/runtime-v2';
 import type { KnownProvider } from '@mariozechner/pi-ai';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
@@ -49,6 +39,66 @@ interface PainRecordResult {
   latencyMs?: number;
 }
 
+async function formatConfigDiagnostic(stateDir: string, errMsg: string): Promise<void> {
+  const config = resolveRuntimeConfig(stateDir);
+  const missing: string[] = [];
+  if (!config.provider) missing.push('provider');
+  if (!config.model) missing.push('model');
+  if (!config.apiKeyEnv) missing.push('apiKeyEnv');
+  if (config.provider) {
+    try {
+      const { getProviders } = await import('@mariozechner/pi-ai');
+      const knownProviders = getProviders();
+      if (!knownProviders.includes(config.provider as KnownProvider) && !config.baseUrl) {
+        missing.push('baseUrl');
+      }
+    } catch {
+      // pi-ai may not be available
+    }
+  }
+
+  console.error('Error: Pain signal bridge initialization failed\n');
+
+  if (missing.length > 0) {
+    console.error('  Missing configuration:');
+    for (const m of missing) {
+      console.error(`    - ${m}`);
+    }
+    console.error('');
+  }
+
+  if (config.provider || config.model || config.apiKeyEnv || config.baseUrl) {
+    console.error('  Current workflow policy (pd-runtime-v2-diagnosis):');
+    console.error(`    runtimeKind: ${config.runtimeKind}`);
+    if (config.provider) console.error(`    provider:    ${config.provider}`);
+    if (config.model) console.error(`    model:       ${config.model}`);
+    if (config.apiKeyEnv) console.error(`    apiKeyEnv:   ${config.apiKeyEnv}`);
+    if (config.baseUrl) console.error(`    baseUrl:     ${config.baseUrl}`);
+    console.error('');
+  }
+
+  console.error('  To diagnose and configure your runtime, run:');
+  console.error('    pd runtime probe --runtime pi-ai --provider <name> --model <id> --apiKeyEnv <name>');
+  console.error('');
+  console.error(`  Details: ${errMsg}`);
+}
+
+function serviceOutputToResult(out: PainToPrincipleOutput): PainRecordResult {
+  return {
+    painId: out.painId,
+    taskId: out.taskId,
+    runId: out.runId,
+    artifactId: out.artifactId,
+    candidateIds: out.candidateIds,
+    ledgerEntryIds: out.ledgerEntryIds,
+    status: out.status,
+    message: out.message,
+    observabilityWarnings: out.observabilityWarnings.length > 0 ? out.observabilityWarnings : undefined,
+    failureCategory: out.failureCategory,
+    latencyMs: out.latencyMs,
+  };
+}
+
 export async function handlePainRecord(opts: RecordOptions): Promise<void> {
   if (!opts.reason) {
     console.error('Error: --reason <text> is required');
@@ -64,146 +114,35 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
   const stateDir = `${workspaceDir}/.state`;
 
-  const painId = `manual_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-  const taskId = `diagnosis_${painId}`;
   const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir });
+  const service = new PainToPrincipleService({
+    workspaceDir,
+    stateDir,
+    ledgerAdapter,
+    owner: 'pd-cli',
+    autoIntakeEnabled: true,
+  });
 
-  let bridge = undefined;
-  try {
-    bridge = await createPainSignalBridge({
-      workspaceDir,
-      stateDir,
-      ledgerAdapter,
-      owner: 'pd-cli',
-      autoIntakeEnabled: true,
-    });
-  } catch (err) {
-    const isRuntimeUnavailable =
-      err instanceof PDRuntimeError && err.category === 'runtime_unavailable';
+  const painId = `manual_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
-    if (isRuntimeUnavailable || (err instanceof Error && /missing required fields|not found in env|api key/i.test(err.message))) {
-      // Show diagnostic info for config/env failures
-      const config = resolveRuntimeConfig(stateDir);
-      const missing: string[] = [];
-      if (!config.provider) missing.push('provider');
-      if (!config.model) missing.push('model');
-      if (!config.apiKeyEnv) missing.push('apiKeyEnv');
-      if (config.provider) {
-        try {
-          const { getProviders } = await import('@mariozechner/pi-ai');
-          const knownProviders = getProviders();
-          if (!knownProviders.includes(config.provider as KnownProvider) && !config.baseUrl) {
-            missing.push('baseUrl');
-          }
-        } catch {
-          // pi-ai may not be available
-        }
-      }
-
-      console.error('Error: Pain signal bridge initialization failed\n');
-
-      if (missing.length > 0) {
-        console.error('  Missing configuration:');
-        for (const m of missing) {
-          console.error(`    - ${m}`);
-        }
-        console.error('');
-      }
-
-      if (config.provider || config.model || config.apiKeyEnv || config.baseUrl) {
-        console.error('  Current workflow policy (pd-runtime-v2-diagnosis):');
-        console.error(`    runtimeKind: ${config.runtimeKind}`);
-        if (config.provider) console.error(`    provider:    ${config.provider}`);
-        if (config.model) console.error(`    model:       ${config.model}`);
-        if (config.apiKeyEnv) console.error(`    apiKeyEnv:   ${config.apiKeyEnv}`);
-        if (config.baseUrl) console.error(`    baseUrl:     ${config.baseUrl}`);
-        console.error('');
-      }
-
-      console.error('  To diagnose and configure your runtime, run:');
-      console.error('    pd runtime probe --runtime pi-ai --provider <name> --model <id> --apiKeyEnv <name>');
-      console.error('');
-
-      const errMsg = err instanceof Error ? err.message : String(err);
-      console.error(`  Details: ${errMsg}`);
-      process.exit(1);
-    }
-
-    // Unknown error — re-throw for generic handling
-    throw err;
-  }
-
-  const painData = {
+  // Service never throws — all errors surfaced via result
+  const out = await service.recordPain({
     painId,
-    taskId,
-    painType: 'user_frustration' as const,
+    painType: 'user_frustration',
     source: opts.source ?? 'manual',
     reason: opts.reason,
     score: opts.score ?? 80,
     sessionId: 'cli',
     agentId: 'pd-cli',
-  };
-
-  const observability = recordPainSignalObservability({
-    workspaceDir,
-    stateDir,
-    data: painData,
   });
 
-  function classifyResult(br: PainSignalBridgeResult): string | undefined {
-    if (br.errorCategory) {
-      return FAILURE_CATEGORY_MAP[br.errorCategory] ?? 'runtime_unavailable';
-    }
-    if (br.status === 'failed') {
-      if (br.candidateIds.length === 0) return 'candidate_missing';
-      if (br.ledgerEntryIds.length === 0) return 'ledger_write_failed';
-    }
-    return undefined;
+  const result = serviceOutputToResult(out);
+
+  // Config init failure → show diagnostic guidance
+  if (result.status !== 'succeeded' && result.failureCategory === 'config_missing') {
+    await formatConfigDiagnostic(stateDir, result.message ?? 'configuration error');
+    process.exit(1);
   }
-
-  function classifyCatch(err: unknown): string | undefined {
-    if (err instanceof PDRuntimeError && err.category) {
-      return FAILURE_CATEGORY_MAP[err.category] ?? 'runtime_unavailable';
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/api[_\s]?key|not found in env|XIAOMI_KEY|OPENROUTER|missing required/i.test(msg)) return 'config_missing';
-    if (/timeout|timed[_\s]?out/i.test(msg)) return 'runtime_timeout';
-    if (/output.*invalid|validation.*fail/i.test(msg)) return 'output_invalid';
-    return 'runtime_unavailable';
-  }
-
-  const startTime = Date.now();
-  const result = await (async (): Promise<PainRecordResult> => {
-    const bridgeResult = await bridge.onPainDetected(painData);
-    const latencyMs = Date.now() - startTime;
-
-    return {
-      painId: bridgeResult.painId,
-      taskId: bridgeResult.taskId,
-      runId: bridgeResult.runId,
-      artifactId: bridgeResult.artifactId,
-      candidateIds: bridgeResult.candidateIds,
-      ledgerEntryIds: bridgeResult.ledgerEntryIds,
-      status: bridgeResult.status,
-      message: bridgeResult.message,
-      observabilityWarnings: observability.warnings.length > 0 ? observability.warnings : undefined,
-      failureCategory: classifyResult(bridgeResult),
-      latencyMs,
-    };
-  })().catch((err: unknown) => {
-    const latencyMs = Date.now() - startTime;
-    return {
-      painId,
-      taskId,
-      status: 'failed' as const,
-      candidateIds: [],
-      ledgerEntryIds: [],
-      message: err instanceof Error ? err.message : String(err),
-      observabilityWarnings: observability.warnings.length > 0 ? observability.warnings : undefined,
-      failureCategory: classifyCatch(err),
-      latencyMs,
-    };
-  });
 
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));

--- a/packages/pd-cli/src/commands/pain-record.ts
+++ b/packages/pd-cli/src/commands/pain-record.ts
@@ -152,8 +152,13 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
 
   // Config init failure → show diagnostic guidance
   if (result.status !== 'succeeded' && result.failureCategory === 'config_missing') {
-    await formatConfigDiagnostic(stateDir, result.message ?? 'configuration error');
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      await formatConfigDiagnostic(stateDir, result.message ?? 'configuration error');
+    }
     process.exit(1);
+    return;
   }
 
   if (opts.json) {

--- a/packages/pd-cli/src/commands/pain-record.ts
+++ b/packages/pd-cli/src/commands/pain-record.ts
@@ -13,7 +13,7 @@ import {
   PrincipleTreeLedgerAdapter,
   resolveRuntimeConfig,
 } from '@principles/core/runtime-v2';
-import type { PainToPrincipleOutput } from '@principles/core/runtime-v2';
+import type { PainToPrincipleOutput, FailureCategory } from '@principles/core/runtime-v2';
 import type { KnownProvider } from '@mariozechner/pi-ai';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
@@ -35,12 +35,23 @@ interface PainRecordResult {
   status: 'succeeded' | 'skipped' | 'failed' | 'retried';
   message?: string;
   observabilityWarnings?: string[];
-  failureCategory?: string;
+  failureCategory?: FailureCategory;
   latencyMs?: number;
 }
 
 async function formatConfigDiagnostic(stateDir: string, errMsg: string): Promise<void> {
-  const config = resolveRuntimeConfig(stateDir);
+  const config = (() => {
+    try {
+      return resolveRuntimeConfig(stateDir);
+    } catch {
+      return null;
+    }
+  })();
+  if (!config) {
+    console.error('Error: Pain signal processing failed — configuration issue\n');
+    console.error(`  Details: ${errMsg}`);
+    return;
+  }
   const missing: string[] = [];
   if (!config.provider) missing.push('provider');
   if (!config.model) missing.push('model');
@@ -57,7 +68,7 @@ async function formatConfigDiagnostic(stateDir: string, errMsg: string): Promise
     }
   }
 
-  console.error('Error: Pain signal bridge initialization failed\n');
+  console.error('Error: Pain signal processing failed — configuration issue\n');
 
   if (missing.length > 0) {
     console.error('  Missing configuration:');
@@ -93,6 +104,7 @@ function serviceOutputToResult(out: PainToPrincipleOutput): PainRecordResult {
     ledgerEntryIds: out.ledgerEntryIds,
     status: out.status,
     message: out.message,
+    // Omit empty warnings from JSON output for cleaner display
     observabilityWarnings: out.observabilityWarnings.length > 0 ? out.observabilityWarnings : undefined,
     failureCategory: out.failureCategory,
     latencyMs: out.latencyMs,
@@ -146,7 +158,7 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
 
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));
-    if (result.status !== 'succeeded') process.exit(1);
+    if (result.status === 'failed') process.exit(1);
   } else {
     if (result.status === 'succeeded') {
       console.log('[OK] Pain signal recorded via Runtime v2 bridge');
@@ -162,6 +174,14 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
       console.log(`   Workspace: ${workspaceDir}`);
       console.log(`\nDiagnostician pipeline running. Check progress with:`);
       console.log(`   pd task show ${result.taskId} --workspace "${workspaceDir}"`);
+    } else if (result.status === 'skipped') {
+      console.log('[SKIP] Pain signal already processed:', result.message);
+      console.log(`   Pain ID: ${result.painId}`);
+      console.log(`   Task ID: ${result.taskId}`);
+    } else if (result.status === 'retried') {
+      console.log('[RETRY] Pain signal triggered retry:', result.message);
+      console.log(`   Pain ID: ${result.painId}`);
+      console.log(`   Task ID: ${result.taskId}`);
     } else {
       console.error('[FAIL] Pain signal failed:', result.message);
       process.exit(1);

--- a/packages/pd-cli/tests/commands/pain-record.test.ts
+++ b/packages/pd-cli/tests/commands/pain-record.test.ts
@@ -8,7 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Mock setup ──────────────────────────────────────────────────────────────
 
-let mockRecordPainResult: Record<string, unknown>;
+let mockRecordPainResult: PainToPrincipleOutput;
+let lastRecordPainInput: PainToPrincipleInput | null = null;
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
@@ -16,7 +17,12 @@ vi.mock('../../src/resolve-workspace.js', () => ({
 
 vi.mock('@principles/core/runtime-v2', () => ({
   PainToPrincipleService: vi.fn().mockImplementation(function() {
-    return { recordPain: vi.fn(async () => mockRecordPainResult) };
+    return {
+      recordPain: vi.fn(async (input: PainToPrincipleInput) => {
+        lastRecordPainInput = input;
+        return mockRecordPainResult;
+      }),
+    };
   }),
   PrincipleTreeLedgerAdapter: vi.fn().mockImplementation(function() { return {}; }),
   resolveRuntimeConfig: vi.fn().mockReturnValue({
@@ -30,9 +36,13 @@ vi.mock('@principles/core/runtime-v2', () => ({
 }));
 
 import { handlePainRecord } from '../../src/commands/pain-record.js';
-import type { PainToPrincipleOutput } from '@principles/core/runtime-v2';
+import type { PainToPrincipleOutput, PainToPrincipleInput, FailureCategory } from '@principles/core/runtime-v2';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+}
 
 const SUCCEEDED_RESULT: PainToPrincipleOutput = {
   status: 'succeeded',
@@ -55,8 +65,22 @@ function makeFailedResult(overrides?: Partial<PainToPrincipleOutput>): PainToPri
     ledgerEntryIds: [],
     message: 'something went wrong',
     observabilityWarnings: [],
-    failureCategory: 'runtime_unavailable',
+    failureCategory: 'runtime_unavailable' as FailureCategory,
     latencyMs: 10,
+    ...overrides,
+  };
+}
+
+function makeSkippedResult(overrides?: Partial<PainToPrincipleOutput>): PainToPrincipleOutput {
+  return {
+    status: 'skipped',
+    painId: 'manual_123_abc',
+    taskId: 'diagnosis_manual_123_abc',
+    candidateIds: [],
+    ledgerEntryIds: [],
+    message: 'already leased',
+    observabilityWarnings: [],
+    latencyMs: 5,
     ...overrides,
   };
 }
@@ -67,12 +91,13 @@ describe('pd pain record', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRecordPainResult = { ...SUCCEEDED_RESULT };
+    lastRecordPainInput = null;
   });
 
   // 1. --reason required
   it('exits 1 when --reason is missing', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: undefined });
 
@@ -86,7 +111,7 @@ describe('pd pain record', () => {
   // 2. --score out of range
   it('exits 1 when --score is out of range', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: 'test', score: 150 });
 
@@ -100,7 +125,7 @@ describe('pd pain record', () => {
   // 3. Happy path --json output
   it('outputs JSON with all fields on success (--json)', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: 'test pain', json: true });
 
@@ -124,7 +149,7 @@ describe('pd pain record', () => {
   // 4. Happy path text output
   it('outputs human-readable summary on success (text)', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: 'test pain' });
 
@@ -136,11 +161,11 @@ describe('pd pain record', () => {
     exitSpy.mockRestore();
   });
 
-  // 5. Non-succeeded exits 1 with --json
-  it('exits 1 on non-succeeded status (--json)', async () => {
+  // 5. Failed exits 1 with --json
+  it('exits 1 on failed status (--json)', async () => {
     mockRecordPainResult = makeFailedResult();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: 'test pain', json: true });
 
@@ -152,11 +177,11 @@ describe('pd pain record', () => {
     exitSpy.mockRestore();
   });
 
-  // 6. Non-succeeded exits 1 (text)
-  it('exits 1 on non-succeeded status (text)', async () => {
+  // 6. Failed exits 1 (text)
+  it('exits 1 on failed status (text)', async () => {
     mockRecordPainResult = makeFailedResult();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: 'test pain' });
 
@@ -171,19 +196,64 @@ describe('pd pain record', () => {
   // 7. config_missing shows diagnostic guidance
   it('shows diagnostic guidance on config_missing failure', async () => {
     mockRecordPainResult = makeFailedResult({
-      failureCategory: 'config_missing',
+      failureCategory: 'config_missing' as FailureCategory,
       message: 'API key not found in env',
     });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+    const exitSpy = mockProcessExit();
 
     await handlePainRecord({ reason: 'test pain' });
 
     const allErrorOutput = errorSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    expect(allErrorOutput).toContain('Pain signal');
+    expect(allErrorOutput).toContain('configuration issue');
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     errorSpy.mockRestore();
     exitSpy.mockRestore();
+  });
+
+  // 8. skipped status outputs [SKIP] and does not exit 1
+  it('outputs [SKIP] on skipped status (text)', async () => {
+    mockRecordPainResult = makeSkippedResult();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    const allOutput = logSpy.mock.calls.map(c => c.join(' ')).join(' ');
+    expect(allOutput).toContain('[SKIP]');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 9. skipped status with --json does not exit 1
+  it('outputs skipped status in JSON without exit 1', async () => {
+    mockRecordPainResult = makeSkippedResult();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('skipped');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 10. recordPain called with correct arguments
+  it('passes correct arguments to recordPain', async () => {
+    await handlePainRecord({ reason: 'test pain', score: 90, source: 'ci' });
+
+    expect(lastRecordPainInput).toBeTruthy();
+    expect(lastRecordPainInput!.painType).toBe('user_frustration');
+    expect(lastRecordPainInput!.source).toBe('ci');
+    expect(lastRecordPainInput!.reason).toBe('test pain');
+    expect(lastRecordPainInput!.score).toBe(90);
+    expect(lastRecordPainInput!.sessionId).toBe('cli');
+    expect(lastRecordPainInput!.agentId).toBe('pd-cli');
   });
 });

--- a/packages/pd-cli/tests/commands/pain-record.test.ts
+++ b/packages/pd-cli/tests/commands/pain-record.test.ts
@@ -1,0 +1,189 @@
+/**
+ * pd pain record command unit tests.
+ *
+ * Tests the CLI adapter layer: validation, service delegation, output formatting.
+ * PainToPrincipleService is mocked — its own contract is tested separately.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock setup ──────────────────────────────────────────────────────────────
+
+let mockRecordPainResult: Record<string, unknown>;
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  PainToPrincipleService: vi.fn().mockImplementation(function() {
+    return { recordPain: vi.fn(async () => mockRecordPainResult) };
+  }),
+  PrincipleTreeLedgerAdapter: vi.fn().mockImplementation(function() { return {}; }),
+  resolveRuntimeConfig: vi.fn().mockReturnValue({
+    runtimeKind: 'pi-ai',
+    provider: 'test-provider',
+    model: 'test-model',
+    apiKeyEnv: 'TEST_KEY',
+    timeoutMs: 300000,
+    agentId: 'main',
+  }),
+}));
+
+import { handlePainRecord } from '../../src/commands/pain-record.js';
+import type { PainToPrincipleOutput } from '@principles/core/runtime-v2';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const SUCCEEDED_RESULT: PainToPrincipleOutput = {
+  status: 'succeeded',
+  painId: 'manual_123_abc',
+  taskId: 'diagnosis_manual_123_abc',
+  runId: 'run-001',
+  artifactId: 'art-001',
+  candidateIds: ['c1'],
+  ledgerEntryIds: ['l1'],
+  observabilityWarnings: [],
+  latencyMs: 42,
+};
+
+function makeFailedResult(overrides?: Partial<PainToPrincipleOutput>): PainToPrincipleOutput {
+  return {
+    status: 'failed',
+    painId: 'manual_123_abc',
+    taskId: 'diagnosis_manual_123_abc',
+    candidateIds: [],
+    ledgerEntryIds: [],
+    message: 'something went wrong',
+    observabilityWarnings: [],
+    failureCategory: 'runtime_unavailable',
+    latencyMs: 10,
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pd pain record', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecordPainResult = { ...SUCCEEDED_RESULT };
+  });
+
+  // 1. --reason required
+  it('exits 1 when --reason is missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: undefined });
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--reason'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 2. --score out of range
+  it('exits 1 when --score is out of range', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: 'test', score: 150 });
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--score'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 3. Happy path --json output
+  it('outputs JSON with all fields on success (--json)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    expect(logSpy).toHaveBeenCalled();
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('succeeded');
+    expect(jsonOutput.painId).toBe('manual_123_abc');
+    expect(jsonOutput.taskId).toBe('diagnosis_manual_123_abc');
+    expect(jsonOutput.runId).toBe('run-001');
+    expect(jsonOutput.artifactId).toBe('art-001');
+    expect(jsonOutput.candidateIds).toEqual(['c1']);
+    expect(jsonOutput.ledgerEntryIds).toEqual(['l1']);
+    expect(jsonOutput.observabilityWarnings).toBeUndefined();
+    expect(jsonOutput.latencyMs).toBe(42);
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 4. Happy path text output
+  it('outputs human-readable summary on success (text)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[OK]'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('manual_123_abc'));
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 5. Non-succeeded exits 1 with --json
+  it('exits 1 on non-succeeded status (--json)', async () => {
+    mockRecordPainResult = makeFailedResult();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 6. Non-succeeded exits 1 (text)
+  it('exits 1 on non-succeeded status (text)', async () => {
+    mockRecordPainResult = makeFailedResult();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    const firstErrorArg = errorSpy.mock.calls[0]?.[0] ?? '';
+    expect(firstErrorArg).toContain('[FAIL]');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 7. config_missing shows diagnostic guidance
+  it('shows diagnostic guidance on config_missing failure', async () => {
+    mockRecordPainResult = makeFailedResult({
+      failureCategory: 'config_missing',
+      message: 'API key not found in env',
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    const allErrorOutput = errorSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allErrorOutput).toContain('Pain signal');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
@@ -194,7 +194,7 @@ describe('PainToPrincipleService', () => {
     expect(r.taskId).toBe('custom-task-123');
   });
 
-  // 13. Bridge init failure does NOT write observability (P2 fix)
+  // 13. Bridge init failure does NOT write observability
   it('recordPain does not call observability when createPainSignalBridge throws', async () => {
     mockBridgeInitError = new Error('API key not found in env');
     const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
@@ -202,6 +202,15 @@ describe('PainToPrincipleService', () => {
     expect(observabilityCalled).toBe(false);
     expect(r.observabilityWarnings).toEqual([]);
     expect(r.failureCategory).toBe('config_missing');
+  });
+
+  // 14. Bridge call failure does NOT write observability
+  it('recordPain does not call observability when onPainDetected throws', async () => {
+    mockBridgeError = new Error('runtime crashed');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(observabilityCalled).toBe(false);
+    expect(r.observabilityWarnings).toEqual([]);
   });
 });
 
@@ -213,6 +222,8 @@ describe('PainToPrincipleService error classification parity', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBridgeResult = { ...SUCCEEDED };
+    mockBridgeError = null;
     mockBridgeInitError = null;
     observabilityCalled = false;
     mockObservabilityWarnings = [];
@@ -222,7 +233,7 @@ describe('PainToPrincipleService error classification parity', () => {
 
   it('classifyFromBridge maps all 17 PDErrorCategories correctly', async () => {
     for (const cat of PD_ERROR_CATEGORIES) {
-      mockBridgeResult = { ...SUCCEEDED, status: 'failed', errorCategory: cat, candidateIds: [], ledgerEntryIds: [] };
+      mockBridgeResult = { ...SUCCEEDED, status: 'failed', errorCategory: cat, candidateIds: ['c1'], ledgerEntryIds: ['l1'] };
       const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
       expect(r.failureCategory).toBe(FAILURE_CATEGORY_MAP[cat]);
     }

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
@@ -16,18 +16,22 @@ let mockBridgeResult: PainSignalBridgeResult = {
   status: 'succeeded', painId: '', taskId: '', candidateIds: [], ledgerEntryIds: [],
 };
 let mockBridgeError: Error | null = null;
+let mockBridgeInitError: Error | null = null;
 let observabilityCalled = false;
 let mockObservabilityWarnings: string[] = [];
 let lastPainDetectedData: PainDetectedData | null = null;
 
 vi.mock('../pain-signal-runtime-factory.js', () => ({
-  createPainSignalBridge: vi.fn(async (_opts: PainSignalRuntimeFactoryOptions) => ({
-    onPainDetected: vi.fn(async (data: PainDetectedData) => {
-      lastPainDetectedData = data;
-      if (mockBridgeError) throw mockBridgeError;
-      return { ...mockBridgeResult, taskId: data.taskId ?? mockBridgeResult.taskId };
-    }),
-  })),
+  createPainSignalBridge: vi.fn(async (_opts: PainSignalRuntimeFactoryOptions) => {
+    if (mockBridgeInitError) throw mockBridgeInitError;
+    return {
+      onPainDetected: vi.fn(async (data: PainDetectedData) => {
+        lastPainDetectedData = data;
+        if (mockBridgeError) throw mockBridgeError;
+        return { ...mockBridgeResult, taskId: data.taskId ?? mockBridgeResult.taskId };
+      }),
+    };
+  }),
 }));
 
 vi.mock('../pain-signal-observability.js', () => ({
@@ -62,6 +66,7 @@ describe('PainToPrincipleService', () => {
     vi.clearAllMocks();
     mockBridgeResult = { ...SUCCEEDED };
     mockBridgeError = null;
+    mockBridgeInitError = null;
     observabilityCalled = false;
     mockObservabilityWarnings = [];
     lastPainDetectedData = null;
@@ -188,6 +193,16 @@ describe('PainToPrincipleService', () => {
     const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r', taskId: 'custom-task-123' });
     expect(r.taskId).toBe('custom-task-123');
   });
+
+  // 13. Bridge init failure does NOT write observability (P2 fix)
+  it('recordPain does not call observability when createPainSignalBridge throws', async () => {
+    mockBridgeInitError = new Error('API key not found in env');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(observabilityCalled).toBe(false);
+    expect(r.observabilityWarnings).toEqual([]);
+    expect(r.failureCategory).toBe('config_missing');
+  });
 });
 
 // ── Parity: all 17 PDErrorCategory → FAILURE_CATEGORY_MAP ──────────────────
@@ -198,6 +213,7 @@ describe('PainToPrincipleService error classification parity', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBridgeInitError = null;
     observabilityCalled = false;
     mockObservabilityWarnings = [];
     lastPainDetectedData = null;

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -120,7 +120,8 @@ export class PainToPrincipleService {
         autoIntakeEnabled: this.opts.autoIntakeEnabled,
       });
 
-      // Observability only after bridge init succeeds — avoids orphan events on init failure
+      const bridgeResult = await bridge.onPainDetected(painData);
+
       let observabilityWarnings: string[] = [];
       if (input.recordObservability !== false) {
         const obs = recordPainSignalObservability({
@@ -130,8 +131,6 @@ export class PainToPrincipleService {
         });
         observabilityWarnings = obs.warnings;
       }
-
-      const bridgeResult = await bridge.onPainDetected(painData);
 
       const latencyMs = Date.now() - startTime;
 

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -120,8 +120,7 @@ export class PainToPrincipleService {
         autoIntakeEnabled: this.opts.autoIntakeEnabled,
       });
 
-      const bridgeResult = await bridge.onPainDetected(painData);
-
+      // Observability only after bridge init succeeds — avoids orphan events on init failure
       let observabilityWarnings: string[] = [];
       if (input.recordObservability !== false) {
         const obs = recordPainSignalObservability({
@@ -131,6 +130,8 @@ export class PainToPrincipleService {
         });
         observabilityWarnings = obs.warnings;
       }
+
+      const bridgeResult = await bridge.onPainDetected(painData);
 
       const latencyMs = Date.now() - startTime;
 
@@ -148,20 +149,6 @@ export class PainToPrincipleService {
         latencyMs,
       };
     } catch (err: unknown) {
-      let observabilityWarnings: string[] = [];
-      if (input.recordObservability !== false) {
-        try {
-          const obs = recordPainSignalObservability({
-            workspaceDir: this.opts.workspaceDir,
-            stateDir: this.opts.stateDir,
-            data: painData,
-          });
-          observabilityWarnings = obs.warnings;
-        } catch {
-          // Observability is best-effort; swallow errors on failure path
-        }
-      }
-
       const latencyMs = Date.now() - startTime;
       return {
         status: 'failed',
@@ -170,7 +157,7 @@ export class PainToPrincipleService {
         candidateIds: [],
         ledgerEntryIds: [],
         message: err instanceof Error ? err.message : String(err),
-        observabilityWarnings,
+        observabilityWarnings: [],
         failureCategory: classifyFromError(err),
         latencyMs,
       };


### PR DESCRIPTION
## Summary

Phase B of Runtime V2 core service refactor: migrate `pd pain record` to use the core `PainToPrincipleService` facade. Also fixes P2 review finding about orphan pain observability.

## Changes

### Fix: Orphan pain observability on bridge init failure (commit `734ef791`)

- Moved `recordPainSignalObservability` call from after `onPainDetected` to after `createPainSignalBridge` succeeds
- Removed observability from catch block — bridge init failures no longer leave orphan pain events in `trajectory.db` / `evolution.jsonl`
- Added test: `recordPain does not call observability when createPainSignalBridge throws`

### Refactor: pd-cli uses PainToPrincipleService (commit `b109a718`)

- `handlePainRecord` now delegates to `PainToPrincipleService.recordPain()`
- **Removed from CLI**: `createPainSignalBridge`, `recordPainSignalObservability`, `classifyResult`, `classifyCatch` (141 lines of domain logic removed)
- **Preserved**: validation, workspace resolution, config diagnostic formatting (via `result.failureCategory === 'config_missing'`), JSON/text output shape, non-zero exit behavior
- Service never throws — CLI reads `result.status` for errors

## Tests

- **Core**: 15/15 pass (13 original + 1 P2 fix + 1 parity)
- **pd-cli**: 7/7 new tests (validation, happy path JSON/text, failure, config diagnostic)
- **Build**: both packages pass typecheck and lint

## Related Issues

- Resolves #418 (PRI-18)
- Follow-up to #428 (PRI-17 + PRI-12 Phase A)
- Part of #416 (PRI-16 Runtime V2 core service refactor)

## Test Plan

- [x] Core tests pass (15/15)
- [x] pd-cli tests pass (7/7)
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual: `pd pain record --reason "test" --json` in configured workspace
- [ ] Manual: `pd pain record --reason "test"` (text output)
- [ ] Manual: Verify config error diagnostic when runtime is misconfigured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 命令行现在在结果中区分并显示已跳过（[SKIP]）和已重试（[RETRY]）的状态；JSON 输出包含相应 status 字段。

* **Bug 修复**
  * 在配置缺失场景下改进诊断输出，展示缺失字段和可执行的诊断命令并以 非零 状态退出。
  * 统一失败路径不再产生误导性的可观测性副作用。

* **测试**
  * 扩展并完善痛点记录命令和相关服务的单元/集成测试，覆盖成功、失败、跳过与重试场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->