### PR TITLE
fix(runtime-v2): PRI-65 PITask persistence & hydration

### DIFF
--- a/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
+++ b/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
@@ -255,8 +255,14 @@ export function createInternalizationTrigger(
   // ── start: begin periodic wake cycles ─────────────────────────────────────
 
   function start(ctx: TriggerContext, intervalMs = 5 * 60 * 1000): () => void {
-    // Prevent re-entrancy: if already running, return existing stop
-    if (state.intervalId !== null) return stop;
+    // Prevent re-entrancy: if already running, warn and return existing stop
+    if (state.intervalId !== null) {
+      logger?.warn?.('[PD:InternalizationTrigger] start() called while already running — returning existing stop', {
+        workspaceDir: ctx.workspaceDir,
+        stateDir: ctx.stateDir,
+      });
+      return stop;
+    }
 
     // Immediate first wake
     wake(ctx).catch(err => {

--- a/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
+++ b/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
@@ -19,7 +19,7 @@ import type { TaskRecord } from '@principles/core/runtime-v2';
 import {
   validateInternalizationTaskReady,
   isPeerRunnerKind,
-  isValidPITaskRecord,
+  hydratePITaskRecord,
   type PITaskRecord,
   type PeerRunnerKind,
 } from '@principles/core/runtime-v2';
@@ -165,15 +165,17 @@ export function createInternalizationTrigger(
       const pendingTasks = await provider.listTasks({ status: 'pending' });
       const retryWaitTasks = await provider.listTasks({ status: 'retry_wait' });
 
-      // Filter to only PeerRunner tasks (ignore diagnostician etc.)
-      const pendingPITasks = pendingTasks.filter(
-        (t): t is PITaskRecord =>
-          isPeerRunnerKind(t.taskKind) && isValidPITaskRecord(t),
-      );
-      const retryWaitPITasks = retryWaitTasks.filter(
-        (t): t is PITaskRecord =>
-          isPeerRunnerKind(t.taskKind) && isValidPITaskRecord(t),
-      );
+      // Filter to only PeerRunner tasks, then hydrate PI metadata from diagnosticJson.
+      // Tasks without valid PI metadata in diagnosticJson return null and are filtered out.
+      const pendingPITasks = pendingTasks
+        .filter(t => isPeerRunnerKind(t.taskKind))
+        .map(t => hydratePITaskRecord(t))
+        .filter((t): t is PITaskRecord => t !== null);
+
+      const retryWaitPITasks = retryWaitTasks
+        .filter(t => isPeerRunnerKind(t.taskKind))
+        .map(t => hydratePITaskRecord(t))
+        .filter((t): t is PITaskRecord => t !== null);
 
       const candidateTasks = [...pendingPITasks, ...retryWaitPITasks];
 

--- a/packages/openclaw-plugin/tests/service/internalization-trigger-adapter.test.ts
+++ b/packages/openclaw-plugin/tests/service/internalization-trigger-adapter.test.ts
@@ -1,11 +1,16 @@
 /**
- * Internalization Trigger Adapter - Unit Tests (PRI-63)
+ * Internalization Trigger Adapter - Unit Tests (PRI-63/65)
+ *
+ * PRI-65: Updated to use diagnosticJson for PI metadata, simulating
+ * real SqliteTaskStore behavior where PI fields live inside diagnosticJson.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import type { TaskRecord } from '@principles/core/runtime-v2';
+import { createPITaskDiagnosticJson } from '@principles/core/runtime-v2';
+import type { InternalizationChannel, ArtifactRef } from '@principles/core/runtime-v2';
 
 type MockLogger = {
   debug?: (msg: string, meta?: Record<string, unknown>) => void;
@@ -19,23 +24,52 @@ interface MockProvider {
   getTask: ReturnType<typeof vi.fn>;
 }
 
+/** Create a base TaskRecord (no PI metadata). Provider returns this from SQLite. */
 function makeTask(overrides: Partial<TaskRecord> & { taskId: string; taskKind: string }): TaskRecord {
   return {
     taskId: overrides.taskId,
     taskKind: overrides.taskKind,
     status: overrides.status ?? 'pending',
-    resultRef: undefined,
-    lastError: undefined,
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    updatedAt: overrides.updatedAt ?? new Date().toISOString(),
     attemptCount: 0,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    dependencyTaskIds: overrides.dependencyTaskIds ?? [],
-    correlationId: overrides.correlationId,
-    channel: 'prompt' as TaskRecord['channel'],
-    timeoutMs: 300000,
-    inputArtifactRefs: [],
-    outputArtifactRefs: [],
+    maxAttempts: 3,
+    leaseOwner: undefined,
+    leaseExpiresAt: undefined,
+    lastError: undefined,
+    inputRef: undefined,
+    resultRef: undefined,
     ...overrides,
+  } as TaskRecord;
+}
+
+/** Create a TaskRecord with PI metadata stored in diagnosticJson (simulates SqliteTaskStore). */
+function makePITask(
+  taskId: string,
+  taskKind: string,
+  channel: InternalizationChannel,
+  options?: {
+    status?: TaskRecord['status'];
+    dependencyTaskIds?: string[];
+    parentTaskId?: string;
+    correlationId?: string;
+    timeoutMs?: number;
+    inputArtifactRefs?: ArtifactRef[];
+    outputArtifactRefs?: ArtifactRef[];
+  },
+): TaskRecord {
+  const meta = {
+    dependencyTaskIds: options?.dependencyTaskIds ?? [],
+    channel,
+    timeoutMs: options?.timeoutMs ?? 300000,
+    inputArtifactRefs: options?.inputArtifactRefs ?? [],
+    outputArtifactRefs: options?.outputArtifactRefs ?? [],
+    parentTaskId: options?.parentTaskId,
+    correlationId: options?.correlationId,
+  };
+  return {
+    ...makeTask({ taskId, taskKind, status: options?.status ?? 'pending' }),
+    diagnosticJson: createPITaskDiagnosticJson(meta),
   } as TaskRecord;
 }
 
@@ -72,7 +106,7 @@ describe('Internalization Trigger Adapter', () => {
     });
 
     it('pending task with no deps → logs INTERNALIZATION_TRIGGER_WAKE with correct payload', async () => {
-      const task = makeTask({ taskId: 'task-1', taskKind: 'dreamer', status: 'pending', dependencyTaskIds: [] });
+      const task = makePITask('task-1', 'dreamer', 'prompt', { status: 'pending', dependencyTaskIds: [] });
       mockProvider.listTasks.mockResolvedValue([task]);
       await adapter.wake({ workspaceDir: '/test', stateDir: '/test/.state' });
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -82,7 +116,7 @@ describe('Internalization Trigger Adapter', () => {
     });
 
     it('retry_wait task → logs INTERNALIZATION_TRIGGER_WAKE', async () => {
-      const task = makeTask({ taskId: 'task-retry', taskKind: 'philosopher', status: 'retry_wait', dependencyTaskIds: [] });
+      const task = makePITask('task-retry', 'philosopher', 'prompt', { status: 'retry_wait', dependencyTaskIds: [] });
       mockProvider.listTasks.mockResolvedValue([task]);
       await adapter.wake({ workspaceDir: '/test', stateDir: '/test/.state' });
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -92,8 +126,8 @@ describe('Internalization Trigger Adapter', () => {
     });
 
     it('task with unmet deps → logs INTERNALIZATION_TRIGGER_BLOCKED with gateDecision blocked', async () => {
-      const depTask = makeTask({ taskId: 'dep-1', taskKind: 'scribe', status: 'pending', dependencyTaskIds: [] });
-      const task = makeTask({ taskId: 'task-blocked', taskKind: 'dreamer', status: 'pending', dependencyTaskIds: ['dep-1'] });
+      const depTask = makePITask('dep-1', 'scribe', 'prompt', { status: 'pending', dependencyTaskIds: [] });
+      const task = makePITask('task-blocked', 'dreamer', 'prompt', { status: 'pending', dependencyTaskIds: ['dep-1'] });
       mockProvider.listTasks.mockResolvedValue([task]);
       mockProvider.getTask.mockResolvedValue(depTask);
       await adapter.wake({ workspaceDir: '/test', stateDir: '/test/.state' });
@@ -104,8 +138,8 @@ describe('Internalization Trigger Adapter', () => {
     });
 
     it('task with failed dep → logs INTERNALIZATION_TRIGGER_BLOCKED with dependency_failed', async () => {
-      const depTask = makeTask({ taskId: 'dep-failed', taskKind: 'scribe', status: 'failed', dependencyTaskIds: [] });
-      const task = makeTask({ taskId: 'task-dep-failed', taskKind: 'dreamer', status: 'pending', dependencyTaskIds: ['dep-failed'] });
+      const depTask = makePITask('dep-failed', 'scribe', 'prompt', { status: 'failed', dependencyTaskIds: [] });
+      const task = makePITask('task-dep-failed', 'dreamer', 'prompt', { status: 'pending', dependencyTaskIds: ['dep-failed'] });
       mockProvider.listTasks.mockResolvedValue([task]);
       mockProvider.getTask.mockResolvedValue(depTask);
       await adapter.wake({ workspaceDir: '/test', stateDir: '/test/.state' });
@@ -116,7 +150,7 @@ describe('Internalization Trigger Adapter', () => {
     });
 
     it('task with missing dep → logs INTERNALIZATION_TRIGGER_BLOCKED (fail closed)', async () => {
-      const task = makeTask({ taskId: 'task-missing-dep', taskKind: 'dreamer', status: 'pending', dependencyTaskIds: ['nonexistent'] });
+      const task = makePITask('task-missing-dep', 'dreamer', 'prompt', { status: 'pending', dependencyTaskIds: ['nonexistent'] });
       mockProvider.listTasks.mockResolvedValue([task]);
       mockProvider.getTask.mockResolvedValue(null);
       await adapter.wake({ workspaceDir: '/test', stateDir: '/test/.state' });
@@ -151,7 +185,7 @@ describe('Internalization Trigger Adapter', () => {
   describe('wake — fire and forget', () => {
     it('wake() returns in < 200ms even with many tasks', async () => {
       const manyTasks = Array.from({ length: 20 }, (_, i) =>
-        makeTask({ taskId: `task-${i}`, taskKind: 'dreamer', status: 'pending', dependencyTaskIds: [] }),
+        makePITask(`task-${i}`, 'dreamer', 'prompt', { status: 'pending', dependencyTaskIds: [] }),
       );
       mockProvider.listTasks.mockResolvedValue(manyTasks);
       const start = Date.now();
@@ -160,7 +194,7 @@ describe('Internalization Trigger Adapter', () => {
     });
 
     it('wake() calls only read methods', async () => {
-      const task = makeTask({ taskId: 'task-readonly', taskKind: 'scribe', status: 'pending', dependencyTaskIds: [] });
+      const task = makePITask('task-readonly', 'scribe', 'prompt', { status: 'pending', dependencyTaskIds: [] });
       mockProvider.listTasks.mockResolvedValue([task]);
       await adapter.wake({ workspaceDir: '/test', stateDir: '/test/.state' });
       expect(mockProvider.listTasks).toHaveBeenCalled();
@@ -197,6 +231,21 @@ describe('Internalization Trigger Adapter', () => {
 
     it('does import @principles/core/runtime-v2', () => {
       expect(readAdapterSource()).toContain('@principles/core/runtime-v2');
+    });
+
+    it('imports hydratePITaskRecord from core (not own JSON.parse)', () => {
+      const src = readAdapterSource();
+      expect(src).toContain('hydratePITaskRecord');
+      // Must not contain ad-hoc JSON.parse for PI metadata
+      expect(src).not.toMatch(/JSON\.parse.*diagnosticJson/);
+    });
+
+    it('does NOT use isValidPITaskRecord directly on raw provider tasks', () => {
+      // The adapter now uses hydratePITaskRecord instead of isValidPITaskRecord
+      // to determine if a task is a valid PI task.
+      // isValidPITaskRecord checks top-level fields which don't exist on persisted tasks.
+      const src = readAdapterSource();
+      expect(src).not.toMatch(/isValidPITaskRecord\s*\(\s*t\s*\)/);
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -54,6 +54,8 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-62
   'internalization/internalization-task-guards.ts',
   'internalization/internalization-state-machine.ts',
+  // PRI-65
+  'internalization/pitask-metadata.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -68,6 +70,8 @@ const REQUIRED_TEST_FILES = [
   // Skipping — test file lives at ../internalization/ not __tests__/internalization/
   // PRI-62
   'internalization-state-machine.test.ts',
+  // PRI-65
+  'pitask-metadata.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [

--- a/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
@@ -1,0 +1,313 @@
+/**
+ * PITaskMetadata — Persistence & Hydration Tests (PRI-65)
+ *
+ * RED phase: tests define the expected contract for serializing PITaskMetadata
+ * into diagnosticJson and hydrating it back into PITaskRecord at runtime.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { TaskRecord } from '../task-status.js';
+import type { PITaskRecord, InternalizationChannel, ArtifactRef } from '../internalization/index.js';
+import {
+  serializePITaskMetadata,
+  parsePITaskMetadata,
+  hydratePITaskRecord,
+  createPITaskDiagnosticJson,
+  PI_METADATA_KEY,
+} from '../internalization/pitask-metadata.js';
+import { isValidPITaskRecord } from '../internalization/index.js';
+import { SqliteTaskStore } from '../store/task/sqlite-task-store.js';
+import { SqliteConnection } from '../store/sqlite-connection.js';
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `pitask-metadata-test-${process.pid}-`));
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+function makeBaseTaskRecord(overrides: Partial<TaskRecord> & { taskId: string }): TaskRecord {
+  return {
+    taskKind: overrides.taskKind ?? 'dreamer',
+    status: overrides.status ?? 'pending',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+    attemptCount: 0,
+    maxAttempts: 3,
+    leaseOwner: undefined,
+    leaseExpiresAt: undefined,
+    lastError: undefined,
+    inputRef: undefined,
+    resultRef: undefined,
+    ...overrides,
+  };
+}
+
+import type { PITaskMetadata } from '../internalization/pitask-metadata.js';
+
+function makeMetadata(overrides?: Partial<PITaskMetadata>) {
+  return {
+    dependencyTaskIds: overrides?.dependencyTaskIds ?? [],
+    channel: overrides?.channel ?? ('prompt' as InternalizationChannel),
+    timeoutMs: overrides?.timeoutMs ?? 300000,
+    inputArtifactRefs: overrides?.inputArtifactRefs ?? ([] as ArtifactRef[]),
+    outputArtifactRefs: overrides?.outputArtifactRefs ?? ([] as ArtifactRef[]),
+    parentTaskId: overrides?.parentTaskId,
+    correlationId: overrides?.correlationId,
+  };
+}
+
+describe('PITaskMetadata serialization', () => {
+  it('serializePITaskMetadata produces valid JSON with pi_metadata envelope', () => {
+    const meta = makeMetadata({ channel: 'prompt', timeoutMs: 60000 });
+    const json = serializePITaskMetadata(meta);
+    const parsed = JSON.parse(json);
+    expect(parsed).toHaveProperty(PI_METADATA_KEY);
+    expect(parsed[PI_METADATA_KEY]).toEqual(meta);
+  });
+
+  it('serializePITaskMetadata includes all required fields', () => {
+    const meta = makeMetadata({ channel: 'skill', timeoutMs: 120000 });
+    const json = serializePITaskMetadata(meta);
+    const parsed = JSON.parse(json)[PI_METADATA_KEY];
+    expect(parsed.dependencyTaskIds).toEqual([]);
+    expect(parsed.channel).toBe('skill');
+    expect(parsed.timeoutMs).toBe(120000);
+    expect(parsed.inputArtifactRefs).toEqual([]);
+    expect(parsed.outputArtifactRefs).toEqual([]);
+  });
+
+  it('serializePITaskMetadata includes optional fields when provided', () => {
+    const meta = makeMetadata({
+      parentTaskId: 'parent-1',
+      correlationId: 'corr-abc',
+    });
+    const json = serializePITaskMetadata(meta);
+    const parsed = JSON.parse(json)[PI_METADATA_KEY];
+    expect(parsed.parentTaskId).toBe('parent-1');
+    expect(parsed.correlationId).toBe('corr-abc');
+  });
+
+  it('createPITaskDiagnosticJson is alias for serializePITaskMetadata', () => {
+    const meta = makeMetadata({ channel: 'code_tool_hook' });
+    expect(createPITaskDiagnosticJson(meta)).toBe(serializePITaskMetadata(meta));
+  });
+});
+
+describe('parsePITaskMetadata', () => {
+  it('valid JSON with all required fields → returns PITaskMetadata', () => {
+    const meta = makeMetadata({ channel: 'model_training', timeoutMs: 900000 });
+    const json = serializePITaskMetadata(meta);
+    const result = parsePITaskMetadata(json);
+    expect(result).not.toBeNull();
+    if (result === null) return; // exhaustive guard
+    expect(result.channel).toBe('model_training');
+    expect(result.timeoutMs).toBe(900000);
+    expect(result.dependencyTaskIds).toEqual([]);
+    expect(result.inputArtifactRefs).toEqual([]);
+    expect(result.outputArtifactRefs).toEqual([]);
+  });
+
+  it('invalid JSON → returns null', () => {
+    expect(parsePITaskMetadata('not json at all')).toBeNull();
+    expect(parsePITaskMetadata('{ "pi_metadata": invalid }')).toBeNull();
+    expect(parsePITaskMetadata('')).toBeNull();
+  });
+
+  it('missing pi_metadata key → returns null', () => {
+    expect(parsePITaskMetadata('{}')).toBeNull();
+    expect(parsePITaskMetadata('{"other": "data"}')).toBeNull();
+  });
+
+  it('invalid channel → returns null', () => {
+    const meta = { pi_metadata: { ...makeMetadata(), channel: 'invalid_channel' as InternalizationChannel } };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('missing required fields → returns null', () => {
+    const meta = { pi_metadata: { channel: 'prompt' } }; // missing timeoutMs, arrays
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('parentTaskId present but not non-empty string → returns null (fail closed)', () => {
+    const meta = { pi_metadata: { ...makeMetadata({ channel: 'prompt' }), parentTaskId: '' as string } };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('correlationId present but not non-empty string → returns null (fail closed)', () => {
+    const meta = { pi_metadata: { ...makeMetadata({ channel: 'defer_archive' }), correlationId: '   ' } };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('whitespace-only diagnosticJson → returns null', () => {
+    expect(parsePITaskMetadata('   ')).toBeNull();
+    expect(parsePITaskMetadata('\n\t')).toBeNull();
+  });
+});
+
+describe('hydratePITaskRecord', () => {
+  it('valid diagnosticJson → returns PITaskRecord passing isValidPITaskRecord()', () => {
+    const meta = makeMetadata({ channel: 'skill', timeoutMs: 180000 });
+    const task = makeBaseTaskRecord({ taskId: 'task-hydrated-1', taskKind: 'philosopher' });
+    (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
+
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(isValidPITaskRecord(result)).toBe(true);
+    expect(result.taskId).toBe('task-hydrated-1');
+    expect((result).channel).toBe('skill');
+    expect((result).timeoutMs).toBe(180000);
+    expect((result).dependencyTaskIds).toEqual([]);
+  });
+
+  it('no diagnosticJson → returns null', () => {
+    const task = makeBaseTaskRecord({ taskId: 'task-no-diag' });
+    expect(hydratePITaskRecord(task)).toBeNull();
+  });
+
+  it('empty diagnosticJson string → returns null', () => {
+    const task = makeBaseTaskRecord({ taskId: 'task-empty-diag' });
+    (task as Record<string, unknown>).diagnosticJson = '';
+    expect(hydratePITaskRecord(task)).toBeNull();
+  });
+
+  it('whitespace-only diagnosticJson → returns null', () => {
+    const task = makeBaseTaskRecord({ taskId: 'task-whitespace-diag' });
+    (task as Record<string, unknown>).diagnosticJson = '   \n';
+    expect(hydratePITaskRecord(task)).toBeNull();
+  });
+
+  it('invalid JSON in diagnosticJson → returns null', () => {
+    const task = makeBaseTaskRecord({ taskId: 'task-bad-json' });
+    (task as Record<string, unknown>).diagnosticJson = 'not json';
+    expect(hydratePITaskRecord(task)).toBeNull();
+  });
+
+  it('valid JSON but wrong envelope key → returns null', () => {
+    const task = makeBaseTaskRecord({ taskId: 'task-wrong-key' });
+    (task as Record<string, unknown>).diagnosticJson = JSON.stringify({ other_key: {} });
+    expect(hydratePITaskRecord(task)).toBeNull();
+  });
+
+  it('with dependencyTaskIds and artifactRefs → hydrates correctly', () => {
+    const meta = makeMetadata({
+      channel: 'prompt',
+      dependencyTaskIds: ['dep-1', 'dep-2'],
+      inputArtifactRefs: [{ artifactType: 'principle', ref: 'artifact-1' }],
+      outputArtifactRefs: [{ artifactType: 'rule', ref: 'artifact-2' }],
+    });
+    const task = makeBaseTaskRecord({ taskId: 'task-full-meta', taskKind: 'scribe' });
+    (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
+
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    const pi = result as PITaskRecord;
+    expect(pi.dependencyTaskIds).toEqual(['dep-1', 'dep-2']);
+    expect(pi.inputArtifactRefs).toEqual([{ artifactType: 'principle', ref: 'artifact-1' }]);
+    expect(pi.outputArtifactRefs).toEqual([{ artifactType: 'rule', ref: 'artifact-2' }]);
+  });
+
+  it('taskKind not a PeerRunnerKind → still hydrates metadata (isValidPITaskRecord checks taskKind separately)', () => {
+    // The hydration function does NOT check taskKind; that is the adapter's concern.
+    // hydratePITaskRecord only checks that metadata is valid PI metadata.
+    // Note: isValidPITaskRecord() will return false here because taskKind='diagnostician'
+    // is not a PeerRunnerKind — that is intentional; the adapter filters by taskKind first.
+    const meta = makeMetadata({ channel: 'defer_archive' });
+    const task = makeBaseTaskRecord({ taskId: 'task-diagnostician', taskKind: 'diagnostician' });
+    (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
+
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    expect((result as PITaskRecord).channel).toBe('defer_archive');
+    // isValidPITaskRecord would return false here (diagnostician is not a PeerRunnerKind)
+    // — the adapter's filter pipeline (isPeerRunnerKind first, then hydrate) handles this
+  });
+
+  it('parentTaskId and correlationId present → hydrates correctly', () => {
+    const meta = makeMetadata({
+      channel: 'prompt',
+      parentTaskId: 'parent-task-xyz',
+      correlationId: 'corr-123',
+    });
+    const task = makeBaseTaskRecord({ taskId: 'task-optional-fields' });
+    (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
+
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    const pi = result as PITaskRecord;
+    expect(pi.parentTaskId).toBe('parent-task-xyz');
+    expect(pi.correlationId).toBe('corr-123');
+  });
+});
+
+describe('SqliteTaskStore roundtrip', () => {
+  afterEach(() => {
+    // cleanup handled per-test below
+  });
+
+  it('createTask with diagnosticJson → getTask returns diagnosticJson', async () => {
+    const tmpDir = createTempDir();
+    const conn = new SqliteConnection(tmpDir);
+    const store = new SqliteTaskStore(conn);
+    const meta = makeMetadata({ channel: 'model_training', timeoutMs: 600000 });
+    const diagJson = createPITaskDiagnosticJson(meta);
+
+    const task = makeBaseTaskRecord({ taskId: 'task-sqlite-roundtrip', taskKind: 'artificer' });
+    const created = await store.createTask(task);
+    await store.updateTask(created.taskId, { diagnosticJson: diagJson });
+
+    const retrieved = await store.getTask(created.taskId);
+    expect(retrieved).not.toBeNull();
+    if (retrieved === null) return;
+    expect((retrieved as Record<string, unknown>).diagnosticJson).toBe(diagJson);
+
+    // Hydration still works
+    const hydrated = hydratePITaskRecord(retrieved);
+    expect(hydrated).not.toBeNull();
+    if (hydrated !== null) {
+      expect(isValidPITaskRecord(hydrated)).toBe(true);
+    }
+
+    conn.close();
+    cleanupDir(tmpDir);
+  });
+
+  it('createTask with diagnosticJson directly → getTask returns it', async () => {
+    const tmpDir = createTempDir();
+    const conn = new SqliteConnection(tmpDir);
+    const store = new SqliteTaskStore(conn);
+
+    const meta = makeMetadata({ channel: 'skill', timeoutMs: 120000 });
+    const diagJson = createPITaskDiagnosticJson(meta);
+
+    const task = makeBaseTaskRecord({
+      taskId: 'task-inline-diag',
+      taskKind: 'evaluator',
+      diagnosticJson: diagJson,
+    } as Omit<TaskRecord, 'createdAt' | 'updatedAt'> & { diagnosticJson?: string });
+
+    const created = await store.createTask(task);
+    const retrieved = await store.getTask(created.taskId);
+    expect(retrieved).not.toBeNull();
+    if (retrieved === null) return;
+    expect((retrieved as Record<string, unknown>).diagnosticJson).toBe(diagJson);
+
+    const hydrated = hydratePITaskRecord(retrieved);
+    expect(hydrated).not.toBeNull();
+    if (hydrated !== null) {
+      expect((hydrated).channel).toBe('skill');
+    }
+
+    conn.close();
+    cleanupDir(tmpDir);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
@@ -29,8 +29,9 @@ function createTempDir(): string {
 function cleanupDir(dir: string): void {
   try {
     fs.rmSync(dir, { recursive: true, force: true });
-  } catch {
-    // ignore cleanup errors
+  } catch (err) {
+    // Report but don't throw — cleanup failure shouldn't fail the test
+    console.error('[pitask-metadata.test] cleanupDir failed:', dir, err);
   }
 }
 
@@ -134,6 +135,26 @@ describe('parsePITaskMetadata', () => {
 
   it('missing required fields → returns null', () => {
     const meta = { pi_metadata: { channel: 'prompt' } }; // missing timeoutMs, arrays
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('inputArtifactRefs with invalid element → returns null', () => {
+    const meta = {
+      pi_metadata: {
+        ...makeMetadata({ channel: 'prompt' }),
+        inputArtifactRefs: [{ artifactType: 'principle', ref: 'artifact-1' }, { artifactType: 123, ref: 'bad' }],
+      },
+    };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('outputArtifactRefs with invalid element → returns null', () => {
+    const meta = {
+      pi_metadata: {
+        ...makeMetadata({ channel: 'prompt' }),
+        outputArtifactRefs: [{ artifactType: 'principle', ref: 'artifact-2' }, { artifactType: 'rule', ref: '' }],
+      },
+    };
     expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
   });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
@@ -128,6 +128,22 @@ describe('parsePITaskMetadata', () => {
     expect(parsePITaskMetadata('{"other": "data"}')).toBeNull();
   });
 
+  it('JSON.parse result is not an object (null/number/string/array) → returns null', () => {
+    expect(parsePITaskMetadata('null')).toBeNull();
+    expect(parsePITaskMetadata('123')).toBeNull();
+    expect(parsePITaskMetadata('"foo"')).toBeNull();
+    expect(parsePITaskMetadata('[]')).toBeNull();
+    // pi_metadata present but top-level value is array (not object)
+    expect(parsePITaskMetadata('{"pi_metadata": []}')).toBeNull();
+  });
+
+  it('dependencyTaskIds with non-string elements → returns null', () => {
+    const meta = {
+      pi_metadata: { ...makeMetadata({ channel: 'prompt' }), dependencyTaskIds: ['dep-1', 123, null] },
+    };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
   it('invalid channel → returns null', () => {
     const meta = { pi_metadata: { ...makeMetadata(), channel: 'invalid_channel' as InternalizationChannel } };
     expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
@@ -136,6 +152,24 @@ describe('parsePITaskMetadata', () => {
   it('missing required fields → returns null', () => {
     const meta = { pi_metadata: { channel: 'prompt' } }; // missing timeoutMs, arrays
     expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('parentTaskId explicitly null → returns null (fail closed)', () => {
+    const meta = { pi_metadata: { ...makeMetadata({ channel: 'prompt' }), parentTaskId: null as unknown as string } };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('correlationId explicitly null → returns null (fail closed)', () => {
+    const meta = { pi_metadata: { ...makeMetadata({ channel: 'defer_archive' }), correlationId: null as unknown as string } };
+    expect(parsePITaskMetadata(JSON.stringify(meta))).toBeNull();
+  });
+
+  it('timeoutMs is 0, negative, NaN, or Infinity → returns null', () => {
+    const validMeta = makeMetadata({ channel: 'prompt' });
+    expect(parsePITaskMetadata(JSON.stringify({ pi_metadata: { ...validMeta, timeoutMs: 0 } }))).toBeNull();
+    expect(parsePITaskMetadata(JSON.stringify({ pi_metadata: { ...validMeta, timeoutMs: -1 } }))).toBeNull();
+    expect(parsePITaskMetadata(JSON.stringify({ pi_metadata: { ...validMeta, timeoutMs: NaN } }))).toBeNull();
+    expect(parsePITaskMetadata(JSON.stringify({ pi_metadata: { ...validMeta, timeoutMs: Infinity } }))).toBeNull();
   });
 
   it('inputArtifactRefs with invalid element → returns null', () => {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -404,3 +404,15 @@ export {
   createNextTaskProposal,
   validateInternalizationGraph,
 } from './internalization/internalization-state-machine.js';
+
+// ── PITask Persistence & Hydration (PRI-65) ──────────────────────────────────
+
+export type { PITaskMetadata } from './internalization/pitask-metadata.js';
+
+export {
+  PI_METADATA_KEY,
+  serializePITaskMetadata,
+  parsePITaskMetadata,
+  hydratePITaskRecord,
+  createPITaskDiagnosticJson,
+} from './internalization/pitask-metadata.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -139,3 +139,15 @@ export {
   createNextTaskProposal,
   validateInternalizationGraph,
 } from './internalization-state-machine.js';
+
+// ── PITask Persistence & Hydration (PRI-65) ───────────────────────────────────
+
+export type { PITaskMetadata } from './pitask-metadata.js';
+
+export {
+  PI_METADATA_KEY,
+  serializePITaskMetadata,
+  parsePITaskMetadata,
+  hydratePITaskRecord,
+  createPITaskDiagnosticJson,
+} from './pitask-metadata.js';

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -111,16 +111,21 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
     return null;
   }
 
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
   const rawMeta = parsed[PI_METADATA_KEY];
-  if (!rawMeta || typeof rawMeta !== 'object' || rawMeta === null) return null;
+  if (!rawMeta || typeof rawMeta !== 'object' || rawMeta === null || Array.isArray(rawMeta)) return null;
 
   const m = rawMeta as Record<string, unknown>;
 
   // Required fields
   if (!Array.isArray(m.dependencyTaskIds)) return null;
+  for (const id of m.dependencyTaskIds) {
+    if (typeof id !== 'string') return null;
+  }
   if (typeof m.channel !== 'string') return null;
   if (!isInternalizationChannel(m.channel)) return null;
   if (typeof m.timeoutMs !== 'number') return null;
+  if (!Number.isFinite(m.timeoutMs) || m.timeoutMs <= 0) return null;
   if (!Array.isArray(m.inputArtifactRefs)) return null;
   if (!Array.isArray(m.outputArtifactRefs)) return null;
 
@@ -132,12 +137,12 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
     if (!isValidArtifactRef(ref)) return null;
   }
 
-  // Optional fields: if present, must be non-empty strings
-  if (m.parentTaskId !== undefined && m.parentTaskId !== null) {
+  // Optional fields: if present, must be non-empty strings (null is not accepted)
+  if (m.parentTaskId !== undefined) {
     if (typeof m.parentTaskId !== 'string') return null;
     if (m.parentTaskId.trim() === '') return null;
   }
-  if (m.correlationId !== undefined && m.correlationId !== null) {
+  if (m.correlationId !== undefined) {
     if (typeof m.correlationId !== 'string') return null;
     if (m.correlationId.trim() === '') return null;
   }
@@ -148,8 +153,8 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
     timeoutMs: m.timeoutMs,
     inputArtifactRefs: m.inputArtifactRefs as ArtifactRef[],
     outputArtifactRefs: m.outputArtifactRefs as ArtifactRef[],
-    parentTaskId: m.parentTaskId as string | undefined,
-    correlationId: m.correlationId as string | undefined,
+    parentTaskId: m.parentTaskId,
+    correlationId: m.correlationId,
   };
 }
 

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -73,6 +73,20 @@ export function serializePITaskMetadata(metadata: PITaskMetadata): string {
 /** Alias for serializePITaskMetadata — explicit name for adapter/consumer use. */
 export const createPITaskDiagnosticJson = serializePITaskMetadata;
 
+// ── ArtifactRef validation ─────────────────────────────────────────────────────
+
+/**
+ * Validates a value is a valid ArtifactRef { artifactType: string, ref: string }.
+ * artifactType is accepted as any string — runtime validation of PIArtifactKind
+ * is the caller's responsibility when creating the record.
+ */
+function isValidArtifactRef(value: unknown): value is ArtifactRef {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  return typeof r.artifactType === 'string' && r.artifactType.trim() !== '' &&
+    typeof r.ref === 'string' && r.ref.trim() !== '';
+}
+
 // ── Parsing ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -109,6 +123,14 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
   if (typeof m.timeoutMs !== 'number') return null;
   if (!Array.isArray(m.inputArtifactRefs)) return null;
   if (!Array.isArray(m.outputArtifactRefs)) return null;
+
+  // Validate each ArtifactRef element
+  for (const ref of m.inputArtifactRefs) {
+    if (!isValidArtifactRef(ref)) return null;
+  }
+  for (const ref of m.outputArtifactRefs) {
+    if (!isValidArtifactRef(ref)) return null;
+  }
 
   // Optional fields: if present, must be non-empty strings
   if (m.parentTaskId !== undefined && m.parentTaskId !== null) {

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -1,0 +1,171 @@
+/**
+ * PITaskMetadata — Persistence & Hydration (PRI-65)
+ *
+ * Provides the core-owned serialization/hydration contract for PITaskRecord metadata.
+ *
+ * Problem: PITaskRecord extends TaskRecord with internalization fields
+ * (dependencyTaskIds, channel, timeoutMs, inputArtifactRefs, outputArtifactRefs),
+ * but SqliteTaskStore only persists base TaskRecord fields + diagnostic_json.
+ * There is no second task store — PI metadata must travel inside diagnosticJson.
+ *
+ * Solution: Store PI metadata in diagnosticJson using a namespaced JSON envelope.
+ * This module provides:
+ *   - serializePITaskMetadata  (PITaskMetadata → JSON string for diagnosticJson)
+ *   - parsePITaskMetadata      (JSON string → PITaskMetadata | null, fail closed)
+ *   - hydratePITaskRecord      (TaskRecord from store → PITaskRecord | null, fail closed)
+ *   - createPITaskDiagnosticJson (alias for serialize, explicit name for adapter use)
+ *
+ * Design principles:
+ *   - All functions are pure / total — no exceptions thrown
+ *   - Fail closed: invalid/missing data → null, not error
+ *   - Optional fields (parentTaskId, correlationId) must be non-empty string if present
+ *   - Namespaced key avoids collision with other diagnosticJson uses
+ *
+ * @see ADR-0003 Section 3.4
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ */
+
+import type { TaskRecord } from '../task-status.js';
+import type {
+  PITaskRecord,
+  InternalizationChannel,
+  ArtifactRef,
+} from './peer-runner-contracts.js';
+import { isInternalizationChannel } from './peer-runner-contracts.js';
+
+/** Namespace key used inside diagnosticJson to isolate PI metadata. */
+export const PI_METADATA_KEY = 'pi_metadata' as const;
+
+/**
+ * PI-specific metadata stored inside TaskRecord.diagnosticJson.
+ * All fields must be present except parentTaskId and correlationId (optional).
+ */
+export interface PITaskMetadata {
+  dependencyTaskIds: string[];
+  channel: InternalizationChannel;
+  timeoutMs: number;
+  inputArtifactRefs: ArtifactRef[];
+  outputArtifactRefs: ArtifactRef[];
+  parentTaskId?: string;
+  correlationId?: string;
+}
+
+// ── Serialization ──────────────────────────────────────────────────────────────
+
+/**
+ * Serialize PITaskMetadata into a JSON string suitable for TaskRecord.diagnosticJson.
+ * Uses a namespaced envelope: { "pi_metadata": { ... } }
+ */
+export function serializePITaskMetadata(metadata: PITaskMetadata): string {
+  return JSON.stringify({
+    [PI_METADATA_KEY]: {
+      dependencyTaskIds: metadata.dependencyTaskIds,
+      channel: metadata.channel,
+      timeoutMs: metadata.timeoutMs,
+      inputArtifactRefs: metadata.inputArtifactRefs,
+      outputArtifactRefs: metadata.outputArtifactRefs,
+      parentTaskId: metadata.parentTaskId,
+      correlationId: metadata.correlationId,
+    },
+  });
+}
+
+/** Alias for serializePITaskMetadata — explicit name for adapter/consumer use. */
+export const createPITaskDiagnosticJson = serializePITaskMetadata;
+
+// ── Parsing ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a diagnosticJson string into PITaskMetadata.
+ * Returns null on any parse/validation failure (fail closed).
+ *
+ * Validation rules:
+ *   - Must be valid JSON
+ *   - Must contain pi_metadata key with all required fields
+ *   - channel must be a valid InternalizationChannel
+ *   - parentTaskId / correlationId if present must be non-empty strings
+ */
+export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | null {
+  // Guard: must be non-empty string after trim
+  const trimmed = diagnosticJson.trim();
+  if (!trimmed) return null;
+
+  let parsed: Record<string, unknown>; // eslint-disable-line @typescript-eslint/init-declarations
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  const rawMeta = parsed[PI_METADATA_KEY];
+  if (!rawMeta || typeof rawMeta !== 'object' || rawMeta === null) return null;
+
+  const m = rawMeta as Record<string, unknown>;
+
+  // Required fields
+  if (!Array.isArray(m.dependencyTaskIds)) return null;
+  if (typeof m.channel !== 'string') return null;
+  if (!isInternalizationChannel(m.channel)) return null;
+  if (typeof m.timeoutMs !== 'number') return null;
+  if (!Array.isArray(m.inputArtifactRefs)) return null;
+  if (!Array.isArray(m.outputArtifactRefs)) return null;
+
+  // Optional fields: if present, must be non-empty strings
+  if (m.parentTaskId !== undefined && m.parentTaskId !== null) {
+    if (typeof m.parentTaskId !== 'string') return null;
+    if (m.parentTaskId.trim() === '') return null;
+  }
+  if (m.correlationId !== undefined && m.correlationId !== null) {
+    if (typeof m.correlationId !== 'string') return null;
+    if (m.correlationId.trim() === '') return null;
+  }
+
+  return {
+    dependencyTaskIds: m.dependencyTaskIds as string[],
+    channel: m.channel,
+    timeoutMs: m.timeoutMs,
+    inputArtifactRefs: m.inputArtifactRefs as ArtifactRef[],
+    outputArtifactRefs: m.outputArtifactRefs as ArtifactRef[],
+    parentTaskId: m.parentTaskId as string | undefined,
+    correlationId: m.correlationId as string | undefined,
+  };
+}
+
+// ── Hydration ───────────────────────────────────────────────────────────────────
+
+/**
+ * Hydrate a raw TaskRecord (as returned by SqliteTaskStore.getTask or listTasks)
+ * into a PITaskRecord by reading and parsing its diagnosticJson.
+ *
+ * Returns null if:
+ *   - diagnosticJson is missing or whitespace
+ *   - diagnosticJson is not valid JSON
+ *   - pi_metadata key is missing or invalid
+ *   - Any required PI field fails validation
+ *   - Optional field present but not a non-empty string
+ *
+ * This function does NOT check taskKind — that is the concern of the caller
+ * (plugin trigger adapter filters by isPeerRunnerKind before hydration).
+ */
+export function hydratePITaskRecord(task: TaskRecord): PITaskRecord | null {
+  // Read diagnosticJson from the runtime object (not typed on TaskRecord)
+  const raw = task as Record<string, unknown>;
+  const {diagnosticJson} = raw;
+  if (!diagnosticJson || typeof diagnosticJson !== 'string') return null;
+
+  const meta = parsePITaskMetadata(diagnosticJson);
+  if (!meta) return null;
+
+  // Merge base TaskRecord with PI metadata → PITaskRecord
+  // Cast through unknown to satisfy TypeScript's spread-overlap rules
+  return {
+    ...task,
+    dependencyTaskIds: meta.dependencyTaskIds,
+    channel: meta.channel,
+    timeoutMs: meta.timeoutMs,
+    inputArtifactRefs: meta.inputArtifactRefs,
+    outputArtifactRefs: meta.outputArtifactRefs,
+    parentTaskId: meta.parentTaskId,
+    correlationId: meta.correlationId,
+  } as unknown as PITaskRecord;
+}


### PR DESCRIPTION
## Summary

- Add `PITaskMetadata` interface + `serializePITaskMetadata`/`parsePITaskMetadata` core-owned hydration helpers
- Store PI metadata inside `diagnosticJson` using namespaced envelope `{ "pi_metadata": { ... } }`
- `hydratePITaskRecord()` reads `diagnosticJson` from TaskRecord and merges PI fields; fails closed on any parse/validation error
- Plugin trigger adapter now uses `hydratePITaskRecord` instead of `isValidPITaskRecord` on raw TaskRecords
- Optional fields `parentTaskId`/`correlationId`: must be non-empty string if present (fail closed)
- Element-level validation for `inputArtifactRefs`/`outputArtifactRefs` arrays
- Architecture regression guards for new module

## Test plan

- [x] `npm run build --workspace=@principles/core`
- [x] `npm run typecheck:openclaw-plugin`
- [x] `npx vitest run .../pitask-metadata.test.ts` (25 tests)
- [x] `npx vitest run .../internalization-trigger-adapter.test.ts` (36 tests)
- [x] `npx vitest run .../architecture-regression.test.ts` (268 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进 (Improvements)**
  * 添加了任务操作重入性保护，在函数重复调用时记录警告以增强可追踪性
  * 改进了任务元数据的验证和序列化处理，确保数据完整性

* **测试 (Tests)**
  * 扩展了架构回归测试套件的覆盖范围，加强架构边界检查

<!-- end of auto-generated comment: release notes by coderabbit.ai -->