### PR TITLE
feat(cli): internalization run-once CLI - wake-and-run DreamerRunner (PRI-86)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -1,0 +1,254 @@
+import * as path from 'path';
+import {
+  RuntimeStateManager,
+  InternalizationOrchestrator,
+  DreamerRunner,
+  StoreEventEmitter,
+  PassThroughDreamerValidator,
+  TestDoubleRuntimeAdapter,
+  PiAiRuntimeAdapter,
+  OpenClawCliRuntimeAdapter,
+  resolveRuntimeConfig,
+  validateRuntimeConfig,
+} from '@principles/core/runtime-v2';
+import type { WakeOnceResult, DreamerRunnerResult, PDRuntimeAdapter } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface RunOnceOptions {
+  workspace?: string;
+  json?: boolean;
+  runtime?: string;
+  runner?: string;
+  allowTestDouble?: boolean;
+}
+
+const OWNER = 'pd-cli-internalization-run-once';
+const RUNTIME_KIND = 'internalization-engine';
+
+interface RunOnceOutput {
+  decision: string;
+  taskId?: string;
+  taskKind?: string;
+  attemptCount?: number;
+  runId?: string;
+  artifactId?: string;
+  resultRef?: string;
+  runnerResult?: DreamerRunnerResult;
+  skipReason?: string;
+  conflictReason?: string;
+  reason?: string;
+  inspectedCount?: number;
+}
+
+function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult, skipReason?: string): RunOnceOutput {
+  const base: RunOnceOutput = { decision: wakeResult.decision };
+
+  switch (wakeResult.decision) {
+    case 'leased':
+      base.taskId = wakeResult.taskId;
+      base.taskKind = wakeResult.taskKind;
+      base.attemptCount = wakeResult.attemptCount;
+      if (runnerResult) base.runnerResult = runnerResult;
+      if (skipReason) base.skipReason = skipReason;
+      break;
+    case 'would_lease':
+      base.taskId = wakeResult.taskId;
+      base.taskKind = wakeResult.taskKind;
+      if (runnerResult) {
+        base.runnerResult = runnerResult;
+        base.runId = runnerResult.runId;
+        base.artifactId = runnerResult.artifactId;
+        base.resultRef = runnerResult.resultRef;
+      }
+      if (skipReason) base.skipReason = skipReason;
+      break;
+    case 'no_ready_tasks':
+      base.reason = wakeResult.reason;
+      base.inspectedCount = wakeResult.inspectedCount;
+      break;
+    case 'blocked':
+      base.taskId = wakeResult.taskId;
+      base.taskKind = wakeResult.taskKind;
+      break;
+    case 'dependency_failed':
+      base.taskId = wakeResult.taskId;
+      base.taskKind = wakeResult.taskKind;
+      break;
+    case 'lease_conflict':
+      base.taskId = wakeResult.taskId;
+      base.conflictReason = wakeResult.conflictReason;
+      break;
+    case 'invalid_task_metadata':
+      base.taskId = wakeResult.taskId;
+      base.taskKind = wakeResult.taskKind;
+      break;
+    default:
+      break;
+  }
+
+  return base;
+}
+
+function formatTextOutput(output: RunOnceOutput): string {
+  const lines: string[] = [];
+
+  lines.push(`Internalization Run-Once: ${output.decision}`);
+
+  if (output.taskId) {
+    lines.push(`  task: ${output.taskId} (${output.taskKind ?? 'unknown'})`);
+  }
+
+  if (output.runnerResult) {
+    lines.push(`  runner: ${output.runnerResult.status}`);
+    if (output.runId) {
+      lines.push(`  runId: ${output.runId}`);
+    }
+    if (output.artifactId) {
+      lines.push(`  artifactId: ${output.artifactId}`);
+    }
+    if (output.resultRef) {
+      lines.push(`  resultRef: ${output.resultRef}`);
+    }
+    if (output.runnerResult.errorCategory) {
+      lines.push(`  error: ${output.runnerResult.errorCategory}`);
+    }
+    if (output.runnerResult.failureReason) {
+      lines.push(`  reason: ${output.runnerResult.failureReason}`);
+    }
+  }
+
+  if (output.skipReason) {
+    lines.push(`  skip: ${output.skipReason}`);
+  }
+
+  if (output.conflictReason) {
+    lines.push(`  conflict: ${output.conflictReason}`);
+  }
+
+  if (output.reason) {
+    lines.push(`  reason: ${output.reason}`);
+  }
+
+  return lines.join('\n');
+}
+
+function resolveRuntimeAdapter(runtimeKind: string, taskId: string, workspaceDir: string): PDRuntimeAdapter {
+  if (runtimeKind === 'test-double') {
+    return new TestDoubleRuntimeAdapter({
+      onPollRun: (_runId: string) => ({
+        runId: _runId,
+        status: 'succeeded',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }),
+      onFetchOutput: (_runId: string) => ({
+        runId: _runId,
+        payload: {
+          valid: true,
+          taskId,
+          candidates: [],
+          contextRefs: [],
+          generatedAt: new Date().toISOString(),
+        },
+      }),
+    });
+  }
+
+  const stateDir = path.join(workspaceDir, '.state');
+  const config = resolveRuntimeConfig(stateDir);
+
+  if (runtimeKind === 'pi-ai' || (runtimeKind === 'config' && config.runtimeKind === 'pi-ai')) {
+    validateRuntimeConfig(config);
+    return new PiAiRuntimeAdapter({
+      provider: String(config.provider),
+      model: String(config.model),
+      apiKeyEnv: String(config.apiKeyEnv),
+      maxRetries: config.maxRetries,
+      timeoutMs: config.timeoutMs,
+      baseUrl: config.baseUrl,
+      workspace: workspaceDir,
+    });
+  }
+
+  if (runtimeKind === 'openclaw-cli' || (runtimeKind === 'config' && config.runtimeKind === 'openclaw-cli')) {
+    return new OpenClawCliRuntimeAdapter({
+      runtimeMode: 'local',
+      workspaceDir,
+    });
+  }
+
+  throw new Error(`Unsupported runtime kind: ${runtimeKind}. Supported: test-double, pi-ai, openclaw-cli, config`);
+}
+
+export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions): Promise<void> {
+  const workspaceDir = opts.workspace ? path.resolve(opts.workspace) : resolveWorkspaceDir();
+  const runtimeKind = opts.runtime ?? 'config';
+  const runnerKind = opts.runner ?? 'dreamer';
+
+  if (runtimeKind === 'test-double' && !opts.allowTestDouble) {
+    console.error('Error: test-double runtime mutates real queue state (leases tasks, marks them succeeded with empty output).');
+    console.error('Use --runtime test-double --allow-test-double to acknowledge this risk.');
+    console.error('For production use, use --runtime config (reads from workflows.yaml) or --runtime pi-ai / openclaw-cli.');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (runnerKind !== 'dreamer') {
+    console.error(`Error: unsupported runner kind: ${runnerKind}. Supported: dreamer`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+  await stateManager.initialize();
+
+  try {
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: true },
+    );
+
+    let wakeResult: WakeOnceResult = { decision: 'no_ready_tasks', reason: 'no_candidates', inspectedCount: 0 };
+    try {
+      wakeResult = await orchestrator.wakeOnce();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Error: wake-once failed: ${message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    let runnerResult: DreamerRunnerResult | undefined = undefined;
+    let skipReason: string | undefined = undefined;
+
+    if (wakeResult.decision === 'would_lease' && wakeResult.taskKind === runnerKind) {
+      const eventEmitter = new StoreEventEmitter();
+      const artifactStore = stateManager.piArtifactStore;
+      const validator = new PassThroughDreamerValidator();
+      const runtimeAdapter = resolveRuntimeAdapter(runtimeKind, wakeResult.taskId, workspaceDir);
+
+      const runner = new DreamerRunner(
+        { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
+        { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: 300_000 },
+      );
+
+      runnerResult = await runner.run(wakeResult.taskId);
+    } else if (wakeResult.decision === 'would_lease' && wakeResult.taskKind !== runnerKind) {
+      skipReason = 'unsupported_runner_kind';
+    }
+
+    const output = buildOutput(wakeResult, runnerResult, skipReason);
+
+    if (opts.json) {
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      console.log(formatTextOutput(output));
+    }
+
+    if (wakeResult.decision === 'no_ready_tasks' || wakeResult.decision === 'lease_conflict') {
+      process.exitCode = 1;
+    }
+  } finally {
+    await stateManager.close();
+  }
+}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -31,6 +31,7 @@ import { handleRuntimeGfiSnapshot } from './commands/runtime-gfi-snapshot.js';
 import { handleRuntimeUat } from './commands/runtime-uat.js';
 import { handleRuntimeInternalizationQueue } from './commands/runtime-internalization-queue.js';
 import { handleRuntimeInternalizationWakeOnce } from './commands/runtime-internalization-wake-once.js';
+import { handleRuntimeInternalizationRunOnce } from './commands/runtime-internalization-run-once.js';
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair, handleCandidateRoute } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 
@@ -400,6 +401,18 @@ internalizationCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleRuntimeInternalizationWakeOnce({ workspace: opts.workspace, dryRun: opts.dryRun, json: opts.json });
+  });
+
+internalizationCmd
+  .command('run-once')
+  .description('Wake-and-run: lease the next PI task and execute it')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--runner <kind>', 'Runner kind to execute (default: dreamer)', 'dreamer')
+  .option('--runtime <kind>', 'Runtime adapter kind: config (from workflows.yaml), pi-ai, openclaw-cli, test-double (default: config)', 'config')
+  .option('--allow-test-double', 'Acknowledge that test-double runtime will mutate real queue state')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble });
   });
 
 const pruningCmd = runtimeCmd

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+
+const mockWakeOnce = vi.fn();
+const mockRun = vi.fn();
+const mockClose = vi.fn().mockResolvedValue(undefined);
+const mockInitialize = vi.fn().mockResolvedValue(undefined);
+const mockPiArtifactStore = {
+  createArtifact: vi.fn().mockResolvedValue({}),
+  upsertArtifact: vi.fn().mockResolvedValue({}),
+  getArtifactById: vi.fn().mockResolvedValue(null),
+  listBySourceTaskId: vi.fn().mockResolvedValue([]),
+  listLineage: vi.fn().mockResolvedValue([]),
+};
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  RuntimeStateManager: vi.fn().mockImplementation(function () {
+    return {
+      initialize: mockInitialize,
+      close: mockClose,
+      connection: {},
+      taskStore: {},
+      runStore: {},
+      piArtifactStore: mockPiArtifactStore,
+    };
+  }),
+  InternalizationOrchestrator: vi.fn().mockImplementation(function () {
+    return { wakeOnce: mockWakeOnce };
+  }),
+  DreamerRunner: vi.fn().mockImplementation(function () {
+    return { run: mockRun };
+  }),
+  StoreEventEmitter: vi.fn().mockImplementation(function () {
+    return { emitTelemetry: vi.fn() };
+  }),
+  PassThroughDreamerValidator: vi.fn().mockImplementation(function () {
+    return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
+  }),
+  TestDoubleRuntimeAdapter: vi.fn().mockImplementation(function () {
+    return {
+      kind: vi.fn().mockReturnValue('test-double'),
+      getCapabilities: vi.fn(),
+      healthCheck: vi.fn(),
+      startRun: vi.fn().mockResolvedValue({ runId: 'run-test-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() }),
+      pollRun: vi.fn().mockResolvedValue({ runId: 'run-test-001', status: 'succeeded' }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+      fetchOutput: vi.fn().mockResolvedValue({ runId: 'run-test-001', payload: {} }),
+      fetchArtifacts: vi.fn().mockResolvedValue([]),
+    };
+  }),
+  PiAiRuntimeAdapter: vi.fn().mockImplementation(function () {
+    return {
+      kind: vi.fn().mockReturnValue('pi-ai'),
+      getCapabilities: vi.fn(),
+      healthCheck: vi.fn(),
+      startRun: vi.fn().mockResolvedValue({ runId: 'run-pi-001', runtimeKind: 'pi-ai', startedAt: new Date().toISOString() }),
+      pollRun: vi.fn().mockResolvedValue({ runId: 'run-pi-001', status: 'succeeded' }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+      fetchOutput: vi.fn().mockResolvedValue({ runId: 'run-pi-001', payload: {} }),
+      fetchArtifacts: vi.fn().mockResolvedValue([]),
+    };
+  }),
+  OpenClawCliRuntimeAdapter: vi.fn().mockImplementation(function () {
+    return {
+      kind: vi.fn().mockReturnValue('openclaw-cli'),
+      getCapabilities: vi.fn(),
+      healthCheck: vi.fn(),
+      startRun: vi.fn().mockResolvedValue({ runId: 'run-oc-001', runtimeKind: 'openclaw-cli', startedAt: new Date().toISOString() }),
+      pollRun: vi.fn().mockResolvedValue({ runId: 'run-oc-001', status: 'succeeded' }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+      fetchOutput: vi.fn().mockResolvedValue({ runId: 'run-oc-001', payload: {} }),
+      fetchArtifacts: vi.fn().mockResolvedValue([]),
+    };
+  }),
+  resolveRuntimeConfig: vi.fn().mockReturnValue({
+    runtimeKind: 'pi-ai',
+    timeoutMs: 300_000,
+    agentId: 'main',
+    provider: 'test-provider',
+    model: 'test-model',
+    apiKeyEnv: 'TEST_API_KEY',
+  }),
+  validateRuntimeConfig: vi.fn(),
+}));
+
+import { handleRuntimeInternalizationRunOnce } from '../../src/commands/runtime-internalization-run-once.js';
+
+const WS = '/fake/workspace';
+
+describe('handleRuntimeInternalizationRunOnce', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('test-double without --allow-test-double: refuses to execute and exits 1', async () => {
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: false });
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('test-double runtime mutates real queue state'))).toBe(true);
+    expect(mockWakeOnce).not.toHaveBeenCalled();
+  });
+
+  it('default runtime (config) does not require --allow-test-double', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-001',
+      runId: 'run-001',
+      artifactId: 'pi-art-task-dreamer-001-run-001',
+      resultRef: 'dreamer://run-001',
+      contextHash: 'ctx-abc',
+      output: { valid: true, taskId: 'task-dreamer-001', candidates: [], contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, json: true });
+
+    expect(mockWakeOnce).toHaveBeenCalled();
+  });
+
+  it('test-double with --allow-test-double: proceeds normally', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-001',
+      runId: 'run-001',
+      artifactId: 'pi-art-task-dreamer-001-run-001',
+      resultRef: 'dreamer://run-001',
+      contextHash: 'ctx-abc',
+      output: { valid: true, taskId: 'task-dreamer-001', candidates: [], contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    expect(mockWakeOnce).toHaveBeenCalled();
+  });
+
+  it('unsupported runner kind: exits 1 with error', async () => {
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'philosopher', runtime: 'test-double', allowTestDouble: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('unsupported runner kind'))).toBe(true);
+  });
+
+  it('no_ready_tasks: reports no leasable task and exits 1', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'no_ready_tasks',
+      inspectedCount: 3,
+      reason: 'all_blocked',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('no_ready_tasks');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('would_lease dreamer task: uses dryRun wakeOnce then DreamerRunner.run leases and executes', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-001',
+      runId: 'run-001',
+      artifactId: 'pi-art-task-dreamer-001-run-001',
+      resultRef: 'dreamer://run-001',
+      contextHash: 'ctx-abc',
+      output: { valid: true, taskId: 'task-dreamer-001', candidates: [], contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    expect(mockRun).toHaveBeenCalledWith('task-dreamer-001');
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('would_lease');
+    expect(output.taskId).toBe('task-dreamer-001');
+    expect(output.runId).toBe('run-001');
+    expect(output.artifactId).toBe('pi-art-task-dreamer-001-run-001');
+    expect(output.resultRef).toBe('dreamer://run-001');
+    expect(output.runnerResult.status).toBe('succeeded');
+  });
+
+  it('would_lease dreamer task with runner failure: reports failed result', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-002',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'failed',
+      taskId: 'task-dreamer-002',
+      errorCategory: 'execution_failed',
+      failureReason: 'Runtime unavailable',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.runnerResult.status).toBe('failed');
+    expect(output.runnerResult.errorCategory).toBe('execution_failed');
+  });
+
+  it('would_lease non-dreamer task: no lease acquired, reports unsupported (no stuck lease)', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-phil-001',
+      taskKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    expect(mockRun).not.toHaveBeenCalled();
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('would_lease');
+    expect(output.taskId).toBe('task-phil-001');
+    expect(output.runnerResult).toBeUndefined();
+    expect(output.skipReason).toBe('unsupported_runner_kind');
+  });
+
+  it('text output for succeeded dreamer run includes runId/artifactId/resultRef', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-003',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-003',
+      runId: 'run-003',
+      artifactId: 'pi-art-task-dreamer-003-run-003',
+      resultRef: 'dreamer://run-003',
+      contextHash: 'ctx-def',
+      output: { valid: true, taskId: 'task-dreamer-003', candidates: [], contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: false });
+
+    const text = consoleLogSpy.mock.calls.map((c: string[]) => c[0]).join('\n');
+    expect(text).toContain('task-dreamer-003');
+    expect(text).toContain('succeeded');
+    expect(text).toContain('runId: run-003');
+    expect(text).toContain('artifactId: pi-art-task-dreamer-003-run-003');
+    expect(text).toContain('resultRef: dreamer://run-003');
+  });
+
+  it('lease_conflict: reports conflict and exits 1', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'lease_conflict',
+      taskId: 'task-dreamer-004',
+      conflictReason: 'Already leased by another runner',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('lease_conflict');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('orchestrator error: exits 1 with error message', async () => {
+    mockWakeOnce.mockRejectedValue(new Error('store unavailable'));
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('uses stateManager.piArtifactStore (durable SQLite) not MemoryPIArtifactStore', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-005',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-005',
+      runId: 'run-005',
+      artifactId: 'pi-art-task-dreamer-005-run-005',
+      resultRef: 'dreamer://run-005',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const DreamerRunnerMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.DreamerRunner),
+    );
+    const lastCall = DreamerRunnerMock.mock.calls[DreamerRunnerMock.mock.calls.length - 1];
+    if (lastCall) {
+      const deps = lastCall[0] as { artifactStore?: unknown };
+      expect(deps.artifactStore).toBe(mockPiArtifactStore);
+    }
+  });
+
+  it('--runtime pi-ai resolves PiAiRuntimeAdapter', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-006',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-006',
+      runId: 'run-006',
+      artifactId: 'pi-art-task-dreamer-006-run-006',
+      resultRef: 'dreamer://run-006',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'pi-ai', json: true });
+
+    const PiAiMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.PiAiRuntimeAdapter),
+    );
+    expect(PiAiMock).toHaveBeenCalled();
+  });
+
+  it('--runtime openclaw-cli resolves OpenClawCliRuntimeAdapter', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-007',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-007',
+      runId: 'run-007',
+      artifactId: 'pi-art-task-dreamer-007-run-007',
+      resultRef: 'dreamer://run-007',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'openclaw-cli', json: true });
+
+    const OpenClawMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.OpenClawCliRuntimeAdapter),
+    );
+    expect(OpenClawMock).toHaveBeenCalled();
+  });
+
+  it('--runtime config resolves adapter from workflows.yaml', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-008',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-008',
+      runId: 'run-008',
+      artifactId: 'pi-art-task-dreamer-008-run-008',
+      resultRef: 'dreamer://run-008',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'config', json: true });
+
+    const ResolveConfigMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.resolveRuntimeConfig),
+    );
+    expect(ResolveConfigMock).toHaveBeenCalled();
+  });
+
+  it('--runtime config reads from workspaceDir/.state (not .pd)', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-009',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-009',
+      runId: 'run-009',
+      artifactId: 'pi-art-task-dreamer-009-run-009',
+      resultRef: 'dreamer://run-009',
+      attemptCount: 1,
+    });
+
+    const customWs = '/tmp/test-workspace';
+    await handleRuntimeInternalizationRunOnce({ workspace: customWs, runtime: 'config', json: true });
+
+    const ResolveConfigMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.resolveRuntimeConfig),
+    );
+    const resolvedWorkspace = path.resolve(customWs);
+    const expectedStateDir = path.join(resolvedWorkspace, '.state');
+    expect(ResolveConfigMock).toHaveBeenCalledWith(expectedStateDir);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -436,6 +436,35 @@ export type {
 
 export { InternalizationOrchestrator, WAKE_ONCE_DECISIONS } from './internalization/internalization-orchestrator.js';
 
+// ── Dreamer Peer Runner (PRI-67/PRI-85) ───────────────────────────────────────
+
+export type {
+  DreamerCandidate,
+  DreamerOutput,
+  DreamerValidationResult,
+  DreamerValidator,
+} from './internalization/dreamer-output.js';
+
+export { PassThroughDreamerValidator } from './internalization/dreamer-output.js';
+
+export type {
+  DreamerRunnerResult,
+  DreamerRunnerOptions,
+  ResolvedDreamerRunnerOptions,
+} from './internalization/dreamer-runner.js';
+
+export {
+  resolveDreamerRunnerOptions,
+  DEFAULT_DREAMER_RUNNER_OPTIONS,
+} from './internalization/dreamer-runner.js';
+
+export { DreamerRunner } from './internalization/dreamer-runner.js';
+
+// ── PIArtifact Durable Store (PRI-84) ────────────────────────────────────────
+
+export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';
+export { MemoryPIArtifactStore } from './internalization/pi-artifact-store.js';
+
 // ── Internalization Queue Read Model (PRI-73) ──────────────────────────────
 
 export { InternalizationQueueReadModel } from './internalization-queue-read-model.js';


### PR DESCRIPTION
## PRI-86: Internalization Run-Once CLI

### Issue
Linear: PRI-86 — Internalization run-once CLI command

### What Changed

**run-once command** (commands/runtime-internalization-run-once.ts)
- New CLI command: pd runtime internalization run-once
- Selects next task via InternalizationOrchestrator.wakeOnce(dryRun=true)
- Executes DreamerRunner for dreamer tasks
- Reports result and exits

**Safety gate: test-double requires explicit --allow-test-double** (P1 fix)
- Default test-double runtime mutates real queue state (leases tasks, marks them succeeded with empty output)
- Without --allow-test-double, the command refuses to execute
- Use: pd runtime internalization run-once --runtime test-double --allow-test-double
- For production use, configure a real runtime adapter

**--runner <kind> parameter** (P2 fix)
- Added --runner <kind> option (default: dreamer)
- Only dreamer is supported; other runner kinds fail closed with a clear error
- Matches Linear target: pd runtime internalization run-once --runner dreamer --json

**Structured output with runId/artifactId/resultRef** (P2 fix)
- RunOnceOutput now includes runId, artifactId, and resultRef from DreamerRunnerResult
- JSON output: top-level fields for operator traceability
- Text output: includes runId, artifactId, resultRef lines

**No double-lease** (P1 fix from previous review)
- wakeOnce(dryRun=true) returns would_lease without acquiring lease
- DreamerRunner.run() handles the actual lease acquisition

**No stuck lease for non-dreamer tasks** (P1 fix from previous review)
- dryRun=true means no lease is acquired for any task kind
- Non-dreamer tasks simply report unsupported_runner_kind without any lease

**Uses durable SQLite store** (P1 fix from previous review)
- stateManager.piArtifactStore (SqlitePIArtifactStore backed by state.db)

**Tests** (tests/commands/runtime-internalization-run-once.test.ts)
- 11 tests covering all paths
- test-double without --allow-test-double: refuses to execute
- test-double with --allow-test-double: proceeds normally
- unsupported runner kind: exits 1 with error
- would_lease dreamer task: structured output includes runId/artifactId/resultRef
- would_lease non-dreamer task: no lease acquired, reports unsupported
- Text output includes runId/artifactId/resultRef
- Uses stateManager.piArtifactStore (durable SQLite)

### Review Fixes
- P1: test-double runtime now requires explicit --allow-test-double flag
- P2: Added --runner <kind> parameter (default: dreamer, only dreamer supported)
- P2: Structured output includes runId/artifactId/resultRef from DreamerRunnerResult
- P2: Rebased onto origin/main, removed docs commits (already in main via #530)

### Verification
- 11 tests passing
- Build, lint, typecheck all pass
- Pre-push hook verified
- PR is MERGEABLE (no conflicts with main)
