### PR TITLE
fix(pd-cli): move uat command from pruning to runtime level (PRI-27 follow-up)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-uat.ts
+++ b/packages/pd-cli/src/commands/runtime-uat.ts
@@ -10,7 +10,7 @@
  *   - Consistency and latency statistics with threshold-based exit
  *
  * Requirements:
- *   - XIAOMI_KEY environment variable
+ *   - MINIMAX_API_KEY environment variable
  *   - Built pd-cli (npx pd must be resolvable)
  */
 import { execFileSync } from 'child_process';

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -325,6 +325,22 @@ traceCmd
     await handleTraceShow({ painId: opts.painId, workspace: opts.workspace, json: opts.json });
   });
 
+runtimeCmd
+  .command('uat')
+  .description('Runtime V2 chain UAT baseline runner')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--count <n>', 'Number of iterations (default: 5, max: 50)', parseInt)
+  .option('--min-success-rate <rate>', 'Minimum success rate threshold (default: 1.0)', parseFloat)
+  .option('--json', 'Output machine-readable JSON summary')
+  .action(async (opts) => {
+    await handleRuntimeUat({
+      workspace: opts.workspace,
+      count: opts.count,
+      minSuccessRate: opts.minSuccessRate,
+      json: opts.json,
+    });
+  });
+
 const pruningCmd = runtimeCmd
   .command('pruning')
   .description('Non-destructive pruning metrics and health signals');
@@ -364,22 +380,6 @@ pruningCmd
       note: opts.note,
       reviewer: opts.reviewer,
       workspace: opts.workspace,
-      json: opts.json,
-    });
-  });
-
-pruningCmd
-  .command('uat')
-  .description('Runtime V2 chain UAT baseline runner')
-  .option('-w, --workspace <path>', 'Workspace directory')
-  .option('--count <n>', 'Number of iterations (default: 5, max: 50)', parseInt)
-  .option('--min-success-rate <rate>', 'Minimum success rate threshold (default: 1.0)', parseFloat)
-  .option('--json', 'Output machine-readable JSON summary')
-  .action(async (opts) => {
-    await handleRuntimeUat({
-      workspace: opts.workspace,
-      count: opts.count,
-      minSuccessRate: opts.minSuccessRate,
       json: opts.json,
     });
   });

--- a/packages/pd-cli/tests/commands/cli-command-tree.test.ts
+++ b/packages/pd-cli/tests/commands/cli-command-tree.test.ts
@@ -1,0 +1,53 @@
+/**
+ * CLI command tree structure tests — verify command placement.
+ *
+ * These tests ensure that commands are registered at the correct path in the CLI tree.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+
+function runPdHelp(args: string[]): string {
+  try {
+    return execFileSync('node', ['packages/pd-cli/dist/index.js', ...args], {
+      encoding: 'utf8',
+      cwd: 'D:/Code/principles',
+    });
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'stdout' in err) {
+      return String((err as { stdout: unknown }).stdout);
+    }
+    throw err;
+  }
+}
+
+describe('CLI command tree structure', () => {
+  it('uat command exists under runtime (pd runtime uat --help)', () => {
+    const output = runPdHelp(['runtime', 'uat', '--help']);
+    // Should contain UAT-specific options
+    expect(output).toContain('--workspace');
+    expect(output).toContain('--count');
+    expect(output).toContain('--min-success-rate');
+    expect(output).toContain('--json');
+  });
+
+  it('uat command description mentions Runtime V2 chain UAT', () => {
+    const output = runPdHelp(['runtime', 'uat', '--help']);
+    expect(output).toContain('UAT');
+  });
+
+  it('runtime subcommand list includes uat (pd runtime --help)', () => {
+    const output = runPdHelp(['runtime', '--help']);
+    // Should list 'uat' as a subcommand
+    expect(output).toMatch(/uat\s/);
+  });
+
+  it('pruning subcommand list does NOT include uat (pd runtime pruning --help)', () => {
+    const output = runPdHelp(['runtime', 'pruning', '--help']);
+    // Should only have report, explain, review
+    expect(output).toContain('report');
+    expect(output).toContain('explain');
+    expect(output).toContain('review');
+    // Should NOT have uat
+    expect(output).not.toMatch(/uat\s/);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up fix to PR #449 — correct CLI command placement for UAT baseline runner.

**Before:** `pd runtime pruning uat --workspace <path>`
**After:** `pd runtime uat --workspace <path>`

The UAT baseline runner is a runtime-level reliability command, not a pruning-specific operation. The `pruning` subcommand should only contain domain-specific operations: `report`, `explain`, `review`.

## Changes

| File | Change |
|------|--------|
| `packages/pd-cli/src/index.ts` | Move `.command('uat')` from `pruningCmd` to `runtimeCmd` |
| `packages/pd-cli/src/commands/runtime-uat.ts` | Fix docs: `XIAOMI_KEY` → `MINIMAX_API_KEY` |
| `packages/pd-cli/tests/commands/cli-command-tree.test.ts` | NEW — CLI command tree structure tests |

## Test plan

- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run build --workspace=@principles/pd-cli` passes
- [x] `npx vitest run packages/pd-cli/tests/commands/cli-command-tree.test.ts` — 4/4 pass
- [x] `npx vitest run packages/pd-cli/tests/commands/runtime-uat.test.ts` — 23/23 pass
- [x] `npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts` — 17/17 pass
- [x] Manual: `pd runtime uat --help` shows correct options
- [x] Manual: `pd runtime pruning --help` no longer lists uat
- [x] Manual: `pd runtime --help` lists uat under runtime subcommands