### PR TITLE
fix(pain): broaden dispatch_error classification to tool <name> not found

### DIFF
--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -99,11 +99,10 @@ function createPainId(sessionId: string): string {
 export function classifyToolFailureSource(toolName: string | undefined, error: unknown): 'dispatch_error' | 'tool_failure' {
   if (!toolName || toolName.trim() === '') return 'dispatch_error';
   const msg = String(error ?? '');
-  // Dropped "error:" prefix requirement to catch "failed: unknown tool read_file" style messages.
-  // Word-boundary anchors prevent partial matches (e.g. "report_tool_not_found" would not match).
-  // Trade-off: messages containing "tool not found" without dispatch context (e.g. suppression
-  // warnings) will also match. This is acceptable since OpenClaw does not produce such messages.
-  if (/\btool\s+not\s+found\b/i.test(msg)) return 'dispatch_error';
+  // Dropped "error:" prefix to catch "failed: unknown tool read_file" style messages.
+  // Catches: "tool not found", "tool <name> not found", "unknown tool".
+  // Word-boundary anchors prevent "report_tool_not_found" from matching.
+  if (/\btool\s+(?:\S+\s+)?not\s+found\b/i.test(msg)) return 'dispatch_error';
   if (/\bunknown\s+tool\b/i.test(msg)) return 'dispatch_error';
   return 'tool_failure';
 }

--- a/packages/openclaw-plugin/tests/hooks/pain.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain.test.ts
@@ -35,8 +35,8 @@ describe('classifyToolFailureSource', () => {
   it('"Tool not found" (case insensitive) -> dispatch_error', () => {
     expect(classifyToolFailureSource('read', 'error: tool not found')).toBe('dispatch_error');
     expect(classifyToolFailureSource('read', 'Tool Not Found')).toBe('dispatch_error');
-    // "read_file" contains underscore (word char), breaking \s+ between "tool" and "not"
-    expect(classifyToolFailureSource('read', 'Tool read_file not found')).toBe('tool_failure');
+    // "tool <name> not found" also matches (e.g. "tool read_file not found")
+    expect(classifyToolFailureSource('read', 'Tool read_file not found')).toBe('dispatch_error');
   });
 
   it('"Unknown tool" (case insensitive) -> dispatch_error', () => {


### PR DESCRIPTION
## Summary

Extend `classifyToolFailureSource` regex to match "tool <name> not found" in addition to plain "tool not found":

- Before: `/\btool\s+not\s+found\b/` (plain only)
- After: `/\btool\s+(?:\S+\s+)?not\s+found\b/`

Covers: `"tool not found"`, `"tool read_file not found"`, `"tool some_tool not found"`.
Still rejects: `"report_tool_not_found"` (no `\s` after "tool").

Test updated: `"Tool read_file not found"` → `dispatch_error` (was incorrectly `tool_failure`).

## Test plan
- [x] `npx vitest run packages/openclaw-plugin/tests/hooks/pain.test.ts` — 13 passed
- [x] `npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` — 195 passed
- [x] `npm run build --workspace=@principles/core`
- [x] `npm run build --workspace=@principles/pd-cli`
- [x] `npm run typecheck:openclaw-plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)