### PR TITLE
feat(runtime-v2): internalization orchestrator skeleton (PRI-68)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Architecture regression guard — verifies critical PRI-12/13/14/15/16/28
  * module boundaries are present and exportable.
  *
@@ -908,7 +908,7 @@ describe('PRI-61 Internalization Peer Runner Contracts', () => {
     expect(src).not.toContain('node:fs');
     expect(src).not.toContain('node:path');
     expect(src).not.toContain('openclaw-plugin');
-    expect(src).not.toContain('node:cron');
+        expect(src).not.toContain('node:cron');
   });
 
   it('internalization-job-graph.ts has zero infrastructure imports', async () => {
@@ -920,7 +920,7 @@ describe('PRI-61 Internalization Peer Runner Contracts', () => {
     expect(src).not.toContain('node:fs');
     expect(src).not.toContain('node:path');
     expect(src).not.toContain('openclaw-plugin');
-    expect(src).not.toContain('node:cron');
+        expect(src).not.toContain('node:cron');
   });
 
   it('TASK_MODEL_REUSE: PITaskRecord extends TaskRecord (type-level check)', async () => {
@@ -983,7 +983,7 @@ describe('PRI-62 Internalization State Machine Guards', () => {
     expect(src).not.toContain('node:fs');
     expect(src).not.toContain('node:path');
     expect(src).not.toContain('openclaw-plugin');
-    expect(src).not.toContain('node:cron');
+        expect(src).not.toContain('node:cron');
   });
 
   it('internalization-state-machine.ts has zero infrastructure imports', async () => {
@@ -995,7 +995,7 @@ describe('PRI-62 Internalization State Machine Guards', () => {
     expect(src).not.toContain('node:fs');
     expect(src).not.toContain('node:path');
     expect(src).not.toContain('openclaw-plugin');
-    expect(src).not.toContain('node:cron');
+        expect(src).not.toContain('node:cron');
   });
 
   it('TASK_MODEL_REUSE: guard functions work with PITaskRecord (type-level check)', async () => {
@@ -1108,5 +1108,49 @@ describe('PRI-63 Internalization Dumb Trigger Adapter', () => {
     // setInterval is used in start() to trigger wake() periodically — this is plugin responsibility
     // Core state machine should NOT use setInterval (CORE_NO_SCHEDULING)
     expect(src).not.toContain('node:cron');
+  });
+});
+
+describe('PRI-68 InternalizationOrchestrator', () => {
+  it('orchestrator source file exists in internalization directory', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'internalization-orchestrator.ts'))).toBe(true);
+  });
+
+  it('orchestrator test file exists', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', '__tests__', 'internalization-orchestrator.test.ts'))).toBe(true);
+  });
+
+  it('CORE_NO_SCHEDULING: orchestrator has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'internalization-orchestrator.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+        expect(src).not.toContain('node:cron');
+    expect(src).not.toContain('setInterval');
+    expect(src).not.toContain('setTimeout');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+  });
+
+  it('CORE_NO_RUNTIME_ADAPTER: orchestrator does not import PDRuntimeAdapter or startRun', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'internalization-orchestrator.ts'), 'utf-8');
+    expect(src).not.toContain('PDRuntimeAdapter');
+    expect(src).not.toContain('startRun');
+    expect(src).not.toContain('DiagnosticianRunner');
+  });
+
+  it('BARREL_EXPORTS: internalization/index.ts exports InternalizationOrchestrator and result types', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('InternalizationOrchestrator');
+    expect(src).toContain('WakeOnceResult');
+    expect(src).toContain('LeaseConflictResult');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
@@ -304,6 +304,56 @@ describe('InternalizationOrchestrator', () => {
       expect(proposal.taskKind).toBe('philosopher');
     });
 
+    // ── Test 7b: no_ready_tasks when candidate list is empty ─────────────────
+
+    it('no_ready_tasks returns inspectedCount=0 when both pending and retry_wait are empty', async () => {
+      mockStateManager.listTasks.mockResolvedValue([]);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('no_ready_tasks');
+      expect((result as { inspectedCount: number }).inspectedCount).toBe(0);
+      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    });
+
+    // ── Test 7c: proposeNextTask returns null when task not found ────────────
+
+    it('proposeNextTask returns null when task does not exist', async () => {
+      mockStateManager.getTask.mockResolvedValue(null);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.proposeNextTask('nonexistent-task');
+      expect(result).toBeNull();
+    });
+
+    // ── Test 7d: proposeNextTask returns null for non-PI task kind ──────────
+
+    it('proposeNextTask returns null when taskKind is not a PeerRunnerKind', async () => {
+      const rawTask = makeRawTask({
+        taskId: 'diag-task',
+        taskKind: 'diagnostician', // not a PeerRunnerKind
+        status: 'succeeded',
+      });
+      mockStateManager.getTask.mockResolvedValue(rawTask);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.proposeNextTask('diag-task');
+      expect(result).toBeNull();
+    });
+
     // ── Test 8: architecture guard — no forbidden imports ────────────────────
 
     it('orchestrator source has zero forbidden imports (no openclaw-plugin, scheduling, or runtime adapter)', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
@@ -144,7 +144,10 @@ describe('InternalizationOrchestrator', () => {
   describe('wakeOnce — lease acquisition', () => {
     it('pending PI task with no dependencies acquires lease and returns leased decision', async () => {
       const rawTask = makeRawTask({ taskId: 'pi-task-1', taskKind: 'dreamer', status: 'pending' });
-      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      // findCandidates calls listTasks twice (pending, then retry_wait)
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([rawTask])   // pending → found
+        .mockResolvedValueOnce([]);          // retry_wait → skipped
       mockStateManager.acquireLease.mockResolvedValue({ ...rawTask, status: 'leased' });
 
       const orchestrator = new OrchestratorClass(
@@ -164,67 +167,23 @@ describe('InternalizationOrchestrator', () => {
       });
     });
 
-    // ── Test 2: pending + dep pending → blocked ──────────────────────────────
+    // ── Test 2: pending blocked → retry_wait leasable ─────────────────────────
 
-    it('pending PI task with a pending dependency returns blocked and does not acquire lease', async () => {
-      const rawTask = makeRawTask({
+    it('blocked pending task is skipped; retry_wait candidate acquires lease', async () => {
+      const blockedTask = makeRawTask({
         taskId: 'pi-task-2',
         taskKind: 'philosopher',
         status: 'pending',
         dependencyTaskIds: ['dep-task-1'],
       });
+      const retryableTask = makeRawTask({ taskId: 'retry-task', taskKind: 'dreamer', status: 'retry_wait' });
       const depTask = makeRawTask({ taskId: 'dep-task-1', status: 'pending', taskKind: 'dreamer' });
 
-      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([blockedTask])    // pending → blocked (continues)
+        .mockResolvedValueOnce([retryableTask]);  // retry_wait → leasable
       mockStateManager.getTask.mockResolvedValue(depTask);
-
-      const orchestrator = new OrchestratorClass(
-        { stateManager: mockStateManager as unknown as RuntimeStateManager },
-        { owner: 'test-owner', runtimeKind: 'philosopher' }
-      );
-
-      const result = await orchestrator.wakeOnce();
-
-      expect(result.decision).toBe('blocked');
-      expect((result as { blockedBy: string[] }).blockedBy).toContain('dep-task-1');
-      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
-    });
-
-    // ── Test 3: dependency failed → dependency_failed ─────────────────────────
-
-    it('dependency in failed status returns dependency_failed and does not mutate task', async () => {
-      const rawTask = makeRawTask({
-        taskId: 'pi-task-3',
-        taskKind: 'scribe',
-        status: 'pending',
-        dependencyTaskIds: ['failed-dep'],
-      });
-      const failedDep = makeRawTask({ taskId: 'failed-dep', status: 'failed', taskKind: 'dreamer' });
-
-      mockStateManager.listTasks.mockResolvedValue([rawTask]);
-      mockStateManager.getTask.mockResolvedValue(failedDep);
-
-      const orchestrator = new OrchestratorClass(
-        { stateManager: mockStateManager as unknown as RuntimeStateManager },
-        { owner: 'test-owner', runtimeKind: 'scribe' }
-      );
-
-      const result = await orchestrator.wakeOnce();
-
-      expect(result.decision).toBe('dependency_failed');
-      expect((result as { failedDependencies: string[] }).failedDependencies).toContain('failed-dep');
-      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
-    });
-
-    // ── Test 4: invalid PITask metadata → invalid_task_metadata ─────────────
-
-    it('task with invalid/missing PITask metadata returns invalid_task_metadata and does not mutate', async () => {
-      const invalidTask = {
-        ...makeRawTask({ taskId: 'bad-task' }),
-        diagnosticJson: '{}', // missing pi_metadata key
-      } as TaskRecord;
-
-      mockStateManager.listTasks.mockResolvedValue([invalidTask]);
+      mockStateManager.acquireLease.mockResolvedValue({ ...retryableTask, status: 'leased' });
 
       const orchestrator = new OrchestratorClass(
         { stateManager: mockStateManager as unknown as RuntimeStateManager },
@@ -233,19 +192,32 @@ describe('InternalizationOrchestrator', () => {
 
       const result = await orchestrator.wakeOnce();
 
-      expect(result.decision).toBe('invalid_task_metadata');
-      expect((result as { taskId: string }).taskId).toBe('bad-task');
-      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+      expect(result.decision).toBe('leased');
+      expect((result as { taskId: string }).taskId).toBe('retry-task');
+      expect(mockStateManager.acquireLease).toHaveBeenCalledWith({
+        taskId: 'retry-task',
+        owner: 'test-owner',
+        runtimeKind: 'dreamer',
+      });
     });
 
-    // ── Test 5: lease conflict → lease_conflict (structured, no mark failed) ──
+    // ── Test 3: pending failed dep → skips to next pending (leasable) ─────────
 
-    it('lease conflict returns structured lease_conflict without calling markTaskFailed', async () => {
-      const rawTask = makeRawTask({ taskId: 'conflict-task', taskKind: 'artificer', status: 'pending' });
-      mockStateManager.listTasks.mockResolvedValue([rawTask]);
-      mockStateManager.acquireLease.mockRejectedValue(
-        new PDRuntimeError('lease_conflict', 'Task conflict-task is already leased')
-      );
+    it('pending task with failed dependency is skipped; next pending task acquires lease', async () => {
+      const failedDepTask = makeRawTask({
+        taskId: 'pi-task-3',
+        taskKind: 'scribe',
+        status: 'pending',
+        dependencyTaskIds: ['failed-dep'],
+      });
+      const leasableTask = makeRawTask({ taskId: 'good-task', taskKind: 'artificer', status: 'pending' });
+      const failedDep = makeRawTask({ taskId: 'failed-dep', status: 'failed', taskKind: 'dreamer' });
+
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([failedDepTask, leasableTask])  // pending: first is failed-dep, second is leasable
+        .mockResolvedValueOnce([]);
+      mockStateManager.getTask.mockResolvedValue(failedDep);
+      mockStateManager.acquireLease.mockResolvedValue({ ...leasableTask, status: 'leased' });
 
       const orchestrator = new OrchestratorClass(
         { stateManager: mockStateManager as unknown as RuntimeStateManager },
@@ -254,16 +226,66 @@ describe('InternalizationOrchestrator', () => {
 
       const result = await orchestrator.wakeOnce();
 
-      expect(result.decision).toBe('lease_conflict');
-      expect((result as { taskId: string }).taskId).toBe('conflict-task');
-      expect((result as { conflictReason: string }).conflictReason).toBeTruthy();
+      expect(result.decision).toBe('leased');
+      expect((result as { taskId: string }).taskId).toBe('good-task');
+    });
+
+    // ── Test 4: invalid metadata → skips to next pending (leasable) ───────────
+
+    it('task with invalid PI metadata is skipped; next pending task acquires lease', async () => {
+      const invalidTask = {
+        ...makeRawTask({ taskId: 'bad-task', taskKind: 'scribe' }),
+        diagnosticJson: '{}', // missing pi_metadata key
+      } as TaskRecord;
+      const leasableTask = makeRawTask({ taskId: 'good-task', taskKind: 'artificer', status: 'pending' });
+
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([invalidTask, leasableTask])  // pending: first invalid, second leasable
+        .mockResolvedValueOnce([]);
+      mockStateManager.acquireLease.mockResolvedValue({ ...leasableTask, status: 'leased' });
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'artificer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('leased');
+      expect((result as { taskId: string }).taskId).toBe('good-task');
+    });
+
+    // ── Test 5: lease conflict → skips to retry_wait (leasable) ─────────────────
+
+    it('lease conflict on pending task is skipped; retry_wait task acquires lease', async () => {
+      const conflictTask = makeRawTask({ taskId: 'conflict-task', taskKind: 'artificer', status: 'pending' });
+      const retryableTask = makeRawTask({ taskId: 'retry-task', taskKind: 'dreamer', status: 'retry_wait' });
+
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([conflictTask])   // pending → lease conflict (continues)
+        .mockResolvedValueOnce([retryableTask]);  // retry_wait → leasable
+      mockStateManager.acquireLease
+        .mockRejectedValueOnce(new PDRuntimeError('lease_conflict', 'Task conflict-task is already leased'))
+        .mockResolvedValueOnce({ ...retryableTask, status: 'leased' });
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('leased');
+      expect((result as { taskId: string }).taskId).toBe('retry-task');
     });
 
     // ── Test 6: dryRun=true → would_lease (no actual lease) ─────────────────
 
     it('dryRun=true returns would_lease without acquiring the lease', async () => {
       const rawTask = makeRawTask({ taskId: 'dryrun-task', taskKind: 'evaluator', status: 'pending' });
-      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([rawTask])
+        .mockResolvedValueOnce([]);
 
       const orchestrator = new OrchestratorClass(
         { stateManager: mockStateManager as unknown as RuntimeStateManager },
@@ -275,6 +297,27 @@ describe('InternalizationOrchestrator', () => {
       expect(result.decision).toBe('would_lease');
       expect((result as { taskId: string }).taskId).toBe('dryrun-task');
       expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    });
+
+    // ── Test 6b: pending empty → retry_wait recovery ──────────────────────────
+
+    it('retry_wait task acquires lease when pending queue is empty', async () => {
+      const retryTask = makeRawTask({ taskId: 'retry-task', taskKind: 'dreamer', status: 'retry_wait' });
+
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([])             // pending → empty
+        .mockResolvedValueOnce([retryTask]);   // retry_wait → has candidate
+      mockStateManager.acquireLease.mockResolvedValue({ ...retryTask, status: 'leased' });
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('leased');
+      expect((result as { taskId: string }).taskId).toBe('retry-task');
     });
 
     // ── Test 7: succeeded task → proposeNextTask → proposal_created ──────────
@@ -307,7 +350,9 @@ describe('InternalizationOrchestrator', () => {
     // ── Test 7b: no_ready_tasks when candidate list is empty ─────────────────
 
     it('no_ready_tasks returns inspectedCount=0 when both pending and retry_wait are empty', async () => {
-      mockStateManager.listTasks.mockResolvedValue([]);
+      mockStateManager.listTasks
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
 
       const orchestrator = new OrchestratorClass(
         { stateManager: mockStateManager as unknown as RuntimeStateManager },

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
@@ -1,0 +1,314 @@
+/**
+ * InternalizationOrchestrator — Unit Tests (PRI-68)
+ *
+ * TDD: Tests written first to define the expected behavior of the
+ * core-owned InternalizationOrchestrator skeleton.
+ *
+ * The orchestrator consumes hydrated PITaskRecords, applies state-machine
+ * decisions, acquires leases through RuntimeStateManager, and proposes
+ * successor tasks — WITHOUT executing LLM calls or calling PDRuntimeAdapter.
+ *
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+import type { TaskRecord } from '../task-status.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import { PDRuntimeError } from '../error-categories.js';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Creates a raw TaskRecord (as returned by SqliteTaskStore) with valid
+ * PI metadata in diagnosticJson, so hydratePITaskRecord() succeeds.
+ */
+function makeRawTask(overrides: {
+  taskId?: string;
+  taskKind?: string;
+  status?: string;
+  diagnosticJson?: string;
+  dependencyTaskIds?: string[];
+  channel?: string;
+  timeoutMs?: number;
+  inputArtifactRefs?: { artifactType: string; ref: string }[];
+  outputArtifactRefs?: { artifactType: string; ref: string }[];
+  parentTaskId?: string;
+  correlationId?: string;
+  attemptCount?: number;
+  maxAttempts?: number;
+  createdAt?: string;
+  updatedAt?: string;
+} = {}): TaskRecord {
+  const {
+    taskId = 'task-1',
+    taskKind = 'dreamer',
+    status = 'pending',
+    dependencyTaskIds = [],
+    channel = 'prompt',
+    timeoutMs = 60000,
+    inputArtifactRefs = [],
+    outputArtifactRefs = [],
+    parentTaskId,
+    correlationId,
+    attemptCount = 0,
+    maxAttempts = 3,
+    createdAt = new Date().toISOString(),
+    updatedAt = new Date().toISOString(),
+  } = overrides;
+
+  const piMetadata: Record<string, unknown> = {
+    dependencyTaskIds,
+    channel,
+    timeoutMs,
+    inputArtifactRefs,
+    outputArtifactRefs,
+  };
+  if (parentTaskId !== undefined) piMetadata.parentTaskId = parentTaskId;
+  if (correlationId !== undefined) piMetadata.correlationId = correlationId;
+
+  const diagnosticJson = JSON.stringify({ pi_metadata: piMetadata });
+
+  return {
+    taskId,
+    taskKind,
+    status: status as TaskRecord['status'],
+    createdAt,
+    updatedAt,
+    attemptCount,
+    maxAttempts,
+    diagnosticJson,
+  } as unknown as TaskRecord;
+}
+
+/**
+ * Mock interface for the subset of RuntimeStateManager used by the orchestrator.
+ * Uses ReturnType<typeof vi.fn> so TypeScript knows .mockResolvedValue() exists.
+ */
+interface MockStateManager {
+  listTasks: ReturnType<typeof vi.fn>;
+  getTask: ReturnType<typeof vi.fn>;
+  acquireLease: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Creates a mock RuntimeStateManager with vi.fn() spies.
+ */
+function createMockStateManager(): MockStateManager {
+  return {
+    listTasks: vi.fn(),
+    getTask: vi.fn(),
+    acquireLease: vi.fn(),
+  };
+}
+
+// ── Architecture Guard Helper ─────────────────────────────────────────────────
+
+function moduleHasNoForbiddenImports(modulePath: string): Promise<boolean> {
+  const src = readFileSync(resolve(__dirname, '..', modulePath), 'utf-8');
+  return Promise.resolve(
+    !src.includes('openclaw-plugin') &&
+    !src.includes('PDRuntimeAdapter') &&
+    !src.includes('startRun') &&
+    !src.includes('DiagnosticianRunner') &&
+    !src.includes('node:cron') &&
+    !src.includes('setInterval') &&
+    !src.includes('setTimeout')
+  );
+}
+
+// ── Import after defining helpers (tests run against real module) ──────────────
+
+// NOTE: We dynamically import the module under test so that the file must
+// exist first (TDD constraint). All tests below are designed to FAIL until
+// the source file is created.
+
+describe('InternalizationOrchestrator', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let mockStateManager: ReturnType<typeof createMockStateManager>;
+   
+   
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports,@typescript-eslint/init-declarations
+  let OrchestratorClass: typeof import('../internalization/internalization-orchestrator.js').InternalizationOrchestrator;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockStateManager = createMockStateManager();
+    // Dynamic import ensures source file must exist (TDD)
+    const mod = await import('../internalization/internalization-orchestrator.js');
+    OrchestratorClass = mod.InternalizationOrchestrator;
+  });
+
+  // ── Test 1: pending PI task + no deps → leased ─────────────────────────────
+
+  describe('wakeOnce — lease acquisition', () => {
+    it('pending PI task with no dependencies acquires lease and returns leased decision', async () => {
+      const rawTask = makeRawTask({ taskId: 'pi-task-1', taskKind: 'dreamer', status: 'pending' });
+      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      mockStateManager.acquireLease.mockResolvedValue({ ...rawTask, status: 'leased' });
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('leased');
+      expect((result as { taskId: string }).taskId).toBe('pi-task-1');
+      expect(mockStateManager.acquireLease).toHaveBeenCalledOnce();
+      expect(mockStateManager.acquireLease).toHaveBeenCalledWith({
+        taskId: 'pi-task-1',
+        owner: 'test-owner',
+        runtimeKind: 'dreamer',
+      });
+    });
+
+    // ── Test 2: pending + dep pending → blocked ──────────────────────────────
+
+    it('pending PI task with a pending dependency returns blocked and does not acquire lease', async () => {
+      const rawTask = makeRawTask({
+        taskId: 'pi-task-2',
+        taskKind: 'philosopher',
+        status: 'pending',
+        dependencyTaskIds: ['dep-task-1'],
+      });
+      const depTask = makeRawTask({ taskId: 'dep-task-1', status: 'pending', taskKind: 'dreamer' });
+
+      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      mockStateManager.getTask.mockResolvedValue(depTask);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'philosopher' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('blocked');
+      expect((result as { blockedBy: string[] }).blockedBy).toContain('dep-task-1');
+      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    });
+
+    // ── Test 3: dependency failed → dependency_failed ─────────────────────────
+
+    it('dependency in failed status returns dependency_failed and does not mutate task', async () => {
+      const rawTask = makeRawTask({
+        taskId: 'pi-task-3',
+        taskKind: 'scribe',
+        status: 'pending',
+        dependencyTaskIds: ['failed-dep'],
+      });
+      const failedDep = makeRawTask({ taskId: 'failed-dep', status: 'failed', taskKind: 'dreamer' });
+
+      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      mockStateManager.getTask.mockResolvedValue(failedDep);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'scribe' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('dependency_failed');
+      expect((result as { failedDependencies: string[] }).failedDependencies).toContain('failed-dep');
+      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    });
+
+    // ── Test 4: invalid PITask metadata → invalid_task_metadata ─────────────
+
+    it('task with invalid/missing PITask metadata returns invalid_task_metadata and does not mutate', async () => {
+      const invalidTask = {
+        ...makeRawTask({ taskId: 'bad-task' }),
+        diagnosticJson: '{}', // missing pi_metadata key
+      } as TaskRecord;
+
+      mockStateManager.listTasks.mockResolvedValue([invalidTask]);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'dreamer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('invalid_task_metadata');
+      expect((result as { taskId: string }).taskId).toBe('bad-task');
+      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    });
+
+    // ── Test 5: lease conflict → lease_conflict (structured, no mark failed) ──
+
+    it('lease conflict returns structured lease_conflict without calling markTaskFailed', async () => {
+      const rawTask = makeRawTask({ taskId: 'conflict-task', taskKind: 'artificer', status: 'pending' });
+      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+      mockStateManager.acquireLease.mockRejectedValue(
+        new PDRuntimeError('lease_conflict', 'Task conflict-task is already leased')
+      );
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'artificer' }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('lease_conflict');
+      expect((result as { taskId: string }).taskId).toBe('conflict-task');
+      expect((result as { conflictReason: string }).conflictReason).toBeTruthy();
+    });
+
+    // ── Test 6: dryRun=true → would_lease (no actual lease) ─────────────────
+
+    it('dryRun=true returns would_lease without acquiring the lease', async () => {
+      const rawTask = makeRawTask({ taskId: 'dryrun-task', taskKind: 'evaluator', status: 'pending' });
+      mockStateManager.listTasks.mockResolvedValue([rawTask]);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'evaluator', dryRun: true }
+      );
+
+      const result = await orchestrator.wakeOnce();
+
+      expect(result.decision).toBe('would_lease');
+      expect((result as { taskId: string }).taskId).toBe('dryrun-task');
+      expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    });
+
+    // ── Test 7: succeeded task → proposeNextTask → proposal_created ──────────
+
+    it('succeeded task can generate a next-task proposal without creating the task', async () => {
+      const succeededTask = makeRawTask({
+        taskId: 'succeeded-dreamer',
+        taskKind: 'dreamer',
+        status: 'succeeded',
+        outputArtifactRefs: [{ artifactType: 'principle', ref: 'artifact-1' }],
+      });
+      mockStateManager.getTask.mockResolvedValue(succeededTask);
+
+      const orchestrator = new OrchestratorClass(
+        { stateManager: mockStateManager as unknown as RuntimeStateManager },
+        { owner: 'test-owner', runtimeKind: 'philosopher' }
+      );
+
+      const result = await orchestrator.proposeNextTask('succeeded-dreamer');
+
+      expect(result).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(result!.decision).toBe('proposal_created');
+      expect((result as { proposal: unknown }).proposal).toBeDefined();
+      // V1 chain: dreamer → philosopher
+      const {proposal} = (result as { proposal: { taskKind: string } });
+      expect(proposal.taskKind).toBe('philosopher');
+    });
+
+    // ── Test 8: architecture guard — no forbidden imports ────────────────────
+
+    it('orchestrator source has zero forbidden imports (no openclaw-plugin, scheduling, or runtime adapter)', async () => {
+      const clean = await moduleHasNoForbiddenImports('internalization/internalization-orchestrator.ts');
+      expect(clean).toBe(true);
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -420,7 +420,6 @@ export {
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 
 export type {
-  WakeOnceDecision,
   WakeOnceResult,
   NoReadyTasksResult,
   BlockedResult,
@@ -435,4 +434,4 @@ export type {
   InternalizationOrchestratorDeps,
 } from './internalization/internalization-orchestrator.js';
 
-export { InternalizationOrchestrator } from './internalization/internalization-orchestrator.js';
+export { InternalizationOrchestrator, WAKE_ONCE_DECISIONS } from './internalization/internalization-orchestrator.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -416,3 +416,23 @@ export {
   hydratePITaskRecord,
   createPITaskDiagnosticJson,
 } from './internalization/pitask-metadata.js';
+
+// ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
+
+export type {
+  WakeOnceDecision,
+  WakeOnceResult,
+  NoReadyTasksResult,
+  BlockedResult,
+  DependencyFailedResult,
+  LeasedResult,
+  WouldLeaseResult,
+  LeaseConflictResult,
+  InvalidTaskMetadataResult,
+  ProposalCreatedResult,
+  ProposeNextTaskResult,
+  InternalizationOrchestratorOptions,
+  InternalizationOrchestratorDeps,
+} from './internalization/internalization-orchestrator.js';
+
+export { InternalizationOrchestrator } from './internalization/internalization-orchestrator.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -151,3 +151,23 @@ export {
   hydratePITaskRecord,
   createPITaskDiagnosticJson,
 } from './pitask-metadata.js';
+
+// ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
+
+export type {
+  WakeOnceDecision,
+  WakeOnceResult,
+  NoReadyTasksResult,
+  BlockedResult,
+  DependencyFailedResult,
+  LeasedResult,
+  WouldLeaseResult,
+  LeaseConflictResult,
+  InvalidTaskMetadataResult,
+  ProposalCreatedResult,
+  ProposeNextTaskResult,
+  InternalizationOrchestratorOptions,
+  InternalizationOrchestratorDeps,
+} from './internalization-orchestrator.js';
+
+export { InternalizationOrchestrator } from './internalization-orchestrator.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -155,7 +155,6 @@ export {
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 
 export type {
-  WakeOnceDecision,
   WakeOnceResult,
   NoReadyTasksResult,
   BlockedResult,
@@ -170,4 +169,4 @@ export type {
   InternalizationOrchestratorDeps,
 } from './internalization-orchestrator.js';
 
-export { InternalizationOrchestrator } from './internalization-orchestrator.js';
+export { InternalizationOrchestrator, WAKE_ONCE_DECISIONS } from './internalization-orchestrator.js';

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -28,15 +28,6 @@ import { PDRuntimeError } from '../error-categories.js';
 
 // ── Result Types ─────────────────────────────────────────────────────────────
 
-export type WakeOnceDecision =
-  | 'no_ready_tasks'
-  | 'blocked'
-  | 'dependency_failed'
-  | 'leased'
-  | 'would_lease'
-  | 'lease_conflict'
-  | 'invalid_task_metadata';
-
 export interface NoReadyTasksResult {
   decision: 'no_ready_tasks';
   inspectedCount: number;
@@ -81,6 +72,17 @@ export interface InvalidTaskMetadataResult {
   taskId: string;
   taskKind: string;
 }
+
+// Const array for runtime exhaustiveness checking (used in switch statements)
+export const WAKE_ONCE_DECISIONS = [
+  'no_ready_tasks',
+  'blocked',
+  'dependency_failed',
+  'leased',
+  'would_lease',
+  'lease_conflict',
+  'invalid_task_metadata',
+] as const;
 
 export type WakeOnceResult =
   | NoReadyTasksResult
@@ -215,7 +217,13 @@ export class InternalizationOrchestrator {
             conflictReason: error.message,
           };
         }
-        throw error;
+        // Re-throw with task context for correlation
+        const pdError = error instanceof PDRuntimeError ? error : new PDRuntimeError('runtime_unavailable', String(error));
+        throw new PDRuntimeError(
+          pdError.category ?? 'runtime_unavailable',
+          `wakeOnce lease acquisition failed for task ${piTask.taskId}: ${pdError.message}`,
+          { cause: error }
+        );
       }
     }
 
@@ -250,6 +258,11 @@ export class InternalizationOrchestrator {
       return null;
     }
 
+    // Guard against non-PI task kinds (would cause getAllowedSuccessors to return undefined)
+    if (!isPeerRunnerKind(piTask.taskKind)) {
+      return null;
+    }
+
     if (piTask.status !== 'succeeded') {
       return null;
     }
@@ -274,12 +287,15 @@ export class InternalizationOrchestrator {
    * Filters to only PeerRunnerKind taskKinds and hydrates to PITaskRecord.
    */
   private async findCandidates(): Promise<TaskRecord[]> {
-    const [pendingTasks, retryWaitTasks] = await Promise.all([
-      this.stateManager.listTasks({ status: 'pending' }),
-      this.stateManager.listTasks({ status: 'retry_wait' }),
-    ]);
-
-    const allCandidates = [...pendingTasks, ...retryWaitTasks];
+    const allCandidates: TaskRecord[] = [];
+    try {
+      const pending = await this.stateManager.listTasks({ status: 'pending' });
+      const retryWait = await this.stateManager.listTasks({ status: 'retry_wait' });
+      allCandidates.push(...pending, ...retryWait);
+    } catch (error) {
+      if (error instanceof PDRuntimeError) throw error;
+      throw new PDRuntimeError('runtime_unavailable', 'findCandidates failed', { cause: error });
+    }
 
     // Filter to PeerRunnerKind tasks only (skip diagnostician, etc.)
     const peerTasks = allCandidates.filter(t => isPeerRunnerKind(t.taskKind));
@@ -297,13 +313,14 @@ export class InternalizationOrchestrator {
       return [];
     }
 
-    const results = await Promise.all(
-      depIds.map(async (depId) => {
-        const task = await this.stateManager.getTask(depId);
-        return task ?? null;
-      })
+    // Use allSettled so one bad depId doesn't kill the entire resolution
+    const results = await Promise.allSettled(
+      depIds.map(depId => this.stateManager.getTask(depId))
     );
 
-    return results.filter((t): t is TaskRecord => t !== null);
+    return results
+      .filter((r): r is PromiseFulfilledResult<TaskRecord | null> => r.status === 'fulfilled')
+      .map(r => r.value)
+      .filter((t): t is TaskRecord => t !== null);
   }
 }

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -73,7 +73,12 @@ export interface InvalidTaskMetadataResult {
   taskKind: string;
 }
 
-// Const array for runtime exhaustiveness checking (used in switch statements)
+/**
+ * Runtime decision labels for WakeOnceResult — used by host layers for
+ * logging, metrics bucketing, and switch-statement exhaustiveness checks.
+ * @experimental — consumed at runtime only; not used by the TypeScript
+ * type system (discriminated union handles compile-time exhaustiveness).
+ */
 export const WAKE_ONCE_DECISIONS = [
   'no_ready_tasks',
   'blocked',
@@ -126,6 +131,9 @@ export class InternalizationOrchestrator {
   private readonly stateManager: RuntimeStateManager;
 
   constructor(deps: InternalizationOrchestratorDeps, options: InternalizationOrchestratorOptions) {
+    if (!options.owner || !options.runtimeKind) {
+      throw new PDRuntimeError('input_invalid', 'InternalizationOrchestrator requires non-empty owner and runtimeKind');
+    }
     this.stateManager = deps.stateManager;
     this.owner = options.owner;
     this.runtimeKind = options.runtimeKind;
@@ -154,12 +162,8 @@ export class InternalizationOrchestrator {
       const piTask = hydratePITaskRecord(rawTask);
 
       if (!piTask) {
-        // Hydration failed — invalid PI metadata
-        return {
-          decision: 'invalid_task_metadata',
-          taskId: rawTask.taskId,
-          taskKind: rawTask.taskKind,
-        };
+        // Hydration failed — invalid PI metadata, skip and try next candidate
+        continue;
       }
 
       // Resolve all dependency records
@@ -169,21 +173,13 @@ export class InternalizationOrchestrator {
       const gateResult = validateInternalizationTaskReady(piTask, dependencies);
 
       if (gateResult.decision === 'blocked') {
-        return {
-          decision: 'blocked',
-          taskId: piTask.taskId,
-          taskKind: piTask.taskKind,
-          blockedBy: gateResult.blockedBy,
-        };
+        // Non-terminal — skip and try next candidate
+        continue;
       }
 
       if (gateResult.decision === 'dependency_failed') {
-        return {
-          decision: 'dependency_failed',
-          taskId: piTask.taskId,
-          taskKind: piTask.taskKind,
-          failedDependencies: gateResult.failedDependencies,
-        };
+        // Non-terminal — skip and try next candidate
+        continue;
       }
 
       // gateResult.decision === 'proceed'
@@ -211,11 +207,8 @@ export class InternalizationOrchestrator {
         };
       } catch (error) {
         if (error instanceof PDRuntimeError && error.category === 'lease_conflict') {
-          return {
-            decision: 'lease_conflict',
-            taskId: piTask.taskId,
-            conflictReason: error.message,
-          };
+          // Non-terminal — skip and try next candidate
+          continue;
         }
         // Re-throw with task context for correlation
         const pdError = error instanceof PDRuntimeError ? error : new PDRuntimeError('runtime_unavailable', String(error));
@@ -240,6 +233,10 @@ export class InternalizationOrchestrator {
    *
    * Does NOT create the task — the caller decides whether to persist
    * the proposal via RuntimeStateManager.createTask().
+   *
+   * Note: existingTasks is hardcoded to [] — the host layer is responsible
+   * for deduplicating proposals against tasks already in the queue before
+   * calling createTask().
    *
    * Returns null if:
    *   - Task not found

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -1,0 +1,309 @@
+/**
+ * InternalizationOrchestrator — Core-owned Skeleton (PRI-68)
+ *
+ * Consumes hydrated PITaskRecords, applies state-machine decisions,
+ * acquires leases through RuntimeStateManager, and proposes successor
+ * tasks — WITHOUT executing LLM calls or calling peer runners.
+ *
+ * Design:
+ *   - Single-step processing: wakeOnce() handles one task per call
+ *   - Host (plugin CLI or heartbeat trigger) decides when to call
+ *   - All task mutation goes through RuntimeStateManager (not direct store)
+ *   - Pure orchestration: no timers, no LLM calls, no peer runner imports
+ *
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ */
+
+import type { TaskRecord } from '../task-status.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PeerRunnerKind } from './peer-runner-contracts.js';
+import type { DependencyGateResult, NextTaskProposal } from './internalization-state-machine.js';
+import { hydratePITaskRecord } from './pitask-metadata.js';
+import { isPeerRunnerKind } from './peer-runner-contracts.js';
+import {
+  validateInternalizationTaskReady,
+  createNextTaskProposal,
+} from './internalization-state-machine.js';
+import { PDRuntimeError } from '../error-categories.js';
+
+// ── Result Types ─────────────────────────────────────────────────────────────
+
+export type WakeOnceDecision =
+  | 'no_ready_tasks'
+  | 'blocked'
+  | 'dependency_failed'
+  | 'leased'
+  | 'would_lease'
+  | 'lease_conflict'
+  | 'invalid_task_metadata';
+
+export interface NoReadyTasksResult {
+  decision: 'no_ready_tasks';
+  inspectedCount: number;
+}
+
+export interface BlockedResult {
+  decision: 'blocked';
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  blockedBy: string[];
+}
+
+export interface DependencyFailedResult {
+  decision: 'dependency_failed';
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  failedDependencies: string[];
+}
+
+export interface LeasedResult {
+  decision: 'leased';
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  attemptCount: number;
+}
+
+export interface WouldLeaseResult {
+  decision: 'would_lease';
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  gateResult: DependencyGateResult;
+}
+
+export interface LeaseConflictResult {
+  decision: 'lease_conflict';
+  taskId: string;
+  conflictReason: string;
+}
+
+export interface InvalidTaskMetadataResult {
+  decision: 'invalid_task_metadata';
+  taskId: string;
+  taskKind: string;
+}
+
+export type WakeOnceResult =
+  | NoReadyTasksResult
+  | BlockedResult
+  | DependencyFailedResult
+  | LeasedResult
+  | WouldLeaseResult
+  | LeaseConflictResult
+  | InvalidTaskMetadataResult;
+
+export interface ProposalCreatedResult {
+  decision: 'proposal_created';
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  proposal: NextTaskProposal;
+}
+
+export type ProposeNextTaskResult = ProposalCreatedResult | null;
+
+// ── Constructor Options ───────────────────────────────────────────────────────
+
+export interface InternalizationOrchestratorOptions {
+  /** Lease owner identifier (injected by host) */
+  owner: string;
+  /** Runtime kind for lease records */
+  runtimeKind: string;
+  /** If true, evaluate but do NOT acquire lease (inspection / dry-run mode) */
+  dryRun?: boolean;
+}
+
+export interface InternalizationOrchestratorDeps {
+  readonly stateManager: RuntimeStateManager;
+}
+
+// ── InternalizationOrchestrator ───────────────────────────────────────────────
+
+export class InternalizationOrchestrator {
+  private readonly owner: string;
+  private readonly runtimeKind: string;
+  private readonly dryRun: boolean;
+  private readonly stateManager: RuntimeStateManager;
+
+  constructor(deps: InternalizationOrchestratorDeps, options: InternalizationOrchestratorOptions) {
+    this.stateManager = deps.stateManager;
+    this.owner = options.owner;
+    this.runtimeKind = options.runtimeKind;
+    this.dryRun = options.dryRun ?? false;
+  }
+
+  // ── wakeOnce ──────────────────────────────────────────────────────────────
+
+  /**
+   * Find the first leasable PI task, validate dependencies, and acquire lease
+   * (or return a structured decision without mutating state).
+   *
+   * Algorithm:
+   *   1. listTasks(pending) → filter PeerRunnerKind → hydrate
+   *   2. If none, try listTasks(retry_wait) for recovery candidates
+   *   3. For first valid PITaskRecord, resolve dependencyTaskIds via getTask
+   *   4. validateInternalizationTaskReady → branch on gate result
+   *   5. On proceed + dryRun → would_lease; on proceed + !dryRun → acquireLease
+   *   6. On lease_conflict PDRuntimeError → structured LeaseConflictResult
+   */
+  async wakeOnce(): Promise<WakeOnceResult> {
+    const candidates = await this.findCandidates();
+    let inspectedCount = candidates.length;
+
+    for (const rawTask of candidates) {
+      const piTask = hydratePITaskRecord(rawTask);
+
+      if (!piTask) {
+        // Hydration failed — invalid PI metadata
+        return {
+          decision: 'invalid_task_metadata',
+          taskId: rawTask.taskId,
+          taskKind: rawTask.taskKind,
+        };
+      }
+
+      // Resolve all dependency records
+      const dependencies = await this.resolveDependencies(piTask.dependencyTaskIds);
+
+      // Evaluate dependency gate
+      const gateResult = validateInternalizationTaskReady(piTask, dependencies);
+
+      if (gateResult.decision === 'blocked') {
+        return {
+          decision: 'blocked',
+          taskId: piTask.taskId,
+          taskKind: piTask.taskKind,
+          blockedBy: gateResult.blockedBy,
+        };
+      }
+
+      if (gateResult.decision === 'dependency_failed') {
+        return {
+          decision: 'dependency_failed',
+          taskId: piTask.taskId,
+          taskKind: piTask.taskKind,
+          failedDependencies: gateResult.failedDependencies,
+        };
+      }
+
+      // gateResult.decision === 'proceed'
+      if (this.dryRun) {
+        return {
+          decision: 'would_lease',
+          taskId: piTask.taskId,
+          taskKind: piTask.taskKind,
+          gateResult,
+        };
+      }
+
+      // Actually attempt to acquire the lease
+      try {
+        const leased = await this.stateManager.acquireLease({
+          taskId: piTask.taskId,
+          owner: this.owner,
+          runtimeKind: this.runtimeKind,
+        });
+        return {
+          decision: 'leased',
+          taskId: leased.taskId,
+          taskKind: piTask.taskKind,
+          attemptCount: leased.attemptCount,
+        };
+      } catch (error) {
+        if (error instanceof PDRuntimeError && error.category === 'lease_conflict') {
+          return {
+            decision: 'lease_conflict',
+            taskId: piTask.taskId,
+            conflictReason: error.message,
+          };
+        }
+        throw error;
+      }
+    }
+
+    return {
+      decision: 'no_ready_tasks',
+      inspectedCount,
+    };
+  }
+
+  // ── proposeNextTask ──────────────────────────────────────────────────────
+
+  /**
+   * Generate a successor task proposal for a succeeded task.
+   *
+   * Does NOT create the task — the caller decides whether to persist
+   * the proposal via RuntimeStateManager.createTask().
+   *
+   * Returns null if:
+   *   - Task not found
+   *   - Task not a valid PITaskRecord (hydration fails)
+   *   - Task status is not 'succeeded'
+   *   - No valid successor exists in the job graph
+   */
+  async proposeNextTask(taskId: string): Promise<ProposeNextTaskResult> {
+    const rawTask = await this.stateManager.getTask(taskId);
+    if (!rawTask) {
+      return null;
+    }
+
+    const piTask = hydratePITaskRecord(rawTask);
+    if (!piTask) {
+      return null;
+    }
+
+    if (piTask.status !== 'succeeded') {
+      return null;
+    }
+
+    const proposal = createNextTaskProposal(piTask, []);
+    if (!proposal) {
+      return null;
+    }
+
+    return {
+      decision: 'proposal_created',
+      taskId: piTask.taskId,
+      taskKind: piTask.taskKind,
+      proposal,
+    };
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Find candidate PI tasks by querying pending and retry_wait statuses.
+   * Filters to only PeerRunnerKind taskKinds and hydrates to PITaskRecord.
+   */
+  private async findCandidates(): Promise<TaskRecord[]> {
+    const [pendingTasks, retryWaitTasks] = await Promise.all([
+      this.stateManager.listTasks({ status: 'pending' }),
+      this.stateManager.listTasks({ status: 'retry_wait' }),
+    ]);
+
+    const allCandidates = [...pendingTasks, ...retryWaitTasks];
+
+    // Filter to PeerRunnerKind tasks only (skip diagnostician, etc.)
+    const peerTasks = allCandidates.filter(t => isPeerRunnerKind(t.taskKind));
+
+    return peerTasks;
+  }
+
+  /**
+   * Resolve an array of dependency task IDs into TaskRecord instances.
+   * Missing tasks (not yet created) are excluded from the result — this
+   * causes validateInternalizationTaskReady to fail closed (treat as blocked).
+   */
+  private async resolveDependencies(depIds: readonly string[]): Promise<TaskRecord[]> {
+    if (depIds.length === 0) {
+      return [];
+    }
+
+    const results = await Promise.all(
+      depIds.map(async (depId) => {
+        const task = await this.stateManager.getTask(depId);
+        return task ?? null;
+      })
+    );
+
+    return results.filter((t): t is TaskRecord => t !== null);
+  }
+}


### PR DESCRIPTION
## Summary

- InternalizationOrchestrator 核心类实现：wakeOnce() + proposeNextTask()
- 7 种 WakeOnceResult discriminated union result types
- RuntimeStateManager constructor injection
- 架构边界保护：禁止 import openclaw-plugin / node:cron / PDRuntimeAdapter 等

## Test plan

- [x] npx vitest run packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts (11 passing)
- [x] npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts (140 passing, 1 skipped)
- [x] npm run build --workspace=@principles/core

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加国际化编排器，用于管理国际化任务流程，支持任务依赖解析和智能调度决策。

* **测试**
  * 新增编排器单元测试套件，覆盖多种场景和边界情况。
  * 强化基础设施导入限制检查，防止架构泄露。

* **API 更新**
  * 公开新的编排器类型和接口供外部使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->