### PR TITLE
fix(runtime-v2): recover PRI-12/13/14/16 architecture regressed by #438

### DIFF
--- a/docs/adr/0001-runtime-v2-service-boundaries.md
+++ b/docs/adr/0001-runtime-v2-service-boundaries.md
@@ -1,0 +1,113 @@
+# ADR-0001: Runtime V2 Service Boundaries
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Issues:** PRI-16, PRI-17, PRI-12, PRI-13, PRI-14, PRI-18
+
+## Problem Statement
+
+`pd-cli` and `openclaw-plugin` independently orchestrate the same pain-to-principle pipeline:
+
+- Bridge creation via `createPainSignalBridge()`
+- Observability writes via `recordPainSignalObservability()`
+- Error classification (`classifyResult` / `classifyCatch`)
+- Latency measurement with `Date.now()`
+
+This duplication creates drift risk: pd-cli's `pain-record.ts` and openclaw-plugin's pain hook implement slightly different classification logic, observability call patterns, and error handling. When one changes, the other is easily missed.
+
+## Target Architecture
+
+Four ownership boundaries:
+
+| Boundary | Package | Owns |
+|----------|---------|------|
+| **Core (domain)** | `@principles/core` | Pain-to-principle orchestration, state, read models, service contracts |
+| **CLI (UX)** | `@principles/pd-cli` | Operator UX, output formatting, workspace resolution |
+| **Plugin (hooks)** | `openclaw-plugin` | OpenClaw hook/event adaptation, platform-specific context |
+| **Runtime adapters** | `pi-ai` / openclaw-cli | Model/provider execution only |
+
+## First Boundary: PainToPrincipleService
+
+A core-owned facade wrapping the existing pain-to-principle chain:
+
+```typescript
+class PainToPrincipleService {
+  constructor(opts: PainToPrincipleServiceOptions)
+  async recordPain(input: PainToPrincipleInput): Promise<PainToPrincipleOutput>
+}
+```
+
+Owning: normalized pain input, optional observability write, bridge creation + invocation, latency measurement, failure category mapping, structured result output.
+
+**Reuse rule:** Service internally calls `createPainSignalBridge()`, `recordPainSignalObservability()`, and `FAILURE_CATEGORY_MAP`. It does NOT reassemble `RuntimeStateManager`, `DiagnosticianRunner`, or `CandidateIntakeService` directly.
+
+## Follow-up Boundary: PainChainReadModel
+
+`PainChainReadModel` / `RuntimeChainInspector` for read-side queries (trace by painId, last successful chain, recent chains, missing links). Currently duplicated as inline SQL in `pd runtime trace show` and `pd health --json`.
+
+## Plugin Logic Inventory
+
+Logic that should migrate from callers to core over subsequent issues:
+
+| Logic | Current Owner | Target Owner | Issue |
+|-------|--------------|--------------|-------|
+| Pain observability write | pd-cli manual | `PainToPrincipleService` | PRI-12 |
+| Bridge creation + invocation | pd-cli / plugin | `PainToPrincipleService` | PRI-12 |
+| Failure category mapping | pd-cli `classifyResult`/`classifyCatch` | `PainToPrincipleService` | PRI-12 |
+| Latency measurement | pd-cli manual | `PainToPrincipleService` | PRI-12 |
+| Runtime V2 diagnostician invocation | openclaw-plugin | Core via service | PRI-13 |
+| Pain-chain read model (trace/health) | pd-cli inline SQL | Core `PainChainReadModel` | PRI-14 |
+
+Logic that stays in plugin:
+
+| Logic | Owner | Reason |
+|-------|-------|--------|
+| after_tool_call integration | openclaw-plugin | OpenClaw platform hook |
+| GFI/session tracking | openclaw-plugin | OpenClaw session lifecycle |
+| Diagnostic gate evaluation | openclaw-plugin | Gate logic is plugin-specific |
+| Platform context extraction | openclaw-plugin | OpenClaw-specific metadata |
+| Trajectory/event-log writes (OpenClaw-specific) | openclaw-plugin | Plugin-internal observability |
+
+## Migration Plan
+
+| Phase | Scope | Issue |
+|-------|-------|-------|
+| **A (this round)** | Implement `PainToPrincipleService` + exports, no callers migrated | PRI-17, PRI-12 |
+| **B** | Migrate `pd pain record` to call service | PRI-18 |
+| **C** | Thin openclaw-plugin pain hook to adapter | PRI-13 |
+| **D** | Extract read model, deprecate inline factory | PRI-14 |
+
+## Compatibility Rules
+
+- `PainSignalBridge` class and `createPainSignalBridge()` are unchanged
+- No database schema changes
+- No behavior changes in this round
+
+## Error Classification Contract
+
+Service uses chain-integrity-first classification (moved from pd-cli):
+
+1. If bridge result has `errorCategory` → map via `FAILURE_CATEGORY_MAP`
+2. If `status=failed` and `candidateIds=[]` → `'candidate_missing'` (not `runtime_unavailable`)
+3. If `status=failed` and `ledgerEntryIds=[]` → `'ledger_write_failed'` (not `runtime_unavailable`)
+4. On thrown `PDRuntimeError` → map via `FAILURE_CATEGORY_MAP[err.category]`
+5. On thrown generic Error → regex fallback (`config_missing`, `runtime_timeout`, `output_invalid`, default `runtime_unavailable`)
+
+## Deferred
+
+- No `RuleHost` / `PrincipleCompiler` move
+- No auto-pruning design (PRI-15)
+- No runtime provider selection change
+- No read model extraction (PRI-14)
+
+## Rollback
+
+Delete `pain-to-principle-service.ts` + test + exports from `index.ts`. Zero blast radius since no callers are migrated in this round.
+
+## Testing
+
+- Unit tests: mock `createPainSignalBridge` + `recordPainSignalObservability`, test service external contract
+- Error classification parity: iterate all 17 `PDErrorCategory` values, verify mapping matches `FAILURE_CATEGORY_MAP`
+- Idempotent scenarios: bridge returning `succeeded` (existing) and `skipped` (leased)
+- Chain integrity: `candidate_missing` and `ledger_write_failed` must not map to `runtime_unavailable`
+- Existing `PainSignalBridge` tests remain unchanged

--- a/packages/pd-cli/tests/commands/pain-record.test.ts
+++ b/packages/pd-cli/tests/commands/pain-record.test.ts
@@ -1,0 +1,259 @@
+/**
+ * pd pain record command unit tests.
+ *
+ * Tests the CLI adapter layer: validation, service delegation, output formatting.
+ * PainToPrincipleService is mocked — its own contract is tested separately.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock setup ──────────────────────────────────────────────────────────────
+
+let mockRecordPainResult: PainToPrincipleOutput;
+let lastRecordPainInput: PainToPrincipleInput | null = null;
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  PainToPrincipleService: vi.fn().mockImplementation(function() {
+    return {
+      recordPain: vi.fn(async (input: PainToPrincipleInput) => {
+        lastRecordPainInput = input;
+        return mockRecordPainResult;
+      }),
+    };
+  }),
+  PrincipleTreeLedgerAdapter: vi.fn().mockImplementation(function() { return {}; }),
+  resolveRuntimeConfig: vi.fn().mockReturnValue({
+    runtimeKind: 'pi-ai',
+    provider: 'test-provider',
+    model: 'test-model',
+    apiKeyEnv: 'TEST_KEY',
+    timeoutMs: 300000,
+    agentId: 'main',
+  }),
+}));
+
+import { handlePainRecord } from '../../src/commands/pain-record.js';
+import type { PainToPrincipleOutput, PainToPrincipleInput, FailureCategory } from '@principles/core/runtime-v2';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+}
+
+const SUCCEEDED_RESULT: PainToPrincipleOutput = {
+  status: 'succeeded',
+  painId: 'manual_123_abc',
+  taskId: 'diagnosis_manual_123_abc',
+  runId: 'run-001',
+  artifactId: 'art-001',
+  candidateIds: ['c1'],
+  ledgerEntryIds: ['l1'],
+  observabilityWarnings: [],
+  latencyMs: 42,
+};
+
+function makeFailedResult(overrides?: Partial<PainToPrincipleOutput>): PainToPrincipleOutput {
+  return {
+    status: 'failed',
+    painId: 'manual_123_abc',
+    taskId: 'diagnosis_manual_123_abc',
+    candidateIds: [],
+    ledgerEntryIds: [],
+    message: 'something went wrong',
+    observabilityWarnings: [],
+    failureCategory: 'runtime_unavailable' as FailureCategory,
+    latencyMs: 10,
+    ...overrides,
+  };
+}
+
+function makeSkippedResult(overrides?: Partial<PainToPrincipleOutput>): PainToPrincipleOutput {
+  return {
+    status: 'skipped',
+    painId: 'manual_123_abc',
+    taskId: 'diagnosis_manual_123_abc',
+    candidateIds: [],
+    ledgerEntryIds: [],
+    message: 'already leased',
+    observabilityWarnings: [],
+    latencyMs: 5,
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pd pain record', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecordPainResult = { ...SUCCEEDED_RESULT };
+    lastRecordPainInput = null;
+  });
+
+  // 1. --reason required
+  it('exits 1 when --reason is missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: undefined });
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--reason'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 2. --score out of range
+  it('exits 1 when --score is out of range', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test', score: 150 });
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--score'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 3. Happy path --json output
+  it('outputs JSON with all fields on success (--json)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    expect(logSpy).toHaveBeenCalled();
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('succeeded');
+    expect(jsonOutput.painId).toBe('manual_123_abc');
+    expect(jsonOutput.taskId).toBe('diagnosis_manual_123_abc');
+    expect(jsonOutput.runId).toBe('run-001');
+    expect(jsonOutput.artifactId).toBe('art-001');
+    expect(jsonOutput.candidateIds).toEqual(['c1']);
+    expect(jsonOutput.ledgerEntryIds).toEqual(['l1']);
+    expect(jsonOutput.observabilityWarnings).toBeUndefined();
+    expect(jsonOutput.latencyMs).toBe(42);
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 4. Happy path text output
+  it('outputs human-readable summary on success (text)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[OK]'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('manual_123_abc'));
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 5. Failed exits 1 with --json
+  it('exits 1 on failed status (--json)', async () => {
+    mockRecordPainResult = makeFailedResult();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 6. Failed exits 1 (text)
+  it('exits 1 on failed status (text)', async () => {
+    mockRecordPainResult = makeFailedResult();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    const firstErrorArg = errorSpy.mock.calls[0]?.[0] ?? '';
+    expect(firstErrorArg).toContain('[FAIL]');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 7. config_missing shows diagnostic guidance
+  it('shows diagnostic guidance on config_missing failure', async () => {
+    mockRecordPainResult = makeFailedResult({
+      failureCategory: 'config_missing' as FailureCategory,
+      message: 'API key not found in env',
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    const allErrorOutput = errorSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allErrorOutput).toContain('configuration issue');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 8. skipped status outputs [SKIP] and does not exit 1
+  it('outputs [SKIP] on skipped status (text)', async () => {
+    mockRecordPainResult = makeSkippedResult();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    const allOutput = logSpy.mock.calls.map(c => c.join(' ')).join(' ');
+    expect(allOutput).toContain('[SKIP]');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 9. skipped status with --json does not exit 1
+  it('outputs skipped status in JSON without exit 1', async () => {
+    mockRecordPainResult = makeSkippedResult();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('skipped');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 10. recordPain called with correct arguments
+  it('passes correct arguments to recordPain', async () => {
+    await handlePainRecord({ reason: 'test pain', score: 90, source: 'ci' });
+
+    expect(lastRecordPainInput).toBeTruthy();
+    expect(lastRecordPainInput!.painType).toBe('user_frustration');
+    expect(lastRecordPainInput!.source).toBe('ci');
+    expect(lastRecordPainInput!.reason).toBe('test pain');
+    expect(lastRecordPainInput!.score).toBe(90);
+    expect(lastRecordPainInput!.sessionId).toBe('cli');
+    expect(lastRecordPainInput!.agentId).toBe('pd-cli');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Architecture regression guard — verifies critical PRI-12/13/14/15/16
+ * module boundaries are present and exportable.
+ *
+ * Add entries here whenever a new service/read-model boundary is established.
+ */
+import { describe, it, expect } from 'vitest';
+
+// ── Source-file existence ──────────────────────────────────────────────────
+
+const REQUIRED_SOURCE_FILES = [
+  'pain-to-principle-service.ts',
+  'pain-chain-read-model.ts',
+  'pain-signal-bridge.ts',
+  'pain-signal-runtime-factory.ts',
+  'pain-signal-observability.ts',
+  'pruning-read-model.ts',
+] as const;
+
+const REQUIRED_TEST_FILES = [
+  'pain-to-principle-service.test.ts',
+  'pain-chain-read-model.test.ts',
+  'pruning-read-model.test.ts',
+];
+
+const REQUIRED_DOC_FILES = [
+  '../../../../../docs/adr/0001-runtime-v2-service-boundaries.md',
+];
+
+for (const file of REQUIRED_SOURCE_FILES) {
+  it(`source file ${file} is present`, async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', file))).toBe(true);
+  });
+}
+
+for (const file of REQUIRED_TEST_FILES) {
+  it(`test file __tests__/${file} is present`, async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, file))).toBe(true);
+  });
+}
+
+for (const file of REQUIRED_DOC_FILES) {
+  it(`doc file ${file} is present`, async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, file))).toBe(true);
+  });
+}
+
+// ── Public API exports ─────────────────────────────────────────────────────
+
+describe('runtime-v2 public API (index.ts barrel)', () => {
+  const barrel = import('../index.js');
+
+  const REQUIRED_EXPORTS = [
+    // PRI-12
+    'PainToPrincipleService',
+    // PRI-14
+    'PainChainReadModel',
+    // M8
+    'PainSignalBridge',
+    'createPainSignalBridge',
+    'recordPainSignalObservability',
+    // PRI-15
+    'PruningReadModel',
+    // PRI-13 → factory
+    'resolveRuntimeConfig',
+    'validateRuntimeConfig',
+  ];
+
+  for (const name of REQUIRED_EXPORTS) {
+    it(`exports ${name}`, async () => {
+      const mod = (await barrel) as Record<string, unknown>;
+      expect(mod).toHaveProperty(name);
+      expect(typeof mod[name]).toBe('function');
+    });
+  }
+});
+
+// ── OpenClawPlugin pain hook integration ───────────────────────────────────
+
+describe('openclaw-plugin pain hook integration', () => {
+  it('pain.ts imports createPainSignalBridge from runtime-v2', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const painHookPath = resolve(
+      __dirname,
+      '../../../openclaw-plugin/src/hooks/pain.ts',
+    );
+    if (!existsSync(painHookPath)) {
+      // Skip — no openclaw-plugin in this workspace context.
+      return;
+    }
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync(painHookPath, 'utf-8');
+    expect(src).toContain('createPainSignalBridge');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-chain-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-chain-read-model.test.ts
@@ -1,0 +1,285 @@
+/**
+ * PainChainReadModel unit tests.
+ *
+ * Tests the read model's external contract via dependency-injected RuntimeStateManager.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import { PainChainReadModel } from '../pain-chain-read-model.js';
+
+const WORKSPACE = '/tmp/ws';
+
+let ledgerData: { tree: { principles: Record<string, unknown> } } = { tree: { principles: {} } };
+
+vi.mock('../../principle-tree-ledger.js', () => ({
+  loadLedger: vi.fn(() => ledgerData),
+}));
+
+function setLedgerData(data: typeof ledgerData) {
+  ledgerData = data;
+}
+
+function resetLedgerData() {
+  ledgerData = { tree: { principles: {} } };
+}
+
+function makeMockManager(overrides?: {
+  task?: { taskId: string; status: string; createdAt: string; lastError?: string | null } | null;
+  runs?: { runId: string; taskId: string; startedAt: string; endedAt: string }[];
+  artifactRow?: { artifact_id: string; created_at: string } | undefined;
+  candidates?: { candidateId: string; status: string; createdAt: string }[];
+  initError?: Error | null;
+  dbQueries?: {
+    lastSucceeded?: { task_id: string; input_ref: string | null; created_at: string } | undefined;
+    run?: { run_id: string; started_at: string; ended_at: string } | undefined;
+    artifact?: { artifact_id: string; created_at: string } | undefined;
+  };
+}) {
+  const dbQueries = overrides?.dbQueries;
+  const artifactRow = overrides?.artifactRow;
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      get: vi.fn((..._args: unknown[]) => {
+        if (sql.includes('tasks') && sql.includes('succeeded')) return dbQueries?.lastSucceeded;
+        if (sql.includes('runs') && sql.includes('succeeded')) return dbQueries?.run;
+        if (sql.includes('artifacts') && sql.includes('run_id')) return dbQueries?.artifact ?? artifactRow;
+        return undefined;
+      }),
+      all: vi.fn(() => []),
+    })),
+  };
+  return {
+    initialize: vi.fn(async () => { if (overrides?.initError) throw overrides.initError; }),
+    getTask: vi.fn(async () => overrides?.task ?? null),
+    getRunsByTask: vi.fn(async () => overrides?.runs ?? []),
+    getCandidatesByTaskId: vi.fn(async () => overrides?.candidates ?? []),
+    connection: { getDb: vi.fn(() => db) },
+    close: vi.fn(async () => { /* noop */ }),
+  } as unknown as RuntimeStateManager;
+}
+
+const TASK_SUCCEEDED = {
+  taskId: 'diagnosis_pain-001',
+  status: 'succeeded',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastError: null as string | null,
+};
+
+const RUN_SUCCEEDED = {
+  runId: 'run-001',
+  taskId: 'diagnosis_pain-001',
+  startedAt: '2026-01-01T00:01:00.000Z',
+  endedAt: '2026-01-01T00:05:00.000Z',
+};
+
+const ARTIFACT_ROW = {
+  artifact_id: 'art-001',
+  created_at: '2026-01-01T00:05:30.000Z',
+};
+
+const CANDIDATE_CONSUMED = {
+  candidateId: 'c1',
+  status: 'consumed',
+  createdAt: '2026-01-01T00:06:00.000Z',
+};
+
+const LEDGER_WITH_ENTRY = {
+  tree: {
+    principles: {
+      'l1': { id: 'l1', derivedFromPainIds: ['c1'], createdAt: '2026-01-01T00:07:00.000Z' },
+    },
+  },
+};
+
+describe('PainChainReadModel', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let model: PainChainReadModel;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetLedgerData();
+  });
+
+  // ── traceByPainId ──────────────────────────────────────────────────────
+
+  it('traceByPainId: init failure returns error status', async () => {
+    const mgr = makeMockManager({ initError: new Error('database is locked') });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('error');
+    expect(trace.failureCategory).toBe('runtime_unavailable');
+    expect(trace.missingLinks).toContain('internal_error');
+    await model.close();
+  });
+
+  it('traceByPainId: config error returns config_missing', async () => {
+    const mgr = makeMockManager({ initError: new Error('API key not found in env') });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('error');
+    expect(trace.failureCategory).toBe('config_missing');
+    expect(trace.missingLinks).toContain('state_manager_init');
+    await model.close();
+  });
+
+  it('traceByPainId: no task returns not_found', async () => {
+    const mgr = makeMockManager({ task: null });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('not_found');
+    expect(trace.failureCategory).toBe('runtime_unavailable');
+    expect(trace.missingLinks).toContain('task');
+    expect(trace.painId).toBe('pain-001');
+    expect(trace.taskId).toBe('diagnosis_pain-001');
+    await model.close();
+  });
+
+  it('traceByPainId: full chain success with latency', async () => {
+    setLedgerData(LEDGER_WITH_ENTRY);
+    const mgr = makeMockManager({
+      task: TASK_SUCCEEDED,
+      runs: [RUN_SUCCEEDED],
+      artifactRow: ARTIFACT_ROW,
+      candidates: [CANDIDATE_CONSUMED],
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('succeeded');
+    expect(trace.painId).toBe('pain-001');
+    expect(trace.runId).toBe('run-001');
+    expect(trace.artifactId).toBe('art-001');
+    expect(trace.candidateIds).toEqual(['c1']);
+    expect(trace.ledgerEntryIds).toEqual(['l1']);
+    expect(trace.latencyMs.painToTask).toBe(60000);
+    expect(trace.latencyMs.taskToRun).toBe(240000);
+    expect(trace.latencyMs.runToArtifact).toBe(30000);
+    expect(trace.latencyMs.artifactToCandidate).toBe(30000);
+    expect(trace.latencyMs.candidateToLedger).toBe(60000);
+    expect(trace.missingLinks).toEqual([]);
+    await model.close();
+  });
+
+  it('traceByPainId: failed task with errorCategory', async () => {
+    const mgr = makeMockManager({
+      task: { ...TASK_SUCCEEDED, status: 'failed', lastError: 'timeout' },
+      runs: [],
+      candidates: [],
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('failed');
+    expect(trace.failureCategory).toBe('runtime_timeout');
+    await model.close();
+  });
+
+  it('traceByPainId: failed task with JSON lastError', async () => {
+    const mgr = makeMockManager({
+      task: { ...TASK_SUCCEEDED, status: 'failed', lastError: JSON.stringify({ category: 'execution_failed' }) },
+      runs: [],
+      candidates: [],
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('failed');
+    expect(trace.failureCategory).toBe('runtime_unavailable');
+    await model.close();
+  });
+
+  it('traceByPainId: succeeded task with no candidates → candidate_missing', async () => {
+    const mgr = makeMockManager({
+      task: TASK_SUCCEEDED,
+      runs: [RUN_SUCCEEDED],
+      artifactRow: ARTIFACT_ROW,
+      candidates: [],
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('failed');
+    expect(trace.failureCategory).toBe('candidate_missing');
+    expect(trace.missingLinks.length).toBeGreaterThan(0);
+    await model.close();
+  });
+
+  it('traceByPainId: consumed candidate missing from ledger → degraded + missingLinks', async () => {
+    const mgr = makeMockManager({
+      task: TASK_SUCCEEDED,
+      runs: [RUN_SUCCEEDED],
+      artifactRow: ARTIFACT_ROW,
+      candidates: [CANDIDATE_CONSUMED],
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const trace = await model.traceByPainId('pain-001');
+    expect(trace.status).toBe('degraded');
+    expect(trace.failureCategory).toBe('ledger_write_failed');
+    expect(trace.missingLinks).toEqual(
+      expect.arrayContaining([expect.stringContaining('consumed but missing from ledger')])
+    );
+    await model.close();
+  });
+
+  // ── getLastSuccessfulChain ─────────────────────────────────────────────
+
+  it('getLastSuccessfulChain: init failure returns undefined', async () => {
+    const mgr = makeMockManager({ initError: new Error('database is locked') });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const chain = await model.getLastSuccessfulChain();
+    expect(chain).toBeUndefined();
+    await model.close();
+  });
+
+  it('getLastSuccessfulChain: no succeeded tasks returns undefined', async () => {
+    const mgr = makeMockManager({ dbQueries: { lastSucceeded: undefined } });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const chain = await model.getLastSuccessfulChain();
+    expect(chain).toBeUndefined();
+    await model.close();
+  });
+
+  it('getLastSuccessfulChain: full chain with segment latencies', async () => {
+    setLedgerData(LEDGER_WITH_ENTRY);
+    const mgr = makeMockManager({
+      candidates: [CANDIDATE_CONSUMED],
+      dbQueries: {
+        lastSucceeded: { task_id: 'diagnosis_pain-001', input_ref: 'pain-001', created_at: '2026-01-01T00:00:00.000Z' },
+        run: { run_id: 'run-001', started_at: '2026-01-01T00:01:00.000Z', ended_at: '2026-01-01T00:05:00.000Z' },
+        artifact: { artifact_id: 'art-001', created_at: '2026-01-01T00:05:30.000Z' },
+      },
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const chain = await model.getLastSuccessfulChain();
+    expect(chain).toBeDefined();
+    if (!chain) return;
+    expect(chain.status).toBe('succeeded');
+    expect(chain.painId).toBe('pain-001');
+    expect(chain.runId).toBe('run-001');
+    expect(chain.artifactId).toBe('art-001');
+    expect(chain.latencyMs.painToTask).toBe(60000);
+    expect(chain.latencyMs.taskToRun).toBe(240000);
+    expect(chain.latencyMs.runToArtifact).toBe(30000);
+    await model.close();
+  });
+
+  it('getLastSuccessfulChain: no run returns undefined', async () => {
+    const mgr = makeMockManager({
+      candidates: [CANDIDATE_CONSUMED],
+      dbQueries: {
+        lastSucceeded: { task_id: 'diagnosis_pain-001', input_ref: 'pain-001', created_at: '2026-01-01T00:00:00.000Z' },
+        run: undefined,
+      },
+    });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    const chain = await model.getLastSuccessfulChain();
+    expect(chain).toBeUndefined();
+    await model.close();
+  });
+
+  // ── Dependency injection ───────────────────────────────────────────────
+
+  it('does not close injected stateManager', async () => {
+    const mgr = makeMockManager({ task: null });
+    model = new PainChainReadModel({ workspaceDir: WORKSPACE, stateManager: mgr });
+    await model.traceByPainId('pain-001');
+    await model.close();
+    expect(mgr.close).not.toHaveBeenCalled();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-to-principle-service.test.ts
@@ -1,0 +1,241 @@
+/**
+ * PainToPrincipleService unit tests.
+ *
+ * Tests the service's external contract via mocked bridge and observability.
+ * Does NOT test PainSignalBridge internals.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PDRuntimeError, PD_ERROR_CATEGORIES, FAILURE_CATEGORY_MAP } from '../error-categories.js';
+import type { PainSignalBridgeResult, PainDetectedData } from '../pain-signal-bridge.js';
+import type { RecordPainSignalObservabilityOptions, PainSignalObservabilityResult } from '../pain-signal-observability.js';
+import type { PainSignalRuntimeFactoryOptions } from '../pain-signal-runtime-factory.js';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockBridgeResult: PainSignalBridgeResult = {
+  status: 'succeeded', painId: '', taskId: '', candidateIds: [], ledgerEntryIds: [],
+};
+let mockBridgeError: Error | null = null;
+let mockBridgeInitError: Error | null = null;
+let observabilityCalled = false;
+let mockObservabilityWarnings: string[] = [];
+let lastPainDetectedData: PainDetectedData | null = null;
+
+vi.mock('../pain-signal-runtime-factory.js', () => ({
+  createPainSignalBridge: vi.fn(async (_opts: PainSignalRuntimeFactoryOptions) => {
+    if (mockBridgeInitError) throw mockBridgeInitError;
+    return {
+      onPainDetected: vi.fn(async (data: PainDetectedData) => {
+        lastPainDetectedData = data;
+        if (mockBridgeError) throw mockBridgeError;
+        return { ...mockBridgeResult, taskId: data.taskId ?? mockBridgeResult.taskId };
+      }),
+    };
+  }),
+}));
+
+vi.mock('../pain-signal-observability.js', () => ({
+  recordPainSignalObservability: vi.fn((_opts: RecordPainSignalObservabilityOptions): PainSignalObservabilityResult => {
+    observabilityCalled = true;
+    return { warnings: mockObservabilityWarnings };
+  }),
+}));
+
+import { PainToPrincipleService } from '../pain-to-principle-service.js';
+import type { PainToPrincipleServiceOptions } from '../pain-to-principle-service.js';
+import type { LedgerAdapter } from '../candidate-intake.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const SUCCEEDED: PainSignalBridgeResult = {
+  status: 'succeeded', painId: 'pain-001', taskId: 'diagnosis_pain-001',
+  runId: 'run-001', artifactId: 'art-001', candidateIds: ['c1'], ledgerEntryIds: ['l1'],
+};
+
+function makeOpts(overrides?: Partial<PainToPrincipleServiceOptions>): PainToPrincipleServiceOptions {
+  return { workspaceDir: '/tmp/ws', stateDir: '/tmp/st', ledgerAdapter: {} as LedgerAdapter, ...overrides };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PainToPrincipleService', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let service: PainToPrincipleService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBridgeResult = { ...SUCCEEDED };
+    mockBridgeError = null;
+    mockBridgeInitError = null;
+    observabilityCalled = false;
+    mockObservabilityWarnings = [];
+    lastPainDetectedData = null;
+    service = new PainToPrincipleService(makeOpts());
+  });
+
+  // 1. Happy path
+  it('recordPain returns succeeded with all fields', async () => {
+    const r = await service.recordPain({ painId: 'pain-001', painType: 'user_frustration', source: 'manual', reason: 'test' });
+    expect(r.status).toBe('succeeded');
+    expect(r.painId).toBe('pain-001');
+    expect(r.taskId).toBe('diagnosis_pain-001');
+    expect(r.runId).toBe('run-001');
+    expect(r.artifactId).toBe('art-001');
+    expect(r.candidateIds).toEqual(['c1']);
+    expect(r.ledgerEntryIds).toEqual(['l1']);
+    expect(r.observabilityWarnings).toEqual([]);
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(r.failureCategory).toBeUndefined();
+  });
+
+  // 1b. Full input contract: all PainDetectedData fields passed to bridge
+  it('recordPain passes complete PainDetectedData to bridge', async () => {
+    await service.recordPain({
+      painId: 'pain-002',
+      painType: 'subagent_error',
+      source: 'auto',
+      reason: 'timeout',
+      score: 80,
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+      taskId: 'custom-task',
+      traceId: 'trace-1',
+    });
+    expect(lastPainDetectedData).toEqual({
+      painId: 'pain-002',
+      painType: 'subagent_error',
+      source: 'auto',
+      reason: 'timeout',
+      score: 80,
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+      taskId: 'custom-task',
+      traceId: 'trace-1',
+    });
+  });
+
+  // 2. Bridge returns failed with errorCategory → FAILURE_CATEGORY_MAP
+  it('recordPain returns failed when bridge returns failed with errorCategory', async () => {
+    mockBridgeResult = { ...SUCCEEDED, status: 'failed', errorCategory: 'timeout', candidateIds: [], ledgerEntryIds: [] };
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(r.failureCategory).toBe('runtime_timeout');
+  });
+
+  // 3. Idempotent: bridge returns skipped (leased)
+  it('recordPain returns skipped when bridge returns skipped (idempotent leased)', async () => {
+    mockBridgeResult = { status: 'skipped', painId: 'pain-001', taskId: 'diagnosis_pain-001', candidateIds: [], ledgerEntryIds: [], message: 'already leased' };
+    const r = await service.recordPain({ painId: 'pain-001', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('skipped');
+    expect(r.failureCategory).toBeUndefined();
+  });
+
+  // 4. Idempotent: bridge returns succeeded (existing)
+  it('recordPain returns succeeded when bridge returns succeeded (idempotent existing)', async () => {
+    const r = await service.recordPain({ painId: 'pain-001', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('succeeded');
+    expect(r.candidateIds).toEqual(['c1']);
+  });
+
+  // 5. candidate_missing classification
+  it('recordPain classifies candidate_missing', async () => {
+    mockBridgeResult = { ...SUCCEEDED, status: 'failed', candidateIds: [], ledgerEntryIds: [], message: 'no candidates' };
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.failureCategory).toBe('candidate_missing');
+  });
+
+  // 6. ledger_write_failed classification
+  it('recordPain classifies ledger_write_failed', async () => {
+    mockBridgeResult = { ...SUCCEEDED, status: 'failed', candidateIds: ['c1'], ledgerEntryIds: [], message: 'no ledger' };
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.failureCategory).toBe('ledger_write_failed');
+  });
+
+  // 7. observability skip
+  it('recordPain skips observability when recordObservability=false', async () => {
+    await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r', recordObservability: false });
+    expect(observabilityCalled).toBe(false);
+  });
+
+  // 8. observability warnings passthrough
+  it('recordPain includes observability warnings', async () => {
+    mockObservabilityWarnings = ['warn1', 'warn2'];
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.observabilityWarnings).toEqual(['warn1', 'warn2']);
+  });
+
+  // 9. Bridge throws PDRuntimeError
+  it('recordPain catches bridge throw PDRuntimeError', async () => {
+    mockBridgeError = new PDRuntimeError('storage_unavailable', 'disk full');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(r.failureCategory).toBe('ledger_write_failed');
+    expect(r.message).toContain('storage_unavailable');
+  });
+
+  // 10. Bridge throws generic Error
+  it('recordPain catches bridge throw generic Error', async () => {
+    mockBridgeError = new Error('Something timed out unexpectedly');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(r.failureCategory).toBe('runtime_timeout');
+  });
+
+  // 11. latencyMs present and non-negative
+  it('recordPain computes latencyMs', async () => {
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(typeof r.latencyMs).toBe('number');
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // 12. Custom taskId passthrough
+  it('recordPain uses provided taskId', async () => {
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r', taskId: 'custom-task-123' });
+    expect(r.taskId).toBe('custom-task-123');
+  });
+
+  // 13. Bridge init failure does NOT write observability
+  it('recordPain does not call observability when createPainSignalBridge throws', async () => {
+    mockBridgeInitError = new Error('API key not found in env');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(observabilityCalled).toBe(false);
+    expect(r.observabilityWarnings).toEqual([]);
+    expect(r.failureCategory).toBe('config_missing');
+  });
+
+  // 14. Bridge call failure does NOT write observability
+  it('recordPain does not call observability when onPainDetected throws', async () => {
+    mockBridgeError = new Error('runtime crashed');
+    const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+    expect(r.status).toBe('failed');
+    expect(observabilityCalled).toBe(false);
+    expect(r.observabilityWarnings).toEqual([]);
+  });
+});
+
+// ── Parity: all 17 PDErrorCategory → FAILURE_CATEGORY_MAP ──────────────────
+
+describe('PainToPrincipleService error classification parity', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let service: PainToPrincipleService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBridgeResult = { ...SUCCEEDED };
+    mockBridgeError = null;
+    mockBridgeInitError = null;
+    observabilityCalled = false;
+    mockObservabilityWarnings = [];
+    lastPainDetectedData = null;
+    service = new PainToPrincipleService(makeOpts());
+  });
+
+  it('classifyFromBridge maps all 17 PDErrorCategories correctly', async () => {
+    for (const cat of PD_ERROR_CATEGORIES) {
+      mockBridgeResult = { ...SUCCEEDED, status: 'failed', errorCategory: cat, candidateIds: ['c1'], ledgerEntryIds: ['l1'] };
+      const r = await service.recordPain({ painId: 'p', painType: 'tool_failure', source: 's', reason: 'r' });
+      expect(r.failureCategory).toBe(FAILURE_CATEGORY_MAP[cat]);
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
@@ -1,0 +1,568 @@
+/**
+ * PruningReadModel unit tests — PRI-15.
+ *
+ * Tests the non-destructive read model's external contract.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PruningReadModel } from '../pruning-read-model.js';
+import type { LedgerPrinciple } from '../../principle-tree-ledger.js';
+
+// ── Test fixtures ──────────────────────────────────────────────────────────────
+
+const WORKSPACE = '/tmp/ws';
+
+interface LedgerStore {
+  tree: {
+    principles: Record<string, LedgerPrinciple>;
+  };
+}
+
+const LEDGER_EMPTY: LedgerStore = { tree: { principles: {} } };
+
+const LEDGER_MIXED: LedgerStore = {
+  tree: {
+    principles: {
+      active1: {
+        id: 'active1',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        derivedFromPainIds: ['c_active1'],
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        version: 1,
+        text: '',
+        triggerPattern: '',
+        action: '',
+        priority: 'P1',
+        scope: 'general',
+        evaluability: 'deterministic',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+      } as LedgerPrinciple,
+      old_watch: {
+        id: 'old_watch',
+        status: 'active',
+        createdAt: '2026-03-18T00:00:00.000Z',
+        updatedAt: '2025-12-01T00:00:00.000Z',
+        derivedFromPainIds: [],
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        version: 1,
+        text: '',
+        triggerPattern: '',
+        action: '',
+        priority: 'P1',
+        scope: 'general',
+        evaluability: 'deterministic',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+      } as LedgerPrinciple,
+      old_review: {
+        id: 'old_review',
+        status: 'active',
+        createdAt: '2026-01-02T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        derivedFromPainIds: [],
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        version: 1,
+        text: '',
+        triggerPattern: '',
+        action: '',
+        priority: 'P1',
+        scope: 'general',
+        evaluability: 'deterministic',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+      } as LedgerPrinciple,
+      archived1: {
+        id: 'archived1',
+        status: 'archived',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        derivedFromPainIds: [],
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        version: 1,
+        text: '',
+        triggerPattern: '',
+        action: '',
+        priority: 'P1',
+        scope: 'general',
+        evaluability: 'deterministic',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+      } as LedgerPrinciple,
+    },
+  },
+};
+
+const LEDGER_PROBATION: LedgerStore = {
+  tree: {
+    principles: {
+      prob1: {
+        id: 'prob1',
+        status: 'probation',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        derivedFromPainIds: ['c_old1'],
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        version: 1,
+        text: '',
+        triggerPattern: '',
+        action: '',
+        priority: 'P1',
+        scope: 'general',
+        evaluability: 'deterministic',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+      } as LedgerPrinciple,
+    },
+  },
+};
+
+const LEDGER_DEPRECATED: LedgerStore = {
+  tree: {
+    principles: {
+      dep1: {
+        id: 'dep1',
+        status: 'deprecated',
+        createdAt: '2025-06-01T00:00:00.000Z',
+        updatedAt: '2025-06-01T00:00:00.000Z',
+        derivedFromPainIds: [],
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        version: 1,
+        text: '',
+        triggerPattern: '',
+        action: '',
+        priority: 'P1',
+        scope: 'general',
+        evaluability: 'deterministic',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+      } as LedgerPrinciple,
+    },
+  },
+};
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+let mockLedgerData: LedgerStore = LEDGER_EMPTY;
+let mockCandidateRows: { candidate_id: string; created_at: string }[] = [];
+let mockDbExists = false;
+
+vi.mock('../../principle-tree-ledger.js', () => ({
+  loadLedger: vi.fn(() => mockLedgerData),
+}));
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(function (this: Record<string, unknown>) {
+    this.prepare = vi.fn(() => ({
+      all: vi.fn(() => mockCandidateRows),
+    }));
+    this.close = vi.fn();
+  }),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => mockDbExists),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function reset() {
+  mockLedgerData = LEDGER_EMPTY;
+  mockCandidateRows = [];
+  mockDbExists = false;
+  vi.clearAllMocks();
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('PruningReadModel', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('empty ledger returns empty signals', () => {
+    mockLedgerData = LEDGER_EMPTY;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+    expect(signals).toEqual([]);
+  });
+
+  it('status grouping counts correct', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const byStatus: Record<string, number> = {};
+    for (const s of signals) {
+      byStatus[s.status] = (byStatus[s.status] ?? 0) + 1;
+    }
+    expect(byStatus.active).toBe(3);
+    expect(byStatus.archived).toBe(1);
+  });
+
+  it('old principle with no recent candidate → riskLevel watch', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const oldWatch = signals.find((s) => s.principleId === 'old_watch');
+    expect(oldWatch).toBeDefined();
+    expect(oldWatch && oldWatch.riskLevel).toBe('watch');
+    expect(oldWatch && oldWatch.reasons.some((r) => r.includes('watch'))).toBe(true);
+  });
+
+  it('very old principle with no derived candidates → riskLevel review', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const oldReview = signals.find((s) => s.principleId === 'old_review');
+    expect(oldReview).toBeDefined();
+    expect(oldReview && oldReview.riskLevel).toBe('review');
+    expect(oldReview && oldReview.reasons.some((r) => r.includes('review'))).toBe(true);
+  });
+
+  it('recent derived candidate → riskLevel none', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const active1 = signals.find((s) => s.principleId === 'active1');
+    expect(active1).toBeDefined();
+    expect(active1 && active1.riskLevel).toBe('none');
+    expect(active1 && active1.derivedPainCount).toBe(1);
+  });
+
+  it('all derived candidates present in DB → orphan count 0', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          p_orphan: {
+            id: 'p_orphan',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: ['c_in_db'],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    mockCandidateRows = [
+      { candidate_id: 'c_in_db', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+    const summary = model.getHealthSummary();
+
+    const [s0] = signals;
+    expect(s0).toBeDefined();
+    if (!s0) return;
+    expect(s0.matchedCandidateCount).toBe(1);
+    expect(s0.orphanCandidateCount).toBe(0);
+    expect(summary.orphanDerivedCandidateCount).toBe(0);
+  });
+
+  it('orphan candidates detected when derived ID not in DB', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          p1: {
+            id: 'p1',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: ['c_missing'],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    mockCandidateRows = [];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+    const summary = model.getHealthSummary();
+
+    const [s0] = signals;
+    expect(s0).toBeDefined();
+    if (!s0) return;
+    expect(s0.orphanCandidateCount).toBe(1);
+    expect(s0.matchedCandidateCount).toBe(0);
+    expect(summary.orphanDerivedCandidateCount).toBe(1);
+  });
+
+  it('gap reason when derivedPainCount > 0 but matchedCandidateCount === 0', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          p_gap: {
+            id: 'p_gap',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: ['c_orphan'],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    mockCandidateRows = [];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const [s0] = signals;
+    expect(s0).toBeDefined();
+    if (!s0) return;
+    expect(s0.reasons.some((r) => r.includes('gap'))).toBe(true);
+  });
+
+  it('principle in probation → reasons include status source', () => {
+    mockLedgerData = LEDGER_PROBATION;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const prob = signals.find((s) => s.principleId === 'prob1');
+    expect(prob).toBeDefined();
+    expect(prob && prob.status).toBe('probation');
+    expect(prob && prob.reasons.some((r) => r.includes('probation'))).toBe(true);
+  });
+
+  it('deprecated principle → reasons include deprecated status', () => {
+    mockLedgerData = LEDGER_DEPRECATED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const dep = signals.find((s) => s.principleId === 'dep1');
+    expect(dep).toBeDefined();
+    expect(dep && dep.status).toBe('deprecated');
+    expect(dep && dep.reasons.some((r) => r.includes('deprecated'))).toBe(true);
+  });
+
+  it('empty ledger returns zero summary counts', () => {
+    mockLedgerData = LEDGER_EMPTY;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const summary = model.getHealthSummary();
+
+    expect(summary.totalPrinciples).toBe(0);
+    expect(summary.watchCount).toBe(0);
+    expect(summary.reviewCount).toBe(0);
+    expect(summary.averageAgeDays).toBe(0);
+    expect(summary.generatedAt).toBeTruthy();
+  });
+
+  it('recent candidate present → orphan count 0', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          p1: {
+            id: 'p1',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: ['c_recent1'],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    mockCandidateRows = [
+      { candidate_id: 'c_recent1', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+    const summary = model.getHealthSummary();
+
+    expect(summary.totalPrinciples).toBe(1);
+    const [s0] = signals;
+    expect(s0).toBeDefined();
+    if (!s0) return;
+    expect(s0.orphanCandidateCount).toBe(0);
+    expect(summary.orphanDerivedCandidateCount).toBe(0);
+  });
+
+  it('DB does not exist → graceful degradation, orphan count reflects missing DB', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const summary = model.getHealthSummary();
+
+    expect(summary.totalPrinciples).toBe(4);
+    expect(summary.orphanDerivedCandidateCount).toBe(1);
+  });
+
+  it('custom threshold options respected', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          mid_age: {
+            id: 'mid_age',
+            status: 'active',
+            createdAt: '2026-03-18T00:00:00.000Z',
+            updatedAt: '2025-12-01T00:00:00.000Z',
+            derivedFromPainIds: [],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    mockDbExists = false;
+
+    const modelDefault = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signalsDefault = modelDefault.getPrincipleSignals();
+    expect(signalsDefault.length).toBe(1);
+    const signalDefault0 = signalsDefault.at(0);
+    expect(signalDefault0 && signalDefault0.riskLevel).toBe('watch');
+
+    const modelCustom = new PruningReadModel({
+      workspaceDir: WORKSPACE,
+      watchThresholdDays: 90,
+    });
+    const signalsCustom = modelCustom.getPrincipleSignals();
+    expect(signalsCustom.length).toBe(1);
+    const signalCustom0 = signalsCustom.at(0);
+    expect(signalCustom0 && signalCustom0.riskLevel).toBe('none');
+  });
+
+  it('invalid createdAt returns large ageDays (not 0)', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          bad_date: {
+            id: 'bad_date',
+            status: 'active',
+            createdAt: 'not-a-date',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: [],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+
+    const [s0] = signals;
+    expect(s0).toBeDefined();
+    if (!s0) return;
+    expect(s0.ageDays).toBe(9999);
+    expect(s0.riskLevel).toBe('review');
+  });
+
+  it('getHealthSummary reuses signals without duplicate DB query', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockCandidateRows = [];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const summary = model.getHealthSummary();
+
+    expect(summary.totalPrinciples).toBe(4);
+    expect(summary.orphanDerivedCandidateCount).toBe(1);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/trajectory-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/trajectory-store.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listCorrectionSamples, reviewCorrectionSample } from '../../trajectory-store.js';
+
+const mockPrepare = vi.fn();
+const mockClose = vi.fn();
+let shouldThrowOnOpen = false;
+
+vi.mock('better-sqlite3', () => {
+  return {
+    default: vi.fn(function (this: Record<string, unknown>) {
+      if (shouldThrowOnOpen) {
+        throw new Error('SQLITE_CANTOPEN: unable to open database file');
+      }
+      this.prepare = mockPrepare;
+      this.close = mockClose;
+    }),
+  };
+});
+
+describe('listCorrectionSamples', () => {
+  beforeEach(() => {
+    shouldThrowOnOpen = false;
+    mockPrepare.mockReset();
+    mockClose.mockReset();
+  });
+
+  it('returns empty array when DB cannot be opened', () => {
+    shouldThrowOnOpen = true;
+    const result = listCorrectionSamples('/fake/workspace');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when DB cannot be opened with custom status', () => {
+    shouldThrowOnOpen = true;
+    const result = listCorrectionSamples('/fake/workspace', 'approved');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when query throws (e.g. table missing)', () => {
+    mockPrepare.mockReturnValue({ all: () => { throw new Error('SQLITE_ERROR: no such table: correction_samples'); } });
+    const result = listCorrectionSamples('/fake/workspace');
+    expect(result).toEqual([]);
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('maps rows to CorrectionSampleRecord when query succeeds', () => {
+    mockPrepare.mockReturnValue({
+      all: () => [{
+        sample_id: 's1',
+        session_id: 'sess1',
+        bad_assistant_turn_id: 1,
+        user_correction_turn_id: 2,
+        recovery_tool_span_json: '{"tool":"edit"}',
+        diff_excerpt: 'old→new',
+        principle_ids_json: '["p1"]',
+        quality_score: 0.8,
+        review_status: 'pending',
+        export_mode: 'raw',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      }],
+    });
+    const result = listCorrectionSamples('/fake/workspace');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      sampleId: 's1',
+      sessionId: 'sess1',
+      badAssistantTurnId: 1,
+      userCorrectionTurnId: 2,
+      recoveryToolSpanJson: '{"tool":"edit"}',
+      diffExcerpt: 'old→new',
+      principleIdsJson: '["p1"]',
+      qualityScore: 0.8,
+      reviewStatus: 'pending',
+      exportMode: 'raw',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('passes status parameter to query', () => {
+    const mockAll = vi.fn().mockReturnValue([]);
+    mockPrepare.mockReturnValue({ all: mockAll });
+    listCorrectionSamples('/fake/workspace', 'rejected');
+    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('FROM correction_samples'));
+    expect(mockAll).toHaveBeenCalledWith('rejected');
+  });
+
+  it('handles null-ish row fields with defaults', () => {
+    mockPrepare.mockReturnValue({
+      all: () => [{
+        sample_id: 's2',
+        session_id: 'sess2',
+        bad_assistant_turn_id: 3,
+        user_correction_turn_id: 4,
+        recovery_tool_span_json: null,
+        diff_excerpt: null,
+        principle_ids_json: null,
+        quality_score: 0,
+        review_status: 'pending',
+        export_mode: 'redacted',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      }],
+    });
+    const [row] = listCorrectionSamples('/fake/workspace');
+    expect(row).toBeDefined();
+    if (!row) return;
+    expect(row.recoveryToolSpanJson).toBe('');
+    expect(row.diffExcerpt).toBe('');
+    expect(row.principleIdsJson).toBe('[]');
+  });
+});
+
+describe('reviewCorrectionSample', () => {
+  beforeEach(() => {
+    shouldThrowOnOpen = false;
+    mockPrepare.mockReset();
+    mockClose.mockReset();
+  });
+
+  it('throws descriptive error when DB cannot be opened', () => {
+    shouldThrowOnOpen = true;
+    expect(() => {
+      reviewCorrectionSample('s1', 'approved', 'note', '/fake/workspace');
+    }).toThrow(/Database not found or cannot be opened/);
+  });
+
+  it('throws when sample not found (update changes=0)', () => {
+    mockPrepare.mockReturnValue({ run: () => ({ changes: 0 }) });
+    expect(() => {
+      reviewCorrectionSample('missing-id', 'approved', undefined, '/fake/workspace');
+    }).toThrow(/Sample not found: missing-id/);
+    expect(mockClose).toHaveBeenCalled();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -213,6 +213,14 @@ export { recordPainSignalObservability } from './pain-signal-observability.js';
 export type { PainSignalObservabilityResult, RecordPainSignalObservabilityOptions } from './pain-signal-observability.js';
 export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfig, validateRuntimeConfig, type PainSignalRuntimeFactoryOptions, type RuntimeConfig } from './pain-signal-runtime-factory.js';
 
+// Pain-to-Principle service facade (PRI-12)
+export { PainToPrincipleService } from './pain-to-principle-service.js';
+export type { PainToPrincipleServiceOptions, PainToPrincipleInput, PainToPrincipleOutput, FailureCategory } from './pain-to-principle-service.js';
+
+// Pain-chain read model (PRI-14)
+export { PainChainReadModel } from './pain-chain-read-model.js';
+export type { PainChainTrace, PainChainTraceLatencyMs, PainChainReadModelOptions } from './pain-chain-read-model.js';
+
 // Migration bridge
 export { EvolutionQueueItemMigrator } from './store/task-migration.js';
 

--- a/packages/principles-core/src/runtime-v2/pain-chain-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pain-chain-read-model.ts
@@ -1,0 +1,328 @@
+/**
+ * PainChainReadModel — shared core read model for pain-to-principle chain inspection.
+ *
+ * Encapsulates the complete pain→task→run→artifact→candidate→ledger traversal
+ * so CLI commands (trace, health) do not duplicate SQL/ledger logic.
+ *
+ * PRI-14: Extract shared Runtime V2 pain-chain read model.
+ */
+import * as path from 'path';
+import { RuntimeStateManager } from './store/runtime-state-manager.js';
+import { loadLedger } from '../principle-tree-ledger.js';
+import { mapFailureCategory, isPDErrorCategory } from './error-categories.js';
+import type { FailureCategory } from './pain-to-principle-service.js';
+import { createDiagnosticianTaskId } from './pain-signal-bridge.js';
+
+export interface PainChainTraceLatencyMs {
+  painToTask?: number;
+  taskToRun?: number;
+  runToArtifact?: number;
+  artifactToCandidate?: number;
+  candidateToLedger?: number;
+}
+
+export interface PainChainTrace {
+  painId: string;
+  taskId: string;
+  runId?: string;
+  artifactId?: string;
+  candidateIds: string[];
+  ledgerEntryIds: string[];
+  status: string;
+  latencyMs: PainChainTraceLatencyMs;
+  failureCategory: FailureCategory | null;
+  checkedAt: string;
+  missingLinks: string[];
+}
+
+function parseTaskErrorCategory(task: { lastError?: string | null }): string | null {
+  if (!task.lastError) return null;
+  if (isPDErrorCategory(task.lastError)) return task.lastError;
+  try {
+    const parsed = JSON.parse(task.lastError);
+    return parsed.category ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface PainChainReadModelOptions {
+  workspaceDir: string;
+  stateManager?: RuntimeStateManager;
+}
+
+export class PainChainReadModel {
+  private readonly workspaceDir: string;
+  private stateManager: RuntimeStateManager | null = null;
+  private readonly injectedStateManager: RuntimeStateManager | null;
+  private ownsStateManager = false;
+
+  constructor(opts: PainChainReadModelOptions) {
+    this.workspaceDir = opts.workspaceDir;
+    this.injectedStateManager = opts.stateManager ?? null;
+    if (this.injectedStateManager) {
+      this.stateManager = this.injectedStateManager;
+      this.ownsStateManager = false;
+    }
+  }
+
+  private initialized = false;
+
+  private async getStateManager(): Promise<RuntimeStateManager> {
+    if (!this.stateManager) {
+      this.stateManager = new RuntimeStateManager({ workspaceDir: this.workspaceDir });
+      this.ownsStateManager = true;
+    }
+    if (!this.initialized) {
+      await this.stateManager.initialize();
+      this.initialized = true;
+    }
+    return this.stateManager;
+  }
+
+  async traceByPainId(painId: string): Promise<PainChainTrace> {
+    const taskId = createDiagnosticianTaskId(painId);
+    const checkedAt = new Date().toISOString();
+    const missingLinks: string[] = [];
+
+    try {
+      const manager = await this.getStateManager();
+
+      const task = await manager.getTask(taskId);
+      if (!task) {
+        return {
+          painId,
+          taskId,
+          status: 'not_found',
+          failureCategory: 'runtime_unavailable',
+          checkedAt,
+          missingLinks: ['task'],
+          candidateIds: [],
+          ledgerEntryIds: [],
+          latencyMs: {},
+        };
+      }
+
+      const runs = await manager.getRunsByTask(taskId);
+      const latestRun = runs.length > 0
+        ? runs.reduce((a, b) => (a.startedAt > b.startedAt ? a : b))
+        : undefined;
+
+      let artifactId: string | undefined = undefined;
+      let artifactCreatedAt: string | undefined = undefined;
+      if (latestRun) {
+        const runRows = manager.connection.getDb()
+          .prepare('SELECT artifact_id, created_at FROM artifacts WHERE run_id = ? ORDER BY created_at DESC LIMIT 1')
+          .get(latestRun.runId) as { artifact_id: string; created_at: string } | undefined;
+        if (runRows) {
+          artifactId = runRows.artifact_id;
+          artifactCreatedAt = runRows.created_at;
+        }
+      }
+
+      const candidates = await manager.getCandidatesByTaskId(taskId);
+
+      const ledgerStateDir = path.join(this.workspaceDir, '.state');
+      const ledger = loadLedger(ledgerStateDir);
+      const principleEntries = Object.values(ledger.tree.principles);
+
+      const candidateToLedgerEntry = new Map<string, string>();
+      for (const entry of principleEntries) {
+        const e = entry as { id: string; derivedFromPainIds?: string[] };
+        for (const cid of e.derivedFromPainIds ?? []) {
+          candidateToLedgerEntry.set(cid, e.id);
+        }
+      }
+
+      const candidateIds = candidates.map(c => c.candidateId);
+      const ledgerEntryIds: string[] = [];
+      for (const c of candidates) {
+        const entryId = candidateToLedgerEntry.get(c.candidateId);
+        if (entryId) {
+          ledgerEntryIds.push(entryId);
+        } else if (c.status === 'consumed') {
+          missingLinks.push(`candidate:${c.candidateId} consumed but missing from ledger`);
+        }
+      }
+
+      const latencyMs: PainChainTraceLatencyMs = {};
+      if (task.createdAt && latestRun?.startedAt) {
+        latencyMs.painToTask = Math.max(0, new Date(latestRun.startedAt).getTime() - new Date(task.createdAt).getTime());
+      }
+      if (latestRun?.startedAt && latestRun?.endedAt) {
+        latencyMs.taskToRun = Math.max(0, new Date(latestRun.endedAt).getTime() - new Date(latestRun.startedAt).getTime());
+      }
+      if (latestRun?.endedAt && artifactCreatedAt) {
+        latencyMs.runToArtifact = Math.max(0, new Date(artifactCreatedAt).getTime() - new Date(latestRun.endedAt).getTime());
+      }
+      if (artifactCreatedAt && candidates.length > 0) {
+        const [firstCandidate] = candidates;
+        if (firstCandidate) {
+          latencyMs.artifactToCandidate = Math.max(0, new Date(firstCandidate.createdAt).getTime() - new Date(artifactCreatedAt).getTime());
+        }
+      }
+      if (candidates.length > 0 && ledgerEntryIds.length > 0) {
+        const [lastCandidate] = candidates.slice(-1);
+        if (lastCandidate) {
+          let earliestLedgerAt: string | undefined = undefined;
+          for (const entry of principleEntries) {
+            const e = entry as { id: string; createdAt?: string };
+            if (ledgerEntryIds.includes(e.id) && e.createdAt) {
+              if (!earliestLedgerAt || e.createdAt < earliestLedgerAt) earliestLedgerAt = e.createdAt;
+            }
+          }
+          if (earliestLedgerAt) {
+            latencyMs.candidateToLedger = Math.max(0, new Date(earliestLedgerAt).getTime() - new Date(lastCandidate.createdAt).getTime());
+          }
+        }
+      }
+
+      let status: string = task.status;
+      let failureCategory: FailureCategory | null = null;
+
+      if (task.status === 'failed') {
+        const errorCat = parseTaskErrorCategory(task);
+        failureCategory = (mapFailureCategory(errorCat) as FailureCategory) ?? 'runtime_unavailable';
+      } else if (task.status === 'succeeded') {
+        if (candidateIds.length === 0) {
+          status = 'failed';
+          failureCategory = 'candidate_missing';
+          missingLinks.push('No candidates generated for succeeded task');
+        } else if (ledgerEntryIds.length === 0) {
+          status = 'degraded';
+          failureCategory = 'ledger_write_failed';
+          missingLinks.push('Candidates present but no matching ledger entries');
+        }
+      }
+
+      return {
+        painId,
+        taskId,
+        runId: latestRun?.runId,
+        artifactId,
+        candidateIds,
+        ledgerEntryIds,
+        status,
+        latencyMs,
+        failureCategory,
+        checkedAt,
+        missingLinks,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const isConfigError = /disk|unavailable|config|api[_\s]?key|not found in env/i.test(message);
+      return {
+        painId,
+        taskId,
+        status: 'error',
+        failureCategory: isConfigError ? 'config_missing' : 'runtime_unavailable',
+        checkedAt,
+        missingLinks: [isConfigError ? 'state_manager_init' : 'internal_error'],
+        candidateIds: [],
+        ledgerEntryIds: [],
+        latencyMs: {},
+      };
+    }
+  }
+
+  async getLastSuccessfulChain(): Promise<PainChainTrace | undefined> {
+    try {
+      const manager = await this.getStateManager();
+      const db = manager.connection.getDb();
+
+      const lastSucceeded = db.prepare(
+        "SELECT task_id, input_ref, created_at FROM tasks WHERE status = 'succeeded' ORDER BY updated_at DESC LIMIT 1"
+      ).get() as { task_id: string; input_ref: string | null; created_at: string } | undefined;
+      if (!lastSucceeded) return undefined;
+
+      const painId = lastSucceeded.input_ref ?? lastSucceeded.task_id.replace('diagnosis_', '');
+      const taskId = lastSucceeded.task_id;
+
+      const run = db.prepare(
+        "SELECT run_id, started_at, ended_at FROM runs WHERE task_id = ? AND execution_status = 'succeeded' ORDER BY started_at DESC LIMIT 1"
+      ).get(taskId) as { run_id: string; started_at: string; ended_at: string } | undefined;
+      if (!run) return undefined;
+
+      const artifacts = db.prepare(
+        "SELECT artifact_id, created_at FROM artifacts WHERE run_id = ? ORDER BY created_at DESC LIMIT 1"
+      ).get(run.run_id) as { artifact_id: string; created_at: string } | undefined;
+      if (!artifacts) return undefined;
+
+      const candidates = await manager.getCandidatesByTaskId(taskId);
+      if (candidates.length === 0) return undefined;
+
+      const ledgerStateDir = path.join(this.workspaceDir, '.state');
+      const ledger = loadLedger(ledgerStateDir);
+      const principleEntries = Object.values(ledger.tree.principles);
+      const candidateToLedgerEntry = new Map<string, string>();
+      for (const entry of principleEntries) {
+        const e = entry as { id: string; derivedFromPainIds?: string[] };
+        for (const cid of e.derivedFromPainIds ?? []) {
+          candidateToLedgerEntry.set(cid, e.id);
+        }
+      }
+
+      const candidateIds = candidates.map(c => c.candidateId);
+      const ledgerEntryIds: string[] = [];
+      for (const c of candidates) {
+        const entryId = candidateToLedgerEntry.get(c.candidateId);
+        if (entryId) ledgerEntryIds.push(entryId);
+      }
+
+      const latencyMs: PainChainTraceLatencyMs = {};
+      if (lastSucceeded.created_at && run.started_at) {
+        latencyMs.painToTask = Math.max(0, new Date(run.started_at).getTime() - new Date(lastSucceeded.created_at).getTime());
+      }
+      if (run.started_at && run.ended_at) {
+        latencyMs.taskToRun = Math.max(0, new Date(run.ended_at).getTime() - new Date(run.started_at).getTime());
+      }
+      if (run.ended_at && artifacts.created_at) {
+        latencyMs.runToArtifact = Math.max(0, new Date(artifacts.created_at).getTime() - new Date(run.ended_at).getTime());
+      }
+      if (artifacts.created_at && candidates.length > 0) {
+        const [firstCandidate] = candidates;
+        if (firstCandidate) {
+          latencyMs.artifactToCandidate = Math.max(0, new Date(firstCandidate.createdAt).getTime() - new Date(artifacts.created_at).getTime());
+        }
+      }
+      if (candidates.length > 0 && ledgerEntryIds.length > 0) {
+        const [lastCandidate] = candidates.slice(-1);
+        if (lastCandidate) {
+          let earliestLedgerAt: string | undefined = undefined;
+          for (const entry of principleEntries) {
+            const e = entry as { id: string; createdAt?: string };
+            if (ledgerEntryIds.includes(e.id) && e.createdAt) {
+              if (!earliestLedgerAt || e.createdAt < earliestLedgerAt) earliestLedgerAt = e.createdAt;
+            }
+          }
+          if (earliestLedgerAt) {
+            latencyMs.candidateToLedger = Math.max(0, new Date(earliestLedgerAt).getTime() - new Date(lastCandidate.createdAt).getTime());
+          }
+        }
+      }
+
+      return {
+        painId,
+        taskId,
+        runId: run.run_id,
+        artifactId: artifacts.artifact_id,
+        candidateIds,
+        ledgerEntryIds,
+        status: 'succeeded',
+        latencyMs,
+        failureCategory: null,
+        checkedAt: new Date().toISOString(),
+        missingLinks: [],
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.stateManager && this.ownsStateManager) {
+      await this.stateManager.close();
+    }
+    this.stateManager = null;
+  }
+}

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -65,7 +65,7 @@ export interface PainSignalBridgeOptions {
   autoIntakeEnabled?: boolean;
 }
 
-function createDiagnosticianTaskId(painId: string): string {
+export function createDiagnosticianTaskId(painId: string): string {
   return `diagnosis_${painId}`;
 }
 

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -1,0 +1,165 @@
+/**
+ * PainToPrincipleService — core-owned facade for the pain-to-principle chain.
+ *
+ * Wraps PainSignalBridge + observability + error classification + latency.
+ * Callers (pd-cli, openclaw-plugin) should use this instead of composing
+ * bridge/observability/classification manually.
+ *
+ * PRI-12: Introduce facade without migrating callers.
+ */
+import { createPainSignalBridge } from './pain-signal-runtime-factory.js';
+import { recordPainSignalObservability } from './pain-signal-observability.js';
+import { FAILURE_CATEGORY_MAP } from './error-categories.js';
+import { createDiagnosticianTaskId } from './pain-signal-bridge.js';
+import type { PainDetectedData, PainSignalBridgeResult } from './pain-signal-bridge.js';
+import { PDRuntimeError } from './error-categories.js';
+import type { LedgerAdapter } from './candidate-intake.js';
+
+export type FailureCategory =
+  | 'runtime_unavailable'
+  | 'config_missing'
+  | 'runtime_timeout'
+  | 'output_invalid'
+  | 'artifact_missing'
+  | 'ledger_write_failed'
+  | 'candidate_missing';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface PainToPrincipleServiceOptions {
+  workspaceDir: string;
+  stateDir: string;
+  ledgerAdapter: LedgerAdapter;
+  owner?: string;
+  autoIntakeEnabled?: boolean;
+}
+
+export interface PainToPrincipleInput {
+  painId: string;
+  painType: PainDetectedData['painType'];
+  source: string;
+  reason: string;
+  score?: number;
+  sessionId?: string;
+  agentId?: string;
+  taskId?: string;
+  traceId?: string;
+  recordObservability?: boolean;
+}
+
+export interface PainToPrincipleOutput {
+  status: 'succeeded' | 'skipped' | 'failed' | 'retried';
+  painId: string;
+  taskId: string;
+  runId?: string;
+  artifactId?: string;
+  candidateIds: string[];
+  ledgerEntryIds: string[];
+  message?: string;
+  observabilityWarnings: string[];
+  failureCategory?: FailureCategory;
+  latencyMs: number;
+}
+
+// ── Error classification ───────────────────────────────────────────────────
+
+function classifyFromBridge(result: PainSignalBridgeResult): FailureCategory | undefined {
+  if (result.errorCategory) {
+    return (FAILURE_CATEGORY_MAP[result.errorCategory] as FailureCategory) ?? 'runtime_unavailable';
+  }
+  if (result.status === 'failed') {
+    if (result.candidateIds.length === 0) return 'candidate_missing';
+    if (result.ledgerEntryIds.length === 0) return 'ledger_write_failed';
+  }
+  return undefined;
+}
+
+function classifyFromError(err: unknown): FailureCategory {
+  if (err instanceof PDRuntimeError && err.category) {
+    return (FAILURE_CATEGORY_MAP[err.category] as FailureCategory) ?? 'runtime_unavailable';
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/api[_\s]?key|not found in env|missing required/i.test(msg)) return 'config_missing';
+  if (/timeout|timed[_\s]?out/i.test(msg)) return 'runtime_timeout';
+  if (/output.*invalid|validation.*fail/i.test(msg)) return 'output_invalid';
+  return 'runtime_unavailable';
+}
+
+// ── Service ────────────────────────────────────────────────────────────────
+
+export class PainToPrincipleService {
+  private readonly opts: PainToPrincipleServiceOptions;
+
+  constructor(opts: PainToPrincipleServiceOptions) {
+    this.opts = opts;
+  }
+
+  async recordPain(input: PainToPrincipleInput): Promise<PainToPrincipleOutput> {
+    const startTime = Date.now();
+    const {painId} = input;
+    const taskId = input.taskId ?? createDiagnosticianTaskId(painId);
+
+    const painData: PainDetectedData = {
+      painId,
+      painType: input.painType,
+      source: input.source,
+      reason: input.reason,
+      score: input.score,
+      sessionId: input.sessionId,
+      agentId: input.agentId,
+      taskId,
+      traceId: input.traceId,
+    };
+
+    try {
+      const bridge = await createPainSignalBridge({
+        workspaceDir: this.opts.workspaceDir,
+        stateDir: this.opts.stateDir,
+        ledgerAdapter: this.opts.ledgerAdapter,
+        owner: this.opts.owner,
+        autoIntakeEnabled: this.opts.autoIntakeEnabled,
+      });
+
+      const bridgeResult = await bridge.onPainDetected(painData);
+
+      let observabilityWarnings: string[] = [];
+      if (input.recordObservability !== false) {
+        const obs = recordPainSignalObservability({
+          workspaceDir: this.opts.workspaceDir,
+          stateDir: this.opts.stateDir,
+          data: painData,
+        });
+        observabilityWarnings = obs.warnings;
+      }
+
+      const latencyMs = Date.now() - startTime;
+
+      return {
+        status: bridgeResult.status,
+        painId: bridgeResult.painId,
+        taskId: bridgeResult.taskId,
+        runId: bridgeResult.runId,
+        artifactId: bridgeResult.artifactId,
+        candidateIds: bridgeResult.candidateIds,
+        ledgerEntryIds: bridgeResult.ledgerEntryIds,
+        message: bridgeResult.message,
+        observabilityWarnings,
+        failureCategory: classifyFromBridge(bridgeResult),
+        latencyMs,
+      };
+    } catch (err: unknown) {
+      const latencyMs = Date.now() - startTime;
+      return {
+        status: 'failed',
+        painId,
+        taskId,
+        candidateIds: [],
+        ledgerEntryIds: [],
+        message: err instanceof Error ? err.message : String(err),
+        observabilityWarnings: [],
+        failureCategory: classifyFromError(err),
+        latencyMs,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR #438 (candidate scoring) 在 rebase 时删除了 PRI-12/13/14/16 的核心文件:

- **PRI-12** `PainToPrincipleService` 源码 + 测试
- **PRI-14** `PainChainReadModel` 源码 + 测试
- **PRI-15** `pruning-read-model.test.ts` + `pd-cli pain-record.test.ts`
- **PRI-16** ADR-0001 (`docs/adr/0001-runtime-v2-service-boundaries.md`)
- `trajectory-store.test.ts`
- `runtime-v2/index.ts` 的 barrel re-exports

本 PR 从 `ea0a0d4d` 恢复所有文件，并修复了 `createDiagnosticianTaskId` 未导出的问题。

### Architecture regression guard

新增 `packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts`:
- 验证所有 critical source/doc/test 文件存在
- 验证 barrel exports 完整
- 被后续 PR 删除时会 RED，阻止合并

## Test plan

- [x] `npm run build --workspace=@principles/core` ✅
- [x] `npm run build --workspace=@principles/pd-cli` ✅
- [x] Architecture regression guard: 19/19 pass
- [ ] Manual: `pd pain record --help` 正常工作
- [ ] Manual: `pd runtime pruning report` 正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)