### PR TITLE
feat(cli): add candidate route inspect command (PRI-46)

### DIFF
--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -492,20 +492,22 @@ export async function handleCandidateRoute(opts: CandidateRouteOptions): Promise
     let recommendation: { kind: string; description: string; triggerPattern?: string; action?: string; abstractedPrinciple?: string } | undefined = undefined;
     let usedFallback = false;
 
-    try {
-      const parsed = JSON.parse(candidate.sourceRecommendationJson);
-      if (parsed?.kind) {
-        recommendation = {
-          kind: parsed.kind,
-          description: parsed.description ?? candidate.description,
-          triggerPattern: parsed.triggerPattern,
-          action: parsed.action,
-          abstractedPrinciple: parsed.abstractedPrinciple,
-        };
-      } else {
-        throw new Error('missing kind');
-      }
-    } catch {
+    if (candidate.sourceRecommendationJson) {
+      try {
+        const parsed = JSON.parse(candidate.sourceRecommendationJson);
+        if (parsed?.kind) {
+          recommendation = {
+            kind: parsed.kind,
+            description: parsed.description ?? candidate.description,
+            triggerPattern: parsed.triggerPattern,
+            action: parsed.action,
+            abstractedPrinciple: parsed.abstractedPrinciple,
+          };
+        }
+      } catch { /* fall through to column fallback */ }
+    }
+
+    if (!recommendation) {
       const row = stateManager.connection.getDb().prepare(
         'SELECT recommendation_kind, trigger_pattern, action, abstracted_principle FROM principle_candidates WHERE candidate_id = ?',
       ).get(opts.candidateId) as

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -7,6 +7,7 @@
  *   pd candidate intake --candidate-id <id> [--workspace <path>] [--json] [--dry-run]
  *   pd candidate audit --workspace <path> [--json]
  *   pd candidate repair --candidate-id <id> --workspace <path> [--json]
+ *   pd candidate route --candidate-id <id> --workspace <path> [--json]
  */
 import { randomUUID } from 'crypto';
 import * as path from 'path';
@@ -18,6 +19,7 @@ import {
   CandidateIntakeError,
   loadLedger,
   getLedgerFilePathPublic,
+  decideInternalizationRoute,
   type LedgerPrincipleEntry,
 } from '@principles/core/runtime-v2';
 import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
@@ -454,6 +456,110 @@ export async function handleCandidateRepair(opts: CandidateRepairOptions): Promi
       console.error(`Repair failed: ${String(err)}`);
     }
     process.exit(1);
+  } finally {
+    await stateManager.close();
+  }
+}
+
+// ── Route (Internalization Inspection) ──────────────────────────────────────
+
+interface CandidateRouteOptions {
+  candidateId: string;
+  workspace?: string;
+  json?: boolean;
+}
+
+/**
+ * pd candidate route --candidate-id <id> --workspace <path> [--json]
+ *
+ * Read-only: shows which internalization pipeline route a candidate will enter,
+ * whether it's ready, and what fields are missing.
+ */
+export async function handleCandidateRoute(opts: CandidateRouteOptions): Promise<void> {
+  const workspaceDir = resolveWorkspaceDir(opts.workspace);
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+
+  try {
+    await stateManager.initialize();
+
+    const candidate = await stateManager.getCandidate(opts.candidateId);
+    if (!candidate) {
+      console.error(`Candidate not found: ${opts.candidateId}`);
+      process.exit(1);
+      return; // unreachable in production, needed for test mocks
+    }
+
+    let recommendation: { kind: string; description: string; triggerPattern?: string; action?: string; abstractedPrinciple?: string } | undefined = undefined;
+    let usedFallback = false;
+
+    try {
+      const parsed = JSON.parse(candidate.sourceRecommendationJson);
+      if (parsed?.kind) {
+        recommendation = {
+          kind: parsed.kind,
+          description: parsed.description ?? candidate.description,
+          triggerPattern: parsed.triggerPattern,
+          action: parsed.action,
+          abstractedPrinciple: parsed.abstractedPrinciple,
+        };
+      } else {
+        throw new Error('missing kind');
+      }
+    } catch {
+      const row = stateManager.connection.getDb().prepare(
+        'SELECT recommendation_kind, trigger_pattern, action, abstracted_principle FROM principle_candidates WHERE candidate_id = ?',
+      ).get(opts.candidateId) as
+        { recommendation_kind: string; trigger_pattern: string | null; action: string | null; abstracted_principle: string | null } | undefined;
+
+      if (row) {
+        recommendation = {
+          kind: row.recommendation_kind,
+          description: candidate.description,
+          triggerPattern: row.trigger_pattern ?? undefined,
+          action: row.action ?? undefined,
+          abstractedPrinciple: row.abstracted_principle ?? undefined,
+        };
+        usedFallback = true;
+      } else {
+        recommendation = {
+          kind: 'defer' as const,
+          description: candidate.description || 'No recommendation data available',
+        };
+      }
+    }
+
+    if (!recommendation) {
+      recommendation = { kind: 'defer', description: candidate.description || 'No recommendation data available' };
+    }
+
+    const decision = decideInternalizationRoute(recommendation as Parameters<typeof decideInternalizationRoute>[0]);
+
+    const result = {
+      candidateId: opts.candidateId,
+      recommendationKind: recommendation.kind,
+      route: decision.route,
+      ready: decision.ready,
+      missingFields: decision.missingFields,
+      reason: decision.reason,
+      nextAction: decision.nextAction,
+      ...(usedFallback && { _meta: { source: 'column_fallback' } }),
+    };
+
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`\nCandidate Route: ${result.candidateId}\n`);
+      console.log(`  Kind:           ${result.recommendationKind}`);
+      console.log(`  Route:          ${result.route}`);
+      console.log(`  Ready:          ${result.ready}`);
+      console.log(`  Missing Fields: ${result.missingFields.length > 0 ? result.missingFields.join(', ') : '(none)'}`);
+      console.log(`  Reason:         ${result.reason}`);
+      console.log(`  Next Action:    ${result.nextAction}`);
+      if (usedFallback) {
+        console.log(`  Source:         column_fallback (source_recommendation_json unavailable)`);
+      }
+      console.log('');
+    }
   } finally {
     await stateManager.close();
   }

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -528,10 +528,6 @@ export async function handleCandidateRoute(opts: CandidateRouteOptions): Promise
       }
     }
 
-    if (!recommendation) {
-      recommendation = { kind: 'defer', description: candidate.description || 'No recommendation data available' };
-    }
-
     const decision = decideInternalizationRoute(recommendation as Parameters<typeof decideInternalizationRoute>[0]);
 
     const result = {

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -28,7 +28,7 @@ import { handleTraceShow } from './commands/trace.js';
 import { handlePruningReport, handlePruningExplain, handlePruningReview } from './commands/runtime-pruning.js';
 import { handleRuntimeHealthSnapshot } from './commands/runtime-health-snapshot.js';
 import { handleRuntimeUat } from './commands/runtime-uat.js';
-import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair } from './commands/candidate.js';
+import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair, handleCandidateRoute } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
 const program = new Command();
@@ -451,6 +451,16 @@ candidateCmd
   .option('--json', 'Output as JSON')
   .action(async (opts) => {
     await handleCandidateRepair(opts);
+  });
+
+candidateCmd
+  .command('route')
+  .description('Show internalization route decision for a candidate')
+  .requiredOption('--candidate-id <id>', 'Candidate ID to inspect')
+  .requiredOption('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output as JSON')
+  .action(async (opts) => {
+    await handleCandidateRoute(opts);
   });
 
 // ── Artifact inspection commands ────────────────────────────────────────────

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -457,7 +457,7 @@ candidateCmd
   .command('route')
   .description('Show internalization route decision for a candidate')
   .requiredOption('--candidate-id <id>', 'Candidate ID to inspect')
-  .requiredOption('-w, --workspace <path>', 'Workspace directory')
+  .option('-w, --workspace <path>', 'Workspace directory')
   .option('--json', 'Output as JSON')
   .action(async (opts) => {
     await handleCandidateRoute(opts);

--- a/packages/pd-cli/tests/commands/candidate-route.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-route.test.ts
@@ -163,7 +163,32 @@ describe('handleCandidateRoute', () => {
     expect(parsed.recommendationKind).toBe('principle');
   });
 
-  // ── 4. Prompt candidate ─────────────────────────────────────────────────
+  // ── 4. Implementation candidate ──────────────────────────────────────────
+
+  it('implementation candidate routes to implementation-candidate', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: JSON.stringify({
+        kind: 'implementation',
+        description: 'Auto-add error boundary to React components',
+      }),
+    }));
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: true,
+      route: 'implementation-candidate',
+      missingFields: [],
+      reason: 'Implementation recommendation ready for candidate pipeline.',
+      nextAction: 'Proceed with implementation-candidate intake and compilation.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-003b', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.route).toBe('implementation-candidate');
+    expect(parsed.ready).toBe(true);
+    expect(parsed.recommendationKind).toBe('implementation');
+  });
+
+  // ── 5. Prompt candidate ─────────────────────────────────────────────────
 
   it('prompt candidate routes to prompt-injection-candidate', async () => {
     mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
@@ -187,7 +212,7 @@ describe('handleCandidateRoute', () => {
     expect(parsed.ready).toBe(true);
   });
 
-  // ── 5. Defer candidate ──────────────────────────────────────────────────
+  // ── 6. Defer candidate ──────────────────────────────────────────────────
 
   it('defer candidate routes to deferred with ready=false', async () => {
     mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
@@ -212,7 +237,7 @@ describe('handleCandidateRoute', () => {
     expect(parsed.reason).toContain('deferred');
   });
 
-  // ── 6. Candidate not found ──────────────────────────────────────────────
+  // ── 7. Candidate not found ──────────────────────────────────────────────
 
   it('candidate not found exits 1 with error message', async () => {
     mockStateManager.getCandidate.mockResolvedValue(null);
@@ -223,7 +248,7 @@ describe('handleCandidateRoute', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  // ── 7. Malformed source_recommendation_json uses column fallback ────────
+  // ── 8. Malformed source_recommendation_json uses column fallback ────────
 
   it('malformed source_recommendation_json falls back to DB columns', async () => {
     mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
@@ -255,7 +280,7 @@ describe('handleCandidateRoute', () => {
     expect(parsed._meta?.source).toBe('column_fallback');
   });
 
-  // ── 8. Text output includes route/ready/missingFields ───────────────────
+  // ── 9. Text output includes route/ready/missingFields ───────────────────
 
   it('text output includes route, ready, and missingFields', async () => {
     mockStateManager.getCandidate.mockResolvedValue(mockCandidate());

--- a/packages/pd-cli/tests/commands/candidate-route.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-route.test.ts
@@ -1,0 +1,278 @@
+/**
+ * PRI-46: pd candidate route — Internalization route inspection tests
+ *
+ * Tests that handleCandidateRoute correctly loads a candidate,
+ * reconstructs the recommendation, calls decideInternalizationRoute,
+ * and outputs the decision as JSON or text.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleCandidateRoute } from '../../src/commands/candidate.js';
+
+// ── Mock setup ──────────────────────────────────────────────────────────────
+
+const { mockStateManager, MockRuntimeStateManager } = vi.hoisted(() => {
+  const mockStateManager = {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getCandidate: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    connection: {
+      getDb: vi.fn(),
+    },
+  };
+
+  function MockRuntimeStateManager(this: any) {
+    return mockStateManager;
+  }
+  MockRuntimeStateManager.prototype = {};
+
+  return { mockStateManager, MockRuntimeStateManager };
+});
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  RuntimeStateManager: MockRuntimeStateManager,
+  decideInternalizationRoute: vi.fn(),
+}));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/test-workspace'),
+}));
+
+import { decideInternalizationRoute } from '@principles/core/runtime-v2';
+
+// ── Test fixtures ───────────────────────────────────────────────────────────
+
+const mockCandidate = (overrides: Partial<{
+  candidateId: string;
+  sourceRecommendationJson: string;
+  description: string;
+}> = {}) => ({
+  candidateId: overrides.candidateId ?? 'cand-001',
+  artifactId: 'art-001',
+  taskId: 'task-001',
+  sourceRunId: 'run-001',
+  title: 'Test candidate',
+  description: overrides.description ?? 'Test recommendation',
+  confidence: 0.85,
+  sourceRecommendationJson: overrides.sourceRecommendationJson ?? JSON.stringify({
+    kind: 'rule',
+    description: 'Block force push',
+    triggerPattern: 'git\\s+push\\s+--force',
+    action: 'block and require approval',
+  }),
+  status: 'pending' as const,
+  createdAt: '2026-05-04T00:00:00.000Z',
+});
+
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+});
+
+afterEach(() => {
+  consoleLogSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+  exitSpy.mockRestore();
+  vi.clearAllMocks();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('handleCandidateRoute', () => {
+  // ── 1. Ready rule candidate ─────────────────────────────────────────────
+
+  it('ready rule candidate outputs JSON with ready=true and route=rule-candidate', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate());
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: true,
+      route: 'rule-candidate',
+      missingFields: [],
+      reason: 'Rule recommendation ready for candidate pipeline.',
+      nextAction: 'Proceed with rule-candidate compilation.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-001', workspace: '/tmp/ws', json: true });
+
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    const jsonOutput = consoleLogSpy.mock.calls.find(call => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.candidateId).toBe('cand-001');
+    expect(parsed.recommendationKind).toBe('rule');
+    expect(parsed.route).toBe('rule-candidate');
+    expect(parsed.ready).toBe(true);
+    expect(parsed.missingFields).toEqual([]);
+  });
+
+  // ── 2. Incomplete rule candidate ────────────────────────────────────────
+
+  it('incomplete rule candidate (missing triggerPattern) outputs ready=false with missingFields', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: JSON.stringify({
+        kind: 'rule',
+        description: 'Incomplete rule',
+        action: 'block',
+      }),
+    }));
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: false,
+      route: 'rule-candidate',
+      missingFields: ['triggerPattern'],
+      reason: 'Rule recommendation incomplete: missing triggerPattern.',
+      nextAction: 'Re-run diagnostician with PHASE 4 taxonomy to generate missing rule fields.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-002', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.ready).toBe(false);
+    expect(parsed.missingFields).toContain('triggerPattern');
+    expect(parsed.route).toBe('rule-candidate');
+  });
+
+  // ── 3. Principle candidate ──────────────────────────────────────────────
+
+  it('principle candidate with abstractedPrinciple routes to principle-ledger', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: JSON.stringify({
+        kind: 'principle',
+        description: 'Avoid mixing concerns',
+        abstractedPrinciple: 'Separate concerns into distinct modules',
+      }),
+    }));
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: true,
+      route: 'principle-ledger',
+      missingFields: [],
+      reason: 'Principle recommendation ready for ledger write path.',
+      nextAction: 'Proceed with principle-ledger intake.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-003', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.route).toBe('principle-ledger');
+    expect(parsed.ready).toBe(true);
+    expect(parsed.recommendationKind).toBe('principle');
+  });
+
+  // ── 4. Prompt candidate ─────────────────────────────────────────────────
+
+  it('prompt candidate routes to prompt-injection-candidate', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: JSON.stringify({
+        kind: 'prompt',
+        description: 'Add safety reminder to system prompt',
+      }),
+    }));
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: true,
+      route: 'prompt-injection-candidate',
+      missingFields: [],
+      reason: 'Prompt recommendation ready for injection candidate pipeline.',
+      nextAction: 'Proceed with prompt-injection-candidate intake.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-004', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.route).toBe('prompt-injection-candidate');
+    expect(parsed.ready).toBe(true);
+  });
+
+  // ── 5. Defer candidate ──────────────────────────────────────────────────
+
+  it('defer candidate routes to deferred with ready=false', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: JSON.stringify({
+        kind: 'defer',
+        description: 'Not actionable yet',
+      }),
+    }));
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: false,
+      route: 'deferred',
+      missingFields: [],
+      reason: 'Recommendation explicitly deferred — no internalization action required.',
+      nextAction: 'No action needed. Re-evaluate if context changes.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-005', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.route).toBe('deferred');
+    expect(parsed.ready).toBe(false);
+    expect(parsed.reason).toContain('deferred');
+  });
+
+  // ── 6. Candidate not found ──────────────────────────────────────────────
+
+  it('candidate not found exits 1 with error message', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(null);
+
+    await handleCandidateRoute({ candidateId: 'nonexistent', workspace: '/tmp/ws', json: true });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  // ── 7. Malformed source_recommendation_json uses column fallback ────────
+
+  it('malformed source_recommendation_json falls back to DB columns', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: 'not-valid-json{{{',
+    }));
+    mockStateManager.connection.getDb.mockReturnValue({
+      prepare: () => ({
+        get: () => ({
+          recommendation_kind: 'implementation',
+          trigger_pattern: null,
+          action: null,
+          abstracted_principle: null,
+        }),
+      }),
+    });
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: true,
+      route: 'implementation-candidate',
+      missingFields: [],
+      reason: 'Implementation recommendation ready for candidate pipeline.',
+      nextAction: 'Proceed with implementation-candidate intake and compilation.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-006', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.route).toBe('implementation-candidate');
+    expect(parsed.ready).toBe(true);
+    expect(parsed._meta?.source).toBe('column_fallback');
+  });
+
+  // ── 8. Text output includes route/ready/missingFields ───────────────────
+
+  it('text output includes route, ready, and missingFields', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate());
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: true,
+      route: 'rule-candidate',
+      missingFields: [],
+      reason: 'Rule recommendation ready for candidate pipeline.',
+      nextAction: 'Proceed with rule-candidate compilation.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-001', workspace: '/tmp/ws', json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(call => call[0]).join('\n');
+    expect(allOutput).toContain('cand-001');
+    expect(allOutput).toContain('rule-candidate');
+    expect(allOutput).toContain('Ready:          true');
+    expect(allOutput).toContain('(none)');
+  });
+});

--- a/packages/pd-cli/tests/commands/candidate-route.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-route.test.ts
@@ -237,7 +237,32 @@ describe('handleCandidateRoute', () => {
     expect(parsed.reason).toContain('deferred');
   });
 
-  // ── 7. Candidate not found ──────────────────────────────────────────────
+  // ── 7. Unknown kind routes to deferred ──────────────────────────────────
+
+  it('unknown recommendation kind routes to deferred', async () => {
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate({
+      sourceRecommendationJson: JSON.stringify({
+        kind: 'unknown_nonsense',
+        description: 'Bad kind',
+      }),
+    }));
+    (decideInternalizationRoute as ReturnType<typeof vi.fn>).mockReturnValue({
+      ready: false,
+      route: 'deferred',
+      missingFields: [],
+      reason: 'Unrecognized recommendation kind "unknown_nonsense" — deferred to safe default.',
+      nextAction: 'Review diagnostician output for unsupported recommendation kind.',
+    });
+
+    await handleCandidateRoute({ candidateId: 'cand-005b', workspace: '/tmp/ws', json: true });
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(parsed.route).toBe('deferred');
+    expect(parsed.ready).toBe(false);
+    expect(parsed.recommendationKind).toBe('unknown_nonsense');
+  });
+
+  // ── 8. Candidate not found ──────────────────────────────────────────────
 
   it('candidate not found exits 1 with error message', async () => {
     mockStateManager.getCandidate.mockResolvedValue(null);


### PR DESCRIPTION
## Summary

- Add `pd candidate route --candidate-id <id> --workspace <path> [--json]` — read-only CLI command for internalization route inspection
- Loads candidate from DB, reconstructs `DiagnosticianRecommendation` (with column fallback for malformed JSON), calls core `decideInternalizationRoute`, outputs route/ready/missingFields/nextAction
- 8 TDD tests covering all 5 recommendation kinds, not-found, malformed JSON fallback, text output

## Command

```
pd candidate route --candidate-id <id> --workspace <path> [--json]
```

### JSON Output Shape
```json
{
  "candidateId": "...",
  "recommendationKind": "rule",
  "route": "rule-candidate",
  "ready": true,
  "missingFields": [],
  "reason": "Rule recommendation ready for candidate pipeline.",
  "nextAction": "Proceed with rule-candidate compilation."
}
```

## Test plan
- [x] 8/8 candidate-route tests pass
- [x] 12/12 core internalization-route tests pass (no regression)
- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run build --workspace=@principles/pd-cli` passes
- [x] `npm run typecheck:openclaw-plugin` passes
- [x] Pre-push hooks (lint, build, verify-merge) pass

## Non-Goals
- No mutation, no DB writes, no ledger changes
- No plugin behavior changes
- No schema changes

Depends on: PRI-43 (merged, PR #467)