### PR TITLE
feat(gfi): PRI-78 GFI observability — read model + CLI + runtime-summary

### DIFF
--- a/packages/openclaw-plugin/src/service/runtime-summary-service.ts
+++ b/packages/openclaw-plugin/src/service/runtime-summary-service.ts
@@ -315,6 +315,10 @@ export class RuntimeSummaryService {
       sessionPeak ?? (Number.isFinite(dailyGfiPeak) ? Number(dailyGfiPeak) : null);
 
     // PRI-78: Build authoritative GFI workspace snapshot (active vs stale)
+    // Note: gfiBySource and consecutiveErrors are intentionally stubbed — session-tracker
+    // does not yet persist full GfiState. workspaceSnapshot reflects degraded data
+    // (empty sources, no consecutive error tracking). Full fidelity requires PRI-77 persistence.
+    // TODO(PRI-78b): populate gfiBySource and consecutiveErrors from session tracker
     const gfiWorkspaceSnapshot: GfiWorkspaceSnapshot = buildGfiWorkspaceSnapshot({
       sessions: sessions.map((s) => ({
         sessionId: s.sessionId,
@@ -322,6 +326,7 @@ export class RuntimeSummaryService {
         gfiBySource: {},
         consecutiveErrors: 0,
         lastActivityAt: s.lastActivityAt ?? 0,
+        dailyGfiPeak: s.dailyGfiPeak,
       })),
       nowMs: Date.now(),
     });
@@ -374,6 +379,7 @@ export class RuntimeSummaryService {
         db.close();
       }
     } catch { /* task store not yet initialized — 0 pending */ }
+    // TODO(PRI-XXX): distinguish "not initialized" from permission/corruption/query errors
     const runtimeDiagnosis = {
       pendingTasks: pendingRuntimeDiagTasks,
       tasksWrittenToday: diagDailyStats?.diagnosisTasksWritten ?? 0,

--- a/packages/openclaw-plugin/src/service/runtime-summary-service.ts
+++ b/packages/openclaw-plugin/src/service/runtime-summary-service.ts
@@ -325,7 +325,7 @@ export class RuntimeSummaryService {
         currentGfi: s.currentGfi ?? 0,
         gfiBySource: {},
         consecutiveErrors: 0,
-        lastActivityAt: s.lastActivityAt ?? 0,
+        lastActivityAt: s.lastControlActivityAt ?? s.lastActivityAt ?? 0,
         dailyGfiPeak: s.dailyGfiPeak,
       })),
       nowMs: Date.now(),

--- a/packages/openclaw-plugin/src/service/runtime-summary-service.ts
+++ b/packages/openclaw-plugin/src/service/runtime-summary-service.ts
@@ -8,6 +8,8 @@ import { evaluatePhase3Inputs } from './phase3-input-filter.js';
 import { TrajectoryRegistry } from '../core/trajectory.js';
 import type { WorkflowStage } from '../core/workflow-funnel-loader.js';
 import type { RuntimeTruth, AnalyticsTruth } from '../types/runtime-summary.js';
+import { buildGfiWorkspaceSnapshot } from '@principles/core/runtime-v2';
+import type { GfiWorkspaceSnapshot } from '@principles/core/runtime-v2';
 
 export type RuntimeDataQuality = 'authoritative' | 'partial';
 export type RuntimeRewardPolicy =
@@ -47,6 +49,7 @@ export interface RuntimeSummary {
     peak: number | null;
     sources: RuntimeSummarySource[];
     dataQuality: RuntimeDataQuality;
+    workspaceSnapshot?: GfiWorkspaceSnapshot;
   };
   evolution: {
     queue: {
@@ -311,6 +314,18 @@ export class RuntimeSummaryService {
     const gfiPeak =
       sessionPeak ?? (Number.isFinite(dailyGfiPeak) ? Number(dailyGfiPeak) : null);
 
+    // PRI-78: Build authoritative GFI workspace snapshot (active vs stale)
+    const gfiWorkspaceSnapshot: GfiWorkspaceSnapshot = buildGfiWorkspaceSnapshot({
+      sessions: sessions.map((s) => ({
+        sessionId: s.sessionId,
+        currentGfi: s.currentGfi ?? 0,
+        gfiBySource: {},
+        consecutiveErrors: 0,
+        lastActivityAt: s.lastActivityAt ?? 0,
+      })),
+      nowMs: Date.now(),
+    });
+
     pushWarning(warnings, GFI_PARTIAL_WARNING);
     if (sessionPeak === null && Number.isFinite(dailyGfiPeak)) {
       pushWarning(warnings, DAILY_GFI_WARNING);
@@ -433,6 +448,7 @@ export class RuntimeSummaryService {
         peak: gfiPeak,
         sources: gfiSources,
         dataQuality: 'partial',
+        workspaceSnapshot: gfiWorkspaceSnapshot,
       },
       evolution: {
         queue: queueStats,

--- a/packages/pd-cli/src/commands/runtime-gfi-snapshot.ts
+++ b/packages/pd-cli/src/commands/runtime-gfi-snapshot.ts
@@ -1,0 +1,127 @@
+/**
+ * pd runtime health gfi command — GFI workspace snapshot for Runtime V2.
+ *
+ * Usage:
+ *   pd runtime health gfi --workspace <path> --json
+ *
+ * Shows active vs stale session breakdown for GFI visibility.
+ * Stale sessions (>2h inactive) do NOT influence the active snapshot.
+ *
+ * PRI-78: GFI Observability
+ */
+import * as path from 'path';
+import * as fs from 'fs';
+import { buildGfiWorkspaceSnapshot } from '@principles/core/runtime-v2';
+import type { GfiWorkspaceSnapshot } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface GfiSnapshotOptions {
+  workspace?: string;
+  json?: boolean;
+}
+
+function formatTextOutput(snapshot: GfiWorkspaceSnapshot): string {
+  const lines: string[] = [];
+
+  lines.push('GFI Workspace Snapshot');
+  lines.push(`generatedAt: ${snapshot.generatedAt}`);
+  lines.push('');
+
+  if (snapshot.active) {
+    const a = snapshot.active;
+    lines.push('ACTIVE SESSION');
+    lines.push(`  currentGfi: ${a.currentGfi}  stage: ${a.stage}`);
+    lines.push(`  dominantSource: ${a.dominantSource ?? '(none)'}`);
+    lines.push(`  consecutiveErrors: ${a.consecutiveErrors}`);
+    lines.push(`  dailyGfiPeak: ${a.dailyGfiPeak ?? '(none)'}`);
+    lines.push(`  attitudeMode: ${a.consumers.attitudeMode}`);
+    lines.push(`  painDiagnosticReason: ${a.consumers.painDiagnosticReason}`);
+  } else {
+    lines.push('ACTIVE SESSION: (none)');
+  }
+
+  lines.push('');
+
+  if (snapshot.staleSessionCount > 0 && snapshot.staleGfiRange) {
+    lines.push(`STALE SESSIONS: ${snapshot.staleSessionCount} session(s)` +
+      ` (GFI range: ${snapshot.staleGfiRange.min}-${snapshot.staleGfiRange.max})`);
+  } else {
+    lines.push('STALE SESSIONS: 0');
+  }
+
+  lines.push('');
+  lines.push(`TOTAL: ${snapshot.totalSessionCount} session(s) (${snapshot.activeSessionCount} active)`);
+
+  return lines.join('\n');
+}
+
+function readPersistedSessions(workspaceDir: string): {
+  sessionId: string;
+  currentGfi: number;
+  gfiBySource?: Record<string, number>;
+  lastErrorSource?: string;
+  consecutiveErrors: number;
+  lastGfiDecayAt?: number;
+  dailyGfiPeak?: number;
+  lastActivityAt: number;
+}[] {
+  const sessionDir = path.join(workspaceDir, '.state', 'sessions');
+
+  if (!fs.existsSync(sessionDir)) {
+    return [];
+  }
+
+  const sessions: {
+    sessionId: string;
+    currentGfi: number;
+    gfiBySource?: Record<string, number>;
+    lastErrorSource?: string;
+    consecutiveErrors: number;
+    lastGfiDecayAt?: number;
+    dailyGfiPeak?: number;
+    lastActivityAt: number;
+  }[] = [];
+
+  for (const file of fs.readdirSync(sessionDir)) {
+    if (!file.endsWith('.json')) continue;
+    try {
+      const raw = fs.readFileSync(path.join(sessionDir, file), 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed?.sessionId) {
+        sessions.push({
+          sessionId: parsed.sessionId ?? file.replace('.json', ''),
+          currentGfi: parsed.currentGfi ?? 0,
+          gfiBySource: parsed.gfiBySource,
+          lastErrorSource: parsed.lastErrorSource,
+          consecutiveErrors: parsed.consecutiveErrors ?? 0,
+          lastGfiDecayAt: parsed.lastGfiDecayAt,
+          dailyGfiPeak: parsed.dailyGfiPeak,
+          lastActivityAt: parsed.lastActivityAt ?? parsed.lastControlActivityAt ?? 0,
+        });
+      }
+    } catch {
+      // Skip malformed session files
+    }
+  }
+
+  return sessions;
+}
+
+export async function handleRuntimeGfiSnapshot(opts: GfiSnapshotOptions): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const sessions = readPersistedSessions(workspaceDir);
+
+  const snapshot = buildGfiWorkspaceSnapshot({
+    sessions,
+    nowMs: Date.now(),
+  });
+
+  if (opts.json) {
+    console.log(JSON.stringify(snapshot, null, 2));
+  } else {
+    console.log(formatTextOutput(snapshot));
+  }
+}

--- a/packages/pd-cli/src/commands/runtime-gfi-snapshot.ts
+++ b/packages/pd-cli/src/commands/runtime-gfi-snapshot.ts
@@ -81,6 +81,7 @@ function readPersistedSessions(workspaceDir: string): {
     dailyGfiPeak?: number;
     lastActivityAt: number;
   }[] = [];
+  let skippedCount = 0;
 
   for (const file of fs.readdirSync(sessionDir)) {
     if (!file.endsWith('.json')) continue;
@@ -98,10 +99,16 @@ function readPersistedSessions(workspaceDir: string): {
           dailyGfiPeak: parsed.dailyGfiPeak,
           lastActivityAt: parsed.lastActivityAt ?? parsed.lastControlActivityAt ?? 0,
         });
+      } else {
+        skippedCount++;
       }
     } catch {
-      // Skip malformed session files
+      skippedCount++;
     }
+  }
+
+  if (skippedCount > 0) {
+    console.warn(`[runtime-gfi-snapshot] Skipped ${skippedCount} malformed session file(s)`);
   }
 
   return sessions;

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -27,6 +27,7 @@ import { handleFlowShow } from './commands/flow.js';
 import { handleTraceShow } from './commands/trace.js';
 import { handlePruningReport, handlePruningExplain, handlePruningReview, handlePruningRollback } from './commands/runtime-pruning.js';
 import { handleRuntimeHealthSnapshot } from './commands/runtime-health-snapshot.js';
+import { handleRuntimeGfiSnapshot } from './commands/runtime-gfi-snapshot.js';
 import { handleRuntimeUat } from './commands/runtime-uat.js';
 import { handleRuntimeInternalizationQueue } from './commands/runtime-internalization-queue.js';
 import { handleRuntimeInternalizationWakeOnce } from './commands/runtime-internalization-wake-once.js';
@@ -355,6 +356,15 @@ runtimeHealthCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleRuntimeHealthSnapshot({ workspace: opts.workspace, json: opts.json });
+  });
+
+runtimeHealthCmd
+  .command('gfi')
+  .description('GFI workspace snapshot — active vs stale session breakdown')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeGfiSnapshot({ workspace: opts.workspace, json: opts.json });
   });
 
 const internalizationCmd = runtimeCmd

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -1369,6 +1369,7 @@ describe('PRI-76 GFI core kernel boundary', () => {
     'gfi/gfi-types.ts',
     'gfi/gfi-policy.ts',
     'gfi/gfi-kernel.ts',
+    'gfi/gfi-read-model.ts',
     'gfi/index.ts',
   ];
 
@@ -1402,5 +1403,32 @@ describe('PRI-76 GFI core kernel boundary', () => {
     expect(src).toContain('GfiStage');
     expect(src).toContain('GfiSource');
     expect(src).toContain('GfiSnapshot');
+    expect(src).toContain('buildGfiWorkspaceSnapshot');
+    expect(src).toContain('GfiReadModelInput');
+    expect(src).toContain('GfiWorkspaceSnapshot');
+  });
+});
+
+// ── PRI-78: GFI observability boundary ──────────────────────────────────────
+
+describe('PRI-78 GFI observability boundary', () => {
+  it('gfi-read-model.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'gfi/gfi-read-model.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('node:process');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('pd-cli runtime-gfi-snapshot.ts imports from @principles/core/runtime-v2', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(
+      resolve(__dirname, '../../../../pd-cli/src/commands/runtime-gfi-snapshot.ts'),
+      'utf-8'
+    );
+    expect(src).toContain("from '@principles/core/runtime-v2'");
   });
 });

--- a/packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-read-model.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import type { GfiReadModelInput } from '../gfi-read-model.js';
+import { buildGfiWorkspaceSnapshot } from '../gfi-read-model.js';
+
+describe('buildGfiWorkspaceSnapshot', () => {
+  const nowMs = 1000 * 60 * 60 * 10; // 10 hours ago in ms
+
+  function makeSession(overrides: Partial<GfiReadModelInput['sessions'][0]> = {}): GfiReadModelInput['sessions'][0] {
+    return {
+      sessionId: 's_test',
+      currentGfi: 0,
+      gfiBySource: {},
+      consecutiveErrors: 0,
+      lastActivityAt: nowMs,
+      ...overrides,
+    };
+  }
+
+  describe('active session selection', () => {
+    it('recent session -> non-null snapshot', () => {
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 50, lastActivityAt: nowMs })],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active).not.toBeNull();
+      expect(result.active?.currentGfi).toBe(50);
+      expect(result.activeSessionCount).toBe(1);
+      expect(result.staleSessionCount).toBe(0);
+      expect(result.totalSessionCount).toBe(1);
+    });
+
+    it('only stale sessions -> null active with non-zero stale count', () => {
+      const twoHoursAgo = nowMs - 2 * 60 * 60 * 1000;
+      const input: GfiReadModelInput = {
+        sessions: [
+          makeSession({ sessionId: 's_1', currentGfi: 30, lastActivityAt: twoHoursAgo }),
+          makeSession({ sessionId: 's_2', currentGfi: 50, lastActivityAt: twoHoursAgo - 1000 }),
+        ],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active).toBeNull();
+      expect(result.staleSessionCount).toBe(2);
+      expect(result.staleGfiRange).toEqual({ min: 30, max: 50 });
+      expect(result.activeSessionCount).toBe(0);
+      expect(result.totalSessionCount).toBe(2);
+    });
+
+    it('mixed active/stale -> active selected, stale counted', () => {
+      const twoHoursAgo = nowMs - 2 * 60 * 60 * 1000;
+      const input: GfiReadModelInput = {
+        sessions: [
+          makeSession({ sessionId: 's_1', currentGfi: 30, lastActivityAt: twoHoursAgo }),
+          makeSession({ sessionId: 's_2', currentGfi: 70, lastActivityAt: nowMs }), // active
+        ],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active).not.toBeNull();
+      expect(result.active?.currentGfi).toBe(70);
+      expect(result.activeSessionCount).toBe(1);
+      expect(result.staleSessionCount).toBe(1);
+      expect(result.totalSessionCount).toBe(2);
+    });
+
+    it('multiple active -> highest GFI wins (tie-break: most recent)', () => {
+      const input: GfiReadModelInput = {
+        sessions: [
+          makeSession({ sessionId: 's_1', currentGfi: 40, lastActivityAt: nowMs + 5000 }),
+          makeSession({ sessionId: 's_2', currentGfi: 75, lastActivityAt: nowMs + 3000 }),
+          makeSession({ sessionId: 's_3', currentGfi: 75, lastActivityAt: nowMs + 4000 }), // tie with s_2 but more recent
+        ],
+        nowMs: nowMs + 10000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active).not.toBeNull();
+      // s_3 has same GFI as s_2 but more recent
+      expect(result.active?.currentGfi).toBe(75);
+      // Most recent among ties
+      expect(result.activeSessionCount).toBe(3);
+      expect(result.staleSessionCount).toBe(0);
+    });
+  });
+
+  describe('stale vs active boundary', () => {
+    it('session exactly at cutoff is active', () => {
+      const cutoffMs = 2 * 60 * 60 * 1000; // 2 hours
+      const atCutoff = nowMs - cutoffMs + 1; // 1ms before cutoff
+
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 50, lastActivityAt: atCutoff })],
+        nowMs: nowMs,
+        staleCutoffMs: cutoffMs,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active).not.toBeNull();
+      expect(result.activeSessionCount).toBe(1);
+      expect(result.staleSessionCount).toBe(0);
+    });
+
+    it('custom staleCutoffMs override', () => {
+      // Using baseNow as the reference "current time"
+      const baseNow = nowMs + 1000; // 10 hours + 1 second ago
+      const fiveMinAgo = baseNow - 5 * 60 * 1000; // 5 minutes before baseNow
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 50, lastActivityAt: fiveMinAgo })],
+        nowMs: baseNow,
+        staleCutoffMs: 10 * 60 * 1000, // 10 minutes
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      // Session is 5 minutes old, cutoff is 10 minutes -> ACTIVE
+      expect(result.active).not.toBeNull();
+      expect(result.active?.currentGfi).toBe(50);
+
+      // Now test with session older than cutoff
+      const fifteenMinAgo = baseNow - 15 * 60 * 1000;
+      const input2: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 50, lastActivityAt: fifteenMinAgo })],
+        nowMs: baseNow,
+        staleCutoffMs: 10 * 60 * 1000, // 10 minutes
+      };
+
+      const result2 = buildGfiWorkspaceSnapshot(input2);
+
+      // Session is 15 minutes old, cutoff is 10 minutes -> STALE
+      expect(result2.active).toBeNull();
+      expect(result2.staleSessionCount).toBe(1);
+    });
+  });
+
+  describe('GfiSnapshot content', () => {
+    it('snapshot includes correct stage, dominant source, policy thresholds', () => {
+      const input: GfiReadModelInput = {
+        sessions: [
+          makeSession({
+            sessionId: 's_1',
+            currentGfi: 75,
+            gfiBySource: { tool_failure: 50, dispatch_error: 25 },
+            consecutiveErrors: 3,
+            lastErrorSource: 'tool_failure',
+            dailyGfiPeak: 80,
+            lastActivityAt: nowMs,
+          }),
+        ],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active).not.toBeNull();
+      expect(result.active?.stage).toBe('critical'); // 75 >= 70 (critical threshold)
+      expect(result.active?.dominantSource).toBe('tool_failure'); // 50 > 25
+      expect(result.active?.consecutiveErrors).toBe(3);
+      expect(result.active?.dailyGfiPeak).toBe(80);
+      expect(result.active?.policy.elevatedThreshold).toBe(40);
+      expect(result.active?.policy.criticalThreshold).toBe(70);
+      expect(result.active?.policy.saturatedThreshold).toBe(100);
+      expect(result.active?.consumers.attitudeMode).toBe('humble_recovery');
+      expect(result.active?.consumers.painDiagnosticReason).toBe('high_gfi');
+    });
+
+    it('saturated stage when currentGfi >= 100', () => {
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 100, lastActivityAt: nowMs })],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active?.stage).toBe('saturated');
+    });
+
+    it('stable stage when currentGfi < 40', () => {
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 20, lastActivityAt: nowMs })],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.active?.stage).toBe('stable');
+      expect(result.active?.consumers.attitudeMode).toBe('efficient');
+      expect(result.active?.consumers.painDiagnosticReason).toBe('none');
+    });
+  });
+
+  describe('stale GFI range', () => {
+    it('empty stale range when no stale sessions', () => {
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 50, lastActivityAt: nowMs })],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.staleGfiRange).toBeNull();
+    });
+
+    it('stale range with single session', () => {
+      const twoHoursAgo = nowMs - 2 * 60 * 60 * 1000;
+      const input: GfiReadModelInput = {
+        sessions: [makeSession({ sessionId: 's_1', currentGfi: 45, lastActivityAt: twoHoursAgo })],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.staleGfiRange).toEqual({ min: 45, max: 45 });
+    });
+  });
+
+  describe('generatedAt', () => {
+    it('includes ISO timestamp', () => {
+      const input: GfiReadModelInput = {
+        sessions: [],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      expect(result.generatedAt).toBeDefined();
+      expect(new Date(result.generatedAt).toISOString()).toBe(result.generatedAt);
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-read-model.test.ts
@@ -220,6 +220,25 @@ describe('buildGfiWorkspaceSnapshot', () => {
 
       expect(result.staleGfiRange).toEqual({ min: 45, max: 45 });
     });
+
+    it('stale range with multiple sessions — min/max computed across all', () => {
+      const twoHoursAgo = nowMs - 2 * 60 * 60 * 1000;
+      const input: GfiReadModelInput = {
+        sessions: [
+          makeSession({ sessionId: 's_1', currentGfi: 10, lastActivityAt: twoHoursAgo - 4000 }),
+          makeSession({ sessionId: 's_2', currentGfi: 90, lastActivityAt: twoHoursAgo - 2000 }),
+          makeSession({ sessionId: 's_3', currentGfi: 45, lastActivityAt: twoHoursAgo }),
+        ],
+        nowMs: nowMs + 1000,
+      };
+
+      const result = buildGfiWorkspaceSnapshot(input);
+
+      // s_1 is min (10), s_2 is max (90)
+      expect(result.staleGfiRange).toEqual({ min: 10, max: 90 });
+      expect(result.staleSessionCount).toBe(3);
+      expect(result.active).toBeNull();
+    });
   });
 
   describe('generatedAt', () => {

--- a/packages/principles-core/src/runtime-v2/gfi/gfi-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/gfi-read-model.ts
@@ -1,0 +1,143 @@
+/**
+ * GFI Observability Read Model
+ *
+ * Pure domain model for building workspace-level GFI snapshots.
+ * Partitions sessions into active vs stale and produces an authoritative snapshot
+ * for operator visibility.
+ *
+ * PRI-78: GFI Observability
+ */
+
+import type { GfiPolicy, GfiSource, GfiSnapshot, GfiState } from './gfi-types.js';
+import { DEFAULT_GFI_POLICY } from './gfi-policy.js';
+import { createGfiSnapshot } from './gfi-kernel.js';
+
+export interface GfiReadModelInput {
+  sessions: {
+    sessionId: string;
+    currentGfi: number;
+    gfiBySource?: Partial<Record<GfiSource, number>>;
+    lastErrorSource?: string;
+    consecutiveErrors: number;
+    lastGfiDecayAt?: number;
+    dailyGfiPeak?: number;
+    lastActivityAt: number;
+    workspaceDir?: string;
+  }[];
+  nowMs: number;
+  staleCutoffMs?: number; // default: 2 hours
+  policy?: GfiPolicy;
+}
+
+export interface GfiWorkspaceSnapshot {
+  active: GfiSnapshot | null;
+  staleSessionCount: number;
+  staleGfiRange: { min: number; max: number } | null;
+  totalSessionCount: number;
+  activeSessionCount: number;
+  generatedAt: string;
+}
+
+const DEFAULT_STALE_CUTOFF_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
+ * Convert a session's fields to a GfiState for snapshot creation.
+ * Note: lastErrorHash is not persisted across sessions, so we omit it.
+ */
+function sessionToGfiState(
+  session: GfiReadModelInput['sessions'][0],
+): GfiState {
+  return {
+    currentGfi: session.currentGfi ?? 0,
+    gfiBySource: (session.gfiBySource ?? {}),
+    lastErrorSource: session.lastErrorSource,
+    consecutiveErrors: session.consecutiveErrors ?? 0,
+    lastGfiDecayAt: session.lastGfiDecayAt,
+    dailyGfiPeak: session.dailyGfiPeak,
+  };
+}
+
+/**
+ * Build a workspace-level GFI snapshot from session data.
+ *
+ * Algorithm:
+ * 1. Default stale cutoff to 2 hours if not provided
+ * 2. Partition sessions into active (lastActivityAt >= nowMs - staleCutoffMs) and stale
+ * 3. Select active session with highest currentGfi (tie-break: most recent lastActivityAt)
+ * 4. Build GfiSnapshot for selected active session using createGfiSnapshot
+ * 5. Compute staleGfiRange from stale sessions' currentGfi values
+ * 6. Return GfiWorkspaceSnapshot
+ *
+ * Key invariant: stale sessions do NOT influence the active snapshot.
+ * This prevents old UAT sessions with GFI=197.8 from making current health look critical.
+ */
+export function buildGfiWorkspaceSnapshot(
+  input: GfiReadModelInput,
+): GfiWorkspaceSnapshot {
+  const { sessions, nowMs, policy = DEFAULT_GFI_POLICY } = input;
+  const staleCutoffMs = input.staleCutoffMs ?? DEFAULT_STALE_CUTOFF_MS;
+
+  if (sessions.length === 0) {
+    return {
+      active: null,
+      staleSessionCount: 0,
+      staleGfiRange: null,
+      totalSessionCount: 0,
+      activeSessionCount: 0,
+      generatedAt: new Date(nowMs).toISOString(),
+    };
+  }
+
+  const cutoffTime = nowMs - staleCutoffMs;
+
+  // Partition sessions
+  const activeSessions: GfiReadModelInput['sessions'] = [];
+  const staleSessions: GfiReadModelInput['sessions'] = [];
+
+  for (const session of sessions) {
+    if (session.lastActivityAt >= cutoffTime) {
+      activeSessions.push(session);
+    } else {
+      staleSessions.push(session);
+    }
+  }
+
+  // Select active session: highest currentGfi, tie-break by most recent lastActivityAt
+  let selectedActive: GfiReadModelInput['sessions'][0] | null = null;
+
+  for (const session of activeSessions) {
+    if (
+      selectedActive === null ||
+      session.currentGfi > selectedActive.currentGfi ||
+      (session.currentGfi === selectedActive.currentGfi &&
+        session.lastActivityAt > selectedActive.lastActivityAt)
+    ) {
+      selectedActive = session;
+    }
+  }
+
+  // Build snapshot for active session
+  const activeSnapshot: GfiSnapshot | null = selectedActive
+    ? createGfiSnapshot(sessionToGfiState(selectedActive), policy)
+    : null;
+
+  // Compute stale GFI range
+  let staleGfiRange: { min: number; max: number } | null = null;
+
+  if (staleSessions.length > 0) {
+    const staleGfis = staleSessions.map((s) => s.currentGfi ?? 0);
+    staleGfiRange = {
+      min: Math.min(...staleGfis),
+      max: Math.max(...staleGfis),
+    };
+  }
+
+  return {
+    active: activeSnapshot,
+    staleSessionCount: staleSessions.length,
+    staleGfiRange,
+    totalSessionCount: sessions.length,
+    activeSessionCount: activeSessions.length,
+    generatedAt: new Date(nowMs).toISOString(),
+  };
+}

--- a/packages/principles-core/src/runtime-v2/gfi/gfi-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/gfi-read-model.ts
@@ -15,23 +15,40 @@ import { createGfiSnapshot } from './gfi-kernel.js';
 export interface GfiReadModelInput {
   sessions: {
     sessionId: string;
-    currentGfi: number;
+    /** Defaults to 0 if omitted */
+    currentGfi?: number;
     gfiBySource?: Partial<Record<GfiSource, number>>;
     lastErrorSource?: string;
-    consecutiveErrors: number;
+    /** Defaults to 0 if omitted */
+    consecutiveErrors?: number;
     lastGfiDecayAt?: number;
     dailyGfiPeak?: number;
-    lastActivityAt: number;
-    workspaceDir?: string;
+    /** Defaults to 0 if omitted — session older than cutoff is classified stale */
+    lastActivityAt?: number;
   }[];
   nowMs: number;
-  staleCutoffMs?: number; // default: 2 hours
+  /** Sessions with lastActivityAt < nowMs - staleCutoffMs are classified stale. Default: 2 hours */
+  staleCutoffMs?: number;
   policy?: GfiPolicy;
 }
 
+/**
+ * Workspace-level GFI snapshot — partitions sessions into active vs stale.
+ *
+ * Invariant: `active === null` iff `activeSessionCount === 0` (no active sessions exist).
+ * Invariant: `staleGfiRange === null` iff `staleSessionCount === 0` (not an error state).
+ */
 export interface GfiWorkspaceSnapshot {
+  /**
+   * Snapshot for the highest-GFI active session.
+   * Null when there are no active sessions (all stale, or no sessions exist).
+   */
   active: GfiSnapshot | null;
   staleSessionCount: number;
+  /**
+   * Min/max GFI across all stale sessions.
+   * Null when staleSessionCount === 0 (no stale sessions — not an error state).
+   */
   staleGfiRange: { min: number; max: number } | null;
   totalSessionCount: number;
   activeSessionCount: number;
@@ -95,7 +112,7 @@ export function buildGfiWorkspaceSnapshot(
   const staleSessions: GfiReadModelInput['sessions'] = [];
 
   for (const session of sessions) {
-    if (session.lastActivityAt >= cutoffTime) {
+    if ((session.lastActivityAt ?? 0) >= cutoffTime) {
       activeSessions.push(session);
     } else {
       staleSessions.push(session);
@@ -108,9 +125,9 @@ export function buildGfiWorkspaceSnapshot(
   for (const session of activeSessions) {
     if (
       selectedActive === null ||
-      session.currentGfi > selectedActive.currentGfi ||
-      (session.currentGfi === selectedActive.currentGfi &&
-        session.lastActivityAt > selectedActive.lastActivityAt)
+      (session.currentGfi ?? 0) > (selectedActive.currentGfi ?? 0) ||
+      ((session.currentGfi ?? 0) === (selectedActive.currentGfi ?? 0) &&
+        (session.lastActivityAt ?? 0) > (selectedActive.lastActivityAt ?? 0))
     ) {
       selectedActive = session;
     }

--- a/packages/principles-core/src/runtime-v2/gfi/index.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/index.ts
@@ -8,6 +8,8 @@ export {
   createGfiSnapshot,
 } from './gfi-kernel.js';
 
+export { buildGfiWorkspaceSnapshot } from './gfi-read-model.js';
+
 export type {
   GfiState,
   GfiEvent,
@@ -16,3 +18,5 @@ export type {
   GfiSource,
   GfiSnapshot,
 } from './gfi-types.js';
+
+export type { GfiReadModelInput, GfiWorkspaceSnapshot } from './gfi-read-model.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -466,3 +466,8 @@ export type {
   GfiSource,
   GfiSnapshot,
 } from './gfi/index.js';
+
+// ── GFI Workspace Read Model (PRI-78) ──────────────────────────────────────
+
+export { buildGfiWorkspaceSnapshot } from './gfi/index.js';
+export type { GfiReadModelInput, GfiWorkspaceSnapshot } from './gfi/index.js';


### PR DESCRIPTION
## Summary

- **PRI-78: GFI Observability** — adds operator-visible GFI workspace snapshot for Runtime V2
- `buildGfiWorkspaceSnapshot` pure function in `@principles/core` partitions sessions into active (≤2h) vs stale
- `pd runtime health gfi` CLI command shows active vs stale breakdown
- `RuntimeSummaryService` now includes `workspaceSnapshot` with authoritative active GFI snapshot
- Stale sessions (D2: old UAT sessions with GFI=197.8) no longer pollute active health view

## Files Changed

| File | Change |
|------|--------|
| `runtime-v2/gfi/gfi-read-model.ts` | New — buildGfiWorkspaceSnapshot pure function |
| `runtime-v2/gfi/__tests__/gfi-read-model.test.ts` | New — 12 unit tests |
| `pd-cli/src/commands/runtime-gfi-snapshot.ts` | New — CLI handler |
| `pd-cli/src/index.ts` | Register `runtime health gfi` subcommand |
| `openclaw-plugin/src/service/runtime-summary-service.ts` | Add workspaceSnapshot to RuntimeSummary |
| `runtime-v2/gfi/index.ts` | Re-export read model |
| `runtime-v2/index.ts` | Re-export read model |
| `architecture-regression.test.ts` | Add PRI-78 guards |

## Test Plan

- [x] `npm run build --workspace=@principles/core` passes
- [x] `npm run build --workspace=@principles/pd-cli` passes  
- [x] `npx vitest run packages/principles-core/src/runtime-v2/gfi/__tests__/` — 12 tests pass
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` — all pass
- [x] `pd runtime health gfi --workspace "D:\.openclaw\workspace" --json` — verified stale sessions visible
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 GFI 工作区快照 CLI（带 --workspace 和 --json 选项），可输出 JSON 或人类可读报告，展示生成时间、活跃/陈旧会话与 GFI 范围概览
  * 运行时汇总现在可包含可选的工作区快照数据，提供按会话汇总的活跃/陈旧视图

* **测试**
  * 增加 GFI 读模型和架构回归测试，覆盖活跃选择、陈旧判定、峰值与诊断字段等行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->