### PR TITLE
fix(test): add recommendation_kind filter to m5-05 assertion 5 SQL query

### DIFF
--- a/packages/principles-core/src/runtime-v2/runner/__tests__/m5-05-e2e.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/m5-05-e2e.test.ts
@@ -266,8 +266,8 @@ describe('E2E m5-05', () => {
       // E2EV-01 assertion 5: candidates exist in DB (D-07)
       // Output has 2 kind='principle' recommendations → expect 2 candidate rows
       const candidateRows = db.prepare(
-        'SELECT * FROM principle_candidates WHERE artifact_id = ? AND status = ?',
-      ).all(artifactId, PENDING_STATUS) as { candidate_id: string; description: string }[];
+        'SELECT * FROM principle_candidates WHERE artifact_id = ? AND status = ? AND recommendation_kind = ?',
+      ).all(artifactId, PENDING_STATUS, 'principle') as { candidate_id: string; description: string }[];
       expect(candidateRows).toHaveLength(2);
       expect(candidateRows.every((c) => c.description.length > 0)).toBe(true);
 


### PR DESCRIPTION
PRI-31 updated diagnostician-committer to persist all 5 taxonomy kinds, not only 'principle'. candidateCount assertions were correctly updated from 2 to 3, but E2EV-01 assertion 5 SQL query was missed — it selected all candidates (now 3 rows) while asserting toHaveLength(2).

Fix: add AND recommendation_kind = 'principle' to match the comment intent (verify 2 principle-kind candidate rows).

- vitest m5-05: 4/4 passed
- verify:merge (lint + build + typecheck): all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 优化了数据库断言的过滤条件，现在更精确地验证候选项数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->