### PR TITLE
docs(architecture): 重构顶层架构文档，消除不一致性和过度设计

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,12 @@
 <!-- generated-by: gsd-doc-writer -->
+
+> ⚠️ **废弃状态 (DEPRECATED)**: 本文档已被 [docs/architecture/](docs/architecture/README.md) 目录下的新架构文档替代。
+> - **废弃原因**: 原架构描述已被 [PD_SYSTEM_ARCHITECTURE.md](docs/architecture/PD_SYSTEM_ARCHITECTURE.md) 取代
+> - **替代文档**: 请查阅 [docs/architecture/README.md](docs/architecture/README.md) 获取当前架构文档索引
+> - **废弃日期**: 2026-05-09
+
+---
+
 # Architecture
 
 **Principles Disciple** is an OpenClaw plugin that transforms AI assistants from simple task-executors into self-improving teammates. The system captures failures ("pain signals"), distills them into reusable principles, and applies this learned wisdom to avoid repeating mistakes.

--- a/docs/architecture/DATA_ARCHITECTURE.md
+++ b/docs/architecture/DATA_ARCHITECTURE.md
@@ -8,7 +8,9 @@
 
 ## 1. 存储组件概览
 
-PD 系统的持久化存储分为两个物理文件：
+### 1.1 Runtime V2 Canonical Storage
+
+PD Runtime V2 的权威存储分为两个物理事实源：
 
 | 物理文件 | 技术 | 内容 |
 |---------|------|------|
@@ -16,6 +18,21 @@ PD 系统的持久化存储分为两个物理文件：
 | `{workspace}/.state/principle_training_state.json` | JSON 文件 | Principle Tree 账本（Principle / Rule / Implementation） |
 
 > **关键事实**: `RuntimeStateManager` + `SqliteConnection` 创建 `{workspace}/.pd/state.db`，所有 runtime-v2 store 模块（task/run/commit/candidate/artifact/history/trajectory）复用同一条 SQLite connection。不存在独立的 `candidate.db`、`trajectory.db` 或 `history.db`。
+
+### 1.2 Plugin/Host Auxiliary State
+
+以下辅助状态由 plugin/host 管理，不属于 Runtime V2 authoritative store，但存在于工作区中：
+
+| 路径 | 说明 | 管理方 |
+|------|------|--------|
+| `{workspace}/.state/trajectory.db` | OpenClaw 原始轨迹数据（plugin 写入） | openclaw-plugin |
+| `{workspace}/.state/sessions/` | 会话记录 | openclaw-plugin |
+| `{workspace}/.state/event-log.jsonl` | 事件日志 | openclaw-plugin |
+| `{workspace}/.state/daily-stats/` | 每日统计 | openclaw-plugin |
+| `{workspace}/.state/CURRENT_FOCUS` | 当前焦点 | openclaw-plugin |
+| `{workspace}/.state/evolution.jsonl` | 进化事件流 | openclaw-plugin |
+
+> **注意**: 这些辅助状态可能在未来版本迁移到 Runtime V2 canonical store，但当前由 plugin 独立管理。架构文档中的"存储"如无特别说明，均指 Runtime V2 canonical storage。
 
 ---
 

--- a/docs/architecture/DATA_ARCHITECTURE.md
+++ b/docs/architecture/DATA_ARCHITECTURE.md
@@ -1,101 +1,73 @@
 # PD 数据架构 (Data Architecture)
 
-> **状态**: Draft
+> **状态**: Active
 > **最后更新**: 2026-05-09
-> **背景**: 定义 PD 系统的数据存储架构、读写分离策略、以及与 ADR-0001/ADR-0002 一致的迁移计划。
+> **背景**: 定义 PD 系统的数据存储架构、读写分离策略、以及与 ADR-0001/ADR-0002 一致的迁移计划。所有物理路径已通过 `rg` 验证。
 
 ---
 
 ## 1. 存储组件概览
 
-PD 系统使用多种存储机制，按用途分为以下几类：
+PD 系统的持久化存储分为两个物理文件：
 
-### 1.1 按存储技术分类
-
-| 存储类型 | 技术 | 用途 |
+| 物理文件 | 技术 | 内容 |
 |---------|------|------|
-| **State Store** | SQLite (per-workspace) | 痛点、任务、运行记录、轨迹 |
-| **Ledger Store** | JSON 文件 | Principle Tree 账本 |
-| **Artifact Store** | 文件系统 | Code Implementation 资产 |
-| **Candidate Store** | SQLite | Candidate Intake 队列 |
-| **History Store** | SQLite | 查询优化和历史记录 |
+| `{workspace}/.pd/state.db` | SQLite | Task / Run / Commit / Candidate / Artifact / History / Trajectory（共享一条 SqliteConnection） |
+| `{workspace}/.state/principle_training_state.json` | JSON 文件 | Principle Tree 账本（Principle / Rule / Implementation） |
 
-### 1.2 按物理位置分类
-
-| 位置 | 内容 |
-|------|------|
-| `{workspace}/.pd/state/` | Per-workspace 状态 |
-| `{workspace}/.pd/state/ledger/` | Ledger JSON 文件 |
-| `{workspace}/.pd/state/artifacts/` | Implementation 代码资产 |
-| `~/.openclaw/` | 全局配置和 OpenClaw 状态 |
-| `@principles/core` 内存 | 运行时缓存和内存状态 |
+> **关键事实**: `RuntimeStateManager` + `SqliteConnection` 创建 `{workspace}/.pd/state.db`，所有 runtime-v2 store 模块（task/run/commit/candidate/artifact/history/trajectory）复用同一条 SQLite connection。不存在独立的 `candidate.db`、`trajectory.db` 或 `history.db`。
 
 ---
 
 ## 2. 存储组件详细说明
 
-### 2.1 State Store（状态存储）
+### 2.1 State Store（SQLite 统一存储）
 
-State Store 是 PD 的核心写侧存储，使用 SQLite 实现。
+**物理文件**: `{workspace}/.pd/state.db`  
+**创建入口**: `packages/principles-core/src/runtime-v2/store/sqlite-connection.ts`  
+**管理器**: `packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts`
 
-**文件位置**: `{workspace}/.pd/state/state.db`
+所有 runtime-v2 store 模块共享此 SQLite 数据库：
 
-**核心表结构**:
+| Store 模块 | 代码位置 | 用途 |
+|-----------|---------|------|
+| TaskStore | `runtime-v2/store/task/` | 诊断任务队列 |
+| RunStore | `runtime-v2/store/run/` | 运行记录 |
+| CommitStore | `runtime-v2/store/commit/` | Diagnostician 提交记录 |
+| CandidateStore | `runtime-v2/store/candidate/` | Candidate Intake 队列 |
+| ArtifactStore | `runtime-v2/store/artifact/` | Code Implementation 资产元数据 |
+| HistoryQuery | `runtime-v2/store/history/` | 历史查询 |
+| TrajectoryLocator | `runtime-v2/store/trajectory/` | Agent 行为轨迹 |
 
-| 表名 | 用途 | 关联模块 |
-|------|------|---------|
-| `tasks` | 诊断任务队列 | TaskStore |
-| `runs` | 运行记录 | RunStore |
-| `commits` | Diagnostician 提交记录 | CommitStore |
-| `events` | 事件日志 | EventLog |
-| `pain_signals` | Pain Signal 记录 | PainSignalBridge |
-
-**TaskStore 结构** (`runtime-v2/store/task/`):
-
-```
-TaskStore
-├── TaskStore 接口
-├── MemoryTaskStore (测试用)
-└── SqliteTaskStore (生产用)
-    └── task-migration.ts (Schema 迁移)
-```
-
-**RunStore 结构** (`runtime-v2/store/run/`):
+每个 Store 模块的结构：
 
 ```
-RunStore
-├── RunStore 接口
-├── MemoryRunStore (测试用)
-└── SqliteRunStore (生产用)
+{StoreName}/
+├── {store-name}.ts          # 接口定义
+├── memory-{store-name}.ts   # 内存实现（测试用）
+└── sqlite-{store-name}.ts   # SQLite 实现（生产用）
 ```
 
-**CommitStore 结构** (`runtime-v2/store/commit/`):
+**辅助模块**:
 
-```
-CommitStore
-├── CommitStore 接口
-├── MemoryCommitStore (测试用)
-├── SqliteCommitStore (生产用)
-└── DiagnosticianCommitter (提交逻辑)
-```
+| 模块 | 代码位置 | 用途 |
+|------|---------|------|
+| LeaseManager | `runtime-v2/store/lifecycle/` | 分布式租约管理 |
+| RecoverySweep | `runtime-v2/store/lifecycle/` | 故障恢复扫描 |
+| RetryPolicy | `runtime-v2/store/lifecycle/` | 重试策略 |
+| ContextAssembler | `runtime-v2/store/context/` | Pain Chain 上下文组装 |
+| DiagnosticianCommitter | `runtime-v2/store/commit/` | 提交原子性保证 |
+| IdempotentTransitions | `runtime-v2/store/` | 幂等状态转换 |
+| task-migration.ts | `runtime-v2/store/` | SQLite schema 迁移 |
 
-### 2.2 Ledger Store（账本存储）
+### 2.2 Ledger Store（JSON 账本）
+
+**物理文件**: `{workspace}/.state/principle_training_state.json`  
+**代码位置**: `packages/principles-core/src/principle-tree-ledger.ts`
 
 Ledger Store 存储 Principle Tree 的持久化状态。
 
-**文件位置**: `{workspace}/.pd/state/ledger/`
-
-**文件结构**:
-
-```
-ledger/
-├── ledger.json          # Principle/Rule/Implementation 主账本
-├── metadata.json        # 账本元信息（版本、更新时间）
-└── backups/             # 自动备份
-    └── YYYY-MM-DD.json  # 每日备份
-```
-
-**数据结构**（见 `principle-tree-ledger.ts`）:
+**数据结构**:
 
 ```typescript
 interface PrincipleTree {
@@ -107,101 +79,10 @@ interface PrincipleTree {
 }
 ```
 
-### 2.3 Artifact Store（资产存储）
+**适配器**: `packages/principles-core/src/runtime-v2/adapter/principle-tree-ledger-adapter.ts`  
+将 JSON 文件操作适配为 runtime-v2 可用的接口。
 
-Artifact Store 存储 Rule Implementation 的代码资产。
-
-**文件位置**: `{workspace}/.pd/state/artifacts/`
-
-**文件结构**:
-
-```
-artifacts/
-├── {implId}/
-│   ├── source.ts        # 实现源代码
-│   ├── metadata.json    # 元信息（创建时间、状态）
-│   └── validation.json  # 验证结果
-└── index.json           # 资产索引
-```
-
-### 2.4 Candidate Store（候选存储）
-
-Candidate Store 存储待处理的 Principle/Rule Candidate。
-
-**文件位置**: `{workspace}/.pd/state/candidate.db`
-
-**核心表结构**:
-
-| 表名 | 用途 |
-|------|------|
-| `principle_candidates` | Principle 候选 |
-| `rule_candidates` | Rule 候选 |
-| `implementation_candidates` | Implementation 候选 |
-
-**实现** (`runtime-v2/store/candidate/`):
-
-```
-CandidateStore
-├── CandidateStore 接口
-├── MemoryCandidateStore (测试用)
-└── SqliteCandidateStore (生产用)
-```
-
-### 2.5 History Store（历史查询）
-
-History Store 提供高效的历史查询能力。
-
-**文件位置**: `{workspace}/.pd/state/state.db`（与 State Store 共享 SQLite 连接）
-
-**实现** (`runtime-v2/store/history/`):
-
-```
-HistoryQuery
-├── HistoryQuery 接口
-├── SqliteHistoryQuery (生产用)
-└── ResilientHistoryQuery (带重试的包装)
-```
-
-> **注意**: History Store 复用 State Store 的 SQLite 数据库，不使用独立的 `history.db`。查询通过 `SqliteHistoryQuery` 接口实现，具体表结构由 `task-migration.ts` 管理。
-
-### 2.6 Context Store（上下文组装）
-
-Context Store 提供 Pain Chain 上下文组装能力。
-
-**实现** (`runtime-v2/store/context/`):
-
-```
-ContextAssembler
-├── ContextAssembler 接口
-├── SqliteContextAssembler (生产用)
-└── ResilientContextAssembler (带重试的包装)
-```
-
-### 2.7 Trajectory Store（轨迹存储）
-
-Trajectory Store 存储 Agent 行为轨迹。
-
-**文件位置**: `{workspace}/.pd/state/trajectory.db`
-
-**实现** (`runtime-v2/store/trajectory/`):
-
-```
-TrajectoryLocator
-├── TrajectoryLocator 接口
-└── SqliteTrajectoryLocator (生产用)
-```
-
-### 2.8 Lifecycle Store（生命周期管理）
-
-Lifecycle Store 管理分布式锁和恢复机制。
-
-**实现** (`runtime-v2/store/lifecycle/`):
-
-```
-LeaseManager      # 分布式租约管理
-RecoverySweep     # 故障恢复扫描
-RetryPolicy       # 重试策略
-```
+> **注意**: Ledger 的物理路径是 `.state/principle_training_state.json`（不是 `.pd/state/ledger/`）。这与 OpenClaw plugin 的历史路径约定一致。
 
 ---
 
@@ -216,7 +97,7 @@ PainSignal → PainBridge → TaskStore → RunStore → CommitStore → Candida
 ```
 
 **写入保证**:
-- 使用 `LeaseManager` 确保分布式锁
+- 使用 `LeaseManager` 确保租约互斥
 - 使用 `IdempotentTransitions` 确保幂等性
 - 使用 `DiagnosticianCommitter` 保证提交原子性
 
@@ -224,12 +105,13 @@ PainSignal → PainBridge → TaskStore → RunStore → CommitStore → Candida
 
 **读侧服务**:
 
-| 读模型 | 用途 |
-|--------|------|
-| `PainChainReadModel` | Pain Chain 全链路追踪 |
-| `PruningReadModel` | Pruning 信号生成 |
-| `LifecycleReadModel` | Principle 生命周期状态 |
-| `OperatorHealthReadModel` | Operator 健康状态 |
+| 读模型 | 代码位置 | 用途 |
+|--------|---------|------|
+| `PainChainReadModel` | `runtime-v2/pain-chain-read-model.ts` | Pain Chain 全链路追踪 |
+| `PruningReadModel` | `runtime-v2/pruning-read-model.ts` | Pruning 信号生成 |
+| `LifecycleReadModel` | `runtime-v2/internalization/lifecycle-read-model.ts` | Principle 生命周期状态 |
+| `OperatorHealthReadModel` | `runtime-v2/operator-health-read-model.ts` | Operator 健康状态 |
+| `GfiReadModel` | `runtime-v2/gfi/gfi-read-model.ts` | 摩擦力指标快照 |
 
 **读取原则**:
 - 所有读操作都是非破坏性的
@@ -242,25 +124,28 @@ PainSignal → PainBridge → TaskStore → RunStore → CommitStore → Candida
 
 ```mermaid
 flowchart TD
-    subgraph WriteSide["写侧 (Write Side)"]
-        PS[Pain Signal]
-        PB[PainBridge]
+    subgraph SQLite["{workspace}/.pd/state.db"]
         TS[TaskStore]
         RS[RunStore]
         CS[CommitStore]
         CAN[CandidateStore]
-        LED[Ledger]
         ART[ArtifactStore]
+        HQ[HistoryQuery]
+        TL[TrajectoryLocator]
     end
 
-    subgraph ReadSide["读侧 (Read Side)"]
+    subgraph JSON["{workspace}/.state/principle_training_state.json"]
+        LED[Ledger: Principle/Rule/Implementation]
+    end
+
+    subgraph ReadModels["读侧"]
         PCRM[PainChainReadModel]
         PRM[PruningReadModel]
         LRM[LifecycleReadModel]
         OHRM[OperatorHealthReadModel]
     end
 
-    PS --> PB
+    PS[PainSignal] --> PB[PainBridge]
     PB --> TS
     TS --> RS
     RS --> CS
@@ -271,6 +156,8 @@ flowchart TD
     LED --> PRM
     LED --> LRM
     PCRM --> OHRM
+    HQ -.-> PCRM
+    TL -.-> PCRM
 ```
 
 ---
@@ -284,15 +171,16 @@ flowchart TD
 | PainToPrincipleService | plugin | `@principles/core` | ✅ Done |
 | PainChainReadModel | pd-cli | `@principles/core` | ✅ Done |
 | PruningReadModel | plugin | `@principles/core` | ✅ Done |
+| PrincipleTreeLedger | plugin | `@principles/core` | ✅ Done |
+| TemplateGenerator | plugin | `@principles/core` | ✅ Done |
 
 ### 5.2 进行中迁移（ADR-0002）
 
 | 组件 | 原位置 | 目标位置 | 状态 |
 |------|--------|---------|------|
-| RuleHost contracts | plugin | `@principles/core` | ⏳ PRI-42 |
-| TemplateGenerator | plugin | `@principles/core` | ⏳ PRI-44 |
-| LifecycleMetrics | plugin | `@principles/core` | ⏳ PRI-42 |
-| RoutingPolicy | plugin | `@principles/core` | ⏳ PRI-43 |
+| RuleHost contracts | plugin | `@principles/core` | ✅ Done (PRI-42) |
+| RoutingPolicy | plugin | `@principles/core` | ✅ Done (PRI-43) |
+| LifecycleMetrics | plugin | `@principles/core` | ✅ Done (PRI-42) |
 
 ### 5.3 待迁移
 

--- a/docs/architecture/DATA_ARCHITECTURE.md
+++ b/docs/architecture/DATA_ARCHITECTURE.md
@@ -1,0 +1,312 @@
+# PD 数据架构 (Data Architecture)
+
+> **状态**: Draft
+> **最后更新**: 2026-05-09
+> **背景**: 定义 PD 系统的数据存储架构、读写分离策略、以及与 ADR-0001/ADR-0002 一致的迁移计划。
+
+---
+
+## 1. 存储组件概览
+
+PD 系统使用多种存储机制，按用途分为以下几类：
+
+### 1.1 按存储技术分类
+
+| 存储类型 | 技术 | 用途 |
+|---------|------|------|
+| **State Store** | SQLite (per-workspace) | 痛点、任务、运行记录、轨迹 |
+| **Ledger Store** | JSON 文件 | Principle Tree 账本 |
+| **Artifact Store** | 文件系统 | Code Implementation 资产 |
+| **Candidate Store** | SQLite | Candidate Intake 队列 |
+| **History Store** | SQLite | 查询优化和历史记录 |
+
+### 1.2 按物理位置分类
+
+| 位置 | 内容 |
+|------|------|
+| `{workspace}/.pd/state/` | Per-workspace 状态 |
+| `{workspace}/.pd/state/ledger/` | Ledger JSON 文件 |
+| `{workspace}/.pd/state/artifacts/` | Implementation 代码资产 |
+| `~/.openclaw/` | 全局配置和 OpenClaw 状态 |
+| `@principles/core` 内存 | 运行时缓存和内存状态 |
+
+---
+
+## 2. 存储组件详细说明
+
+### 2.1 State Store（状态存储）
+
+State Store 是 PD 的核心写侧存储，使用 SQLite 实现。
+
+**文件位置**: `{workspace}/.pd/state/state.db`
+
+**核心表结构**:
+
+| 表名 | 用途 | 关联模块 |
+|------|------|---------|
+| `tasks` | 诊断任务队列 | TaskStore |
+| `runs` | 运行记录 | RunStore |
+| `commits` | Diagnostician 提交记录 | CommitStore |
+| `events` | 事件日志 | EventLog |
+| `pain_signals` | Pain Signal 记录 | PainSignalBridge |
+
+**TaskStore 结构** (`runtime-v2/store/task/`):
+
+```
+TaskStore
+├── TaskStore 接口
+├── MemoryTaskStore (测试用)
+└── SqliteTaskStore (生产用)
+    └── task-migration.ts (Schema 迁移)
+```
+
+**RunStore 结构** (`runtime-v2/store/run/`):
+
+```
+RunStore
+├── RunStore 接口
+├── MemoryRunStore (测试用)
+└── SqliteRunStore (生产用)
+```
+
+**CommitStore 结构** (`runtime-v2/store/commit/`):
+
+```
+CommitStore
+├── CommitStore 接口
+├── MemoryCommitStore (测试用)
+├── SqliteCommitStore (生产用)
+└── DiagnosticianCommitter (提交逻辑)
+```
+
+### 2.2 Ledger Store（账本存储）
+
+Ledger Store 存储 Principle Tree 的持久化状态。
+
+**文件位置**: `{workspace}/.pd/state/ledger/`
+
+**文件结构**:
+
+```
+ledger/
+├── ledger.json          # Principle/Rule/Implementation 主账本
+├── metadata.json        # 账本元信息（版本、更新时间）
+└── backups/             # 自动备份
+    └── YYYY-MM-DD.json  # 每日备份
+```
+
+**数据结构**（见 `principle-tree-ledger.ts`）:
+
+```typescript
+interface PrincipleTree {
+  principles: LedgerPrinciple[];
+  rules: LedgerRule[];
+  implementations: LedgerImplementation[];
+  version: string;
+  updatedAt: number;
+}
+```
+
+### 2.3 Artifact Store（资产存储）
+
+Artifact Store 存储 Rule Implementation 的代码资产。
+
+**文件位置**: `{workspace}/.pd/state/artifacts/`
+
+**文件结构**:
+
+```
+artifacts/
+├── {implId}/
+│   ├── source.ts        # 实现源代码
+│   ├── metadata.json    # 元信息（创建时间、状态）
+│   └── validation.json  # 验证结果
+└── index.json           # 资产索引
+```
+
+### 2.4 Candidate Store（候选存储）
+
+Candidate Store 存储待处理的 Principle/Rule Candidate。
+
+**文件位置**: `{workspace}/.pd/state/candidate.db`
+
+**核心表结构**:
+
+| 表名 | 用途 |
+|------|------|
+| `principle_candidates` | Principle 候选 |
+| `rule_candidates` | Rule 候选 |
+| `implementation_candidates` | Implementation 候选 |
+
+**实现** (`runtime-v2/store/candidate/`):
+
+```
+CandidateStore
+├── CandidateStore 接口
+├── MemoryCandidateStore (测试用)
+└── SqliteCandidateStore (生产用)
+```
+
+### 2.5 History Store（历史查询）
+
+History Store 提供高效的历史查询能力。
+
+**文件位置**: `{workspace}/.pd/state/state.db`（与 State Store 共享 SQLite 连接）
+
+**实现** (`runtime-v2/store/history/`):
+
+```
+HistoryQuery
+├── HistoryQuery 接口
+├── SqliteHistoryQuery (生产用)
+└── ResilientHistoryQuery (带重试的包装)
+```
+
+> **注意**: History Store 复用 State Store 的 SQLite 数据库，不使用独立的 `history.db`。查询通过 `SqliteHistoryQuery` 接口实现，具体表结构由 `task-migration.ts` 管理。
+
+### 2.6 Context Store（上下文组装）
+
+Context Store 提供 Pain Chain 上下文组装能力。
+
+**实现** (`runtime-v2/store/context/`):
+
+```
+ContextAssembler
+├── ContextAssembler 接口
+├── SqliteContextAssembler (生产用)
+└── ResilientContextAssembler (带重试的包装)
+```
+
+### 2.7 Trajectory Store（轨迹存储）
+
+Trajectory Store 存储 Agent 行为轨迹。
+
+**文件位置**: `{workspace}/.pd/state/trajectory.db`
+
+**实现** (`runtime-v2/store/trajectory/`):
+
+```
+TrajectoryLocator
+├── TrajectoryLocator 接口
+└── SqliteTrajectoryLocator (生产用)
+```
+
+### 2.8 Lifecycle Store（生命周期管理）
+
+Lifecycle Store 管理分布式锁和恢复机制。
+
+**实现** (`runtime-v2/store/lifecycle/`):
+
+```
+LeaseManager      # 分布式租约管理
+RecoverySweep     # 故障恢复扫描
+RetryPolicy       # 重试策略
+```
+
+---
+
+## 3. 读写分离策略
+
+### 3.1 写侧（Write Side）
+
+**写侧统一入口**: `PainToPrincipleService`
+
+```
+PainSignal → PainBridge → TaskStore → RunStore → CommitStore → CandidateStore → Ledger
+```
+
+**写入保证**:
+- 使用 `LeaseManager` 确保分布式锁
+- 使用 `IdempotentTransitions` 确保幂等性
+- 使用 `DiagnosticianCommitter` 保证提交原子性
+
+### 3.2 读侧（Read Side）
+
+**读侧服务**:
+
+| 读模型 | 用途 |
+|--------|------|
+| `PainChainReadModel` | Pain Chain 全链路追踪 |
+| `PruningReadModel` | Pruning 信号生成 |
+| `LifecycleReadModel` | Principle 生命周期状态 |
+| `OperatorHealthReadModel` | Operator 健康状态 |
+
+**读取原则**:
+- 所有读操作都是非破坏性的
+- 读模型不修改底层状态
+- 使用 `Resilient*` 包装器处理临时故障
+
+---
+
+## 4. 数据流图
+
+```mermaid
+flowchart TD
+    subgraph WriteSide["写侧 (Write Side)"]
+        PS[Pain Signal]
+        PB[PainBridge]
+        TS[TaskStore]
+        RS[RunStore]
+        CS[CommitStore]
+        CAN[CandidateStore]
+        LED[Ledger]
+        ART[ArtifactStore]
+    end
+
+    subgraph ReadSide["读侧 (Read Side)"]
+        PCRM[PainChainReadModel]
+        PRM[PruningReadModel]
+        LRM[LifecycleReadModel]
+        OHRM[OperatorHealthReadModel]
+    end
+
+    PS --> PB
+    PB --> TS
+    TS --> RS
+    RS --> CS
+    CS --> CAN
+    CAN --> LED
+    CAN --> ART
+    LED --> PCRM
+    LED --> PRM
+    LED --> LRM
+    PCRM --> OHRM
+```
+
+---
+
+## 5. 迁移计划
+
+### 5.1 已完成迁移（ADR-0001）
+
+| 组件 | 原位置 | 新位置 | 状态 |
+|------|--------|--------|------|
+| PainToPrincipleService | plugin | `@principles/core` | ✅ Done |
+| PainChainReadModel | pd-cli | `@principles/core` | ✅ Done |
+| PruningReadModel | plugin | `@principles/core` | ✅ Done |
+
+### 5.2 进行中迁移（ADR-0002）
+
+| 组件 | 原位置 | 目标位置 | 状态 |
+|------|--------|---------|------|
+| RuleHost contracts | plugin | `@principles/core` | ⏳ PRI-42 |
+| TemplateGenerator | plugin | `@principles/core` | ⏳ PRI-44 |
+| LifecycleMetrics | plugin | `@principles/core` | ⏳ PRI-42 |
+| RoutingPolicy | plugin | `@principles/core` | ⏳ PRI-43 |
+
+### 5.3 待迁移
+
+| 组件 | 原位置 | 目标位置 | 依赖 |
+|------|--------|---------|------|
+| Store modularization | `@principles/core` | `@principles/core/store/` | PRI-47 |
+| Artifact store cleanup | plugin | `@principles/core` | Post M6 |
+
+---
+
+## 6. 相关文档
+
+| 文档 | 说明 |
+|------|------|
+| [PD_SYSTEM_ARCHITECTURE.md](./PD_SYSTEM_ARCHITECTURE.md) | 系统架构蓝图 |
+| [ADR-0001](../adr/0001-runtime-v2-service-boundaries.md) | Runtime V2 Service Boundaries |
+| [ADR-0002](../adr/0002-hard-internalization-core-boundary.md) | Hard Internalization Core Boundary |

--- a/docs/architecture/DOMAIN_MODEL.md
+++ b/docs/architecture/DOMAIN_MODEL.md
@@ -159,10 +159,11 @@ Rule 必须绑定上下文，否则无法测试与执行。后续 Rule 模型和
 
 ## 3. 三类内化路线
 
-Principle 可以通过不同路线影响系统行为。不要把内化只理解为生成代码。
+Principle 可以通过不同路线影响系统行为。**本节与 [PD_System_Dynamics_Model.md](./PD_System_Dynamics_Model.md) Section 4 保持术语一致，使用 L1/L2/L3 编号作为 canonical 别名。**
 
-### 3.1 Prompt / Skill / SOP 内化
+### 3.1 L1: Prompt / Skill / SOP 内化（软内化）
 
+- **L1 别名**：软内化
 - **目标**: 影响 LLM 的思考方式、注意事项、流程习惯。
 - **载体**:
   - system prompt
@@ -178,8 +179,9 @@ Principle 可以通过不同路线影响系统行为。不要把内化只理解�
   - 遵循不稳定
   - 难以证明生效
 
-### 3.2 Code / Hook / Tool 内化
+### 3.2 L2: Code / Hook / Tool 内化（硬内化）
 
+- **L2 别名**：硬内化
 - **目标**: 通过确定性逻辑影响或拦截 agent 行为。
 - **载体**:
   - RuleHost implementation
@@ -196,8 +198,9 @@ Principle 可以通过不同路线影响系统行为。不要把内化只理解�
   - 与真实 workflow 不匹配
   - 需要回滚和 shadow/probation
 
-### 3.3 Model Parameter / LoRA 内化
+### 3.3 L3: Model Parameter / LoRA 内化（模型参数化）
 
+- **L3 别名**：模型参数化
 - **目标**: 通过模型参数或偏好学习改变默认行为倾向。
 - **载体**:
   - LoRA
@@ -263,20 +266,35 @@ Pruning Review 是 append-only audit log，不改变实体生命周期。当前�
 
 ## 6. 当前代码映射
 
-| 领域概念 | 当前主要位置 | 说明 |
-| --- | --- | --- |
-| Pain Signal | `packages/principles-core/src/runtime-v2/pain-to-principle-service.ts` | Runtime V2 写侧统一入口 |
-| Pain Chain Read Model | `packages/principles-core/src/runtime-v2/pain-chain-read-model.ts` | pain -> task -> run -> candidate -> ledger 读侧 |
-| Principle | `packages/openclaw-plugin/src/types/principle-tree-schema.ts` | 当前仍在 plugin types 中定义 |
-| LedgerPrinciple | `packages/openclaw-plugin/src/core/principle-tree-ledger.ts` | ledger 文件中的 Principle |
-| Rule / LedgerRule | `packages/openclaw-plugin/src/types/principle-tree-schema.ts`, `principle-tree-ledger.ts` | Principle 的可验证投影 |
-| Implementation | `packages/openclaw-plugin/src/types/principle-tree-schema.ts` | Rule 的承载物 |
-| Code Implementation Asset | `packages/openclaw-plugin/src/core/code-implementation-storage.ts` | code implementation 的文件资产 |
-| RuleHost | `packages/openclaw-plugin/src/core/rule-host.ts` | code implementation 的执行宿主 |
-| RuleHostInput/Result | `packages/openclaw-plugin/src/core/rule-host-types.ts` | active implementation 的执行契约 |
-| Pruning Signal | `packages/principles-core/src/runtime-v2/pruning-read-model.ts` | non-destructive read model |
-| Pruning Review | `packages/principles-core/src/runtime-v2/pruning-review-log.ts` | append-only audit log |
-| Diagnostician Recommendation | `packages/principles-core/src/runtime-v2/diagnostician-output.ts` | recommendation taxonomy schema |
+| 领域概念 | 当前主要位置 | 目标位置 | 迁移状态 | 说明 |
+| --- | --- | --- | --- | --- |
+| Pain Signal | `packages/principles-core/src/runtime-v2/pain-to-principle-service.ts` | - | ✅ Done (ADR-0001) | Runtime V2 写侧统一入口 |
+| Pain Chain Read Model | `packages/principles-core/src/runtime-v2/pain-chain-read-model.ts` | - | ✅ Done (ADR-0001) | pain -> task -> run -> candidate -> ledger 读侧 |
+| Principle Schema | `packages/openclaw-plugin/src/types/principle-tree-schema.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | 类型定义迁移中 |
+| LedgerPrinciple | `packages/openclaw-plugin/src/core/principle-tree-ledger.ts` | - | 🔒 Keep in plugin | ledger 文件操作保留在 plugin |
+| Rule / LedgerRule | `packages/openclaw-plugin/src/types/principle-tree-schema.ts`, `principle-tree-ledger.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | 类型迁移中 |
+| Implementation Schema | `packages/openclaw-plugin/src/types/principle-tree-schema.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | 类型定义迁移中 |
+| Code Implementation Asset | `packages/openclaw-plugin/src/core/code-implementation-storage.ts` | - | 🔒 Keep in plugin | 文件系统操作保留在 plugin |
+| RuleHost | `packages/openclaw-plugin/src/core/rule-host.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | PRI-45 拆分中 |
+| RuleHostInput/Result | `packages/openclaw-plugin/src/core/rule-host-types.ts` | `@principles/core` | ✅ Done (PRI-42) | 已迁移至 `internalization/rule-host-contracts.ts` |
+| RuleHost Helpers | `packages/openclaw-plugin/src/core/rule-host-helpers.ts` | `@principles/core` | ✅ Done (PRI-42) | 已迁移 |
+| Lifecycle Metrics | `packages/openclaw-plugin/src/core/principle-internalization/lifecycle-metrics.ts` | `@principles/core` | ✅ Done (PRI-42) | 已迁移至 `internalization/` |
+| Routing Policy | `packages/openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts` | `@principles/core` | ✅ Done (PRI-43) | 已迁移至 `internalization/routing-policy.ts` |
+| Template Generator | `packages/openclaw-plugin/src/core/principle-compiler/template-generator.ts` | `@principles/core` | ⏳ Pending (PRI-44) | 模板生成逻辑迁移中 |
+| Pruning Signal | `packages/principles-core/src/runtime-v2/pruning-read-model.ts` | - | ✅ Done | non-destructive read model |
+| Pruning Review | `packages/principles-core/src/runtime-v2/pruning-review-log.ts` | - | ✅ Done | append-only audit log |
+| Diagnostician Recommendation | `packages/principles-core/src/runtime-v2/diagnostician-output.ts` | - | ✅ Done | recommendation taxonomy schema |
+
+**迁移状态说明**:
+- ✅ Done: 已完成迁移
+- ⏳ Pending: 迁移计划中（见 ADR-0002）
+- 🔒 Keep in plugin: 保留在 plugin（基础设施绑定）
+
+---
+
+**相关 ADR**:
+- [ADR-0001: Runtime V2 Service Boundaries](../adr/0001-runtime-v2-service-boundaries.md)
+- [ADR-0002: Hard Internalization Core Boundary](../adr/0002-hard-internalization-core-boundary.md)
 
 ---
 

--- a/docs/architecture/DOMAIN_MODEL.md
+++ b/docs/architecture/DOMAIN_MODEL.md
@@ -271,7 +271,7 @@ Pruning Review 是 append-only audit log，不改变实体生命周期。当前�
 | Pain Signal | `packages/principles-core/src/runtime-v2/pain-to-principle-service.ts` | - | ✅ Done (ADR-0001) | Runtime V2 写侧统一入口 |
 | Pain Chain Read Model | `packages/principles-core/src/runtime-v2/pain-chain-read-model.ts` | - | ✅ Done (ADR-0001) | pain -> task -> run -> candidate -> ledger 读侧 |
 | Principle Schema | `packages/openclaw-plugin/src/types/principle-tree-schema.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | 类型定义迁移中 |
-| LedgerPrinciple | `packages/openclaw-plugin/src/core/principle-tree-ledger.ts` | - | 🔒 Keep in plugin | ledger 文件操作保留在 plugin |
+| LedgerPrinciple | `packages/openclaw-plugin/src/core/principle-tree-ledger.ts` | `@principles/core` | ✅ Done | 已迁移至 `packages/principles-core/src/principle-tree-ledger.ts` |
 | Rule / LedgerRule | `packages/openclaw-plugin/src/types/principle-tree-schema.ts`, `principle-tree-ledger.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | 类型迁移中 |
 | Implementation Schema | `packages/openclaw-plugin/src/types/principle-tree-schema.ts` | `@principles/core` | ⏳ Pending (ADR-0002) | 类型定义迁移中 |
 | Code Implementation Asset | `packages/openclaw-plugin/src/core/code-implementation-storage.ts` | - | 🔒 Keep in plugin | 文件系统操作保留在 plugin |
@@ -280,7 +280,7 @@ Pruning Review 是 append-only audit log，不改变实体生命周期。当前�
 | RuleHost Helpers | `packages/openclaw-plugin/src/core/rule-host-helpers.ts` | `@principles/core` | ✅ Done (PRI-42) | 已迁移 |
 | Lifecycle Metrics | `packages/openclaw-plugin/src/core/principle-internalization/lifecycle-metrics.ts` | `@principles/core` | ✅ Done (PRI-42) | 已迁移至 `internalization/` |
 | Routing Policy | `packages/openclaw-plugin/src/core/principle-internalization/internalization-routing-policy.ts` | `@principles/core` | ✅ Done (PRI-43) | 已迁移至 `internalization/routing-policy.ts` |
-| Template Generator | `packages/openclaw-plugin/src/core/principle-compiler/template-generator.ts` | `@principles/core` | ⏳ Pending (PRI-44) | 模板生成逻辑迁移中 |
+| Template Generator | `packages/openclaw-plugin/src/core/principle-compiler/template-generator.ts` | `@principles/core` | ✅ Done | 已迁移至 `runtime-v2/internalization/template-generator.ts` |
 | Pruning Signal | `packages/principles-core/src/runtime-v2/pruning-read-model.ts` | - | ✅ Done | non-destructive read model |
 | Pruning Review | `packages/principles-core/src/runtime-v2/pruning-review-log.ts` | - | ✅ Done | append-only audit log |
 | Diagnostician Recommendation | `packages/principles-core/src/runtime-v2/diagnostician-output.ts` | - | ✅ Done | recommendation taxonomy schema |

--- a/docs/architecture/ERROR_ARCHITECTURE.md
+++ b/docs/architecture/ERROR_ARCHITECTURE.md
@@ -32,9 +32,9 @@ PD Runtime V2 使用统一的错误分类体系。所有 PD 组件、适配器�
 | `workspace_invalid` | 工作区无效 | 工作区路径不存在 |
 | `query_invalid` | 查询无效 | Read Model 查询参数错误 |
 
-### 1.2 FAILURE_CATEGORY_MAP（9 个用户可见类别）
+### 1.2 FAILURE_CATEGORY_MAP（6 个用户可见类别）
 
-17 个内部错误码映射为 9 个用户可见类别，用于 CLI trace 和 pain-record 命令：
+17 个内部错误码映射为 6 个用户可见类别，用于 CLI trace 和 pain-record 命令：
 
 | 用户可见类别 | 对应内部错误码 |
 |-------------|--------------|
@@ -134,13 +134,15 @@ DiagnosticianRunner
 ```
 Store Operations
     │
-    ├── 正常路径: 内存缓存 → 同步写入 → 返回成功
+    ├── 正常路径: SQLite 同步写入 → 返回成功
     │
     └── 降级路径:
-        ├── 写入失败 → PDRuntimeError('storage_unavailable') → Resilient* 包装器自动重试 ✅
-        ├── 读取失败 → Resilient* 包装器 → 自动重试 ✅
+        ├── 写入失败 → PDRuntimeError('storage_unavailable') → 调用方决定重试或失败 🎯
+        ├── 读取失败 → ResilientContextAssembler / ResilientHistoryQuery 自动重试 ✅
         └── 锁获取失败 → PDRuntimeError('lease_conflict') → 等待重试 🎯
 ```
+
+> **注意**: `Resilient*` 包装器（`ResilientContextAssembler`、`ResilientHistoryQuery`）是读侧/上下文降级包装，不是通用写入重试。SQLite store 写失败通常直接抛出 `PDRuntimeError('storage_unavailable')`，由调用方决定重试策略。
 
 ---
 

--- a/docs/architecture/ERROR_ARCHITECTURE.md
+++ b/docs/architecture/ERROR_ARCHITECTURE.md
@@ -1,0 +1,151 @@
+# PD 错误处理架构 (Error Handling Architecture)
+
+> **状态**: Active
+> **最后更新**: 2026-05-09
+> **代码实现**: `packages/principles-core/src/runtime-v2/error-categories.ts`
+
+---
+
+## 1. 错误分类体系
+
+PD Runtime V2 使用统一的错误分类体系。所有 PD 组件、适配器、CLI 命令和事件**必须**使用这些类别，不得发明本地错误码。
+
+### 1.1 PDErrorCategory（17 个内部错误码）
+
+| 错误类别 | 说明 | 典型场景 |
+|---------|------|---------|
+| `runtime_unavailable` | 运行时不可用 | 适配器初始化失败、连接断开 |
+| `capability_missing` | 能力缺失 | 运行时不支持结构化 JSON 输出 |
+| `input_invalid` | 输入无效 | Task 参数校验失败 |
+| `lease_conflict` | 租约冲突 | 并发写入同一 Task |
+| `lease_expired` | 租约过期 | Diagnostician 执行超时 |
+| `execution_failed` | 执行失败 | 模型返回错误 |
+| `timeout` | 超时 | 适配器调用超时 |
+| `cancelled` | 已取消 | 用户主动取消 |
+| `output_invalid` | 输出无效 | Diagnostician 输出解析失败 |
+| `artifact_commit_failed` | 资产提交失败 | 候选写入磁盘失败 |
+| `max_attempts_exceeded` | 超过最大重试 | 重试策略耗尽 |
+| `context_assembly_failed` | 上下文组装失败 | Pain Chain 查询异常 |
+| `history_not_found` | 历史未找到 | 查询不存在的 Run |
+| `trajectory_ambiguous` | 轨迹模糊 | 多条轨迹匹配 |
+| `storage_unavailable` | 存储不可用 | SQLite 连接失败 |
+| `workspace_invalid` | 工作区无效 | 工作区路径不存在 |
+| `query_invalid` | 查询无效 | Read Model 查询参数错误 |
+
+### 1.2 FAILURE_CATEGORY_MAP（9 个用户可见类别）
+
+17 个内部错误码映射为 9 个用户可见类别，用于 CLI trace 和 pain-record 命令：
+
+| 用户可见类别 | 对应内部错误码 |
+|-------------|--------------|
+| `runtime_unavailable` | `runtime_unavailable`, `lease_conflict`, `lease_expired`, `execution_failed`, `context_assembly_failed`, `history_not_found`, `trajectory_ambiguous`, `query_invalid` |
+| `config_missing` | `capability_missing`, `input_invalid`, `workspace_invalid` |
+| `runtime_timeout` | `timeout`, `cancelled`, `max_attempts_exceeded` |
+| `output_invalid` | `output_invalid` |
+| `artifact_missing` | `artifact_commit_failed` |
+| `ledger_write_failed` | `storage_unavailable` |
+
+---
+
+## 2. 核心错误类
+
+### 2.1 PDRuntimeError
+
+```typescript
+class PDRuntimeError extends Error {
+  readonly category: PDErrorCategory;
+  readonly details?: Record<string, unknown>;
+
+  constructor(category: PDErrorCategory, message: string, details?: Record<string, unknown>) {
+    super(`[${category}] ${message}`);
+    this.name = 'PDRuntimeError';
+    this.category = category;
+    this.details = details;
+  }
+}
+```
+
+**使用规范**：
+- 适配器和服务在 runtime-v2 路径中应抛出 `PDRuntimeError` 而非通用 `Error`
+- `category` 必须是 `PDErrorCategory` 的合法值（TypeBox 运行时校验）
+- `details` 用于附加上下文（如 taskId、runId、painSignalId）
+
+### 2.2 已废弃的错误体系
+
+以下旧错误体系已被 `PDRuntimeError` + `PDErrorCategory` 取代：
+- `TrinityRuntimeFailureCode`（openclaw-plugin）→ 已废弃
+- `TaskResolution`（openclaw-plugin）→ 已废弃（legacy marker-file 值保留为 legacy-only）
+- `PdError` 类层级（openclaw-plugin）→ 可包装 `PDErrorCategory`
+
+---
+
+## 3. 错误传播策略
+
+### 3.1 传播原则
+
+1. **向上传播**：错误从底层组件向上传播到调用方
+2. **分类包装**：捕获的未知错误应包装为 `PDRuntimeError`，选择最匹配的 `PDErrorCategory`
+3. **不吞没**：除非明确设计降级路径，否则不应吞没错误
+
+### 3.2 常见映射
+
+| 底层错误 | 包装为 |
+|---------|--------|
+| 适配器连接失败 | `PDRuntimeError('runtime_unavailable', ...)` |
+| 模型调用超时 | `PDRuntimeError('timeout', ...)` |
+| 输出解析失败 | `PDRuntimeError('output_invalid', ...)` |
+| SQLite 写入失败 | `PDRuntimeError('storage_unavailable', ...)` |
+| 租约获取失败 | `PDRuntimeError('lease_conflict', ...)` |
+
+---
+
+## 4. 降级路径
+
+### 4.1 Pain Chain 降级
+
+```
+PainSignalBridge
+    │
+    ├── 正常路径: PainSignal → Task → Run → Candidate → Ledger
+    │
+    └── 降级路径:
+        ├── Bridge 调用失败 → PDRuntimeError('runtime_unavailable') → 返回 skipped
+        ├── Lease 超时 → PDRuntimeError('lease_expired') → RecoverySweep 重试
+        └── 上下文组装失败 → PDRuntimeError('context_assembly_failed') → 返回 partial
+```
+
+### 4.2 Diagnostician 降级
+
+```
+DiagnosticianRunner
+    │
+    ├── 正常路径: Prompt → Output → Validate → Commit
+    │
+    └── 降级路径:
+        ├── 超时 → PDRuntimeError('timeout') → RunnerResult.status = 'timed_out'
+        ├── 解析失败 → PDRuntimeError('output_invalid') → 尝试修复 → 仍失败则返回
+        └── 最大重试 → PDRuntimeError('max_attempts_exceeded') → 返回失败
+```
+
+### 4.3 Storage 降级
+
+```
+Store Operations
+    │
+    ├── 正常路径: 内存缓存 → 同步写入 → 返回成功
+    │
+    └── 降级路径:
+        ├── 写入失败 → PDRuntimeError('storage_unavailable') → 重试 3 次
+        ├── 读取失败 → Resilient* 包装器 → 自动重试
+        └── 锁获取失败 → PDRuntimeError('lease_conflict') → 等待重试
+```
+
+---
+
+## 5. 相关文档
+
+| 文档 | 说明 |
+|------|------|
+| [PD_SYSTEM_ARCHITECTURE.md](./PD_SYSTEM_ARCHITECTURE.md) | 系统架构蓝图 |
+| [DATA_ARCHITECTURE.md](./DATA_ARCHITECTURE.md) | 数据存储架构 |
+| [ADR-0001](../adr/0001-runtime-v2-service-boundaries.md) | Runtime V2 Service Boundaries |

--- a/docs/architecture/ERROR_ARCHITECTURE.md
+++ b/docs/architecture/ERROR_ARCHITECTURE.md
@@ -65,9 +65,9 @@ class PDRuntimeError extends Error {
 }
 ```
 
-**使用规范**：
+**使用规范**:
 - 适配器和服务在 runtime-v2 路径中应抛出 `PDRuntimeError` 而非通用 `Error`
-- `category` 必须是 `PDErrorCategory` 的合法值（TypeBox 运行时校验）
+- `category` 必须是 `PDErrorCategory` 的合法值（`isPDErrorCategory()` 可用于运行时校验，但 `PDRuntimeError` constructor 本身不做校验）
 - `details` 用于附加上下文（如 taskId、runId、painSignalId）
 
 ### 2.2 已废弃的错误体系
@@ -101,6 +101,8 @@ class PDRuntimeError extends Error {
 
 ## 4. 降级路径
 
+> **说明**: 以下降级路径描述的是**目标规范 / recommended behavior**，而非当前所有路径的完整实现状态。标注了 ✅ 的路径已有代码实现，标注为 🎯 的路径是推荐行为但尚未统一实现。
+
 ### 4.1 Pain Chain 降级
 
 ```
@@ -109,9 +111,9 @@ PainSignalBridge
     ├── 正常路径: PainSignal → Task → Run → Candidate → Ledger
     │
     └── 降级路径:
-        ├── Bridge 调用失败 → PDRuntimeError('runtime_unavailable') → 返回 skipped
-        ├── Lease 超时 → PDRuntimeError('lease_expired') → RecoverySweep 重试
-        └── 上下文组装失败 → PDRuntimeError('context_assembly_failed') → 返回 partial
+        ├── Bridge 调用失败 → PDRuntimeError('runtime_unavailable') → 返回 skipped ✅
+        ├── Lease 超时 → PDRuntimeError('lease_expired') → RecoverySweep 重试 ✅
+        └── 上下文组装失败 → PDRuntimeError('context_assembly_failed') → 返回 partial 🎯
 ```
 
 ### 4.2 Diagnostician 降级
@@ -122,9 +124,9 @@ DiagnosticianRunner
     ├── 正常路径: Prompt → Output → Validate → Commit
     │
     └── 降级路径:
-        ├── 超时 → PDRuntimeError('timeout') → RunnerResult.status = 'timed_out'
-        ├── 解析失败 → PDRuntimeError('output_invalid') → 尝试修复 → 仍失败则返回
-        └── 最大重试 → PDRuntimeError('max_attempts_exceeded') → 返回失败
+        ├── 超时 → PDRuntimeError('timeout') → RunnerResult.status = 'timed_out' ✅
+        ├── 解析失败 → PDRuntimeError('output_invalid') → 尝试修复 → 仍失败则返回 ✅
+        └── 最大重试 → PDRuntimeError('max_attempts_exceeded') → 返回失败 ✅
 ```
 
 ### 4.3 Storage 降级
@@ -135,9 +137,9 @@ Store Operations
     ├── 正常路径: 内存缓存 → 同步写入 → 返回成功
     │
     └── 降级路径:
-        ├── 写入失败 → PDRuntimeError('storage_unavailable') → 重试 3 次
-        ├── 读取失败 → Resilient* 包装器 → 自动重试
-        └── 锁获取失败 → PDRuntimeError('lease_conflict') → 等待重试
+        ├── 写入失败 → PDRuntimeError('storage_unavailable') → Resilient* 包装器自动重试 ✅
+        ├── 读取失败 → Resilient* 包装器 → 自动重试 ✅
+        └── 锁获取失败 → PDRuntimeError('lease_conflict') → 等待重试 🎯
 ```
 
 ---

--- a/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
@@ -10,13 +10,13 @@
 
 ## 0. 包边界与所有权
 
-| 包 | 角色 | 核心目录 | 依赖方向 |
+| 包 | 角色 | 核心目录 | 依赖约束 |
 |----|------|---------|---------|
-| `@principles/core` | Domain Core | `runtime-v2/` | 无外部依赖 |
-| `openclaw-plugin` | Host Integration | `core/`, `hooks/`, `service/` | ← `@principles/core` |
-| `@principles/pd-cli` | Operator CLI | `src/commands/` | ← `@principles/core` |
+| `@principles/core` | Domain Core | `packages/principles-core/src/runtime-v2/` | 不依赖 openclaw-plugin / pd-cli（可依赖 TypeBox、SQLite、node/fs/path 等基础设施库） |
+| `openclaw-plugin` | Host Integration | `packages/openclaw-plugin/src/` | ← `@principles/core` |
+| `@principles/pd-cli` | Operator CLI | `packages/pd-cli/src/commands/` | ← `@principles/core` |
 
-> **核心约束**: `@principles/core` 不得依赖 `openclaw-plugin` 或 `@principles/pd-cli`。
+> **核心约束**: `@principles/core` 不得反向依赖 `openclaw-plugin` 或 `@principles/pd-cli`。Core Runtime SDK 可以依赖 TypeBox、better-sqlite3、node:path 等 infrastructure 库。
 
 ---
 
@@ -56,12 +56,12 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 | 步骤 | 代码位置 | 说明 |
 |------|---------|------|
-| Pain Signal 捕获 | `hooks/pain.ts` | Hook 层捕获执行失败 |
-| Pain Bridge | `core/pain-signal-bridge.ts` | 转换为标准 Task 输入 |
-| Task 入队 | `store/task/` | SQLite 持久化 |
-| Diagnostician 执行 | `runner/diagnostician-runner.ts` | 调用 LLM 诊断 |
-| Candidate Intake | `candidate-intake-service.ts` | 摄入诊断产出 |
-| Ledger 登记 | `adapter/principle-tree-ledger-adapter.ts` | 写入 Principle Tree |
+| Pain Signal 捕获 | `openclaw-plugin/src/hooks/pain.ts` | Hook 层捕获执行失败 |
+| Pain Bridge | `principles-core/src/runtime-v2/pain-signal-bridge.ts` | 转换为标准 Task 输入 |
+| Task 入队 | `principles-core/src/runtime-v2/store/task/` | SQLite 持久化 |
+| Diagnostician 执行 | `principles-core/src/runtime-v2/runner/diagnostician-runner.ts` | 调用 LLM 诊断 |
+| Candidate Intake | `principles-core/src/runtime-v2/candidate-intake-service.ts` | 摄入诊断产出 |
+| Ledger 登记 | `principles-core/src/runtime-v2/adapter/principle-tree-ledger-adapter.ts` | 写入 Principle Tree |
 
 **关键接口**:
 - `PainSignalBridge.createAndInvoke()` — 痛点上报
@@ -78,11 +78,11 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 | 步骤 | 代码位置 | 说明 |
 |------|---------|------|
-| 路由决策 | `internalization/routing-policy.ts` | 决定 L1/L2 内化路线 |
-| 编排执行 | `internalization/internalization-orchestrator.ts` | 协调内化任务 |
-| 模板生成 | `internalization/template-generator.ts` | L2: 生成 Rule 代码模板 |
-| RuleHost 评估 | `internalization/rule-host-evaluator.ts` | L2: 执行 Rule 逻辑 |
-| 生命周期管理 | `internalization/lifecycle-metrics.ts` | 追踪 Rule 健康度 |
+| 路由决策 | `principles-core/src/runtime-v2/internalization/routing-policy.ts` | 决定 L1/L2 内化路线 |
+| 编排执行 | `principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts` | 协调内化任务 |
+| 模板生成 | `principles-core/src/runtime-v2/internalization/template-generator.ts` | L2: 生成 Rule 代码模板 |
+| RuleHost 评估 | `principles-core/src/runtime-v2/internalization/rule-host-evaluator.ts` | L2: 执行 Rule 逻辑 |
+| 生命周期管理 | `principles-core/src/runtime-v2/internalization/lifecycle-metrics.ts` | 追踪 Rule 健康度 |
 
 **内化路线**（详见 [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) Section 3）:
 
@@ -96,18 +96,27 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 **核心价值**: 清理无效知识，防止知识库膨胀。
 
+**当前已实现**:
+
 ```
-[Principle Tree] → [PruningReadModel] → [Pruning Signal] → [Pruning Review] → [Pruning Action]
+[Principle Tree] → [PruningReadModel] → [Pruning Signal] → [Pruning Review Log]
 ```
 
-| 步骤 | 代码位置 | 说明 |
-|------|---------|------|
-| 健康度扫描 | `pruning-read-model.ts` | 计算使用率和违背率 |
-| 信号生成 | `pruning-mask.ts` | 生成 Pruning Signal |
-| 审计记录 | `pruning-review-log.ts` | 只读的审计日志 |
-| 执行修剪 | CLI `prune` 命令 | 操作员确认后执行 |
+| 步骤 | 代码位置 | 说明 | 实现状态 |
+|------|---------|------|---------|
+| 健康度扫描 | `principles-core/src/runtime-v2/pruning-read-model.ts` | 计算使用率和违背率 | ✅ 已实现 |
+| 信号生成 | `principles-core/src/runtime-v2/pruning-mask.ts` | 生成 Pruning Signal | ✅ 已实现 |
+| 审计记录 | `principles-core/src/runtime-v2/pruning-review-log.ts` | 只读的 append-only 审计日志 | ✅ 已实现 |
 
-**关键约束**: Pruning Review 和 Pruning Action 严格分离。Review 只读，Action 需人工确认。
+**关键约束**: PruningReadModel 是非破坏性读模型，PruningReviewLog 是 append-only 审计日志。两者均不修改 Ledger 或 state.db。
+
+**未来能力（未实现）**:
+
+| 能力 | 说明 | 前置条件 |
+|------|------|---------|
+| PruningAction | 执行实际的 Principle/Rule 删除或降级 | 需要独立 issue、dry-run 验证、人类确认、rollback plan |
+
+> **⚠️ 重要**: 当前代码中没有 `prune` CLI 命令或 PruningAction 实现。任何修剪动作必须经过操作员手动审查 PruningReadModel 输出后，通过直接编辑 Ledger 文件完成。
 
 ### Pipeline 4: Nocturnal（夜间训练链路）⚠️ 实验性
 
@@ -119,12 +128,12 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 | 步骤 | 代码位置 | 说明 |
 |------|---------|------|
-| Trinity 反思链 | `core/nocturnal-trinity.ts` | Dreamer → Philosopher → Scribe |
-| 数据导出 | `core/nocturnal-export.ts` | 生成 ORPO 训练数据 |
-| 训练执行 | `core/training-program.ts` | 调用外部 Python 训练器 |
-| Checkpoint 注册 | `core/model-training-registry.ts` | 训练产出登记 |
-| 推广门控 | `core/promotion-gate.ts` | 评估后决定是否部署 |
-| 部署注册 | `core/model-deployment-registry.ts` | 部署状态管理 |
+| Trinity 反思链 | `openclaw-plugin/src/core/nocturnal-trinity.ts` | Dreamer → Philosopher → Scribe |
+| 数据导出 | `openclaw-plugin/src/core/nocturnal-export.ts` | 生成 ORPO 训练数据 |
+| 训练执行 | `openclaw-plugin/src/core/training-program.ts` | 调用外部 Python 训练器 |
+| Checkpoint 注册 | `openclaw-plugin/src/core/model-training-registry.ts` | 训练产出登记 |
+| 推广门控 | `openclaw-plugin/src/core/promotion-gate.ts` | 评估后决定是否部署 |
+| 部署注册 | `openclaw-plugin/src/core/model-deployment-registry.ts` | 部署状态管理 |
 
 > **⚠️ 实验性标记**: 此流水线涉及外部 Python 训练器、GPU 硬件依赖和模型评估，目前仅在 `local-reader` profile 下测试。`LOCAL_EDITOR_ENABLED = false`。不建议在生产环境依赖此流水线。
 
@@ -136,7 +145,7 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 ### GFI（Global Friction Index）
 
-**代码位置**: `runtime-v2/gfi/`
+**代码位置**: `packages/principles-core/src/runtime-v2/gfi/`
 
 追踪工作区的摩擦力指标，用于自适应阈值调整。
 
@@ -148,7 +157,7 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 ### Runtime Adapter
 
-**代码位置**: `runtime-v2/adapter/`
+**代码位置**: `packages/principles-core/src/runtime-v2/adapter/`
 
 解耦 PD 逻辑与外部 LLM 运行时。
 
@@ -160,7 +169,7 @@ PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线�
 
 ### Error System
 
-**代码位置**: `runtime-v2/error-categories.ts`
+**代码位置**: `packages/principles-core/src/runtime-v2/error-categories.ts`
 
 统一错误分类，详见 [ERROR_ARCHITECTURE.md](./ERROR_ARCHITECTURE.md)。
 
@@ -186,12 +195,14 @@ graph TD
         direction TB
         P1["Pipeline 1: Pain Chain<br/>PainBridge → Task → Run → Candidate → Ledger"]
         P2["Pipeline 2: Internalization<br/>Routing → Compile → RuleHost → Lifecycle"]
-        P3["Pipeline 3: Pruning<br/>ReadModel → Signal → Review → Action"]
+        P3["Pipeline 3: Pruning (已实现)<br/>ReadModel → Signal → Review Log"]
+        P3F["Pipeline 3: Pruning (未来)<br/>Review → Action ⚠️"]
         GFI["GFI Module"]
         Adapter["Runtime Adapter"]
         Err["Error System"]
     end
     class CorePkg core
+    class P3F experimental
 
     subgraph PluginPkg["📦 openclaw-plugin"]
         direction TB
@@ -213,6 +224,7 @@ graph TD
     Adapter --> Model
     P2 --> P1
     P3 --> User
+    P3 -.-> P3F
     P4 --> Model
     Services --> P1
     CLI --> CorePkg

--- a/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
@@ -1,161 +1,234 @@
 # PD 系统架构蓝图 (System Architecture Blueprint)
 
-> **状态**: 规划中 (Draft)
-> **最后更新**: 2026-05-07
-> **背景**: 基于系统动力学（System Dynamics）和本体树（DOMAIN_MODEL.md）重构设计的 PD 分层架构蓝图。
+> **状态**: Accepted
+> **最后更新**: 2026-05-09
+> **背景**: 基于系统动力学（System Dynamics）和本体树（DOMAIN_MODEL.md）重构设计的 PD 分层架构蓝图。本文档与 ADR-0001、ADR-0002 保持一致。
 
-本文档定义了 PD 系统的 **3 大物理层级** 和 **5 个功能子系统**。该架构彻底分离了“知识管理”、“执行编排”和“环境交互”，为后续的代码重构明确了物理边界。
-
----
-
-## 1. 核心领域与运行时 SDK 层 (Core Domain & Runtime SDK Layer) —— *系统的“大脑与记忆”*
-
-**定位**：承载 PD 的核心领域模型、运行时服务、读模型、状态机和适配器契约。它对 OpenClaw 等宿主保持解耦，但可以通过明确的 SDK 边界拥有 Runtime V2 的 store、read model、service facade 和 adapter contract。
-**边界约束**：不得依赖 OpenClaw plugin hook、OpenClaw UI、宿主会话对象或宿主专属命令；可以定义并实现 core-owned runtime 组件，例如 `RuntimeStateManager`、`PainToPrincipleService`、`PainChainReadModel`、`InternalizationOrchestrator` 和 operator read models。
-
-本层内部需要区分两类职责：
-
-- **Pure Domain Model**：纯类型、纯决策函数、schema、本体约束和状态机规则。应尽量无 I/O。
-- **Core Runtime SDK**：面向 CLI、plugin、未来 IDE/standalone host 复用的运行时服务、读模型、store adapter 和 runtime adapter contract。允许通过 adapter 访问 `.pd/state.db`、`.state` ledger 或外部 runtime，但不能反向依赖宿主实现。
-
-### 子系统 1：领域知识管理树 (Ontology Tree Subsystem)
-- **核心功能**：管理 `Principle`（原则）、`Rule`（规则）和 `Implementation`（实现）的增删改查及生命周期转换（Candidate -> Probation -> Active -> Archived）。
-- **边界**：只负责验证数据合法性（例如：Rule 必须归属于 Principle）。不管这些数据怎么存、怎么被注入。
-
-### 子系统 2：知识代谢与修剪 (Metabolism & Pruning Subsystem)
-- **核心功能**：系统动力学中的“减压回路”。扫描孤儿节点，计算原则的使用率和违背率，生成 `Pruning Signal`（修剪信号）。接收操作员的 `Pruning Review`（只读的审计记录）。真正的降级或归档被称为 `Pruning Action`（Future Scope），需要干跑 (dry-run)、人类确认和回滚计划，而不是由 Review 直接执行。
-- **边界**：不直接拦截请求，只提供“健康报告”和“淘汰提案”。
+本文档定义 PD 系统的 **3 大物理层级** 和 **4 条核心流水线**。架构以实际代码结构为锚点，每条流水线直接映射到可追踪的代码目录和文件。
 
 ---
 
-## 2. 编排与动力引擎层 (Orchestration Engine Layer) —— *系统的“心脏与泵”*
+## 0. 包边界与所有权
 
-**定位**：负责将底层的知识模型与外围的请求连接起来，驱动异步工作流，管理系统状态机。
-**边界约束**：依赖第 1 层，通过 Adapter（适配器模式）调用外围环境。
+| 包 | 角色 | 核心目录 | 依赖方向 |
+|----|------|---------|---------|
+| `@principles/core` | Domain Core | `runtime-v2/` | 无外部依赖 |
+| `openclaw-plugin` | Host Integration | `core/`, `hooks/`, `service/` | ← `@principles/core` |
+| `@principles/pd-cli` | Operator CLI | `src/commands/` | ← `@principles/core` |
 
-### 子系统 3：自动化进化环 (Automated Evolution Subsystem)
-- **核心功能**：系统动力学中的“增长回路”。包含 `Evolution Worker` 和基于 `workflows.yaml` 的工作流引擎。将环境传来的 `Pain Signal`（痛点流量）转化为诊断任务，分配给专门的 `Diagnostician Agent`，并将产出摄入为新的 `Principle/Rule`（增加存量）。
-- **边界**：只负责流程的流转（Task 状态机）。诊断的具体动作委托给模型执行。
-
----
-
-## 3. 宿主接入与执行层 (Host Integration Layer) —— *系统的“眼耳手脚”*
-
-**定位**：与外部环境（如 OpenClaw 框架、终端 CLI、文件系统）的硬接触点。
-**边界约束**：最外层代码，负责处理输入输出、拦截、格式转换。
-
-### 子系统 4：感知与门控 (Perception & Gating Subsystem)
-- **核心功能**：包含所有的 Hooks。
-  - **感知**：监听执行失败、用户纠正，提取上下文，生成并上报 `Pain Signal`。
-  - **门控 (RuleHost)**：在 `before_tool_call` 时，向第 1 层查询当前活跃的 `Rule`，如果匹配则执行硬拦截（Block/RequireApproval）。
-- **边界**：绝对不能包含业务逻辑（如判断这个痛点是不是新痛点）。它只负责“捕获抛出”和“拿牌照拦人”。
-
-### 子系统 5：心智注入与代理 (Mind Injection & Agent Subsystem)
-- **核心功能**：
-  - **注入**：在 `before_prompt_build` 时，向第 1 层查询活跃的 `Principle`，计算上下文预算，格式化后注入给主模型的 System Prompt。
-  - **路由**：提供 `AgentSpec` 规范，管理用于诊断、修复的各类专属子代理（Subagents）的调用和销毁。
-- **边界**：只做格式化（Prompt 组装）和调用外部模型 API。
+> **核心约束**: `@principles/core` 不得依赖 `openclaw-plugin` 或 `@principles/pd-cli`。
 
 ---
 
-## 🗺️ 系统架构图 (Architecture Diagram)
+## 1. 三层架构
+
+### Layer 1: Core Domain & Runtime SDK（`@principles/core`）
+
+承载 PD 的核心领域逻辑。所有不依赖 OpenClaw API 的业务代码都属于此层。
+
+**代码位置**: `packages/principles-core/src/runtime-v2/`
+
+### Layer 2: Orchestration & Services（`openclaw-plugin/service/`）
+
+驱动异步工作流、管理队列和调度。依赖 Layer 1，通过 Adapter 调用外部模型。
+
+**代码位置**: `packages/openclaw-plugin/src/service/`
+
+### Layer 3: Host Integration（`openclaw-plugin/hooks/`）
+
+与 OpenClaw 框架的硬接触点。只做输入捕获和输出注入，不含业务逻辑。
+
+**代码位置**: `packages/openclaw-plugin/src/hooks/`
+
+---
+
+## 2. 四条核心流水线
+
+PD 系统的核心行为可以归纳为 4 条数据流水线。每条流水线有明确的输入、处理步骤和输出。
+
+### Pipeline 1: Pain Chain（痛点链路）
+
+**核心价值**: 将环境中的失败信号转化为可复用的知识。
+
+```
+[Pain Signal] → [PainBridge] → [TaskStore] → [DiagnosticianRunner] → [CandidateIntake] → [Ledger]
+```
+
+| 步骤 | 代码位置 | 说明 |
+|------|---------|------|
+| Pain Signal 捕获 | `hooks/pain.ts` | Hook 层捕获执行失败 |
+| Pain Bridge | `core/pain-signal-bridge.ts` | 转换为标准 Task 输入 |
+| Task 入队 | `store/task/` | SQLite 持久化 |
+| Diagnostician 执行 | `runner/diagnostician-runner.ts` | 调用 LLM 诊断 |
+| Candidate Intake | `candidate-intake-service.ts` | 摄入诊断产出 |
+| Ledger 登记 | `adapter/principle-tree-ledger-adapter.ts` | 写入 Principle Tree |
+
+**关键接口**:
+- `PainSignalBridge.createAndInvoke()` — 痛点上报
+- `DiagnosticianRunner.run()` — 诊断执行
+- `CandidateIntakeService.process()` — 候选摄入
+
+### Pipeline 2: Internalization（内化链路）
+
+**核心价值**: 将 Principle 转化为可执行的 Rule/Implementation。
+
+```
+[Principle] → [RoutingPolicy] → [InternalizationOrchestrator] → [TemplateGenerator/RuleHost] → [LifecycleMetrics] → [Active Rule]
+```
+
+| 步骤 | 代码位置 | 说明 |
+|------|---------|------|
+| 路由决策 | `internalization/routing-policy.ts` | 决定 L1/L2 内化路线 |
+| 编排执行 | `internalization/internalization-orchestrator.ts` | 协调内化任务 |
+| 模板生成 | `internalization/template-generator.ts` | L2: 生成 Rule 代码模板 |
+| RuleHost 评估 | `internalization/rule-host-evaluator.ts` | L2: 执行 Rule 逻辑 |
+| 生命周期管理 | `internalization/lifecycle-metrics.ts` | 追踪 Rule 健康度 |
+
+**内化路线**（详见 [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) Section 3）:
+
+| 路线 | 载体 | 状态 |
+|------|------|------|
+| L1: 软内化 | System Prompt 注入 | ✅ 生产可用 |
+| L2: 硬内化 | RuleHost / Hook / Tool | ✅ 生产可用 |
+| L3: 模型参数化 | LoRA / Fine-tuning | ⚠️ 实验性（见 Pipeline 4） |
+
+### Pipeline 3: Pruning（修剪链路）
+
+**核心价值**: 清理无效知识，防止知识库膨胀。
+
+```
+[Principle Tree] → [PruningReadModel] → [Pruning Signal] → [Pruning Review] → [Pruning Action]
+```
+
+| 步骤 | 代码位置 | 说明 |
+|------|---------|------|
+| 健康度扫描 | `pruning-read-model.ts` | 计算使用率和违背率 |
+| 信号生成 | `pruning-mask.ts` | 生成 Pruning Signal |
+| 审计记录 | `pruning-review-log.ts` | 只读的审计日志 |
+| 执行修剪 | CLI `prune` 命令 | 操作员确认后执行 |
+
+**关键约束**: Pruning Review 和 Pruning Action 严格分离。Review 只读，Action 需人工确认。
+
+### Pipeline 4: Nocturnal（夜间训练链路）⚠️ 实验性
+
+**核心价值**: 通过离线训练将知识固化到模型参数中。
+
+```
+[Session Data] → [Trinity Chain] → [Export] → [Training] → [Checkpoint] → [Promotion Gate] → [Deployment]
+```
+
+| 步骤 | 代码位置 | 说明 |
+|------|---------|------|
+| Trinity 反思链 | `core/nocturnal-trinity.ts` | Dreamer → Philosopher → Scribe |
+| 数据导出 | `core/nocturnal-export.ts` | 生成 ORPO 训练数据 |
+| 训练执行 | `core/training-program.ts` | 调用外部 Python 训练器 |
+| Checkpoint 注册 | `core/model-training-registry.ts` | 训练产出登记 |
+| 推广门控 | `core/promotion-gate.ts` | 评估后决定是否部署 |
+| 部署注册 | `core/model-deployment-registry.ts` | 部署状态管理 |
+
+> **⚠️ 实验性标记**: 此流水线涉及外部 Python 训练器、GPU 硬件依赖和模型评估，目前仅在 `local-reader` profile 下测试。`LOCAL_EDITOR_ENABLED = false`。不建议在生产环境依赖此流水线。
+
+---
+
+## 3. 辅助模块
+
+以下模块为流水线提供支撑，但不构成独立流水线：
+
+### GFI（Global Friction Index）
+
+**代码位置**: `runtime-v2/gfi/`
+
+追踪工作区的摩擦力指标，用于自适应阈值调整。
+
+| 组件 | 说明 |
+|------|------|
+| `gfi-kernel.ts` | 摩擦力计算核心（applyFriction / applyDecay / applyRelief） |
+| `gfi-policy.ts` | 摩擦力策略配置 |
+| `gfi-read-model.ts` | 工作区摩擦力快照 |
+
+### Runtime Adapter
+
+**代码位置**: `runtime-v2/adapter/`
+
+解耦 PD 逻辑与外部 LLM 运行时。
+
+| 适配器 | 说明 |
+|--------|------|
+| `openclaw-cli-runtime-adapter.ts` | OpenClaw CLI 执行 |
+| `pi-ai-runtime-adapter.ts` | 直接 LLM API 调用 |
+| `test-double-runtime-adapter.ts` | 测试替身 |
+
+### Error System
+
+**代码位置**: `runtime-v2/error-categories.ts`
+
+统一错误分类，详见 [ERROR_ARCHITECTURE.md](./ERROR_ARCHITECTURE.md)。
+
+---
+
+## 4. 系统架构图
 
 ```mermaid
 graph TD
-    %% ================= 样式定义 =================
     classDef external fill:#f9f9f9,stroke:#333,stroke-width:2px,stroke-dasharray: 5 5
-    classDef layer3 fill:#e1f5fe,stroke:#4fc3f7,stroke-width:2px
-    classDef layer2 fill:#fff3e0,stroke:#64b5f6,stroke-width:2px
-    classDef layer1 fill:#f3e5f5,stroke:#0277bd,stroke-width:2px
-    classDef data fill:#eceff1,stroke:#9c27b0,stroke-width:2px
+    classDef core fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    classDef plugin fill:#fff3e0,stroke:#ff9800,stroke-width:2px
+    classDef experimental fill:#fce4ec,stroke:#c62828,stroke-width:2px,stroke-dasharray: 3 3
 
-    %% ================= 外部环境 =================
-    subgraph Environment["🌍 外部环境 (External)"]
-        User(["👨‍💻 用户 (User)"])
-        OpenClaw["🤖 OpenClaw Core"]
-        FileSystem["📁 业务代码/文件系统"]
+    subgraph Environment["外部环境"]
+        OpenClaw["OpenClaw Gateway"]
+        Model["LLM Model"]
+        User["操作员"]
     end
     class Environment external
 
-    %% ================= 宿主接入与执行层 =================
-    subgraph Layer3["🛡️ Layer 3: 宿主接入与执行层 (Host Integration)"]
-        direction LR
-        subgraph Subsystem4["👀 子系统4: 感知与门控"]
-            PainBridge["🔥 Pain Signal Bridge\n(痛点捕捉)"]
-            RuleGate["⛔ RuleHost Gate\n(工具硬拦截)"]
-        end
-
-        subgraph Subsystem5["🧠 子系统5: 心智注入与代理"]
-            PromptInjector["💉 Prompt Injector\n(软原则注入)"]
-            AgentRunner["🏃‍♂️ Subagent Runner\n(驱动特殊代理)"]
-        end
-    end
-    class Layer3 layer3
-
-    %% ================= 编排与动力引擎层 =================
-    subgraph Layer2["⚙️ Layer 2: 编排与动力引擎层 (Orchestration Engine)"]
+    subgraph CorePkg["📦 @principles/core"]
         direction TB
-        subgraph Subsystem3["🔄 子系统3: 自动化进化环"]
-            Worker["👷 Evolution Worker\n(后台守护进程)"]
-            WorkflowEngine["📜 Workflow Engine\n(YAML 流程驱动)"]
-            TaskManager["📋 Task State Machine\n(诊断/反思任务队列)"]
-
-            Worker -->|定时触发| WorkflowEngine
-            WorkflowEngine <-->|读写状态| TaskManager
-        end
+        P1["Pipeline 1: Pain Chain<br/>PainBridge → Task → Run → Candidate → Ledger"]
+        P2["Pipeline 2: Internalization<br/>Routing → Compile → RuleHost → Lifecycle"]
+        P3["Pipeline 3: Pruning<br/>ReadModel → Signal → Review → Action"]
+        GFI["GFI Module"]
+        Adapter["Runtime Adapter"]
+        Err["Error System"]
     end
-    class Layer2 layer2
+    class CorePkg core
 
-    %% ================= 核心领域层 =================
-    subgraph Layer1["🌳 Layer 1: 核心领域与运行时 SDK 层 (Core Domain & Runtime SDK)"]
-        direction LR
-        subgraph Subsystem1["📚 子系统1: 知识管理树"]
-            PrincipleEntity["🌱 Principle (软原则)\n[价值观/What]"]
-            RuleEntity["🌿 Rule (硬规则)\n[契约/When/How]"]
-            ImplEntity["🍂 Implementation\n[承载代码]"]
-
-            PrincipleEntity -->|1:N 派生| RuleEntity
-            RuleEntity -->|1:N 承载| ImplEntity
-        end
-
-        subgraph Subsystem2["✂️ 子系统2: 知识代谢与修剪"]
-            ReadModel["📊 Health Read Model\n(发现孤儿/冲突)"]
-            ReviewController["🔍 Pruning Review\n(人类只读审计)"]
-            PruningAction["🧾 Pruning Action\n(Future: dry-run/confirm/rollback)"]
-        end
+    subgraph PluginPkg["📦 openclaw-plugin"]
+        direction TB
+        Hooks["Hooks Layer<br/>pain / gate / prompt / trajectory"]
+        Services["Services Layer<br/>evolution-worker / nocturnal-service"]
+        P4["Pipeline 4: Nocturnal ⚠️<br/>Trinity → Export → Training → Deployment"]
     end
-    class Layer1 layer1
+    class PluginPkg plugin
+    class P4 experimental
 
-    %% ================= 数据持久层 =================
-    subgraph DataLayer["💾 数据持久层 (State & Persistence)"]
-        LedgerDB[("📘 Principle Ledger\n(知识账本)")]
-        StateDB[("🗄️ State DB\n(痛点/任务/轨迹)")]
+    subgraph CLI["📦 @principles/pd-cli"]
+        CLICmds["CLI Commands<br/>diagnose / probe / trace"]
     end
-    class DataLayer data
 
-    %% ================= 核心信息流转 (System Dynamics) =================
-
-    %% 1. 痛点流入 (感知)
-    OpenClaw --执行报错/纠正--> PainBridge
-    PainBridge -.上报痛点流量.-> StateDB
-    PainBridge ==>|唤醒| TaskManager
-
-    %% 2. 诊断与进化 (增长回路)
-    TaskManager -->|分配诊断任务| AgentRunner
-    AgentRunner --调用大模型--> OpenClaw
-    AgentRunner ==>|产出| Subsystem1
-    Subsystem1 -.写入存量.-> LedgerDB
-
-    %% 3. 约束与拦截 (执行反作用)
-    LedgerDB -.查询硬规则.-> RuleGate
-    RuleGate --拦截危险操作--> OpenClaw
-    LedgerDB -.查询软原则.-> PromptInjector
-    PromptInjector --注入上下文--> OpenClaw
-
-    %% 4. 代谢与修剪 (减压回路)
-    LedgerDB -.分析使用率.-> ReadModel
-    ReadModel --> ReviewController
-    User --"pd pruning" CLI--> ReviewController
-    ReviewController -.审计意图.-> PruningAction
-    PruningAction -.未来执行生命周期变更.-> Subsystem1
+    OpenClaw --> Hooks
+    Hooks --> P1
+    Hooks --> P2
+    P1 --> Adapter
+    Adapter --> Model
+    P2 --> P1
+    P3 --> User
+    P4 --> Model
+    Services --> P1
+    CLI --> CorePkg
+    GFI -.-> P1
+    Err -.-> P1
+    Err -.-> P2
 ```
+
+---
+
+## 5. 相关文档
+
+| 文档 | 说明 |
+|------|------|
+| [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) | 核心领域术语和本体定义 |
+| [DATA_ARCHITECTURE.md](./DATA_ARCHITECTURE.md) | 数据存储架构 |
+| [ERROR_ARCHITECTURE.md](./ERROR_ARCHITECTURE.md) | 错误处理架构 |
+| [ADR-0001](../adr/0001-runtime-v2-service-boundaries.md) | Runtime V2 Service Boundaries |
+| [ADR-0002](../adr/0002-hard-internalization-core-boundary.md) | Hard Internalization Core Boundary |

--- a/docs/architecture/PD_System_Dynamics_Model.md
+++ b/docs/architecture/PD_System_Dynamics_Model.md
@@ -61,7 +61,9 @@ PD 系统的生与死，由以下三个相互交织的反馈环决定：
 
 ## 4. 破局机制：三类内化路线 (Three Internalization Routes)
 
-根据回路 3 的要求，PD 系统的“内化”绝不仅仅是攒数据做 LoRA 训练。我们将 PD 的减压机制解构为三个层级：
+根据回路 3 的要求，PD 系统的"内化"绝不仅仅是攒数据做 LoRA 训练。我们将 PD 的减压机制解构为三个层级：
+
+> **术语说明**：本节使用 L1/L2/L3 编号与 [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) Section 3 保持一致。L1=软内化（Prompt），L2=硬内化（Code/Hook/Tool），L3=模型参数化（LoRA）。
 
 ### L1: 软内化 (Prompt / Skill / SOP)
 *   **载体**：System Prompt、Skill 文档、SOP。

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,19 +1,119 @@
 # PD 架构文档索引 (Architecture Documentation Index)
 
-本目录包含 Principles Disciple (PD) 项目的核心架构文档。这些文档按照不同的抽象层级和用途进行组织：
+> **最后更新**: 2026-05-09
+> **语言**: 中文（部分子文档为英文）
 
-## 1. 核心本体 (The Ontology)
-- **[DOMAIN_MODEL.md](./DOMAIN_MODEL.md)**: **强制执行 (LOCKED-ONTOLOGY)**。定义了项目的统一领域语言（Ubiquitous Language）和核心实体（Principle, Rule, Implementation）的语义及生命周期。它是所有重构和开发的最高准则。
+本目录包含 Principles Disciple (PD) 项目的核心架构文档。这些文档按照不同的抽象层级和用途进行组织。
 
-## 2. 目标架构蓝图 (Target Architecture)
-- **[PD_SYSTEM_ARCHITECTURE.md](./PD_SYSTEM_ARCHITECTURE.md)**: **目标分层架构蓝图**。详细规划了 3 大物理层级和 5 个功能子系统。它定义了各子系统的功能边界和物理边界，是代码重构的实施蓝图。
-  - 注意：其中的 Core 层包含 **Pure Domain Model** 与 **Core Runtime SDK** 两个子边界。不要把“core 不依赖宿主”误读为“core 不能拥有 Runtime V2 store/read-model/service”。
+---
 
-## 3. 战略分析 (Strategic Analysis)
-- **[PD_System_Dynamics_Model.md](./PD_System_Dynamics_Model.md)**: **战略/系统动力学分析**。从系统动力学（Stock, Flow, Feedback Loop）视角解释系统进化的动力源泉和瓶颈（上下文压力）。此文档提供宏观视角，**不得覆盖或违反 DOMAIN_MODEL.md 中的实体定义**。
+## 📖 推荐阅读顺序
 
-## 4. 历史与细节设计 (Historical & Detailed Design)
-- **[pd-task-manager.md](./pd-task-manager.md)**: 任务管理器的详细设计文档。除非明确重新验证，否则视为历史设计参考。
+```
+1. DOMAIN_MODEL.md          → 理解核心术语和领域语言
+        ↓
+2. PD_SYSTEM_ARCHITECTURE.md → 理解三层架构和四条流水线
+        ↓
+3. DATA_ARCHITECTURE.md     → 理解数据存储架构
+        ↓
+4. ERROR_ARCHITECTURE.md    → 理解错误处理策略
+        ↓
+5. PD_System_Dynamics_Model.md → 理解系统动力学（宏观视角）
+```
+
+---
+
+## 🗂️ 文档分类
+
+### 核心本体 (LOCKED)
+
+| 文档 | 状态 | 说明 |
+|------|------|------|
+| [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) | **LOCKED-ONTOLOGY** | 统一领域语言，Principle/Rule/Implementation 光谱模型，生命周期状态机 |
+
+### 目标架构蓝图 (Active)
+
+| 文档 | 状态 | 说明 |
+|------|------|------|
+| [PD_SYSTEM_ARCHITECTURE.md](./PD_SYSTEM_ARCHITECTURE.md) | **Accepted** | 3 大物理层级，4 条核心流水线，包边界 |
+| [DATA_ARCHITECTURE.md](./DATA_ARCHITECTURE.md) | **Active** | 数据存储架构，读写分离，迁移策略 |
+| [ERROR_ARCHITECTURE.md](./ERROR_ARCHITECTURE.md) | **Active** | PDErrorCategory 错误分类，PDRuntimeError，降级路径 |
+
+### 战略分析 (Reference)
+
+| 文档 | 状态 | 说明 |
+|------|------|------|
+| [PD_System_Dynamics_Model.md](./PD_System_Dynamics_Model.md) | **Final** | 系统动力学视角，存量/流量/反馈回路分析 |
+
+### 历史与废弃文档
+
+| 文档 | 状态 | 说明 |
+|------|------|------|
+| [pd-task-manager.md](./pd-task-manager.md) | **Partially Implemented** | Task Manager 设计，已部分实施（cron-initializer.ts 已删除） |
+
+---
+
+## 🔍 决策查阅指南
+
+| 遇到的问题 | 应该查阅的文档 |
+|------------|---------------|
+| **术语/命名歧义** | DOMAIN_MODEL.md → 命名禁区（Section 8） |
+| **代码放哪个包** | PD_SYSTEM_ARCHITECTURE.md → Section 0（包边界） |
+| **流水线边界争议** | PD_SYSTEM_ARCHITECTURE.md → Section 2（四条流水线） |
+| **数据存储选型** | DATA_ARCHITECTURE.md |
+| **错误处理策略** | ERROR_ARCHITECTURE.md |
+| **系统行为分析** | PD_System_Dynamics_Model.md |
+| **迁移计划查询** | ADR（见下方）或 architecture-governance/GRADUAL_ROADMAP.md |
+
+---
+
+## 📎 相关文档
+
+### 架构决策记录 (ADR)
+
+| ADR | 状态 | 主题 |
+|-----|------|------|
+| [ADR-0001](../adr/0001-runtime-v2-service-boundaries.md) | Accepted | Runtime V2 Service Boundaries |
+| [ADR-0002](../adr/0002-hard-internalization-core-boundary.md) | Accepted | Hard Internalization Core Boundary |
+
+### 架构治理
+
+| 文档 | 说明 |
+|------|------|
+| [architecture-governance/](../architecture-governance/README.md) | 渐进式架构治理，增量迁移策略 |
+| [architecture-governance/PRINCIPLE-TREE-ARCHITECTURE.md](../architecture-governance/PRINCIPLE-TREE-ARCHITECTURE.md) | 原则树设计的具象化约定 |
+
+### 废弃文档
+
+| 文档 | 废弃原因 |
+|------|---------|
+| [../ARCHITECTURE.md](../ARCHITECTURE.md) | 已被 PD_SYSTEM_ARCHITECTURE.md 取代 |
+
+---
+
+## 🏗️ 文档贡献规范
+
+1. **术语使用**：所有代码、schema、Linear issue title 和 ADR 必须使用 DOMAIN_MODEL.md 定义的标准术语
+2. **状态标记**：每个文档头部必须标注状态（Draft / Active / Accepted / LOCKED-ONTOLOGY / Deprecated）
+3. **交叉引用**：文档间应互相引用，避免重复定义
+4. **废弃处理**：废弃文档必须添加废弃标记并指向替代文档
+5. **代码锚点**：架构描述必须指向实际代码位置，不得描述不存在的组件
+
+---
+
+## 🔗 核心概念索引
+
+| 概念 | 定义位置 | 状态 |
+|------|---------|------|
+| Principle | DOMAIN_MODEL.md Section 1-2 | LOCKED |
+| Rule | DOMAIN_MODEL.md Section 1-3 | LOCKED |
+| Implementation | DOMAIN_MODEL.md Section 1-4 | LOCKED |
+| Pain Signal | DOMAIN_MODEL.md Section 4 | LOCKED |
+| Internalization (L1/L2/L3) | DOMAIN_MODEL.md Section 3 | LOCKED |
+| Pruning Signal | DOMAIN_MODEL.md Section 4 | LOCKED |
+| Pruning Review | DOMAIN_MODEL.md Section 5.3 | LOCKED |
+| PDErrorCategory | ERROR_ARCHITECTURE.md Section 1 | Active |
+| GFI | PD_SYSTEM_ARCHITECTURE.md Section 3 | Active |
 
 ---
 

--- a/docs/architecture/pd-task-manager.md
+++ b/docs/architecture/pd-task-manager.md
@@ -1,9 +1,16 @@
 # PD Task Manager — Design Document
 
-> **Status**: Draft  
-> **Date**: 2026-04-07  
-> **Author**: Qwen-Coder  
+> **Status**: Partially Implemented
+> **Date**: 2026-04-07
+> **Author**: Qwen-Coder
 > **Related PR**: [#174](https://github.com/csuzngjh/principles/pull/174)
+>
+> **⚠️ 实现状态**：
+> - ✅ PDTaskSpec 类型定义已创建
+> - ✅ PDTaskStore 已创建
+> - ✅ cron-initializer.ts 已删除
+> - ⏳ PDTaskService（Plugin Service 集成）待完成
+> - 📁 本文档保留作为迁移计划参考
 
 ---
 

--- a/docs/architecture/pd-task-manager.md
+++ b/docs/architecture/pd-task-manager.md
@@ -45,9 +45,9 @@ The common pattern: **these are background maintenance tasks that should not blo
 
 ## 2. Problem Statement
 
-### 2.1 Current Implementation (cron-initializer.ts)
+### 2.1 Historical Prototype (cron-initializer.ts) — DELETED
 
-The current code lives in `packages/openclaw-plugin/src/core/cron-initializer.ts`. It:
+The original prototype lived in `packages/openclaw-plugin/src/core/cron-initializer.ts` (now deleted). It:
 
 1. Reads `~/.openclaw/cron/jobs.json` directly via `fs.readFileSync`
 2. Checks if a job named "PD Empathy Optimizer" already exists

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -71,6 +71,9 @@ const REQUIRED_SOURCE_FILES = [
   'gfi/gfi-policy.ts',
   'gfi/gfi-kernel.ts',
   'gfi/index.ts',
+  // PRI-84
+  'internalization/pi-artifact.ts',
+  'internalization/pi-artifact-store.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [

--- a/packages/principles-core/src/runtime-v2/__tests__/pi-artifact-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pi-artifact-store.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  MemoryPIArtifactStore,
+} from '../internalization/pi-artifact-store.js';
+import type {
+  PIArtifactRecord,
+  PIArtifactStore,
+} from '../internalization/pi-artifact.js';
+
+function makeRecord(overrides: Partial<PIArtifactRecord> = {}): PIArtifactRecord {
+  return {
+    artifactId: overrides.artifactId ?? 'art-001',
+    artifactKind: overrides.artifactKind ?? 'principle',
+    sourceTaskId: overrides.sourceTaskId ?? 'task-001',
+    sourcePrincipleId: overrides.sourcePrincipleId,
+    sourceRuleId: overrides.sourceRuleId,
+    lineageArtifactIds: overrides.lineageArtifactIds ?? [],
+    validationStatus: overrides.validationStatus ?? 'pending',
+    contentJson: overrides.contentJson ?? '{}',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+describe('PIArtifactStore contract (PRI-84)', () => {
+  let store: PIArtifactStore = new MemoryPIArtifactStore();
+
+  beforeEach(() => {
+    store = new MemoryPIArtifactStore();
+  });
+
+  it('createArtifact persists a PIArtifact and returns it', async () => {
+    const record = makeRecord();
+
+    const result = await store.createArtifact(record);
+
+    expect(result).toEqual(record);
+
+    const fetched = await store.getArtifactById(record.artifactId);
+    expect(fetched).toEqual(record);
+  });
+
+  it('getArtifactById returns null for unknown artifact', async () => {
+    const result = await store.getArtifactById('nonexistent');
+
+    expect(result).toBeNull();
+  });
+
+  it('listBySourceTaskId returns all artifacts for a source task', async () => {
+    const r1 = makeRecord({ artifactId: 'art-1', sourceTaskId: 'task-A', artifactKind: 'principle' });
+    const r2 = makeRecord({ artifactId: 'art-2', sourceTaskId: 'task-A', artifactKind: 'rule' });
+    const r3 = makeRecord({ artifactId: 'art-3', sourceTaskId: 'task-B', artifactKind: 'principle' });
+
+    await store.createArtifact(r1);
+    await store.createArtifact(r2);
+    await store.createArtifact(r3);
+
+    const results = await store.listBySourceTaskId('task-A');
+
+    expect(results).toHaveLength(2);
+    expect(results.map(r => r.artifactId)).toEqual(expect.arrayContaining(['art-1', 'art-2']));
+  });
+
+  it('listLineage returns artifacts linked via lineageArtifactIds', async () => {
+    const parent = makeRecord({ artifactId: 'parent-art', sourceTaskId: 'task-parent', artifactKind: 'principle' });
+    const child = makeRecord({
+      artifactId: 'child-art',
+      sourceTaskId: 'task-child',
+      artifactKind: 'rule',
+      lineageArtifactIds: ['parent-art'],
+    });
+
+    await store.createArtifact(parent);
+    await store.createArtifact(child);
+
+    const lineage = await store.listLineage('child-art');
+
+    expect(lineage).toHaveLength(1);
+    expect(lineage[0]?.artifactId).toBe('parent-art');
+  });
+
+  it('idempotency: same sourceTaskId + artifactKind does not create duplicate', async () => {
+    const r1 = makeRecord({ sourceTaskId: 'task-X', artifactKind: 'principle' });
+    await store.createArtifact(r1);
+
+    const r2 = makeRecord({
+      artifactId: 'art-dup',
+      sourceTaskId: 'task-X',
+      artifactKind: 'principle',
+    });
+
+    await expect(store.createArtifact(r2)).rejects.toThrow();
+  });
+
+  it('upsertArtifact creates new when no matching sourceTaskId+kind exists', async () => {
+    const record = makeRecord({ sourceTaskId: 'task-Y', artifactKind: 'rule' });
+
+    const result = await store.upsertArtifact(record);
+
+    expect(result.artifactId).toBe(record.artifactId);
+
+    const fetched = await store.getArtifactById(record.artifactId);
+    expect(fetched).toEqual(record);
+  });
+
+  it('upsertArtifact updates existing when matching sourceTaskId+kind exists', async () => {
+    const original = makeRecord({
+      artifactId: 'art-original',
+      sourceTaskId: 'task-Z',
+      artifactKind: 'principle',
+      contentJson: '{"old": true}',
+    });
+    await store.createArtifact(original);
+
+    const updated = makeRecord({
+      artifactId: 'art-updated',
+      sourceTaskId: 'task-Z',
+      artifactKind: 'principle',
+      contentJson: '{"new": true}',
+      validationStatus: 'validated',
+    });
+
+    const result = await store.upsertArtifact(updated);
+
+    expect(result.contentJson).toBe('{"new": true}');
+    expect(result.validationStatus).toBe('validated');
+
+    const fetched = await store.getArtifactById('art-original');
+    expect(fetched).toBeNull();
+
+    const newFetched = await store.getArtifactById('art-updated');
+    expect(newFetched).toBeDefined();
+    if (newFetched) {
+      expect(newFetched.contentJson).toBe('{"new": true}');
+    }
+  });
+
+  it('listLineage returns empty array when no lineage refs', async () => {
+    const record = makeRecord({ artifactId: 'solo-art', lineageArtifactIds: [] });
+    await store.createArtifact(record);
+
+    const lineage = await store.listLineage('solo-art');
+
+    expect(lineage).toEqual([]);
+  });
+
+  it('allows different artifactKinds for same sourceTaskId', async () => {
+    const r1 = makeRecord({ artifactId: 'art-p', sourceTaskId: 'task-M', artifactKind: 'principle' });
+    const r2 = makeRecord({ artifactId: 'art-r', sourceTaskId: 'task-M', artifactKind: 'rule' });
+
+    await store.createArtifact(r1);
+    await store.createArtifact(r2);
+
+    const results = await store.listBySourceTaskId('task-M');
+    expect(results).toHaveLength(2);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -194,3 +194,8 @@ export type {
 } from './internalization-orchestrator.js';
 
 export { InternalizationOrchestrator, WAKE_ONCE_DECISIONS } from './internalization-orchestrator.js';
+
+// ── PIArtifact Durable Store (PRI-84) ────────────────────────────────────────
+
+export type { PIArtifactRecord, PIArtifactStore } from './pi-artifact.js';
+export { MemoryPIArtifactStore } from './pi-artifact-store.js';

--- a/packages/principles-core/src/runtime-v2/internalization/pi-artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pi-artifact-store.ts
@@ -1,0 +1,66 @@
+import type { PIArtifactRecord, PIArtifactStore } from './pi-artifact.js';
+
+export class MemoryPIArtifactStore implements PIArtifactStore {
+  private readonly artifacts = new Map<string, PIArtifactRecord>();
+
+  private readonly idempotencyIndex = new Map<string, string>();
+
+  private static idempotencyKey(sourceTaskId: string, artifactKind: string): string {
+    return `${sourceTaskId}::${artifactKind}`;
+  }
+
+  async createArtifact(record: PIArtifactRecord): Promise<PIArtifactRecord> {
+    const key = MemoryPIArtifactStore.idempotencyKey(record.sourceTaskId, record.artifactKind);
+    const existingId = this.idempotencyIndex.get(key);
+    if (existingId) {
+      throw new Error(
+        `Duplicate PIArtifact: sourceTaskId=${record.sourceTaskId} artifactKind=${record.artifactKind} already exists as ${existingId}`,
+      );
+    }
+
+    this.artifacts.set(record.artifactId, record);
+    this.idempotencyIndex.set(key, record.artifactId);
+    return record;
+  }
+
+  async upsertArtifact(record: PIArtifactRecord): Promise<PIArtifactRecord> {
+    const key = MemoryPIArtifactStore.idempotencyKey(record.sourceTaskId, record.artifactKind);
+    const existingId = this.idempotencyIndex.get(key);
+
+    if (existingId) {
+      this.artifacts.delete(existingId);
+    }
+
+    this.artifacts.set(record.artifactId, record);
+    this.idempotencyIndex.set(key, record.artifactId);
+    return record;
+  }
+
+  async getArtifactById(artifactId: string): Promise<PIArtifactRecord | null> {
+    return this.artifacts.get(artifactId) ?? null;
+  }
+
+  async listBySourceTaskId(sourceTaskId: string): Promise<PIArtifactRecord[]> {
+    const results: PIArtifactRecord[] = [];
+    for (const record of this.artifacts.values()) {
+      if (record.sourceTaskId === sourceTaskId) {
+        results.push(record);
+      }
+    }
+    return results;
+  }
+
+  async listLineage(artifactId: string): Promise<PIArtifactRecord[]> {
+    const artifact = this.artifacts.get(artifactId);
+    if (!artifact) return [];
+
+    const results: PIArtifactRecord[] = [];
+    for (const lineageId of artifact.lineageArtifactIds) {
+      const found = this.artifacts.get(lineageId);
+      if (found) {
+        results.push(found);
+      }
+    }
+    return results;
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/pi-artifact.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pi-artifact.ts
@@ -1,0 +1,24 @@
+import type { PIArtifactKind, PIArtifactValidationStatus } from './peer-runner-contracts.js';
+
+export type { PIArtifactKind, PIArtifactValidationStatus };
+
+export interface PIArtifactRecord {
+  artifactId: string;
+  artifactKind: PIArtifactKind;
+  sourceTaskId: string;
+  sourcePrincipleId?: string;
+  sourceRuleId?: string;
+  lineageArtifactIds: string[];
+  validationStatus: PIArtifactValidationStatus;
+  contentJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PIArtifactStore {
+  createArtifact(record: PIArtifactRecord): Promise<PIArtifactRecord>;
+  upsertArtifact(record: PIArtifactRecord): Promise<PIArtifactRecord>;
+  getArtifactById(artifactId: string): Promise<PIArtifactRecord | null>;
+  listBySourceTaskId(sourceTaskId: string): Promise<PIArtifactRecord[]>;
+  listLineage(artifactId: string): Promise<PIArtifactRecord[]>;
+}


### PR DESCRIPTION
## Summary

重构 `docs/architecture/` 目录下的顶层设计文档，解决多轮评审发现的一致性问题和过度设计。

## Changes

### 核心架构重构
- 8 子系统改为 4 流水线架构: Pain Chain / Internalization / Pruning / Nocturnal，每条流水线直接映射到代码文件路径
- PD_SYSTEM_ARCHITECTURE.md 状态提升: Draft 改为 Accepted
- 旧 docs/ARCHITECTURE.md 添加 DEPRECATED 标记

### 一致性修复
- 物理存储路径: 虚构的 .pd/state/ 修正为 .pd/state.db (SQLite 统一) + .state/principle_training_state.json (Ledger)
- 错误体系: 虚构的 5 类 Error + 15 子类修正为对齐实际代码的 PDRuntimeError + 17 个 PDErrorCategory
- 内化路线命名: DOMAIN_MODEL + Dynamics 统一 L1/L2/L3 别名
- 代码映射表: DOMAIN_MODEL.md 增加迁移状态列，LedgerPrinciple/TemplateGenerator 标记为 Done
- Pruning Action: 明确标记为未来能力（当前只有 ReadModel + ReviewLog）
- 包边界: 从"无外部依赖"改为"不依赖 openclaw-plugin/pd-cli"
- 代码锚点: 全部写完整包内路径（含 principles-core/src/runtime-v2/ 前缀）

### 消除过度设计
- 移除虚构的 Error 类层级
- L3 (LoRA) 从核心架构降级为 Pipeline 4 实验性标记
- 移除 Layer 1 内部 Pure Domain Model vs Runtime SDK 的理论拆分
- 降级路径区分已实现 vs 目标规范

### 新增文档
- DATA_ARCHITECTURE.md: 存储组件、读写分离、迁移计划、Plugin/Host Auxiliary State
- ERROR_ARCHITECTURE.md: PDErrorCategory、PDRuntimeError、降级路径

### 其他
- README.md: 增加阅读顺序、决策查阅指南、核心概念索引
- pd-task-manager.md: 标记 Partially Implemented，cron-initializer.ts 标记 DELETED

## Commits (3 pure docs commits)

| Commit | Description |
|--------|-------------|
| 883d3520 | 重构顶层架构文档，消除不一致性和过度设计 |
| d484cd16 | 修复评审发现的代码锚点/存储路径/实现状态不一致 |
| 8bd13cd5 | 修复 storage 降级路径/用户可见类别数/存储范围表述 |

## Verification

所有代码锚点可通过 rg --files 验证：
- packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
- packages/principles-core/src/runtime-v2/internalization/template-generator.ts
- packages/principles-core/src/runtime-v2/pruning-read-model.ts
- packages/principles-core/src/runtime-v2/error-categories.ts
- packages/principles-core/src/principle-tree-ledger.ts
