### PR TITLE
🧹 fix: unskip abandoned session tests and remove obsolete fallback in nocturnal-runtime

### DIFF
--- a/packages/openclaw-plugin/src/service/nocturnal-runtime.ts
+++ b/packages/openclaw-plugin/src/service/nocturnal-runtime.ts
@@ -63,20 +63,6 @@ function isSystemSession(state: SessionState): boolean {
     if (sessionId?.startsWith('boot-')) return true;
     if (sessionId?.startsWith('probe-')) return true;
 
-    // CRITICAL FIX: Legacy sessions from persistence may have missing trigger/sessionKey
-    // If both are missing AND the session is old (inactive > abandoned threshold),
-    // treat as legacy/orphan to avoid blocking idle detection with unknown sessions.
-    // Recent sessions without trigger/sessionKey are likely real user sessions still
-    // being enriched — do NOT classify them as system sessions.
-    const ABANDONED_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
-    if (!trigger && !sessionKey) {
-        const inactiveFor = Date.now() - state.lastActivityAt;
-        if (inactiveFor > ABANDONED_THRESHOLD_MS) {
-            return true; // Legacy/orphan session — don't block idle detection
-        }
-        // Recent session without metadata — likely a real user session, let it through
-    }
-
     return false;
 }
 

--- a/packages/openclaw-plugin/tests/service/nocturnal-runtime.test.ts
+++ b/packages/openclaw-plugin/tests/service/nocturnal-runtime.test.ts
@@ -80,8 +80,7 @@ describe('NocturnalRuntime', () => {
             expect(result.idleForMs).toBeGreaterThan(30 * 60 * 1000);
         });
 
-        // TODO: Fix - abandonedSessionIds not being populated correctly
-        it.skip('should treat abandoned sessions as not contributing to idle check', () => {
+        it('should treat abandoned sessions as not contributing to idle check', () => {
             // Session active 3 hours ago — should be treated as abandoned
             vi.setSystemTime(new Date('2026-03-27T09:00:00.000Z')); // 3 hours before "now"
             trackToolRead('session-abandoned', 'src/main.ts', workspaceDir);
@@ -98,8 +97,7 @@ describe('NocturnalRuntime', () => {
             expect(result.reason).toContain('abandoned session(s) ignored');
         });
 
-        // TODO: Fix - abandonedSessionIds not being populated correctly
-        it.skip('should ignore ancient sessions but still detect recent activity from other sessions', () => {
+        it('should ignore ancient sessions but still detect recent activity from other sessions', () => {
             // Ancient session (4 hours ago — abandoned)
             vi.setSystemTime(new Date('2026-03-27T08:00:00.000Z'));
             trackToolRead('session-ancient', 'src/main.ts', workspaceDir);
@@ -402,8 +400,7 @@ describe('NocturnalRuntime', () => {
             expect(result.userActiveSessions).toBe(0);
         });
 
-        // TODO: Fix - abandonedSessionIds not being populated correctly
-        it.skip('should not incorrectly block when there are abandoned AND active sessions', () => {
+        it('should not incorrectly block when there are abandoned AND active sessions', () => {
             // Abandoned session (3 hours ago)
             vi.setSystemTime(new Date('2026-03-27T09:00:00.000Z'));
             trackToolRead('session-abandoned', 'src/main.ts', workspaceDir);


### PR DESCRIPTION
🎯 **What:** Re-enabled skipped tests for abandoned session logic in `nocturnal-runtime.test.ts` and removed an obsolete fallback block in `isSystemSession`.
💡 **Why:** A legacy "CRITICAL FIX" band-aid inside `isSystemSession` was prematurely filtering out test sessions that lacked `trigger` or `sessionKey` and were sufficiently old (in this case, intentionally mocked as abandoned sessions). These sessions were falsely classified as system sessions instead of propagating to the actual abandoned session logic in `checkWorkspaceIdle`. By removing this obsolete band-aid, old, un-labeled sessions correctly flow down as normal sessions, hit the `> abandonedThresholdMs` check, and get pushed to `abandonedSessionIds` array, allowing the tests to pass.
✅ **Verification:** Verified by un-skipping the three related tests in `nocturnal-runtime.test.ts` and observing them pass locally using `npm test`. The removal of the band-aid is safe because the exact same sessions it targeted (old, unknown sessions) are now properly handled by the main abandoned session loop, resulting in the same correct behavior (they don't block idle detection) but with accurate categorization.
✨ **Result:** Improved code health by removing dead code, restoring test coverage for abandoned sessions, and cleaning up TODOs.

---
*PR created automatically by Jules for task [10499899313248047231](https://jules.google.com/task/10499899313248047231) started by @csuzngjh*