### PR TITLE
fix(runtime-v2): clarify model training route semantics (PRI-66)

### DIFF
--- a/docs/adr/0003-peer-agent-state-machine-orchestration.md
+++ b/docs/adr/0003-peer-agent-state-machine-orchestration.md
@@ -194,7 +194,7 @@ interface ArtifactRef {
 
 ### 3.7 Job Graph Topology
 
-**Allowed edges (v1):**
+**Allowed edges (v1 policy B — trainer is terminal successor of rollout_reviewer only):**
 
 ```text
 dreamer → philosopher
@@ -202,8 +202,13 @@ philosopher → scribe
 scribe → artificer
 artificer → evaluator
 evaluator → rollout_reviewer
-[any runner] → (model_training channel) → trainer
+rollout_reviewer → trainer (model_training channel only)
 ```
+
+**v1 policy B notes:**
+- Training is only proposed after a successful rollout review — training must be based on evaluated, production-ready artifacts, not arbitrary intermediate runner outputs.
+- Fan-out to trainer from arbitrary runners (dreamer/philosopher/scribe/artificer/evaluator) is **future scope (v2+)**.
+- Fan-in to trainer (multiple paths merging into trainer) is **future scope (v2+)**.
 
 **DAG rules:**
 1. **No cycles** — graph must be acyclic

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-peer-runner-contracts.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-peer-runner-contracts.test.ts
@@ -227,18 +227,19 @@ describe('Job Graph', () => {
   // ── validateEdge ──────────────────────────────────────────────────────────
 
   describe('validateEdge', () => {
-    it('returns true for all ALLOWED_EDGES', async () => {
+    it('returns true for all non-trainer ALLOWED_EDGES (channel-free edges)', async () => {
       const { validateEdge } = await import('../internalization/internalization-job-graph.js');
 
-      const allowedEdges = [
+      const nonTrainerEdges = [
         ['dreamer', 'philosopher'] as const,
         ['philosopher', 'scribe'] as const,
         ['scribe', 'artificer'] as const,
         ['artificer', 'evaluator'] as const,
         ['evaluator', 'rollout_reviewer'] as const,
+        // Note: rollout_reviewer→trainer requires model_training channel (tested separately)
       ];
 
-      for (const [from, to] of allowedEdges) {
+      for (const [from, to] of nonTrainerEdges) {
         expect(validateEdge(from, to)).toBe(true);
       }
     });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-peer-runner-contracts.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-peer-runner-contracts.test.ts
@@ -266,28 +266,33 @@ describe('Job Graph', () => {
       expect(validateEdge('philosopher', 'evaluator')).toBe(false);
     });
 
-    it('requires model_training channel for trainer target', async () => {
+    it('requires model_training channel for rollout_reviewer → trainer transition', async () => {
       const { validateEdge, MODEL_TRAINING_CHANNEL } = await import(
         '../internalization/internalization-job-graph.js'
       );
 
-      // Without channel, trainer is not reachable
-      expect(validateEdge('dreamer', 'trainer')).toBe(false);
-      expect(validateEdge('scribe', 'trainer')).toBe(false);
+      // Without channel, trainer is not reachable from any runner
+      expect(validateEdge('rollout_reviewer', 'trainer')).toBe(false);
 
-      // With model_training channel, trainer is reachable from any runner
-      expect(validateEdge('dreamer', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(true);
-      expect(validateEdge('philosopher', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(true);
-      expect(validateEdge('scribe', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(true);
-      expect(validateEdge('artificer', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(true);
+      // Only rollout_reviewer + model_training channel reaches trainer
+      expect(validateEdge('rollout_reviewer', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(true);
+
+      // Other runners with model_training channel CANNOT reach trainer in v1
+      expect(validateEdge('dreamer', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(false);
+      expect(validateEdge('philosopher', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(false);
+      expect(validateEdge('scribe', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(false);
+      expect(validateEdge('artificer', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(false);
+      expect(validateEdge('evaluator', 'trainer', MODEL_TRAINING_CHANNEL)).toBe(false);
     });
 
     it('rejects trainer with non-model_training channel', async () => {
       const { validateEdge } = await import('../internalization/internalization-job-graph.js');
 
-      expect(validateEdge('dreamer', 'trainer', 'prompt')).toBe(false);
-      expect(validateEdge('dreamer', 'trainer', 'skill')).toBe(false);
-      expect(validateEdge('dreamer', 'trainer', 'defer_archive')).toBe(false);
+      // rollout_reviewer + non-model_training channels cannot reach trainer
+      expect(validateEdge('rollout_reviewer', 'trainer', 'prompt')).toBe(false);
+      expect(validateEdge('rollout_reviewer', 'trainer', 'skill')).toBe(false);
+      expect(validateEdge('rollout_reviewer', 'trainer', 'defer_archive')).toBe(false);
+      expect(validateEdge('rollout_reviewer', 'trainer', 'code_tool_hook')).toBe(false);
     });
   });
 
@@ -373,14 +378,15 @@ describe('Job Graph', () => {
 
   describe('getAllowedSuccessors', () => {
     it('returns correct successors for dreamer', async () => {
-      const { getAllowedSuccessors, TRAINER_KIND } = await import(
+      const { getAllowedSuccessors } = await import(
         '../internalization/internalization-job-graph.js'
       );
 
       const successors = getAllowedSuccessors('dreamer');
 
       expect(successors).toContain('philosopher');
-      expect(successors).toContain(TRAINER_KIND);
+      // trainer is only reached after rollout_reviewer in v1 (Policy B)
+      expect(successors).not.toContain('trainer');
       expect(successors).not.toContain('scribe');
       expect(successors).not.toContain('artificer');
     });
@@ -392,20 +398,21 @@ describe('Job Graph', () => {
       expect(successors).not.toContain('trainer');
     });
 
-    it('returns correct successors for scribe (including trainer)', async () => {
-      const { getAllowedSuccessors, TRAINER_KIND } = await import(
+    it('returns correct successors for scribe (linear chain only)', async () => {
+      const { getAllowedSuccessors } = await import(
         '../internalization/internalization-job-graph.js'
       );
 
       const successors = getAllowedSuccessors('scribe');
 
       expect(successors).toContain('artificer');
-      expect(successors).toContain(TRAINER_KIND);
+      // trainer only via rollout_reviewer in v1
+      expect(successors).not.toContain('trainer');
       expect(successors).not.toContain('philosopher');
       expect(successors).not.toContain('dreamer');
     });
 
-    it('returns correct successors for evaluator', async () => {
+    it('returns correct successors for evaluator (rollout_reviewer only, no trainer shortcut)', async () => {
       const { getAllowedSuccessors, TRAINER_KIND } = await import(
         '../internalization/internalization-job-graph.js'
       );
@@ -413,10 +420,11 @@ describe('Job Graph', () => {
       const successors = getAllowedSuccessors('evaluator');
 
       expect(successors).toContain('rollout_reviewer');
-      expect(successors).toContain(TRAINER_KIND);
+      // v1 policy B: trainer only via rollout_reviewer, not as shortcut from evaluator
+      expect(successors).not.toContain(TRAINER_KIND);
     });
 
-    it('returns correct successors for artificer (including trainer)', async () => {
+    it('returns correct successors for artificer (evaluator only, no trainer shortcut)', async () => {
       const { getAllowedSuccessors, TRAINER_KIND } = await import(
         '../internalization/internalization-job-graph.js'
       );
@@ -424,16 +432,15 @@ describe('Job Graph', () => {
       const successors = getAllowedSuccessors('artificer');
 
       expect(successors).toContain('evaluator');
-      expect(successors).toContain(TRAINER_KIND);
+      expect(successors).not.toContain(TRAINER_KIND);
       expect(successors).not.toContain('scribe');
     });
 
-    it('returns trainer for rollout_reviewer (via model_training channel)', async () => {
+    it('returns [trainer] for rollout_reviewer (terminal v1 successor via model_training)', async () => {
       const { getAllowedSuccessors, TRAINER_KIND } = await import(
         '../internalization/internalization-job-graph.js'
       );
 
-      // Any non-trainer runner can reach trainer via model_training channel
       const successors = getAllowedSuccessors('rollout_reviewer');
       expect(successors).toContain(TRAINER_KIND);
       expect(successors).not.toContain('rollout_reviewer');
@@ -478,25 +485,24 @@ describe('Job Graph', () => {
       expect(preds).toEqual(['evaluator']);
     });
 
-    it('returns empty array for trainer (reached via channel, not edges)', async () => {
+    it('returns [rollout_reviewer] for trainer (v1 terminal predecessor)', async () => {
       const { getAllowedPredecessors } = await import('../internalization/internalization-job-graph.js');
 
       const preds = getAllowedPredecessors('trainer');
-      // trainer has no predecessor edges in ALLOWED_EDGES
-      // it is reached via model_training channel from any runner
-      expect(preds).toEqual([]);
+      // v1 policy B: trainer is terminal successor of rollout_reviewer only
+      expect(preds).toEqual(['rollout_reviewer']);
     });
   });
 
   // ── ALLOWED_EDGES constant ───────────────────────────────────────────────
 
   describe('ALLOWED_EDGES', () => {
-    it('has exactly 5 edges', async () => {
+    it('has exactly 6 edges (v1 linear chain + rollout_reviewer→trainer)', async () => {
       const { ALLOWED_EDGES } = await import('../internalization/internalization-job-graph.js');
-      expect(ALLOWED_EDGES).toHaveLength(5);
+      expect(ALLOWED_EDGES).toHaveLength(6);
     });
 
-    it('covers dreamer→philosopher→scribe→artificer→evaluator→rollout_reviewer chain', async () => {
+    it('covers dreamer→philosopher→scribe→artificer→evaluator→rollout_reviewer→trainer chain', async () => {
       const { ALLOWED_EDGES } = await import('../internalization/internalization-job-graph.js');
 
       const edgeSet = new Set(ALLOWED_EDGES.map(([f, t]) => `${f}→${t}`));
@@ -506,6 +512,7 @@ describe('Job Graph', () => {
       expect(edgeSet.has('scribe→artificer')).toBe(true);
       expect(edgeSet.has('artificer→evaluator')).toBe(true);
       expect(edgeSet.has('evaluator→rollout_reviewer')).toBe(true);
+      expect(edgeSet.has('rollout_reviewer→trainer')).toBe(true);
     });
 
     it('is readonly (cannot be modified)', async () => {
@@ -513,7 +520,7 @@ describe('Job Graph', () => {
 
       // ReadonlyArray<...> means the outer array reference is immutable at TypeScript level
       expect(Array.isArray(ALLOWED_EDGES)).toBe(true);
-      expect(ALLOWED_EDGES).toHaveLength(5);
+      expect(ALLOWED_EDGES).toHaveLength(6);
 
       // Verify each edge is a readonly tuple
       for (const edge of ALLOWED_EDGES) {
@@ -524,7 +531,7 @@ describe('Job Graph', () => {
       // Verify edges are in expected order
       const edgeStrings = ALLOWED_EDGES.map(([f, t]) => `${f}→${t}`);
       expect(edgeStrings[0]).toBe('dreamer→philosopher');
-      expect(edgeStrings[4]).toBe('evaluator→rollout_reviewer');
+      expect(edgeStrings[5]).toBe('rollout_reviewer→trainer');
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
@@ -448,8 +448,7 @@ describe('createNextTaskProposal', () => {
     expect(result).not.toBeNull();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const r = result!;
-    // getAllowedSuccessors returns ['philosopher', 'trainer'] for dreamer;
-    // first element is philosopher (direct ALLOWED_EDGES successor)
+    // getAllowedSuccessors returns ['philosopher'] for dreamer (v1 Policy B: trainer only via rollout_reviewer)
     expect(r.taskKind).toBe('philosopher');
     expect(r.channel).toBe('model_training');
   });
@@ -744,6 +743,20 @@ describe('isArtifactRejected', () => {
       validationStatus: 'pending' as const,
     };
     expect(isArtifactRejected(artifact)).toBe(false);
+  });
+// ── Policy B: model_training still follows full chain — trainer only after rollout_reviewer ─
+
+  it('rollout_reviewer + defer_archive → null (non-model_training channel)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      channel: 'defer_archive',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
@@ -477,6 +477,149 @@ describe('createNextTaskProposal', () => {
     const result = createNextTaskProposal(task, []);
     expect(result).toBeNull();
   });
+
+  // ── Policy B: model_training still follows full chain — trainer only after rollout_reviewer ─
+
+  it('philosopher + model_training → scribe (not trainer)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'phil-1',
+      taskKind: 'philosopher',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [{ artifactType: 'rule', ref: 'art-2' }],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    expect(r.taskKind).toBe('scribe');
+    expect(r.taskKind).not.toBe('trainer');
+  });
+
+  it('scribe + model_training → artificer (not trainer)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'scribe-1',
+      taskKind: 'scribe',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    expect(r.taskKind).toBe('artificer');
+    expect(r.taskKind).not.toBe('trainer');
+  });
+
+  it('artificer + model_training → evaluator (not trainer)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'art-1',
+      taskKind: 'artificer',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    expect(r.taskKind).toBe('evaluator');
+    expect(r.taskKind).not.toBe('trainer');
+  });
+
+  it('evaluator + model_training → rollout_reviewer (not trainer)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'eval-1',
+      taskKind: 'evaluator',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    expect(r.taskKind).toBe('rollout_reviewer');
+    expect(r.taskKind).not.toBe('trainer');
+  });
+
+  it('dreamer + model_training → philosopher (not trainer)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'dreamer-1',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [{ artifactType: 'training_data', ref: 'td-1' }],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const r = result!;
+    expect(r.taskKind).toBe('philosopher');
+    expect(r.taskKind).not.toBe('trainer');
+    expect(r.channel).toBe('model_training');
+  });
+
+  it('rollout_reviewer + model_training → trainer (terminal v1 successor)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      channel: 'model_training',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result!.taskKind).toBe('trainer');
+  });
+
+  it('rollout_reviewer + skill → null (non-model_training channel, no valid successor)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      channel: 'skill',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    // rollout_reviewer has no non-model_training successors; skill channel blocks trainer
+    expect(result).toBeNull();
+  });
+
+  it('rollout_reviewer + code_tool_hook → null (non-model_training channel, no valid successor)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      channel: 'code_tool_hook',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).toBeNull();
+  });
+
+  it('rollout_reviewer + prompt → null (explicit)', async () => {
+    const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+    const task = makePITask({
+      taskId: 'rr-1',
+      taskKind: 'rollout_reviewer',
+      status: 'succeeded',
+      channel: 'prompt',
+      outputArtifactRefs: [],
+    });
+    const result = createNextTaskProposal(task, []);
+    expect(result).toBeNull();
+  });
 });
 
 // ── validateInternalizationGraph ──────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-job-graph.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-job-graph.ts
@@ -20,6 +20,9 @@ import type { InternalizationChannel, PeerRunnerKind } from './peer-runner-contr
  * Allowed edges in the job graph (v1).
  * Each tuple is [from, to] meaning from → to is a legal transition.
  *
+ * v1 policy B: trainer is terminal successor of rollout_reviewer only.
+ * Fan-out to trainer from arbitrary runners is future scope (v2+).
+ *
  * @see ADR-0003 Section 3.7
  */
 export const ALLOWED_EDGES: readonly (readonly [PeerRunnerKind, PeerRunnerKind])[] = [
@@ -28,11 +31,12 @@ export const ALLOWED_EDGES: readonly (readonly [PeerRunnerKind, PeerRunnerKind])
   ['scribe', 'artificer'] as const,
   ['artificer', 'evaluator'] as const,
   ['evaluator', 'rollout_reviewer'] as const,
+  ['rollout_reviewer', 'trainer'] as const,
 ] as const;
 
 /**
- * The channel required to reach the trainer runner.
- * Any runner can create a trainer task via this channel.
+ * The channel required for the rollout_reviewer → trainer transition.
+ * v1 policy B: trainer is terminal successor of rollout_reviewer only.
  */
 export const MODEL_TRAINING_CHANNEL: InternalizationChannel = 'model_training';
 
@@ -47,7 +51,8 @@ export const TRAINER_KIND: PeerRunnerKind = 'trainer';
  * Validates whether a transition from one runner to another is legal.
  *
  * For non-trainer targets: checks ALLOWED_EDGES
- * For trainer target: requires model_training channel
+ * For trainer target: requires model_training channel AND source must be rollout_reviewer
+ *   (v1 policy B: trainer is terminal successor of rollout_reviewer only)
  *
  * @param from - Source peer runner kind
  * @param to - Target peer runner kind
@@ -58,9 +63,9 @@ export function validateEdge(
   to: PeerRunnerKind,
   channel?: InternalizationChannel,
 ): boolean {
-  // Trainer can only be reached via model_training channel
+  // Trainer requires model_training channel AND rollout_reviewer source (v1 policy B)
   if (to === TRAINER_KIND) {
-    return channel === MODEL_TRAINING_CHANNEL;
+    return from === 'rollout_reviewer' && channel === MODEL_TRAINING_CHANNEL;
   }
 
   // Non-trainer targets: check allowed edges
@@ -145,20 +150,16 @@ export function isAcyclic(
 /**
  * Returns all allowed successor runner kinds for a given runner.
  *
+ * v1 policy B: returns only ALLOWED_EDGES successors.
+ * trainer is terminal v1 successor of rollout_reviewer only (no fan-out shortcut).
+ *
  * @param from - Source peer runner kind
  * @returns Array of allowed successor runner kinds
  */
 export function getAllowedSuccessors(from: PeerRunnerKind): PeerRunnerKind[] {
-  const direct = ALLOWED_EDGES
+  return ALLOWED_EDGES
     .filter(([f]) => f === from)
     .map(([, t]) => t);
-
-  // Any runner (except trainer) can reach trainer via model_training
-  if (from !== TRAINER_KIND && !direct.includes(TRAINER_KIND)) {
-    direct.push(TRAINER_KIND);
-  }
-
-  return direct;
 }
 
 /**

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -282,7 +282,7 @@ export function decideArtifactRejectionFeedback(
  *   - scribe → artificer
  *   - artificer → evaluator
  *   - evaluator → rollout_reviewer
- *   - Any runner (+ model_training channel) → trainer
+ *   - rollout_reviewer → trainer (model_training channel only, v1 terminal successor)
  *
  * Requires currentTask.status === 'succeeded' — non-terminal tasks
  * must not generate successor proposals (prevents pipeline乱序).


### PR DESCRIPTION
## Summary

- **Policy B**: trainer is terminal v1 successor of `rollout_reviewer` only; fan-out to trainer from arbitrary runners is future scope (v2+)
- model_training channel still follows full internalization chain — not a shortcut to trainer from any runner
- ADR-0003 Section 3.7 topology updated to reflect v1 behavior

## Changes

| File | Change |
|------|--------|
| `internalization-job-graph.ts` | Add `rollout_reviewer→trainer` 6th edge; restrict `validateEdge` (trainer requires rollout_reviewer + model_training); simplify `getAllowedSuccessors` (ALLOWED_EDGES only) |
| `internalization-state-machine.ts` | Update JSDoc to reflect v1 policy B |
| `0003-peer-agent-state-machine-orchestration.md` | Section 3.7 topology + v1 policy B notes |
| `internalization-peer-runner-contracts.test.ts` | Updated 6 tests for new behavior |
| `internalization-state-machine.test.ts` | Added 8 new TDD tests |

## Test Results

```
Test Files  6 passed (6)
Tests  487 passed | 2 skipped (489)
```

## Verification

```bash
npm run build --workspace=@principles/core
npm run typecheck:openclaw-plugin
npx vitest run packages/principles-core/src/runtime-v2/__tests__/internalization-peer-runner-contracts.test.ts packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
```

## Remaining Risks

- Fan-out/fan-in to trainer from arbitrary runners is future scope — orchestrator implementers must NOT route training tasks to wrong next runner in v1 (covered by tests)
- No other code paths depend on `validateEdge(any→trainer)` or `getAllowedSuccessors` fan-out behavior (verified by test suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发行说明

* **文档**
  * 更新了对等代理状态机编排的治理策略文档，明确系统内部工作流序列的约束条件

* **测试**
  * 扩展测试覆盖范围，验证改进后的系统工作流管理逻辑，确保多场景下的可靠性和一致性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->