### PR TITLE
feat(pri-83): Runtime Health Snapshot GFI Summary Integration

### DIFF
--- a/packages/pd-cli/src/commands/runtime-health-snapshot.ts
+++ b/packages/pd-cli/src/commands/runtime-health-snapshot.ts
@@ -57,6 +57,15 @@ function formatTextOutput(snapshot: OperatorHealthSnapshot): string {
   }
   lines.push('');
 
+  // GFI
+  if (snapshot.gfi.active) {
+    const g = snapshot.gfi.active;
+    lines.push(`gfi: stage=${g.stage} currentGfi=${g.currentGfi} dominantSource=${g.dominantSource ?? '-'} sessions=${snapshot.gfi.activeSessionCount}active/${snapshot.gfi.staleSessionCount}stale`);
+  } else {
+    lines.push('gfi: (no active sessions)');
+  }
+  lines.push('');
+
   // Actions
   if (snapshot.recommendedActions.length === 0) {
     lines.push('No actions recommended.');

--- a/packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-health-snapshot.test.ts
@@ -58,6 +58,14 @@ function healthySnapshot() {
       reviewCount: 0,
       orphanDerivedCandidateCount: 0,
     },
+    gfi: {
+      active: null,
+      staleSessionCount: 0,
+      staleGfiRange: null,
+      totalSessionCount: 0,
+      activeSessionCount: 0,
+      generatedAt: '2026-05-03T12:00:00.000Z',
+    },
     overallStatus: 'healthy' as const,
     recommendedActions: [],
   };
@@ -255,5 +263,94 @@ describe('handleRuntimeHealthSnapshot', () => {
     expect(jsonOutput.recommendedActions).toHaveLength(3);
 
     exitSpy.mockRestore();
+  });
+
+  // ── GFI section (PRI-83) ──────────────────────────────────────────────────
+
+  it('includes gfi section in JSON output with active session data', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      gfi: {
+        active: {
+          currentGfi: 42,
+          stage: 'elevated',
+          dominantSource: 'tool_failure',
+          consecutiveErrors: 2,
+          dailyGfiPeak: 55,
+          consumers: {
+            attitudeMode: 'conciliatory',
+            painDiagnosticReason: 'high_gfi',
+          },
+        },
+        staleSessionCount: 1,
+        staleGfiRange: { min: 10, max: 20 },
+        totalSessionCount: 2,
+        activeSessionCount: 1,
+        generatedAt: '2026-05-03T12:00:00.000Z',
+      },
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.gfi).toBeDefined();
+    expect(jsonOutput.gfi.active).not.toBeNull();
+    expect(jsonOutput.gfi.active.currentGfi).toBe(42);
+    expect(jsonOutput.gfi.active.stage).toBe('elevated');
+    expect(jsonOutput.gfi.active.dominantSource).toBe('tool_failure');
+    expect(jsonOutput.gfi.activeSessionCount).toBe(1);
+    expect(jsonOutput.gfi.staleSessionCount).toBe(1);
+  });
+
+  it('includes compact GFI line in text output', async () => {
+    const snapshot = {
+      ...healthySnapshot(),
+      gfi: {
+        active: {
+          currentGfi: 42,
+          stage: 'elevated',
+          dominantSource: 'tool_failure',
+          consecutiveErrors: 2,
+          dailyGfiPeak: 55,
+          consumers: {
+            attitudeMode: 'conciliatory',
+            painDiagnosticReason: 'high_gfi',
+          },
+        },
+        staleSessionCount: 0,
+        staleGfiRange: null,
+        totalSessionCount: 1,
+        activeSessionCount: 1,
+        generatedAt: '2026-05-03T12:00:00.000Z',
+      },
+    };
+    mockSnapshotFn.mockResolvedValue(snapshot);
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('gfi:');
+    expect(allOutput).toContain('elevated');
+    expect(allOutput).toContain('42');
+  });
+
+  it('shows no active sessions in text when gfi.active is null', async () => {
+    mockSnapshotFn.mockResolvedValue(healthySnapshot());
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('no active sessions');
+  });
+
+  it('does not mark runtime unhealthy solely for missing GFI data', async () => {
+    mockSnapshotFn.mockResolvedValue(healthySnapshot());
+
+    await handleRuntimeHealthSnapshot({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.gfi.active).toBeNull();
+    expect(jsonOutput.overallStatus).toBe('healthy');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/operator-health-gfi.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/operator-health-gfi.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { OperatorHealthReadModel } from '../operator-health-read-model.js';
+import BetterSqlite3 from 'better-sqlite3';
+
+function initTestDb(stateDbPath: string): void {
+  const db = new BetterSqlite3(stateDbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      task_id TEXT PRIMARY KEY,
+      task_kind TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS runs (
+      run_id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      runtime_kind TEXT NOT NULL,
+      started_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS artifacts (
+      artifact_id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      artifact_kind TEXT NOT NULL,
+      content_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS principle_candidates (
+      candidate_id TEXT PRIMARY KEY,
+      artifact_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      source_run_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      description TEXT NOT NULL,
+      confidence REAL,
+      source_recommendation_json TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+  db.close();
+}
+
+describe('OperatorHealthReadModel GFI integration (PRI-83)', () => {
+  let tmpDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-health-gfi-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('includes gfi section in snapshot when session data exists', async () => {
+    const pdDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    initTestDb(path.join(pdDir, 'state.db'));
+
+    const sessionDir = path.join(tmpDir, '.state', 'sessions');
+    fs.mkdirSync(sessionDir, { recursive: true });
+
+    const nowMs = Date.now();
+    fs.writeFileSync(path.join(sessionDir, 'sess-001.json'), JSON.stringify({
+      sessionId: 'sess-001',
+      currentGfi: 42,
+      gfiBySource: { tool_failure: 30, stuck_loop: 12 },
+      lastErrorSource: 'tool_failure',
+      consecutiveErrors: 2,
+      lastActivityAt: nowMs,
+    }));
+
+    const model = new OperatorHealthReadModel({ workspaceDir: tmpDir });
+    try {
+      const snapshot = await model.getSnapshot();
+
+      expect(snapshot.gfi).toBeDefined();
+      expect(snapshot.gfi.active).not.toBeNull();
+      if (snapshot.gfi.active) {
+        expect(snapshot.gfi.active.currentGfi).toBe(42);
+        expect(snapshot.gfi.active.stage).toBeDefined();
+        expect(snapshot.gfi.active.dominantSource).toBeDefined();
+      }
+      expect(snapshot.gfi.activeSessionCount).toBeGreaterThanOrEqual(1);
+      expect(snapshot.gfi.generatedAt).toBeDefined();
+    } finally {
+      await model.close();
+    }
+  });
+
+  it('returns gfi.active = null when no session data exists', async () => {
+    const pdDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    initTestDb(path.join(pdDir, 'state.db'));
+
+    const model = new OperatorHealthReadModel({ workspaceDir: tmpDir });
+    try {
+      const snapshot = await model.getSnapshot();
+
+      expect(snapshot.gfi).toBeDefined();
+      expect(snapshot.gfi.active).toBeNull();
+      expect(snapshot.gfi.staleSessionCount).toBe(0);
+      expect(snapshot.gfi.activeSessionCount).toBe(0);
+    } finally {
+      await model.close();
+    }
+  });
+
+  it('does not mark runtime unhealthy solely for missing GFI', async () => {
+    const model = new OperatorHealthReadModel({ workspaceDir: tmpDir });
+    try {
+      const snapshot = await model.getSnapshot();
+
+      expect(snapshot.gfi.active).toBeNull();
+    } finally {
+      await model.close();
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
@@ -13,6 +13,9 @@ import type { PainChainTrace } from './pain-chain-read-model.js';
 import { PruningReadModel } from './pruning-read-model.js';
 import { auditCandidateLedgerConsistency } from './candidate-audit.js';
 import type { CandidateAuditResult } from './candidate-audit.js';
+import { buildGfiWorkspaceSnapshot } from './gfi/gfi-read-model.js';
+import type { GfiWorkspaceSnapshot } from './gfi/gfi-read-model.js';
+import type { GfiSource } from './gfi/gfi-types.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -35,6 +38,7 @@ export interface OperatorHealthSnapshot {
     reviewCount: number;
     orphanDerivedCandidateCount: number;
   };
+  gfi: GfiWorkspaceSnapshot;
   overallStatus: OverallHealthStatus;
   recommendedActions: string[];
 }
@@ -46,6 +50,51 @@ export interface OperatorHealthReadModelOptions {
 }
 
 // ── Read model ───────────────────────────────────────────────────────────────
+
+interface PersistedSession {
+  sessionId: string;
+  currentGfi: number;
+  gfiBySource?: Partial<Record<GfiSource, number>>;
+  lastErrorSource?: string;
+  consecutiveErrors: number;
+  lastGfiDecayAt?: number;
+  dailyGfiPeak?: number;
+  lastActivityAt: number;
+}
+
+function readPersistedSessions(workspaceDir: string): PersistedSession[] {
+  const sessionDir = path.join(workspaceDir, '.state', 'sessions');
+
+  if (!fs.existsSync(sessionDir)) {
+    return [];
+  }
+
+  const sessions: PersistedSession[] = [];
+
+  for (const file of fs.readdirSync(sessionDir)) {
+    if (!file.endsWith('.json')) continue;
+    try {
+      const raw = fs.readFileSync(path.join(sessionDir, file), 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed?.sessionId) {
+        sessions.push({
+          sessionId: parsed.sessionId ?? file.replace('.json', ''),
+          currentGfi: parsed.currentGfi ?? 0,
+          gfiBySource: parsed.gfiBySource,
+          lastErrorSource: parsed.lastErrorSource,
+          consecutiveErrors: parsed.consecutiveErrors ?? 0,
+          lastGfiDecayAt: parsed.lastGfiDecayAt,
+          dailyGfiPeak: parsed.dailyGfiPeak,
+          lastActivityAt: parsed.lastActivityAt ?? parsed.lastControlActivityAt ?? 0,
+        });
+      }
+    } catch {
+      // skip malformed session files
+    }
+  }
+
+  return sessions;
+}
 
 export class OperatorHealthReadModel {
   private readonly workspaceDir: string;
@@ -107,6 +156,23 @@ export class OperatorHealthReadModel {
       // Graceful — pruning section stays zeroed
     }
 
+    // ── GFI ───────────────────────────────────────────────────────────────
+    const gfi: GfiWorkspaceSnapshot = (() => {
+      try {
+        const sessions = readPersistedSessions(this.workspaceDir);
+        return buildGfiWorkspaceSnapshot({ sessions, nowMs: Date.now() });
+      } catch {
+        return {
+          active: null,
+          staleSessionCount: 0,
+          staleGfiRange: null,
+          totalSessionCount: 0,
+          activeSessionCount: 0,
+          generatedAt: new Date().toISOString(),
+        };
+      }
+    })();
+
     // ── Compute overallStatus ─────────────────────────────────────────────
     let overallStatus: OverallHealthStatus = 'healthy';
 
@@ -152,6 +218,7 @@ export class OperatorHealthReadModel {
         missingLedgerCount: audit.missingLedgerCount,
       },
       pruning: { watchCount, reviewCount, orphanDerivedCandidateCount },
+      gfi,
       overallStatus,
       recommendedActions,
     };
@@ -162,7 +229,6 @@ export class OperatorHealthReadModel {
       await this.ownedPainChainReadModel.close();
       this.ownedPainChainReadModel = null;
     }
-    // PruningReadModel uses better-sqlite3 readonly — close to release file handle
     if (this.ownedPruningReadModel) {
       this.ownedPruningReadModel = null;
     }


### PR DESCRIPTION
PRI-83: Integrate GFI summary into runtime health snapshot. Core: add gfi field to OperatorHealthSnapshot, read sessions, build GFI snapshot. CLI: add GFI text line. GFI missing does not affect overallStatus. Tests: 3 core + 4 CLI. All passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 运行时健康快照的文本输出现包含 GFI 部分，显示活跃会话状态（阶段、当前 GFI、主要源和会话计数）
* 无活跃 GFI 时显示 "(no active sessions)" 消息

## 测试
* 增加了 GFI 会话行为的单元测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->