### PR TITLE
feat(core): DreamerRunner vertical slice - artifact writing + lineage (PRI-85)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
@@ -315,6 +315,8 @@ describe('DreamerRunner vertical slice (PRI-85)', () => {
       (call: unknown[]) => (call[0] as { eventType: string }).eventType === 'dreamer_lineage_partial',
     );
     expect(lineagePartialEvents.length).toBeGreaterThanOrEqual(1);
-    expect((lineagePartialEvents[0][0] as { payload: { resolvedCount: number } }).payload.resolvedCount).toBe(1);
+    const [firstEvent] = lineagePartialEvents;
+    expect(firstEvent).toBeDefined();
+    expect((firstEvent?.[0] as { payload: { resolvedCount: number } }).payload.resolvedCount).toBe(1);
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
@@ -265,4 +265,56 @@ describe('DreamerRunner vertical slice (PRI-85)', () => {
 
     expect(failingDeps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
   });
+
+  it('lineage with rejected artifact queries: emits dreamer_lineage_partial telemetry, task still succeeds with partial lineage', async () => {
+    const partialStore = {
+      createArtifact: vi.fn().mockResolvedValue({}),
+      upsertArtifact: vi.fn().mockResolvedValue({}),
+      getArtifactById: vi.fn().mockResolvedValue(null),
+      listBySourceTaskId: vi.fn().mockImplementation(async (depId: string) => {
+        if (depId === 'task-pre-fail') {
+          throw new Error('artifact store unavailable');
+        }
+        return [{ artifactId: 'pre-art-ok', sourceTaskId: depId }];
+      }),
+      listLineage: vi.fn().mockResolvedValue([]),
+    } as unknown as PIArtifactStore;
+
+    const partialDeps = createMockDeps(partialStore);
+
+    const baseTask = makeTask();
+    const taskWithDeps = Object.assign({}, baseTask, {
+      diagnosticJson: serializePITaskMetadata({
+        dependencyTaskIds: ['task-pre-ok', 'task-pre-fail'],
+        channel: 'prompt',
+        timeoutMs: 30000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const getTaskMock = vi.fn().mockImplementation(async (id: string) => {
+      if (id === 'task-pre-ok') return Object.assign({}, makeTask(), { taskId: 'task-pre-ok', resultRef: 'dreamer://run-ok' });
+      if (id === 'task-pre-fail') return Object.assign({}, makeTask(), { taskId: 'task-pre-fail', resultRef: 'dreamer://run-fail' });
+      return taskWithDeps;
+    });
+    (partialDeps.stateManager as unknown as Record<string, unknown>).getTask = getTaskMock;
+
+    const runner = new DreamerRunner(partialDeps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-001');
+
+    expect(result.status).toBe('succeeded');
+
+    const lineagePartialEvents = (partialDeps.eventEmitter.emitTelemetry as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[0] as { eventType: string }).eventType === 'dreamer_lineage_partial',
+    );
+    expect(lineagePartialEvents.length).toBeGreaterThanOrEqual(1);
+    expect((lineagePartialEvents[0][0] as { payload: { resolvedCount: number } }).payload.resolvedCount).toBe(1);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DreamerRunner } from '../internalization/dreamer-runner.js';
+import type { DreamerRunnerDeps } from '../internalization/dreamer-runner.js';
+import type { PIArtifactStore } from '../internalization/pi-artifact.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { DreamerOutput, DreamerValidationResult } from '../internalization/dreamer-output.js';
+import type { TaskRecord } from '../task-status.js';
+import { createMinimalPITaskRecord } from '../internalization/peer-runner-contracts.js';
+import { serializePITaskMetadata } from '../internalization/pitask-metadata.js';
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  const base = createMinimalPITaskRecord('task-dreamer-001', 'dreamer', 'prompt');
+  return {
+    ...base,
+    status: overrides.status ?? 'leased',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+    attemptCount: overrides.attemptCount ?? 1,
+    maxAttempts: overrides.maxAttempts ?? 3,
+    resultRef: overrides.resultRef,
+  };
+}
+
+function makeDreamerOutput(): DreamerOutput {
+  return {
+    valid: true,
+    taskId: 'task-dreamer-001',
+    candidates: [
+      {
+        candidateIndex: 0,
+        badDecision: 'Ignored error handling',
+        betterDecision: 'Add try/catch around async calls',
+        rationale: 'Error handling prevents unhandled rejections',
+        confidence: 0.85,
+        riskLevel: 'low',
+        strategicPerspective: 'reliability',
+      },
+    ],
+    contextRefs: [],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function createMockDeps(artifactStore: PIArtifactStore): DreamerRunnerDeps {
+  const mockTask = makeTask();
+
+  const stateManager = {
+    acquireLease: vi.fn().mockResolvedValue(mockTask),
+    getTask: vi.fn().mockResolvedValue(mockTask),
+    getRunsByTask: vi.fn().mockResolvedValue([{
+      runId: 'run-001',
+      taskId: 'task-dreamer-001',
+      runtimeKind: 'dreamer' as const,
+      startedAt: new Date().toISOString(),
+    }]),
+    updateRunOutput: vi.fn().mockResolvedValue(undefined),
+    markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+    markTaskFailed: vi.fn().mockResolvedValue(undefined),
+    markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+    getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+  } as unknown as RuntimeStateManager;
+
+  const runHandle: RunHandle = { runId: 'run-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+  const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-001' };
+
+  const runtimeAdapter = {
+    startRun: vi.fn().mockResolvedValue(runHandle),
+    pollRun: vi.fn().mockResolvedValue(succeededStatus),
+    fetchOutput: vi.fn().mockResolvedValue({
+      payload: makeDreamerOutput(),
+    }),
+    cancelRun: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PDRuntimeAdapter;
+
+  const eventEmitter = {
+    emitTelemetry: vi.fn(),
+  } as unknown as StoreEventEmitter;
+
+  const validator = {
+    validate: vi.fn().mockResolvedValue({ valid: true, errors: [] } as DreamerValidationResult),
+  };
+
+  return { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore };
+}
+
+describe('DreamerRunner vertical slice (PRI-85)', () => {
+  let artifactStore: PIArtifactStore = new MemoryPIArtifactStore();
+  let deps: DreamerRunnerDeps = createMockDeps(artifactStore);
+
+  beforeEach(() => {
+    artifactStore = new MemoryPIArtifactStore();
+    deps = createMockDeps(artifactStore);
+  });
+
+  it('success path: creates PIArtifact via PIArtifactStore and marks task succeeded with dreamer:// resultRef', async () => {
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-001');
+
+    expect(result.status).toBe('succeeded');
+    expect(result.taskId).toBe('task-dreamer-001');
+
+    const artifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
+    expect(artifacts.length).toBeGreaterThanOrEqual(1);
+
+    const [artifact] = artifacts;
+    if (artifact) {
+      expect(artifact.artifactKind).toBe('principle');
+      expect(artifact.sourceTaskId).toBe('task-dreamer-001');
+      expect(artifact.validationStatus).toBe('pending');
+      expect(artifact.contentJson).toBeDefined();
+    }
+
+    expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
+      'task-dreamer-001',
+      expect.stringContaining('dreamer://'),
+    );
+  });
+
+  it('adapter failure: task retried, no artifact created', async () => {
+    vi.mocked(deps.runtimeAdapter.startRun).mockRejectedValue(
+      new Error('Runtime unavailable'),
+    );
+
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-001');
+
+    expect(result.status).toBe('failed');
+
+    const artifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('validation failure: task retried, no artifact created', async () => {
+    vi.mocked(deps.validator.validate).mockResolvedValue({
+      valid: false,
+      errors: ['Missing badDecision'],
+    });
+
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-001');
+
+    expect(result.status).toBe('failed');
+
+    const artifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('idempotent execution: calling run() twice for same task does not create duplicate artifacts', async () => {
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    await runner.run('task-dreamer-001');
+
+    const firstArtifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
+    expect(firstArtifacts).toHaveLength(1);
+
+    await runner.run('task-dreamer-001');
+
+    const secondArtifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
+    expect(secondArtifacts).toHaveLength(1);
+  });
+
+  it('artifact lineage: artifact has lineageArtifactIds from predecessor context', async () => {
+    await artifactStore.createArtifact({
+      artifactId: 'pre-art-001',
+      artifactKind: 'principle',
+      sourceTaskId: 'task-pre-001',
+      lineageArtifactIds: [],
+      validationStatus: 'validated',
+      contentJson: '{}',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const baseTask = makeTask();
+    const taskWithDeps = Object.assign({}, baseTask, {
+      diagnosticJson: serializePITaskMetadata({
+        dependencyTaskIds: ['task-pre-001'],
+        channel: 'prompt',
+        timeoutMs: 30000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const depTask = Object.assign({}, makeTask(), {
+      taskId: 'task-pre-001',
+      resultRef: 'dreamer://run-pre',
+    });
+
+    const getTaskMock = vi.fn().mockImplementation(async (id: string) => {
+      if (id === 'task-pre-001') return depTask;
+      return taskWithDeps;
+    });
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = getTaskMock;
+
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-001');
+
+    expect(result.status).toBe('succeeded');
+
+    const artifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
+    expect(artifacts.length).toBeGreaterThanOrEqual(1);
+
+    if (artifacts[0]) {
+      expect(artifacts[0].lineageArtifactIds).toContain('pre-art-001');
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
@@ -237,4 +237,29 @@ describe('DreamerRunner vertical slice (PRI-85)', () => {
       expect(artifacts[0].lineageArtifactIds).toContain('pre-art-001');
     }
   });
+
+  it('artifact write failure: task is retried/failed, NOT marked succeeded', async () => {
+    const failingStore = {
+      createArtifact: vi.fn().mockRejectedValue(new Error('store write failed')),
+      upsertArtifact: vi.fn().mockRejectedValue(new Error('store write failed')),
+      getArtifactById: vi.fn().mockResolvedValue(null),
+      listBySourceTaskId: vi.fn().mockResolvedValue([]),
+      listLineage: vi.fn().mockResolvedValue([]),
+    } as unknown as PIArtifactStore;
+
+    const failingDeps = createMockDeps(failingStore);
+
+    const runner = new DreamerRunner(failingDeps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-001');
+
+    expect(result.status).toBe('failed');
+
+    expect(failingDeps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
@@ -107,6 +107,9 @@ describe('DreamerRunner vertical slice (PRI-85)', () => {
 
     expect(result.status).toBe('succeeded');
     expect(result.taskId).toBe('task-dreamer-001');
+    expect(result.runId).toBe('run-001');
+    expect(result.artifactId).toBe('pi-art-task-dreamer-001-run-001');
+    expect(result.resultRef).toContain('dreamer://');
 
     const artifacts = await artifactStore.listBySourceTaskId('task-dreamer-001');
     expect(artifacts.length).toBeGreaterThanOrEqual(1);

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner.test.ts
@@ -27,6 +27,7 @@ import type { TaskRecord } from '../task-status.js';
 import { PDRuntimeError } from '../error-categories.js';
 import { DreamerRunner } from '../internalization/dreamer-runner.js';
 import { createMinimalPITaskRecord } from '../internalization/peer-runner-contracts.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
 
 // ── Test fixtures ──────────────────────────────────────────────────────────────
 
@@ -182,6 +183,7 @@ function createRunner(mocks: ReturnType<typeof createMocks>) {
       runtimeAdapter: mocks.mockRuntimeAdapter,
       eventEmitter: mocks.mockEventEmitter,
       validator: mocks.mockValidator,
+      artifactStore: new MemoryPIArtifactStore(),
     },
     {
       owner: OWNER,

--- a/packages/principles-core/src/runtime-v2/__tests__/pi-artifact-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pi-artifact-store.test.ts
@@ -206,7 +206,9 @@ describe('MemoryPIArtifactStore index consistency (PRI-84)', () => {
 
     const results = await store.listBySourceTaskId('task-X');
     expect(results).toHaveLength(1);
-    expect(results[0].artifactId).toBe('art-v2');
+    const [first] = results;
+    expect(first).toBeDefined();
+    expect(first?.artifactId).toBe('art-v2');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/pi-artifact-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pi-artifact-store.test.ts
@@ -175,6 +175,41 @@ function createStoreContractTests(
 
 createStoreContractTests('MemoryPIArtifactStore', () => new MemoryPIArtifactStore());
 
+describe('MemoryPIArtifactStore index consistency (PRI-84)', () => {
+  let store: MemoryPIArtifactStore = new MemoryPIArtifactStore();
+
+  beforeEach(() => {
+    store = new MemoryPIArtifactStore();
+  });
+
+  it('upsertArtifact with different artifactId cleans up old idempotency entries', async () => {
+    const r1 = makeRecord({ artifactId: 'art-old', sourceTaskId: 'task-1', artifactKind: 'principle' });
+    await store.createArtifact(r1);
+
+    const r2 = makeRecord({ artifactId: 'art-new', sourceTaskId: 'task-1', artifactKind: 'principle' });
+    await store.upsertArtifact(r2);
+
+    const byId = await store.getArtifactById('art-old');
+    expect(byId).toBeNull();
+
+    const byIdNew = await store.getArtifactById('art-new');
+    expect(byIdNew).not.toBeNull();
+    expect(byIdNew?.artifactId).toBe('art-new');
+  });
+
+  it('upsertArtifact does not leave dangling entries in artifacts map', async () => {
+    const r1 = makeRecord({ artifactId: 'art-v1', sourceTaskId: 'task-X', artifactKind: 'principle' });
+    await store.createArtifact(r1);
+
+    const r2 = makeRecord({ artifactId: 'art-v2', sourceTaskId: 'task-X', artifactKind: 'principle' });
+    await store.upsertArtifact(r2);
+
+    const results = await store.listBySourceTaskId('task-X');
+    expect(results).toHaveLength(1);
+    expect(results[0].artifactId).toBe('art-v2');
+  });
+});
+
 describe('SqlitePIArtifactStore contract (PRI-84)', () => {
   let tmpDir = '';
   let connection: SqliteConnection = new SqliteConnection(os.tmpdir());

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -33,6 +33,7 @@ import type {
 } from '../runtime-protocol.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import type { DreamerOutput, DreamerValidator } from './dreamer-output.js';
+import type { PIArtifactStore } from './pi-artifact.js';
 import type { TaskRecord } from '../task-status.js';
 import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
 import type { TelemetryEvent } from '../../telemetry-event.js';
@@ -98,6 +99,7 @@ export interface DreamerRunnerDeps {
   readonly runtimeAdapter: PDRuntimeAdapter;
   readonly eventEmitter: StoreEventEmitter;
   readonly validator: DreamerValidator;
+  readonly artifactStore: PIArtifactStore;
 }
 
 // ── Context types for error handling ─────────────────────────────────────────
@@ -133,12 +135,14 @@ export class DreamerRunner {
   private readonly runtimeAdapter: PDRuntimeAdapter;
   private readonly eventEmitter: StoreEventEmitter;
   private readonly validator: DreamerValidator;
+  private readonly artifactStore: PIArtifactStore;
 
   constructor(deps: DreamerRunnerDeps, options: DreamerRunnerOptions) {
     this.stateManager = deps.stateManager;
     this.runtimeAdapter = deps.runtimeAdapter;
     this.eventEmitter = deps.eventEmitter;
     this.validator = deps.validator;
+    this.artifactStore = deps.artifactStore;
     this.resolvedOptions = resolveDreamerRunnerOptions(options);
   }
 
@@ -345,6 +349,28 @@ export class DreamerRunner {
     return latestRun.runId;
   }
 
+  private async resolveLineageArtifactIds(taskId: string): Promise<string[]> {
+    const task = await this.stateManager.getTask(taskId);
+    if (!task) return [];
+
+    const piTask = hydratePITaskRecord(task);
+    const deps = piTask?.dependencyTaskIds ?? [];
+    if (deps.length === 0) return [];
+
+    const lineageIds: string[] = [];
+    const results = await Promise.allSettled(
+      deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+    );
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        for (const artifact of result.value) {
+          lineageIds.push(artifact.artifactId);
+        }
+      }
+    }
+    return lineageIds;
+  }
+
   private async invokeRuntime(taskId: string, contextHash: string): Promise<RunHandle> {
     const startInput: StartRunInput = {
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
@@ -413,6 +439,20 @@ export class DreamerRunner {
         riskLevel: candidate.riskLevel,
       });
     }
+
+    // Write PIArtifact via artifactStore (idempotent upsert)
+    const lineageArtifactIds = await this.resolveLineageArtifactIds(ctx.taskId);
+    const now = new Date().toISOString();
+    await this.artifactStore.upsertArtifact({
+      artifactId: `pi-art-${ctx.taskId}-${ctx.runId}`,
+      artifactKind: 'principle',
+      sourceTaskId: ctx.taskId,
+      lineageArtifactIds,
+      validationStatus: 'pending',
+      contentJson: JSON.stringify(ctx.output),
+      createdAt: now,
+      updatedAt: now,
+    });
 
     // Mark task succeeded with dreamer:// resultRef
     const resultRef = `dreamer://${ctx.runId}`;

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -47,6 +47,9 @@ export type DreamerRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
 export interface DreamerRunnerResult {
   readonly status: DreamerRunnerResultStatus;
   readonly taskId: string;
+  readonly runId?: string;
+  readonly artifactId?: string;
+  readonly resultRef?: string;
   readonly contextHash?: string;
   readonly output?: DreamerOutput;
   readonly errorCategory?: PDErrorCategory;
@@ -454,10 +457,11 @@ export class DreamerRunner {
       });
     }
 
+    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
     const now = new Date().toISOString();
     try {
       await this.artifactStore.upsertArtifact({
-        artifactId: `pi-art-${ctx.taskId}-${ctx.runId}`,
+        artifactId,
         artifactKind: 'principle',
         sourceTaskId: ctx.taskId,
         lineageArtifactIds,
@@ -502,6 +506,9 @@ export class DreamerRunner {
     return {
       status: 'succeeded',
       taskId: ctx.taskId,
+      runId: ctx.runId,
+      artifactId,
+      resultRef,
       contextHash: ctx.contextHash,
       output: ctx.output,
       attemptCount: ctx.task.attemptCount,

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -352,15 +352,16 @@ export class DreamerRunner {
     return latestRun.runId;
   }
 
-  private async resolveLineageArtifactIds(taskId: string): Promise<string[]> {
+  private async resolveLineageArtifactIds(taskId: string): Promise<{ ids: string[]; hasRejected: boolean }> {
     const task = await this.stateManager.getTask(taskId);
-    if (!task) return [];
+    if (!task) return { ids: [], hasRejected: false };
 
     const piTask = hydratePITaskRecord(task);
     const deps = piTask?.dependencyTaskIds ?? [];
-    if (deps.length === 0) return [];
+    if (deps.length === 0) return { ids: [], hasRejected: false };
 
     const lineageIds: string[] = [];
+    let hasRejected = false;
     const results = await Promise.allSettled(
       deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
     );
@@ -369,9 +370,11 @@ export class DreamerRunner {
         for (const artifact of result.value) {
           lineageIds.push(artifact.artifactId);
         }
+      } else {
+        hasRejected = true;
       }
     }
-    return lineageIds;
+    return { ids: lineageIds, hasRejected };
   }
 
   private async invokeRuntime(taskId: string, contextHash: string): Promise<RunHandle> {
@@ -448,12 +451,23 @@ export class DreamerRunner {
     // If artifact write fails, the task must NOT be marked succeeded —
     // downstream runners (Philosopher/Scribe) require durable artifact input.
     let lineageArtifactIds: string[] = [];
+    let lineageHasRejected = false;
     try {
-      lineageArtifactIds = await this.resolveLineageArtifactIds(ctx.taskId);
+      const lineageResult = await this.resolveLineageArtifactIds(ctx.taskId);
+      lineageArtifactIds = lineageResult.ids;
+      lineageHasRejected = lineageResult.hasRejected;
     } catch (lineageErr) {
       this.emitDreamerEvent('dreamer_lineage_resolve_failed', ctx.taskId, {
         runId: ctx.runId,
         errorMessage: lineageErr instanceof Error ? lineageErr.message : String(lineageErr),
+      });
+    }
+
+    if (lineageHasRejected) {
+      this.emitDreamerEvent('dreamer_lineage_partial', ctx.taskId, {
+        runId: ctx.runId,
+        resolvedCount: lineageArtifactIds.length,
+        warning: 'Some dependency artifact queries were rejected; lineage may be incomplete',
       });
     }
 

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -441,18 +441,43 @@ export class DreamerRunner {
     }
 
     // Write PIArtifact via artifactStore (idempotent upsert)
-    const lineageArtifactIds = await this.resolveLineageArtifactIds(ctx.taskId);
+    // PIArtifact is the core durable output of DreamerRunner.
+    // If artifact write fails, the task must NOT be marked succeeded —
+    // downstream runners (Philosopher/Scribe) require durable artifact input.
+    let lineageArtifactIds: string[] = [];
+    try {
+      lineageArtifactIds = await this.resolveLineageArtifactIds(ctx.taskId);
+    } catch (lineageErr) {
+      this.emitDreamerEvent('dreamer_lineage_resolve_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: lineageErr instanceof Error ? lineageErr.message : String(lineageErr),
+      });
+    }
+
     const now = new Date().toISOString();
-    await this.artifactStore.upsertArtifact({
-      artifactId: `pi-art-${ctx.taskId}-${ctx.runId}`,
-      artifactKind: 'principle',
-      sourceTaskId: ctx.taskId,
-      lineageArtifactIds,
-      validationStatus: 'pending',
-      contentJson: JSON.stringify(ctx.output),
-      createdAt: now,
-      updatedAt: now,
-    });
+    try {
+      await this.artifactStore.upsertArtifact({
+        artifactId: `pi-art-${ctx.taskId}-${ctx.runId}`,
+        artifactKind: 'principle',
+        sourceTaskId: ctx.taskId,
+        lineageArtifactIds,
+        validationStatus: 'pending',
+        contentJson: JSON.stringify(ctx.output),
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (artifactErr) {
+      this.emitDreamerEvent('dreamer_artifact_write_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
+      });
+      return this.retryOrFail({
+        taskId: ctx.taskId,
+        task: ctx.task,
+        errorCategory: 'artifact_commit_failed',
+        failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
+      });
+    }
 
     // Mark task succeeded with dreamer:// resultRef
     const resultRef = `dreamer://${ctx.runId}`;

--- a/packages/principles-core/src/runtime-v2/internalization/pi-artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pi-artifact-store.ts
@@ -29,6 +29,11 @@ export class MemoryPIArtifactStore implements PIArtifactStore {
 
     if (existingId) {
       this.artifacts.delete(existingId);
+      for (const [idxKey, idxVal] of this.idempotencyIndex.entries()) {
+        if (idxVal === existingId && idxKey !== key) {
+          this.idempotencyIndex.delete(idxKey);
+        }
+      }
     }
 
     this.artifacts.set(record.artifactId, record);


### PR DESCRIPTION
## PRI-85: DreamerRunner Vertical Slice

### Issue
Linear: PRI-85 — DreamerRunner vertical slice

### What Changed

**DreamerRunner** (internalization/dreamer-runner.ts)
- Full lease -> build context -> invoke runtime -> poll -> fetch output -> validate -> succeed/fail pipeline
- Uses PDRuntimeAdapter for all LLM execution (no direct SDK calls)
- Uses RuntimeStateManager for all state operations
- PIArtifact write via artifactStore.upsertArtifact (idempotent)
- Lineage resolution from predecessor task artifacts

**DreamerRunnerResult** now exposes runId/artifactId/resultRef
- runId: the store run record ID
- artifactId: the PIArtifact ID (pi-art-{taskId}-{runId})
- resultRef: the dreamer:// result reference
- Enables operators to trace the durable artifact written by each run

**Artifact write failure -> retryOrFail** (P1 fix)
- Original: artifact write failure was swallowed, task marked succeeded
- Fixed: artifact write failure now goes to retryOrFail with artifact_commit_failed error category
- PIArtifact is the core durable output of DreamerRunner — without it, downstream runners (Philosopher/Scribe) have no input
- Task is NOT marked succeeded when artifact write fails

**Tests** (__tests__/dreamer-runner-vslice.test.ts)
- Success path: creates PIArtifact and marks task succeeded with dreamer:// resultRef
- Result includes runId, artifactId, resultRef
- Adapter failure: task retried, no artifact created
- Validation failure: task retried, no artifact created
- Idempotent execution: calling run() twice does not create duplicate artifacts
- Artifact lineage: artifact has lineageArtifactIds from predecessor context
- Artifact write failure: task is retried/failed, NOT marked succeeded

### Review Fixes
- P1: Artifact write failure now goes to retryOrFail (not swallowed as succeeded)
- P1: Fix is in this PR itself, not in downstream PR #529
- P2: DreamerRunnerResult now exposes runId/artifactId/resultRef for operator traceability
- P2: Rebased onto origin/main, removed docs commits (already in main via #530)

### Verification
- 6 DreamerRunner tests passing
- Build, lint, typecheck all pass
- Pre-push hook verified
- PR is MERGEABLE (no conflicts with main)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了人工制品持久化能力，成功的 Dreamer 输出现已作为 PI 人工制品存储。
  * 实现了血缘追踪，自动记录前驱任务的人工制品关联。

* **Bug 修复**
  * 改进了人工制品写入失败时的错误处理流程。
  * 优化了部分血缘场景的容错机制，支持单个依赖查询失败时继续执行。

* **测试**
  * 扩展了 DreamerRunner 的垂直切片测试覆盖范围。
  * 新增人工制品存储索引一致性验证测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->