### PR TITLE
fix(core): restore PRI-28 exports in index.ts (deleted by PR #452)

### DIFF
--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -241,3 +241,11 @@ export type { PrinciplePruningSignal, PruningHealthSummary, PruningReadModelOpti
 // Pruning review audit log (PRI-24)
 export { appendPruningReview, listPruningReviews } from './pruning-review-log.js';
 export type { PruningReviewDecision, PruningReviewRecord, AppendPruningReviewInput } from './pruning-review-log.js';
+
+// Candidate audit (PRI-28)
+export { auditCandidateLedgerConsistency } from './candidate-audit.js';
+export type { CandidateAuditResult } from './candidate-audit.js';
+
+// Operator health snapshot (PRI-28)
+export { OperatorHealthReadModel } from './operator-health-read-model.js';
+export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHealthStatus } from './operator-health-read-model.js';


### PR DESCRIPTION
## Summary

PR #452 accidentally removed PRI-28 module exports from `runtime-v2/index.ts`:
- `auditCandidateLedgerConsistency`
- `OperatorHealthReadModel`
- Related types

This PR restores those exports.

## Root Cause

PR #452 deleted the source files but also removed the exports from `index.ts`, breaking the public API even though the files were later restored in PR #453.

## Test plan

- [x] Build passes
- [x] 11 PRI-28 tests pass (6 operator-health + 5 candidate-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)