### PR TITLE
feat(core): calibrate diagnostician recommendation taxonomy (PRI-31)

### DIFF
--- a/packages/principles-core/src/runtime-v2/diagnostician-output.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-output.ts
@@ -40,9 +40,9 @@ export type RecommendationKind = Static<typeof RecommendationKindSchema>;
 export const DiagnosticianRecommendationSchema = Type.Object({
   kind: RecommendationKindSchema,
   description: Type.String({ minLength: 1 }),
-  /** Trigger pattern (regex/keywords) — required when kind is 'principle' */
+  /** Trigger pattern (regex/keywords) — required when kind is 'rule' */
   triggerPattern: Type.Optional(Type.String()),
-  /** Action to take when pattern matches — required when kind is 'principle' */
+  /** Action to take when pattern matches — required when kind is 'rule' */
   action: Type.Optional(Type.String()),
   /** Highly abstracted principle (≤200 chars) — required when kind is 'principle'
    * @see MAX_ABSTRACTED_PRINCIPLE_CHARS in runner/default-validator.ts

--- a/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
@@ -134,11 +134,15 @@ Classify into ONE: People | Design | Assumption | Tooling
 - Assumption: wrong assumptions about env/versions/deps
 - Tooling: tool misconfiguration, API changes
 
-PHASE 4 — Principle Extraction:
-Extract ONE highly abstracted principle (max 200 chars, cross-scenario).
-- trigger_pattern: regex/keywords for when this applies
-- action: what to do differently
-- abstracted_principle: one sentence, max 200 chars
+PHASE 4 — Recommendation Taxonomy & Distillation:
+Analyze the root cause and propose actionable recommendations. Classify each recommendation into one of FIVE categories based on the taxonomy below.
+
+TAXONOMY DEFINITIONS:
+1. "rule": Deterministic constraints. Use for specific tool blocks or path protections. A "rule" MUST have a precise 'triggerPattern' and 'action' for physical interception.
+2. "principle": Abstract, reusable wisdom. Use for high-level architectural guidelines. MUST have 'abstractedPrinciple'.
+3. "implementation": Code-level candidate. Use for extremely specific code patches.
+4. "prompt": Context/Skill injection. Use to influence the agent's workflow habits.
+5. "defer": Insufficient evidence. Use for network timeouts or noise.
 
 OUTPUT FORMAT (pure JSON, no markdown):
 {
@@ -151,13 +155,12 @@ OUTPUT FORMAT (pure JSON, no markdown):
   "evidence": [{"sourceRef": "<sourceRef from context or conversationWindow entry>", "note": "<what this shows>"}],
   "recommendations": [
     {
-      "kind": "principle",
-      "description": "<specific action>",
-      "triggerPattern": "<regex/keywords>",
-      "action": "<what to do differently>",
-      "abstractedPrinciple": "<one sentence, max 200 chars>"
-    },
-    {"kind": "rule|implementation|defer", "description": "<specific action>"}
+      "kind": "principle|rule|implementation|prompt|defer",
+      "description": "<Detailed explanation>",
+      "triggerPattern": "<Regex/keywords. REQUIRED if kind is 'rule'>",
+      "action": "<Required behavior change. REQUIRED if kind is 'rule'>",
+      "abstractedPrinciple": "<One sentence summary. REQUIRED if kind is 'principle'>"
+    }
   ],
   "confidence": 0.0-1.0,
   "ambiguityNotes": ["<optional: anything uncertain>"]

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
@@ -194,4 +194,62 @@ describe('DiagnosticianPromptBuilder', () => {
       expect(parsed).not.toHaveProperty('workspaceDir');
     });
   });
+
+  // ── PRI-31: Recommendation taxonomy in prompt ────────────────────────────
+
+  describe('recommendation taxonomy in prompt (PRI-31)', () => {
+    it('prompt contains all 5 taxonomy kinds', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const instruction = result.promptInput.diagnosticInstruction;
+      expect(instruction).toContain('"principle"');
+      expect(instruction).toContain('"rule"');
+      expect(instruction).toContain('"implementation"');
+      expect(instruction).toContain('"prompt"');
+      expect(instruction).toContain('"defer"');
+    });
+
+    it('prompt states rule requires triggerPattern+action', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const instruction = result.promptInput.diagnosticInstruction;
+      expect(instruction).toMatch(/rule.*triggerPattern/i);
+      expect(instruction).toMatch(/rule.*action/i);
+    });
+
+    it('prompt states principle requires abstractedPrinciple', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const instruction = result.promptInput.diagnosticInstruction;
+      expect(instruction).toMatch(/principle.*abstractedPrinciple/i);
+    });
+
+    it('prompt does NOT say "Extract ONE highly abstracted principle"', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const instruction = result.promptInput.diagnosticInstruction;
+      expect(instruction).not.toContain('Extract ONE highly abstracted principle');
+    });
+
+    it('prompt output example is a full DiagnosticianOutputV1 object', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const instruction = result.promptInput.diagnosticInstruction;
+      // Must include top-level DiagnosticianOutputV1 fields in the output format
+      expect(instruction).toContain('"valid"');
+      expect(instruction).toContain('"diagnosisId"');
+      expect(instruction).toContain('"confidence"');
+    });
+
+    it('prompt does not show principle as the only detailed example', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const instruction = result.promptInput.diagnosticInstruction;
+      // All 5 kinds should appear in the taxonomy definitions
+      const taxonomyBlock = (/TAXONOMY[\s\S]*?OUTPUT FORMAT/.exec(instruction))?.[0] ?? '';
+      expect(taxonomyBlock).toContain('"rule"');
+      expect(taxonomyBlock).toContain('"principle"');
+      expect(taxonomyBlock).toContain('"implementation"');
+    });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/default-validator.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/default-validator.test.ts
@@ -283,7 +283,7 @@ describe('recommendations shape', () => {
 
   it('all valid RecommendationKind values pass', async () => {
     const validator = new DefaultDiagnosticianValidator();
-    const kinds = ['rule', 'implementation', 'prompt', 'defer'] as const;
+    const kinds = ['implementation', 'prompt', 'defer'] as const;
     for (const kind of kinds) {
       const result = await validator.validate(
         makeValidOutput({
@@ -293,14 +293,20 @@ describe('recommendations shape', () => {
       );
       assertValid(result);
     }
-    // principle kind requires triggerPattern/action/abstractedPrinciple
+    // rule requires triggerPattern + action
+    const ruleResult = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'rule', description: 'Block unsafe paths', triggerPattern: '^\\.\\./', action: 'Reject path traversal' }],
+      }),
+      'task-001',
+    );
+    assertValid(ruleResult);
+    // principle requires abstractedPrinciple (triggerPattern/action optional)
     const principleResult = await validator.validate(
       makeValidOutput({
         recommendations: [{
           kind: 'principle',
           description: 'Validate tool arguments before execution',
-          triggerPattern: 'tool.*argument',
-          action: 'Use schema validation',
           abstractedPrinciple: 'Validate inputs before execution',
         }],
       }),
@@ -317,8 +323,6 @@ describe('recommendations shape', () => {
         recommendations: [{
           kind: 'principle',
           description: 'Validate tool arguments before execution',
-          triggerPattern: 'tool.*argument',
-          action: 'Use schema validation',
           abstractedPrinciple: longPrinciple,
         }],
       }),
@@ -335,8 +339,6 @@ describe('recommendations shape', () => {
         recommendations: [{
           kind: 'principle',
           description: 'Validate tool arguments before execution',
-          triggerPattern: 'tool.*argument',
-          action: 'Use schema validation',
           abstractedPrinciple: tooLongPrinciple,
         }],
       }),
@@ -354,14 +356,144 @@ describe('recommendations shape', () => {
         recommendations: [{
           kind: 'principle',
           description: 'Validate tool arguments before execution',
-          triggerPattern: 'tool.*argument',
-          action: 'Use schema validation',
           abstractedPrinciple: principle41,
         }],
       }),
       'task-001',
     );
     assertValid(result);
+  });
+});
+
+// ── PRI-31: Recommendation taxonomy calibration ─────────────────────────────
+
+describe('recommendation taxonomy calibration (PRI-31)', () => {
+  // principle: only abstractedPrinciple required
+  it('principle without abstractedPrinciple fails', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'principle', description: 'Use immutable data' }],
+      }),
+      'task-001',
+    );
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('abstractedPrinciple'))).toBe(true);
+  });
+
+  it('principle without triggerPattern passes (not required)', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'principle', description: 'Use immutable data', abstractedPrinciple: 'Prefer immutability' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  it('principle without action passes (not required)', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'principle', description: 'Use immutable data', abstractedPrinciple: 'Prefer immutability' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  it('principle with abstractedPrinciple only passes', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'principle', description: 'Use immutable data', abstractedPrinciple: 'Prefer immutability' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  // rule: triggerPattern + action required
+  it('rule without triggerPattern fails', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'rule', description: 'Block unsafe paths', action: 'Reject path traversal' }],
+      }),
+      'task-001',
+    );
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('triggerPattern'))).toBe(true);
+  });
+
+  it('rule without action fails', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'rule', description: 'Block unsafe paths', triggerPattern: '^\\.\\./' }],
+      }),
+      'task-001',
+    );
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('action'))).toBe(true);
+  });
+
+  it('rule with triggerPattern and action passes', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'rule', description: 'Block unsafe paths', triggerPattern: '^\\.\\./', action: 'Reject path traversal' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  // implementation, prompt, defer: no additional required fields
+  it('implementation minimal (kind+description) passes', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'implementation', description: 'Add try-catch around async call' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  it('prompt minimal (kind+description) passes', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'prompt', description: 'Inject SOP for file operations' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  it('defer minimal (kind+description) passes', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'defer', description: 'Insufficient evidence to determine root cause' }],
+      }),
+      'task-001',
+    );
+    assertValid(result);
+  });
+
+  it('principle abstractedPrinciple over 200 chars fails (taxonomy)', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const result = await validator.validate(
+      makeValidOutput({
+        recommendations: [{ kind: 'principle', description: 'Abstract', abstractedPrinciple: 'x'.repeat(201) }],
+      }),
+      'task-001',
+    );
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('abstractedPrinciple') && e.includes('200'))).toBe(true);
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/runner/default-validator.ts
+++ b/packages/principles-core/src/runtime-v2/runner/default-validator.ts
@@ -124,18 +124,8 @@ export class DefaultDiagnosticianValidator implements DiagnosticianValidator {
         if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
         detailErrors.push(msg);
       }
-      // Principle recommendations require structural fields (triggerPattern, action, abstractedPrinciple)
+      // Principle: only abstractedPrinciple required (triggerPattern/action optional)
       if (rec.kind === 'principle') {
-        if (!rec.triggerPattern || rec.triggerPattern.trim() === '') {
-          const msg = 'recommendations[].triggerPattern is required when kind is "principle"';
-          if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
-          detailErrors.push(msg);
-        }
-        if (!rec.action || rec.action.trim() === '') {
-          const msg = 'recommendations[].action is required when kind is "principle"';
-          if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
-          detailErrors.push(msg);
-        }
         if (!rec.abstractedPrinciple || rec.abstractedPrinciple.trim() === '') {
           const msg = 'recommendations[].abstractedPrinciple is required when kind is "principle"';
           if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
@@ -143,6 +133,19 @@ export class DefaultDiagnosticianValidator implements DiagnosticianValidator {
         }
         if (rec.abstractedPrinciple && rec.abstractedPrinciple.length > MAX_ABSTRACTED_PRINCIPLE_CHARS) {
           const msg = `recommendations[].abstractedPrinciple must be ${MAX_ABSTRACTED_PRINCIPLE_CHARS} characters or fewer`;
+          if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
+          detailErrors.push(msg);
+        }
+      }
+      // Rule: triggerPattern + action required (deterministic constraint)
+      if (rec.kind === 'rule') {
+        if (!rec.triggerPattern || rec.triggerPattern.trim() === '') {
+          const msg = 'recommendations[].triggerPattern is required when kind is "rule"';
+          if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
+          detailErrors.push(msg);
+        }
+        if (!rec.action || rec.action.trim() === '') {
+          const msg = 'recommendations[].action is required when kind is "rule"';
           if (!isVerbose) return buildResult(false, '1 field invalid: recommendations', [msg]);
           detailErrors.push(msg);
         }


### PR DESCRIPTION
## Summary

TDD-driven taxonomy calibration for Diagnostician recommendation output:

**Validator changes (default-validator.ts):**
- `principle`: only `abstractedPrinciple` required (triggerPattern/action now optional)
- `rule`: `triggerPattern` + `action` now required (deterministic constraint)
- `implementation`/`prompt`/`defer`: no additional required fields

**Prompt changes (diagnostician-prompt-builder.ts):**
- Replaced "Extract ONE highly abstracted principle" bias with 5-category taxonomy
- Output example now shows full DiagnosticianOutputV1 structure

**Field comments (diagnostician-output.ts):**
- Updated JSDoc to reflect new requirements (rule=triggerPattern/action, principle=abstractedPrinciple)

## Tests

- 17 new tests (11 validator + 6 prompt-builder)
- 0 regressions (63 validator + 32 prompt-builder all pass)
- Build passes

## Not in scope

- No RuleHost/PrincipleCompiler changes
- No DB schema changes
- No real LLM eval (static taxonomy contract only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 引入推荐分类法，支持五种推荐类型（规则、原则、实施、提示、延迟），每种类型具有特定验证要求。

* **改进**
  * 强化诊断系统的验证逻辑，确保各类推荐符合相应的字段要求。
  * 扩展测试覆盖，验证推荐分类法和输出格式的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->