### PR TITLE
feat(core): add internalization state machine guards (PRI-62)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -51,6 +51,9 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-61
   'internalization/peer-runner-contracts.ts',
   'internalization/internalization-job-graph.ts',
+  // PRI-62
+  'internalization/internalization-task-guards.ts',
+  'internalization/internalization-state-machine.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -63,6 +66,8 @@ const REQUIRED_TEST_FILES = [
   'candidate-audit.test.ts',
   // PRI-56 (lifecycle-read-model.test.ts is at internalization/lifecycle-read-model.test.ts, not in __tests__/)
   // Skipping — test file lives at ../internalization/ not __tests__/internalization/
+  // PRI-62
+  'internalization-state-machine.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [
@@ -936,5 +941,78 @@ describe('PRI-61 Internalization Peer Runner Contracts', () => {
     // Edge validation is read-only — no task creation or state mutation
     const result = validateEdge('dreamer', 'philosopher');
     expect(typeof result).toBe('boolean');
+  });
+});
+
+// ── PRI-62: Internalization State Machine Guards ─────────────────────────────
+
+describe('PRI-62 Internalization State Machine Guards', () => {
+  it('core barrel exports state machine guard functions', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('validateInternalizationTaskReady');
+    expect(src).toContain('validateTaskTransition');
+    expect(src).toContain('decideArtifactRejectionFeedback');
+    expect(src).toContain('createNextTaskProposal');
+    expect(src).toContain('validateInternalizationGraph');
+  });
+
+  it('core barrel exports guard utility functions', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('canAcquireLease');
+    expect(src).toContain('areDependenciesMet');
+    expect(src).toContain('canTransitionTo');
+    expect(src).toContain('isResultRefImmutable');
+    expect(src).toContain('canUpdateLastError');
+    expect(src).toContain('isArtifactRejected');
+  });
+
+  it('internalization-task-guards.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '..', 'internalization', 'internalization-task-guards.ts'
+    ), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('internalization-state-machine.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '..', 'internalization', 'internalization-state-machine.ts'
+    ), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('TASK_MODEL_REUSE: guard functions work with PITaskRecord (type-level check)', async () => {
+    // If PITaskRecord didn't properly extend TaskRecord, TypeScript would error
+    // at compile time in peer-runner-contracts.ts and internalization-task-guards.ts
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '..', 'internalization', 'internalization-task-guards.ts'
+    ), 'utf-8');
+    expect(src).toContain('task: PITaskRecord');
+  });
+
+  it('PEER_NO_DIRECT_CHAINING: state machine returns proposals, not execute calls', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    // Pure function — returns an object, no side effects
+    const { createMinimalPITaskRecord } = await import('../internalization/peer-runner-contracts.js');
+    const task = createMinimalPITaskRecord('t1', 'dreamer', 'prompt');
+    task.status = 'succeeded';
+    task.outputArtifactRefs = [];
+    const result = createNextTaskProposal(task, []);
+    expect(result === null || typeof result === 'object').toBe(true);
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
@@ -178,6 +178,11 @@ describe('canTransitionTo', () => {
     expect(canTransitionTo('leased', 'failed')).toBe(true);
   });
 
+  it('leased → pending is valid (lease release / force-expire)', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('leased', 'pending')).toBe(true);
+  });
+
   it('retry_wait → pending is valid (recovery sweep reset)', async () => {
     const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
     expect(canTransitionTo('retry_wait', 'pending')).toBe(true);
@@ -398,21 +403,36 @@ describe('createNextTaskProposal', () => {
     expect(result!.taskKind).toBe('rollout_reviewer');
   });
 
-  it('rollout_reviewer succeeded → trainer (can reach trainer via model_training channel)', async () => {
+  it('rollout_reviewer succeeded + model_training channel → trainer', async () => {
     const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
     const task = makePITask({
       taskId: 'rr-1',
       taskKind: 'rollout_reviewer',
       status: 'succeeded',
+      channel: 'model_training',
       outputArtifactRefs: [],
     });
     const result = createNextTaskProposal(task, []);
-    // rollout_reviewer has no direct ALLOWED_EDGES successors, but getAllowedSuccessors
-    // appends trainer as a reachable alternative (any runner can reach trainer
-    // via model_training channel)
+    // rollout_reviewer has no direct ALLOWED_EDGES successors.
+    // With model_training channel it can reach trainer (via getAllowedSuccessors filter).
     expect(result).not.toBeNull();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result!.taskKind).toBe('trainer');
+  });
+
+  it('rollout_reviewer succeeded + prompt channel → null (channel constraint blocks trainer)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      channel: 'prompt',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    // rollout_reviewer → trainer requires model_training channel.
+    // With prompt channel, no valid successor exists → null.
+    expect(result).toBeNull();
   });
 
   it('dreamer succeeded → philosopher (first in ALLOWED_EDGES, channel passed through)', async () => {
@@ -432,6 +452,30 @@ describe('createNextTaskProposal', () => {
     // first element is philosopher (direct ALLOWED_EDGES successor)
     expect(r.taskKind).toBe('philosopher');
     expect(r.channel).toBe('model_training');
+  });
+
+  it('pending task → null (non-succeeded status must not generate proposal)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'dreamer-1',
+      taskKind: 'dreamer',
+      status: 'pending',
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'art-1' }],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).toBeNull();
+  });
+
+  it('failed task → null (non-succeeded status must not generate proposal)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'dreamer-1',
+      taskKind: 'dreamer',
+      status: 'failed',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
@@ -144,6 +144,15 @@ describe('areDependenciesMet', () => {
     // dep-2 does not exist in deps array
     expect(areDependenciesMet(makePITask({ dependencyTaskIds: ['dep-1', 'dep-2'] }), deps)).toBe(false);
   });
+
+  it('one dep succeeded, one dep in retry_wait returns false (fail closed)', async () => {
+    const { areDependenciesMet } = await import('../internalization/internalization-task-guards.js');
+    const deps = [
+      makeTask({ taskId: 'dep-1', status: 'succeeded' }),
+      makeTask({ taskId: 'dep-2', status: 'retry_wait' }),
+    ];
+    expect(areDependenciesMet(makePITask({ dependencyTaskIds: ['dep-1', 'dep-2'] }), deps)).toBe(false);
+  });
 });
 
 // ── canTransitionTo ──────────────────────────────────────────────────────────
@@ -308,7 +317,7 @@ describe('decideArtifactRejectionFeedback', () => {
     const task = makePITask({ taskKind: 'scribe', status: 'succeeded' });
     const result = decideArtifactRejectionFeedback(artifact, task);
     expect(result.action).toBe('create_corrective_task');
-    expect(result.correctiveTaskKind).toBe('scribe');
+    expect((result as { correctiveTaskKind: string }).correctiveTaskKind).toBe('scribe');
   });
 
   it('artificer artifact rejected → create corrective artificer task', async () => {
@@ -323,7 +332,7 @@ describe('decideArtifactRejectionFeedback', () => {
     const task = makePITask({ taskKind: 'artificer', status: 'succeeded' });
     const result = decideArtifactRejectionFeedback(artifact, task);
     expect(result.action).toBe('create_corrective_task');
-    expect(result.correctiveTaskKind).toBe('artificer');
+    expect((result as { correctiveTaskKind: string }).correctiveTaskKind).toBe('artificer');
   });
 
   it('other runner artifact rejected → escalate', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Internalization State Machine Guards — Unit Tests (PRI-62)
+ *
+ * TDD: Tests written first to define the expected behavior of guard functions
+ * and state-machine decision logic for the Internalization Engine.
+ */
+import { describe, it, expect } from 'vitest';
+import type { TaskRecord } from '../task-status.js';
+import type { PITaskRecord, LineageRef } from '../internalization/peer-runner-contracts.js';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+// ── Test helpers ───────────────────────────────────────────────────────────────
+
+function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
+  const {
+    taskId = 'test-task',
+    taskKind = 'dreamer',
+    status = 'pending',
+    createdAt = new Date().toISOString(),
+    updatedAt = new Date().toISOString(),
+    attemptCount = 0,
+    maxAttempts = 3,
+    dependencyTaskIds = [],
+    channel = 'prompt',
+    timeoutMs = 60000,
+    inputArtifactRefs = [],
+    outputArtifactRefs = [],
+  } = overrides;
+  return {
+    taskId,
+    taskKind,
+    status,
+    createdAt,
+    updatedAt,
+    attemptCount,
+    maxAttempts,
+    dependencyTaskIds,
+    channel,
+    timeoutMs,
+    inputArtifactRefs,
+    outputArtifactRefs,
+  } as PITaskRecord;
+}
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  const {
+    taskId = 'dep-task',
+    status = 'succeeded',
+    createdAt = new Date().toISOString(),
+    updatedAt = new Date().toISOString(),
+    attemptCount = 0,
+    maxAttempts = 3,
+  } = overrides;
+  return {
+    taskId,
+    status,
+    createdAt,
+    updatedAt,
+    attemptCount,
+    maxAttempts,
+  } as TaskRecord;
+}
+
+// ── Architecture Guard Helpers ────────────────────────────────────────────────
+
+function moduleHasNoInfraImports(modulePath: string): Promise<boolean> {
+  const src = readFileSync(resolve(__dirname, '..', modulePath), 'utf-8');
+  return Promise.resolve(
+    !src.includes('node:fs') &&
+    !src.includes('node:path') &&
+    !src.includes('openclaw-plugin') &&
+    !src.includes('node:cron')
+  );
+}
+
+// ── canAcquireLease ───────────────────────────────────────────────────────────
+
+describe('canAcquireLease', () => {
+  it('pending task can be leased', async () => {
+    const { canAcquireLease } = await import('../internalization/internalization-task-guards.js');
+    expect(canAcquireLease(makePITask({ status: 'pending' }))).toBe(true);
+  });
+
+  it('retry_wait task can be leased (recovery allowed)', async () => {
+    const { canAcquireLease } = await import('../internalization/internalization-task-guards.js');
+    expect(canAcquireLease(makePITask({ status: 'retry_wait' }))).toBe(true);
+  });
+
+  it('leased task cannot be leased again', async () => {
+    const { canAcquireLease } = await import('../internalization/internalization-task-guards.js');
+    expect(canAcquireLease(makePITask({ status: 'leased' }))).toBe(false);
+  });
+
+  it('succeeded task cannot be leased (terminal)', async () => {
+    const { canAcquireLease } = await import('../internalization/internalization-task-guards.js');
+    expect(canAcquireLease(makePITask({ status: 'succeeded' }))).toBe(false);
+  });
+
+  it('failed task cannot be leased (terminal)', async () => {
+    const { canAcquireLease } = await import('../internalization/internalization-task-guards.js');
+    expect(canAcquireLease(makePITask({ status: 'failed' }))).toBe(false);
+  });
+});
+
+// ── areDependenciesMet ────────────────────────────────────────────────────────
+
+describe('areDependenciesMet', () => {
+  it('empty dependencyTaskIds returns true', async () => {
+    const { areDependenciesMet } = await import('../internalization/internalization-task-guards.js');
+    expect(areDependenciesMet(makePITask({ dependencyTaskIds: [] }), [])).toBe(true);
+  });
+
+  it('all dependencies succeeded returns true', async () => {
+    const { areDependenciesMet } = await import('../internalization/internalization-task-guards.js');
+    const deps = [
+      makeTask({ taskId: 'dep-1', status: 'succeeded' }),
+      makeTask({ taskId: 'dep-2', status: 'succeeded' }),
+    ];
+    expect(areDependenciesMet(makePITask({ dependencyTaskIds: ['dep-1', 'dep-2'] }), deps)).toBe(true);
+  });
+
+  it('dependency still pending returns false', async () => {
+    const { areDependenciesMet } = await import('../internalization/internalization-task-guards.js');
+    const deps = [
+      makeTask({ taskId: 'dep-1', status: 'succeeded' }),
+      makeTask({ taskId: 'dep-2', status: 'pending' }),
+    ];
+    expect(areDependenciesMet(makePITask({ dependencyTaskIds: ['dep-1', 'dep-2'] }), deps)).toBe(false);
+  });
+
+  it('dependency failed returns false (fail closed)', async () => {
+    const { areDependenciesMet } = await import('../internalization/internalization-task-guards.js');
+    const deps = [
+      makeTask({ taskId: 'dep-1', status: 'succeeded' }),
+      makeTask({ taskId: 'dep-2', status: 'failed' }),
+    ];
+    expect(areDependenciesMet(makePITask({ dependencyTaskIds: ['dep-1', 'dep-2'] }), deps)).toBe(false);
+  });
+
+  it('dependency not found returns false (fail closed)', async () => {
+    const { areDependenciesMet } = await import('../internalization/internalization-task-guards.js');
+    const deps = [makeTask({ taskId: 'dep-1', status: 'succeeded' })];
+    // dep-2 does not exist in deps array
+    expect(areDependenciesMet(makePITask({ dependencyTaskIds: ['dep-1', 'dep-2'] }), deps)).toBe(false);
+  });
+});
+
+// ── canTransitionTo ──────────────────────────────────────────────────────────
+
+describe('canTransitionTo', () => {
+  it('pending → leased is valid', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('pending', 'leased')).toBe(true);
+  });
+
+  it('leased → succeeded is valid', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('leased', 'succeeded')).toBe(true);
+  });
+
+  it('leased → retry_wait is valid', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('leased', 'retry_wait')).toBe(true);
+  });
+
+  it('leased → failed is valid', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('leased', 'failed')).toBe(true);
+  });
+
+  it('retry_wait → pending is valid (recovery sweep reset)', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('retry_wait', 'pending')).toBe(true);
+  });
+
+  it('succeeded → any state is invalid (terminal)', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('succeeded', 'pending')).toBe(false);
+    expect(canTransitionTo('succeeded', 'leased')).toBe(false);
+    expect(canTransitionTo('succeeded', 'retry_wait')).toBe(false);
+    expect(canTransitionTo('succeeded', 'failed')).toBe(false);
+  });
+
+  it('failed → any state is invalid (terminal)', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('failed', 'pending')).toBe(false);
+    expect(canTransitionTo('failed', 'leased')).toBe(false);
+    expect(canTransitionTo('failed', 'retry_wait')).toBe(false);
+    expect(canTransitionTo('failed', 'succeeded')).toBe(false);
+  });
+
+  it('pending → succeeded is invalid (must lease first)', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('pending', 'succeeded')).toBe(false);
+  });
+
+  it('pending → retry_wait is invalid', async () => {
+    const { canTransitionTo } = await import('../internalization/internalization-task-guards.js');
+    expect(canTransitionTo('pending', 'retry_wait')).toBe(false);
+  });
+});
+
+// ── validateInternalizationTaskReady ──────────────────────────────────────────
+
+describe('validateInternalizationTaskReady', () => {
+  it('no deps + pending → proceed', async () => {
+    const { validateInternalizationTaskReady } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'pending', dependencyTaskIds: [] });
+    const result = validateInternalizationTaskReady(task, []);
+    expect(result.decision).toBe('proceed');
+    expect(result.ready).toBe(true);
+    expect(result.blockedBy).toHaveLength(0);
+  });
+
+  it('all deps succeeded → proceed', async () => {
+    const { validateInternalizationTaskReady } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'pending', dependencyTaskIds: ['dep-1'] });
+    const deps = [makeTask({ taskId: 'dep-1', status: 'succeeded' })];
+    const result = validateInternalizationTaskReady(task, deps);
+    expect(result.decision).toBe('proceed');
+    expect(result.ready).toBe(true);
+  });
+
+  it('dep pending → blocked', async () => {
+    const { validateInternalizationTaskReady } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'pending', dependencyTaskIds: ['dep-1'] });
+    const deps = [makeTask({ taskId: 'dep-1', status: 'pending' })];
+    const result = validateInternalizationTaskReady(task, deps);
+    expect(result.decision).toBe('blocked');
+    expect(result.ready).toBe(false);
+    expect(result.blockedBy).toContain('dep-1');
+  });
+
+  it('dep failed → dependency_failed (NOT auto-fail)', async () => {
+    const { validateInternalizationTaskReady } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'pending', dependencyTaskIds: ['dep-1'] });
+    const deps = [makeTask({ taskId: 'dep-1', status: 'failed' })];
+    const result = validateInternalizationTaskReady(task, deps);
+    expect(result.decision).toBe('dependency_failed');
+    expect(result.ready).toBe(false);
+    expect(result.failedDependencies).toContain('dep-1');
+  });
+
+  it('task already leased → blocked', async () => {
+    const { validateInternalizationTaskReady } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'leased', dependencyTaskIds: [] });
+    const result = validateInternalizationTaskReady(task, []);
+    expect(result.decision).toBe('blocked');
+    expect(result.ready).toBe(false);
+  });
+});
+
+// ── validateTaskTransition ───────────────────────────────────────────────────
+
+describe('validateTaskTransition', () => {
+  it('valid transition returns valid=true', async () => {
+    const { validateTaskTransition } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'pending' });
+    const result = validateTaskTransition(task, 'leased');
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('terminal state transition returns valid=false with reason', async () => {
+    const { validateTaskTransition } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'succeeded' });
+    const result = validateTaskTransition(task, 'failed');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('illegal pending → succeeded returns invalid', async () => {
+    const { validateTaskTransition } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({ status: 'pending' });
+    const result = validateTaskTransition(task, 'succeeded');
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ── decideArtifactRejectionFeedback ───────────────────────────────────────────
+
+describe('decideArtifactRejectionFeedback', () => {
+  it('rejected artifact does NOT set task to failed', async () => {
+    const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'principle' as const,
+      sourceTaskId: 'scribe-task',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'rejected' as const,
+    };
+    const task = makePITask({ taskKind: 'scribe', status: 'succeeded' });
+    const result = decideArtifactRejectionFeedback(artifact, task);
+    // Key assertion: decision is about corrective task, not task failure
+    expect(result.action).not.toBe('task_failed');
+  });
+
+  it('scribe artifact rejected → create corrective scribe task', async () => {
+    const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'rule' as const,
+      sourceTaskId: 'scribe-task',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'rejected' as const,
+    };
+    const task = makePITask({ taskKind: 'scribe', status: 'succeeded' });
+    const result = decideArtifactRejectionFeedback(artifact, task);
+    expect(result.action).toBe('create_corrective_task');
+    expect(result.correctiveTaskKind).toBe('scribe');
+  });
+
+  it('artificer artifact rejected → create corrective artificer task', async () => {
+    const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'patch' as const,
+      sourceTaskId: 'artificer-task',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'rejected' as const,
+    };
+    const task = makePITask({ taskKind: 'artificer', status: 'succeeded' });
+    const result = decideArtifactRejectionFeedback(artifact, task);
+    expect(result.action).toBe('create_corrective_task');
+    expect(result.correctiveTaskKind).toBe('artificer');
+  });
+
+  it('other runner artifact rejected → escalate', async () => {
+    const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'principle' as const,
+      sourceTaskId: 'dreamer-task',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'rejected' as const,
+    };
+    const task = makePITask({ taskKind: 'dreamer', status: 'succeeded' });
+    const result = decideArtifactRejectionFeedback(artifact, task);
+    expect(result.action).toBe('escalate');
+  });
+});
+
+// ── createNextTaskProposal ────────────────────────────────────────────────────
+
+describe('createNextTaskProposal', () => {
+  it('dreamer succeeded → propose philosopher', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'dreamer-1',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'art-1' }],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    expect(r.taskKind).toBe('philosopher');
+    expect(r.parentTaskId).toBe('dreamer-1');
+    expect(r.dependencyTaskIds).toContain('dreamer-1');
+  });
+
+  it('philosopher succeeded → propose scribe', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'phil-1',
+      taskKind: 'philosopher',
+      status: 'succeeded',
+      outputArtifactRefs: [{ artifactType: 'rule', ref: 'art-2' }],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result!.taskKind).toBe('scribe');
+  });
+
+  it('evaluator succeeded → propose rollout_reviewer', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'eval-1',
+      taskKind: 'evaluator',
+      status: 'succeeded',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result!.taskKind).toBe('rollout_reviewer');
+  });
+
+  it('rollout_reviewer succeeded → trainer (can reach trainer via model_training channel)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    // rollout_reviewer has no direct ALLOWED_EDGES successors, but getAllowedSuccessors
+    // appends trainer as a reachable alternative (any runner can reach trainer
+    // via model_training channel)
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result!.taskKind).toBe('trainer');
+  });
+
+  it('dreamer succeeded → philosopher (first in ALLOWED_EDGES, channel passed through)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'dreamer-1',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [{ artifactType: 'training_data', ref: 'td-1' }],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    // getAllowedSuccessors returns ['philosopher', 'trainer'] for dreamer;
+    // first element is philosopher (direct ALLOWED_EDGES successor)
+    expect(r.taskKind).toBe('philosopher');
+    expect(r.channel).toBe('model_training');
+  });
+});
+
+// ── validateInternalizationGraph ──────────────────────────────────────────────
+
+describe('validateInternalizationGraph', () => {
+  it('valid linear chain → valid', async () => {
+    const { validateInternalizationGraph } = await import('../internalization/internalization-state-machine.js');
+    const tasks = [
+      makePITask({ taskId: 't1', taskKind: 'dreamer', dependencyTaskIds: [] }),
+      makePITask({ taskId: 't2', taskKind: 'philosopher', dependencyTaskIds: ['t1'] }),
+      makePITask({ taskId: 't3', taskKind: 'scribe', dependencyTaskIds: ['t2'] }),
+    ];
+    const result = validateInternalizationGraph(tasks);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('graph with cycle → invalid + cycle error', async () => {
+    const { validateInternalizationGraph } = await import('../internalization/internalization-state-machine.js');
+    // t1 → t2 → t3 → t1 (cycle)
+    const tasks = [
+      makePITask({ taskId: 't1', taskKind: 'dreamer', dependencyTaskIds: ['t3'] }),
+      makePITask({ taskId: 't2', taskKind: 'philosopher', dependencyTaskIds: ['t1'] }),
+      makePITask({ taskId: 't3', taskKind: 'scribe', dependencyTaskIds: ['t2'] }),
+    ];
+    const result = validateInternalizationGraph(tasks);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.type === 'cycle')).toBe(true);
+  });
+
+  it('graph with disallowed edge → invalid + disallowed_edge error', async () => {
+    const { validateInternalizationGraph } = await import('../internalization/internalization-state-machine.js');
+    // scribe → dreamer is NOT a valid edge (must go through pipeline)
+    const tasks = [
+      makePITask({ taskId: 't1', taskKind: 'scribe', dependencyTaskIds: [] }),
+      makePITask({ taskId: 't2', taskKind: 'dreamer', dependencyTaskIds: ['t1'] }),
+    ];
+    const result = validateInternalizationGraph(tasks);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.type === 'disallowed_edge')).toBe(true);
+  });
+
+  it('empty graph → valid', async () => {
+    const { validateInternalizationGraph } = await import('../internalization/internalization-state-machine.js');
+    const result = validateInternalizationGraph([]);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ── isResultRefImmutable / canUpdateLastError ────────────────────────────────
+
+describe('isResultRefImmutable', () => {
+  it('succeeded task has immutable resultRef', async () => {
+    const { isResultRefImmutable } = await import('../internalization/internalization-task-guards.js');
+    expect(isResultRefImmutable(makePITask({ status: 'succeeded' }))).toBe(true);
+  });
+
+  it('pending task resultRef is not yet set', async () => {
+    const { isResultRefImmutable } = await import('../internalization/internalization-task-guards.js');
+    // Immutable check is only meaningful after succeeded; pending can still be set
+    expect(isResultRefImmutable(makePITask({ status: 'pending' }))).toBe(false);
+  });
+});
+
+describe('canUpdateLastError', () => {
+  it('retry_wait task can update lastError', async () => {
+    const { canUpdateLastError } = await import('../internalization/internalization-task-guards.js');
+    expect(canUpdateLastError(makePITask({ status: 'retry_wait' }))).toBe(true);
+  });
+
+  it('failed task can update lastError', async () => {
+    const { canUpdateLastError } = await import('../internalization/internalization-task-guards.js');
+    expect(canUpdateLastError(makePITask({ status: 'failed' }))).toBe(true);
+  });
+
+  it('pending task cannot update lastError', async () => {
+    const { canUpdateLastError } = await import('../internalization/internalization-task-guards.js');
+    expect(canUpdateLastError(makePITask({ status: 'pending' }))).toBe(false);
+  });
+
+  it('succeeded task cannot update lastError', async () => {
+    const { canUpdateLastError } = await import('../internalization/internalization-task-guards.js');
+    expect(canUpdateLastError(makePITask({ status: 'succeeded' }))).toBe(false);
+  });
+});
+
+// ── isArtifactRejected ───────────────────────────────────────────────────────
+
+describe('isArtifactRejected', () => {
+  it('rejected artifact returns true', async () => {
+    const { isArtifactRejected } = await import('../internalization/internalization-task-guards.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'principle' as const,
+      sourceTaskId: 'task-1',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'rejected' as const,
+    };
+    expect(isArtifactRejected(artifact)).toBe(true);
+  });
+
+  it('validated artifact returns false', async () => {
+    const { isArtifactRejected } = await import('../internalization/internalization-task-guards.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'principle' as const,
+      sourceTaskId: 'task-1',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'validated' as const,
+    };
+    expect(isArtifactRejected(artifact)).toBe(false);
+  });
+
+  it('pending artifact returns false', async () => {
+    const { isArtifactRejected } = await import('../internalization/internalization-task-guards.js');
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'principle' as const,
+      sourceTaskId: 'task-1',
+      lineageRefs: [] as LineageRef[],
+      validationStatus: 'pending' as const,
+    };
+    expect(isArtifactRejected(artifact)).toBe(false);
+  });
+});
+
+// ── Architecture Guards ───────────────────────────────────────────────────────
+
+describe('Architecture Guards: no infrastructure imports', () => {
+  it('internalization-task-guards.ts has zero infra imports', async () => {
+    expect(await moduleHasNoInfraImports('internalization/internalization-task-guards.ts')).toBe(true);
+  });
+
+  it('internalization-state-machine.ts has zero infra imports', async () => {
+    expect(await moduleHasNoInfraImports('internalization/internalization-state-machine.ts')).toBe(true);
+  });
+
+  it('state machine guard does not call PDRuntimeAdapter', async () => {
+    const src = readFileSync(resolve(__dirname, '..', 'internalization/internalization-state-machine.ts'), 'utf-8');
+    // PDRuntimeAdapter is only mentioned in a comment — no actual runtime call
+    expect(src).not.toMatch(/\bPDRuntimeAdapter\s*\(/);
+  });
+
+  it('guard functions return proposals, not direct createTask calls', async () => {
+    const src = readFileSync(resolve(__dirname, '..', 'internalization/internalization-state-machine.ts'), 'utf-8');
+    // Pure return values — no store mutation functions called
+    expect(src).not.toMatch(/\bcreateTask\s*\(/);
+    expect(src).not.toMatch(/\bmarkTask\S+\s*\(/);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -373,3 +373,34 @@ export {
   getAllowedSuccessors,
   getAllowedPredecessors,
 } from './internalization/internalization-job-graph.js';
+
+// ── Internalization State Machine Guards (PRI-62) ─────────────────────────────
+
+export {
+  canAcquireLease,
+  areDependenciesMet,
+  canTransitionTo,
+  isResultRefImmutable,
+  canUpdateLastError,
+  isArtifactRejected,
+} from './internalization/internalization-task-guards.js';
+
+export type {
+  DependencyGateDecision,
+  DependencyGateResult,
+  TransitionValidation,
+  RejectionFeedbackAction,
+  RejectionFeedbackResult,
+  NextTaskProposal,
+  GraphErrorType,
+  GraphValidationError,
+  GraphValidationResult,
+} from './internalization/internalization-state-machine.js';
+
+export {
+  validateInternalizationTaskReady,
+  validateTaskTransition,
+  decideArtifactRejectionFeedback,
+  createNextTaskProposal,
+  validateInternalizationGraph,
+} from './internalization/internalization-state-machine.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -108,3 +108,34 @@ export {
   getAllowedSuccessors,
   getAllowedPredecessors,
 } from './internalization-job-graph.js';
+
+// ── State Machine Guards (PRI-62) ────────────────────────────────────────────────
+
+export {
+  canAcquireLease,
+  areDependenciesMet,
+  canTransitionTo,
+  isResultRefImmutable,
+  canUpdateLastError,
+  isArtifactRejected,
+} from './internalization-task-guards.js';
+
+export type {
+  DependencyGateDecision,
+  DependencyGateResult,
+  TransitionValidation,
+  RejectionFeedbackAction,
+  RejectionFeedbackResult,
+  NextTaskProposal,
+  GraphErrorType,
+  GraphValidationError,
+  GraphValidationResult,
+} from './internalization-state-machine.js';
+
+export {
+  validateInternalizationTaskReady,
+  validateTaskTransition,
+  decideArtifactRejectionFeedback,
+  createNextTaskProposal,
+  validateInternalizationGraph,
+} from './internalization-state-machine.js';

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -284,33 +284,48 @@ export function decideArtifactRejectionFeedback(
  *   - evaluator → rollout_reviewer
  *   - Any runner (+ model_training channel) → trainer
  *
- * Returns null if the current task has no successors (e.g., rollout_reviewer
- * is a terminal node in the v1 chain).
+ * Requires currentTask.status === 'succeeded' — non-terminal tasks
+ * must not generate successor proposals (prevents pipeline乱序).
  *
- * Note: this only proposes the immediate next step — the Orchestrator
- * is responsible for enqueueing and tracking the full chain.
+ * Filters successors by channel constraint: a runner kind transition
+ * is only valid when validateEdge(fromKind, toKind, channel) is true.
+ * For example, rollout_reviewer → trainer requires channel === 'model_training'.
+ *
+ * Returns null if the task is not succeeded or no channel-valid
+ * successors exist.
  */
 export function createNextTaskProposal(
   currentTask: PITaskRecord,
   _artifacts: PIArtifact[],
   channel?: InternalizationChannel,
 ): NextTaskProposal | null {
-  const successors = getAllowedSuccessors(currentTask.taskKind);
-
-  if (successors.length === 0) {
+  if (currentTask.status !== 'succeeded') {
     return null;
   }
 
-  // V1: take the first successor (linear chain)
+  const effectiveChannel = channel ?? currentTask.channel;
+  const successors = getAllowedSuccessors(currentTask.taskKind);
+
+  // Filter to only channel-valid successors (M1: prevent invalid trainer proposal)
+  const validSuccessors = successors.filter(s =>
+    validateEdge(currentTask.taskKind, s, effectiveChannel),
+  );
+
+  if (validSuccessors.length === 0) {
+    return null;
+  }
+
+  // V1: take the first valid successor (linear chain)
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const nextKind = successors[0]!;
+  const nextKind = validSuccessors[0]!;
 
   return {
     taskKind: nextKind,
     parentTaskId: currentTask.taskId,
     dependencyTaskIds: [currentTask.taskId],
-    inputArtifactRefs: currentTask.outputArtifactRefs,
-    channel: channel ?? currentTask.channel,
+    // Defensive copy: prevent caller from mutating source task outputArtifactRefs (M2)
+    inputArtifactRefs: [...currentTask.outputArtifactRefs],
+    channel: effectiveChannel,
     correlationId: currentTask.correlationId,
   };
 }

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -1,0 +1,370 @@
+/**
+ * Internalization State Machine (PRI-62)
+ *
+ * Pure decision functions for the Internalization Engine state machine.
+ * These functions return structured proposals — they do NOT mutate store state,
+ * do NOT call PDRuntimeAdapter, and do NOT execute createTask.
+ *
+ * Orchestrator (future PRI-62 scope) is responsible for consuming these
+ * decisions and invoking RuntimeStateManager to apply transitions.
+ *
+ * Key design:
+ *   - Guard functions (task-guards.ts) validate individual conditions
+ *   - State machine functions compose guards into actionable decisions
+ *   - All functions are pure: same inputs → same outputs, no side effects
+ *
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ */
+
+import type { PDTaskStatus, TaskRecord } from '../task-status.js';
+import type {
+  PITaskRecord,
+  PeerRunnerKind,
+  InternalizationChannel,
+  PIArtifact,
+  ArtifactRef,
+} from './peer-runner-contracts.js';
+import { getAllowedSuccessors, isAcyclic, validateEdge } from './internalization-job-graph.js';
+
+import {
+  canAcquireLease,
+  canTransitionTo,
+} from './internalization-task-guards.js';
+
+// ── Dependency Gate Types ─────────────────────────────────────────────────────
+
+/**
+ * Decision when evaluating if a task is ready to execute.
+ *
+ *   proceed:            All conditions met — task can be leased and executed
+ *   blocked:            Dependencies not yet satisfied — wait for them
+ *   dependency_failed:   At least one dependency has failed — escalate policy needed
+ */
+export type DependencyGateDecision = 'proceed' | 'blocked' | 'dependency_failed';
+
+export interface DependencyGateResult {
+  decision: DependencyGateDecision;
+  /** Whether the task is ready to execute (same as decision === 'proceed') */
+  ready: boolean;
+  /** Task IDs that are blocking execution (status != succeeded) */
+  blockedBy: string[];
+  /** Task IDs that have failed — for escalation policy decision */
+  failedDependencies: string[];
+}
+
+// ── Transition Validation Types ───────────────────────────────────────────────
+
+export interface TransitionValidation {
+  valid: boolean;
+  /** Human-readable reason if invalid */
+  reason?: string;
+}
+
+// ── Rejection Feedback Types ─────────────────────────────────────────────────
+
+/**
+ * Action to take when an artifact has been rejected.
+ *
+ *   create_corrective_task: Re-run the same or corrective runner kind
+ *   escalate:               Human review needed
+ */
+export type RejectionFeedbackAction = 'create_corrective_task' | 'escalate';
+
+export interface RejectionFeedbackResult {
+  action: RejectionFeedbackAction;
+  /** The runner kind to use for corrective task (if action is create_corrective_task) */
+  correctiveTaskKind?: PeerRunnerKind;
+  rejectedArtifactId: string;
+  sourceTaskId: string;
+  sourceTaskKind: PeerRunnerKind;
+  rejectionReason?: string;
+}
+
+// ── Next Task Proposal Types ─────────────────────────────────────────────────
+
+export interface NextTaskProposal {
+  taskKind: PeerRunnerKind;
+  parentTaskId: string;
+  dependencyTaskIds: string[];
+  inputArtifactRefs: ArtifactRef[];
+  channel: InternalizationChannel;
+  correlationId?: string;
+}
+
+// ── Graph Validation Types ───────────────────────────────────────────────────
+
+export type GraphErrorType = 'cycle' | 'disallowed_edge' | 'missing_dependency';
+
+export interface GraphValidationError {
+  type: GraphErrorType;
+  message: string;
+  taskId?: string;
+  fromKind?: string;
+  toKind?: string;
+}
+
+export interface GraphValidationResult {
+  valid: boolean;
+  errors: GraphValidationError[];
+}
+
+// ── Core Decision Functions ──────────────────────────────────────────────────
+
+/**
+ * Validates whether a task is ready to be leased and executed.
+ *
+ * Combines:
+ *   1. canAcquireLease — task status must be pending or retry_wait
+ *   2. areDependenciesMet — all dependencyTaskIds must be succeeded
+ *
+ * Note: dependency failure (dependency_failed) does NOT automatically fail
+ * the dependent task. The escalation policy (PRI-62 follow-up) decides
+ * how to handle dependency failures.
+ */
+export function validateInternalizationTaskReady(
+  task: PITaskRecord,
+  dependencies: readonly TaskRecord[],
+): DependencyGateResult {
+  const blockedBy: string[] = [];
+  const failedDependencies: string[] = [];
+
+  // Check if task status allows leasing
+  if (!canAcquireLease(task)) {
+    // Task is already leased, succeeded, or failed — blocked
+    return {
+      decision: 'blocked',
+      ready: false,
+      blockedBy: [],
+      failedDependencies: [],
+    };
+  }
+
+  // Collect dependency statuses
+  const depMap = new Map(dependencies.map(d => [d.taskId, d]));
+
+  for (const depId of task.dependencyTaskIds) {
+    const dep = depMap.get(depId);
+    if (!dep) {
+      // Dependency not found — fail closed
+      blockedBy.push(depId);
+    } else if (dep.status === 'succeeded') {
+      // OK
+    } else if (dep.status === 'failed') {
+      failedDependencies.push(depId);
+    } else {
+      blockedBy.push(depId);
+    }
+  }
+
+  // Determine decision
+  if (failedDependencies.length > 0) {
+    return {
+      decision: 'dependency_failed',
+      ready: false,
+      blockedBy,
+      failedDependencies,
+    };
+  }
+
+  if (blockedBy.length > 0) {
+    return {
+      decision: 'blocked',
+      ready: false,
+      blockedBy,
+      failedDependencies: [],
+    };
+  }
+
+  return {
+    decision: 'proceed',
+    ready: true,
+    blockedBy: [],
+    failedDependencies: [],
+  };
+}
+
+/**
+ * Validates whether a task status transition is permitted.
+ *
+ * Uses canTransitionTo internally and adds human-readable reasons
+ * for invalid transitions.
+ */
+export function validateTaskTransition(
+  task: PITaskRecord,
+  newStatus: PDTaskStatus,
+): TransitionValidation {
+  if (canTransitionTo(task.status, newStatus)) {
+    return { valid: true };
+  }
+
+  const reason = ((): string => {
+    if (task.status === 'succeeded' || task.status === 'failed') {
+      return `Terminal state: ${task.status} cannot transition to ${newStatus}`;
+    }
+    if (newStatus === 'succeeded' && task.status !== 'leased') {
+      return `Cannot transition directly to succeeded: task must be leased first (currently ${task.status})`;
+    }
+    if (task.status === 'pending' && newStatus !== 'leased') {
+      return `Pending task can only transition to leased (not ${newStatus})`;
+    }
+    return `Invalid transition from ${task.status} to ${newStatus}`;
+  })();
+
+  return { valid: false, reason };
+}
+
+/**
+ * Decides what action to take when an artifact has been rejected.
+ *
+ * Per ADR-0003 Section 3.7 rejection feedback loop:
+ *   - Artifact rejected ≠ task failed (they are separate concerns)
+ *   - Rejected artifacts can generate corrective task proposals
+ *   - Scribe/Artificer rejections → corrective task (re-run)
+ *   - Other runners → escalate for human review
+ *
+ * This function returns a proposal; the Orchestrator decides whether
+ * to act on it.
+ */
+export function decideArtifactRejectionFeedback(
+  artifact: PIArtifact,
+  task: PITaskRecord,
+): RejectionFeedbackResult {
+  const base = {
+    rejectedArtifactId: artifact.artifactId,
+    sourceTaskId: artifact.sourceTaskId,
+    sourceTaskKind: task.taskKind,
+  };
+
+  // Scribe rejections → re-run scribe to regenerate
+  if (task.taskKind === 'scribe') {
+    return {
+      ...base,
+      action: 'create_corrective_task',
+      correctiveTaskKind: 'scribe',
+    };
+  }
+
+  // Artificer rejections → re-run artificer to re-validate
+  if (task.taskKind === 'artificer') {
+    return {
+      ...base,
+      action: 'create_corrective_task',
+      correctiveTaskKind: 'artificer',
+    };
+  }
+
+  // All other runners → escalate for human review
+  return {
+    ...base,
+    action: 'escalate',
+  };
+}
+
+/**
+ * Proposes the next task in the pipeline after a task succeeds.
+ *
+ * Uses the job graph (getAllowedSuccessors) to determine valid next steps:
+ *   - dreamer → philosopher
+ *   - philosopher → scribe
+ *   - scribe → artificer
+ *   - artificer → evaluator
+ *   - evaluator → rollout_reviewer
+ *   - Any runner (+ model_training channel) → trainer
+ *
+ * Returns null if the current task has no successors (e.g., rollout_reviewer
+ * is a terminal node in the v1 chain).
+ *
+ * Note: this only proposes the immediate next step — the Orchestrator
+ * is responsible for enqueueing and tracking the full chain.
+ */
+export function createNextTaskProposal(
+  currentTask: PITaskRecord,
+  _artifacts: PIArtifact[],
+  channel?: InternalizationChannel,
+): NextTaskProposal | null {
+  const successors = getAllowedSuccessors(currentTask.taskKind);
+
+  if (successors.length === 0) {
+    return null;
+  }
+
+  // V1: take the first successor (linear chain)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const nextKind = successors[0]!;
+
+  return {
+    taskKind: nextKind,
+    parentTaskId: currentTask.taskId,
+    dependencyTaskIds: [currentTask.taskId],
+    inputArtifactRefs: currentTask.outputArtifactRefs,
+    channel: channel ?? currentTask.channel,
+    correlationId: currentTask.correlationId,
+  };
+}
+
+/**
+ * Validates an entire task graph for structural correctness.
+ *
+ * Checks:
+ *   1. No cycles — uses isAcyclic() on extracted edges
+ *   2. All edges are in ALLOWED_EDGES (via validateEdge)
+ *   3. All dependencyTaskIds reference existing tasks (fail closed)
+ *
+ * Note: this does NOT check dependency status (use validateInternalizationTaskReady
+ * for that) — only structural validity.
+ */
+export function validateInternalizationGraph(tasks: PITaskRecord[]): GraphValidationResult {
+  const errors: GraphValidationError[] = [];
+  const taskMap = new Map(tasks.map(t => [t.taskId, t]));
+
+  // Build dependency edges for cycle detection
+  const edgesForCycle: (readonly [string, string])[] = [];
+  for (const task of tasks) {
+    for (const depId of task.dependencyTaskIds) {
+      const dep = taskMap.get(depId);
+      if (dep) {
+        edgesForCycle.push([depId, task.taskId]);
+      }
+    }
+  }
+
+  // Check 1: cycles (using isAcyclic on dependency edges)
+  if (!isAcyclic(edgesForCycle)) {
+    errors.push({
+      type: 'cycle',
+      message: 'Task graph contains a cycle — dependencies cannot be satisfied',
+    });
+  }
+
+  // Check 2: disallowed edges (using validateEdge on runner kind transitions)
+  for (const task of tasks) {
+    for (const depId of task.dependencyTaskIds) {
+      const dep = taskMap.get(depId);
+      if (!dep) {
+        errors.push({
+          type: 'missing_dependency',
+          message: `Task ${task.taskId} depends on ${depId} which does not exist in the graph`,
+          taskId: task.taskId,
+        });
+        continue;
+      }
+
+      // Use the current task's channel for edge validation
+      const edgeValid = validateEdge(dep.taskKind, task.taskKind, task.channel);
+      if (!edgeValid) {
+        errors.push({
+          type: 'disallowed_edge',
+          message: `Disallowed edge: ${dep.taskKind} → ${task.taskKind}`,
+          taskId: task.taskId,
+          fromKind: dep.taskKind,
+          toKind: task.taskKind,
+        });
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -70,15 +70,28 @@ export interface TransitionValidation {
  */
 export type RejectionFeedbackAction = 'create_corrective_task' | 'escalate';
 
-export interface RejectionFeedbackResult {
-  action: RejectionFeedbackAction;
-  /** The runner kind to use for corrective task (if action is create_corrective_task) */
-  correctiveTaskKind?: PeerRunnerKind;
-  rejectedArtifactId: string;
-  sourceTaskId: string;
-  sourceTaskKind: PeerRunnerKind;
-  rejectionReason?: string;
-}
+/**
+ * Discriminated union for artifact rejection feedback.
+ *
+ * create_corrective_task: correctiveTaskKind is required
+ * escalate: correctiveTaskKind is absent
+ */
+export type RejectionFeedbackResult =
+  | {
+      action: 'create_corrective_task';
+      correctiveTaskKind: PeerRunnerKind;
+      rejectedArtifactId: string;
+      sourceTaskId: string;
+      sourceTaskKind: PeerRunnerKind;
+      rejectionReason?: string;
+    }
+  | {
+      action: 'escalate';
+      rejectedArtifactId: string;
+      sourceTaskId: string;
+      sourceTaskKind: PeerRunnerKind;
+      rejectionReason?: string;
+    };
 
 // ── Next Task Proposal Types ─────────────────────────────────────────────────
 

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
@@ -1,0 +1,127 @@
+/**
+ * Internalization Task Guards (PRI-62)
+ *
+ * Pure Boolean guard functions that validate individual conditions
+ * for the Internalization Engine state machine.
+ *
+ * Key constraints (ADR-0003 Section 3.9):
+ *   - Terminal task states: succeeded and failed only
+ *   - resultRef is immutable only after status transitions to succeeded
+ *   - lastError can be updated during retry_wait and failed transitions
+ *   - dependencyTaskIds gating must fail closed
+ *
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ */
+
+import type { PDTaskStatus, TaskRecord } from '../task-status.js';
+import type { PITaskRecord, PIArtifact } from './peer-runner-contracts.js';
+
+// ── Lease Acquisition Guards ─────────────────────────────────────────────────
+
+/**
+ * Returns true if the task status allows acquiring a lease.
+ *
+ * Only `pending` and `retry_wait` can be leased:
+ *   - pending: task is waiting for a runner to pick it up
+ *   - retry_wait: task is recovering after a transient failure
+ *
+ * Terminal states (succeeded/failed) are not leaseable.
+ * `leased` tasks already have an active lease and cannot be re-leased.
+ */
+export function canAcquireLease(task: PITaskRecord): boolean {
+  return task.status === 'pending' || task.status === 'retry_wait';
+}
+
+// ── Dependency Gate ───────────────────────────────────────────────────────────
+
+/**
+ * Returns true if ALL dependency tasks have reached succeeded state.
+ *
+ * Fail-closed: if ANY dependency is not found in the dependencies array,
+ * or is not in succeeded state, returns false.
+ *
+ * Empty dependencyTaskIds means no gating — returns true.
+ */
+export function areDependenciesMet(
+  task: PITaskRecord,
+  dependencies: readonly TaskRecord[],
+): boolean {
+  if (task.dependencyTaskIds.length === 0) {
+    return true;
+  }
+
+  const depMap = new Map(dependencies.map(d => [d.taskId, d]));
+
+  for (const depId of task.dependencyTaskIds) {
+    const dep = depMap.get(depId);
+    if (!dep || dep.status !== 'succeeded') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ── Status Transition Guards ─────────────────────────────────────────────────
+
+/**
+ * Returns true if a PDTaskStatus transition is valid per ADR-0003 Section 3.8.
+ *
+ * Valid transitions:
+ *   pending  → leased
+ *   leased   → succeeded
+ *   leased   → retry_wait
+ *   leased   → failed
+ *   retry_wait → pending  (recovery sweep resets)
+ *
+ * Terminal states (succeeded, failed) cannot transition to any other state.
+ */
+export function canTransitionTo(currentStatus: PDTaskStatus, newStatus: PDTaskStatus): boolean {
+  switch (currentStatus) {
+    case 'pending':
+      return newStatus === 'leased';
+    case 'leased':
+      return newStatus === 'succeeded' || newStatus === 'retry_wait' || newStatus === 'failed';
+    case 'retry_wait':
+      return newStatus === 'pending';
+    case 'succeeded':
+    case 'failed':
+      return false; // Terminal states
+    default:
+      return false;
+  }
+}
+
+// ── Immutability Guards ─────────────────────────────────────────────────────
+
+/**
+ * Returns true if resultRef is now immutable (task reached succeeded).
+ *
+ * Per ADR-0003: resultRef becomes immutable after task enters succeeded state.
+ * Before succeeded, resultRef may still be set or updated.
+ */
+export function isResultRefImmutable(task: PITaskRecord): boolean {
+  return task.status === 'succeeded';
+}
+
+/**
+ * Returns true if lastError can be updated for this task.
+ *
+ * lastError can be updated during retry_wait and failed transitions.
+ * It is NOT updated during pending (no error yet) or succeeded (terminal).
+ */
+export function canUpdateLastError(task: PITaskRecord): boolean {
+  return task.status === 'retry_wait' || task.status === 'failed';
+}
+
+// ── Artifact Guards ──────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the artifact has been rejected by the evaluator.
+ *
+ * Per ADR-0003 Section 3.7: rejected artifacts trigger a corrective feedback
+ * loop but do NOT directly set the source task to failed.
+ */
+export function isArtifactRejected(artifact: PIArtifact): boolean {
+  return artifact.validationStatus === 'rejected';
+}

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
@@ -68,11 +68,12 @@ export function areDependenciesMet(
  * Returns true if a PDTaskStatus transition is valid per ADR-0003 Section 3.8.
  *
  * Valid transitions:
- *   pending  → leased
- *   leased   → succeeded
- *   leased   → retry_wait
- *   leased   → failed
- *   retry_wait → pending  (recovery sweep resets)
+ *   pending     → leased
+ *   leased      → succeeded
+ *   leased      → retry_wait
+ *   leased      → failed
+ *   leased      → pending   (lease release / force-expire — e.g. LeaseManager.releaseLease)
+ *   retry_wait  → pending   (recovery sweep resets)
  *
  * Terminal states (succeeded, failed) cannot transition to any other state.
  */
@@ -81,12 +82,17 @@ export function canTransitionTo(currentStatus: PDTaskStatus, newStatus: PDTaskSt
     case 'pending':
       return newStatus === 'leased';
     case 'leased':
-      return newStatus === 'succeeded' || newStatus === 'retry_wait' || newStatus === 'failed';
+      return (
+        newStatus === 'succeeded' ||
+        newStatus === 'retry_wait' ||
+        newStatus === 'failed' ||
+        newStatus === 'pending'
+      );
     case 'retry_wait':
       return newStatus === 'pending';
     case 'succeeded':
     case 'failed':
-      return false; // Terminal states
+      return false;
     default:
       return false;
   }


### PR DESCRIPTION
## Summary

Add pure guard functions and state-machine decision logic for the Internalization Engine. Implements ADR-0003 Section 3.7-3.8 rules:

- **Task guards** (`internalization-task-guards.ts`): `canAcquireLease`, `areDependenciesMet`, `canTransitionTo`, `isResultRefImmutable`, `canUpdateLastError`, `isArtifactRejected`
- **State machine** (`internalization-state-machine.ts`): `validateInternalizationTaskReady`, `validateTaskTransition`, `decideArtifactRejectionFeedback`, `createNextTaskProposal`, `validateInternalizationGraph`
- **53 unit tests** covering dependency gating, terminal states, retry_wait recovery, artifact rejection feedback loops, and graph validation
- **6 architecture regression guards** for zero-infrastructure imports and proposal-only design

## Test plan

- [x] `npm run build --workspace=@principles/core`
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts` (53 passed)
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` (125 passed)
- [x] `npm run build --workspace=@principles/pd-cli`

## Non-goals (per PRI-62 scope)

- No Orchestrator implementation
- No RuntimeStateManager modifications
- No fan-out/fan-in implementation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了任务防护和状态机验证功能，支持依赖网关、状态转换验证、任务提案生成和图验证等核心能力
  * 扩展公开API以支持新增的状态机类型和验证函数

* **测试**
  * 添加了综合测试套件，覆盖任务防护、状态转换、依赖管理和图验证的各项行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->