### PR TITLE
refactor(core): modularize store layer Phase 3 — M5 extraction + test doubles (PRI-47)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -607,4 +607,15 @@ describe('PRI-47 store modularization Phase 2', () => {
       expect(mod).toHaveProperty(sym);
     }
   });
+
+  it('barrel exports Memory*Store test doubles', async () => {
+    const mod = (await import('../index.js')) as Record<string, unknown>;
+    const memoryStores = [
+      'MemoryTaskStore', 'MemoryRunStore', 'MemoryCommitStore',
+      'MemoryCandidateStore', 'MemoryArtifactStore',
+    ];
+    for (const sym of memoryStores) {
+      expect(mod).toHaveProperty(sym);
+    }
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -320,7 +320,86 @@ describe('PRI-44 principle-compiler core boundary', () => {
   });
 });
 
-// ── pd-cli command boundary guards ─────────────────────────────────────────
+// ── PRI-47: Store layer modularization Phase 3 ──────────────────────────────
+
+describe('PRI-47 store modularization Phase 3', () => {
+  it('store/candidate/index.ts exists and re-exports CandidateStore + SqliteCandidateStore + MemoryCandidateStore', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const indexPath = resolve(__dirname, '..', 'store', 'candidate', 'index.ts');
+    expect(existsSync(indexPath)).toBe(true);
+    const src = readFileSync(indexPath, 'utf-8');
+    expect(src).toContain('CandidateStore');
+    expect(src).toContain('SqliteCandidateStore');
+    expect(src).toContain('MemoryCandidateStore');
+  });
+
+  it('store/artifact/index.ts exists and re-exports ArtifactStore + SqliteArtifactStore + MemoryArtifactStore', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const indexPath = resolve(__dirname, '..', 'store', 'artifact', 'index.ts');
+    expect(existsSync(indexPath)).toBe(true);
+    const src = readFileSync(indexPath, 'utf-8');
+    expect(src).toContain('ArtifactStore');
+    expect(src).toContain('SqliteArtifactStore');
+    expect(src).toContain('MemoryArtifactStore');
+  });
+
+  it('store/commit/index.ts re-exports CommitStore + SqliteCommitStore + MemoryCommitStore', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const indexPath = resolve(__dirname, '..', 'store', 'commit', 'index.ts');
+    const src = readFileSync(indexPath, 'utf-8');
+    expect(src).toContain('CommitStore');
+    expect(src).toContain('SqliteCommitStore');
+    expect(src).toContain('MemoryCommitStore');
+  });
+
+  it('store/task/index.ts re-exports MemoryTaskStore', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const indexPath = resolve(__dirname, '..', 'store', 'task', 'index.ts');
+    const src = readFileSync(indexPath, 'utf-8');
+    expect(src).toContain('MemoryTaskStore');
+  });
+
+  it('store/run/index.ts re-exports MemoryRunStore', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const indexPath = resolve(__dirname, '..', 'store', 'run', 'index.ts');
+    const src = readFileSync(indexPath, 'utf-8');
+    expect(src).toContain('MemoryRunStore');
+  });
+
+  it('RuntimeStateManager has zero inline SQL (no db.prepare calls)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'store', 'runtime-state-manager.ts'), 'utf-8');
+    expect(src).not.toContain('db.prepare');
+  });
+
+  it('Memory*Store test double files exist', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const base = resolve(__dirname, '..', 'store');
+    expect(existsSync(resolve(base, 'task', 'memory-task-store.ts'))).toBe(true);
+    expect(existsSync(resolve(base, 'run', 'memory-run-store.ts'))).toBe(true);
+    expect(existsSync(resolve(base, 'commit', 'memory-commit-store.ts'))).toBe(true);
+    expect(existsSync(resolve(base, 'candidate', 'memory-candidate-store.ts'))).toBe(true);
+    expect(existsSync(resolve(base, 'artifact', 'memory-artifact-store.ts'))).toBe(true);
+  });
+
+  it('Phase 3 M5 types NOT defined inline in runtime-state-manager.ts', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'store', 'runtime-state-manager.ts'), 'utf-8');
+    // CommitRecord, CandidateRecord, ArtifactRecord, ArtifactWithCandidates should be re-exported from submodules
+    expect(src).not.toMatch(/^export interface CommitRecord/m);
+    expect(src).not.toMatch(/^export interface CandidateRecord/m);
+    expect(src).not.toMatch(/^export interface ArtifactRecord/m);
+    expect(src).not.toMatch(/^export interface ArtifactWithCandidates/m);
+  });
+});
 
 describe('pd-cli command boundaries', () => {
   it('pain-record.ts does not import createPainSignalBridge or recordPainSignalObservability', async () => {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -116,6 +116,11 @@ export { CandidateIntakeService, CandidateIntakeServiceOptions } from './candida
 // Store
 export { SqliteTaskStore } from './store/task/sqlite-task-store.js';
 export { SqliteRunStore } from './store/run/sqlite-run-store.js';
+export { MemoryTaskStore } from './store/task/memory-task-store.js';
+export { MemoryRunStore } from './store/run/memory-run-store.js';
+export { MemoryCommitStore } from './store/commit/memory-commit-store.js';
+export { MemoryCandidateStore } from './store/candidate/memory-candidate-store.js';
+export { MemoryArtifactStore } from './store/artifact/memory-artifact-store.js';
 export { SqliteConnection } from './store/sqlite-connection.js';
 export { SqliteTrajectoryLocator } from './store/trajectory/sqlite-trajectory-locator.js';
 export { SqliteHistoryQuery } from './store/history/sqlite-history-query.js';

--- a/packages/principles-core/src/runtime-v2/store/artifact/artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/artifact/artifact-store.ts
@@ -1,0 +1,33 @@
+/**
+ * ArtifactStore — abstract interface for artifact queries.
+ */
+import type { CandidateRecord } from '../candidate/candidate-store.js';
+
+// Re-export CandidateRecord so consumers can import it from this module
+export type { CandidateRecord } from '../candidate/candidate-store.js';
+
+export interface ArtifactRecord {
+  artifactId: string;
+  runId: string;
+  taskId: string;
+  artifactKind: string;
+  contentJson: string;
+  createdAt: string;
+}
+
+export interface ArtifactWithCandidates {
+  artifact: ArtifactRecord;
+  candidates: CandidateRecord[];
+}
+
+export interface ArtifactStore {
+  /**
+   * Returns a single artifact by ID, or null if not found.
+   */
+  getArtifact(artifactId: string): Promise<ArtifactRecord | null>;
+
+  /**
+   * Returns an artifact with its inline candidate array, or null if artifact not found.
+   */
+  getArtifactWithCandidates(artifactId: string): Promise<ArtifactWithCandidates | null>;
+}

--- a/packages/principles-core/src/runtime-v2/store/artifact/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/artifact/index.ts
@@ -1,0 +1,3 @@
+export type { ArtifactRecord, ArtifactWithCandidates, ArtifactStore } from './artifact-store.js';
+export { SqliteArtifactStore } from './sqlite-artifact-store.js';
+export { MemoryArtifactStore } from './memory-artifact-store.js';

--- a/packages/principles-core/src/runtime-v2/store/artifact/memory-artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/artifact/memory-artifact-store.ts
@@ -1,0 +1,33 @@
+/**
+ * ArtifactStore — in-memory test double using a Map.
+ */
+import type { ArtifactRecord, ArtifactWithCandidates, ArtifactStore } from './artifact-store.js';
+import type { CandidateRecord } from '../candidate/candidate-store.js';
+
+export class MemoryArtifactStore implements ArtifactStore {
+  private readonly artifacts = new Map<string, ArtifactRecord>();
+  private readonly candidatesByArtifact = new Map<string, CandidateRecord[]>();
+
+  async getArtifact(artifactId: string): Promise<ArtifactRecord | null> {
+    return this.artifacts.get(artifactId) ?? null;
+  }
+
+  async getArtifactWithCandidates(artifactId: string): Promise<ArtifactWithCandidates | null> {
+    const artifact = this.artifacts.get(artifactId);
+    if (!artifact) return null;
+    return {
+      artifact,
+      candidates: this.candidatesByArtifact.get(artifactId) ?? [],
+    };
+  }
+
+  insert(record: ArtifactRecord, candidates: CandidateRecord[] = []): void {
+    this.artifacts.set(record.artifactId, record);
+    this.candidatesByArtifact.set(record.artifactId, candidates);
+  }
+
+  clear(): void {
+    this.artifacts.clear();
+    this.candidatesByArtifact.clear();
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/artifact/sqlite-artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/artifact/sqlite-artifact-store.ts
@@ -1,0 +1,52 @@
+/**
+ * SQLite implementation of ArtifactStore.
+ */
+import type { SqliteConnection } from '../sqlite-connection.js';
+import type { CandidateRecord } from '../candidate/candidate-store.js';
+import type { ArtifactRecord, ArtifactWithCandidates, ArtifactStore } from './artifact-store.js';
+
+export class SqliteArtifactStore implements ArtifactStore {
+  constructor(private readonly connection: SqliteConnection) {}
+
+  async getArtifact(artifactId: string): Promise<ArtifactRecord | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare(`
+      SELECT artifact_id, run_id, task_id, artifact_kind, content_json, created_at
+      FROM artifacts WHERE artifact_id = ?
+    `).get(artifactId) as { artifact_id: string; run_id: string; task_id: string; artifact_kind: string; content_json: string; created_at: string } | undefined;
+    if (!row) return null;
+    return {
+      artifactId: row.artifact_id,
+      runId: row.run_id,
+      taskId: row.task_id,
+      artifactKind: row.artifact_kind,
+      contentJson: row.content_json,
+      createdAt: row.created_at,
+    };
+  }
+
+  async getArtifactWithCandidates(artifactId: string): Promise<ArtifactWithCandidates | null> {
+    const artifact = await this.getArtifact(artifactId);
+    if (!artifact) return null;
+    const db = this.connection.getDb();
+    const candidateRows = db.prepare(`
+      SELECT candidate_id, artifact_id, task_id, source_run_id, title, description,
+             confidence, source_recommendation_json, status, created_at
+      FROM principle_candidates WHERE artifact_id = ?
+      ORDER BY created_at DESC
+    `).all(artifactId) as { candidate_id: string; artifact_id: string; task_id: string; source_run_id: string; title: string; description: string; confidence: number | null; source_recommendation_json: string; status: string; created_at: string }[];
+    const candidates: CandidateRecord[] = candidateRows.map((r) => ({
+      candidateId: r.candidate_id,
+      artifactId: r.artifact_id,
+      taskId: r.task_id,
+      sourceRunId: r.source_run_id,
+      title: r.title,
+      description: r.description,
+      confidence: r.confidence,
+      sourceRecommendationJson: r.source_recommendation_json,
+      status: r.status as CandidateRecord['status'],
+      createdAt: r.created_at,
+    }));
+    return { artifact, candidates };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/candidate/candidate-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/candidate/candidate-store.ts
@@ -1,0 +1,27 @@
+/**
+ * CandidateStore — abstract interface for principle candidate queries.
+ */
+export interface CandidateRecord {
+  candidateId: string;
+  artifactId: string;
+  taskId: string;
+  sourceRunId: string;
+  title: string;
+  description: string;
+  confidence: number | null;
+  sourceRecommendationJson: string;
+  status: 'pending' | 'consumed' | 'expired';
+  createdAt: string;
+}
+
+export interface CandidateStore {
+  /**
+   * Returns all principle candidates reachable via tasks→runs→commits chain for a given taskId.
+   */
+  getCandidatesByTaskId(taskId: string): Promise<CandidateRecord[]>;
+
+  /**
+   * Returns a single candidate by ID, or null if not found.
+   */
+  getCandidate(candidateId: string): Promise<CandidateRecord | null>;
+}

--- a/packages/principles-core/src/runtime-v2/store/candidate/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/candidate/index.ts
@@ -1,0 +1,3 @@
+export type { CandidateRecord, CandidateStore } from './candidate-store.js';
+export { SqliteCandidateStore } from './sqlite-candidate-store.js';
+export { MemoryCandidateStore } from './memory-candidate-store.js';

--- a/packages/principles-core/src/runtime-v2/store/candidate/memory-candidate-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/candidate/memory-candidate-store.ts
@@ -6,6 +6,12 @@ import type { CandidateRecord, CandidateStore } from './candidate-store.js';
 export class MemoryCandidateStore implements CandidateStore {
   private readonly candidates = new Map<string, CandidateRecord>();
 
+  /**
+   * Returns candidates filtered directly by taskId field.
+   * Note: SQLite version JOINs tasks→runs→commits→candidates.
+   * This test double uses the denormalized taskId field directly,
+   * which is equivalent in normal data flows.
+   */
   async getCandidatesByTaskId(taskId: string): Promise<CandidateRecord[]> {
     return [...this.candidates.values()].filter((c) => c.taskId === taskId);
   }

--- a/packages/principles-core/src/runtime-v2/store/candidate/memory-candidate-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/candidate/memory-candidate-store.ts
@@ -1,0 +1,24 @@
+/**
+ * CandidateStore — in-memory test double using a Map.
+ */
+import type { CandidateRecord, CandidateStore } from './candidate-store.js';
+
+export class MemoryCandidateStore implements CandidateStore {
+  private readonly candidates = new Map<string, CandidateRecord>();
+
+  async getCandidatesByTaskId(taskId: string): Promise<CandidateRecord[]> {
+    return [...this.candidates.values()].filter((c) => c.taskId === taskId);
+  }
+
+  async getCandidate(candidateId: string): Promise<CandidateRecord | null> {
+    return this.candidates.get(candidateId) ?? null;
+  }
+
+  insert(record: CandidateRecord): void {
+    this.candidates.set(record.candidateId, record);
+  }
+
+  clear(): void {
+    this.candidates.clear();
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/candidate/sqlite-candidate-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/candidate/sqlite-candidate-store.ts
@@ -1,0 +1,57 @@
+/**
+ * SQLite implementation of CandidateStore.
+ */
+import type { SqliteConnection } from '../sqlite-connection.js';
+import type { CandidateRecord, CandidateStore } from './candidate-store.js';
+
+export class SqliteCandidateStore implements CandidateStore {
+  constructor(private readonly connection: SqliteConnection) {}
+
+  async getCandidatesByTaskId(taskId: string): Promise<CandidateRecord[]> {
+    const db = this.connection.getDb();
+    const rows = db.prepare(`
+      SELECT pc.candidate_id, pc.artifact_id, pc.task_id, pc.source_run_id,
+             pc.title, pc.description, pc.confidence, pc.status, pc.created_at, pc.source_recommendation_json
+      FROM principle_candidates pc
+      JOIN commits c ON c.artifact_id = pc.artifact_id
+      JOIN runs r ON r.run_id = c.run_id
+      JOIN tasks t ON t.task_id = r.task_id
+      WHERE t.task_id = ?
+      ORDER BY pc.created_at DESC
+    `).all(taskId) as { candidate_id: string; artifact_id: string; task_id: string; source_run_id: string; title: string; description: string; confidence: number | null; status: string; created_at: string; source_recommendation_json: string }[];
+    return rows.map((r) => ({
+      candidateId: r.candidate_id,
+      artifactId: r.artifact_id,
+      taskId: r.task_id,
+      sourceRunId: r.source_run_id,
+      title: r.title,
+      description: r.description,
+      confidence: r.confidence,
+      sourceRecommendationJson: r.source_recommendation_json,
+      status: r.status as CandidateRecord['status'],
+      createdAt: r.created_at,
+    }));
+  }
+
+  async getCandidate(candidateId: string): Promise<CandidateRecord | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare(`
+      SELECT candidate_id, artifact_id, task_id, source_run_id, title, description,
+             confidence, source_recommendation_json, status, created_at
+      FROM principle_candidates WHERE candidate_id = ?
+    `).get(candidateId) as { candidate_id: string; artifact_id: string; task_id: string; source_run_id: string; title: string; description: string; confidence: number | null; source_recommendation_json: string; status: string; created_at: string } | undefined;
+    if (!row) return null;
+    return {
+      candidateId: row.candidate_id,
+      artifactId: row.artifact_id,
+      taskId: row.task_id,
+      sourceRunId: row.source_run_id,
+      title: row.title,
+      description: row.description,
+      confidence: row.confidence,
+      sourceRecommendationJson: row.source_recommendation_json,
+      status: row.status as CandidateRecord['status'],
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/commit/commit-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/commit/commit-store.ts
@@ -1,0 +1,19 @@
+/**
+ * CommitStore — abstract interface for commit record queries.
+ */
+export interface CommitRecord {
+  commitId: string;
+  taskId: string;
+  runId: string;
+  artifactId: string;
+  idempotencyKey: string;
+  status: string;
+  createdAt: string;
+}
+
+export interface CommitStore {
+  /**
+   * Returns the most recent CommitRecord for a task, or null if no commit exists.
+   */
+  getCommitByTaskId(taskId: string): Promise<CommitRecord | null>;
+}

--- a/packages/principles-core/src/runtime-v2/store/commit/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/commit/index.ts
@@ -1,2 +1,6 @@
+export type { CommitRecord } from './commit-store.js';
 export type { DiagnosticianCommitter, CommitInput, CommitResult } from './diagnostician-committer.js';
 export { SqliteDiagnosticianCommitter } from './diagnostician-committer.js';
+export { SqliteCommitStore } from './sqlite-commit-store.js';
+export { MemoryCommitStore } from './memory-commit-store.js';
+export type { CommitStore } from './commit-store.js';

--- a/packages/principles-core/src/runtime-v2/store/commit/memory-commit-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/commit/memory-commit-store.ts
@@ -6,6 +6,11 @@ import type { CommitRecord, CommitStore } from './commit-store.js';
 export class MemoryCommitStore implements CommitStore {
   private readonly commits = new Map<string, CommitRecord>();
 
+  /**
+   * Returns the first commit for the task by insertion order.
+   * Note: SQLite version uses ORDER BY created_at DESC LIMIT 1 (newest first).
+   * This test double returns the first match for simplicity.
+   */
   async getCommitByTaskId(taskId: string): Promise<CommitRecord | null> {
     return [...this.commits.values()].find((c) => c.taskId === taskId) ?? null;
   }

--- a/packages/principles-core/src/runtime-v2/store/commit/memory-commit-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/commit/memory-commit-store.ts
@@ -1,0 +1,20 @@
+/**
+ * CommitStore — in-memory test double using a Map.
+ */
+import type { CommitRecord, CommitStore } from './commit-store.js';
+
+export class MemoryCommitStore implements CommitStore {
+  private readonly commits = new Map<string, CommitRecord>();
+
+  async getCommitByTaskId(taskId: string): Promise<CommitRecord | null> {
+    return [...this.commits.values()].find((c) => c.taskId === taskId) ?? null;
+  }
+
+  insert(record: CommitRecord): void {
+    this.commits.set(record.commitId, record);
+  }
+
+  clear(): void {
+    this.commits.clear();
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/commit/sqlite-commit-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/commit/sqlite-commit-store.ts
@@ -1,0 +1,27 @@
+/**
+ * SQLite implementation of CommitStore.
+ */
+import type { SqliteConnection } from '../sqlite-connection.js';
+import type { CommitRecord, CommitStore } from './commit-store.js';
+
+export class SqliteCommitStore implements CommitStore {
+  constructor(private readonly connection: SqliteConnection) {}
+
+  async getCommitByTaskId(taskId: string): Promise<CommitRecord | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare(`
+      SELECT commit_id, task_id, run_id, artifact_id, idempotency_key, status, created_at
+      FROM commits WHERE task_id = ? ORDER BY created_at DESC LIMIT 1
+    `).get(taskId) as { commit_id: string; task_id: string; run_id: string; artifact_id: string; idempotency_key: string; status: string; created_at: string } | undefined;
+    if (!row) return null;
+    return {
+      commitId: row.commit_id,
+      taskId: row.task_id,
+      runId: row.run_id,
+      artifactId: row.artifact_id,
+      idempotencyKey: row.idempotency_key,
+      status: row.status,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/run/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/run/index.ts
@@ -1,2 +1,3 @@
-export type { RunStore, RunRecord } from './run-store.js';
+export type { RunRecord, RunStore } from './run-store.js';
 export { SqliteRunStore } from './sqlite-run-store.js';
+export { MemoryRunStore } from './memory-run-store.js';

--- a/packages/principles-core/src/runtime-v2/store/run/memory-run-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/run/memory-run-store.ts
@@ -1,0 +1,46 @@
+/**
+ * RunStore — in-memory test double using a Map.
+ */
+import type { RunRecord, RunStore } from './run-store.js';
+
+export class MemoryRunStore implements RunStore {
+  private readonly runs = new Map<string, RunRecord>();
+
+  async createRun(record: Omit<RunRecord, 'createdAt' | 'updatedAt'>): Promise<RunRecord> {
+    const now = new Date().toISOString();
+    const full: RunRecord = { ...record, createdAt: now, updatedAt: now } as RunRecord;
+    this.runs.set(record.runId, full);
+    return full;
+  }
+
+  async listRunsByTask(taskId: string): Promise<RunRecord[]> {
+    return [...this.runs.values()].filter((r) => r.taskId === taskId);
+  }
+
+  async getRun(runId: string): Promise<RunRecord | null> {
+    return this.runs.get(runId) ?? null;
+  }
+
+  async updateRun(
+    runId: string,
+    patch: Partial<Pick<RunRecord, 'endedAt' | 'reason' | 'outputRef' | 'outputPayload' | 'errorCategory' | 'executionStatus'>>,
+  ): Promise<RunRecord> {
+    const existing = this.runs.get(runId);
+    if (!existing) throw new Error(`Run not found: ${runId}`);
+    const updated: RunRecord = { ...existing, ...patch };
+    this.runs.set(runId, updated);
+    return updated;
+  }
+
+  async deleteRun(runId: string): Promise<boolean> {
+    return this.runs.delete(runId);
+  }
+
+  insert(record: RunRecord): void {
+    this.runs.set(record.runId, record);
+  }
+
+  clear(): void {
+    this.runs.clear();
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
@@ -32,6 +32,20 @@ import { SqliteConnection as SqliteConnectionClass } from './sqlite-connection.j
 import { DefaultLeaseManager } from './lifecycle/lease-manager.js';
 import { DefaultRetryPolicy } from './lifecycle/retry-policy.js';
 import { DefaultRecoverySweep } from './lifecycle/recovery-sweep.js';
+import { SqliteCommitStore } from './commit/sqlite-commit-store.js';
+import { SqliteCandidateStore } from './candidate/sqlite-candidate-store.js';
+import { SqliteArtifactStore } from './artifact/sqlite-artifact-store.js';
+import type { CommitStore } from './commit/commit-store.js';
+import type { CandidateStore } from './candidate/candidate-store.js';
+import type { ArtifactStore } from './artifact/artifact-store.js';
+import type { CommitRecord } from './commit/commit-store.js';
+import type { CandidateRecord } from './candidate/candidate-store.js';
+import type { ArtifactRecord, ArtifactWithCandidates } from './artifact/artifact-store.js';
+
+// Re-export M5 types for backward compatibility
+export type { CommitRecord } from './commit/commit-store.js';
+export type { CandidateRecord } from './candidate/candidate-store.js';
+export type { ArtifactRecord, ArtifactWithCandidates } from './artifact/artifact-store.js';
 
 // ── Options ──────────────────────────────────────────────────────────────────
 
@@ -44,51 +58,15 @@ export interface RuntimeStateManagerOptions {
   retryPolicyConfig?: RetryPolicyConfig;
 }
 
-// ── M5 Query Result Types ─────────────────────────────────────────────────────
-
-export interface CommitRecord {
-  commitId: string;
-  taskId: string;
-  runId: string;
-  artifactId: string;
-  idempotencyKey: string;
-  status: string;
-  createdAt: string;
-}
-
-export interface CandidateRecord {
-  candidateId: string;
-  artifactId: string;
-  taskId: string;
-  sourceRunId: string;
-  title: string;
-  description: string;
-  confidence: number | null;
-  sourceRecommendationJson: string;
-  status: 'pending' | 'consumed' | 'expired';
-  createdAt: string;
-}
-
-export interface ArtifactRecord {
-  artifactId: string;
-  runId: string;
-  taskId: string;
-  artifactKind: string;
-  contentJson: string;
-  createdAt: string;
-}
-
-export interface ArtifactWithCandidates {
-  artifact: ArtifactRecord;
-  candidates: CandidateRecord[];
-}
-
 // ── RuntimeStateManager ──────────────────────────────────────────────────────
 
 export class RuntimeStateManager {
   private _connection!: SqliteConnection;
   private _taskStore!: TaskStore;
   private _runStore!: RunStore;
+  private _commitStore!: CommitStore;
+  private _candidateStore!: CandidateStore;
+  private _artifactStore!: ArtifactStore;
   private leaseManager!: LeaseManager;
   private retryPolicy!: RetryPolicy;
   private recoverySweep!: RecoverySweep;
@@ -108,6 +86,9 @@ export class RuntimeStateManager {
     this._connection = new SqliteConnectionClass(this.options.workspaceDir);
     this._taskStore = new SqliteTaskStore(this._connection);
     this._runStore = new SqliteRunStore(this._connection);
+    this._commitStore = new SqliteCommitStore(this._connection);
+    this._candidateStore = new SqliteCandidateStore(this._connection);
+    this._artifactStore = new SqliteArtifactStore(this._connection);
 
     this.retryPolicy = new DefaultRetryPolicy(this.options.retryPolicyConfig);
 
@@ -228,7 +209,7 @@ export class RuntimeStateManager {
     return this.leaseManager.isLeaseExpired(task);
   }
 
-  // ── Task completion events ────────────────────────────────────────────────
+  // ── Task completion events ───────────────────────────────────────────────
 
   /** Mark a task as succeeded and emit task_succeeded event. */
   async markTaskSucceeded(taskId: string, resultRef?: string): Promise<TaskRecord> {
@@ -372,76 +353,31 @@ export class RuntimeStateManager {
     return this.retryPolicy;
   }
 
-  // ── M5 Query methods ───────────────────────────────────────────────────────
+  // ── M5 Query methods (delegated to store modules) ────────────────────────
 
-  /** Returns the most recent CommitRecord for a task, or null if no commit exists. */
   async getCommitByTaskId(taskId: string): Promise<CommitRecord | null> {
     this.assertInitialized();
-    const db = this._connection.getDb();
-    const row = db.prepare(`
-      SELECT commit_id, task_id, run_id, artifact_id, idempotency_key, status, created_at
-      FROM commits WHERE task_id = ? ORDER BY created_at DESC LIMIT 1
-    `).get(taskId) as { commit_id: string; task_id: string; run_id: string; artifact_id: string; idempotency_key: string; status: string; created_at: string } | undefined;
-    if (!row) return null;
-    return { commitId: row.commit_id, taskId: row.task_id, runId: row.run_id, artifactId: row.artifact_id, idempotencyKey: row.idempotency_key, status: row.status, createdAt: row.created_at };
+    return this._commitStore.getCommitByTaskId(taskId);
   }
 
-  /** Returns all principle candidates reachable via tasks→runs→commits chain for a given taskId. */
   async getCandidatesByTaskId(taskId: string): Promise<CandidateRecord[]> {
     this.assertInitialized();
-    const db = this._connection.getDb();
-    const rows = db.prepare(`
-      SELECT pc.candidate_id, pc.artifact_id, pc.task_id, pc.source_run_id,
-             pc.title, pc.description, pc.confidence, pc.status, pc.created_at, pc.source_recommendation_json
-      FROM principle_candidates pc
-      JOIN commits c ON c.artifact_id = pc.artifact_id
-      JOIN runs r ON r.run_id = c.run_id
-      JOIN tasks t ON t.task_id = r.task_id
-      WHERE t.task_id = ?
-      ORDER BY pc.created_at DESC
-    `).all(taskId) as { candidate_id: string; artifact_id: string; task_id: string; source_run_id: string; title: string; description: string; confidence: number | null; status: string; created_at: string; source_recommendation_json: string }[];
-    return rows.map((r) => ({ candidateId: r.candidate_id, artifactId: r.artifact_id, taskId: r.task_id, sourceRunId: r.source_run_id, title: r.title, description: r.description, confidence: r.confidence, sourceRecommendationJson: r.source_recommendation_json, status: r.status as CandidateRecord['status'], createdAt: r.created_at }));
+    return this._candidateStore.getCandidatesByTaskId(taskId);
   }
 
-  /** Returns a single candidate by ID, or null if not found. */
   async getCandidate(candidateId: string): Promise<CandidateRecord | null> {
     this.assertInitialized();
-    const db = this._connection.getDb();
-    const row = db.prepare(`
-      SELECT candidate_id, artifact_id, task_id, source_run_id, title, description,
-             confidence, source_recommendation_json, status, created_at
-      FROM principle_candidates WHERE candidate_id = ?
-    `).get(candidateId) as { candidate_id: string; artifact_id: string; task_id: string; source_run_id: string; title: string; description: string; confidence: number | null; source_recommendation_json: string; status: string; created_at: string } | undefined;
-    if (!row) return null;
-    return { candidateId: row.candidate_id, artifactId: row.artifact_id, taskId: row.task_id, sourceRunId: row.source_run_id, title: row.title, description: row.description, confidence: row.confidence, sourceRecommendationJson: row.source_recommendation_json, status: row.status as CandidateRecord['status'], createdAt: row.created_at };
+    return this._candidateStore.getCandidate(candidateId);
   }
 
-  /** Returns a single artifact by ID, or null if not found. */
   async getArtifact(artifactId: string): Promise<ArtifactRecord | null> {
     this.assertInitialized();
-    const db = this._connection.getDb();
-    const row = db.prepare(`
-      SELECT artifact_id, run_id, task_id, artifact_kind, content_json, created_at
-      FROM artifacts WHERE artifact_id = ?
-    `).get(artifactId) as { artifact_id: string; run_id: string; task_id: string; artifact_kind: string; content_json: string; created_at: string } | undefined;
-    if (!row) return null;
-    return { artifactId: row.artifact_id, runId: row.run_id, taskId: row.task_id, artifactKind: row.artifact_kind, contentJson: row.content_json, createdAt: row.created_at };
+    return this._artifactStore.getArtifact(artifactId);
   }
 
-  /** Returns an artifact with its inline candidate array, or null if artifact not found. */
   async getArtifactWithCandidates(artifactId: string): Promise<ArtifactWithCandidates | null> {
     this.assertInitialized();
-    const artifact = await this.getArtifact(artifactId);
-    if (!artifact) return null;
-    const db = this._connection.getDb();
-    const rows = db.prepare(`
-      SELECT candidate_id, artifact_id, task_id, source_run_id, title, description,
-             confidence, source_recommendation_json, status, created_at
-      FROM principle_candidates WHERE artifact_id = ?
-      ORDER BY created_at DESC
-    `).all(artifactId) as { candidate_id: string; artifact_id: string; task_id: string; source_run_id: string; title: string; description: string; confidence: number | null; source_recommendation_json: string; status: string; created_at: string }[];
-    const candidates: CandidateRecord[] = rows.map((r) => ({ candidateId: r.candidate_id, artifactId: r.artifact_id, taskId: r.task_id, sourceRunId: r.source_run_id, title: r.title, description: r.description, confidence: r.confidence, sourceRecommendationJson: r.source_recommendation_json, status: r.status as CandidateRecord['status'], createdAt: r.created_at }));
-    return { artifact, candidates };
+    return this._artifactStore.getArtifactWithCandidates(artifactId);
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/store/task/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/task/index.ts
@@ -1,2 +1,3 @@
 export type { TaskStore, TaskStoreFilter, TaskStoreUpdatePatch } from './task-store.js';
 export { SqliteTaskStore } from './sqlite-task-store.js';
+export { MemoryTaskStore } from './memory-task-store.js';

--- a/packages/principles-core/src/runtime-v2/store/task/memory-task-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/task/memory-task-store.ts
@@ -1,0 +1,51 @@
+/**
+ * TaskStore — in-memory test double using a Map.
+ */
+import type { TaskRecord } from '../../task-status.js';
+import type { TaskStore, TaskStoreFilter, TaskStoreUpdatePatch } from './task-store.js';
+
+export class MemoryTaskStore implements TaskStore {
+  private readonly tasks = new Map<string, TaskRecord>();
+
+  async createTask(record: Omit<TaskRecord, 'createdAt' | 'updatedAt'> & { diagnosticJson?: string }): Promise<TaskRecord> {
+    const now = new Date().toISOString();
+    const full: TaskRecord = {
+      ...record,
+      createdAt: now,
+      updatedAt: now,
+    } as TaskRecord;
+    this.tasks.set(record.taskId, full);
+    return full;
+  }
+
+  async getTask(taskId: string): Promise<TaskRecord | null> {
+    return this.tasks.get(taskId) ?? null;
+  }
+
+  async updateTask(taskId: string, patch: TaskStoreUpdatePatch): Promise<TaskRecord> {
+    const existing = this.tasks.get(taskId);
+    if (!existing) throw new Error(`Task not found: ${taskId}`);
+    const updated: TaskRecord = {
+      ...existing,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    } as TaskRecord;
+    this.tasks.set(taskId, updated);
+    return updated;
+  }
+
+  async listTasks(filter?: TaskStoreFilter): Promise<TaskRecord[]> {
+    let results = [...this.tasks.values()];
+    if (filter?.status) results = results.filter((t) => t.status === filter.status);
+    if (filter?.taskKind) results = results.filter((t) => t.taskKind === filter.taskKind);
+    return results;
+  }
+
+  async deleteTask(taskId: string): Promise<boolean> {
+    return this.tasks.delete(taskId);
+  }
+
+  clear(): void {
+    this.tasks.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3 extracts the 5 inline SQL query methods (M5) from `RuntimeStateManager` into dedicated store modules with clean interface/impl separation:

- `store/commit/`: `CommitStore` interface + `SqliteCommitStore` + `MemoryCommitStore`
- `store/candidate/`: `CandidateStore` interface + `SqliteCandidateStore` + `MemoryCandidateStore`
- `store/artifact/`: `ArtifactStore` interface + `SqliteArtifactStore` + `MemoryArtifactStore`

M5 types (`CommitRecord`, `CandidateRecord`, `ArtifactRecord`, `ArtifactWithCandidates`) now live in their respective store modules and are re-exported from `RuntimeStateManager` for backward compatibility.

Added `Memory*Store` in-memory test doubles for all 5 store interfaces (useful for unit tests without SQLite).

Architecture regression guards updated for Phase 3 boundaries.

## Test plan

- [x] Store tests: 190 pass
- [x] Architecture regression: 77 pass  
- [x] Core build: pass
- [x] Plugin typecheck: pass
- [x] pd-cli build: pass

## Verification

```bash
npm run build --workspace=@principles/core
npx vitest run packages/principles-core/src/runtime-v2/store/
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
npm run typecheck:openclaw-plugin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化运行时状态管理架构，将数据存储层进行模块化组织。

* **测试**
  * 添加架构回归测试，确保存储层模块组织符合预期标准。

* **功能改进**
  * 提供内存存储实现以支持测试场景，改善代码可测试性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->