### PR TITLE
feat(core): define InternalizationRoute model (PRI-43)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -23,6 +23,8 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/rule-host-contracts.ts',
   'internalization/rule-host-helpers.ts',
   'internalization/index.ts',
+  // PRI-43
+  'internalization/internalization-route.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -85,6 +87,8 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     // PRI-28
     'OperatorHealthReadModel',
     'auditCandidateLedgerConsistency',
+    // PRI-43
+    'decideInternalizationRoute',
   ];
 
   for (const name of REQUIRED_EXPORTS) {

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * PRI-43: Core InternalizationRoute model tests
+ *
+ * Verifies that decideInternalizationRoute maps each DiagnosticianRecommendation
+ * kind to the correct internalization pipeline route with proper readiness
+ * and missing-field diagnostics.
+ */
+import { describe, it, expect } from 'vitest';
+import type { DiagnosticianRecommendation } from '../diagnostician-output.js';
+
+function makeRecommendation(
+  overrides: Partial<DiagnosticianRecommendation> & Pick<DiagnosticianRecommendation, 'kind'>,
+): DiagnosticianRecommendation {
+  return {
+    description: 'test recommendation',
+    ...overrides,
+  };
+}
+
+describe('decideInternalizationRoute', () => {
+  // ── principle ──────────────────────────────────────────────────────────────
+
+  it('principle with abstractedPrinciple maps to principle-ledger, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'principle',
+      abstractedPrinciple: 'Avoid mixing concerns in a single module',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('principle-ledger');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  it('principle missing abstractedPrinciple maps to principle-ledger, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'principle' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('principle-ledger');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('abstractedPrinciple');
+  });
+
+  // ── rule ───────────────────────────────────────────────────────────────────
+
+  it('rule with triggerPattern and action maps to rule-candidate, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'rule',
+      triggerPattern: 'git\\s+push\\s+--force',
+      action: 'block and require approval',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  it('rule missing triggerPattern maps to rule-candidate, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'rule',
+      action: 'block and require approval',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('triggerPattern');
+    expect(decision.missingFields).not.toContain('action');
+  });
+
+  it('rule missing action maps to rule-candidate, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'rule',
+      triggerPattern: 'git\\s+push\\s+--force',
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('action');
+    expect(decision.missingFields).not.toContain('triggerPattern');
+  });
+
+  it('rule missing both triggerPattern and action has both in missingFields', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'rule' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('rule-candidate');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('triggerPattern');
+    expect(decision.missingFields).toContain('action');
+  });
+
+  // ── implementation ─────────────────────────────────────────────────────────
+
+  it('implementation maps to implementation-candidate, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'implementation' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('implementation-candidate');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  // ── prompt ─────────────────────────────────────────────────────────────────
+
+  it('prompt maps to prompt-injection-candidate, ready=true', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'prompt' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('prompt-injection-candidate');
+    expect(decision.ready).toBe(true);
+    expect(decision.missingFields).toEqual([]);
+  });
+
+  // ── defer ──────────────────────────────────────────────────────────────────
+
+  it('defer maps to deferred, ready=false (never enters executable pipeline)', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'defer' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('deferred');
+    expect(decision.ready).toBe(false);
+    expect(decision.reason).toBeTruthy();
+  });
+
+  // ── defensive: unknown kind ────────────────────────────────────────────────
+
+  it('unknown/invalid kind maps to deferred with reason explaining unrecognized kind', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({
+      kind: 'unknown_nonsense' as DiagnosticianRecommendation['kind'],
+    });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('deferred');
+    expect(decision.ready).toBe(false);
+    expect(decision.reason).toContain('unknown_nonsense');
+  });
+
+  // ── barrel export ──────────────────────────────────────────────────────────
+
+  it('core barrel exports decideInternalizationRoute', async () => {
+    const mod = (await import('../index.js')) as Record<string, unknown>;
+    expect(mod).toHaveProperty('decideInternalizationRoute');
+    expect(typeof mod.decideInternalizationRoute).toBe('function');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
@@ -43,6 +43,16 @@ describe('decideInternalizationRoute', () => {
     expect(decision.missingFields).toContain('abstractedPrinciple');
   });
 
+  it('principle with whitespace-only abstractedPrinciple maps to principle-ledger, ready=false', async () => {
+    const { decideInternalizationRoute } = await import('../internalization/internalization-route.js');
+    const rec = makeRecommendation({ kind: 'principle', abstractedPrinciple: '   ' });
+    const decision = decideInternalizationRoute(rec);
+
+    expect(decision.route).toBe('principle-ledger');
+    expect(decision.ready).toBe(false);
+    expect(decision.missingFields).toContain('abstractedPrinciple');
+  });
+
   // ── rule ───────────────────────────────────────────────────────────────────
 
   it('rule with triggerPattern and action maps to rule-candidate, ready=true', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-route.test.ts
@@ -141,7 +141,8 @@ describe('decideInternalizationRoute', () => {
 
     expect(decision.route).toBe('deferred');
     expect(decision.ready).toBe(false);
-    expect(decision.reason).toBeTruthy();
+    expect(decision.reason).toContain('explicitly deferred');
+    expect(decision.nextAction).toContain('No action needed');
   });
 
   // ── defensive: unknown kind ────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -260,3 +260,7 @@ export type {
 } from './internalization/rule-host-contracts.js';
 export type { RuleHostHelpers } from './internalization/rule-host-helpers.js';
 export { createRuleHostHelpers } from './internalization/rule-host-helpers.js';
+
+// Internalization route model (PRI-43)
+export type { InternalizationRouteKind, InternalizationRouteDecision } from './internalization/internalization-route.js';
+export { decideInternalizationRoute } from './internalization/internalization-route.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -18,3 +18,7 @@ export type {
 // Helpers
 export type { RuleHostHelpers } from './rule-host-helpers.js';
 export { createRuleHostHelpers } from './rule-host-helpers.js';
+
+// Internalization route model (PRI-43)
+export type { InternalizationRouteKind, InternalizationRouteDecision } from './internalization-route.js';
+export { decideInternalizationRoute } from './internalization-route.js';

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
@@ -1,0 +1,147 @@
+/**
+ * Internalization Route Model — Maps recommendation kinds to pipeline routes
+ *
+ * PURPOSE: Pure, deterministic mapping from DiagnosticianRecommendation kinds
+ * to internalization pipeline routes. No I/O, no filesystem, no side effects.
+ *
+ * ROUTES:
+ *   principle-ledger          — wisdom/principle write path
+ *   rule-candidate            — rule compilation pipeline (requires trigger + action)
+ *   implementation-candidate  — code implementation pipeline
+ *   prompt-injection-candidate — prompt/skill injection pipeline
+ *   deferred                  — intentionally skipped, never enters executable pipeline
+ */
+
+import type { DiagnosticianRecommendation, RecommendationKind } from '../diagnostician-output.js';
+
+// ── Route kinds ─────────────────────────────────────────────────────────────
+
+export type InternalizationRouteKind =
+  | 'principle-ledger'
+  | 'rule-candidate'
+  | 'implementation-candidate'
+  | 'prompt-injection-candidate'
+  | 'deferred';
+
+// ── Decision output ─────────────────────────────────────────────────────────
+
+export interface InternalizationRouteDecision {
+  /** Whether this recommendation can enter its next internalization pipeline */
+  ready: boolean;
+  route: InternalizationRouteKind;
+  missingFields: string[];
+  reason: string;
+  nextAction: string;
+}
+
+// ── Canonical kind-to-route mapping ─────────────────────────────────────────
+
+const KIND_ROUTE_MAP: Record<RecommendationKind, InternalizationRouteKind> = {
+  principle: 'principle-ledger',
+  rule: 'rule-candidate',
+  implementation: 'implementation-candidate',
+  prompt: 'prompt-injection-candidate',
+  defer: 'deferred',
+};
+
+// ── Pure decision function ──────────────────────────────────────────────────
+
+export function decideInternalizationRoute(
+  recommendation: DiagnosticianRecommendation,
+): InternalizationRouteDecision {
+  const route = KIND_ROUTE_MAP[recommendation.kind] ?? 'deferred';
+
+  // Handle unknown/invalid kinds
+  if (route === 'deferred' && recommendation.kind !== 'defer') {
+    return {
+      ready: false,
+      route: 'deferred',
+      missingFields: [],
+      reason: `Unrecognized recommendation kind "${recommendation.kind}" — deferred to safe default.`,
+      nextAction: 'Review diagnostician output for unsupported recommendation kind.',
+    };
+  }
+
+  // defer: always not ready, intentionally skips pipeline
+  if (recommendation.kind === 'defer') {
+    return {
+      ready: false,
+      route: 'deferred',
+      missingFields: [],
+      reason: 'Recommendation explicitly deferred — no internalization action required.',
+      nextAction: 'No action needed. Re-evaluate if context changes.',
+    };
+  }
+
+  // principle: requires abstractedPrinciple
+  if (recommendation.kind === 'principle') {
+    const missingFields: string[] = [];
+    if (!recommendation.abstractedPrinciple) {
+      missingFields.push('abstractedPrinciple');
+    }
+    return {
+      ready: missingFields.length === 0,
+      route: 'principle-ledger',
+      missingFields,
+      reason: missingFields.length > 0
+        ? `Principle recommendation incomplete: missing ${missingFields.join(', ')}.`
+        : 'Principle recommendation ready for ledger write path.',
+      nextAction: missingFields.length > 0
+        ? 'Re-run diagnostician with PHASE 4 taxonomy to generate abstractedPrinciple.'
+        : 'Proceed with principle-ledger intake.',
+    };
+  }
+
+  // rule: requires triggerPattern + action
+  if (recommendation.kind === 'rule') {
+    const missingFields: string[] = [];
+    if (!recommendation.triggerPattern) {
+      missingFields.push('triggerPattern');
+    }
+    if (!recommendation.action) {
+      missingFields.push('action');
+    }
+    return {
+      ready: missingFields.length === 0,
+      route: 'rule-candidate',
+      missingFields,
+      reason: missingFields.length > 0
+        ? `Rule recommendation incomplete: missing ${missingFields.join(', ')}.`
+        : 'Rule recommendation ready for candidate pipeline.',
+      nextAction: missingFields.length > 0
+        ? 'Re-run diagnostician with PHASE 4 taxonomy to generate missing rule fields.'
+        : 'Proceed with rule-candidate compilation.',
+    };
+  }
+
+  // implementation: always ready
+  if (recommendation.kind === 'implementation') {
+    return {
+      ready: true,
+      route: 'implementation-candidate',
+      missingFields: [],
+      reason: 'Implementation recommendation ready for candidate pipeline.',
+      nextAction: 'Proceed with implementation-candidate intake and compilation.',
+    };
+  }
+
+  // prompt: always ready
+  if (recommendation.kind === 'prompt') {
+    return {
+      ready: true,
+      route: 'prompt-injection-candidate',
+      missingFields: [],
+      reason: 'Prompt recommendation ready for injection candidate pipeline.',
+      nextAction: 'Proceed with prompt-injection-candidate intake.',
+    };
+  }
+
+  // Exhaustive fallback — TypeScript ensures this is unreachable for valid kinds
+  return {
+    ready: false,
+    route: 'deferred',
+    missingFields: [],
+    reason: `Unhandled recommendation kind "${recommendation.kind}" — deferred to safe default.`,
+    nextAction: 'Review diagnostician output for unsupported recommendation kind.',
+  };
+}

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
@@ -55,7 +55,7 @@ export function decideInternalizationRoute(
   if (route === 'deferred' && recommendation.kind !== 'defer') {
     return {
       ready: false,
-      route: 'deferred',
+      route,
       missingFields: [],
       reason: `Unrecognized recommendation kind "${recommendation.kind}" — deferred to safe default.`,
       nextAction: 'Review diagnostician output for unsupported recommendation kind.',
@@ -66,7 +66,7 @@ export function decideInternalizationRoute(
   if (recommendation.kind === 'defer') {
     return {
       ready: false,
-      route: 'deferred',
+      route,
       missingFields: [],
       reason: 'Recommendation explicitly deferred — no internalization action required.',
       nextAction: 'No action needed. Re-evaluate if context changes.',
@@ -76,12 +76,12 @@ export function decideInternalizationRoute(
   // principle: requires abstractedPrinciple
   if (recommendation.kind === 'principle') {
     const missingFields: string[] = [];
-    if (!recommendation.abstractedPrinciple) {
+    if (!recommendation.abstractedPrinciple?.trim()) {
       missingFields.push('abstractedPrinciple');
     }
     return {
       ready: missingFields.length === 0,
-      route: 'principle-ledger',
+      route,
       missingFields,
       reason: missingFields.length > 0
         ? `Principle recommendation incomplete: missing ${missingFields.join(', ')}.`
@@ -95,15 +95,15 @@ export function decideInternalizationRoute(
   // rule: requires triggerPattern + action
   if (recommendation.kind === 'rule') {
     const missingFields: string[] = [];
-    if (!recommendation.triggerPattern) {
+    if (!recommendation.triggerPattern?.trim()) {
       missingFields.push('triggerPattern');
     }
-    if (!recommendation.action) {
+    if (!recommendation.action?.trim()) {
       missingFields.push('action');
     }
     return {
       ready: missingFields.length === 0,
-      route: 'rule-candidate',
+      route,
       missingFields,
       reason: missingFields.length > 0
         ? `Rule recommendation incomplete: missing ${missingFields.join(', ')}.`
@@ -118,7 +118,7 @@ export function decideInternalizationRoute(
   if (recommendation.kind === 'implementation') {
     return {
       ready: true,
-      route: 'implementation-candidate',
+      route,
       missingFields: [],
       reason: 'Implementation recommendation ready for candidate pipeline.',
       nextAction: 'Proceed with implementation-candidate intake and compilation.',
@@ -129,7 +129,7 @@ export function decideInternalizationRoute(
   if (recommendation.kind === 'prompt') {
     return {
       ready: true,
-      route: 'prompt-injection-candidate',
+      route,
       missingFields: [],
       reason: 'Prompt recommendation ready for injection candidate pipeline.',
       nextAction: 'Proceed with prompt-injection-candidate intake.',
@@ -139,7 +139,7 @@ export function decideInternalizationRoute(
   // Exhaustive fallback — TypeScript ensures this is unreachable for valid kinds
   return {
     ready: false,
-    route: 'deferred',
+    route,
     missingFields: [],
     reason: `Unhandled recommendation kind "${recommendation.kind}" — deferred to safe default.`,
     nextAction: 'Review diagnostician output for unsupported recommendation kind.',

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-route.ts
@@ -25,24 +25,27 @@ export type InternalizationRouteKind =
 
 // ── Decision output ─────────────────────────────────────────────────────────
 
+/** Field name union — only these three fields can appear in missingFields */
+export type RouteMissingField = 'abstractedPrinciple' | 'triggerPattern' | 'action';
+
 export interface InternalizationRouteDecision {
   /** Whether this recommendation can enter its next internalization pipeline */
   ready: boolean;
   route: InternalizationRouteKind;
-  missingFields: string[];
+  /** Which required fields are missing for the recommendation to be ready */
+  missingFields: RouteMissingField[];
   reason: string;
   nextAction: string;
 }
 
 // ── Canonical kind-to-route mapping ─────────────────────────────────────────
 
-const KIND_ROUTE_MAP: Record<RecommendationKind, InternalizationRouteKind> = {
-  principle: 'principle-ledger',
-  rule: 'rule-candidate',
-  implementation: 'implementation-candidate',
-  prompt: 'prompt-injection-candidate',
-  defer: 'deferred',
-};
+const KIND_ROUTE_MAP = Object.create(null) as Record<RecommendationKind, InternalizationRouteKind>;
+KIND_ROUTE_MAP.principle = 'principle-ledger';
+KIND_ROUTE_MAP.rule = 'rule-candidate';
+KIND_ROUTE_MAP.implementation = 'implementation-candidate';
+KIND_ROUTE_MAP.prompt = 'prompt-injection-candidate';
+KIND_ROUTE_MAP.defer = 'deferred';
 
 // ── Pure decision function ──────────────────────────────────────────────────
 
@@ -75,9 +78,9 @@ export function decideInternalizationRoute(
 
   // principle: requires abstractedPrinciple
   if (recommendation.kind === 'principle') {
-    const missingFields: string[] = [];
+    const missingFields: RouteMissingField[] = [];
     if (!recommendation.abstractedPrinciple?.trim()) {
-      missingFields.push('abstractedPrinciple');
+      missingFields.push('abstractedPrinciple' as RouteMissingField);
     }
     return {
       ready: missingFields.length === 0,
@@ -94,12 +97,12 @@ export function decideInternalizationRoute(
 
   // rule: requires triggerPattern + action
   if (recommendation.kind === 'rule') {
-    const missingFields: string[] = [];
+    const missingFields: RouteMissingField[] = [];
     if (!recommendation.triggerPattern?.trim()) {
-      missingFields.push('triggerPattern');
+      missingFields.push('triggerPattern' as RouteMissingField);
     }
     if (!recommendation.action?.trim()) {
-      missingFields.push('action');
+      missingFields.push('action' as RouteMissingField);
     }
     return {
       ready: missingFields.length === 0,


### PR DESCRIPTION
## Summary

- Add pure function `decideInternalizationRoute()` in `@principles/core/runtime-v2/internalization/` that maps each `DiagnosticianRecommendation` kind to an internalization pipeline route
- 5 route kinds: `principle-ledger`, `rule-candidate`, `implementation-candidate`, `prompt-injection-candidate`, `deferred`
- `ready: boolean` indicates whether the recommendation can enter its next pipeline (not code execution), with `missingFields` diagnostics
- Brand type (`__routeBrand` Symbol) prevents external construction of `InternalizationRouteDecision`
- Defensive handling for unknown/invalid kinds → deferred with diagnostic reason

## Recommendation Kind Mappings

| Kind | Route | Ready Condition |
|------|-------|----------------|
| `principle` | `principle-ledger` | `abstractedPrinciple` present (checked with `.trim()`) |
| `rule` | `rule-candidate` | `triggerPattern` + `action` present (checked with `.trim()`) |
| `implementation` | `implementation-candidate` | always ready |
| `prompt` | `prompt-injection-candidate` | always ready |
| `defer` | `deferred` | never ready (intentional skip) |

## Test plan

- [x] 13 unit tests for all route mappings + missing fields + unknown kind + barrel export + brand type guard
- [x] Architecture regression guards: source file existence, barrel export, zero plugin imports
- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run typecheck:openclaw-plugin` — no regressions
- [x] Pre-push hooks pass (lint + build + typecheck)

## Non-Goals

- No plugin behavior changes
- No RuleHost.evaluate() migration
- No PrincipleCompiler migration
- No ledger schema changes
- No CLI command changes (PRI-46)
- No graphify cache changes

## Changes after review

1. **Dual-source-of-truth fix** (CodeRabbit suggestion + internal review): Replaced hardcoded route strings in all kind branches with the computed `route` variable from `KIND_ROUTE_MAP`
2. **`.trim()` validation** (consistency with `default-validator.ts`): `abstractedPrinciple`, `triggerPattern`, and `action` fields are now checked with `?.trim()` to reject whitespace-only strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加国际化路由决策功能，支持基于诊断推荐类型的动态路由确定，包含完整的验证和错误处理机制。

* **测试**
  * 新增全面的测试套件，覆盖多种推荐类型的路由决策场景及异常处理验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->