### PR TITLE
fix(runtime-v2): compute pain-chain latency independent of candidate ordering

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/pain-chain-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-chain-read-model.test.ts
@@ -83,10 +83,24 @@ const CANDIDATE_CONSUMED = {
   createdAt: '2026-01-01T00:06:00.000Z',
 };
 
+const CANDIDATES_CONSUMED = [
+  { candidateId: 'c2', status: 'consumed', createdAt: '2026-01-01T00:08:00.000Z' },
+  { candidateId: 'c1', status: 'consumed', createdAt: '2026-01-01T00:06:00.000Z' },
+  { candidateId: 'c3', status: 'consumed', createdAt: '2026-01-01T00:07:00.000Z' },
+];
+
 const LEDGER_WITH_ENTRY = {
   tree: {
     principles: {
       'l1': { id: 'l1', derivedFromPainIds: ['c1'], createdAt: '2026-01-01T00:07:00.000Z' },
+    },
+  },
+};
+
+const LEDGER_WITH_MULTI_ENTRY = {
+  tree: {
+    principles: {
+      'l1': { id: 'l1', derivedFromPainIds: ['c1', 'c2', 'c3'], createdAt: '2026-01-01T00:10:00.000Z' },
     },
   },
 };
@@ -217,6 +231,24 @@ describe('PainChainReadModel', () => {
     await model.close();
   });
 
+  it('traceByPainId: multiple candidates ordered by createdAt DESC — uses earliest for artifactToCandidate', async () => {
+    setLedgerData(LEDGER_WITH_MULTI_ENTRY);
+    const mgr = makeMockManager({
+      task: TASK_SUCCEEDED,
+      runs: [RUN_SUCCEEDED],
+      artifactRow: ARTIFACT_ROW,
+      candidates: CANDIDATES_CONSUMED,
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('succeeded');
+    expect(trace.candidateIds).toEqual(['c2', 'c1', 'c3']);
+    expect(trace.ledgerEntryIds).toEqual(['l1']);
+    expect(trace.latencyMs.artifactToCandidate).toBe(30000);
+    expect(trace.latencyMs.candidateToLedger).toBe(120000);
+    await model.close();
+  });
+
   // ── getLastSuccessfulChain ─────────────────────────────────────────────
 
   it('getLastSuccessfulChain: init failure returns undefined', async () => {
@@ -270,6 +302,28 @@ describe('PainChainReadModel', () => {
     model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
     const chain = await model.getLastSuccessfulChain();
     expect(chain).toBeUndefined();
+    await model.close();
+  });
+
+  it('getLastSuccessfulChain: multiple candidates — uses earliest for artifactToCandidate', async () => {
+    setLedgerData(LEDGER_WITH_MULTI_ENTRY);
+    const mgr = makeMockManager({
+      candidates: CANDIDATES_CONSUMED,
+      dbQueries: {
+        lastSucceeded: { task_id: 'diagnosis_pain-001', input_ref: 'pain-001', created_at: '2026-01-01T00:00:00.000Z' },
+        run: { run_id: 'run-001', started_at: '2026-01-01T00:01:00.000Z', ended_at: '2026-01-01T00:05:00.000Z' },
+        artifact: { artifact_id: 'art-001', created_at: '2026-01-01T00:05:30.000Z' },
+      },
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const chain = await model.getLastSuccessfulChain();
+    expect(chain).toBeDefined();
+    if (!chain) return;
+    expect(chain.status).toBe('succeeded');
+    expect(chain.candidateIds).toEqual(['c2', 'c1', 'c3']);
+    expect(chain.ledgerEntryIds).toEqual(['l1']);
+    expect(chain.latencyMs.artifactToCandidate).toBe(30000);
+    expect(chain.latencyMs.candidateToLedger).toBe(120000);
     await model.close();
   });
 

--- a/packages/principles-core/src/runtime-v2/pain-chain-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pain-chain-read-model.ts
@@ -222,6 +222,7 @@ export class PainChainReadModel {
       };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
+      console.error(`[PainChainReadModel] traceByPainId(${painId}) failed: ${message}`);
       const isConfigError = /disk|unavailable|config|api[_\s]?key|not found in env/i.test(message);
       return {
         painId,
@@ -340,7 +341,9 @@ export class PainChainReadModel {
         checkedAt: new Date().toISOString(),
         missingLinks: [],
       };
-    } catch {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[PainChainReadModel] getLastSuccessfulChain failed: ${message}`);
       return undefined;
     }
   }

--- a/packages/principles-core/src/runtime-v2/pain-chain-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pain-chain-read-model.ts
@@ -136,10 +136,14 @@ export class PainChainReadModel {
 
       const candidateIds = candidates.map(c => c.candidateId);
       const ledgerEntryIds: string[] = [];
+      const seenEntryIds = new Set<string>();
       for (const c of candidates) {
         const entryId = candidateToLedgerEntry.get(c.candidateId);
         if (entryId) {
-          ledgerEntryIds.push(entryId);
+          if (!seenEntryIds.has(entryId)) {
+            seenEntryIds.add(entryId);
+            ledgerEntryIds.push(entryId);
+          }
         } else if (c.status === 'consumed') {
           missingLinks.push(`candidate:${c.candidateId} consumed but missing from ledger`);
         }
@@ -156,14 +160,22 @@ export class PainChainReadModel {
         latencyMs.runToArtifact = Math.max(0, new Date(artifactCreatedAt).getTime() - new Date(latestRun.endedAt).getTime());
       }
       if (artifactCreatedAt && candidates.length > 0) {
-        const [firstCandidate] = candidates;
-        if (firstCandidate) {
-          latencyMs.artifactToCandidate = Math.max(0, new Date(firstCandidate.createdAt).getTime() - new Date(artifactCreatedAt).getTime());
+        const [first] = candidates;
+        if (first) {
+          let earliestCandidateAt = first.createdAt;
+          for (const c of candidates) {
+            if (c.createdAt < earliestCandidateAt) earliestCandidateAt = c.createdAt;
+          }
+          latencyMs.artifactToCandidate = Math.max(0, new Date(earliestCandidateAt).getTime() - new Date(artifactCreatedAt).getTime());
         }
       }
       if (candidates.length > 0 && ledgerEntryIds.length > 0) {
-        const [lastCandidate] = candidates.slice(-1);
-        if (lastCandidate) {
+        const [first] = candidates;
+        if (first) {
+          let latestCandidateAt = first.createdAt;
+          for (const c of candidates) {
+            if (c.createdAt > latestCandidateAt) latestCandidateAt = c.createdAt;
+          }
           let earliestLedgerAt: string | undefined = undefined;
           for (const entry of principleEntries) {
             const e = entry as { id: string; createdAt?: string };
@@ -172,7 +184,7 @@ export class PainChainReadModel {
             }
           }
           if (earliestLedgerAt) {
-            latencyMs.candidateToLedger = Math.max(0, new Date(earliestLedgerAt).getTime() - new Date(lastCandidate.createdAt).getTime());
+            latencyMs.candidateToLedger = Math.max(0, new Date(earliestLedgerAt).getTime() - new Date(latestCandidateAt).getTime());
           }
         }
       }
@@ -264,9 +276,15 @@ export class PainChainReadModel {
 
       const candidateIds = candidates.map(c => c.candidateId);
       const ledgerEntryIds: string[] = [];
+      const seenEntryIds = new Set<string>();
       for (const c of candidates) {
         const entryId = candidateToLedgerEntry.get(c.candidateId);
-        if (entryId) ledgerEntryIds.push(entryId);
+        if (entryId) {
+          if (!seenEntryIds.has(entryId)) {
+            seenEntryIds.add(entryId);
+            ledgerEntryIds.push(entryId);
+          }
+        }
       }
 
       const latencyMs: PainChainTraceLatencyMs = {};
@@ -280,14 +298,22 @@ export class PainChainReadModel {
         latencyMs.runToArtifact = Math.max(0, new Date(artifacts.created_at).getTime() - new Date(run.ended_at).getTime());
       }
       if (artifacts.created_at && candidates.length > 0) {
-        const [firstCandidate] = candidates;
-        if (firstCandidate) {
-          latencyMs.artifactToCandidate = Math.max(0, new Date(firstCandidate.createdAt).getTime() - new Date(artifacts.created_at).getTime());
+        const [first] = candidates;
+        if (first) {
+          let earliestCandidateAt = first.createdAt;
+          for (const c of candidates) {
+            if (c.createdAt < earliestCandidateAt) earliestCandidateAt = c.createdAt;
+          }
+          latencyMs.artifactToCandidate = Math.max(0, new Date(earliestCandidateAt).getTime() - new Date(artifacts.created_at).getTime());
         }
       }
       if (candidates.length > 0 && ledgerEntryIds.length > 0) {
-        const [lastCandidate] = candidates.slice(-1);
-        if (lastCandidate) {
+        const [first] = candidates;
+        if (first) {
+          let latestCandidateAt = first.createdAt;
+          for (const c of candidates) {
+            if (c.createdAt > latestCandidateAt) latestCandidateAt = c.createdAt;
+          }
           let earliestLedgerAt: string | undefined = undefined;
           for (const entry of principleEntries) {
             const e = entry as { id: string; createdAt?: string };
@@ -296,7 +322,7 @@ export class PainChainReadModel {
             }
           }
           if (earliestLedgerAt) {
-            latencyMs.candidateToLedger = Math.max(0, new Date(earliestLedgerAt).getTime() - new Date(lastCandidate.createdAt).getTime());
+            latencyMs.candidateToLedger = Math.max(0, new Date(earliestLedgerAt).getTime() - new Date(latestCandidateAt).getTime());
           }
         }
       }


### PR DESCRIPTION
## Summary

- `traceByPainId` 和 `getLastSuccessfulChain` 中的 latency 计算不再依赖 `candidates[0]`（最新）或 `candidates.slice(-1)`（最旧）
- 改用显式循环遍历找 min/max candidate timestamp
- Candidates 返回按 `created_at DESC` 排序（最新优先）
- `artifactToCandidate` 现在正确使用最早 candidate 的 `createdAt`
- `candidateToLedger` 使用最新 candidate 的 `createdAt`
- 多 candidate 映射到同一 ledger entry 时去重 `ledgerEntryIds`

## Test plan

- [x] 15/15 vitest tests pass
- [x] `npm run build --workspace=@principles/core`
- [x] `npm run build --workspace=@principles/pd-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **Bug修复**
  * 修复账本条目重复处理问题，确保数据去重正确
  * 优化延迟计算逻辑，提升时间戳处理的准确性
  * 增强错误处理机制，改进错误日志记录

* **测试**
  * 新增测试用例覆盖多候选项场景，验证处理的正确性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->