### PR TITLE
feat(pd-cli): runtime V2 repeated UAT baseline runner (PRI-27)

### DIFF
--- a/docs/architecture/DOMAIN_MODEL.md
+++ b/docs/architecture/DOMAIN_MODEL.md
@@ -303,6 +303,7 @@ Pruning Review 是 append-only audit log，不改变实体生命周期。当前�
 - `PolicyRule`（除非明确是 Rule 的子类型）
 - `WisdomItem`
 - `MemoryRule`
+- `PendingPrinciple`（请严格区分是业务生命周期的 `candidate` 还是数据摄入阶段的 `pending` 状态，见 5.2 节）
 
 如果只是 UI 文案或外部说明可以使用自然语言同义词，但代码、schema、Linear issue title 和 ADR 必须使用本文标准术语。
 
@@ -310,3 +311,4 @@ Pruning Review 是 append-only audit log，不改变实体生命周期。当前�
 
 > **架构师批注**:
 > Principle 是 PD 的管理核心；Rule 是 Principle 的实操化投影；Implementation 是 Rule 的行为承载物。后续所有重构都应减少这三者之间的语义混淆，而不是新增一套平行概念。
+e 的行为承载物。后续所有重构都应减少这三者之间的语义混淆，而不是新增一套平行概念。

--- a/packages/pd-cli/src/commands/runtime-uat.ts
+++ b/packages/pd-cli/src/commands/runtime-uat.ts
@@ -1,0 +1,323 @@
+/**
+ * pd runtime uat command — Runtime V2 chain UAT baseline runner.
+ *
+ * Usage:
+ *   pd runtime uat --workspace <path> --count <N> [--min-success-rate <rate>] [--json]
+ *
+ * Runs N consecutive pd pain record iterations and verifies:
+ *   - Every run produces painId, taskId, runId, artifactId, candidateIds, ledgerEntryIds
+ *   - Candidate audit returns "ok" after each run
+ *   - Consistency and latency statistics with threshold-based exit
+ *
+ * Requirements:
+ *   - XIAOMI_KEY environment variable
+ *   - Built pd-cli (npx pd must be resolvable)
+ */
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface UatOptions {
+  workspace?: string;
+  count?: number;
+  minSuccessRate?: number;
+  json?: boolean;
+}
+
+interface PainRecordResult {
+  iteration: number;
+  painId?: string;
+  taskId?: string;
+  runId?: string;
+  artifactId?: string;
+  candidateIds: string[];
+  ledgerEntryIds: string[];
+  status: string;
+  failureCategory?: string;
+  latencyMs?: number;
+  wallTimeMs: number;
+  auditStatus: string;
+  error?: string;
+  rawOutput?: string;
+}
+
+interface UatSummary {
+  generatedAt: string;
+  workspace: string;
+  totalRuns: number;
+  successful: number;
+  failed: number;
+  successRate: number;
+  p50LatencyMs?: number;
+  p95LatencyMs?: number;
+  failuresByCategory: Record<string, number>;
+  ledgerConsistencyOk: boolean;
+  allHaveCandidates: boolean;
+  allHaveLedger: boolean;
+  perRun: PainRecordResult[];
+}
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+export function parseUatArgs(argv: string[]): UatOptions {
+  const args: UatOptions = { count: 5 };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--workspace' || argv[i] === '-w') {
+      args.workspace = argv[++i] ?? '';
+    } else if (argv[i] === '--count') {
+      const n = parseInt(argv[++i] ?? '5', 10);
+      args.count = isNaN(n) ? 5 : n;
+    } else if (argv[i] === '--min-success-rate') {
+      const rate = parseFloat(argv[++i] ?? '1.0');
+      args.minSuccessRate = isNaN(rate) ? 1.0 : rate;
+    }
+  }
+  return args;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+export function parseJsonOutput(output: string): unknown {
+  try {
+    return JSON.parse(output.trim());
+  } catch {
+    // Find the last line that looks like a JSON object
+    const lines = output.trim().split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (line.startsWith('{')) {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // keep searching
+        }
+      }
+    }
+    throw new Error(`No JSON found in output: ${output.slice(0, 200)}`);
+  }
+}
+
+export function percentile(arr: number[], p: number): number | undefined {
+  if (arr.length === 0) return undefined;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.ceil(sorted.length * p / 100) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+// ── Core UAT runner ───────────────────────────────────────────────────────────
+
+function pd(args: string[], workspace: string, timeoutMs = 300_000): string {
+  const fullArgs = [...args, '--workspace', workspace];
+  try {
+    return execFileSync('npx', ['pd', ...fullArgs], {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      env: { ...process.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && (err as { code: string }).code === 'ENOENT') {
+      throw new Error('pd CLI not found — run: npm run build --workspace=@principles/pd-cli', { cause: err });
+    }
+    if (err && typeof err === 'object' && 'stdout' in err) {
+      return String((err as { stdout: unknown }).stdout);
+    }
+    throw err;
+  }
+}
+
+interface IterationConfig {
+  iteration: number;
+  reason: string;
+  workspace: string;
+  timeoutMs?: number;
+}
+
+export function runUatIteration(config: IterationConfig): PainRecordResult {
+  const { iteration, reason, workspace, timeoutMs = 300_000 } = config;
+  const iterStart = Date.now();
+
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let recordOutput: string;
+  try {
+    recordOutput = pd(['pain', 'record', '--reason', reason, '--score', '85', '--source', 'manual', '--json'], workspace, timeoutMs);
+  } catch (err: unknown) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return {
+      iteration,
+      status: 'script_error',
+      failureCategory: 'runtime_unavailable',
+      error: cause,
+      wallTimeMs: Date.now() - iterStart,
+      auditStatus: 'unknown',
+      candidateIds: [],
+      ledgerEntryIds: [],
+    };
+  }
+
+  const wallTimeMs = Date.now() - iterStart;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseJsonOutput(recordOutput) as Record<string, unknown>;
+  } catch {
+    return {
+      iteration,
+      status: 'parse_error',
+      failureCategory: 'output_invalid',
+      rawOutput: recordOutput.slice(0, 500),
+      wallTimeMs,
+      auditStatus: 'unknown',
+      candidateIds: [],
+      ledgerEntryIds: [],
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let auditStatus: string;
+  try {
+    const auditOut = pd(['candidate', 'audit', '--json'], workspace, 30_000);
+    const audit = parseJsonOutput(auditOut) as { status?: string };
+    auditStatus = audit.status ?? 'unknown';
+  } catch {
+    auditStatus = 'audit_error';
+  }
+
+  return {
+    iteration,
+    painId: parsed.painId as string | undefined,
+    taskId: parsed.taskId as string | undefined,
+    runId: parsed.runId as string | undefined,
+    artifactId: parsed.artifactId as string | undefined,
+    candidateIds: (parsed.candidateIds as string[]) ?? [],
+    ledgerEntryIds: (parsed.ledgerEntryIds as string[]) ?? [],
+    status: parsed.status as string ?? 'unknown',
+    failureCategory: parsed.failureCategory as string | undefined,
+    latencyMs: parsed.latencyMs as number | undefined,
+    wallTimeMs,
+    auditStatus,
+  };
+}
+
+export function computeUatSummary(results: PainRecordResult[], workspace: string): UatSummary {
+  const succeeded = results.filter(r => r.status === 'succeeded');
+  const failed = results.filter(r => r.status === 'failed' || r.status === 'script_error' || r.status === 'parse_error');
+  const successRate = results.length > 0 ? succeeded.length / results.length : 0;
+
+  const latencies = results
+    .map(r => r.wallTimeMs)
+    .filter(ms => typeof ms === 'number' && ms > 0);
+
+  const failuresByCategory: Record<string, number> = {};
+  for (const r of results) {
+    const cat = r.failureCategory ?? (r.status !== 'succeeded' ? 'unknown' : null);
+    if (cat) {
+      failuresByCategory[cat] = (failuresByCategory[cat] ?? 0) + 1;
+    }
+  }
+
+  const auditsOk = results.filter(r => r.auditStatus === 'ok').length;
+  const ledgerConsistencyOk = auditsOk === results.length;
+  const allHaveCandidates = results.every(r => r.candidateIds && r.candidateIds.length > 0);
+  const allHaveLedger = results.every(r => r.ledgerEntryIds && r.ledgerEntryIds.length > 0);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    workspace,
+    totalRuns: results.length,
+    successful: succeeded.length,
+    failed: failed.length,
+    successRate: Number(successRate.toFixed(2)),
+    p50LatencyMs: percentile(latencies, 50),
+    p95LatencyMs: percentile(latencies, 95),
+    failuresByCategory,
+    ledgerConsistencyOk,
+    allHaveCandidates,
+    allHaveLedger,
+    perRun: results,
+  };
+}
+
+export function shouldExitWithError(summary: UatSummary, minSuccessRate = 1.0): boolean {
+  if (summary.successRate < minSuccessRate) return true;
+  if (!summary.ledgerConsistencyOk) return true;
+  if (!summary.allHaveCandidates) return true;
+  if (!summary.allHaveLedger) return true;
+  return false;
+}
+
+// ── CLI handler ───────────────────────────────────────────────────────────────
+
+export async function handleRuntimeUat(opts: UatOptions): Promise<void> {
+  const workspace = opts.workspace
+    ? path.resolve(opts.workspace)
+    : '';
+
+  const count = Math.max(1, Math.min(opts.count ?? 5, 50));
+  const minSuccessRate = opts.minSuccessRate ?? 1.0;
+
+  if (!workspace) {
+    console.error('Error: --workspace <path> is required');
+    process.exit(1);
+  }
+
+  console.error(`[${new Date().toISOString()}] Runtime V2 Chain UAT — workspace: ${workspace}, count: ${count}`);
+
+  // Check MINIMAX_API_KEY
+  if (!process.env.MINIMAX_API_KEY) {
+    console.error('Error: MINIMAX_API_KEY environment variable not set');
+    process.exit(1);
+  }
+
+  const results: PainRecordResult[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const reason = `UAT chain test ${i + 1}/${count} — ${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const result = runUatIteration({ iteration: i + 1, reason, workspace });
+    results.push(result);
+
+    const icon = result.status === 'succeeded' ? '✓' : '✗';
+    console.error(
+      `  ${icon} iter=${result.iteration} status=${result.status} ` +
+      `candidates=${result.candidateIds.length} ` +
+      `ledger=${result.ledgerEntryIds.length} ` +
+      `wallTime=${result.wallTimeMs}ms` +
+      (result.failureCategory ? ` category=${result.failureCategory}` : '')
+    );
+  }
+
+  const summary = computeUatSummary(results, workspace);
+
+  if (opts.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.error('');
+    console.error('═'.repeat(60));
+    console.error('UAT SUMMARY');
+    console.error('═'.repeat(60));
+    console.error(`  totalRuns:          ${summary.totalRuns}`);
+    console.error(`  successful:         ${summary.successful}`);
+    console.error(`  failed:             ${summary.failed}`);
+    console.error(`  successRate:        ${summary.successRate}`);
+    if (summary.p50LatencyMs !== undefined) console.error(`  p50LatencyMs:       ${summary.p50LatencyMs}`);
+    if (summary.p95LatencyMs !== undefined) console.error(`  p95LatencyMs:       ${summary.p95LatencyMs}`);
+    console.error(`  ledgerConsistencyOk:${summary.ledgerConsistencyOk}`);
+    console.error(`  allHaveCandidates:  ${summary.allHaveCandidates}`);
+    console.error(`  allHaveLedger:      ${summary.allHaveLedger}`);
+    const cats = Object.entries(summary.failuresByCategory);
+    if (cats.length > 0) {
+      console.error(`  failuresByCategory: ${JSON.stringify(summary.failuresByCategory)}`);
+    }
+  }
+
+  if (shouldExitWithError(summary, minSuccessRate)) {
+    console.error('');
+    console.error(`FAIL: successRate=${summary.successRate} (threshold: ${minSuccessRate}) ` +
+      `ledger=${summary.ledgerConsistencyOk} candidates=${summary.allHaveCandidates} ledger=${summary.allHaveLedger}`);
+    process.exit(1);
+  }
+
+  console.error('');
+  console.error('✓ ALL CHECKS PASSED');
+}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -26,6 +26,7 @@ import { handleRuntimeProbe } from './commands/runtime.js';
 import { handleFlowShow } from './commands/flow.js';
 import { handleTraceShow } from './commands/trace.js';
 import { handlePruningReport, handlePruningExplain, handlePruningReview } from './commands/runtime-pruning.js';
+import { handleRuntimeUat } from './commands/runtime-uat.js';
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
@@ -363,6 +364,22 @@ pruningCmd
       note: opts.note,
       reviewer: opts.reviewer,
       workspace: opts.workspace,
+      json: opts.json,
+    });
+  });
+
+pruningCmd
+  .command('uat')
+  .description('Runtime V2 chain UAT baseline runner')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--count <n>', 'Number of iterations (default: 5, max: 50)', parseInt)
+  .option('--min-success-rate <rate>', 'Minimum success rate threshold (default: 1.0)', parseFloat)
+  .option('--json', 'Output machine-readable JSON summary')
+  .action(async (opts) => {
+    await handleRuntimeUat({
+      workspace: opts.workspace,
+      count: opts.count,
+      minSuccessRate: opts.minSuccessRate,
       json: opts.json,
     });
   });

--- a/packages/pd-cli/tests/commands/runtime-uat.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-uat.test.ts
@@ -1,0 +1,281 @@
+/**
+ * pd runtime uat CLI unit tests.
+ * Tests parseUatArgs, computeUatSummary, shouldExitWithError.
+ * Integration tests with real pd calls are done manually via
+ *   node scripts/uat/runtime-v2-chain-uat.mjs --workspace <path> --count 2 --json
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock child_process before importing the module under test ────────────────
+
+const { mockExecFileSync } = vi.hoisted(() => {
+  return { mockExecFileSync: vi.fn() };
+});
+
+vi.mock('child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+// ── Import after mock setup ─────────────────────────────────────────────────
+
+import {
+  parseUatArgs,
+  computeUatSummary,
+  shouldExitWithError,
+  type PainRecordResult,
+} from '../../src/commands/runtime-uat.js';
+
+// ── parseUatArgs ─────────────────────────────────────────────────────────────
+
+describe('parseUatArgs', () => {
+  it('defaults count to 5 when not provided', () => {
+    const result = parseUatArgs([]);
+    expect(result.count).toBe(5);
+  });
+
+  it('parses --count', () => {
+    const result = parseUatArgs(['--count', '10']);
+    expect(result.count).toBe(10);
+  });
+
+  it('parses --workspace', () => {
+    const result = parseUatArgs(['--workspace', '/tmp/ws']);
+    expect(result.workspace).toBe('/tmp/ws');
+  });
+
+  it('parses --min-success-rate', () => {
+    const result = parseUatArgs(['--min-success-rate', '0.8']);
+    expect(result.minSuccessRate).toBe(0.8);
+  });
+
+  it('parses -w as alias for --workspace', () => {
+    const result = parseUatArgs(['-w', '/custom/path']);
+    expect(result.workspace).toBe('/custom/path');
+  });
+
+  it('clamps count to [1, 50]', () => {
+    expect(parseUatArgs(['--count', '1']).count).toBe(1);
+    expect(parseUatArgs(['--count', '50']).count).toBe(50);
+  });
+});
+
+// ── computeUatSummary ────────────────────────────────────────────────────────
+
+describe('computeUatSummary', () => {
+  const ws = '/tmp/test-workspace';
+
+  it('computes successRate correctly', () => {
+    const results: PainRecordResult[] = [
+      makeResult(1, 'succeeded', ['c1'], ['l1']),
+      makeResult(2, 'succeeded', ['c2'], ['l2']),
+      makeResult(3, 'failed', ['c3'], ['l3']),
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.successRate).toBeCloseTo(0.67, 2);
+    expect(summary.successful).toBe(2);
+    expect(summary.failed).toBe(1);
+  });
+
+  it('computes failuresByCategory from failureCategory field', () => {
+    const results: PainRecordResult[] = [
+      { ...makeResult(1, 'failed', [], []), failureCategory: 'runtime_unavailable' },
+      { ...makeResult(2, 'failed', [], []), failureCategory: 'runtime_unavailable' },
+      { ...makeResult(3, 'failed', [], []), failureCategory: 'output_invalid' },
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.failuresByCategory).toEqual({
+      runtime_unavailable: 2,
+      output_invalid: 1,
+    });
+  });
+
+  it('ledgerConsistencyOk true when all audits are ok', () => {
+    const results: PainRecordResult[] = [
+      makeResult(1, 'succeeded', ['c1'], ['l1'], 100, 'ok'),
+      makeResult(2, 'succeeded', ['c2'], ['l2'], 100, 'ok'),
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.ledgerConsistencyOk).toBe(true);
+  });
+
+  it('ledgerConsistencyOk false when any audit fails', () => {
+    const results: PainRecordResult[] = [
+      makeResult(1, 'succeeded', ['c1'], ['l1'], 100, 'ok'),
+      makeResult(2, 'succeeded', ['c2'], ['l2'], 100, 'error'),
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.ledgerConsistencyOk).toBe(false);
+  });
+
+  it('allHaveCandidates false when any candidateIds empty', () => {
+    const results: PainRecordResult[] = [
+      makeResult(1, 'succeeded', ['c1'], ['l1']),
+      makeResult(2, 'succeeded', [], ['l2']),
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.allHaveCandidates).toBe(false);
+  });
+
+  it('allHaveLedger false when any ledgerEntryIds empty', () => {
+    const results: PainRecordResult[] = [
+      makeResult(1, 'succeeded', ['c1'], ['l1']),
+      makeResult(2, 'succeeded', ['c2'], []),
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.allHaveLedger).toBe(false);
+  });
+
+  it('p50LatencyMs and p95LatencyMs computed from wallTimeMs', () => {
+    const results: PainRecordResult[] = [
+      makeResult(1, 'succeeded', ['c1'], ['l1'], 100),
+      makeResult(2, 'succeeded', ['c2'], ['l2'], 200),
+      makeResult(3, 'succeeded', ['c3'], ['l3'], 300),
+      makeResult(4, 'succeeded', ['c4'], ['l4'], 400),
+    ];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.p50LatencyMs).toBeDefined();
+    expect(summary.p95LatencyMs).toBeDefined();
+    expect(summary.p50LatencyMs).toBeLessThanOrEqual(summary.p95LatencyMs!);
+  });
+
+  it('includes perRun in summary', () => {
+    const results: PainRecordResult[] = [makeResult(1, 'succeeded', ['c1'], ['l1'])];
+    const summary = computeUatSummary(results, ws);
+    expect(summary.perRun).toHaveLength(1);
+    expect(summary.perRun[0].iteration).toBe(1);
+  });
+
+  it('generatedAt is ISO string', () => {
+    const summary = computeUatSummary([], ws);
+    expect(summary.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+// ── shouldExitWithError ─────────────────────────────────────────────────────
+
+describe('shouldExitWithError', () => {
+  const ws = '/tmp/test-workspace';
+
+  it('returns false when all checks pass and minSuccessRate=1.0', () => {
+    const summary = makeSummary(ws, 5, 5, true, true, true);
+    expect(shouldExitWithError(summary, 1.0)).toBe(false);
+  });
+
+  it('returns true when successRate below threshold', () => {
+    const summary = makeSummary(ws, 5, 3, true, true, true);
+    expect(shouldExitWithError(summary, 1.0)).toBe(true);
+    expect(shouldExitWithError(summary, 0.5)).toBe(false);
+  });
+
+  it('returns true when ledgerConsistencyOk is false', () => {
+    const summary = makeSummary(ws, 5, 5, false, true, true);
+    expect(shouldExitWithError(summary, 1.0)).toBe(true);
+  });
+
+  it('returns true when allHaveCandidates is false', () => {
+    const summary = makeSummary(ws, 5, 5, true, false, true);
+    expect(shouldExitWithError(summary, 1.0)).toBe(true);
+  });
+
+  it('returns true when allHaveLedger is false', () => {
+    const summary = makeSummary(ws, 5, 5, true, true, false);
+    expect(shouldExitWithError(summary, 1.0)).toBe(true);
+  });
+
+  it('default minSuccessRate is 1.0', () => {
+    const summary = makeSummary(ws, 5, 5, true, true, true);
+    expect(shouldExitWithError(summary)).toBe(false);
+    expect(shouldExitWithError(summary, 1.0)).toBe(false);
+  });
+});
+
+// ── handleRuntimeUat guard rails ─────────────────────────────────────────────
+// Real execFileSync integration is tested manually via:
+//   node scripts/uat/runtime-v2-chain-uat.mjs --workspace <path> --count 2 --json
+
+describe('handleRuntimeUat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFileSync.mockReset();
+  });
+
+  it('exits 1 when --workspace is missing', async () => {
+    const { handleRuntimeUat } = await import('../../src/commands/runtime-uat.js');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`exit:${code}`);
+    }) as (code: number) => never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(handleRuntimeUat({})).rejects.toThrow('exit:1');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--workspace'));
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits 1 when MINIMAX_API_KEY is not set', async () => {
+    delete process.env.MINIMAX_API_KEY;
+    const { handleRuntimeUat } = await import('../../src/commands/runtime-uat.js');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`exit:${code}`);
+    }) as (code: number) => never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(handleRuntimeUat({ workspace: '/tmp/test-ws' })).rejects.toThrow('exit:1');
+    exitSpy.mockRestore();
+  });
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResult(
+  iteration: number,
+  status: string,
+  candidateIds: string[],
+  ledgerEntryIds: string[],
+  wallTimeMs = 1000,
+  auditStatus = 'ok',
+  failureCategory?: string,
+): PainRecordResult {
+  return {
+    iteration,
+    painId: status === 'succeeded' ? `pain-${iteration}` : undefined,
+    taskId: status === 'succeeded' ? `task-${iteration}` : undefined,
+    runId: status === 'succeeded' ? `run-${iteration}` : undefined,
+    artifactId: status === 'succeeded' ? `art-${iteration}` : undefined,
+    candidateIds,
+    ledgerEntryIds,
+    status,
+    failureCategory,
+    wallTimeMs,
+    auditStatus,
+  };
+}
+
+function makeSummary(
+  workspace: string,
+  totalRuns: number,
+  successful: number,
+  ledgerConsistencyOk: boolean,
+  allHaveCandidates: boolean,
+  allHaveLedger: boolean,
+): import('../../src/commands/runtime-uat.js').UatSummary {
+  const results: PainRecordResult[] = Array.from({ length: totalRuns }, (_, i) =>
+    makeResult(i + 1, i < successful ? 'succeeded' : 'failed', ['c1'], ['l1'])
+  );
+  return {
+    generatedAt: new Date().toISOString(),
+    workspace,
+    totalRuns,
+    successful,
+    failed: totalRuns - successful,
+    successRate: Number((successful / totalRuns).toFixed(2)),
+    p50LatencyMs: 500,
+    p95LatencyMs: 900,
+    failuresByCategory: {},
+    ledgerConsistencyOk,
+    allHaveCandidates,
+    allHaveLedger,
+    perRun: results,
+  };
+}

--- a/scripts/uat/runtime-v2-chain-uat.mjs
+++ b/scripts/uat/runtime-v2-chain-uat.mjs
@@ -11,7 +11,7 @@
  *   - Consistency and latency statistics
  *
  * Requirements:
- *   - XIAOMI_KEY environment variable
+ *   - MINIMAX_API_KEY environment variable
  *   - Built pd-cli (npx pd must be resolvable)
  */
 
@@ -106,11 +106,11 @@ async function main() {
   log('');
 
   // 1. Check environment
-  if (!process.env.XIAOMI_KEY) {
-    error('XIAOMI_KEY environment variable not set');
+  if (!process.env.MINIMAX_API_KEY) {
+    error('MINIMAX_API_KEY environment variable not set');
     process.exit(1);
   }
-  log('✓ XIAOMI_KEY is set');
+  log('✓ MINIMAX_API_KEY is set');
 
   // 2. Runtime probe
   log('Probing runtime...');


### PR DESCRIPTION
## Summary

- Add `pd runtime pruning uat` command for repeatable Runtime V2 chain UAT baseline
- Supports `--workspace`, `--count` (default 5, max 50), `--min-success-rate` (default 1.0), `--json` flags
- Runs N consecutive `pd pain record` iterations, verifying painId/taskId/runId/artifactId/candidateIds/ledgerEntryIds
- Candidate audit check after each run; reports successRate, p50/p95 latency, failuresByCategory, ledger consistency
- Exits 0 on all checks passed, exits 1 on threshold breach or ledger consistency failure
- Replace `XIAOMI_KEY` with `MINIMAX_API_KEY` in UAT script (Xiaomi API quota exhausted)
- 23 unit tests covering `parseUatArgs`, `computeUatSummary`, `shouldExitWithError`

## Test plan

- [x] `npm run build --workspace=@principles/pd-cli` passes
- [x] `npx vitest run packages/pd-cli/tests/commands/runtime-uat.test.ts` — 23/23 pass
- [x] ESLint pre-commit hook passes (0 errors)
- [ ] Manual: `pd runtime pruning uat --workspace <path> --count 1 --json` with valid MINIMAX_API_KEY
- [ ] Manual: Verify exit code 1 on threshold breach

## Files changed

| File | Change |
|------|--------|
| `packages/pd-cli/src/commands/runtime-uat.ts` | NEW — UAT runner implementation |
| `packages/pd-cli/tests/commands/runtime-uat.test.ts` | NEW — 23 unit tests |
| `packages/pd-cli/src/index.ts` | Register `pruning uat` subcommand |
| `scripts/uat/runtime-v2-chain-uat.mjs` | XIAOMI_KEY → MINIMAX_API_KEY |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `pd runtime uat` CLI 命令，用于运行 Runtime v2 链的 UAT 基准测试，支持配置工作区、迭代次数、成功率阈值等参数，支持 JSON 和文本格式输出。

* **文档**
  * 更新架构域模型文档中的命名禁区约束，新增术语规范。

* **测试**
  * 为新增 UAT 命令模块添加完整的测试套件。

* **Chores**
  * 更新 UAT 脚本环境变量配置要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->