### PR TITLE
test: add boundary condition and edge case coverage for core modules

### DIFF
--- a/packages/openclaw-plugin/tests/core/pain-diagnostic-gate.test.ts
+++ b/packages/openclaw-plugin/tests/core/pain-diagnostic-gate.test.ts
@@ -225,4 +225,230 @@ describe('PainDiagnosticGate', () => {
       reason: 'subagent_error',
     });
   });
+
+  it('normalizes llm_ prefixed sources (non-paralysis) to semantic', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'llm_confusion',
+      score: 60,
+      currentGfi: 0,
+      sessionId: 's1',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: true,
+      reason: 'semantic_pain',
+    });
+  });
+
+  it('llm_paralysis is NOT normalized to semantic', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'llm_paralysis',
+      score: 40,
+      currentGfi: 0,
+      sessionId: 's1',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: true,
+      reason: 'llm_paralysis',
+    });
+  });
+
+  it('skips llm_paralysis when score < painTrigger', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'llm_paralysis',
+      score: 39,
+      currentGfi: 0,
+      sessionId: 's1',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: false,
+      reason: 'below_gate',
+    });
+  });
+
+  it('cooldownMs=0 disables cooldown (allows re-diagnosis)', () => {
+    const input = {
+      source: 'tool_failure',
+      score: 50,
+      currentGfi: 72,
+      sessionId: 's1',
+      errorHash: 'same',
+      nowMs: 1_000,
+      cooldownMs: 0,
+    };
+
+    expect(evaluatePainDiagnosticGate(input).shouldDiagnose).toBe(true);
+    expect(evaluatePainDiagnosticGate({ ...input, nowMs: 2_000 }).shouldDiagnose).toBe(true);
+  });
+
+  it('treats NaN score as 0 (below gate)', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'tool_failure',
+      score: NaN,
+      currentGfi: 72,
+      consecutiveErrors: 4,
+      sessionId: 's1',
+    });
+
+    expect(decision.shouldDiagnose).toBe(true);
+    expect(decision.reason).toBe('repeated_failure');
+  });
+
+  it('treats NaN currentGfi as 0', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'tool_failure',
+      score: 50,
+      currentGfi: NaN,
+      consecutiveErrors: 1,
+      sessionId: 's1',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: false,
+      reason: 'below_gate',
+    });
+  });
+
+  it('treats Infinity score as finite for gate evaluation', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'tool_failure',
+      score: Infinity,
+      currentGfi: 0,
+      isRisky: true,
+      sessionId: 's1',
+    });
+
+    expect(decision.shouldDiagnose).toBe(false);
+  });
+
+  it('treats NaN consecutiveErrors as 0', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'tool_failure',
+      score: 50,
+      currentGfi: 50,
+      consecutiveErrors: NaN,
+      sessionId: 's1',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: false,
+      reason: 'below_gate',
+    });
+  });
+
+  it('episodeKey includes sessionId, source, and errorHash', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'manual',
+      score: 1,
+      currentGfi: 0,
+      sessionId: 's-ep',
+      errorHash: 'hash-abc',
+    });
+
+    expect(decision.episodeKey).toContain('s-ep');
+    expect(decision.episodeKey).toContain('manual');
+    expect(decision.episodeKey).toContain('hash-abc');
+  });
+
+  it('episodeKey uses "unknown" when sessionId missing', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'manual',
+      score: 1,
+      currentGfi: 0,
+    });
+
+    expect(decision.episodeKey).toContain('unknown');
+  });
+
+  it('episodeKey uses "no-hash" when errorHash missing', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'manual',
+      score: 1,
+      currentGfi: 0,
+      sessionId: 's1',
+    });
+
+    expect(decision.episodeKey).toContain('no-hash');
+  });
+
+  it('manual pain is still subject to cooldown', () => {
+    const input = {
+      source: 'manual',
+      score: 100,
+      currentGfi: 0,
+      sessionId: 's1',
+      nowMs: 1_000,
+    };
+
+    const first = evaluatePainDiagnosticGate(input);
+    expect(first.shouldDiagnose).toBe(true);
+
+    const second = evaluatePainDiagnosticGate({ ...input, nowMs: 2_000 });
+    expect(second).toMatchObject({
+      shouldDiagnose: false,
+      reason: 'cooldown',
+    });
+  });
+
+  it('different errorHash produces different episodeKey (no cooldown cross-contamination)', () => {
+    const base = {
+      source: 'tool_failure',
+      score: 50,
+      currentGfi: 72,
+      sessionId: 's1',
+      nowMs: 1_000,
+    };
+
+    expect(evaluatePainDiagnosticGate({ ...base, errorHash: 'hash-a' }).shouldDiagnose).toBe(true);
+    expect(evaluatePainDiagnosticGate({ ...base, errorHash: 'hash-b', nowMs: 2_000 }).shouldDiagnose).toBe(true);
+  });
+
+  it('highGfi defaults to max(highSeverity, painTrigger+30)', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'tool_failure',
+      score: 50,
+      currentGfi: 72,
+      consecutiveErrors: 1,
+      sessionId: 's1',
+      thresholds: {
+        painTrigger: 40,
+        highSeverity: 70,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: true,
+      reason: 'high_gfi',
+    });
+  });
+
+  it('gate_block source falls through to below_gate when no other condition met', () => {
+    const decision = evaluatePainDiagnosticGate({
+      source: 'gate_blocked',
+      score: 10,
+      currentGfi: 5,
+      consecutiveErrors: 0,
+      sessionId: 's1',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDiagnose: false,
+      reason: 'below_gate',
+    });
+  });
+
+  it('returns detail string in every decision', () => {
+    const cases = [
+      { source: 'manual' as const, score: 1, currentGfi: 0 },
+      { source: 'tool_failure' as const, score: 10, currentGfi: 5, consecutiveErrors: 0 },
+    ];
+
+    for (const input of cases) {
+      const decision = evaluatePainDiagnosticGate({ ...input, sessionId: 's1' });
+      expect(typeof decision.detail).toBe('string');
+      expect(decision.detail.length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/packages/openclaw-plugin/tests/hooks/pain.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain.test.ts
@@ -63,6 +63,38 @@ describe('classifyToolFailureSource', () => {
     expect(classifyToolFailureSource('read', '')).toBe('tool_failure');
     expect(classifyToolFailureSource('read', 123)).toBe('tool_failure');
   });
+
+  it('word-boundary: "report_tool_not_found" does NOT match dispatch pattern', () => {
+    expect(classifyToolFailureSource('read', 'report_tool_not_found')).toBe('tool_failure');
+  });
+
+  it('word-boundary: "atoolnotfound" (no spaces) does NOT match dispatch pattern', () => {
+    expect(classifyToolFailureSource('read', 'atoolnotfound')).toBe('tool_failure');
+  });
+
+  it('word-boundary: "unknown_tool" (underscore, no space) does NOT match dispatch pattern', () => {
+    expect(classifyToolFailureSource('read', 'unknown_tool')).toBe('tool_failure');
+  });
+
+  it('whitespace-only toolName -> dispatch_error', () => {
+    expect(classifyToolFailureSource('   ', 'tool not found')).toBe('dispatch_error');
+  });
+
+  it('numeric error value -> tool_failure', () => {
+    expect(classifyToolFailureSource('read', 42)).toBe('tool_failure');
+  });
+
+  it('object error value -> tool_failure', () => {
+    expect(classifyToolFailureSource('read', { code: 'ENOENT' })).toBe('tool_failure');
+  });
+
+  it('"tool <name> not found" with multi-word tool name -> dispatch_error', () => {
+    expect(classifyToolFailureSource('read', 'tool my_custom_tool not found')).toBe('dispatch_error');
+  });
+
+  it('partial match "not found" without "tool" prefix -> tool_failure', () => {
+    expect(classifyToolFailureSource('read', 'file not found')).toBe('tool_failure');
+  });
 });
 
 describe('Post-Write Checks & Pain Hook', () => {

--- a/packages/principles-core/src/prompt-builder/__tests__/empathy-keyword-matching.test.ts
+++ b/packages/principles-core/src/prompt-builder/__tests__/empathy-keyword-matching.test.ts
@@ -331,4 +331,109 @@ describe('Empathy Keyword Matching (core)', () => {
       expect(normalizeSeverity('MODERATE')).toBe('moderate');
     });
   });
+
+  describe('scoreToSeverity boundary values', () => {
+    it('score exactly 0.3 is moderate', () => {
+      expect(scoreToSeverity(0.3)).toBe('moderate');
+    });
+
+    it('score exactly 0.6 is severe', () => {
+      expect(scoreToSeverity(0.6)).toBe('severe');
+    });
+
+    it('score just below 0.3 is mild', () => {
+      expect(scoreToSeverity(0.29)).toBe('mild');
+    });
+
+    it('score just below 0.6 is moderate', () => {
+      expect(scoreToSeverity(0.59)).toBe('moderate');
+    });
+
+    it('score 0 is mild', () => {
+      expect(scoreToSeverity(0)).toBe('mild');
+    });
+
+    it('score 1 is severe', () => {
+      expect(scoreToSeverity(1)).toBe('severe');
+    });
+  });
+
+  describe('severityToPenalty with custom config', () => {
+    it('uses custom penalty values', () => {
+      const customConfig = {
+        ...DEFAULT_EMPATHY_KEYWORD_CONFIG,
+        penaltyMild: 5,
+        penaltyModerate: 15,
+        penaltySevere: 50,
+      };
+      expect(severityToPenalty('mild', customConfig)).toBe(5);
+      expect(severityToPenalty('moderate', customConfig)).toBe(15);
+      expect(severityToPenalty('severe', customConfig)).toBe(50);
+    });
+  });
+
+  describe('matchEmpathyKeywords edge cases', () => {
+    it('whitespace-only text returns no match', () => {
+      const store = createDefaultKeywordStore('zh');
+      const result = matchEmpathyKeywords('   \t\n  ', store);
+
+      expect(result.matched).toBe(false);
+      expect(result.score).toBe(0);
+    });
+
+    it('maxTermsPerMessage limits matched terms', () => {
+      const store = createDefaultKeywordStore('zh');
+      const config = { ...DEFAULT_EMPATHY_KEYWORD_CONFIG, maxTermsPerMessage: 2 };
+      const result = matchEmpathyKeywords('不对 错了 搞错了', store, config);
+
+      expect(result.matchedTerms.length).toBeLessThanOrEqual(2);
+    });
+
+    it('adjusted weight accounts for falsePositiveRate', () => {
+      const store = createDefaultKeywordStore('zh');
+      const term = '垃圾';
+      const entry = store.terms[term];
+      expect(entry).toBeDefined();
+      const expectedWeight = entry!.weight * (1 - entry!.falsePositiveRate);
+
+      const result = matchEmpathyKeywords(term, store);
+
+      expect(result.score).toBeCloseTo(expectedWeight, 2);
+    });
+  });
+
+  describe('applyKeywordUpdates edge cases', () => {
+    it('remove non-existent term is no-op', () => {
+      const store = createDefaultKeywordStore('zh');
+      const result = applyKeywordUpdates(store, { 'nonexistent': { action: 'remove' } });
+
+      expect(result.removed).toBe(0);
+    });
+
+    it('add with default weight and falsePositiveRate', () => {
+      const store = createDefaultKeywordStore('zh');
+      const result = applyKeywordUpdates(store, { 'testTerm': { action: 'add' } });
+
+      expect(result.added).toBe(1);
+      expect(store.terms.testTerm?.weight).toBe(0.5);
+      expect(store.terms.testTerm?.falsePositiveRate).toBe(0.2);
+      expect(store.terms.testTerm?.source).toBe('llm_discovered');
+    });
+
+    it('add with examples', () => {
+      const store = createDefaultKeywordStore('zh');
+      applyKeywordUpdates(store, {
+        'testTerm': { action: 'add', examples: ['example 1', 'example 2'] },
+      });
+
+      expect(store.terms.testTerm?.examples).toEqual(['example 1', 'example 2']);
+    });
+
+    it('empty updates object returns zeros', () => {
+      const store = createDefaultKeywordStore('zh');
+      const result = applyKeywordUpdates(store, {});
+
+      expect(result).toEqual({ added: 0, updated: 0, removed: 0 });
+    });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-kernel.test.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-kernel.test.ts
@@ -7,7 +7,7 @@ import {
   createGfiSnapshot,
   DEFAULT_GFI_POLICY,
 } from '../gfi-kernel.js';
-import type { GfiState, GfiEvent, GfiPolicy } from '../gfi-types.js';
+import type { GfiState, GfiEvent, GfiPolicy, GfiSource } from '../gfi-types.js';
 
 function makeState(overrides: Partial<GfiState> = {}): GfiState {
   return {
@@ -524,5 +524,233 @@ describe('DEFAULT_GFI_POLICY', () => {
     expect(typeof elevated).toBe('number');
     expect(typeof critical).toBe('number');
     expect(typeof saturated).toBe('number');
+  });
+});
+
+describe('applyFriction edge cases', () => {
+  it('event without hash sets consecutiveErrors to 1', () => {
+    const state = makeState({
+      currentGfi: 10,
+      gfiBySource: { tool_failure: 10 },
+      consecutiveErrors: 3,
+      lastErrorHash: 'abc',
+    });
+    const event: GfiEvent = { source: 'tool_failure', baseScore: 20 };
+    const next = applyFriction(state, event, DEFAULT_GFI_POLICY);
+
+    expect(next.consecutiveErrors).toBe(1);
+    expect(next.lastErrorHash).toBeUndefined();
+  });
+
+  it('event with undefined hash resets consecutiveErrors', () => {
+    const state = makeState({
+      currentGfi: 10,
+      consecutiveErrors: 5,
+      lastErrorHash: 'abc',
+    });
+    const event: GfiEvent = { source: 'dispatch_error', baseScore: 15, hash: undefined };
+    const next = applyFriction(state, event, DEFAULT_GFI_POLICY);
+
+    expect(next.consecutiveErrors).toBe(1);
+  });
+
+  it('accumulates across multiple sources correctly', () => {
+    const state = makeState({ currentGfi: 0, gfiBySource: {} });
+    const events: GfiEvent[] = [
+      { source: 'tool_failure', baseScore: 10 },
+      { source: 'dispatch_error', baseScore: 15 },
+      { source: 'user_empathy', baseScore: 20 },
+    ];
+
+    let current = state;
+    for (const event of events) {
+      current = applyFriction(current, event, DEFAULT_GFI_POLICY);
+    }
+
+    expect(current.currentGfi).toBe(45);
+    expect(current.gfiBySource.tool_failure).toBe(10);
+    expect(current.gfiBySource.dispatch_error).toBe(15);
+    expect(current.gfiBySource.user_empathy).toBe(20);
+  });
+
+  it('tracks dailyGfiPeak across friction events', () => {
+    const state = makeState({ currentGfi: 50, dailyGfiPeak: 60 });
+    const event: GfiEvent = { source: 'tool_failure', baseScore: 30 };
+    const next = applyFriction(state, event, DEFAULT_GFI_POLICY);
+
+    expect(next.currentGfi).toBe(80);
+    expect(next.dailyGfiPeak).toBe(80);
+  });
+
+  it('dailyGfiPeak does not decrease on lower friction', () => {
+    const state = makeState({ currentGfi: 50, dailyGfiPeak: 100 });
+    const event: GfiEvent = { source: 'tool_failure', baseScore: 10 };
+    const next = applyFriction(state, event, DEFAULT_GFI_POLICY);
+
+    expect(next.dailyGfiPeak).toBe(100);
+  });
+});
+
+describe('applyDecay edge cases', () => {
+  it('zero elapsed minutes does not change currentGfi', () => {
+    const state = makeState({ currentGfi: 50, gfiBySource: { tool_failure: 50 } });
+    const next = applyDecay(state, 0, DEFAULT_GFI_POLICY, 'stable', FIXED_NOW);
+
+    expect(next.currentGfi).toBe(50);
+    expect(next.gfiBySource.tool_failure).toBe(50);
+  });
+
+  it('large elapsed minutes drives GFI to 0', () => {
+    const state = makeState({ currentGfi: 50, gfiBySource: { tool_failure: 50 } });
+    const next = applyDecay(state, 1000, DEFAULT_GFI_POLICY, 'stable', FIXED_NOW);
+
+    expect(next.currentGfi).toBe(0);
+  });
+
+  it('decay never produces negative currentGfi', () => {
+    const state = makeState({ currentGfi: 1, gfiBySource: { tool_failure: 1 } });
+    const next = applyDecay(state, 100, DEFAULT_GFI_POLICY, 'saturated', FIXED_NOW);
+
+    expect(next.currentGfi).toBeGreaterThanOrEqual(0);
+  });
+
+  it('empty source ledger with large elapsed minutes drives currentGfi to 0', () => {
+    const state = makeState({ currentGfi: 5, gfiBySource: {} });
+    const next = applyDecay(state, 1000, DEFAULT_GFI_POLICY, 'stable', FIXED_NOW);
+
+    expect(next.currentGfi).toBe(0);
+  });
+});
+
+describe('applyRelief edge cases', () => {
+  it('source-specific relief on non-existent source is no-op', () => {
+    const state = makeState({
+      currentGfi: 50,
+      gfiBySource: { tool_failure: 50 },
+      consecutiveErrors: 2,
+    });
+    const next = applyRelief(state, { source: 'dispatch_error', amount: 10 }, FIXED_NOW, DEFAULT_GFI_POLICY);
+
+    expect(next.currentGfi).toBe(50);
+    expect(next.gfiBySource.tool_failure).toBe(50);
+  });
+
+  it('source-specific relief greater than source value zeroes source', () => {
+    const state = makeState({
+      currentGfi: 30,
+      gfiBySource: { tool_failure: 30 },
+      consecutiveErrors: 2,
+      lastErrorSource: 'dispatch_error',
+    });
+    const next = applyRelief(state, { source: 'tool_failure', amount: 100 }, FIXED_NOW, DEFAULT_GFI_POLICY);
+
+    expect(next.gfiBySource.tool_failure).toBeUndefined();
+    expect(next.currentGfi).toBe(0);
+  });
+
+  it('ratio-based relief prunes sources that drop to 0', () => {
+    const state = makeState({
+      currentGfi: 4,
+      gfiBySource: { tool_failure: 4 },
+    });
+    const policy = makePolicy({ relief: { toolSuccessRatio: 0.99, minPruneBelow: 1 } });
+    const next = applyRelief(state, { source: 'tool_failure', amount: 0 }, FIXED_NOW, policy);
+
+    expect(next.gfiBySource.tool_failure).toBeUndefined();
+    expect(next.currentGfi).toBe(0);
+  });
+
+  it('full reset preserves dailyGfiPeak', () => {
+    const state = makeState({
+      currentGfi: 80,
+      gfiBySource: { tool_failure: 80 },
+      dailyGfiPeak: 95,
+    });
+    const next = applyRelief(state, { source: 'all', amount: 100 }, FIXED_NOW, DEFAULT_GFI_POLICY);
+
+    expect(next.currentGfi).toBe(0);
+    expect(next.dailyGfiPeak).toBe(95);
+  });
+
+  it('relief on lastErrorSource resets consecutiveErrors', () => {
+    const state = makeState({
+      currentGfi: 50,
+      gfiBySource: { tool_failure: 50 },
+      consecutiveErrors: 3,
+      lastErrorHash: 'abc',
+      lastErrorSource: 'tool_failure',
+    });
+    const next = applyRelief(state, { source: 'tool_failure', amount: 10 }, FIXED_NOW, DEFAULT_GFI_POLICY);
+
+    expect(next.consecutiveErrors).toBe(0);
+    expect(next.lastErrorHash).toBeUndefined();
+    expect(next.lastErrorSource).toBeUndefined();
+  });
+
+  it('relief on different source preserves consecutiveErrors', () => {
+    const state = makeState({
+      currentGfi: 50,
+      gfiBySource: { tool_failure: 30, dispatch_error: 20 },
+      consecutiveErrors: 3,
+      lastErrorHash: 'abc',
+      lastErrorSource: 'tool_failure',
+    });
+    const next = applyRelief(state, { source: 'dispatch_error', amount: 10 }, FIXED_NOW, DEFAULT_GFI_POLICY);
+
+    expect(next.consecutiveErrors).toBe(3);
+    expect(next.lastErrorHash).toBe('abc');
+    expect(next.lastErrorSource).toBe('tool_failure');
+  });
+});
+
+describe('classifyGfiStage edge cases', () => {
+  it('negative GFI is classified as stable', () => {
+    expect(classifyGfiStage(-10, DEFAULT_GFI_POLICY)).toBe('stable');
+  });
+
+  it('zero GFI is stable', () => {
+    expect(classifyGfiStage(0, DEFAULT_GFI_POLICY)).toBe('stable');
+  });
+
+  it('custom policy thresholds', () => {
+    const policy = makePolicy({
+      stageThresholds: { elevated: 20, critical: 50, saturated: 80 },
+    });
+    expect(classifyGfiStage(25, policy)).toBe('elevated');
+    expect(classifyGfiStage(55, policy)).toBe('critical');
+    expect(classifyGfiStage(85, policy)).toBe('saturated');
+  });
+});
+
+describe('createGfiSnapshot edge cases', () => {
+  it('dominantSource picks first when tied', () => {
+    const state = makeState({
+      currentGfi: 40,
+      gfiBySource: { tool_failure: 20, dispatch_error: 20 },
+    });
+    const snapshot = createGfiSnapshot(state, DEFAULT_GFI_POLICY);
+
+    expect(snapshot.dominantSource).not.toBeNull();
+    const domValue = snapshot.dominantSource ? snapshot.sources[snapshot.dominantSource as GfiSource] : undefined;
+    expect([20, 20]).toContain(domValue ?? 0);
+  });
+
+  it('lastDecayAt is formatted as ISO string when present', () => {
+    const state = makeState({
+      currentGfi: 30,
+      gfiBySource: { tool_failure: 30 },
+      lastGfiDecayAt: 1700000000000,
+    });
+    const snapshot = createGfiSnapshot(state, DEFAULT_GFI_POLICY);
+
+    expect(snapshot.lastDecayAt).toBeDefined();
+    expect(typeof snapshot.lastDecayAt).toBe('string');
+  });
+
+  it('lastDecayAt is undefined when not present', () => {
+    const state = makeState({ currentGfi: 30, gfiBySource: { tool_failure: 30 } });
+    const snapshot = createGfiSnapshot(state, DEFAULT_GFI_POLICY);
+
+    expect(snapshot.lastDecayAt).toBeUndefined();
   });
 });

--- a/packages/principles-core/vitest.config.ts
+++ b/packages/principles-core/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/**/*.test.ts', 'src/prompt-builder/__tests__/**/*.test.ts', 'src/runtime-v2/store/**/*.test.ts', 'src/runtime-v2/runner/**/*.test.ts', 'src/runtime-v2/utils/**/*.test.ts', 'src/runtime-v2/adapter/**/*.test.ts', 'src/runtime-v2/diagnostician/**/*.test.ts', 'src/runtime-v2/__tests__/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/prompt-builder/__tests__/**/*.test.ts', 'src/runtime-v2/store/**/*.test.ts', 'src/runtime-v2/runner/**/*.test.ts', 'src/runtime-v2/utils/**/*.test.ts', 'src/runtime-v2/adapter/**/*.test.ts', 'src/runtime-v2/diagnostician/**/*.test.ts', 'src/runtime-v2/__tests__/**/*.test.ts', 'src/runtime-v2/gfi/__tests__/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## 测试缺口分析 — 边界条件与极端情况覆盖

### 背景
审查近期合并代码（#515–#524），在覆盖率缺口对产品稳定性构成实质风险的地方补充测试。

### 新增测试（共 59 个，全部通过 ✅）

#### 1. PainDiagnosticGate — 16 个新测试
- `llm_` 前缀源归一化为 `semantic_pain` / `llm_paralysis` 不归一化
- `cooldownMs=0` 禁用冷却机制
- `NaN`/`Infinity` 输入的防御性处理
- `episodeKey` 构建正确性（缺失 sessionId/errorHash 时的降级）
- manual pain 受冷却约束
- 不同 errorHash 不互相冷却
- `highGfi` 默认值计算
- 所有决策包含 `detail` 字符串

#### 2. classifyToolFailureSource — 8 个新测试
- Word-boundary 防误匹配（`report_tool_not_found`、`atoolnotfound`、`unknown_tool`）
- 纯空白 toolName → dispatch_error
- 数值型/对象型 error → tool_failure
- 多词工具名 `tool <name> not found` 正确匹配
- 无 "tool" 前缀的 "not found" 不误匹配

#### 3. GFI Kernel — 22 个新测试
- `applyFriction`: 无 hash 事件重置 consecutiveErrors、多源累积、dailyGfiPeak 跟踪
- `applyDecay`: 零分钟/大时间衰减、永不产生负值、空源账本
- `applyRelief`: 非存在源 no-op、超量归零、比率归零后删除源、完全重置保留 dailyGfiPeak、lastErrorSource 重置/保留计数
- `classifyGfiStage`: 负值、自定义阈值
- `createGfiSnapshot`: dominantSource 平局、lastDecayAt 格式化

#### 4. Empathy 关键词匹配 — 13 个新测试
- `scoreToSeverity` 精确边界值（0.3/0.6）
- 自定义惩罚值配置
- 纯空白文本不匹配
- `maxTermsPerMessage` 限制
- `falsePositiveRate` 权重调整
- `applyKeywordUpdates` 边界情况

### 修改的文件
| 文件 | 新增测试数 |
|------|-----------|
| `packages/openclaw-plugin/tests/core/pain-diagnostic-gate.test.ts` | +16 |
| `packages/openclaw-plugin/tests/hooks/pain.test.ts` | +8 |
| `packages/principles-core/src/runtime-v2/gfi/__tests__/gfi-kernel.test.ts` | +22 |
| `packages/principles-core/src/prompt-builder/__tests__/empathy-keyword-matching.test.ts` | +13 |
| `packages/principles-core/vitest.config.ts` | 配置更新 |

### 跳过的内容
- Focus compression: 已有 313 行测试，缺口主要是重构迁移
- Runtime summary service: 依赖 SQLite，属集成测试范畴
- Event types: 纯类型定义，无行为逻辑
- GFI policy: 纯配置常量，已在 kernel 测试中间接覆盖