### PR TITLE
fix(openclaw-plugin): add sync-plugin npm script alias

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -38,7 +38,8 @@
     "lint": "eslint \"src/**/*.ts\"",
     "bootstrap-rules": "node scripts/bootstrap-rules.mjs",
     "compile-principles": "node scripts/compile-principles.mjs",
-    "validate-live-path": "tsx scripts/validate-live-path.ts"
+    "validate-live-path": "tsx scripts/validate-live-path.ts",
+    "sync-plugin": "node scripts/sync-plugin.mjs"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Summary
- 添加 `npm run sync-plugin` 作为 `node scripts/sync-plugin.mjs` 的别名
- 消除路径混淆：新用户不需要记住正确的路径

## Test plan
- [x] `npm run sync-plugin` 在 `packages/openclaw-plugin` 目录下验证通过
- [x] CI 所有检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

* **杂项**
  * 添加了新的插件同步脚本命令以支持构建工作流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->