### PR TITLE
feat(core): define InternalizationRoute model (PRI-43)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -23,6 +23,8 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/rule-host-contracts.ts',
   'internalization/rule-host-helpers.ts',
   'internalization/index.ts',
+  // PRI-43
+  'internalization/internalization-route.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -85,6 +87,8 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     // PRI-28
     'OperatorHealthReadModel',
     'auditCandidateLedgerConsistency',
+    // PRI-43
+    'decideInternalizationRoute',
   ];
 
   for (const name of REQUIRED_EXPORTS) {

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * PRI-43: Core InternalizationRoute model tests
+ *
+ * Verifies that decideInternalizationRoute maps each DiagnosticianRecommendation
+ * kind to the correct internalization pipeline route with proper readiness
+ * and missing-field diagnostics.
+ */
+import { describe, it, expect } from 'vitest';
+import type { DiagnosticianRecommendation } from '../diagnostician-output.js';
+
+function makeRecommendation(
+  overrides: Partial<DiagnosticianRecommendation> & Pick<DiagnosticianRecommendation, 'kind'>,
+): DiagnosticianRecommendation {
+  return {
+    description: 'test recommendation',
+    ...overrides,
+  };
+}
+
+describe('decideInternalizationRoute', () => {
+  // ── principle ──────────────────────────────────────────────────────────────
+
+  it('principle with abstractedPrinciple maps to principle-ledger, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'principle',
+      abstractedPrinciple: 'Avoid mixing concerns in a single module',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('principle-ledger');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  it('principle missing abstractedPrinciple maps to principle-ledger, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'principle' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('principle-ledger');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('abstractedPrinciple');
+  });
+
+  // ── rule ───────────────────────────────────────────────────────────────────
+
+  it('rule with triggerPattern and action maps to rule-candidate, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'rule',
+      triggerPattern: 'git\\s+push\\s+--force',
+      action: 'block and require approval',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  it('rule missing triggerPattern maps to rule-candidate, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'rule',
+      action: 'block and require approval',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('triggerPattern');
+    expect(decision.missingFields).not.toContain('action');
+  });
+
+  it('rule missing action maps to rule-candidate, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'rule',
+      triggerPattern: 'git\\s+push\\s+--force',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('action');
+    expect(decision.missingFields).not.toContain('triggerPattern');
+  });
+
+  it('rule missing both triggerPattern and action has both in missingFields', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'rule' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('triggerPattern');
+    expect(decision.missingFields).toContain('action');
+  });
+
+  // ── implementation ─────────────────────────────────────────────────────────
+
+  it('implementation maps to implementation-candidate, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'implementation' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('implementation-candidate');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  // ── prompt ─────────────────────────────────────────────────────────────────
+
+  it('prompt maps to prompt-injection-candidate, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'prompt' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('prompt-injection-candidate');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  // ── defer ──────────────────────────────────────────────────────────────────
+
+  it('defer maps to deferred, ready=false (never enters executable pipeline)', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'defer' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('deferred');
+    expect(decision.ready).toBe(false);
+    expect(decision.reason).toBeTruthy();
+  });
+
+  // ── defensive: unknown kind ────────────────────────────────────────────────
+
+  it('unknown/invalid kind maps to deferred with reason explaining unrecognized kind', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'unknown_nonsense' as DiagnosticianRecommendation['kind'],
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('deferred');
+    expect(decision.ready).toBe(false);
+    expect(decision.reason).toContain('unknown_nonsense');
+  });
+
+  // ── barrel export ──────────────────────────────────────────────────────────
+
+  it('core barrel exports decideInternalizationRoute', async () => {
+    const mod = (await import('../index.js')) as Record<string, unknown>;
+    expect(mod).toHaveProperty('decideInternalizationRoute');
+    expect(typeof mod.decideInternalizationRoute).toBe('function');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -260,3 +260,7 @@ export type {
 } from './internalization/rule-host-contracts.js';
 export type { RuleHostHelpers } from './internalization/rule-host-helpers.js';
 export { createRuleHostHelpers } from './internalization/rule-host-helpers.js';
+
+// Internalization route model (PRI-43)
+export type { InternalizationRouteKind, InternalizationRouteDecision } from './internalization/internalization-route.js';
+export { decideInternalizationRoute } from './internalization/internalization-route.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -18,3 +18,7 @@ export type {
 // Helpers
 export type { RuleHostHelpers } from './rule-host-helpers.js';
 export { createRuleHostHelpers } from './rule-host-helpers.js';
+
+// Internalization route model (PRI-43)
+export type { InternalizationRouteKind, InternalizationRouteDecision } from './internalization-route.js';
+export { decideInternalizationRoute } from './internalization-route.js';

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
@@ -1,0 +1,147 @@
+/**
+ * Internalization Route Model — Maps recommendation kinds to pipeline routes
+ *
+ * PURPOSE: Pure, deterministic mapping from DiagnosticianRecommendation kinds
+ * to internalization pipeline routes. No I/O, no filesystem, no side effects.
+ *
+ * ROUTES:
+ *   principle-ledger          — wisdom/principle write path
+ *   rule-candidate            — rule compilation pipeline (requires trigger + action)
+ *   implementation-candidate  — code implementation pipeline
+ *   prompt-injection-candidate — prompt/skill injection pipeline
+ *   deferred                  — intentionally skipped, never enters executable pipeline
+ */
+
+import type { DiagnosticianRecommendation, RecommendationKind } from '../diagnostician-output.js';
+
+// ── Route kinds ─────────────────────────────────────────────────────────────
+
+export type InternalizationRouteKind =
+  | 'principle-ledger'
+  | 'rule-candidate'
+  | 'implementation-candidate'
+  | 'prompt-injection-candidate'
+  | 'deferred';
+
+// ── Decision output ─────────────────────────────────────────────────────────
+
+export interface InternalizationRouteDecision {
+  /** Whether this recommendation can enter its next internalization pipeline */
+  ready: boolean;
+  route: InternalizationRouteKind;
+  missingFields: string[];
+  reason: string;
+  nextAction: string;
+}
+
+// ── Canonical kind-to-route mapping ─────────────────────────────────────────
+
+const KIND_ROUTE_MAP: Record<RecommendationKind, InternalizationRouteKind> = {
+  principle: 'principle-ledger',
+  rule: 'rule-candidate',
+  implementation: 'implementation-candidate',
+  prompt: 'prompt-injection-candidate',
+  defer: 'deferred',
+};
+
+// ── Pure decision function ──────────────────────────────────────────────────
+
+export function decideInternalizationRoute(
+  recommendation: DiagnosticianRecommendation,
+): InternalizationRouteDecision {
+  const route = KIND_ROUTE_MAP[recommendation.kind] ?? 'deferred';
+
+  // Handle unknown/invalid kinds
+  if (route === 'deferred' && recommendation.kind !== 'defer') {
+    return {
+      ready: false,
+      route: 'deferred',
+      missingFields: [],
+      reason: `Unrecognized recommendation kind "${recommendation.kind}" — deferred to safe default.`,
+      nextAction: 'Review diagnostician output for unsupported recommendation kind.',
+    };
+  }
+
+  // defer: always not ready, intentionally skips pipeline
+  if (recommendation.kind === 'defer') {
+    return {
+      ready: false,
+      route: 'deferred',
+      missingFields: [],
+      reason: 'Recommendation explicitly deferred — no internalization action required.',
+      nextAction: 'No action needed. Re-evaluate if context changes.',
+    };
+  }
+
+  // principle: requires abstractedPrinciple
+  if (recommendation.kind === 'principle') {
+    const missingFields: string[] = [];
+    if (!recommendation.abstractedPrinciple) {
+      missingFields.push('abstractedPrinciple');
+    }
+    return {
+      ready: missingFields.length === 0,
+      route: 'principle-ledger',
+      missingFields,
+      reason: missingFields.length > 0
+        ? `Principle recommendation incomplete: missing ${missingFields.join(', ')}.`
+        : 'Principle recommendation ready for ledger write path.',
+      nextAction: missingFields.length > 0
+        ? 'Re-run diagnostician with PHASE 4 taxonomy to generate abstractedPrinciple.'
+        : 'Proceed with principle-ledger intake.',
+    };
+  }
+
+  // rule: requires triggerPattern + action
+  if (recommendation.kind === 'rule') {
+    const missingFields: string[] = [];
+    if (!recommendation.triggerPattern) {
+      missingFields.push('triggerPattern');
+    }
+    if (!recommendation.action) {
+      missingFields.push('action');
+    }
+    return {
+      ready: missingFields.length === 0,
+      route: 'rule-candidate',
+      missingFields,
+      reason: missingFields.length > 0
+        ? `Rule recommendation incomplete: missing ${missingFields.join(', ')}.`
+        : 'Rule recommendation ready for candidate pipeline.',
+      nextAction: missingFields.length > 0
+        ? 'Re-run diagnostician with PHASE 4 taxonomy to generate missing rule fields.'
+        : 'Proceed with rule-candidate compilation.',
+    };
+  }
+
+  // implementation: always ready
+  if (recommendation.kind === 'implementation') {
+    return {
+      ready: true,
+      route: 'implementation-candidate',
+      missingFields: [],
+      reason: 'Implementation recommendation ready for candidate pipeline.',
+      nextAction: 'Proceed with implementation-candidate intake and compilation.',
+    };
+  }
+
+  // prompt: always ready
+  if (recommendation.kind === 'prompt') {
+    return {
+      ready: true,
+      route: 'prompt-injection-candidate',
+      missingFields: [],
+      reason: 'Prompt recommendation ready for injection candidate pipeline.',
+      nextAction: 'Proceed with prompt-injection-candidate intake.',
+    };
+  }
+
+  // Exhaustive fallback — TypeScript ensures this is unreachable for valid kinds
+  return {
+    ready: false,
+    route: 'deferred',
+    missingFields: [],
+    reason: `Unhandled recommendation kind "${recommendation.kind}" — deferred to safe default.`,
+    nextAction: 'Review diagnostician output for unsupported recommendation kind.',
+  };
+}


### PR DESCRIPTION
## Summary

- Add pure function `decideInternalizationRoute()` in `@principles/core/runtime-v2/internalization/` that maps each `DiagnosticianRecommendation` kind to an internalization pipeline route
- 5 route kinds: `principle-ledger`, `rule-candidate`, `implementation-candidate`, `prompt-injection-candidate`, `deferred`
- Readiness field (`ready: boolean`) indicates whether the recommendation can enter its next pipeline, with `missingFields` diagnostics for incomplete recommendations
- Defensive handling for unknown/invalid kinds → deferred with diagnostic reason

## Recommendation Kind Mappings

| Kind | Route | Ready When |
|------|-------|------------|
| `principle` | `principle-ledger` | `abstractedPrinciple` present |
| `rule` | `rule-candidate` | `triggerPattern` + `action` present |
| `implementation` | `implementation-candidate` | always |
| `prompt` | `prompt-injection-candidate` | always |
| `defer` | `deferred` | never (intentional skip) |

## Test plan

- [x] 11 unit tests for all route mappings + missing fields + unknown kind + barrel export
- [x] Architecture regression guards: source file existence, barrel export, zero plugin imports
- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run typecheck:openclaw-plugin` — no regressions
- [x] Pre-push hooks pass (lint + build + typecheck)

## Non-Goals

- No plugin behavior changes
- No RuleHost.evaluate() migration
- No PrincipleCompiler migration
- No ledger schema changes
- No CLI command changes (PRI-46)
- No graphify cache changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加国际化路由决策功能，支持多种诊断建议类型的智能路由和验证能力。

* **测试**
  * 新增国际化路由决策的全面测试覆盖，包括各类诊断类型和字段验证场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->