### PR TITLE
feat(pd-cli): add pruning review workflow

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,123 +1,50 @@
-# Plan: PRI-23 + PRI-24 Pruning Review Foundation
+# Plan: PRI-25 — Pruning Review CLI Workflow
 
 **Date:** 2026-05-02
 **Status:** READY
 
 ## Context
 
-M2 Principle Lifecycle Review 的第一批开发。目标：
-- PRI-23: CLI explain command（读 PruningReadModel，不写任何状态）
-- PRI-24: Core append-only review log（写 JSONL，不碰 ledger）
-
-Non-goals: 不实现 review CLI、不修改 ledger 状态、不做自动 pruning。
+PRI-23 (explain) and PRI-24 (audit log) are merged. Now implement the review CLI that connects them.
 
 ---
 
-## Scope A: PRI-23 `pd runtime pruning explain`
-
-### Files to Modify
-
-| File | Change |
-|------|--------|
-| `packages/pd-cli/tests/commands/runtime-pruning.test.ts` | 新增 explain 测试用例 |
-| `packages/pd-cli/src/commands/runtime-pruning.ts` | 新增 `handlePruningExplain` |
-| `packages/pd-cli/src/index.ts` | 注册 `explain` 子命令 |
+## PRI-25: `pd runtime pruning review` CLI
 
 ### Command Shape
 
 ```
-pd runtime pruning explain --principle-id <id> [--workspace <path>] [--json]
+pd runtime pruning review \
+  --principle-id <id> \
+  --decision keep|defer|archive-candidate \
+  --note "..." \
+  [--workspace <path>] \
+  [--json]
 ```
 
 ### Behavior
 
-1. 实例化 `PruningReadModel`，调用 `getPrincipleSignals()`
-2. 找到匹配 `principleId` 的 signal
-3. **JSON mode**: `{ workspace, principleId, signal, generatedAt }` → `console.log(JSON.stringify(...))`
-4. **Text mode**: 输出 principleId, status, riskLevel, ageDays, derivedPainCount, matchedCandidateCount, orphanCandidateCount, reasons, read-only note
-5. **找不到**: JSON mode `process.exit(1)` + 结构化错误，text mode 打印错误 + `process.exit(1)`
-6. **不写** ledger / state.db / review log
-
-### TDD Tests (add to `runtime-pruning.test.ts`)
-
-```typescript
-it('explain --json outputs matching signal for p_watch', ...)
-it('explain text output includes reason lines and read-only note', ...)
-it('explain missing principle exits 1 with error', ...)
-it('explain passes explicit workspace to PruningReadModel', ...)
-it('explain does not call any write/append API', ...)
-```
+1. Instantiate `PruningReadModel`, call `getPrincipleSignals()`
+2. Find matching signal for `principleId`
+3. **Missing principle**: exit 1, no log written
+4. **Invalid decision**: exit 1, no log written
+5. **archive-candidate + no note**: exit 1, no log written
+6. Call `appendPruningReview(workspaceDir, { principleId, decision, note, reviewer, signalSnapshot })`
+7. **JSON mode**: `{ reviewId, principleId, decision, reviewer, reviewedAt }`
+8. **Text mode**: print all fields + audit-only note
 
 ---
 
-## Scope B: PRI-24 `pruning-review-log.ts`
-
-### Files to Add
-
-| File | Change |
-|------|--------|
-| `packages/principles-core/src/runtime-v2/pruning-review-log.ts` | NEW — core audit log |
-| `packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts` | NEW — TDD tests |
-| `packages/principles-core/src/runtime-v2/index.ts` | 新增导出 |
-
-### API
+## TDD Tests (in `runtime-pruning.test.ts`)
 
 ```typescript
-export type PruningReviewDecision = 'keep' | 'defer' | 'archive-candidate';
-
-export interface PruningReviewRecord {
-  reviewId: string;        // UUID
-  principleId: string;
-  decision: PruningReviewDecision;
-  note: string;
-  reviewer: string;
-  reviewedAt: string;      // ISO timestamp
-  signalSnapshot: PrinciplePruningSignal;
-}
-
-export interface AppendPruningReviewInput {
-  principleId: string;
-  decision: PruningReviewDecision;
-  note?: string;
-  reviewer?: string;
-  signalSnapshot: PrinciplePruningSignal;
-}
-
-export function appendPruningReview(
-  workspaceDir: string,
-  input: AppendPruningReviewInput,
-): PruningReviewRecord;
-
-export function listPruningReviews(
-  workspaceDir: string,
-  filter?: { principleId?: string },
-): PruningReviewRecord[];
-```
-
-### Storage
-
-- Path: `<workspace>/.state/pruning_reviews.jsonl`
-- Format: 每行一个完整 JSON record
-- `.state` 目录不存在则创建
-- corrupt line 处理: **跳过并继续**（不抛错），测试验证此行为
-
-### Validation
-
-- invalid decision → `throw new Error('Invalid decision: ...')`
-- `reviewer` 默认为 `'operator'`
-
-### TDD Tests
-
-```typescript
-// 1. append creates .state/pruning_reviews.jsonl
-// 2. append returns record with reviewId (UUID) and reviewedAt (ISO)
-// 3. list returns appended records
-// 4. list filters by principleId
-// 5. invalid decision rejected with clear Error
-// 6. append preserves previous records (append twice, list returns 2)
-// 7. missing log returns []
-// 8. does not modify ledger file
-// 9. corrupt line skipped on list
+it('review --json writes review record and outputs reviewId', ...)
+it('review text output includes audit-only / no mutation note', ...)
+it('review missing principle exits 1 and does not append', ...)
+it('review invalid decision exits 1 and does not append', ...)
+it('archive-candidate without note exits 1', ...)
+it('review passes workspace to PruningReadModel and appendPruningReview', ...)
+it('review captures signalSnapshot from matching signal', ...)
 ```
 
 ---
@@ -125,21 +52,11 @@ export function listPruningReviews(
 ## Verification
 
 ```bash
-# PRI-24 tests
-npx vitest run packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts \
-  --exclude "**/.worktrees/**"
-
-# PRI-23 tests
-npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts \
-  --exclude "**/.worktrees/**"
-
-# Architecture guard
-npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts \
-  --exclude "**/.worktrees/**"
-
-# Build
 npm run build --workspace=@principles/core
 npm run build --workspace=@principles/pd-cli
+npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts --exclude "**/.worktrees/**"
+npx vitest run packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts --exclude "**/.worktrees/**"
+npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts --exclude "**/.worktrees/**"
 ```
 
 ---
@@ -148,23 +65,22 @@ npm run build --workspace=@principles/pd-cli
 
 ```bash
 git checkout main && git pull origin main
-git checkout -b codex/pri-23-24-pruning-review-foundation
+git checkout -b codex/pri-25-pruning-review-cli
 ```
 
 ## Commit
 
 ```
-feat(runtime-v2): add pruning explain and review log foundation
+feat(pd-cli): add pruning review workflow
 
-- pd runtime pruning explain --principle-id --json/--text (read-only)
-- core append-only pruning review log (JSONL)
-- TDD: all new files have corresponding tests
-- architecture regression guard updated
+- pd runtime pruning review --principle-id --decision --note
+- archives audit record to pruning_reviews.jsonl
+- validates decision and note requirements before writing
+- does not modify principle ledger or state.db
 ```
 
 ## Linear Update
 
-- PRI-23: comment with test/validation results → mark **Done**
-- PRI-24: comment with test/validation results → mark **Done**
-- PRI-19: comment 说明已拆为 PRI-23..PRI-26，当前不单独执行
-- 不要动 PRI-25（除非加 blocked/unblocked comment）
+- PRI-25 → In Progress (start)
+- PRI-25 → Done (after merge, comment with PR + tests)
+- PRI-26: comment → PRI-25 done, can start docs

--- a/docs/architecture/DOMAIN_MODEL.md
+++ b/docs/architecture/DOMAIN_MODEL.md
@@ -1,0 +1,61 @@
+# PD 核心领域模型与通用语言 (Ubiquitous Language)
+
+> **文档状态**: 强制执行 (LOCKED-ONTOLOGY)
+> **最后更新**: 2026-05-02
+> **背景**: 本文档是对 `docs/architecture-governance/PRINCIPLE-TREE-ARCHITECTURE.md` 的具象化与工程化约定，旨在消除日常开发中的语义分裂。
+
+---
+
+## 1. 核心三层进化模型 (The 3-Tier Evolution Hierarchy)
+
+在 PD 系统中，知识的内化必须严格遵循“原则 -> 规则 -> 实现”的三层降维结构。任何代码变量命名、UI 展示和 Linear Issue 描述必须使用以下标准术语。
+
+### 1.1 原则 (Principle) - 树根
+*   **英文名**: `Principle` / `LedgerPrinciple`
+*   **语义定义**: 高维智慧、价值观、哲学指导。它描述了“为什么（Why）”和“大方向（What）”。
+*   **数据载体**: 自然语言（通常存在 Prompt 中）。
+*   **示例**: `P_001` - "保持代码库的原子性，不要混合多个任务的修改。"
+*   **生命周期**: 由 `Diagnostician` (诊断者) 从痛点中提炼。属于 **L1 软内化资产**。
+
+### 1.2 规则 (Rule) - 树干
+*   **英文名**: `Rule` / `LedgerRule`
+*   **语义定义**: 原则在特定边界下的**契约化表达**。它是一组可验证的触发条件和预期行为。
+*   **数据载体**: 结构化元数据 (JSON Schema)。包含 `triggerCondition` 和 `enforcement`。
+*   **示例**: `R_001_A` - "在 `packages/core` 目录下执行 write 工具时，必须确保当前只有一个 task 在进行。"
+*   **关系约束**: 一个 Principle 可以衍生出多个 Rules (1:N)。
+
+### 1.3 实现 (Implementation) - 树叶
+*   **英文名**: `Implementation` / `CodeCandidate`
+*   **语义定义**: 规则的具体**物理执行肌肉**。它是大模型或人类编写的真实代码。
+*   **数据载体**: JavaScript 沙盒代码 (`.js`)，包含 `meta` 和 `evaluate()` 函数。
+*   **示例**: `IMPL_001_A_v1` - 一段通过正则表达式检查传入参数并返回 `{ decision: 'block' }` 的代码。
+*   **关系约束**: 一个 Rule 可以有多个 Implementations 候选，但同一时间只能有一个是 `active` 的。属于 **L2 硬内化资产**。
+
+---
+
+## 2. 系统动力学与流量词汇 (System Dynamics Flow)
+
+为了配合 PD 的系统动力学（SD）监控，以下术语用于描述系统运行时的动态行为：
+
+*   **痛点 (Pain / Pain Signal)**：Agent 在执行任务时遭遇的具体挫败（报错、超时、人类负面反馈）。它是驱动进化的**原始输入流量**。
+*   **诊断 (Diagnosis)**：寻找痛点根因的分析过程。
+*   **分类 (Taxonomy)**：`Diagnostician` 将学到的经验划分为 `principle`、`rule` 或 `defer` 的决策动作。**分类精度**决定了软硬转换的效率。
+*   **内化 (Internalization)**：将“文字原则”转化为“硬逻辑代码”的整个流水线作业（从 L1 向 L2 的转移）。
+*   **剪枝 (Pruning)**：当 L2 的硬实现（Implementation）生效后，将 L1 的软原则从系统 Prompt 中物理剔除的行为。这是实现**系统减压**的最终动作。
+
+---
+
+## 3. 状态机规范 (State Machine Ontology)
+
+在描述规则或实现的生命周期时，**严禁使用** `needs_training`、`pending` 等模糊词汇，必须使用以下标准生命周期状态：
+
+1.  **Candidate (候选)**：新生成的代码实现，尚未经过安全校验，静置在库中。
+2.  **Probation (试用/影子模式)**：通过了静态安全校验，正在系统中运行，但不阻断真实操作（仅记录命中率）。
+3.  **Active (激活/实装)**：正式生效的规则或实现，具备物理拦截能力（如触发 `block` 或 `requireApproval`）。
+4.  **Archived (归档)**：因历史原因保留，但不再参与任何运算。
+5.  **Deprecated (废弃)**：规则或原则已被更优的逻辑替代，正式退出舞台。
+
+---
+
+> **架构师批注**: 
+> 任何开发者在提交 PR 时，若发现新增的接口或变量名未包含上述领域词汇（例如发明了 `Law`、`Guideline`、`ConstraintCode` 等非标准词汇），请在 Code Review 阶段主动拦截并要求重构。

--- a/packages/pd-cli/src/commands/runtime-pruning.ts
+++ b/packages/pd-cli/src/commands/runtime-pruning.ts
@@ -8,7 +8,7 @@
 
 import * as path from 'path';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
-import { PruningReadModel } from '@principles/core/runtime-v2';
+import { PruningReadModel, appendPruningReview } from '@principles/core/runtime-v2';
 
 interface PruningReportOptions {
   workspace?: string;
@@ -88,6 +88,83 @@ export interface PruningExplainOptions {
   principleId: string;
   workspace?: string;
   json?: boolean;
+}
+
+export interface PruningReviewOptions {
+  principleId: string;
+  decision: string;
+  note?: string;
+  reviewer?: string;
+  workspace?: string;
+  json?: boolean;
+}
+
+export function handlePruningReview(opts: PruningReviewOptions): void {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const model = new PruningReadModel({ workspaceDir });
+  const signals = model.getPrincipleSignals();
+
+  const signal = signals.find((s) => s.principleId === opts.principleId);
+
+  if (!signal) {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: `Principle not found: '${opts.principleId}'` }));
+    } else {
+      console.error(`Error: Principle not found: '${opts.principleId}'`);
+    }
+    process.exit(1);
+    return;
+  }
+
+  if (opts.decision !== 'keep' && opts.decision !== 'defer' && opts.decision !== 'archive-candidate') {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: `Invalid decision: '${opts.decision}'. Must be one of: keep, defer, archive-candidate` }));
+    } else {
+      console.error(`Error: Invalid decision: '${opts.decision}'. Must be one of: keep, defer, archive-candidate`);
+    }
+    process.exit(1);
+    return;
+  }
+
+  if (opts.decision === 'archive-candidate' && !opts.note) {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: 'archive-candidate decision requires --note' }));
+    } else {
+      console.error('Error: archive-candidate decision requires --note');
+    }
+    process.exit(1);
+    return;
+  }
+
+  const record = appendPruningReview(workspaceDir, {
+    principleId: signal.principleId,
+    decision: opts.decision,
+    note: opts.note ?? '',
+    reviewer: opts.reviewer,
+    signalSnapshot: signal,
+  });
+
+  if (opts.json) {
+    console.log(JSON.stringify({
+      reviewId: record.reviewId,
+      principleId: record.principleId,
+      decision: record.decision,
+      reviewer: record.reviewer,
+      reviewedAt: record.reviewedAt,
+    }));
+    return;
+  }
+
+  console.log(`reviewId: ${record.reviewId}`);
+  console.log(`principleId: ${record.principleId}`);
+  console.log(`decision: ${record.decision}`);
+  console.log(`reviewer: ${record.reviewer}`);
+  console.log(`reviewedAt: ${record.reviewedAt}`);
+  console.log('');
+  console.log('NOTE: This audit record does not modify the principle.');
 }
 
 export function handlePruningExplain(opts: PruningExplainOptions): void {

--- a/packages/pd-cli/src/commands/runtime-pruning.ts
+++ b/packages/pd-cli/src/commands/runtime-pruning.ts
@@ -9,6 +9,7 @@
 import * as path from 'path';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import { PruningReadModel, appendPruningReview } from '@principles/core/runtime-v2';
+import type { PruningReviewDecision } from '@principles/core/runtime-v2';
 
 interface PruningReportOptions {
   workspace?: string;
@@ -92,7 +93,7 @@ export interface PruningExplainOptions {
 
 export interface PruningReviewOptions {
   principleId: string;
-  decision: string;
+  decision: PruningReviewDecision;
   note?: string;
   reviewer?: string;
   workspace?: string;
@@ -116,7 +117,7 @@ export function handlePruningReview(opts: PruningReviewOptions): void {
       console.error(`Error: Principle not found: '${opts.principleId}'`);
     }
     process.exit(1);
-    return;
+    return; // satisfies TypeScript control flow (process.exit is [noreturn] in tests)
   }
 
   if (opts.decision !== 'keep' && opts.decision !== 'defer' && opts.decision !== 'archive-candidate') {

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -25,7 +25,7 @@ import { handleDiagnoseStatus, handleDiagnoseRun } from './commands/diagnose.js'
 import { handleRuntimeProbe } from './commands/runtime.js';
 import { handleFlowShow } from './commands/flow.js';
 import { handleTraceShow } from './commands/trace.js';
-import { handlePruningReport, handlePruningExplain } from './commands/runtime-pruning.js';
+import { handlePruningReport, handlePruningExplain, handlePruningReview } from './commands/runtime-pruning.js';
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
@@ -345,6 +345,26 @@ pruningCmd
   .option('--json', 'Output raw JSON')
   .action((opts) => {
     handlePruningExplain({ principleId: opts.principleId, workspace: opts.workspace, json: opts.json });
+  });
+
+pruningCmd
+  .command('review')
+  .description('Record a human pruning decision for a flagged principle')
+  .requiredOption('--principle-id <id>', 'Principle ID to review')
+  .requiredOption('--decision <decision>', "Decision: keep, defer, or archive-candidate")
+  .option('--note <text>', 'Review note (required for archive-candidate)')
+  .option('--reviewer <name>', 'Reviewer name', 'operator')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action((opts) => {
+    handlePruningReview({
+      principleId: opts.principleId,
+      decision: opts.decision,
+      note: opts.note,
+      reviewer: opts.reviewer,
+      workspace: opts.workspace,
+      json: opts.json,
+    });
   });
 
 // ── Candidate inspection commands ───────────────────────────────────────────

--- a/packages/pd-cli/tests/commands/runtime-pruning.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-pruning.test.ts
@@ -1,5 +1,5 @@
 /**
- * pd runtime pruning report — CLI unit tests.
+ * pd runtime pruning CLI unit tests — report, explain, review.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -52,6 +52,8 @@ const { MockPruningReadModel } = vi.hoisted(() => {
   return { MockPruningReadModel };
 }, { validateType: false });
 
+const mockAppendPruningReview = vi.hoisted(() => vi.fn());
+
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/test-workspace'),
 }));
@@ -60,10 +62,13 @@ vi.mock('@principles/core/runtime-v2', () => ({
   PruningReadModel: vi.fn().mockImplementation(function () {
     return new MockPruningReadModel();
   }),
+  appendPruningReview: mockAppendPruningReview,
 }));
 
-import { handlePruningReport } from '../../src/commands/runtime-pruning.js';
+import { handlePruningReport, handlePruningExplain, handlePruningReview } from '../../src/commands/runtime-pruning.js';
 import { PruningReadModel } from '@principles/core/runtime-v2';
+
+// ── pd runtime pruning report ───────────────────────────────────────────────
 
 describe('pd runtime pruning report', () => {
   beforeEach(() => {
@@ -158,9 +163,8 @@ describe('pd runtime pruning explain', () => {
     vi.clearAllMocks();
   });
 
-  it('explain --json outputs matching signal for p_watch', async () => {
+  it('explain --json outputs matching signal for p_watch', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
     handlePruningExplain({ principleId: 'p_watch', json: true });
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
@@ -171,9 +175,8 @@ describe('pd runtime pruning explain', () => {
     consoleSpy.mockRestore();
   });
 
-  it('explain text output includes reason lines and read-only note', async () => {
+  it('explain text output includes reason lines and read-only note', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
     handlePruningExplain({ principleId: 'p_watch', json: false });
     const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(output).toContain('p_watch');
@@ -182,23 +185,131 @@ describe('pd runtime pruning explain', () => {
     consoleSpy.mockRestore();
   });
 
-  it('explain missing principle exits 1', async () => {
+  it('explain missing principle exits 1', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
-    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
     handlePruningExplain({ principleId: 'nonexistent', json: false });
     expect(processSpy).toHaveBeenCalledWith(1);
     consoleSpy.mockRestore();
     processSpy.mockRestore();
   });
 
-  it('explain passes explicit workspace to PruningReadModel', async () => {
+  it('explain passes explicit workspace to PruningReadModel', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { handlePruningExplain } = await import('../../src/commands/runtime-pruning.js');
     handlePruningExplain({ principleId: 'p_watch', workspace: '/custom/workspace', json: false });
     const calls = (PruningReadModel as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls.length).toBeGreaterThan(0);
     expect(String(calls[calls.length - 1][0].workspaceDir)).toMatch(/custom.*workspace/);
+    consoleSpy.mockRestore();
+  });
+});
+
+// ── pd runtime pruning review ───────────────────────────────────────────────
+
+describe('pd runtime pruning review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAppendPruningReview.mockReset();
+    mockAppendPruningReview.mockReturnValue({
+      reviewId: 'review-uuid-123',
+      principleId: 'p_watch',
+      decision: 'keep',
+      note: '',
+      reviewer: 'operator',
+      reviewedAt: '2026-05-02T00:00:00.000Z',
+      signalSnapshot: {
+        principleId: 'p_watch',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        derivedCandidateIds: [],
+        derivedPainCount: 0,
+        matchedCandidateCount: 0,
+        recentCandidateCount: 0,
+        orphanCandidateCount: 0,
+        ageDays: 45,
+        riskLevel: 'watch',
+        reasons: ['watch: principle older than 30 days'],
+      },
+    });
+  });
+
+  it('review --json writes review record and outputs reviewId', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    handlePruningReview({ principleId: 'p_watch', decision: 'keep', json: true });
+    expect(mockAppendPruningReview).toHaveBeenCalledTimes(1);
+    const callInput = mockAppendPruningReview.mock.calls[0]![1];
+    expect(callInput.principleId).toBe('p_watch');
+    expect(callInput.decision).toBe('keep');
+    expect(callInput.signalSnapshot).toBeDefined();
+    expect(callInput.signalSnapshot.principleId).toBe('p_watch');
+    const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.reviewId).toBe('review-uuid-123');
+    expect(output.principleId).toBe('p_watch');
+    expect(output.decision).toBe('keep');
+    expect(output.reviewedAt).toBeDefined();
+    consoleSpy.mockRestore();
+  });
+
+  it('review text output includes audit-only / no mutation note', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    handlePruningReview({ principleId: 'p_watch', decision: 'keep', note: 'looks fine', json: false });
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('reviewId');
+    expect(output).toContain('reviewer');
+    expect(output).toContain('NOTE: This audit record does not modify the principle.');
+    consoleSpy.mockRestore();
+  });
+
+  it('review missing principle exits 1 and does not append', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
+    handlePruningReview({ principleId: 'nonexistent', decision: 'keep', json: false });
+    expect(mockAppendPruningReview).not.toHaveBeenCalled();
+    expect(processSpy).toHaveBeenCalledWith(1);
+    consoleSpy.mockRestore();
+    processSpy.mockRestore();
+  });
+
+  it('review invalid decision exits 1 and does not append', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
+    // @ts-expect-error — testing invalid input
+    handlePruningReview({ principleId: 'p_watch', decision: 'invalid', json: false });
+    expect(mockAppendPruningReview).not.toHaveBeenCalled();
+    expect(processSpy).toHaveBeenCalledWith(1);
+    consoleSpy.mockRestore();
+    processSpy.mockRestore();
+  });
+
+  it('archive-candidate without note exits 1', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
+    handlePruningReview({ principleId: 'p_watch', decision: 'archive-candidate', note: undefined, json: false });
+    expect(mockAppendPruningReview).not.toHaveBeenCalled();
+    expect(processSpy).toHaveBeenCalledWith(1);
+    consoleSpy.mockRestore();
+    processSpy.mockRestore();
+  });
+
+  it('review passes workspace to PruningReadModel and appendPruningReview', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    handlePruningReview({ principleId: 'p_watch', decision: 'keep', workspace: '/custom/workspace', json: false });
+    const modelCalls = (PruningReadModel as ReturnType<typeof vi.fn>).mock.calls;
+    expect(modelCalls.length).toBeGreaterThan(0);
+    expect(modelCalls[modelCalls.length - 1][0].workspaceDir).toMatch(/custom[\\/]workspace/);
+    expect(mockAppendPruningReview).toHaveBeenCalledWith(expect.stringMatching(/custom[\\/]workspace/), expect.any(Object));
+    consoleSpy.mockRestore();
+  });
+
+  it('review captures signalSnapshot from matching signal', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    handlePruningReview({ principleId: 'p_watch', decision: 'defer', note: 'deferring', json: true });
+    const callInput = mockAppendPruningReview.mock.calls[0]![1];
+    expect(callInput.signalSnapshot).toMatchObject({
+      principleId: 'p_watch',
+      riskLevel: 'watch',
+    });
     consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- `pd runtime pruning review` CLI command for recording human pruning decisions
- Connects `PruningReadModel` (signal lookup) → `appendPruningReview` (JSONL audit log)
- Does NOT modify principle ledger or state.db — purely audit

## Test plan

- [x] `npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts` — 17 passed
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/pruning-review-log.test.ts` — 11 passed
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` — 22 passed
- [x] `npm run build --workspace=@principles/core` ✅
- [x] `npm run build --workspace=@principles/pd-cli` ✅

## Changed files

- `packages/pd-cli/src/commands/runtime-pruning.ts` — `handlePruningReview`
- `packages/pd-cli/src/index.ts` — registered `review` subcommand
- `packages/pd-cli/tests/commands/runtime-pruning.test.ts` — 7 new tests

## Remaining risk

- No ledger writes, no state.db mutations
- archive-candidate validation before write
- invalid decision validation before write

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `pd runtime pruning review` CLI 命令，支持记录决策处理（保留、延期或标记为存档候选）
  * 支持 JSON 和文本输出格式
  * 包含可选的决策备注和操作人员标识

* **测试**
  * 新增完整的命令测试覆盖，包含有效和无效输入场景

* **文档**
  * 更新规划文档，明确新命令的行为规范和输出要求

<!-- end of auto-generated comment: release notes by coderabbit.ai -->