### PR TITLE
feat(pd-cli): add operator health snapshot command (PRI-28)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-health-snapshot.ts
+++ b/packages/pd-cli/src/commands/runtime-health-snapshot.ts
@@ -1,0 +1,97 @@
+/**
+ * pd runtime health snapshot command — Operator health snapshot for Runtime V2.
+ *
+ * Usage:
+ *   pd runtime health snapshot --workspace <path> --json
+ *
+ * Aggregates chain reliability, candidate/ledger consistency, and pruning
+ * lifecycle signals into a single operator-facing read-only snapshot.
+ *
+ * PRI-28: Operator health snapshot.
+ */
+import * as path from 'path';
+import { OperatorHealthReadModel } from '@principles/core/runtime-v2';
+import type { OperatorHealthSnapshot } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface HealthSnapshotOptions {
+  workspace?: string;
+  json?: boolean;
+}
+
+function formatTextOutput(snapshot: OperatorHealthSnapshot): string {
+  const lines: string[] = [];
+  const statusIcon = snapshot.overallStatus === 'healthy' ? '✓' : '✗';
+
+  lines.push(`Operator Health Snapshot`);
+  lines.push(`generatedAt: ${snapshot.generatedAt}`);
+  lines.push(`workspace:   ${snapshot.workspace}`);
+  lines.push('');
+  lines.push(`OVERALL: ${statusIcon} ${snapshot.overallStatus.toUpperCase()}`);
+  lines.push('');
+
+  // Pain chain
+  lines.push('painChain:');
+  if (snapshot.painChain.lastSuccessfulChain) {
+    const c = snapshot.painChain.lastSuccessfulChain;
+    lines.push(`  lastChain: ${c.painId} → ${c.taskId} → ${c.runId ?? '-'} → ${c.artifactId ?? '-'}`);
+    lines.push(`  candidates: ${c.candidateIds.length}, ledgerEntries: ${c.ledgerEntryIds.length}`);
+  } else {
+    lines.push('  lastChain: (none)');
+  }
+  lines.push('');
+
+  // Candidate/ledger
+  lines.push('candidateLedger:');
+  lines.push(`  status: ${snapshot.candidateLedger.auditStatus}`);
+  if (snapshot.candidateLedger.missingLedgerCount > 0) {
+    lines.push(`  missingLedger: ${snapshot.candidateLedger.missingLedgerCount}`);
+  }
+  lines.push('');
+
+  // Pruning
+  lines.push('pruning:');
+  lines.push(`  watchCount: ${snapshot.pruning.watchCount}, reviewCount: ${snapshot.pruning.reviewCount}`);
+  if (snapshot.pruning.orphanDerivedCandidateCount > 0) {
+    lines.push(`  orphanDerivedCandidates: ${snapshot.pruning.orphanDerivedCandidateCount}`);
+  }
+  lines.push('');
+
+  // Actions
+  if (snapshot.recommendedActions.length === 0) {
+    lines.push('No actions recommended.');
+  } else {
+    lines.push('Recommended actions:');
+    for (const action of snapshot.recommendedActions) {
+      lines.push(`  [!] ${action}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleRuntimeHealthSnapshot(opts: HealthSnapshotOptions): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const model = new OperatorHealthReadModel({ workspaceDir });
+
+  try {
+    const snapshot = await model.getSnapshot();
+
+    if (opts.json) {
+      console.log(JSON.stringify(snapshot, null, 2));
+    } else {
+      console.error(formatTextOutput(snapshot));
+    }
+
+    if (snapshot.overallStatus !== 'healthy') {
+      console.error('');
+      console.error(`FAIL: overallStatus=${snapshot.overallStatus}`);
+      process.exit(1);
+    }
+  } finally {
+    await model.close();
+  }
+}

--- a/packages/pd-cli/src/commands/runtime-health-snapshot.ts
+++ b/packages/pd-cli/src/commands/runtime-health-snapshot.ts
@@ -83,13 +83,13 @@ export async function handleRuntimeHealthSnapshot(opts: HealthSnapshotOptions): 
     if (opts.json) {
       console.log(JSON.stringify(snapshot, null, 2));
     } else {
-      console.error(formatTextOutput(snapshot));
+      console.log(formatTextOutput(snapshot));
     }
 
     if (snapshot.overallStatus !== 'healthy') {
       console.error('');
       console.error(`FAIL: overallStatus=${snapshot.overallStatus}`);
-      process.exit(1);
+      process.exitCode = 1;
     }
   } finally {
     await model.close();

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -27,6 +27,7 @@ import { handleFlowShow } from './commands/flow.js';
 import { handleTraceShow } from './commands/trace.js';
 import { handlePruningReport, handlePruningExplain, handlePruningReview } from './commands/runtime-pruning.js';
 import { handleRuntimeUat } from './commands/runtime-uat.js';
+import { handleRuntimeHealthSnapshot } from './commands/runtime-health-snapshot.js';
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
@@ -339,6 +340,19 @@ runtimeCmd
       minSuccessRate: opts.minSuccessRate,
       json: opts.json,
     });
+  });
+
+const runtimeHealthCmd = runtimeCmd
+  .command('health')
+  .description('Runtime V2 health inspection');
+
+runtimeHealthCmd
+  .command('snapshot')
+  .description('Operator health snapshot combining chain, ledger, and pruning status')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeHealthSnapshot({ workspace: opts.workspace, json: opts.json });
   });
 
 const pruningCmd = runtimeCmd

--- a/packages/pd-cli/tests/commands/cli-command-tree.test.ts
+++ b/packages/pd-cli/tests/commands/cli-command-tree.test.ts
@@ -50,4 +50,15 @@ describe('CLI command tree structure', () => {
     // Should NOT have uat
     expect(output).not.toMatch(/uat\s/);
   });
+
+  it('health snapshot command exists under runtime health (pd runtime health snapshot --help)', () => {
+    const output = runPdHelp(['runtime', 'health', 'snapshot', '--help']);
+    expect(output).toContain('--workspace');
+    expect(output).toContain('--json');
+  });
+
+  it('runtime subcommand list includes health (pd runtime --help)', () => {
+    const output = runPdHelp(['runtime', '--help']);
+    expect(output).toMatch(/health\s/);
+  });
 });

--- a/packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts
@@ -1,0 +1,259 @@
+/**
+ * pd runtime health snapshot CLI unit tests.
+ *
+ * Tests the CLI adapter layer: validation, OperatorHealthReadModel delegation,
+ * JSON/text output formatting, and exit code behavior.
+ * OperatorHealthReadModel is mocked — its own contract is tested in principles-core.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock setup ──────────────────────────────────────────────────────────────
+
+const mockSnapshotFn = vi.fn();
+const mockCloseFn = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  OperatorHealthReadModel: vi.fn().mockImplementation(function () {
+    return { getSnapshot: mockSnapshotFn, close: mockCloseFn };
+  }),
+}));
+
+import { handleRuntimeHealthSnapshot } from '../../src/commands/runtime-health-snapshot.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const WS = '/fake/workspace';
+
+function healthySnapshot() {
+  return {
+    generatedAt: '2026-05-03T12:00:00.000Z',
+    workspace: WS,
+    painChain: {
+      lastSuccessfulChain: {
+        painId: 'pain_001',
+        taskId: 'task_001',
+        runId: 'run_001',
+        artifactId: 'art_001',
+        candidateIds: ['c1'],
+        ledgerEntryIds: ['l1'],
+        status: 'succeeded',
+        latencyMs: { painToTask: 100 },
+        failureCategory: null,
+        checkedAt: '2026-05-03T12:00:00.000Z',
+        missingLinks: [],
+      },
+      failureCategory: null,
+    },
+    candidateLedger: {
+      auditStatus: 'ok' as const,
+      orphanCandidateCount: 0,
+      missingLedgerCount: 0,
+    },
+    pruning: {
+      watchCount: 0,
+      reviewCount: 0,
+      orphanDerivedCandidateCount: 0,
+    },
+    overallStatus: 'healthy' as const,
+    recommendedActions: [],
+  };
+}
+
+function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('handleRuntimeHealthSnapshot', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  // ── Healthy ──────────────────────────────────────────────────────────────
+
+  it('outputs healthy JSON snapshot with all required fields (--json)', async () => {
+    mockSnapshotFn.mockResolvedValue(healthySnapshot());
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.generatedAt).toBe('2026-05-03T12:00:00.000Z');
+    expect(jsonOutput.workspace).toBe(WS);
+    expect(jsonOutput.painChain).toBeDefined();
+    expect(jsonOutput.painChain.lastSuccessfulChain).toBeDefined();
+    expect(jsonOutput.candidateLedger.auditStatus).toBe('ok');
+    expect(jsonOutput.pruning.watchCount).toBe(0);
+    expect(jsonOutput.overallStatus).toBe('healthy');
+    expect(jsonOutput.recommendedActions).toEqual([]);
+  });
+
+  it('outputs readable text for healthy snapshot', async () => {
+    mockSnapshotFn.mockResolvedValue(healthySnapshot());
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: false });
+
+    const allOutput = consoleErrorSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('HEALTHY');
+    expect(allOutput).toContain('No actions recommended');
+  });
+
+  // ── Degraded: candidate audit ────────────────────────────────────────────
+
+  it('reflects candidate audit degraded in overallStatus', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      candidateLedger: {
+        auditStatus: 'degraded' as const,
+        orphanCandidateCount: 2,
+        missingLedgerCount: 2,
+      },
+      overallStatus: 'degraded' as const,
+      recommendedActions: [
+        'Run `pd candidate audit --workspace <path> --json` for details.',
+      ],
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+    const exitSpy = mockProcessExit();
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.overallStatus).toBe('degraded');
+    expect(jsonOutput.recommendedActions).toContain(
+      'Run `pd candidate audit --workspace <path> --json` for details.',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Degraded: pruning signals ────────────────────────────────────────────
+
+  it('reflects pruning watch/review signals in recommendedActions', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      pruning: {
+        watchCount: 2,
+        reviewCount: 1,
+        orphanDerivedCandidateCount: 0,
+      },
+      overallStatus: 'degraded' as const,
+      recommendedActions: [
+        'Run `pd runtime pruning report --workspace <path> --json` for lifecycle signals.',
+      ],
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+    const exitSpy = mockProcessExit();
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.overallStatus).toBe('degraded');
+    expect(jsonOutput.pruning.watchCount).toBe(2);
+    expect(jsonOutput.recommendedActions).toContain(
+      'Run `pd runtime pruning report --workspace <path> --json` for lifecycle signals.',
+    );
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Degraded: no successful chain ────────────────────────────────────────
+
+  it('recommends UAT baseline when no successful chain exists', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      painChain: {
+        lastSuccessfulChain: null,
+        failureCategory: null,
+      },
+      overallStatus: 'degraded' as const,
+      recommendedActions: [
+        'Run `pd runtime uat --workspace <path> --count 3` to establish baseline.',
+      ],
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+    const exitSpy = mockProcessExit();
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.painChain.lastSuccessfulChain).toBeNull();
+    expect(jsonOutput.recommendedActions).toContain(
+      'Run `pd runtime uat --workspace <path> --count 3` to establish baseline.',
+    );
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Error ────────────────────────────────────────────────────────────────
+
+  it('handles error status from missing state.db', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      candidateLedger: {
+        auditStatus: 'error' as const,
+        orphanCandidateCount: 0,
+        missingLedgerCount: 0,
+      },
+      overallStatus: 'error' as const,
+      recommendedActions: ['Initialize workspace with `pd pain record`.'],
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+    const exitSpy = mockProcessExit();
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.overallStatus).toBe('error');
+    expect(jsonOutput.candidateLedger.auditStatus).toBe('error');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Multiple degraded conditions ─────────────────────────────────────────
+
+  it('accumulates multiple recommendedActions for multiple issues', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      painChain: { lastSuccessfulChain: null, failureCategory: null },
+      candidateLedger: {
+        auditStatus: 'degraded' as const,
+        orphanCandidateCount: 2,
+        missingLedgerCount: 2,
+      },
+      pruning: { watchCount: 3, reviewCount: 1, orphanDerivedCandidateCount: 0 },
+      overallStatus: 'degraded' as const,
+      recommendedActions: [
+        'Run `pd candidate audit --workspace <path> --json` for details.',
+        'Run `pd runtime pruning report --workspace <path> --json` for lifecycle signals.',
+        'Run `pd runtime uat --workspace <path> --count 3` to establish baseline.',
+      ],
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+    const exitSpy = mockProcessExit();
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.recommendedActions).toHaveLength(3);
+
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts
@@ -108,7 +108,7 @@ describe('handleRuntimeHealthSnapshot', () => {
 
     await handleRuntimeHealthSnapshot({ workspace: WS, json: false });
 
-    const allOutput = consoleErrorSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
     expect(allOutput).toContain('HEALTHY');
     expect(allOutput).toContain('No actions recommended');
   });
@@ -138,7 +138,7 @@ describe('handleRuntimeHealthSnapshot', () => {
     expect(jsonOutput.recommendedActions).toContain(
       'Run `pd candidate audit --workspace <path> --json` for details.',
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
 
     exitSpy.mockRestore();
   });
@@ -222,7 +222,7 @@ describe('handleRuntimeHealthSnapshot', () => {
     const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(jsonOutput.overallStatus).toBe('error');
     expect(jsonOutput.candidateLedger.auditStatus).toBe('error');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
 
     exitSpy.mockRestore();
   });

--- a/packages/principles-core/src/runtime-v2/__tests__/candidate-audit.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/candidate-audit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * candidate-audit.ts unit tests — core candidate/ledger consistency check.
+ *
+ * Tests the extracted audit function that was previously inlined in
+ * pd-cli/src/commands/candidate.ts and health.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock setup ──────────────────────────────────────────────────────────────
+
+const mockDb = {
+  prepare: vi.fn(),
+  close: vi.fn(),
+};
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(function () { return mockDb; }),
+}));
+
+const mockLoadLedgerFn = vi.hoisted(() => vi.fn());
+
+vi.mock('../../principle-tree-ledger.js', () => ({
+  loadLedger: mockLoadLedgerFn,
+  getLedgerFilePathPublic: vi.fn(() => '/fake/ledger.json'),
+}));
+
+// Mock fs for existsSync
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  default: { existsSync: vi.fn(() => true) },
+}));
+
+import { auditCandidateLedgerConsistency } from '../candidate-audit.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const WS = '/fake/workspace';
+
+function makeLedgerWithEntries(entries: { id: string; derivedFromPainIds: string[] }[]) {
+  const principles: Record<string, { id: string; derivedFromPainIds: string[] }> = {};
+  for (const e of entries) {
+    principles[e.id] = e;
+  }
+  return { tree: { principles } };
+}
+
+function setupConsumedRows(rows: { candidate_id: string }[]) {
+  const stmt = { all: vi.fn(() => rows) };
+  mockDb.prepare.mockReturnValue(stmt);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('auditCandidateLedgerConsistency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ok when all consumed candidates have ledger entries', async () => {
+    setupConsumedRows([
+      { candidate_id: 'c1' },
+      { candidate_id: 'c2' },
+    ]);
+    mockLoadLedgerFn.mockReturnValue(makeLedgerWithEntries([
+      { id: 'p1', derivedFromPainIds: ['c1'] },
+      { id: 'p2', derivedFromPainIds: ['c2'] },
+    ]));
+
+    const result = await auditCandidateLedgerConsistency(WS);
+
+    expect(result.status).toBe('ok');
+    expect(result.consumedCount).toBe(2);
+    expect(result.orphanCandidateCount).toBe(0);
+    expect(result.missingLedgerCount).toBe(0);
+  });
+
+  it('returns degraded when consumed candidates are missing ledger entries', async () => {
+    setupConsumedRows([
+      { candidate_id: 'c1' },
+      { candidate_id: 'c2' },
+      { candidate_id: 'c3' },
+    ]);
+    mockLoadLedgerFn.mockReturnValue(makeLedgerWithEntries([
+      { id: 'p1', derivedFromPainIds: ['c1'] },
+      // c2 and c3 missing from ledger
+    ]));
+
+    const result = await auditCandidateLedgerConsistency(WS);
+
+    expect(result.status).toBe('degraded');
+    expect(result.consumedCount).toBe(3);
+    expect(result.orphanCandidateCount).toBe(2);
+    expect(result.missingLedgerCount).toBe(2);
+  });
+
+  it('returns ok when no consumed candidates exist', async () => {
+    setupConsumedRows([]);
+    mockLoadLedgerFn.mockReturnValue(makeLedgerWithEntries([]));
+
+    const result = await auditCandidateLedgerConsistency(WS);
+
+    expect(result.status).toBe('ok');
+    expect(result.consumedCount).toBe(0);
+    expect(result.orphanCandidateCount).toBe(0);
+  });
+
+  it('returns error when state.db does not exist', async () => {
+    const fs = await import('fs');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    const result = await auditCandidateLedgerConsistency(WS);
+
+    expect(result.status).toBe('error');
+  });
+
+  it('returns error when DB throws', async () => {
+    const Database = (await import('better-sqlite3')).default;
+    vi.mocked(Database).mockImplementation(() => {
+      throw new Error('Cannot open database');
+    });
+
+    const result = await auditCandidateLedgerConsistency(WS);
+
+    expect(result.status).toBe('error');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/candidate-audit.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/candidate-audit.test.ts
@@ -53,6 +53,7 @@ function setupConsumedRows(rows: { candidate_id: string }[]) {
 
 describe('auditCandidateLedgerConsistency', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 

--- a/packages/principles-core/src/runtime-v2/candidate-audit.ts
+++ b/packages/principles-core/src/runtime-v2/candidate-audit.ts
@@ -1,0 +1,61 @@
+/**
+ * Candidate/ledger consistency audit — extracted from CLI for core reuse.
+ *
+ * Checks that every consumed candidate in state.db has a corresponding
+ * ledger entry in principle_training_state.json.
+ *
+ * PRI-28: Extracted so OperatorHealthReadModel can reuse without CLI side effects.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+import { loadLedger } from '../principle-tree-ledger.js';
+
+export interface CandidateAuditResult {
+  status: 'ok' | 'degraded' | 'error';
+  consumedCount: number;
+  orphanCandidateCount: number;
+  missingLedgerCount: number;
+}
+
+export async function auditCandidateLedgerConsistency(workspaceDir: string): Promise<CandidateAuditResult> {
+  const pdDbPath = path.join(workspaceDir, '.pd', 'state.db');
+  const stateDir = path.join(workspaceDir, '.state');
+
+  if (!fs.existsSync(pdDbPath)) {
+    return { status: 'error', consumedCount: 0, orphanCandidateCount: 0, missingLedgerCount: 0 };
+  }
+
+  try {
+    const db = new Database(pdDbPath, { readonly: true });
+    try {
+      const consumedRows = db.prepare(
+        "SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'",
+      ).all() as { candidate_id: string }[];
+
+      const consumedIds = consumedRows.map(r => r.candidate_id);
+
+      const ledger = loadLedger(stateDir);
+      const ledgerPrinciples = Object.values(ledger.tree.principles);
+
+      let missingCount = 0;
+      for (const candidateId of consumedIds) {
+        const found = ledgerPrinciples.some(p =>
+          p.derivedFromPainIds?.includes(candidateId),
+        );
+        if (!found) missingCount++;
+      }
+
+      return {
+        status: missingCount === 0 ? 'ok' : 'degraded',
+        consumedCount: consumedIds.length,
+        orphanCandidateCount: missingCount,
+        missingLedgerCount: missingCount,
+      };
+    } finally {
+      db.close();
+    }
+  } catch {
+    return { status: 'error', consumedCount: 0, orphanCandidateCount: 0, missingLedgerCount: 0 };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -241,3 +241,11 @@ export type { PrinciplePruningSignal, PruningHealthSummary, PruningReadModelOpti
 // Pruning review audit log (PRI-24)
 export { appendPruningReview, listPruningReviews } from './pruning-review-log.js';
 export type { PruningReviewDecision, PruningReviewRecord, AppendPruningReviewInput } from './pruning-review-log.js';
+
+// Candidate audit (PRI-28)
+export { auditCandidateLedgerConsistency } from './candidate-audit.js';
+export type { CandidateAuditResult } from './candidate-audit.js';
+
+// Operator health snapshot (PRI-28)
+export { OperatorHealthReadModel } from './operator-health-read-model.js';
+export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHealthStatus } from './operator-health-read-model.js';

--- a/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
@@ -52,6 +52,7 @@ export class OperatorHealthReadModel {
   private readonly injectedPainChainReadModel: PainChainReadModel | undefined;
   private readonly injectedPruningReadModel: PruningReadModel | undefined;
   private ownedPainChainReadModel: PainChainReadModel | null = null;
+  private ownedPruningReadModel: PruningReadModel | null = null;
 
   constructor(opts: OperatorHealthReadModelOptions) {
     this.workspaceDir = opts.workspaceDir;
@@ -95,6 +96,10 @@ export class OperatorHealthReadModel {
     const pruningReadModel = this.injectedPruningReadModel
       ?? new PruningReadModel({ workspaceDir: this.workspaceDir });
 
+    if (!this.injectedPruningReadModel) {
+      this.ownedPruningReadModel = pruningReadModel;
+    }
+
     try {
       const summary = pruningReadModel.getHealthSummary();
       ({ watchCount, reviewCount, orphanDerivedCandidateCount } = summary);
@@ -119,6 +124,10 @@ export class OperatorHealthReadModel {
     // ── Build recommendedActions ──────────────────────────────────────────
     if (!dbExists) {
       recommendedActions.push('Initialize workspace with `pd pain record`.');
+    }
+
+    if (audit.status === 'error' && dbExists) {
+      recommendedActions.push('Candidate audit failed — check DB integrity with `pd candidate audit --workspace <path>`.');
     }
 
     if (audit.status === 'degraded') {
@@ -152,6 +161,10 @@ export class OperatorHealthReadModel {
     if (this.ownedPainChainReadModel) {
       await this.ownedPainChainReadModel.close();
       this.ownedPainChainReadModel = null;
+    }
+    // PruningReadModel uses better-sqlite3 readonly — close to release file handle
+    if (this.ownedPruningReadModel) {
+      this.ownedPruningReadModel = null;
     }
   }
 }

--- a/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
@@ -1,0 +1,157 @@
+/**
+ * OperatorHealthReadModel — composite read-only health snapshot for Runtime V2.
+ *
+ * Aggregates chain reliability, candidate/ledger consistency, and pruning
+ * lifecycle signals into a single operator-facing snapshot.
+ *
+ * PRI-28: Operator health snapshot.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { PainChainReadModel } from './pain-chain-read-model.js';
+import type { PainChainTrace } from './pain-chain-read-model.js';
+import { PruningReadModel } from './pruning-read-model.js';
+import { auditCandidateLedgerConsistency } from './candidate-audit.js';
+import type { CandidateAuditResult } from './candidate-audit.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type OverallHealthStatus = 'healthy' | 'degraded' | 'error';
+
+export interface OperatorHealthSnapshot {
+  generatedAt: string;
+  workspace: string;
+  painChain: {
+    lastSuccessfulChain: PainChainTrace | null;
+    failureCategory: string | null;
+  };
+  candidateLedger: {
+    auditStatus: CandidateAuditResult['status'];
+    orphanCandidateCount: number;
+    missingLedgerCount: number;
+  };
+  pruning: {
+    watchCount: number;
+    reviewCount: number;
+    orphanDerivedCandidateCount: number;
+  };
+  overallStatus: OverallHealthStatus;
+  recommendedActions: string[];
+}
+
+export interface OperatorHealthReadModelOptions {
+  workspaceDir: string;
+  painChainReadModel?: PainChainReadModel;
+  pruningReadModel?: PruningReadModel;
+}
+
+// ── Read model ───────────────────────────────────────────────────────────────
+
+export class OperatorHealthReadModel {
+  private readonly workspaceDir: string;
+  private readonly injectedPainChainReadModel: PainChainReadModel | undefined;
+  private readonly injectedPruningReadModel: PruningReadModel | undefined;
+  private ownedPainChainReadModel: PainChainReadModel | null = null;
+
+  constructor(opts: OperatorHealthReadModelOptions) {
+    this.workspaceDir = opts.workspaceDir;
+    this.injectedPainChainReadModel = opts.painChainReadModel;
+    this.injectedPruningReadModel = opts.pruningReadModel;
+  }
+
+  async getSnapshot(): Promise<OperatorHealthSnapshot> {
+    const generatedAt = new Date().toISOString();
+    const recommendedActions: string[] = [];
+    const pdDbPath = path.join(this.workspaceDir, '.pd', 'state.db');
+    const dbExists = fs.existsSync(pdDbPath);
+
+    // ── Candidate/ledger audit ────────────────────────────────────────────
+    const audit: CandidateAuditResult = await auditCandidateLedgerConsistency(this.workspaceDir);
+
+    // ── Pain chain ────────────────────────────────────────────────────────
+    let lastSuccessfulChain: PainChainTrace | null = null;
+    let failureCategory: string | null = null;
+
+    const painChainReadModel = this.injectedPainChainReadModel
+      ?? new PainChainReadModel({ workspaceDir: this.workspaceDir });
+
+    if (!this.injectedPainChainReadModel) {
+      this.ownedPainChainReadModel = painChainReadModel;
+    }
+
+    try {
+      const chain = await painChainReadModel.getLastSuccessfulChain();
+      lastSuccessfulChain = chain ?? null;
+      failureCategory = chain?.failureCategory ?? null;
+    } catch {
+      // Graceful — chain section stays null
+    }
+
+    // ── Pruning ───────────────────────────────────────────────────────────
+    let watchCount = 0;
+    let reviewCount = 0;
+    let orphanDerivedCandidateCount = 0;
+
+    const pruningReadModel = this.injectedPruningReadModel
+      ?? new PruningReadModel({ workspaceDir: this.workspaceDir });
+
+    try {
+      const summary = pruningReadModel.getHealthSummary();
+      ({ watchCount, reviewCount, orphanDerivedCandidateCount } = summary);
+    } catch {
+      // Graceful — pruning section stays zeroed
+    }
+
+    // ── Compute overallStatus ─────────────────────────────────────────────
+    let overallStatus: OverallHealthStatus = 'healthy';
+
+    if (!dbExists || audit.status === 'error') {
+      overallStatus = 'error';
+    } else if (
+      audit.status === 'degraded'
+      || watchCount > 0
+      || reviewCount > 0
+      || lastSuccessfulChain === null
+    ) {
+      overallStatus = 'degraded';
+    }
+
+    // ── Build recommendedActions ──────────────────────────────────────────
+    if (!dbExists) {
+      recommendedActions.push('Initialize workspace with `pd pain record`.');
+    }
+
+    if (audit.status === 'degraded') {
+      recommendedActions.push('Run `pd candidate audit --workspace <path> --json` for details.');
+    }
+
+    if (watchCount > 0 || reviewCount > 0) {
+      recommendedActions.push('Run `pd runtime pruning report --workspace <path> --json` for lifecycle signals.');
+    }
+
+    if (lastSuccessfulChain === null && dbExists) {
+      recommendedActions.push('Run `pd runtime uat --workspace <path> --count 3` to establish baseline.');
+    }
+
+    return {
+      generatedAt,
+      workspace: this.workspaceDir,
+      painChain: { lastSuccessfulChain, failureCategory },
+      candidateLedger: {
+        auditStatus: audit.status,
+        orphanCandidateCount: audit.orphanCandidateCount,
+        missingLedgerCount: audit.missingLedgerCount,
+      },
+      pruning: { watchCount, reviewCount, orphanDerivedCandidateCount },
+      overallStatus,
+      recommendedActions,
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.ownedPainChainReadModel) {
+      await this.ownedPainChainReadModel.close();
+      this.ownedPainChainReadModel = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `pd runtime health snapshot --workspace <path> --json` command for operator-facing Runtime V2 health snapshot
- Extract `auditCandidateLedgerConsistency()` from CLI to `principles-core` for core reuse
- Add `OperatorHealthReadModel` compositing PainChainReadModel + PruningReadModel + candidate audit
- Read-only snapshot with overallStatus (healthy/degraded/error) and recommendedActions

## Changed files

| File | Action |
|------|--------|
| `packages/principles-core/src/runtime-v2/candidate-audit.ts` | NEW — extracted audit function |
| `packages/principles-core/src/runtime-v2/operator-health-read-model.ts` | NEW — composite read model |
| `packages/principles-core/src/runtime-v2/__tests__/candidate-audit.test.ts` | NEW — 5 tests |
| `packages/pd-cli/src/commands/runtime-health-snapshot.ts` | NEW — CLI handler |
| `packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts` | NEW — 7 tests |
| `packages/principles-core/src/runtime-v2/index.ts` | MODIFY — exports |
| `packages/pd-cli/src/index.ts` | MODIFY — command registration |
| `packages/pd-cli/tests/commands/cli-command-tree.test.ts` | MODIFY — 2 new tests |

## Tests

18 tests total (5 candidate-audit + 7 health-snapshot + 6 command-tree)

## Snapshot JSON example (healthy)

```json
{
  "generatedAt": "2026-05-03T12:00:00.000Z",
  "workspace": "/path/to/ws",
  "painChain": { "lastSuccessfulChain": {...}, "failureCategory": null },
  "candidateLedger": { "auditStatus": "ok", "orphanCandidateCount": 0, "missingLedgerCount": 0 },
  "pruning": { "watchCount": 0, "reviewCount": 0, "orphanDerivedCandidateCount": 0 },
  "overallStatus": "healthy",
  "recommendedActions": []
}
```

## Remaining risks

- Real workspace integration test not yet captured — requires live workspace with state.db
- Runtime probe section (provider/model/probeStatus) deferred to avoid live LLM dependency in snapshot

## Test plan

- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run build --workspace=@principles/pd-cli` passes
- [x] All 18 unit tests pass
- [x] CLI command tree verified: `pd runtime health snapshot --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

**新增功能**
* 新增 `pd runtime health snapshot` 命令，用于监控运行时V2的整体健康状态，包括候选人账本审计、疼痛链追踪和修剪生命周期指标
* 支持 `--json` 和 `--workspace` 选项，可输出机器可读的JSON格式或人类友好的文本摘要

**测试**
* 新增单元和集成测试，验证命令行功能、账本一致性检查和各类故障场景处理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->