### PR TITLE
refactor(openclaw-plugin): delegate pain orchestration to core service (PRI-13)

### DIFF
--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -12,7 +12,7 @@ import type { EvolutionLoopEvent } from '../core/evolution-types.js';
 import type { PluginHookAfterToolCallEvent, PluginHookToolContext, OpenClawPluginApi } from '../openclaw-sdk.js';
 import { validateWorkspaceDir } from '../core/workspace-dir-validation.js';
 import { resolveWorkspaceDir } from '../core/workspace-dir-service.js';
-import { createPainSignalBridge, PrincipleTreeLedgerAdapter, type PainDetectedData } from '@principles/core/runtime-v2';
+import { PrincipleTreeLedgerAdapter, PainToPrincipleService, type PainDetectedData } from '@principles/core/runtime-v2';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 
 /**
@@ -32,13 +32,13 @@ interface ToolParams {
 
 const WRITE_TOOLS = ['write', 'edit', 'apply_patch', 'write_file', 'edit_file', 'replace'];
 
-async function getPainSignalBridge(wctx: WorkspaceContext): Promise<ReturnType<typeof createPainSignalBridge>> {
+function createPainToPrincipleService(wctx: WorkspaceContext): PainToPrincipleService {
   const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: wctx.stateDir });
-  return createPainSignalBridge({
+  return new PainToPrincipleService({
     workspaceDir: wctx.workspaceDir,
     stateDir: wctx.stateDir,
     ledgerAdapter,
-    owner: 'pain-signal-bridge',
+    owner: 'openclaw-plugin',
     autoIntakeEnabled: true,
   });
 }
@@ -59,12 +59,32 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
     const painId = painData?.painId ?? 'unknown';
     const sessionId = painData?.sessionId ?? 'unknown';
     try {
-      const bridge = await getPainSignalBridge(wctx);
-      bridge.onPainDetected(painData).catch((err) => {
-        SystemLogger.log(wctx.workspaceDir, 'BRIDGE_ERROR', `PainSignalBridge failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);
+      const service = createPainToPrincipleService(wctx);
+      service.recordPain({
+        painId: painData.painId,
+        painType: painData.painType,
+        source: painData.source,
+        reason: painData.reason,
+        score: painData.score,
+        sessionId: painData.sessionId,
+        agentId: painData.agentId,
+        taskId: painData.taskId,
+        traceId: painData.traceId,
+      }).then((result) => {
+        if (result.status === 'failed' && result.failureCategory) {
+          SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_FAILED', JSON.stringify({
+            painId: result.painId,
+            taskId: result.taskId,
+            failureCategory: result.failureCategory,
+            latencyMs: result.latencyMs,
+            message: result.message,
+          }));
+        }
+      }).catch((err) => {
+        SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_ERROR', `PainToPrincipleService failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);
       });
     } catch (err) {
-      SystemLogger.log(wctx.workspaceDir, 'BRIDGE_INIT_ERROR', `PainSignalBridge init failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);
+      SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_INIT_ERROR', `PainToPrincipleService init failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);
     }
   }
 }

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -53,14 +53,11 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
   } catch (e) {
     SystemLogger.log(wctx.workspaceDir, 'EVOLUTION_EMIT_WARN', `Failed to emit evolution event: ${String(e)}`);
   }
-  // M8: Bridge pain_detected → diagnostician pipeline (fire-and-forget)
   if (event.type === 'pain_detected') {
     const painData = event.data as PainDetectedData;
-    const painId = painData?.painId ?? 'unknown';
-    const sessionId = painData?.sessionId ?? 'unknown';
     try {
       const service = createPainToPrincipleService(wctx);
-      service.recordPain({
+      const result = await service.recordPain({
         painId: painData.painId,
         painType: painData.painType,
         source: painData.source,
@@ -70,19 +67,26 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
         agentId: painData.agentId,
         taskId: painData.taskId,
         traceId: painData.traceId,
-      }).then((result) => {
-        if (result.status === 'failed' && result.failureCategory) {
-          SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_FAILED', JSON.stringify({
-            painId: result.painId,
-            taskId: result.taskId,
-            failureCategory: result.failureCategory,
-            latencyMs: result.latencyMs,
-            message: result.message,
-          }));
-        }
+        recordObservability: true,
       });
+      if (result.status === 'failed' && result.failureCategory) {
+        SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_FAILED', JSON.stringify({
+          painId: result.painId,
+          taskId: result.taskId,
+          failureCategory: result.failureCategory,
+          latencyMs: result.latencyMs,
+          message: result.message,
+        }));
+      } else if (result.status === 'skipped') {
+        SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_SKIPPED', JSON.stringify({
+          painId: result.painId,
+          taskId: result.taskId,
+          latencyMs: result.latencyMs,
+          message: result.message,
+        }));
+      }
     } catch (err) {
-      SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_INIT_ERROR', `PainToPrincipleService init failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);
+      SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_ERROR', `recordPain threw: ${String(err)}`);
     }
   }
 }

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -80,8 +80,6 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
             message: result.message,
           }));
         }
-      }).catch((err) => {
-        SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_ERROR', `PainToPrincipleService failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);
       });
     } catch (err) {
       SystemLogger.log(wctx.workspaceDir, 'PAIN_SERVICE_INIT_ERROR', `PainToPrincipleService init failed: painId=${painId} sessionId=${sessionId}: ${String(err)}`);

--- a/packages/openclaw-plugin/tests/integration/runtime-v2-pain-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/runtime-v2-pain-guard.test.ts
@@ -69,7 +69,7 @@ describe('Runtime V2 pain entrypoint guard', () => {
 
     expect(source).toMatch(/emitPainDetectedEvent\(wctx,\s*\{/);
     expect(source).toMatch(/type:\s*'pain_detected'/);
-    expect(source).toMatch(/PainSignalBridge|createPainSignalBridge/);
+    expect(source).toMatch(/PainToPrincipleService/);
     expect(source).not.toMatch(/writePainFlag|recordAndWritePainFlag/);
     expect(source).not.toMatch(/writeFileSync\s*\([^)]*painFlagPath/s);
     expect(source).not.toMatch(/atomicWriteFileSync\s*\([^)]*painFlagPath/s);


### PR DESCRIPTION
## Summary

Thin the OpenClaw pain hook so it adapts OpenClaw events into normalized core pain input, while  owns the Runtime V2 pain-to-principle orchestration.

**Plugin retains (unchanged):**
- OpenClaw event parsing (after_tool_call)
- GFI/session tracking (trackFriction, sessionState)
- Diagnostic gate evaluation (evaluatePainDiagnosticGate)
- Cooldown deduplication (gate.reason === 'cooldown')
- OpenClaw-facing structured logging (SystemLogger)

**Delegated to PainToPrincipleService:**
- Pain signal bridge creation and invocation
- Observability write (recordPainSignalObservability)
- Latency measurement
- Failure category classification (classifyFromBridge / classifyFromError)
- Structured result output

**Test updates:**
- : check for  instead of 

**Non-goals (preserved):**
- No GFI/gate logic removal
- No RuleHost/PrincipleCompiler migration
- No database schema changes
- No pd-cli changes

## Test plan

- [x] 12/12 integration tests pass
- [x] 
> principles-disciple-monorepo@1.10.37 typecheck:openclaw-plugin
> cd packages/openclaw-plugin && npx tsc --noEmit
- [x] 
> @principles/core@0.1.0 build
> tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)