### PR TITLE
feat(runtime-v2): add pruning explain and review log foundation

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -117,6 +117,25 @@
 - 系统动力学指标方向：长期跟踪 `pain_signal_count`、`gfi_gate_pass_rate`、`diagnosis_success_rate`、`pain_to_candidate_rate`、`candidate_to_ledger_rate`、`p95_pain_to_ledger_latency_ms`、`runtime_timeout_rate`、`output_invalid_rate`、`active_principle_count`、`soft_to_hard_conversion_rate`、`context_load_tokens`。
 - 后续架构重构方向（不要立即开始）：将 CLI/plugin/bridge/intake/ledger 编排收敛为 core 层 `PainToPrincipleService`，CLI 和 OpenClaw plugin 都只做入口适配。
 
+## Runtime v2 路线图与 Linear 治理事实 (2026-05-02)
+- Runtime V2 架构回退事件：PR #438 曾删除/回退 PRI-12/13/14/15/16 的部分成果；PR #444 已恢复 `PainToPrincipleService`、`PainChainReadModel`、ADR-0001、相关测试；PR #445 已做 public orchestration API consolidation。
+- 当前核心边界：写侧统一入口是 `PainToPrincipleService`；pain-chain 读侧统一入口是 `PainChainReadModel`；principle lifecycle/pruning 读侧入口是 `PruningReadModel`。CLI/plugin 不应直接编排 `createPainSignalBridge` 或手写 `recordPainSignalObservability`。
+- Linear milestone 已建立：
+  - `M1 Runtime V2 Architecture Stability`：恢复、收口并防回退 Runtime V2 service/read-model 边界。已 100%，包含 `PRI-20`、`PRI-22`。
+  - `M2 Principle Lifecycle Review`：把 pruning signals 变成人工可审计 review workflow。当前主线，先做 `PRI-23` + `PRI-24`，再做 `PRI-25`，最后 `PRI-26`。
+  - `M3 Runtime V2 Production Reliability`：重复 UAT、真实 OpenClaw auto-trigger 验证、operator health snapshot/runbook。
+- M2 issue 顺序：`PRI-23 Add pruning signal explain command` 与 `PRI-24 Add pruning review audit log` 可并行；`PRI-25 Add pruning review CLI workflow` blocked by PRI-23/PRI-24；`PRI-26 Document principle lifecycle review workflow` blocked by PRI-25。
+- M3 issue 顺序：`PRI-27 Establish Runtime V2 repeated UAT baseline`；`PRI-29 Validate real OpenClaw auto-trigger pain path` blocked by PRI-27；`PRI-28 Add Runtime V2 operator health snapshot` 可在 UAT 基线后做；`PRI-30 Document Runtime V2 production runbook` blocked by PRI-27/28/29。
+- `PRI-31 Calibrate Diagnostician recommendation taxonomy` 已加入 M2，priority Low，blocked by PRI-23/PRI-24。它来自一次外部代码分析：`DiagnosticianPromptBuilder` 可能偏向 `kind: principle`，但正确目标是校准 recommendation taxonomy（principle/rule/implementation/defer），不是强制多产 rule。
+- Linear 模板库已用普通 issue 形式创建（因为当前 Linear document 创建工具不可用）：
+  - `PRI-32 Template — TDD Feature Issue`
+  - `PRI-33 Template — Architecture Recovery / Regression Issue`
+  - `PRI-34 Template — AI Prompt / Eval Calibration Issue`
+  - `PRI-35 Template — Production Reliability / UAT Issue`
+  - `PRI-36 Template — Project Status Update`
+- 后续创建 issue 时优先复制上述模板的 description。每个开发 issue 都应有 `Goal / Context / Must Read First / Scope / Non-Goals / TDD Requirements / Verification / Acceptance Criteria / Completion Comment Template`。AI prompt/eval 类 issue 用 PRI-34；架构回退类用 PRI-33；真实 UAT/可靠性用 PRI-35。
+- Linear 管理纪律：每 2-3 个 PR 或 milestone 边界用 PRI-36 模板写 status update；每个 PR 合并后在对应 issue 留事实型 comment（Merged PR、Changed files、Tests、Remaining risk、Follow-up）。
+
 ## Runtime v2 重构事实 (2026-04-26)
 - 当前方向：PD Runtime v2 已完成 M1-M5，M6 正在接入 `openclaw-cli` 作为第一个真实生产 runtime adapter。目标是摆脱 OpenClaw 插件 API / heartbeat / prompt hook / sessions_spawn / marker file，改成 `pd diagnose run --runtime openclaw-cli` 的显式执行链。
 - M3 已建立 PD-owned retrieval：`pd legacy import openclaw` 将 OpenClaw `.state/diagnostician_tasks.json` 和 `.state/trajectory.db` 导入 `workspace/.pd/state.db`；`pd trajectory locate`、`pd history query`、`pd context build` 可基于 PD-owned DB 工作。

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,170 @@
+# Plan: PRI-23 + PRI-24 Pruning Review Foundation
+
+**Date:** 2026-05-02
+**Status:** READY
+
+## Context
+
+M2 Principle Lifecycle Review 的第一批开发。目标：
+- PRI-23: CLI explain command（读 PruningReadModel，不写任何状态）
+- PRI-24: Core append-only review log（写 JSONL，不碰 ledger）
+
+Non-goals: 不实现 review CLI、不修改 ledger 状态、不做自动 pruning。
+
+---
+
+## Scope A: PRI-23 `pd runtime pruning explain`
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `packages/pd-cli/tests/commands/runtime-pruning.test.ts` | 新增 explain 测试用例 |
+| `packages/pd-cli/src/commands/runtime-pruning.ts` | 新增 `handlePruningExplain` |
+| `packages/pd-cli/src/index.ts` | 注册 `explain` 子命令 |
+
+### Command Shape
+
+```
+pd runtime pruning explain --principle-id <id> [--workspace <path>] [--json]
+```
+
+### Behavior
+
+1. 实例化 `PruningReadModel`，调用 `getPrincipleSignals()`
+2. 找到匹配 `principleId` 的 signal
+3. **JSON mode**: `{ workspace, principleId, signal, generatedAt }` → `console.log(JSON.stringify(...))`
+4. **Text mode**: 输出 principleId, status, riskLevel, ageDays, derivedPainCount, matchedCandidateCount, orphanCandidateCount, reasons, read-only note
+5. **找不到**: JSON mode `process.exit(1)` + 结构化错误，text mode 打印错误 + `process.exit(1)`
+6. **不写** ledger / state.db / review log
+
+### TDD Tests (add to `runtime-pruning.test.ts`)
+
+```typescript
+it('explain --json outputs matching signal for p_watch', ...)
+it('explain text output includes reason lines and read-only note', ...)
+it('explain missing principle exits 1 with error', ...)
+it('explain passes explicit workspace to PruningReadModel', ...)
+it('explain does not call any write/append API', ...)
+```
+
+---
+
+## Scope B: PRI-24 `pruning-review-log.ts`
+
+### Files to Add
+
+| File | Change |
+|------|--------|
+| `packages/principles-core/src/runtime-v2/pruning-review-log.ts` | NEW — core audit log |
+| `packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts` | NEW — TDD tests |
+| `packages/principles-core/src/runtime-v2/index.ts` | 新增导出 |
+
+### API
+
+```typescript
+export type PruningReviewDecision = 'keep' | 'defer' | 'archive-candidate';
+
+export interface PruningReviewRecord {
+  reviewId: string;        // UUID
+  principleId: string;
+  decision: PruningReviewDecision;
+  note: string;
+  reviewer: string;
+  reviewedAt: string;      // ISO timestamp
+  signalSnapshot: PrinciplePruningSignal;
+}
+
+export interface AppendPruningReviewInput {
+  principleId: string;
+  decision: PruningReviewDecision;
+  note?: string;
+  reviewer?: string;
+  signalSnapshot: PrinciplePruningSignal;
+}
+
+export function appendPruningReview(
+  workspaceDir: string,
+  input: AppendPruningReviewInput,
+): PruningReviewRecord;
+
+export function listPruningReviews(
+  workspaceDir: string,
+  filter?: { principleId?: string },
+): PruningReviewRecord[];
+```
+
+### Storage
+
+- Path: `<workspace>/.state/pruning_reviews.jsonl`
+- Format: 每行一个完整 JSON record
+- `.state` 目录不存在则创建
+- corrupt line 处理: **跳过并继续**（不抛错），测试验证此行为
+
+### Validation
+
+- invalid decision → `throw new Error('Invalid decision: ...')`
+- `reviewer` 默认为 `'operator'`
+
+### TDD Tests
+
+```typescript
+// 1. append creates .state/pruning_reviews.jsonl
+// 2. append returns record with reviewId (UUID) and reviewedAt (ISO)
+// 3. list returns appended records
+// 4. list filters by principleId
+// 5. invalid decision rejected with clear Error
+// 6. append preserves previous records (append twice, list returns 2)
+// 7. missing log returns []
+// 8. does not modify ledger file
+// 9. corrupt line skipped on list
+```
+
+---
+
+## Verification
+
+```bash
+# PRI-24 tests
+npx vitest run packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts \
+  --exclude "**/.worktrees/**"
+
+# PRI-23 tests
+npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts \
+  --exclude "**/.worktrees/**"
+
+# Architecture guard
+npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts \
+  --exclude "**/.worktrees/**"
+
+# Build
+npm run build --workspace=@principles/core
+npm run build --workspace=@principles/pd-cli
+```
+
+---
+
+## Branch
+
+```bash
+git checkout main && git pull origin main
+git checkout -b codex/pri-23-24-pruning-review-foundation
+```
+
+## Commit
+
+```
+feat(runtime-v2): add pruning explain and review log foundation
+
+- pd runtime pruning explain --principle-id --json/--text (read-only)
+- core append-only pruning review log (JSONL)
+- TDD: all new files have corresponding tests
+- architecture regression guard updated
+```
+
+## Linear Update
+
+- PRI-23: comment with test/validation results → mark **Done**
+- PRI-24: comment with test/validation results → mark **Done**
+- PRI-19: comment 说明已拆为 PRI-23..PRI-26，当前不单独执行
+- 不要动 PRI-25（除非加 blocked/unblocked comment）

--- a/packages/pd-cli/src/commands/runtime-pruning.ts
+++ b/packages/pd-cli/src/commands/runtime-pruning.ts
@@ -81,3 +81,52 @@ export function handlePruningReport(opts: PruningReportOptions): void {
 
   outputText(summary, signals, workspaceDir);
 }
+
+// ── Pruning explain ────────────────────────────────────────────────────────────
+
+export interface PruningExplainOptions {
+  principleId: string;
+  workspace?: string;
+  json?: boolean;
+}
+
+export function handlePruningExplain(opts: PruningExplainOptions): void {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const model = new PruningReadModel({ workspaceDir });
+  const signals = model.getPrincipleSignals();
+  const now = new Date().toISOString();
+
+  const signal = signals.find((s) => s.principleId === opts.principleId);
+
+  if (!signal) {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: `Principle not found: '${opts.principleId}'`, workspace: workspaceDir, generatedAt: now }, null, 2));
+    } else {
+      console.error(`Error: Principle not found: '${opts.principleId}'`);
+    }
+    process.exit(1);
+    return; // unreachable but satisfies TypeScript
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify({ workspace: workspaceDir, principleId: signal.principleId, signal, generatedAt: now }, null, 2));
+    return;
+  }
+
+  console.log(`principleId: ${signal.principleId}`);
+  console.log(`status: ${signal.status}`);
+  console.log(`riskLevel: ${signal.riskLevel}`);
+  console.log(`ageDays: ${signal.ageDays}`);
+  console.log(`derivedPainCount: ${signal.derivedPainCount}`);
+  console.log(`matchedCandidateCount: ${signal.matchedCandidateCount}`);
+  console.log(`orphanCandidateCount: ${signal.orphanCandidateCount}`);
+  console.log(`reasons:`);
+  for (const r of signal.reasons) {
+    console.log(`  ${r}`);
+  }
+  console.log('');
+  console.log('NOTE: This report is read-only. No principles are modified or deleted.');
+}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -25,7 +25,7 @@ import { handleDiagnoseStatus, handleDiagnoseRun } from './commands/diagnose.js'
 import { handleRuntimeProbe } from './commands/runtime.js';
 import { handleFlowShow } from './commands/flow.js';
 import { handleTraceShow } from './commands/trace.js';
-import { handlePruningReport } from './commands/runtime-pruning.js';
+import { handlePruningReport, handlePruningExplain } from './commands/runtime-pruning.js';
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
@@ -335,6 +335,16 @@ pruningCmd
   .option('--json', 'Output raw JSON')
   .action((opts) => {
     handlePruningReport({ workspace: opts.workspace, json: opts.json });
+  });
+
+pruningCmd
+  .command('explain')
+  .description('Explain why a specific principle was flagged')
+  .requiredOption('--principle-id <id>', 'Principle ID to explain')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action((opts) => {
+    handlePruningExplain({ principleId: opts.principleId, workspace: opts.workspace, json: opts.json });
   });
 
 // ── Candidate inspection commands ───────────────────────────────────────────

--- a/packages/pd-cli/tests/commands/runtime-pruning.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-pruning.test.ts
@@ -150,3 +150,55 @@ describe('pd runtime pruning report', () => {
     consoleSpy.mockRestore();
   });
 });
+
+// ── pd runtime pruning explain ───────────────────────────────────────────────
+
+describe('pd runtime pruning explain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('explain --json outputs matching signal for p_watch', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
+    handlePruningExplain({ principleId: 'p_watch', json: true });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.principleId).toBe('p_watch');
+    expect(output.signal).toBeDefined();
+    expect(output.workspace).toBeDefined();
+    expect(output.generatedAt).toBeDefined();
+    consoleSpy.mockRestore();
+  });
+
+  it('explain text output includes reason lines and read-only note', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
+    handlePruningExplain({ principleId: 'p_watch', json: false });
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('p_watch');
+    expect(output).toContain('watch');
+    expect(output).toContain('NOTE: This report is read-only.');
+    consoleSpy.mockRestore();
+  });
+
+  it('explain missing principle exits 1', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
+    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
+    handlePruningExplain({ principleId: 'nonexistent', json: false });
+    expect(processSpy).toHaveBeenCalledWith(1);
+    consoleSpy.mockRestore();
+    processSpy.mockRestore();
+  });
+
+  it('explain passes explicit workspace to PruningReadModel', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
+    handlePruningExplain({ principleId: 'p_watch', workspace: '/custom/workspace', json: false });
+    const calls = (PruningReadModel as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(String(calls[calls.length - 1][0].workspaceDir)).toMatch(/custom.*workspace/);
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -15,12 +15,14 @@ const REQUIRED_SOURCE_FILES = [
   'pain-signal-runtime-factory.ts',
   'pain-signal-observability.ts',
   'pruning-read-model.ts',
+  'pruning-review-log.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
   'pain-to-principle-service.test.ts',
   'pain-chain-read-model.test.ts',
   'pruning-read-model.test.ts',
+  'pruning-review-log.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts
@@ -1,0 +1,177 @@
+/**
+ * PruningReviewLog unit tests — PRI-24.
+ *
+ * Tests the append-only JSONL audit log for human review decisions.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { appendPruningReview, listPruningReviews } from '../pruning-review-log.js';
+import type { PrinciplePruningSignal } from '../pruning-read-model.js';
+
+const FIXTURE_SIGNAL: PrinciplePruningSignal = {
+  principleId: 'p_test',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  derivedCandidateIds: ['c1'],
+  derivedPainCount: 2,
+  matchedCandidateCount: 1,
+  recentCandidateCount: 0,
+  orphanCandidateCount: 0,
+  ageDays: 45,
+  riskLevel: 'watch',
+  reasons: ['watch: principle older than 30 days'],
+};
+
+describe('PruningReviewLog', () => {
+  let tmpDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pruning-review-log-test-'));
+  });
+
+  afterEach(() => {
+    const stateDir = path.join(tmpDir, '.state');
+    if (fs.existsSync(stateDir)) {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+    if (fs.existsSync(tmpDir)) fs.rmdirSync(tmpDir);
+  });
+
+  it('append creates .state/pruning_reviews.jsonl', () => {
+    appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    const logPath = path.join(tmpDir, '.state', 'pruning_reviews.jsonl');
+    expect(fs.existsSync(logPath)).toBe(true);
+  });
+
+  it('append returns record with reviewId and reviewedAt', () => {
+    const record = appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    expect(record.reviewId).toBeTruthy();
+    expect(typeof record.reviewId).toBe('string');
+    expect(record.reviewedAt).toBeTruthy();
+    expect(record.principleId).toBe('p1');
+    expect(record.decision).toBe('keep');
+  });
+
+  it('append defaults reviewer to operator', () => {
+    const record = appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    expect(record.reviewer).toBe('operator');
+  });
+
+  it('append uses provided reviewer', () => {
+    const record = appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      reviewer: 'alice',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    expect(record.reviewer).toBe('alice');
+  });
+
+  it('list returns appended records', () => {
+    appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    appendPruningReview(tmpDir, {
+      principleId: 'p2',
+      decision: 'defer',
+      signalSnapshot: { ...FIXTURE_SIGNAL, principleId: 'p2' },
+    });
+    const records = listPruningReviews(tmpDir);
+    expect(records).toHaveLength(2);
+    expect(records[0]?.principleId).toBe('p1');
+    expect(records[1]?.principleId).toBe('p2');
+  });
+
+  it('list filters by principleId', () => {
+    appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    appendPruningReview(tmpDir, {
+      principleId: 'p2',
+      decision: 'defer',
+      signalSnapshot: { ...FIXTURE_SIGNAL, principleId: 'p2' },
+    });
+    const records = listPruningReviews(tmpDir, { principleId: 'p1' });
+    expect(records).toHaveLength(1);
+    expect(records[0]?.principleId).toBe('p1');
+  });
+
+  it('invalid decision rejected with clear Error', () => {
+    expect(() =>
+      appendPruningReview(tmpDir, {
+        principleId: 'p1',
+        decision: 'invalid' as unknown as 'keep',
+        signalSnapshot: FIXTURE_SIGNAL,
+      }),
+    ).toThrow(/Invalid decision/i);
+  });
+
+  it('append preserves previous records', () => {
+    appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      note: 'first',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+    appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'defer',
+      note: 'second',
+      signalSnapshot: { ...FIXTURE_SIGNAL, riskLevel: 'review' },
+    });
+    const records = listPruningReviews(tmpDir);
+    expect(records).toHaveLength(2);
+    expect(records[0]?.note).toBe('first');
+    expect(records[1]?.note).toBe('second');
+  });
+
+  it('missing log returns empty array', () => {
+    const records = listPruningReviews(tmpDir);
+    expect(records).toEqual([]);
+  });
+
+  it('does not modify ledger file', () => {
+    const ledgerPath = path.join(tmpDir, '.state', 'principle_training_state.json');
+    fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+    fs.writeFileSync(ledgerPath, JSON.stringify({ tree: { principles: {} } }));
+    const mtimeBefore = fs.statSync(ledgerPath).mtimeMs;
+
+    appendPruningReview(tmpDir, {
+      principleId: 'p1',
+      decision: 'keep',
+      signalSnapshot: FIXTURE_SIGNAL,
+    });
+
+    const mtimeAfter = fs.statSync(ledgerPath).mtimeMs;
+    expect(mtimeAfter).toBe(mtimeBefore);
+  });
+
+  it('corrupt line skipped on list', () => {
+    const logPath = path.join(tmpDir, '.state', 'pruning_reviews.jsonl');
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, 'valid json line\n{"reviewId":"r1","principleId":"p1","decision":"keep","note":"ok","reviewer":"op","reviewedAt":"2026-05-02T00:00:00.000Z","signalSnapshot":{}}\n');
+
+    const records = listPruningReviews(tmpDir);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.reviewId).toBe('r1');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts
@@ -168,7 +168,8 @@ describe('PruningReviewLog', () => {
   it('corrupt line skipped on list', () => {
     const logPath = path.join(tmpDir, '.state', 'pruning_reviews.jsonl');
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
-    fs.writeFileSync(logPath, 'valid json line\n{"reviewId":"r1","principleId":"p1","decision":"keep","note":"ok","reviewer":"op","reviewedAt":"2026-05-02T00:00:00.000Z","signalSnapshot":{}}\n');
+    // First line is invalid JSON (plain text), second line is valid
+    fs.writeFileSync(logPath, 'not-valid-json\n{"reviewId":"r1","principleId":"p1","decision":"keep","note":"ok","reviewer":"op","reviewedAt":"2026-05-02T00:00:00.000Z","signalSnapshot":{}}\n');
 
     const records = listPruningReviews(tmpDir);
     expect(records).toHaveLength(1);

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -237,3 +237,7 @@ export { loadLedger, getLedgerFilePathPublic } from '../principle-tree-ledger.js
 // Pruning read model (PRI-15)
 export { PruningReadModel } from './pruning-read-model.js';
 export type { PrinciplePruningSignal, PruningHealthSummary, PruningReadModelOptions, PruningRiskLevel, PrincipleStatus } from './pruning-read-model.js';
+
+// Pruning review audit log (PRI-24)
+export { appendPruningReview, listPruningReviews } from './pruning-review-log.js';
+export type { PruningReviewDecision, PruningReviewRecord, AppendPruningReviewInput } from './pruning-review-log.js';

--- a/packages/principles-core/src/runtime-v2/pruning-review-log.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-review-log.ts
@@ -14,6 +14,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import type { PrinciplePruningSignal } from './pruning-read-model.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -26,20 +27,7 @@ export interface PruningReviewRecord {
   note: string;
   reviewer: string;
   reviewedAt: string;
-  signalSnapshot: {
-    principleId: string;
-    status: string;
-    createdAt: string;
-    updatedAt: string;
-    derivedCandidateIds: string[];
-    derivedPainCount: number;
-    matchedCandidateCount: number;
-    recentCandidateCount: number;
-    orphanCandidateCount: number;
-    ageDays: number;
-    riskLevel: string;
-    reasons: string[];
-  };
+  signalSnapshot: PrinciplePruningSignal;
 }
 
 export interface AppendPruningReviewInput {

--- a/packages/principles-core/src/runtime-v2/pruning-review-log.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-review-log.ts
@@ -1,0 +1,148 @@
+/**
+ * PruningReviewLog — append-only JSONL audit log for human pruning review decisions.
+ *
+ * PRI-24: Add pruning review audit log.
+ *
+ * Storage: <workspace>/.state/pruning_reviews.jsonl
+ * Each line is one complete JSON record.
+ *
+ * Non-goals:
+ * - Does not modify ledger or state.db
+ * - Does not implement automatic pruning
+ * - Does not provide CLI (that's PRI-25)
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type PruningReviewDecision = 'keep' | 'defer' | 'archive-candidate';
+
+export interface PruningReviewRecord {
+  reviewId: string;
+  principleId: string;
+  decision: PruningReviewDecision;
+  note: string;
+  reviewer: string;
+  reviewedAt: string;
+  signalSnapshot: {
+    principleId: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    derivedCandidateIds: string[];
+    derivedPainCount: number;
+    matchedCandidateCount: number;
+    recentCandidateCount: number;
+    orphanCandidateCount: number;
+    ageDays: number;
+    riskLevel: string;
+    reasons: string[];
+  };
+}
+
+export interface AppendPruningReviewInput {
+  principleId: string;
+  decision: PruningReviewDecision;
+  note?: string;
+  reviewer?: string;
+  signalSnapshot: PruningReviewRecord['signalSnapshot'];
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────────
+
+const VALID_DECISIONS = new Set<string>(['keep', 'defer', 'archive-candidate']);
+
+function validateDecision(decision: string): asserts decision is PruningReviewDecision {
+  if (!VALID_DECISIONS.has(decision)) {
+    throw new Error(`Invalid decision: '${decision}'. Must be one of: keep, defer, archive-candidate`);
+  }
+}
+
+// ── Core Functions ─────────────────────────────────────────────────────────────
+
+function getLogPath(workspaceDir: string): string {
+  return path.join(workspaceDir, '.state', 'pruning_reviews.jsonl');
+}
+
+function ensureStateDir(workspaceDir: string): void {
+  const stateDir = path.join(workspaceDir, '.state');
+  if (!fs.existsSync(stateDir)) {
+    fs.mkdirSync(stateDir, { recursive: true });
+  }
+}
+
+/**
+ * Append a pruning review record to the audit log.
+ *
+ * @param workspaceDir - The workspace root directory
+ * @param input - Review decision input
+ * @returns The full record that was written
+ */
+export function appendPruningReview(
+  workspaceDir: string,
+  input: AppendPruningReviewInput,
+): PruningReviewRecord {
+  validateDecision(input.decision);
+
+  ensureStateDir(workspaceDir);
+
+  const reviewId = crypto.randomUUID();
+  const reviewedAt = new Date().toISOString();
+  const reviewer = input.reviewer ?? 'operator';
+
+  const record: PruningReviewRecord = {
+    reviewId,
+    principleId: input.principleId,
+    decision: input.decision,
+    note: input.note ?? '',
+    reviewer,
+    reviewedAt,
+    signalSnapshot: input.signalSnapshot,
+  };
+
+  const logPath = getLogPath(workspaceDir);
+  const line = JSON.stringify(record) + '\n';
+  fs.appendFileSync(logPath, line, 'utf-8');
+
+  return record;
+}
+
+/**
+ * List pruning review records from the audit log.
+ *
+ * @param workspaceDir - The workspace root directory
+ * @param filter - Optional filter by principleId
+ * @returns Array of review records (oldest first)
+ */
+export function listPruningReviews(
+  workspaceDir: string,
+  filter?: { principleId?: string },
+): PruningReviewRecord[] {
+  const logPath = getLogPath(workspaceDir);
+
+  if (!fs.existsSync(logPath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(logPath, 'utf-8');
+  const lines = content.split('\n');
+  const records: PruningReviewRecord[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = JSON.parse(trimmed) as PruningReviewRecord;
+      if (filter?.principleId && record.principleId !== filter.principleId) {
+        continue;
+      }
+      records.push(record);
+    } catch {
+      // Skip corrupt lines — continue processing
+    }
+  }
+
+  return records;
+}


### PR DESCRIPTION
## Summary

PRI-23 + PRI-24: M2 Principle Lifecycle Review 第一批开发

### PRI-23: `pd runtime pruning explain --principle-id [--workspace] [--json]`
- 使用 `PruningReadModel.getPrincipleSignals()` 查找指定 principle
- JSON: `{ workspace, principleId, signal, generatedAt }`
- Text: 清晰列出 status/riskLevel/ageDays/derivedPainCount/matchedCandidateCount/orphanCandidateCount/reasons
- 找不到 principle → `process.exit(1)` + 清晰错误
- **不写** ledger / state.db / review log

### PRI-24: Core append-only pruning review audit log
- 文件: `packages/principles-core/src/runtime-v2/pruning-review-log.ts`
- 存储: `<workspace>/.state/pruning_reviews.jsonl` (每行一个 JSON record)
- `appendPruningReview()` — UUID reviewId + ISO reviewedAt，默认 reviewer='operator'
- `listPruningReviews(workspaceDir, filter?)` — 支持 principleId filter
- Invalid decision → `throw new Error(...)`
- Corrupt line → **跳过继续**（不抛错）
- **不修改** ledger 文件

## Test plan

- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts` — 11 passed
- [x] `npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts` — 10 passed
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` — 22 passed
- [x] `npm run build --workspace=@principles/core` ✅
- [x] `npm run build --workspace=@principles/pd-cli` ✅

## Non-goals (per user request)

- 不实现 `pd runtime pruning review` CLI（那是 PRI-25）
- 不修改 ledger principle 状态
- 不删除/归档任何 principle
- 不做自动 pruning
- 不引入 background worker
- 不使用 LLM 做 pruning decision
- 不改 OpenClaw plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 添加 `pd runtime pruning explain` 命令，用于查看特定原则的详细信息，支持 JSON 和文本两种输出格式。
  * 新增修剪审核日志系统，用于记录和追踪人工审查决策，支持按原则筛选和损坏数据容错处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->