### PR TITLE
refactor(core): extract routing-policy.ts to @principles/core (PRI-54)

### DIFF
--- a/packages/openclaw-plugin/src/commands/evolution-status.ts
+++ b/packages/openclaw-plugin/src/commands/evolution-status.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import type { EvolutionReducerImpl } from '../core/evolution-reducer.js';
-import type { InternalizationRouteRecommendation } from '../core/principle-internalization/internalization-routing-policy.js';
+import type { LifecycleRouteRecommendation } from '../core/principle-internalization/internalization-routing-policy.js';
 import { WorkflowFunnelLoader } from '../core/workflow-funnel-loader.js';
 import { resolvePdPath } from '../core/paths.js';
 import { WorkspaceContext } from '../core/workspace-context.js';
@@ -33,7 +33,7 @@ function formatSources(
 }
 
 function formatRouteRecommendations(
-  recommendations: InternalizationRouteRecommendation[],
+  recommendations: LifecycleRouteRecommendation[],
   emptyLabel: string,
 ): string {
   if (recommendations.length === 0) {
@@ -57,7 +57,7 @@ function buildEnglishOutput(
   warnings: string[],
   stats: ReturnType<EvolutionReducerImpl['getStats']>,
   summary: ReturnType<typeof RuntimeSummaryService.getSummary>,
-  recommendations: InternalizationRouteRecommendation[],
+  recommendations: LifecycleRouteRecommendation[],
 ): string {
   const lines: string[] = [
     'Evolution Status',
@@ -129,7 +129,7 @@ function buildChineseOutput(
   warnings: string[],
   stats: ReturnType<EvolutionReducerImpl['getStats']>,
   summary: ReturnType<typeof RuntimeSummaryService.getSummary>,
-  recommendations: InternalizationRouteRecommendation[],
+  recommendations: LifecycleRouteRecommendation[],
 ): string {
   const lines: string[] = [
     '进化状态',

--- a/packages/openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts
+++ b/packages/openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts
@@ -1,208 +1,36 @@
-import type { PrinciplePriority, PrincipleEvaluability, RuleType } from '../../types/principle-tree-schema.js';
-import type { PrincipleLifecycleEvidence } from './lifecycle-read-model.js';
-import {
-  computePrincipleAdherence,
-  computeRuleMetrics,
-  type PrincipleAdherenceResult,
-  type RuleMetricResult,
-} from './lifecycle-metrics.js';
+/**
+ * Internalization Routing Policy — Re-exported from @principles/core (PRI-54)
+ *
+ * Canonical definitions moved to:
+ *   packages/principles-core/src/runtime-v2/internalization/routing-policy.ts
+ *
+ * Types renamed to avoid conflict with InternalizationRouteKind (PRI-43):
+ *   InternalizationRoute → LifecycleRoute
+ *   InternalizationRouteRecommendation → LifecycleRouteRecommendation
+ *   InternalizationRouteEvidenceSummary → LifecycleRouteEvidenceSummary
+ *   recommendInternalizationRoute → recommendLifecycleRoute
+ */
 
-export type InternalizationRoute = 'skill' | 'code' | 'defer';
+import type {
+  LifecycleRoute,
+  LifecycleRouteEvidenceSummary,
+  LifecycleRouteRecommendation,
+} from '@principles/core/runtime-v2';
+import { recommendLifecycleRoute } from '@principles/core/runtime-v2';
 
-export interface InternalizationRouteEvidenceSummary {
-  replayReportCount: number;
-  activeImplementationCount: number;
-  candidateImplementationCount: number;
-  repeatedErrorSignal: number;
-  averageRuleCoverage: number;
-  averageFalsePositiveRate: number;
-  highestRuleCoverageGap: number;
-  dominantRuleType: RuleType | 'mixed';
+export type {
+  LifecycleRoute,
+  LifecycleRouteEvidenceSummary,
+  LifecycleRouteRecommendation,
 }
+export { recommendLifecycleRoute };
 
-export interface InternalizationRouteRecommendation {
-  principleId: string;
-  route: InternalizationRoute;
-  confidence: number;
-  reasonCodes: string[];
-  evidenceSummary: InternalizationRouteEvidenceSummary;
-  nextAction: string;
-}
-
-function clampToPercentage(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.max(0, Math.min(100, Number(value.toFixed(2))));
-}
-
-function dominantRuleType(principle: PrincipleLifecycleEvidence): RuleType | 'mixed' {
-  if (principle.rules.length === 0) {
-    return 'mixed';
-  }
-
-  const distinctTypes = Array.from(new Set(principle.rules.map((rule) => rule.rule.type)));
-  return distinctTypes.length === 1 ? distinctTypes[0] : 'mixed';
-}
-
-function averageCoverageGap(ruleMetrics: Record<string, RuleMetricResult>): number {
-  const coverageGaps = Object.values(ruleMetrics).map((metrics) => Math.max(0, 100 - metrics.coverageRate));
-
-  if (coverageGaps.length === 0) {
-    return 0;
-  }
-
-  return clampToPercentage(
-    coverageGaps.reduce((sum, gap) => sum + gap, 0) / coverageGaps.length,
-  );
-}
-
-function isHighRisk(priority: PrinciplePriority, evaluability: PrincipleEvaluability): boolean {
-  return priority === 'P0' || evaluability === 'deterministic';
-}
-
-function supportsSkillRoute(principle: PrincipleLifecycleEvidence): boolean {
-  return principle.rules.every((rule) =>
-    rule.rule.enforcement !== 'block' || ['skill', 'prompt', 'test'].includes(rule.rule.type),
-  );
-}
-
-function buildEvidenceSummary(
-  principle: PrincipleLifecycleEvidence,
-  adherence: PrincipleAdherenceResult,
-  ruleMetrics: Record<string, RuleMetricResult>,
-): InternalizationRouteEvidenceSummary {
-  return {
-    replayReportCount: principle.summary.replayReportCount,
-    activeImplementationCount: principle.summary.activeImplementationCount,
-    candidateImplementationCount: principle.summary.candidateImplementationCount,
-    repeatedErrorSignal: principle.summary.repeatedErrorSignal,
-    averageRuleCoverage: adherence.averageRuleCoverage,
-    averageFalsePositiveRate: adherence.averageFalsePositiveRate,
-    highestRuleCoverageGap: averageCoverageGap(ruleMetrics),
-    dominantRuleType: dominantRuleType(principle),
-  };
-}
-
-export function recommendInternalizationRoute(
-  principle: PrincipleLifecycleEvidence,
-  precomputedRuleMetrics?: Record<string, RuleMetricResult>,
-  precomputedAdherence?: PrincipleAdherenceResult,
-): InternalizationRouteRecommendation {
-  const ruleMetrics = precomputedRuleMetrics ?? Object.fromEntries(
-    principle.rules.map((rule) => [rule.rule.id, computeRuleMetrics(rule)]),
-  );
-  const adherence = precomputedAdherence ?? computePrincipleAdherence(principle, ruleMetrics);
-  const evidenceSummary = buildEvidenceSummary(principle, adherence, ruleMetrics);
-    const reasonCodes: string[] = [];
-  
-  // ── Axiom-based heuristic modifiers ──
-  const axiomId = principle.principle.coreAxiomId;
-  let codeBoost = 0;
-  let skillBoost = 0;
-  if (axiomId === 'T-05' || axiomId === 'T-08') {
-    codeBoost = 15;
-    reasonCodes.push('axiom_governance_enforcement');
-  } else if (axiomId === 'T-01' || axiomId === 'T-03' || axiomId === 'T-04') {
-    skillBoost = 15;
-    reasonCodes.push('axiom_knowledge_guidance');
-  }
-
-  const highRisk = isHighRisk(principle.principle.priority, principle.principle.evaluability);
-  const hasSparseEvidence =
-    principle.summary.replayReportCount < Math.max(1, principle.rules.length) &&
-    principle.summary.activeImplementationCount === 0 &&
-    principle.summary.candidateImplementationCount === 0 &&
-    principle.summary.repeatedErrorSignal < 2;
-  const stableEnoughToWait =
-    adherence.averageRuleCoverage >= 80 &&
-    adherence.averageFalsePositiveRate <= 15 &&
-    principle.summary.repeatedErrorSignal === 0;
-
-  if (principle.rules.length === 0) {
-    reasonCodes.push('insufficient_data', 'no_material_rules');
-    return {
-      principleId: principle.principle.id,
-      route: 'defer',
-      confidence: 50,
-      reasonCodes,
-      evidenceSummary,
-      nextAction: 'No rules defined for this principle. Create at least one rule via pain→principle→rule pipeline before internalization routing can produce meaningful recommendations.',
-    };
-  }
-
-  if (hasSparseEvidence) {
-    reasonCodes.push('sparse_evidence');
-    return {
-      principleId: principle.principle.id,
-      route: 'defer',
-      confidence: clampToPercentage(78 - principle.summary.repeatedErrorSignal * 8),
-      reasonCodes,
-      evidenceSummary,
-      nextAction: 'Collect more replay evidence or live violations before committing to a heavier implementation path.',
-    };
-  }
-
-  if (stableEnoughToWait) {
-    reasonCodes.push('already_absorbing');
-    return {
-      principleId: principle.principle.id,
-      route: 'defer',
-      confidence: clampToPercentage(70 + adherence.averageRuleCoverage * 0.2),
-      reasonCodes,
-      evidenceSummary,
-      nextAction: 'Defer new implementation work and keep monitoring until the lower layer proves it needs another route.',
-    };
-  }
-
-  const prefersSkillRoute =
-    supportsSkillRoute(principle) &&
-    (
-      (!highRisk &&
-      principle.principle.evaluability !== 'deterministic' &&
-      principle.summary.repeatedErrorSignal <= 2) ||
-      (skillBoost > 0 && codeBoost === 0)
-    ) && codeBoost === 0;
-
-  if (prefersSkillRoute) {
-    reasonCodes.push('cheapest_viable_skill');
-    if (principle.summary.activeImplementationCount === 0) {
-      reasonCodes.push('no_hard_boundary_required');
-    }
-
-    return {
-      principleId: principle.principle.id,
-      route: 'skill',
-      confidence: clampToPercentage(
-        62 + adherence.repeatedErrorReductionScore * 0.12 - adherence.averageFalsePositiveRate * 0.15 + skillBoost,
-      ),
-      reasonCodes,
-      evidenceSummary,
-      nextAction: 'Prefer a skill or prompt-level intervention first, then replay again before escalating to code.',
-    };
-  }
-
-  reasonCodes.push('deterministic_or_high_risk');
-  if (principle.summary.replayReportCount > 0) {
-    reasonCodes.push('replay_evidence_sufficient');
-  }
-  if (principle.summary.repeatedErrorSignal > 0) {
-    reasonCodes.push('repeated_errors_continue');
-  }
-
-  return {
-    principleId: principle.principle.id,
-    route: 'code',
-    confidence: clampToPercentage(
-      58 +
-        evidenceSummary.highestRuleCoverageGap * 0.2 +
-        principle.summary.repeatedErrorSignal * 6 +
-        (highRisk ? 8 : 0) +
-        codeBoost,
-    ),
-    reasonCodes,
-    evidenceSummary,
-    nextAction: 'Prepare a code implementation candidate and keep promotion manual after replay validation.',
-  };
-}
+// Backward-compatible aliases (deprecated — use Lifecycle* names)
+/** @deprecated Use LifecycleRoute */
+export type InternalizationRoute = LifecycleRoute;
+/** @deprecated Use LifecycleRouteEvidenceSummary */
+export type InternalizationRouteEvidenceSummary = LifecycleRouteEvidenceSummary;
+/** @deprecated Use LifecycleRouteRecommendation */
+export type InternalizationRouteRecommendation = LifecycleRouteRecommendation;
+/** @deprecated Use recommendLifecycleRoute */
+export const recommendInternalizationRoute = recommendLifecycleRoute;

--- a/packages/openclaw-plugin/src/core/principle-internalization/principle-lifecycle-service.ts
+++ b/packages/openclaw-plugin/src/core/principle-internalization/principle-lifecycle-service.ts
@@ -17,8 +17,8 @@ import {
   type DeprecatedReadinessAssessment,
 } from './deprecated-readiness.js';
 import {
-  recommendInternalizationRoute,
-  type InternalizationRouteRecommendation,
+  recommendLifecycleRoute,
+  type LifecycleRouteRecommendation,
 } from './internalization-routing-policy.js';
 
 export interface RecomputedPrincipleLifecycle {
@@ -26,7 +26,7 @@ export interface RecomputedPrincipleLifecycle {
   ruleMetrics: Record<string, RuleMetricResult>;
   adherence: PrincipleAdherenceResult;
   deprecatedReadiness: DeprecatedReadinessAssessment;
-  routeRecommendation: InternalizationRouteRecommendation;
+  routeRecommendation: LifecycleRouteRecommendation;
 }
 
 export interface PrincipleLifecycleAssessment {
@@ -35,7 +35,7 @@ export interface PrincipleLifecycleAssessment {
   ruleMetrics: Record<string, RuleMetricResult>;
   adherence: PrincipleAdherenceResult;
   deprecatedReadiness: DeprecatedReadinessAssessment;
-  routeRecommendation: InternalizationRouteRecommendation;
+  routeRecommendation: LifecycleRouteRecommendation;
 }
 
      
@@ -100,7 +100,7 @@ export class PrincipleLifecycleService {
         ruleMetrics,
         adherence,
       );
-      const routeRecommendation = recommendInternalizationRoute(
+      const routeRecommendation = recommendLifecycleRoute(
         principleEvidence,
         ruleMetrics,
         adherence,
@@ -117,7 +117,7 @@ export class PrincipleLifecycleService {
     });
   }
 
-  listRouteRecommendations(readModel = this.buildReadModel()): InternalizationRouteRecommendation[] {
+  listRouteRecommendations(readModel = this.buildReadModel()): LifecycleRouteRecommendation[] {
     return this.listAssessments(readModel).map((assessment) => assessment.routeRecommendation);
   }
 

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -43,6 +43,8 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/lifecycle-metrics.ts',
   // PRI-53
   'internalization/deprecated-readiness.ts',
+  // PRI-54
+  'internalization/routing-policy.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -769,5 +771,39 @@ describe('PRI-53 deprecated readiness', () => {
     expect(src).toContain("from '@principles/core/runtime-v2'");
     expect(src).toContain('assessDeprecatedReadiness');
     expect(src).toContain('DeprecatedReadinessAssessment');
+  });
+});
+
+// ── PRI-54: Routing policy extraction ──────────────────────────────────────────
+
+describe('PRI-54 routing policy', () => {
+  it('core exports all routing policy types/functions from barrel', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('LifecycleRoute');
+    expect(src).toContain('LifecycleRouteRecommendation');
+    expect(src).toContain('LifecycleRouteEvidenceSummary');
+    expect(src).toContain('recommendLifecycleRoute');
+  });
+
+  it('routing-policy.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'routing-policy.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('plugin internalization-routing-policy.ts re-exports from core', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '../../../../openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts'
+    ), 'utf-8');
+    expect(src).toContain("from '@principles/core/runtime-v2'");
+    expect(src).toContain('recommendLifecycleRoute');
+    expect(src).toContain('LifecycleRouteRecommendation');
   });
 });

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -325,3 +325,7 @@ export { computeRuleMetrics, computePrincipleAdherence } from './internalization
 // Deprecated readiness (PRI-53)
 export type { DeprecatedReadinessStatus, DeprecatedReadinessAssessment } from './internalization/deprecated-readiness.js';
 export { assessDeprecatedReadiness } from './internalization/deprecated-readiness.js';
+
+// Lifecycle routing policy (PRI-54)
+export type { LifecycleRoute, LifecycleRouteEvidenceSummary, LifecycleRouteRecommendation } from './internalization/routing-policy.js';
+export { recommendLifecycleRoute } from './internalization/routing-policy.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -60,3 +60,7 @@ export { computeRuleMetrics, computePrincipleAdherence } from './lifecycle-metri
 // Deprecated readiness (PRI-53)
 export type { DeprecatedReadinessStatus, DeprecatedReadinessAssessment } from './deprecated-readiness.js';
 export { assessDeprecatedReadiness } from './deprecated-readiness.js';
+
+// Routing policy (PRI-54)
+export type { LifecycleRoute, LifecycleRouteEvidenceSummary, LifecycleRouteRecommendation } from './routing-policy.js';
+export { recommendLifecycleRoute } from './routing-policy.js';

--- a/packages/principles-core/src/runtime-v2/internalization/routing-policy.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/routing-policy.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import { recommendLifecycleRoute } from './routing-policy.js';
+import type {
+  PrincipleLifecycleEvidence,
+  RuleLifecycleEvidence,
+} from './lifecycle-types.js';
+
+function createRuleEvidence(id: string, overrides: Partial<RuleLifecycleEvidence> = {}): RuleLifecycleEvidence {
+  return {
+    rule: {
+      id,
+      version: 1,
+      name: id,
+      description: id,
+      type: 'hook',
+      triggerCondition: 'tool=write',
+      enforcement: 'block',
+      action: 'block risky write',
+      principleId: 'P-001',
+      status: 'enforced',
+      coverageRate: 0,
+      falsePositiveRate: 0,
+      createdAt: '2026-04-08T00:00:00.000Z',
+      updatedAt: '2026-04-08T00:00:00.000Z',
+    },
+    implementations: [],
+    replayEvidence: {
+      reportCount: 0,
+      latestReports: [],
+      painNegative: { total: 0, passed: 0, failed: 0 },
+      successPositive: { total: 0, passed: 0, failed: 0 },
+      principleAnchor: { total: 0, passed: 0, failed: 0 },
+      passingImplementationIds: [],
+      failingImplementationIds: [],
+      needsReviewImplementationIds: [],
+    },
+    liveEvidence: {
+      activeCount: 0,
+      candidateCount: 0,
+      disabledCount: 0,
+      archivedCount: 0,
+      durablePenaltyCount: 0,
+      rollbackEvidenceCount: 0,
+      hasActiveImplementation: false,
+      hasPassingActiveImplementation: false,
+    },
+    lineageEvidence: {
+      records: [],
+      distinctPainSignalCount: 0,
+      distinctGateBlockCount: 0,
+      repeatedErrorSignal: 0,
+    },
+    ...overrides,
+  };
+}
+
+function createPrincipleEvidence(
+  rules: RuleLifecycleEvidence[],
+  overrides: Partial<PrincipleLifecycleEvidence> = {},
+): PrincipleLifecycleEvidence {
+  return {
+    principle: {
+      id: 'P-001',
+      version: 1,
+      text: 'Do the cheapest safe thing first',
+      triggerPattern: 'write',
+      action: 'prefer cheap safe fixes',
+      status: 'active',
+      priority: 'P1',
+      scope: 'general',
+      evaluability: 'weak_heuristic',
+      valueScore: 0,
+      adherenceRate: 0,
+      painPreventedCount: 0,
+      derivedFromPainIds: [],
+      ruleIds: rules.map((rule) => rule.rule.id),
+      conflictsWithPrincipleIds: [],
+      createdAt: '2026-04-08T00:00:00.000Z',
+      updatedAt: '2026-04-08T00:00:00.000Z',
+    },
+    rules,
+    summary: {
+      replayReportCount: rules.reduce((sum, rule) => sum + rule.replayEvidence.reportCount, 0),
+      activeImplementationCount: rules.reduce((sum, rule) => sum + rule.liveEvidence.activeCount, 0),
+      candidateImplementationCount: rules.reduce((sum, rule) => sum + rule.liveEvidence.candidateCount, 0),
+      disabledImplementationCount: rules.reduce((sum, rule) => sum + rule.liveEvidence.disabledCount, 0),
+      archivedImplementationCount: rules.reduce((sum, rule) => sum + rule.liveEvidence.archivedCount, 0),
+      distinctPainSignalCount: rules.reduce((sum, rule) => sum + rule.lineageEvidence.distinctPainSignalCount, 0),
+      distinctGateBlockCount: rules.reduce((sum, rule) => sum + rule.lineageEvidence.distinctGateBlockCount, 0),
+      repeatedErrorSignal: rules.reduce((sum, rule) => sum + rule.lineageEvidence.repeatedErrorSignal, 0),
+    },
+    ...overrides,
+  };
+}
+
+describe('recommendLifecycleRoute', () => {
+  it('recommends code for deterministic high-risk principles with repeated failures', () => {
+    const recommendation = recommendLifecycleRoute(
+      createPrincipleEvidence(
+        [
+          createRuleEvidence('R-001', {
+            replayEvidence: {
+              reportCount: 2,
+              latestReports: [],
+              painNegative: { total: 4, passed: 2, failed: 2 },
+              successPositive: { total: 2, passed: 2, failed: 0 },
+              principleAnchor: { total: 2, passed: 1, failed: 1 },
+              passingImplementationIds: [],
+              failingImplementationIds: ['IMPL-R-001'],
+              needsReviewImplementationIds: [],
+            },
+            liveEvidence: {
+              activeCount: 1,
+              candidateCount: 0,
+              disabledCount: 0,
+              archivedCount: 0,
+              durablePenaltyCount: 0,
+              rollbackEvidenceCount: 0,
+              hasActiveImplementation: true,
+              hasPassingActiveImplementation: false,
+            },
+            lineageEvidence: {
+              records: [],
+              distinctPainSignalCount: 2,
+              distinctGateBlockCount: 1,
+              repeatedErrorSignal: 3,
+            },
+          }),
+        ],
+        {
+          principle: {
+            ...createPrincipleEvidence([]).principle,
+            priority: 'P0',
+            evaluability: 'deterministic',
+            ruleIds: ['R-001'],
+          },
+          summary: {
+            replayReportCount: 2,
+            activeImplementationCount: 1,
+            candidateImplementationCount: 0,
+            disabledImplementationCount: 0,
+            archivedImplementationCount: 0,
+            distinctPainSignalCount: 2,
+            distinctGateBlockCount: 1,
+            repeatedErrorSignal: 3,
+          },
+        },
+      ),
+    );
+
+    expect(recommendation.route).toBe('code');
+    expect(recommendation.reasonCodes).toContain('deterministic_or_high_risk');
+    expect(recommendation.reasonCodes).toContain('repeated_errors_continue');
+    expect(recommendation.nextAction).toContain('manual');
+  });
+
+  it('recommends skill when a cheaper non-code path is viable', () => {
+    const recommendation = recommendLifecycleRoute(
+      createPrincipleEvidence([
+        createRuleEvidence('R-001', {
+          rule: {
+            ...createRuleEvidence('R-001').rule,
+            type: 'skill',
+            enforcement: 'warn',
+          },
+          replayEvidence: {
+            reportCount: 1,
+            latestReports: [],
+            painNegative: { total: 3, passed: 2, failed: 1 },
+            successPositive: { total: 3, passed: 3, failed: 0 },
+            principleAnchor: { total: 1, passed: 1, failed: 0 },
+            passingImplementationIds: [],
+            failingImplementationIds: [],
+            needsReviewImplementationIds: ['IMPL-R-001'],
+          },
+          liveEvidence: {
+            activeCount: 0,
+            candidateCount: 0,
+            disabledCount: 0,
+            archivedCount: 0,
+            durablePenaltyCount: 0,
+            rollbackEvidenceCount: 0,
+            hasActiveImplementation: false,
+            hasPassingActiveImplementation: false,
+          },
+          lineageEvidence: {
+            records: [],
+            distinctPainSignalCount: 1,
+            distinctGateBlockCount: 0,
+            repeatedErrorSignal: 1,
+          },
+        }),
+      ]),
+    );
+
+    expect(recommendation.route).toBe('skill');
+    expect(recommendation.reasonCodes).toContain('cheapest_viable_skill');
+    expect(recommendation.reasonCodes).toContain('no_hard_boundary_required');
+  });
+
+  it('recommends defer when evidence is too sparse', () => {
+    const recommendation = recommendLifecycleRoute(
+      createPrincipleEvidence([createRuleEvidence('R-001')]),
+    );
+
+    expect(recommendation.route).toBe('defer');
+    expect(recommendation.reasonCodes).toEqual(['sparse_evidence']);
+  });
+
+  it('recommends defer when no rules exist', () => {
+    const recommendation = recommendLifecycleRoute(
+      createPrincipleEvidence([]),
+    );
+
+    expect(recommendation.route).toBe('defer');
+    expect(recommendation.confidence).toBe(50);
+    expect(recommendation.reasonCodes).toContain('insufficient_data');
+    expect(recommendation.reasonCodes).toContain('no_material_rules');
+  });
+
+  it('recommends defer when principle is already absorbing well', () => {
+    const recommendation = recommendLifecycleRoute(
+      createPrincipleEvidence(
+        [createRuleEvidence('R-001', {
+          replayEvidence: {
+            reportCount: 2,
+            latestReports: [],
+            painNegative: { total: 10, passed: 10, failed: 0 },
+            successPositive: { total: 5, passed: 5, failed: 0 },
+            principleAnchor: { total: 2, passed: 2, failed: 0 },
+            passingImplementationIds: ['IMPL-R-001'],
+            failingImplementationIds: [],
+            needsReviewImplementationIds: [],
+          },
+          liveEvidence: {
+            activeCount: 1,
+            candidateCount: 0,
+            disabledCount: 0,
+            archivedCount: 0,
+            durablePenaltyCount: 0,
+            rollbackEvidenceCount: 0,
+            hasActiveImplementation: true,
+            hasPassingActiveImplementation: true,
+          },
+          lineageEvidence: {
+            records: [],
+            distinctPainSignalCount: 0,
+            distinctGateBlockCount: 0,
+            repeatedErrorSignal: 0,
+          },
+        })],
+        {
+          summary: {
+            replayReportCount: 2,
+            activeImplementationCount: 1,
+            candidateImplementationCount: 0,
+            disabledImplementationCount: 0,
+            archivedImplementationCount: 0,
+            distinctPainSignalCount: 0,
+            distinctGateBlockCount: 0,
+            repeatedErrorSignal: 0,
+          },
+        },
+      ),
+    );
+
+    expect(recommendation.route).toBe('defer');
+    expect(recommendation.reasonCodes).toContain('already_absorbing');
+  });
+
+  it('applies axiom boost for governance axioms (T-05)', () => {
+    const recommendation = recommendLifecycleRoute(
+      createPrincipleEvidence(
+        [createRuleEvidence('R-001', {
+          replayEvidence: {
+            reportCount: 2,
+            latestReports: [],
+            painNegative: { total: 4, passed: 2, failed: 2 },
+            successPositive: { total: 2, passed: 2, failed: 0 },
+            principleAnchor: { total: 2, passed: 1, failed: 1 },
+            passingImplementationIds: [],
+            failingImplementationIds: ['IMPL-R-001'],
+            needsReviewImplementationIds: [],
+          },
+          liveEvidence: {
+            activeCount: 1,
+            candidateCount: 0,
+            disabledCount: 0,
+            archivedCount: 0,
+            durablePenaltyCount: 0,
+            rollbackEvidenceCount: 0,
+            hasActiveImplementation: true,
+            hasPassingActiveImplementation: false,
+          },
+          lineageEvidence: {
+            records: [],
+            distinctPainSignalCount: 2,
+            distinctGateBlockCount: 1,
+            repeatedErrorSignal: 1,
+          },
+        })],
+        {
+          principle: {
+            ...createPrincipleEvidence([]).principle,
+            priority: 'P0',
+            evaluability: 'deterministic',
+            coreAxiomId: 'T-05',
+            ruleIds: ['R-001'],
+          },
+          summary: {
+            replayReportCount: 2,
+            activeImplementationCount: 1,
+            candidateImplementationCount: 0,
+            disabledImplementationCount: 0,
+            archivedImplementationCount: 0,
+            distinctPainSignalCount: 2,
+            distinctGateBlockCount: 1,
+            repeatedErrorSignal: 1,
+          },
+        },
+      ),
+    );
+
+    expect(recommendation.route).toBe('code');
+    expect(recommendation.reasonCodes).toContain('axiom_governance_enforcement');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/routing-policy.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/routing-policy.ts
@@ -1,0 +1,254 @@
+import type { PrinciplePriority, PrincipleEvaluability, RuleType } from '../types/index.js';
+import type { PrincipleLifecycleEvidence } from './lifecycle-types.js';
+import {
+  computePrincipleAdherence,
+  computeRuleMetrics,
+  type PrincipleAdherenceResult,
+  type RuleMetricResult,
+} from './lifecycle-metrics.js';
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+export type LifecycleRoute = 'skill' | 'code' | 'defer';
+
+export interface LifecycleRouteEvidenceSummary {
+  replayReportCount: number;
+  activeImplementationCount: number;
+  candidateImplementationCount: number;
+  repeatedErrorSignal: number;
+  averageRuleCoverage: number;
+  averageFalsePositiveRate: number;
+  highestRuleCoverageGap: number;
+  dominantRuleType: RuleType | 'mixed';
+}
+
+export interface LifecycleRouteRecommendation {
+  principleId: string;
+  route: LifecycleRoute;
+  confidence: number;
+  reasonCodes: string[];
+  evidenceSummary: LifecycleRouteEvidenceSummary;
+  nextAction: string;
+}
+
+// ── Named constants ─────────────────────────────────────────────────────────
+
+// Axiom-based heuristic boost values
+const AXIOM_GOVERNANCE_BOOST = 15;
+const AXIOM_KNOWLEDGE_BOOST = 15;
+
+// Sparse evidence thresholds
+const SPARSE_MAX_REPEATED_ERRORS = 2;
+
+// Stable-enough-to-wait thresholds
+const STABLE_MIN_COVERAGE = 80;
+const STABLE_MAX_FP_RATE = 15;
+
+// Confidence: defer (insufficient data)
+const CONFIDENCE_DEFER_INSUFFICIENT = 50;
+
+// Confidence: defer (sparse evidence)
+const CONFIDENCE_DEFER_SPARSE_BASE = 78;
+const CONFIDENCE_DEFER_SPARSE_PENALTY = 8;
+
+// Confidence: defer (stable enough)
+const CONFIDENCE_DEFER_STABLE_BASE = 70;
+const CONFIDENCE_DEFER_STABLE_COVERAGE_WEIGHT = 0.2;
+
+// Confidence: skill route
+const CONFIDENCE_SKILL_BASE = 62;
+const CONFIDENCE_SKILL_ERROR_REDUCTION_WEIGHT = 0.12;
+const CONFIDENCE_SKILL_FP_PENALTY_WEIGHT = 0.15;
+
+// Confidence: code route
+const CONFIDENCE_CODE_BASE = 58;
+const CONFIDENCE_CODE_COVERAGE_GAP_WEIGHT = 0.2;
+const CONFIDENCE_CODE_REPEATED_ERROR_BOOST = 6;
+const CONFIDENCE_CODE_HIGH_RISK_BOOST = 8;
+
+// Skill route threshold
+const SKILL_ROUTE_MAX_REPEATED_ERRORS = 2;
+
+// ── Internal helpers ────────────────────────────────────────────────────────
+
+function clampToPercentage(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Number(value.toFixed(2))));
+}
+
+function dominantRuleType(principle: PrincipleLifecycleEvidence): RuleType | 'mixed' {
+  if (principle.rules.length === 0) {
+    return 'mixed';
+  }
+
+  const types = principle.rules.map((rule) => rule.rule.type);
+  const defined = types.filter((t): t is RuleType => t !== undefined);
+  const distinctTypes = new Set(defined);
+  return distinctTypes.size === 1 ? (defined[0] as RuleType | 'mixed') : 'mixed';
+}
+
+function averageCoverageGap(ruleMetrics: Record<string, RuleMetricResult>): number {
+  const coverageGaps = Object.values(ruleMetrics).map((metrics) => Math.max(0, 100 - metrics.coverageRate));
+
+  if (coverageGaps.length === 0) {
+    return 0;
+  }
+
+  return clampToPercentage(
+    coverageGaps.reduce((sum, gap) => sum + gap, 0) / coverageGaps.length,
+  );
+}
+
+function isHighRisk(priority: PrinciplePriority, evaluability: PrincipleEvaluability): boolean {
+  return priority === 'P0' || evaluability === 'deterministic';
+}
+
+function supportsSkillRoute(principle: PrincipleLifecycleEvidence): boolean {
+  return principle.rules.every((rule) =>
+    rule.rule.enforcement !== 'block' || ['skill', 'prompt', 'test'].includes(rule.rule.type),
+  );
+}
+
+function buildEvidenceSummary(
+  principle: PrincipleLifecycleEvidence,
+  adherence: PrincipleAdherenceResult,
+  ruleMetrics: Record<string, RuleMetricResult>,
+): LifecycleRouteEvidenceSummary {
+  return {
+    replayReportCount: principle.summary.replayReportCount,
+    activeImplementationCount: principle.summary.activeImplementationCount,
+    candidateImplementationCount: principle.summary.candidateImplementationCount,
+    repeatedErrorSignal: principle.summary.repeatedErrorSignal,
+    averageRuleCoverage: adherence.averageRuleCoverage,
+    averageFalsePositiveRate: adherence.averageFalsePositiveRate,
+    highestRuleCoverageGap: averageCoverageGap(ruleMetrics),
+    dominantRuleType: dominantRuleType(principle),
+  };
+}
+
+// ── Public decision function ────────────────────────────────────────────────
+
+export function recommendLifecycleRoute(
+  principle: PrincipleLifecycleEvidence,
+  precomputedRuleMetrics?: Record<string, RuleMetricResult>,
+  precomputedAdherence?: PrincipleAdherenceResult,
+): LifecycleRouteRecommendation {
+  const ruleMetrics = precomputedRuleMetrics ?? Object.fromEntries(
+    principle.rules.map((rule) => [rule.rule.id, computeRuleMetrics(rule)]),
+  );
+  const adherence = precomputedAdherence ?? computePrincipleAdherence(principle, ruleMetrics);
+  const evidenceSummary = buildEvidenceSummary(principle, adherence, ruleMetrics);
+    const reasonCodes: string[] = [];
+
+  // ── Axiom-based heuristic modifiers ──
+  const axiomId = principle.principle.coreAxiomId;
+  let codeBoost = 0;
+  let skillBoost = 0;
+  if (axiomId === 'T-05' || axiomId === 'T-08') {
+    codeBoost = AXIOM_GOVERNANCE_BOOST;
+    reasonCodes.push('axiom_governance_enforcement');
+  } else if (axiomId === 'T-01' || axiomId === 'T-03' || axiomId === 'T-04') {
+    skillBoost = AXIOM_KNOWLEDGE_BOOST;
+    reasonCodes.push('axiom_knowledge_guidance');
+  }
+
+  const highRisk = isHighRisk(principle.principle.priority, principle.principle.evaluability);
+  const hasSparseEvidence =
+    principle.summary.replayReportCount < Math.max(1, principle.rules.length) &&
+    principle.summary.activeImplementationCount === 0 &&
+    principle.summary.candidateImplementationCount === 0 &&
+    principle.summary.repeatedErrorSignal < SPARSE_MAX_REPEATED_ERRORS;
+  const stableEnoughToWait =
+    adherence.averageRuleCoverage >= STABLE_MIN_COVERAGE &&
+    adherence.averageFalsePositiveRate <= STABLE_MAX_FP_RATE &&
+    principle.summary.repeatedErrorSignal === 0;
+
+  if (principle.rules.length === 0) {
+    reasonCodes.push('insufficient_data', 'no_material_rules');
+    return {
+      principleId: principle.principle.id,
+      route: 'defer',
+      confidence: CONFIDENCE_DEFER_INSUFFICIENT,
+      reasonCodes,
+      evidenceSummary,
+      nextAction: 'No rules defined for this principle. Create at least one rule via pain→principle→rule pipeline before internalization routing can produce meaningful recommendations.',
+    };
+  }
+
+  if (hasSparseEvidence) {
+    reasonCodes.push('sparse_evidence');
+    return {
+      principleId: principle.principle.id,
+      route: 'defer',
+      confidence: clampToPercentage(CONFIDENCE_DEFER_SPARSE_BASE - principle.summary.repeatedErrorSignal * CONFIDENCE_DEFER_SPARSE_PENALTY),
+      reasonCodes,
+      evidenceSummary,
+      nextAction: 'Collect more replay evidence or live violations before committing to a heavier implementation path.',
+    };
+  }
+
+  if (stableEnoughToWait) {
+    reasonCodes.push('already_absorbing');
+    return {
+      principleId: principle.principle.id,
+      route: 'defer',
+      confidence: clampToPercentage(CONFIDENCE_DEFER_STABLE_BASE + adherence.averageRuleCoverage * CONFIDENCE_DEFER_STABLE_COVERAGE_WEIGHT),
+      reasonCodes,
+      evidenceSummary,
+      nextAction: 'Defer new implementation work and keep monitoring until the lower layer proves it needs another route.',
+    };
+  }
+
+  const prefersSkillRoute =
+    supportsSkillRoute(principle) &&
+    (
+      (!highRisk &&
+      principle.principle.evaluability !== 'deterministic' &&
+      principle.summary.repeatedErrorSignal <= SKILL_ROUTE_MAX_REPEATED_ERRORS) ||
+      (skillBoost > 0 && codeBoost === 0)
+    ) && codeBoost === 0;
+
+  if (prefersSkillRoute) {
+    reasonCodes.push('cheapest_viable_skill');
+    if (principle.summary.activeImplementationCount === 0) {
+      reasonCodes.push('no_hard_boundary_required');
+    }
+
+    return {
+      principleId: principle.principle.id,
+      route: 'skill',
+      confidence: clampToPercentage(
+        CONFIDENCE_SKILL_BASE + adherence.repeatedErrorReductionScore * CONFIDENCE_SKILL_ERROR_REDUCTION_WEIGHT - adherence.averageFalsePositiveRate * CONFIDENCE_SKILL_FP_PENALTY_WEIGHT + skillBoost,
+      ),
+      reasonCodes,
+      evidenceSummary,
+      nextAction: 'Prefer a skill or prompt-level intervention first, then replay again before escalating to code.',
+    };
+  }
+
+  reasonCodes.push('deterministic_or_high_risk');
+  if (principle.summary.replayReportCount > 0) {
+    reasonCodes.push('replay_evidence_sufficient');
+  }
+  if (principle.summary.repeatedErrorSignal > 0) {
+    reasonCodes.push('repeated_errors_continue');
+  }
+
+  return {
+    principleId: principle.principle.id,
+    route: 'code',
+    confidence: clampToPercentage(
+      CONFIDENCE_CODE_BASE +
+        evidenceSummary.highestRuleCoverageGap * CONFIDENCE_CODE_COVERAGE_GAP_WEIGHT +
+        principle.summary.repeatedErrorSignal * CONFIDENCE_CODE_REPEATED_ERROR_BOOST +
+        (highRisk ? CONFIDENCE_CODE_HIGH_RISK_BOOST : 0) +
+        codeBoost,
+    ),
+    reasonCodes,
+    evidenceSummary,
+    nextAction: 'Prepare a code implementation candidate and keep promotion manual after replay validation.',
+  };
+}


### PR DESCRIPTION
## Summary

- Migrate `internalization-routing-policy.ts` from plugin to `@principles/core/runtime-v2/internalization/`
- Rename types to avoid conflict with `InternalizationRouteKind` (PRI-43): `InternalizationRoute` → `LifecycleRoute`, etc.
- Extract 18 magic numbers to named constants
- Plugin re-exports from core with `@deprecated` aliases for backward compatibility
- Add architecture regression guards for PRI-54

## Test plan

- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run build --workspace=@principles/pd-cli` passes
- [x] `npm run build --workspace=@principles/openclaw-plugin` passes
- [x] Core tests: 107 passed (including new `routing-policy.test.ts`)
- [x] Plugin backward-compat tests: 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 标准化了原则生命周期路由推荐系统，采用一致的命名约定以提高 API 清晰度。

* **Tests**
  * 为路由推荐功能增强了测试覆盖率，涵盖多个场景验证。

* **Backward Compatibility**
  * 保留了旧的命名别名，确保现有集成无缝运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->