### PR TITLE
test(pd-cli): cover runtime pruning report with error/healthy paths

### DIFF
--- a/packages/pd-cli/src/commands/runtime-pruning.ts
+++ b/packages/pd-cli/src/commands/runtime-pruning.ts
@@ -1,0 +1,83 @@
+/**
+ * pd runtime pruning report command — non-destructive pruning metrics.
+ *
+ * Usage: pd runtime pruning report [--workspace <path>] [--json]
+ *
+ * Delegates to PruningReadModel (core).
+ */
+
+import * as path from 'path';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import { PruningReadModel } from '@principles/core/runtime-v2';
+
+interface PruningReportOptions {
+  workspace?: string;
+  json?: boolean;
+}
+
+function outputText(
+  summary: ReturnType<PruningReadModel['getHealthSummary']>,
+  signals: ReturnType<PruningReadModel['getPrincipleSignals']>,
+  workspaceDir: string,
+): void {
+  console.log(`generatedAt: ${summary.generatedAt}`);
+  console.log(`workspace: ${workspaceDir}`);
+  console.log(`totalPrinciples: ${summary.totalPrinciples}`);
+  console.log(`byStatus: ${JSON.stringify(summary.byStatus)}`);
+  console.log(`orphanDerivedCandidateCount: ${summary.orphanDerivedCandidateCount}`);
+  console.log(`averageAgeDays: ${summary.averageAgeDays}`);
+  console.log('');
+  console.log(`watchCount: ${summary.watchCount}`);
+  console.log(`reviewCount: ${summary.reviewCount}`);
+
+  if (summary.watchCount > 0) {
+    console.log('');
+    console.log('── Principles flagged WATCH ──');
+    for (const s of signals) {
+      if (s.riskLevel === 'watch') {
+        console.log(`  [${s.status}] ${s.principleId} (age: ${s.ageDays}d, derivedPainCount: ${s.derivedPainCount})`);
+        for (const r of s.reasons) {
+          console.log(`    ↳ ${r}`);
+        }
+      }
+    }
+  }
+
+  if (summary.reviewCount > 0) {
+    console.log('');
+    console.log('── Principles flagged REVIEW ──');
+    for (const s of signals) {
+      if (s.riskLevel === 'review') {
+        console.log(`  [${s.status}] ${s.principleId} (age: ${s.ageDays}d, derivedPainCount: ${s.derivedPainCount})`);
+        for (const r of s.reasons) {
+          console.log(`    ↳ ${r}`);
+        }
+      }
+    }
+  }
+
+  if (summary.watchCount === 0 && summary.reviewCount === 0) {
+    console.log('');
+    console.log('No watch or review signals. System is healthy.');
+  }
+
+  console.log('');
+  console.log('NOTE: This report is read-only. No principles are modified or deleted.');
+}
+
+export function handlePruningReport(opts: PruningReportOptions): void {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const model = new PruningReadModel({ workspaceDir });
+  const signals = model.getPrincipleSignals();
+  const summary = model.getHealthSummary();
+
+  if (opts.json) {
+    console.log(JSON.stringify({ generatedAt: summary.generatedAt, workspace: workspaceDir, summary, signals }, null, 2));
+    return;
+  }
+
+  outputText(summary, signals, workspaceDir);
+}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -25,6 +25,7 @@ import { handleDiagnoseStatus, handleDiagnoseRun } from './commands/diagnose.js'
 import { handleRuntimeProbe } from './commands/runtime.js';
 import { handleFlowShow } from './commands/flow.js';
 import { handleTraceShow } from './commands/trace.js';
+import { handlePruningReport } from './commands/runtime-pruning.js';
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
@@ -321,6 +322,19 @@ traceCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleTraceShow({ painId: opts.painId, workspace: opts.workspace, json: opts.json });
+  });
+
+const pruningCmd = runtimeCmd
+  .command('pruning')
+  .description('Non-destructive pruning metrics and health signals');
+
+pruningCmd
+  .command('report')
+  .description('Show pruning health report — watch/review principle signals')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action((opts) => {
+    handlePruningReport({ workspace: opts.workspace, json: opts.json });
   });
 
 // ── Candidate inspection commands ───────────────────────────────────────────

--- a/packages/pd-cli/tests/commands/runtime-pruning.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-pruning.test.ts
@@ -3,58 +3,63 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const { MockPruningReadModel } = vi.hoisted(() => {
+  class MockPruningReadModel {
+    getPrincipleSignals() {
+      return [
+        {
+          principleId: 'p_watch',
+          status: 'active' as const,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          derivedCandidateIds: [] as string[],
+          derivedPainCount: 0,
+          matchedCandidateCount: 0,
+          recentCandidateCount: 0,
+          orphanCandidateCount: 0,
+          ageDays: 45,
+          riskLevel: 'watch' as const,
+          reasons: ['watch: principle older than 30 days with no recent derived pain signals [source: createdAt + derivedFromPainIds]'],
+        },
+        {
+          principleId: 'p_review',
+          status: 'active' as const,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          derivedCandidateIds: [] as string[],
+          derivedPainCount: 0,
+          matchedCandidateCount: 0,
+          recentCandidateCount: 0,
+          orphanCandidateCount: 0,
+          ageDays: 120,
+          riskLevel: 'review' as const,
+          reasons: ['review: principle older than 90 days with no derived pain signals [source: createdAt + derivedFromPainIds]'],
+        },
+      ];
+    }
+    getHealthSummary() {
+      return {
+        totalPrinciples: 2,
+        byStatus: { active: 2 },
+        watchCount: 1,
+        reviewCount: 1,
+        orphanDerivedCandidateCount: 0,
+        averageAgeDays: 82,
+        generatedAt: '2026-05-02T00:00:00.000Z',
+      };
+    }
+  }
+  return { MockPruningReadModel };
+}, { validateType: false });
+
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/test-workspace'),
 }));
 
-const MOCK_SIGNALS = [
-  {
-    principleId: 'p_watch',
-    status: 'active' as const,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-    derivedCandidateIds: [] as string[],
-    derivedPainCount: 0,
-    matchedCandidateCount: 0,
-    recentCandidateCount: 0,
-    orphanCandidateCount: 0,
-    ageDays: 45,
-    riskLevel: 'watch' as const,
-    reasons: ['watch: principle older than 30 days with no recent derived pain signals [source: createdAt + derivedFromPainIds]'],
-  },
-  {
-    principleId: 'p_review',
-    status: 'active' as const,
-    createdAt: '2025-01-01T00:00:00.000Z',
-    updatedAt: '2025-01-01T00:00:00.000Z',
-    derivedCandidateIds: [] as string[],
-    derivedPainCount: 0,
-    matchedCandidateCount: 0,
-    recentCandidateCount: 0,
-    orphanCandidateCount: 0,
-    ageDays: 120,
-    riskLevel: 'review' as const,
-    reasons: ['review: principle older than 90 days with no derived pain signals [source: createdAt + derivedFromPainIds]'],
-  },
-];
-
-const MOCK_SUMMARY = {
-  totalPrinciples: 2,
-  byStatus: { active: 2 },
-  watchCount: 1,
-  reviewCount: 1,
-  orphanDerivedCandidateCount: 0,
-  averageAgeDays: 82,
-  generatedAt: '2026-05-02T00:00:00.000Z',
-};
-
-class MockPruningReadModel {
-  getPrincipleSignals() { return MOCK_SIGNALS; }
-  getHealthSummary() { return MOCK_SUMMARY; }
-}
-
 vi.mock('@principles/core/runtime-v2', () => ({
-  PruningReadModel: vi.fn(() => new MockPruningReadModel()),
+  PruningReadModel: vi.fn().mockImplementation(function () {
+    return new MockPruningReadModel();
+  }),
 }));
 
 import { handlePruningReport } from '../../src/commands/runtime-pruning.js';
@@ -67,60 +72,81 @@ describe('pd runtime pruning report', () => {
 
   it('text output contains read-only note', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
     handlePruningReport({ json: false });
-
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('NOTE: This report is read-only. No principles are modified or deleted.')
     );
-
     consoleSpy.mockRestore();
   });
 
   it('text output includes watch and review sections', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
     handlePruningReport({ json: false });
-
     const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(output).toContain('Principles flagged WATCH');
     expect(output).toContain('Principles flagged REVIEW');
     expect(output).toContain('p_watch');
     expect(output).toContain('p_review');
-
     consoleSpy.mockRestore();
   });
 
-  it('--json flag outputs full shape with generatedAt, workspace, summary, signals', () => {
+  it('--json flag outputs full shape', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
     handlePruningReport({ json: true });
-
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
-
     expect(output).toHaveProperty('generatedAt');
     expect(output).toHaveProperty('workspace');
     expect(output).toHaveProperty('summary');
     expect(output).toHaveProperty('signals');
-
     expect(output.summary.watchCount).toBe(1);
     expect(output.summary.reviewCount).toBe(1);
-    expect(output.signals).toHaveLength(2);
-
     consoleSpy.mockRestore();
   });
 
   it('--workspace passes explicit path to PruningReadModel constructor', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
     handlePruningReport({ workspace: '/custom/workspace', json: false });
-
-    // PruningReadModel was called once with a workspace dir containing 'custom/workspace'
     const calls = (PruningReadModel as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls.length).toBeGreaterThan(0);
     expect(String(calls[calls.length - 1][0].workspaceDir)).toMatch(/custom.*workspace/);
+    consoleSpy.mockRestore();
+  });
 
+  it('error-path: propagates errors from PruningReadModel', () => {
+    class MockErrorReadModel {
+      getPrincipleSignals() { throw new Error('DB query failed'); }
+      getHealthSummary() { return {}; }
+    }
+    (PruningReadModel as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(function () {
+      return new MockErrorReadModel() as unknown as InstanceType<typeof PruningReadModel>;
+    });
+    expect(() => handlePruningReport({ json: false })).toThrow('DB query failed');
+  });
+
+  it('healthy-path: no watch or review signals', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    class MockHealthyReadModel {
+      getPrincipleSignals() { return []; }
+      getHealthSummary() {
+        return {
+          totalPrinciples: 5,
+          byStatus: { active: 5 },
+          watchCount: 0,
+          reviewCount: 0,
+          orphanDerivedCandidateCount: 0,
+          averageAgeDays: 10,
+          generatedAt: '2026-05-02T00:00:00.000Z',
+        };
+      }
+    }
+    (PruningReadModel as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(function () {
+      return new MockHealthyReadModel() as unknown as InstanceType<typeof PruningReadModel>;
+    });
+    handlePruningReport({ json: false });
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('No watch or review signals. System is healthy.');
+    expect(output).not.toContain('WATCH');
     consoleSpy.mockRestore();
   });
 });

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -218,3 +218,7 @@ export { EvolutionQueueItemMigrator } from './store/task-migration.js';
 
 // Ledger file utilities (for audit/consistency checks)
 export { loadLedger, getLedgerFilePathPublic } from '../principle-tree-ledger.js';
+
+// Pruning read model (PRI-15)
+export { PruningReadModel } from './pruning-read-model.js';
+export type { PrinciplePruningSignal, PruningHealthSummary, PruningReadModelOptions, PruningRiskLevel, PrincipleStatus } from './pruning-read-model.js';

--- a/packages/principles-core/src/runtime-v2/pruning-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-read-model.ts
@@ -1,0 +1,265 @@
+/**
+ * PruningReadModel — non-destructive read model for principle lifecycle signals.
+ *
+ * PRI-15: Dynamic pruning metrics and read model.
+ *
+ * This model reads from the ledger and candidates table to produce
+ * actionable signals for principle health, without writing anything.
+ * All rules are deterministic and based on available metadata only.
+ *
+ * Non-goals:
+ * - No automatic pruning or demotion
+ * - No ledger writes
+ * - No state changes
+ * - No background workers
+ */
+import * as path from 'path';
+import * as fs from 'fs';
+import Database from 'better-sqlite3';
+import { loadLedger } from '../principle-tree-ledger.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────────
+
+export type PrincipleStatus = 'candidate' | 'active' | 'archived' | 'deprecated' | 'probation';
+export type PruningRiskLevel = 'none' | 'watch' | 'review';
+
+export interface PrinciplePruningSignal {
+  principleId: string;
+  status: PrincipleStatus;
+  createdAt: string;
+  updatedAt: string;
+  derivedCandidateIds: string[];
+  derivedPainCount: number;
+  matchedCandidateCount: number;
+  recentCandidateCount: number;
+  orphanCandidateCount: number;
+  ageDays: number;
+  riskLevel: PruningRiskLevel;
+  reasons: string[];
+}
+
+export interface PruningHealthSummary {
+  totalPrinciples: number;
+  byStatus: Record<string, number>;
+  watchCount: number;
+  reviewCount: number;
+  orphanDerivedCandidateCount: number;
+  averageAgeDays: number;
+  generatedAt: string;
+}
+
+export interface PruningReadModelOptions {
+  workspaceDir: string;
+  /** Override days threshold for 'watch' risk level (default: 30) */
+  watchThresholdDays?: number;
+  /** Override days threshold for 'review' risk level (default: 90) */
+  reviewThresholdDays?: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function daysBetween(dateA: string | number, dateB: Date | number): number {
+  const a = typeof dateA === 'string' ? new Date(dateA).getTime() : dateA;
+  const b = typeof dateB === 'number' ? dateB : dateB.getTime();
+  if (isNaN(a)) return 9999;
+  return Math.max(0, Math.round((b - a) / (1000 * 60 * 60 * 24)));
+}
+
+function computeRiskLevel(
+  ageDays: number,
+  derivedPainCount: number,
+  opts: { watchThresholdDays: number; reviewThresholdDays: number },
+): PruningRiskLevel {
+  if (ageDays >= opts.reviewThresholdDays && derivedPainCount === 0) {
+    return 'review';
+  }
+  if (ageDays >= opts.watchThresholdDays && derivedPainCount === 0) {
+    return 'watch';
+  }
+  return 'none';
+}
+
+function buildReasons(
+  ageDays: number,
+  derivedPainCount: number,
+  params: {
+    matchedCandidateCount: number;
+    recentCandCount: number;
+    orphanCandCount: number;
+    status: PrincipleStatus;
+    watchThresholdDays: number;
+    reviewThresholdDays: number;
+  },
+): string[] {
+  const reasons: string[] = [];
+  const { matchedCandidateCount, recentCandCount, orphanCandCount, status } = params;
+  const opts = { watchThresholdDays: params.watchThresholdDays, reviewThresholdDays: params.reviewThresholdDays };
+
+  if (ageDays >= opts.reviewThresholdDays && derivedPainCount === 0) {
+    reasons.push(`review: principle older than ${opts.reviewThresholdDays} days with no derived pain signals [source: createdAt + derivedFromPainIds]`);
+  } else if (ageDays >= opts.watchThresholdDays && derivedPainCount === 0) {
+    reasons.push(`watch: principle older than ${opts.watchThresholdDays} days with no recent derived pain signals [source: createdAt + derivedFromPainIds]`);
+  }
+
+  if (status === 'probation') {
+    reasons.push('status: principle is in probation status [source: ledger.status]');
+  }
+
+  if (orphanCandCount > 0) {
+    reasons.push(`orphan: ${orphanCandCount} derived candidate(s) not found in candidates table [source: derivedFromPainIds + state.db]`);
+  }
+
+  if (derivedPainCount > 0 && matchedCandidateCount === 0) {
+    reasons.push('gap: derived pain signals exist but no matched candidates in DB [source: derivedFromPainIds + state.db]');
+  }
+
+  if (recentCandCount > 0 && derivedPainCount === 0) {
+    reasons.push('stale: recent candidates exist but none derived from pain signals [source: candidates.createdAt]');
+  }
+
+  if (status === 'deprecated' || status === 'archived') {
+    reasons.push(`status: principle is ${status} [source: ledger.status]`);
+  }
+
+  return reasons;
+}
+
+// ── Main Class ────────────────────────────────────────────────────────────────
+
+export class PruningReadModel {
+  private readonly workspaceDir: string;
+  private readonly watchThresholdDays: number;
+  private readonly reviewThresholdDays: number;
+
+  constructor(opts: PruningReadModelOptions) {
+    this.workspaceDir = opts.workspaceDir;
+    this.watchThresholdDays = opts.watchThresholdDays ?? 30;
+    this.reviewThresholdDays = opts.reviewThresholdDays ?? 90;
+  }
+
+  /**
+   * Build per-principle signals for the current workspace ledger.
+   *
+   * Reads:
+   *   - .state/principle_training_state.json (ledger)
+   *   - .pd/state.db principle_candidates (candidate table)
+   *
+   * Returns one signal per ledger principle entry.
+   */
+  getPrincipleSignals(): PrinciplePruningSignal[] {
+    const now = new Date();
+    const stateDir = path.join(this.workspaceDir, '.state');
+    const ledger = loadLedger(stateDir);
+    const principleEntries = Object.values(ledger.tree.principles);
+
+    if (principleEntries.length === 0) {
+      return [];
+    }
+
+    const candidateCreatedAtMap = new Map<string, string>();
+    const pdDbPath = path.join(this.workspaceDir, '.pd', 'state.db');
+    try {
+      if (fs.existsSync(pdDbPath)) {
+        const db = new Database(pdDbPath, { readonly: true });
+        try {
+          const rows = db.prepare(
+            "SELECT candidate_id, created_at FROM principle_candidates WHERE status = 'consumed'"
+          ).all() as { candidate_id: string; created_at: string }[];
+          for (const r of rows) {
+            candidateCreatedAtMap.set(r.candidate_id, r.created_at);
+          }
+        } finally {
+          db.close();
+        }
+      }
+    } catch {
+      // Graceful degradation — candidate map stays empty
+    }
+
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    const recentCutoff = new Date(now.getTime() - thirtyDaysMs).toISOString();
+
+    return principleEntries.map((p) => {
+      const derivedPainCount = p.derivedFromPainIds?.length ?? 0;
+
+      let matchedCandidateCount = 0;
+      let recentCandidateCount = 0;
+      let orphanCandidateCount = 0;
+      for (const cid of p.derivedFromPainIds ?? []) {
+        const cAt = candidateCreatedAtMap.get(cid);
+        if (cAt) {
+          matchedCandidateCount++;
+          if (cAt >= recentCutoff) recentCandidateCount++;
+        } else {
+          orphanCandidateCount++;
+        }
+      }
+
+      const ageDays = daysBetween(p.createdAt, now);
+
+      const riskLevel = computeRiskLevel(ageDays, derivedPainCount, {
+        watchThresholdDays: this.watchThresholdDays,
+        reviewThresholdDays: this.reviewThresholdDays,
+      });
+
+      const reasons = buildReasons(
+        ageDays,
+        derivedPainCount,
+        {
+          matchedCandidateCount,
+          recentCandCount: recentCandidateCount,
+          orphanCandCount: orphanCandidateCount,
+          status: p.status as PrincipleStatus,
+          watchThresholdDays: this.watchThresholdDays,
+          reviewThresholdDays: this.reviewThresholdDays,
+        },
+      );
+
+      return {
+        principleId: p.id,
+        status: p.status as PrincipleStatus,
+        createdAt: p.createdAt,
+        updatedAt: p.updatedAt ?? p.createdAt,
+        derivedCandidateIds: [...(p.derivedFromPainIds ?? [])],
+        derivedPainCount,
+        matchedCandidateCount,
+        recentCandidateCount,
+        orphanCandidateCount,
+        ageDays,
+        riskLevel,
+        reasons,
+      };
+    });
+  }
+
+  /**
+   * Build aggregate pruning health summary.
+   * Reuses getPrincipleSignals() to avoid duplicate DB queries.
+   */
+  getHealthSummary(): PruningHealthSummary {
+    const now = new Date();
+    const signals = this.getPrincipleSignals();
+
+    const byStatus: Record<string, number> = {};
+    let totalAgeDays = 0;
+    let orphanDerivedCandidateCount = 0;
+
+    for (const s of signals) {
+      byStatus[s.status] = (byStatus[s.status] ?? 0) + 1;
+      totalAgeDays += s.ageDays;
+      orphanDerivedCandidateCount += s.orphanCandidateCount;
+    }
+
+    return {
+      totalPrinciples: signals.length,
+      byStatus,
+      watchCount: signals.filter((s) => s.riskLevel === 'watch').length,
+      reviewCount: signals.filter((s) => s.riskLevel === 'review').length,
+      orphanDerivedCandidateCount,
+      averageAgeDays: signals.length > 0
+        ? Math.round(totalAgeDays / signals.length)
+        : 0,
+      generatedAt: now.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `packages/pd-cli/tests/commands/runtime-pruning.test.ts` with 6 test cases
- Restore `PruningReadModel` export in `runtime-v2/index.ts` (removed by #438)
- Restore `pruning-read-model.ts` source file removed by #438

## Changes
| File | Change |
|------|--------|
| `packages/pd-cli/tests/commands/runtime-pruning.test.ts` | 6 tests: text output, watch/review sections, JSON shape, --workspace, error-path, healthy-path |
| `packages/pd-cli/src/commands/runtime-pruning.ts` | CLI command (from PRI-15) |
| `packages/pd-cli/src/index.ts` | Wire `pd runtime pruning report` subcommand |
| `packages/principles-core/src/runtime-v2/index.ts` | Re-add PruningReadModel export |
| `packages/principles-core/src/runtime-v2/pruning-read-model.ts` | Pruning read model (from PRI-15) |

## Test plan
- [x] 6 unit tests pass (`vitest run tests/commands/runtime-pruning.test.ts`)
- [x] Build passes for all packages
- [x] Lint passes
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `pd runtime pruning report` CLI 命令，用于生成原则运行时健康报告
  * 支持 JSON 和格式化文本两种输出格式
  * 显示标记为 WATCH 或 REVIEW 状态的原则
  * 提供只读、非破坏性的诊断报告功能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->