### PR TITLE
fix(runtime): harden production baseline follow-up issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,8 @@ _scratchpad/
 # Private AI agent files (DO NOT COMMIT)
 GEMINI.md
 CLAUDE.md
-.iflow/
 code-concise/
+.trae
 
 # Docs (Project documentation should be tracked)
 # The docs/ directory itself is NOT ignored, but old state files within it were moved out.

--- a/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
+++ b/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
@@ -47,9 +47,10 @@ type TriggerBlockedEvent = {
   workspaceDir: string;
   taskId: string;
   taskKind: string;
-  gateDecision: 'blocked' | 'dependency_failed';
+  gateDecision: 'blocked' | 'dependency_failed' | 'retry_wait_pending';
   blockedBy?: string[];
   failedDependencies?: string[];
+  retryAfter?: string;
   timestamp: string;
 };
 
@@ -219,7 +220,7 @@ export function createInternalizationTrigger(
           });
           hasReadyTask = true;
         } else {
-          // blocked or dependency_failed — debug visibility for operators
+          // blocked, dependency_failed, or retry_wait_pending — debug visibility for operators
           emitLog(logger, {
             event: 'INTERNALIZATION_TRIGGER_BLOCKED',
             workspaceDir: ctx.workspaceDir,
@@ -228,6 +229,7 @@ export function createInternalizationTrigger(
             gateDecision: gateResult.decision,
             blockedBy: gateResult.decision === 'blocked' ? gateResult.blockedBy : undefined,
             failedDependencies: gateResult.decision === 'dependency_failed' ? gateResult.failedDependencies : undefined,
+            retryAfter: gateResult.decision === 'retry_wait_pending' ? gateResult.retryAfter : undefined,
             timestamp: new Date().toISOString(),
           });
         }

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -321,9 +321,14 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
       correlationId: opts.candidateId,
     });
 
-    const diagObj = JSON.parse(diagnosticJson);
-    diagObj.candidateId = opts.candidateId;
-    const finalDiagnosticJson = JSON.stringify(diagObj);
+    let finalDiagnosticJson = diagnosticJson;
+    try {
+      const diagObj = JSON.parse(diagnosticJson);
+      diagObj.candidateId = opts.candidateId;
+      finalDiagnosticJson = JSON.stringify(diagObj);
+    } catch {
+      finalDiagnosticJson = diagnosticJson;
+    }
 
     const task = await stateManager.createTask({
       taskId,

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -321,13 +321,17 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
       correlationId: opts.candidateId,
     });
 
+    const diagObj = JSON.parse(diagnosticJson);
+    diagObj.candidateId = opts.candidateId;
+    const finalDiagnosticJson = JSON.stringify(diagObj);
+
     const task = await stateManager.createTask({
       taskId,
       taskKind: 'dreamer',
       status: 'pending',
       attemptCount: 0,
       maxAttempts: 3,
-      diagnosticJson,
+      diagnosticJson: finalDiagnosticJson,
     });
 
     const result: CandidateInternalizeResult = {
@@ -670,6 +674,166 @@ export async function handleCandidateRepair(opts: CandidateRepairOptions): Promi
       console.error(`Repair failed: ${String(err)}`);
     }
     process.exit(1);
+  } finally {
+    await stateManager.close();
+  }
+}
+
+// ── Internalization Backfill (consumed candidates missing dreamer tasks) ──────
+
+interface CandidateBackfillOptions {
+  workspace?: string;
+  json?: boolean;
+  dryRun?: boolean;
+  confirm?: boolean;
+}
+
+interface BackfillCandidateResult {
+  candidateId: string;
+  route: string;
+  status: 'would_create' | 'created' | 'existing' | 'deferred' | 'error';
+  taskId?: string;
+  channel?: string;
+  reason?: string;
+}
+
+interface BackfillOutput {
+  mode: 'dry-run' | 'confirm';
+  totalConsumed: number;
+  missingDreamerTask: number;
+  alreadyHaveTask: number;
+  deferred: number;
+  created: number;
+  errors: number;
+  results: BackfillCandidateResult[];
+}
+
+export async function handleCandidateInternalizationBackfill(opts: CandidateBackfillOptions): Promise<void> {
+  const workspaceDir = resolveWorkspaceDir(opts.workspace);
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+  const isConfirm = opts.confirm ?? false;
+
+  try {
+    await stateManager.initialize();
+
+    const db = stateManager.connection.getDb();
+
+    const consumedRows = db.prepare(
+      "SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'"
+    ).all() as { candidate_id: string }[];
+
+    const output: BackfillOutput = {
+      mode: isConfirm ? 'confirm' : 'dry-run',
+      totalConsumed: consumedRows.length,
+      missingDreamerTask: 0,
+      alreadyHaveTask: 0,
+      deferred: 0,
+      created: 0,
+      errors: 0,
+      results: [],
+    };
+
+    for (const row of consumedRows) {
+      const candidateId = row.candidate_id;
+
+      const candidate = await stateManager.getCandidate(candidateId);
+      if (!candidate) {
+        output.errors++;
+        output.results.push({ candidateId, route: 'unknown', status: 'error', reason: 'Candidate not found in DB' });
+        continue;
+      }
+
+      const recommendation = resolveCandidateRecommendation(candidate, stateManager, candidateId);
+      const decision = decideInternalizationRoute(recommendation as Parameters<typeof decideInternalizationRoute>[0]);
+
+      if (!decision.ready || decision.route === 'deferred') {
+        output.deferred++;
+        output.results.push({ candidateId, route: decision.route, status: 'deferred', reason: decision.reason });
+        continue;
+      }
+
+      const channel = ROUTE_CHANNEL_MAP[decision.route] ?? 'prompt';
+      const taskId = `dreamer-${candidateId}-${channel}`;
+
+      const existingTask = await stateManager.getTask(taskId);
+      if (existingTask) {
+        if (isConfirm && existingTask.diagnosticJson) {
+          try {
+            const diagObj = JSON.parse(existingTask.diagnosticJson);
+            if (!diagObj.candidateId) {
+              diagObj.candidateId = candidateId;
+              await stateManager.updateTaskDiagnosticJson(taskId, JSON.stringify(diagObj));
+            }
+          } catch { /* best-effort */ }
+        }
+        output.alreadyHaveTask++;
+        output.results.push({ candidateId, route: decision.route, status: 'existing', taskId: existingTask.taskId, channel });
+        continue;
+      }
+
+      output.missingDreamerTask++;
+
+      if (!isConfirm) {
+        output.results.push({ candidateId, route: decision.route, status: 'would_create', taskId, channel });
+        continue;
+      }
+
+      try {
+        const diagnosticJson = createPITaskDiagnosticJson({
+          dependencyTaskIds: [],
+          channel: channel as 'prompt' | 'skill' | 'code_tool_hook' | 'model_training',
+          timeoutMs: 300_000,
+          inputArtifactRefs: [{ artifactType: 'candidate', ref: `candidate://${candidateId}` }],
+          outputArtifactRefs: [],
+          parentTaskId: undefined,
+          correlationId: candidateId,
+        });
+
+        const diagObj = JSON.parse(diagnosticJson);
+        diagObj.candidateId = candidateId;
+        const finalDiagnosticJson = JSON.stringify(diagObj);
+
+        const task = await stateManager.createTask({
+          taskId,
+          taskKind: 'dreamer',
+          status: 'pending',
+          attemptCount: 0,
+          maxAttempts: 3,
+          diagnosticJson: finalDiagnosticJson,
+        });
+
+        output.created++;
+        output.results.push({ candidateId, route: decision.route, status: 'created', taskId: task.taskId, channel });
+      } catch (err) {
+        output.errors++;
+        output.results.push({ candidateId, route: decision.route, status: 'error', reason: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      console.log(`\nCandidate Internalization Backfill (${output.mode})\n`);
+      console.log(`  total_consumed:      ${output.totalConsumed}`);
+      console.log(`  missing_dreamer:     ${output.missingDreamerTask}`);
+      console.log(`  already_have_task:   ${output.alreadyHaveTask}`);
+      console.log(`  deferred:            ${output.deferred}`);
+      if (isConfirm) {
+        console.log(`  created:             ${output.created}`);
+        console.log(`  errors:              ${output.errors}`);
+      }
+      for (const r of output.results) {
+        console.log(`  ${r.candidateId}: ${r.status} (${r.route})${r.taskId ? ` → ${r.taskId}` : ''}${r.reason ? ` — ${r.reason}` : ''}`);
+      }
+      if (!isConfirm && output.missingDreamerTask > 0) {
+        console.log(`\n  (use --confirm to create missing dreamer tasks)`);
+      }
+      console.log('');
+    }
+
+    if (output.missingDreamerTask > 0 && !isConfirm) {
+      process.exitCode = 1;
+    }
   } finally {
     await stateManager.close();
   }

--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { OperatorHealthReadModel, SchemaConformanceReadModel, PruningReadModel, InternalizationQueueReadModel, auditCandidateLedgerConsistency, buildGfiWorkspaceSnapshot } from '@principles/core/runtime-v2';
+import { OperatorHealthReadModel, SchemaConformanceReadModel, PruningReadModel, InternalizationQueueReadModel, auditCandidateLedgerConsistency, buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from '@principles/core/runtime-v2';
 import type { OperatorHealthSnapshot, SchemaConformanceResult, OrphanDetectionResult, InternalizationQueueSnapshot, GfiWorkspaceSnapshot, CandidateAuditResult } from '@principles/core/runtime-v2';
 import { RuntimeStateManager } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
@@ -48,7 +48,7 @@ function buildRecommendedActions(checks: CanaryCheck[]): string[] {
         actions.push('Run `pd candidate audit --workspace <path> --json` for details.');
         break;
       case 'gfi_snapshot':
-        actions.push('Investigate stale GFI sessions — consider cleanup or session lifecycle review.');
+        actions.push('Investigate GFI sessions — consider cleanup or session lifecycle review.');
         break;
       case 'pruning_orphans':
         actions.push('Run `pd runtime pruning orphans --workspace <path> --dry-run` to inspect orphan candidates.');
@@ -128,14 +128,15 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
           }
         }
         const snapshot: GfiWorkspaceSnapshot = buildGfiWorkspaceSnapshot({ sessions, nowMs: Date.now() });
-        const status = snapshot.staleSessionCount > 20 && snapshot.activeSessionCount === 0 ? 'degraded' : 'healthy';
+        const health = classifyGfiWorkspaceHealth(snapshot);
+        const {status} = health;
         return {
           name: 'gfi_snapshot',
           status,
           summary: status === 'healthy'
             ? `GFI snapshot OK. ${snapshot.activeSessionCount} active, ${snapshot.staleSessionCount} stale sessions.`
-            : `GFI degraded: ${snapshot.staleSessionCount} stale sessions with no active sessions.`,
-          details: snapshot,
+            : `GFI degraded: ${health.reason}`,
+          details: { ...snapshot, healthAssessment: health },
         };
       } catch (err) {
         return { name: 'gfi_snapshot', status: 'error', summary: 'GFI snapshot check failed.', error: String(err) };
@@ -152,7 +153,7 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
           summary: status === 'healthy'
             ? 'No orphan derived candidates found.'
             : `${result.candidates.length} orphan derived candidate(s) found. dbReadable: ${result.dbReadable}`,
-          details: { orphanCount: result.candidates.length, dbReadable: result.dbReadable, samples: result.candidates.slice(0, 5) },
+          details: { orphanDerivedCandidateCount: result.candidates.length, dbReadable: result.dbReadable, samples: result.candidates.slice(0, 5) },
         };
       } catch (err) {
         return { name: 'pruning_orphans', status: 'error', summary: 'Pruning orphan check failed.', error: String(err) };

--- a/packages/pd-cli/src/commands/runtime-internalization-queue.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-queue.ts
@@ -52,6 +52,13 @@ function formatTextOutput(snap: InternalizationQueueSnapshot): string {
     }
   }
 
+  if (snap.retryWaitPendingSummary.count > 0) {
+    lines.push(`  retry_wait_pending: ${snap.retryWaitPendingSummary.count}`);
+    for (const s of snap.retryWaitPendingSummary.samples.slice(0, 3)) {
+      lines.push(`    ${s.taskId} (${s.taskKind}) retry_after: ${s.retryAfter}`);
+    }
+  }
+
   if (snap.noReadyTasks) {
     lines.push(`  no_ready_tasks: ${snap.noReadyTasks.reason} (inspected: ${snap.noReadyTasks.inspectedCount})`);
   }

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -263,6 +263,11 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
 
   // Resolve effective timeout: CLI flag > runner default (300_000)
   const cliTimeoutMs = opts.timeoutMs;
+  if (cliTimeoutMs !== undefined && (!Number.isFinite(cliTimeoutMs) || cliTimeoutMs <= 0)) {
+    console.error(`Error: --timeout-ms must be a positive integer, got: ${opts.timeoutMs}`);
+    process.exitCode = 1;
+    return;
+  }
   const defaultRunnerTimeoutMs = 300_000;
   const effectiveTimeoutMs = cliTimeoutMs ?? defaultRunnerTimeoutMs;
 

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -23,6 +23,7 @@ interface RunOnceOptions {
   runner?: string;
   allowTestDouble?: boolean;
   enqueueNext?: boolean;
+  timeoutMs?: number;
 }
 
 const OWNER = 'pd-cli-internalization-run-once';
@@ -47,6 +48,8 @@ interface RunOnceOutput {
   successorTaskId?: string;
   successorKind?: string;
   enqueueDecision?: string;
+  effectiveTimeoutMs?: number;
+  timeoutSource?: string;
 }
 
 function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult, skipReason?: string): RunOnceOutput {
@@ -150,6 +153,14 @@ function formatTextOutput(output: RunOnceOutput): string {
     lines.push(`  enqueue: ${output.enqueueDecision}`);
   }
 
+  if (output.effectiveTimeoutMs) {
+    lines.push(`  timeout: ${output.effectiveTimeoutMs}ms`);
+  }
+
+  if (output.timeoutSource) {
+    lines.push(`  timeoutSource: ${output.timeoutSource}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -158,6 +169,7 @@ interface ResolveAdapterOptions {
   taskId: string;
   workspaceDir: string;
   runnerKind: string;
+  timeoutMs?: number;
 }
 
 function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
@@ -221,12 +233,14 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
 
   if (opts.runtimeKind === 'pi-ai' || (opts.runtimeKind === 'config' && config.runtimeKind === 'pi-ai')) {
     validateRuntimeConfig(config);
+    // CLI --timeout-ms overrides workflows.yaml timeoutMs
+    const adapterTimeoutMs = opts.timeoutMs ?? config.timeoutMs;
     return new PiAiRuntimeAdapter({
       provider: String(config.provider),
       model: String(config.model),
       apiKeyEnv: String(config.apiKeyEnv),
       maxRetries: config.maxRetries,
-      timeoutMs: config.timeoutMs,
+      timeoutMs: adapterTimeoutMs,
       baseUrl: config.baseUrl,
       workspace: opts.workspaceDir,
     });
@@ -246,6 +260,11 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
   const workspaceDir = opts.workspace ? path.resolve(opts.workspace) : resolveWorkspaceDir();
   const runtimeKind = opts.runtime ?? 'config';
   const runnerKind = opts.runner ?? 'dreamer';
+
+  // Resolve effective timeout: CLI flag > runner default (300_000)
+  const cliTimeoutMs = opts.timeoutMs;
+  const defaultRunnerTimeoutMs = 300_000;
+  const effectiveTimeoutMs = cliTimeoutMs ?? defaultRunnerTimeoutMs;
 
   if (runtimeKind === 'test-double' && !opts.allowTestDouble) {
     console.error('Error: test-double runtime mutates real queue state (leases tasks, marks them succeeded with empty output).');
@@ -286,20 +305,20 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
     if (wakeResult.decision === 'would_lease' && wakeResult.taskKind === runnerKind) {
       const eventEmitter = new StoreEventEmitter();
       const artifactStore = stateManager.piArtifactStore;
-      const runtimeAdapter = resolveRuntimeAdapter({ runtimeKind, taskId: wakeResult.taskId, workspaceDir, runnerKind });
+      const runtimeAdapter = resolveRuntimeAdapter({ runtimeKind, taskId: wakeResult.taskId, workspaceDir, runnerKind, timeoutMs: cliTimeoutMs });
 
       if (runnerKind === 'dreamer') {
         const validator = new DefaultDreamerValidator();
         const runner = new DreamerRunner(
           { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
-          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: 300_000 },
+          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );
         runnerResult = await runner.run(wakeResult.taskId);
       } else if (runnerKind === 'philosopher') {
         const validator = new DefaultPhilosopherValidator();
         const runner = new PhilosopherRunner(
           { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
-          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: 300_000 },
+          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );
         runnerResult = await runner.run(wakeResult.taskId);
       }
@@ -309,6 +328,14 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
 
     const output = buildOutput(wakeResult, runnerResult, skipReason);
     output.runnerKind = runnerKind;
+    output.effectiveTimeoutMs = effectiveTimeoutMs;
+    if (runnerResult?.failureReason?.includes('timeoutSource=')) {
+      const match = /timeoutSource=(\w+)/.exec(runnerResult.failureReason);
+      if (match) {
+        const [, source] = match;
+        output.timeoutSource = source;
+      }
+    }
 
     if (opts.enqueueNext && runnerResult?.status === 'succeeded' && wakeResult.decision === 'would_lease') {
       const commitResult = await orchestrator.commitNextTaskProposal(wakeResult.taskId);

--- a/packages/pd-cli/src/commands/runtime-recovery.ts
+++ b/packages/pd-cli/src/commands/runtime-recovery.ts
@@ -1,0 +1,96 @@
+import * as path from 'path';
+import { RuntimeStateManager } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface RecoverySweepOptions {
+  workspace?: string;
+  dryRun?: boolean;
+  confirm?: boolean;
+  json?: boolean;
+}
+
+interface RecoverySweepOutput {
+  mode: 'dry-run' | 'confirm';
+  expiredLeaseCount: number;
+  expiredLeaseTaskIds: string[];
+  recoveredCount: number;
+  failedCount: number;
+  errors: string[];
+  samples: {
+    taskId: string;
+    previousStatus: string;
+    newStatus: string;
+    wasLeaseExpired: boolean;
+  }[];
+}
+
+function formatTextOutput(output: RecoverySweepOutput): string {
+  const lines: string[] = [];
+
+  lines.push(`Recovery Sweep (${output.mode})`);
+  lines.push(`  expired_leases: ${output.expiredLeaseCount}`);
+
+  if (output.expiredLeaseCount > 0) {
+    lines.push(`  task_ids: ${output.expiredLeaseTaskIds.join(', ')}`);
+  }
+
+  if (output.mode === 'confirm') {
+    lines.push(`  recovered: ${output.recoveredCount}`);
+    lines.push(`  failed: ${output.failedCount}`);
+    if (output.errors.length > 0) {
+      lines.push(`  errors:`);
+      for (const err of output.errors) {
+        lines.push(`    - ${err}`);
+      }
+    }
+    for (const sample of output.samples.slice(0, 5)) {
+      lines.push(`  ${sample.taskId}: ${sample.previousStatus} → ${sample.newStatus}`);
+    }
+  } else {
+    lines.push(`  (use --confirm to recover expired leases)`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Promise<void> {
+  const workspaceDir = opts.workspace ? path.resolve(opts.workspace) : resolveWorkspaceDir();
+  const isConfirm = opts.confirm ?? false;
+  const isDryRun = !isConfirm;
+
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+  await stateManager.initialize();
+
+  try {
+    const expiredLeaseTaskIds = await stateManager.detectExpiredLeases();
+
+    const output: RecoverySweepOutput = {
+      mode: isDryRun ? 'dry-run' : 'confirm',
+      expiredLeaseCount: expiredLeaseTaskIds.length,
+      expiredLeaseTaskIds,
+      recoveredCount: 0,
+      failedCount: 0,
+      errors: [],
+      samples: [],
+    };
+
+    if (isConfirm && expiredLeaseTaskIds.length > 0) {
+      const result = await stateManager.runRecoverySweep();
+      output.recoveredCount = result.recovered;
+      output.errors = result.errors;
+      output.failedCount = result.errors.length;
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      console.log(formatTextOutput(output));
+    }
+
+    if (expiredLeaseTaskIds.length > 0 && isDryRun) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await stateManager.close();
+  }
+}

--- a/packages/pd-cli/src/commands/runtime-recovery.ts
+++ b/packages/pd-cli/src/commands/runtime-recovery.ts
@@ -54,6 +54,11 @@ function formatTextOutput(output: RecoverySweepOutput): string {
 }
 
 export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Promise<void> {
+  if (opts.dryRun && opts.confirm) {
+    console.error('Error: --dry-run and --confirm are mutually exclusive');
+    process.exitCode = 1;
+    return;
+  }
   const workspaceDir = opts.workspace ? path.resolve(opts.workspace) : resolveWorkspaceDir();
   const isConfirm = opts.confirm ?? false;
   const isDryRun = !isConfirm;
@@ -75,10 +80,23 @@ export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Pr
     };
 
     if (isConfirm && expiredLeaseTaskIds.length > 0) {
-      const result = await stateManager.runRecoverySweep();
-      output.recoveredCount = result.recovered;
-      output.errors = result.errors;
-      output.failedCount = result.errors.length;
+      for (const taskId of expiredLeaseTaskIds) {
+        try {
+          const result = await stateManager.recoverTask(taskId);
+          if (result) {
+            output.recoveredCount++;
+            output.samples.push({
+              taskId,
+              previousStatus: result.previousStatus,
+              newStatus: result.newStatus,
+              wasLeaseExpired: true,
+            });
+          }
+        } catch (err) {
+          output.failedCount++;
+          output.errors.push(`${taskId}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
     }
 
     if (opts.json) {

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -32,11 +32,12 @@ import { handleRuntimeUat } from './commands/runtime-uat.js';
 import { handleRuntimeInternalizationQueue } from './commands/runtime-internalization-queue.js';
 import { handleRuntimeInternalizationWakeOnce } from './commands/runtime-internalization-wake-once.js';
 import { handleRuntimeInternalizationRunOnce } from './commands/runtime-internalization-run-once.js';
-import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair, handleCandidateRoute, handleCandidateInternalize } from './commands/candidate.js';
+import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair, handleCandidateRoute, handleCandidateInternalize, handleCandidateInternalizationBackfill } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 import { handleRuntimeCanary } from './commands/runtime-canary.js';
 import { handleRuntimeInternalizationIntegrity } from './commands/runtime-internalization-integrity.js';
 import { handleRuntimeDiagnosticsExport } from './commands/runtime-diagnostics-export.js';
+import { handleRuntimeRecoverySweep } from './commands/runtime-recovery.js';
 
 const program = new Command();
 
@@ -423,9 +424,10 @@ internalizationCmd
   .option('--runtime <kind>', 'Runtime adapter kind: config (from workflows.yaml), pi-ai, openclaw-cli, test-double (default: config)', 'config')
   .option('--allow-test-double', 'Acknowledge that test-double runtime will mutate real queue state')
   .option('--enqueue-next', 'After successful runner execution, commit successor task to queue')
+  .option('--timeout-ms <ms>', 'Runner timeout in milliseconds (default: 300000, overrides workflows.yaml)', parseInt)
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
-    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble, enqueueNext: opts.enqueueNext });
+    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble, enqueueNext: opts.enqueueNext, timeoutMs: opts.timeoutMs });
   });
 
 internalizationCmd
@@ -440,6 +442,21 @@ internalizationCmd
 const diagnosticsCmd = runtimeCmd
   .command('diagnostics')
   .description('Control plane diagnostic bundle operations');
+
+const recoveryCmd = runtimeCmd
+  .command('recovery')
+  .description('Runtime V2 lease recovery operations');
+
+recoveryCmd
+  .command('sweep')
+  .description('Detect and optionally recover expired leases')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--confirm', 'Actually recover expired leases')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeRecoverySweep({ workspace: opts.workspace, dryRun: !opts.confirm, confirm: opts.confirm, json: opts.json });
+  });
 
 diagnosticsCmd
   .command('export')
@@ -545,12 +562,24 @@ candidateCmd
   });
 
 candidateCmd
-  .command('show <candidateId>')
+  .command('show [candidateId]')
   .description('Show detail for a single principle candidate')
   .requiredOption('-w, --workspace <path>', 'Workspace directory')
+  .option('--candidate-id <id>', 'Candidate ID (alternative to positional arg)')
   .option('--json', 'Output raw JSON')
   .action(async (candidateId, opts) => {
-    await handleCandidateShow({ candidateId, ...opts });
+    const resolvedId = opts.candidateId ?? candidateId;
+    if (!resolvedId) {
+      console.error('Error: candidate ID is required (positional or --candidate-id)');
+      process.exitCode = 1;
+      return;
+    }
+    if (candidateId && opts.candidateId && candidateId !== opts.candidateId) {
+      console.error(`Error: conflicting candidate IDs: positional="${candidateId}", --candidate-id="${opts.candidateId}"`);
+      process.exitCode = 1;
+      return;
+    }
+    await handleCandidateShow({ candidateId: resolvedId, ...opts });
   });
 
 candidateCmd
@@ -602,6 +631,21 @@ candidateCmd
   .option('--dry-run', 'Preview without writing to database')
   .action(async (opts) => {
     await handleCandidateInternalize(opts);
+  });
+
+const candidateInternalizationCmd = candidateCmd
+  .command('internalization')
+  .description('Internalization pipeline operations for candidates');
+
+candidateInternalizationCmd
+  .command('backfill')
+  .description('Backfill dreamer tasks for consumed candidates created before Internalization Engine')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--confirm', 'Actually create missing dreamer tasks')
+  .option('--json', 'Output as JSON')
+  .action(async (opts) => {
+    await handleCandidateInternalizationBackfill({ workspace: opts.workspace, dryRun: !opts.confirm, confirm: opts.confirm, json: opts.json });
   });
 
 // ── Artifact inspection commands ────────────────────────────────────────────

--- a/packages/pd-cli/tests/commands/candidate-show.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-show.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCandidateShow, mockResolveWorkspaceDir } = vi.hoisted(() => ({
+  mockCandidateShow: vi.fn(),
+  mockResolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: mockResolveWorkspaceDir,
+}));
+
+vi.mock('../../src/commands/candidate.js', () => ({
+  handleCandidateShow: mockCandidateShow,
+  handleCandidateIntake: vi.fn(),
+  handleCandidateRoute: vi.fn(),
+  handleCandidateInternalize: vi.fn(),
+  handleCandidateAudit: vi.fn(),
+  handleCandidateInternalizationBackfill: vi.fn(),
+}));
+
+import { Command } from 'commander';
+
+function createTestProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+
+  const candidateCmd = program.command('candidate');
+
+  candidateCmd
+    .command('show [candidateId]')
+    .description('Show detail for a single principle candidate')
+    .requiredOption('-w, --workspace <path>', 'Workspace directory')
+    .option('--candidate-id <id>', 'Candidate ID (alternative to positional arg)')
+    .option('--json', 'Output raw JSON')
+    .action(async (candidateId, opts) => {
+      const resolvedId = opts.candidateId ?? candidateId;
+      if (!resolvedId) {
+        throw new Error('candidate ID is required (positional or --candidate-id)');
+      }
+      if (candidateId && opts.candidateId && candidateId !== opts.candidateId) {
+        throw new Error(`conflicting candidate IDs: positional="${candidateId}", --candidate-id="${opts.candidateId}"`);
+      }
+      await mockCandidateShow({ candidateId: resolvedId, ...opts });
+    });
+
+  return program;
+}
+
+describe('candidate show CLI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCandidateShow.mockResolvedValue(undefined);
+  });
+
+  it('positional candidateId works', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'show', 'c_123', '-w', '/ws']);
+
+    expect(mockCandidateShow).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateId: 'c_123' }),
+    );
+  });
+
+  it('--candidate-id works', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'show', '-w', '/ws', '--candidate-id', 'c_456']);
+
+    expect(mockCandidateShow).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateId: 'c_456' }),
+    );
+  });
+
+  it('both positional and --candidate-id with same value works', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'show', 'c_789', '-w', '/ws', '--candidate-id', 'c_789']);
+
+    expect(mockCandidateShow).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateId: 'c_789' }),
+    );
+  });
+
+  it('conflicting positional and --candidate-id throws error', async () => {
+    const program = createTestProgram();
+    await expect(
+      program.parseAsync(['node', 'pd', 'candidate', 'show', 'c_a', '-w', '/ws', '--candidate-id', 'c_b']),
+    ).rejects.toThrow('conflicting candidate IDs');
+  });
+
+  it('neither positional nor --candidate-id throws error', async () => {
+    const program = createTestProgram();
+    await expect(
+      program.parseAsync(['node', 'pd', 'candidate', 'show', '-w', '/ws']),
+    ).rejects.toThrow('candidate ID is required');
+  });
+});

--- a/packages/pd-cli/tests/commands/runtime-canary.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-canary.test.ts
@@ -10,6 +10,7 @@ const {
   mockStateManagerClose,
   mockAuditConsistency,
   mockBuildGfiSnapshot,
+  mockClassifyGfiHealth,
 } = vi.hoisted(() => ({
   mockSchemaCheck: vi.fn(),
   mockHealthSnapshot: vi.fn(),
@@ -20,6 +21,7 @@ const {
   mockStateManagerClose: vi.fn().mockResolvedValue(undefined),
   mockAuditConsistency: vi.fn(),
   mockBuildGfiSnapshot: vi.fn(),
+  mockClassifyGfiHealth: vi.fn(),
 }));
 
 vi.mock('../../src/resolve-workspace.js', () => ({
@@ -44,6 +46,7 @@ vi.mock('@principles/core/runtime-v2', () => ({
   }),
   auditCandidateLedgerConsistency: mockAuditConsistency,
   buildGfiWorkspaceSnapshot: mockBuildGfiSnapshot,
+  classifyGfiWorkspaceHealth: mockClassifyGfiHealth,
 }));
 
 import { runCanaryChecks } from '../../src/commands/runtime-canary.js';
@@ -108,6 +111,7 @@ describe('runCanaryChecks', () => {
     mockStateManagerClose.mockResolvedValue(undefined);
     mockAuditConsistency.mockResolvedValue({ status: 'ok', consumedCount: 0, orphanCandidateCount: 0, missingLedgerCount: 0 });
     mockBuildGfiSnapshot.mockReturnValue(healthyGfiSnapshot());
+    mockClassifyGfiHealth.mockReturnValue({ status: 'healthy', reason: '0 active, 0 stale sessions', staleGfiDegradedThreshold: 40 });
   });
 
   it('returns healthy when all checks are healthy', async () => {

--- a/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
@@ -37,6 +37,7 @@ function emptySnapshot() {
     sampleInvalidTaskIds: [],
     blockedSummary: { count: 0, samples: [] },
     dependencyFailedSummary: { count: 0, samples: [] },
+    retryWaitPendingSummary: { count: 0, samples: [] },
     readyTasks: [],
     noReadyTasks: { reason: 'no_candidates', inspectedCount: 0 },
   };

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -680,4 +680,146 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.artifactId).toBe('pi-art-rk');
     expect(output.resultRef).toBe('dreamer://run-rk');
   });
+
+  it('--timeout-ms passes effectiveTimeoutMs to DreamerRunner and output', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-tm',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-tm',
+      runId: 'run-tm',
+      artifactId: 'pi-art-tm',
+      resultRef: 'dreamer://run-tm',
+      contextHash: 'ctx-tm',
+      output: { valid: true, taskId: 'task-dreamer-tm', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, timeoutMs: 180_000, json: true });
+
+    const DreamerRunnerMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.DreamerRunner),
+    );
+    const lastCall = DreamerRunnerMock.mock.calls[DreamerRunnerMock.mock.calls.length - 1];
+    if (lastCall) {
+      const opts = lastCall[1] as { timeoutMs?: number };
+      expect(opts.timeoutMs).toBe(180_000);
+    }
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.effectiveTimeoutMs).toBe(180_000);
+  });
+
+  it('default timeoutMs is 300000 when --timeout-ms not provided', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-dt',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-dt',
+      runId: 'run-dt',
+      artifactId: 'pi-art-dt',
+      resultRef: 'dreamer://run-dt',
+      contextHash: 'ctx-dt',
+      output: { valid: true, taskId: 'task-dreamer-dt', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const DreamerRunnerMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.DreamerRunner),
+    );
+    const lastCall = DreamerRunnerMock.mock.calls[DreamerRunnerMock.mock.calls.length - 1];
+    if (lastCall) {
+      const opts = lastCall[1] as { timeoutMs?: number };
+      expect(opts.timeoutMs).toBe(300_000);
+    }
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.effectiveTimeoutMs).toBe(300_000);
+  });
+
+  it('timeout source extracted from failureReason on timeout', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-ts',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'failed',
+      taskId: 'task-dreamer-ts',
+      errorCategory: 'timeout',
+      failureReason: '[timeout] LLM request timed out after 300000ms (timeoutSource=provider_request)',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, timeoutMs: 300_000, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.timeoutSource).toBe('provider_request');
+    expect(output.effectiveTimeoutMs).toBe(300_000);
+  });
+
+  it('timeout source extracted as runner_poll from abort timeout', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-rp',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'failed',
+      taskId: 'task-dreamer-rp',
+      errorCategory: 'timeout',
+      failureReason: '[timeout] LLM request timed out after 300000ms (timeoutSource=runner_poll)',
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.timeoutSource).toBe('runner_poll');
+  });
+
+  it('--timeout-ms overrides workflows.yaml timeoutMs for PiAiRuntimeAdapter', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-ov',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-ov',
+      runId: 'run-ov',
+      artifactId: 'pi-art-ov',
+      resultRef: 'dreamer://run-ov',
+      contextHash: 'ctx-ov',
+      output: { valid: true, taskId: 'task-dreamer-ov', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'config', timeoutMs: 240_000, json: true });
+
+    const PiAiMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.PiAiRuntimeAdapter),
+    );
+    const lastCall = PiAiMock.mock.calls[PiAiMock.mock.calls.length - 1];
+    if (lastCall) {
+      const config = lastCall[0] as { timeoutMs?: number };
+      expect(config.timeoutMs).toBe(240_000);
+    }
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.effectiveTimeoutMs).toBe(240_000);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/gfi-workspace-health.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/gfi-workspace-health.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { classifyGfiWorkspaceHealth } from '../gfi/gfi-read-model.js';
+import type { GfiWorkspaceSnapshot } from '../gfi/gfi-read-model.js';
+
+function makeSnapshot(overrides: Partial<GfiWorkspaceSnapshot>): GfiWorkspaceSnapshot {
+  return {
+    active: null,
+    staleSessionCount: 0,
+    staleGfiRange: null,
+    totalSessionCount: 0,
+    activeSessionCount: 0,
+    generatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('classifyGfiWorkspaceHealth', () => {
+  it('0 active + stale low GFI → healthy', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 0,
+      staleSessionCount: 40,
+      staleGfiRange: { min: 0, max: 4.6875 },
+      totalSessionCount: 40,
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('healthy');
+    expect(result.reason).toContain('low GFI');
+  });
+
+  it('0 active + stale high GFI → degraded', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 0,
+      staleSessionCount: 25,
+      staleGfiRange: { min: 10, max: 55 },
+      totalSessionCount: 25,
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('degraded');
+    expect(result.reason).toContain('high GFI');
+  });
+
+  it('active session with elevated GFI → degraded', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 1,
+      staleSessionCount: 0,
+      totalSessionCount: 1,
+      active: {
+        currentGfi: 65,
+        stage: 'elevated' as const,
+        sources: {},
+        dominantSource: null,
+        consecutiveErrors: 3,
+        lastErrorSource: 'tool_failure',
+        policy: {
+          elevatedThreshold: 40,
+          criticalThreshold: 70,
+          saturatedThreshold: 100,
+          repeatedFailureMultiplierMax: 3.0,
+        },
+        consumers: { attitudeMode: 'conciliatory' as const, painDiagnosticReason: 'high_gfi' as const },
+      },
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('degraded');
+    expect(result.reason).toContain('elevated GFI');
+  });
+
+  it('active session with stable GFI → healthy', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 1,
+      staleSessionCount: 5,
+      staleGfiRange: { min: 0, max: 3 },
+      totalSessionCount: 6,
+      active: {
+        currentGfi: 5,
+        stage: 'stable' as const,
+        sources: {},
+        dominantSource: null,
+        consecutiveErrors: 0,
+        policy: {
+          elevatedThreshold: 40,
+          criticalThreshold: 70,
+          saturatedThreshold: 100,
+          repeatedFailureMultiplierMax: 3.0,
+        },
+        consumers: { attitudeMode: 'efficient' as const, painDiagnosticReason: 'none' as const },
+      },
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('healthy');
+  });
+
+  it('0 active + 0 stale → healthy', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 0,
+      staleSessionCount: 0,
+      totalSessionCount: 0,
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('healthy');
+  });
+
+  it('respects custom staleGfiDegradedThreshold', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 0,
+      staleSessionCount: 30,
+      staleGfiRange: { min: 5, max: 15 },
+      totalSessionCount: 30,
+    });
+
+    const resultDefault = classifyGfiWorkspaceHealth(snapshot);
+    expect(resultDefault.status).toBe('healthy');
+
+    const resultLowThreshold = classifyGfiWorkspaceHealth(snapshot, { staleGfiDegradedThreshold: 10 });
+    expect(resultLowThreshold.status).toBe('degraded');
+  });
+
+  it('0 active + stale GFI exactly at threshold → degraded', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 0,
+      staleSessionCount: 25,
+      staleGfiRange: { min: 0, max: 40 },
+      totalSessionCount: 25,
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('degraded');
+  });
+
+  it('0 active + stale GFI just below threshold → healthy', () => {
+    const snapshot = makeSnapshot({
+      activeSessionCount: 0,
+      staleSessionCount: 25,
+      staleGfiRange: { min: 0, max: 39.9 },
+      totalSessionCount: 25,
+    });
+
+    const result = classifyGfiWorkspaceHealth(snapshot);
+
+    expect(result.status).toBe('healthy');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/operator-health-gfi-degraded.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/operator-health-gfi-degraded.test.ts
@@ -52,7 +52,7 @@ describe('OperatorHealthReadModel GFI health checks (CANARY-02)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('flags degraded when staleSessionCount > 20 and no active sessions', async () => {
+  it('0 active + stale low GFI → healthy (not degraded)', async () => {
     const pdDir = path.join(tmpDir, '.pd');
     fs.mkdirSync(pdDir, { recursive: true });
     initMinimalDb(pdDir);
@@ -82,7 +82,79 @@ describe('OperatorHealthReadModel GFI health checks (CANARY-02)', () => {
       const s = await model.getSnapshot();
       expect(s.gfi.staleSessionCount).toBeGreaterThanOrEqual(20);
       expect(s.gfi.activeSessionCount).toBe(0);
+      expect(s.overallStatus).toBe('healthy');
+    } finally {
+      await model.close();
+    }
+  });
+
+  it('0 active + stale high GFI → degraded', async () => {
+    const pdDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    initMinimalDb(pdDir);
+
+    const sessionDir = path.join(tmpDir, '.state', 'sessions');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const nowMs = Date.now();
+    for (let i = 0; i < 25; i++) {
+      fs.writeFileSync(path.join(sessionDir, `stale-${i}.json`), JSON.stringify({
+        sessionId: `stale-${i}`,
+        currentGfi: 50,
+        consecutiveErrors: 3,
+        lastActivityAt: nowMs - (4 * 60 * 60 * 1000),
+      }));
+    }
+
+    const chain = {
+      getLastSuccessfulChain: () => Promise.resolve(healthyChain()),
+      close: () => Promise.resolve(),
+    };
+
+    const model = new OperatorHealthReadModel({
+      workspaceDir: tmpDir,
+      painChainReadModel: chain as unknown as PainChainReadModel,
+    });
+    try {
+      const s = await model.getSnapshot();
+      expect(s.gfi.staleSessionCount).toBeGreaterThanOrEqual(20);
+      expect(s.gfi.activeSessionCount).toBe(0);
       expect(s.overallStatus).toBe('degraded');
+      expect(s.recommendedActions.some(a => a.includes('GFI degraded'))).toBe(true);
+    } finally {
+      await model.close();
+    }
+  });
+
+  it('recommendedActions only includes GFI cleanup when truly degraded', async () => {
+    const pdDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    initMinimalDb(pdDir);
+
+    const sessionDir = path.join(tmpDir, '.state', 'sessions');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const nowMs = Date.now();
+    for (let i = 0; i < 30; i++) {
+      fs.writeFileSync(path.join(sessionDir, `stale-${i}.json`), JSON.stringify({
+        sessionId: `stale-${i}`,
+        currentGfi: 3,
+        consecutiveErrors: 0,
+        lastActivityAt: nowMs - (4 * 60 * 60 * 1000),
+      }));
+    }
+
+    const chain = {
+      getLastSuccessfulChain: () => Promise.resolve(healthyChain()),
+      close: () => Promise.resolve(),
+    };
+
+    const model = new OperatorHealthReadModel({
+      workspaceDir: tmpDir,
+      painChainReadModel: chain as unknown as PainChainReadModel,
+    });
+    try {
+      const s = await model.getSnapshot();
+      expect(s.overallStatus).toBe('healthy');
+      expect(s.recommendedActions.some(a => a.includes('GFI degraded'))).toBe(false);
     } finally {
       await model.close();
     }

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-signal-bridge-retried.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-signal-bridge-retried.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression test for: retried task with empty candidateIds in pain chain trace.
+ *
+ * Issue: When DiagnosticianRunner returns status='retried', PainSignalBridge.onPainDetected()
+ * returned candidateIds=[] and ledgerEntryIds=[], but trace show also showed candidateIds=[].
+ * This made the UAT report "output_invalid" and allHaveCandidates=false.
+ *
+ * The bridge correctly propagates retried status with empty candidates (since no commit was made).
+ * The fix verifies this behavior is stable and trace show correctly reads the task state.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { DiagnosticianRunner } from '../runner/diagnostician-runner.js';
+import type { CandidateIntakeService } from '../candidate-intake-service.js';
+import type { LedgerAdapter } from '../candidate-intake.js';
+import { PainSignalBridge } from '../pain-signal-bridge.js';
+import type { RunnerResult } from '../runner/runner-result.js';
+
+const TASK_ID = 'diagnosis_pain-retry-001';
+const PAIN_ID = 'pain-retry-001';
+
+interface MockStateManager {
+  getTask: ReturnType<typeof vi.fn>;
+  createTask: ReturnType<typeof vi.fn>;
+  updateTask: ReturnType<typeof vi.fn>;
+  getCandidatesByTaskId: ReturnType<typeof vi.fn>;
+  getRunsByTask: ReturnType<typeof vi.fn>;
+  getRetryPolicy: ReturnType<typeof vi.fn>;
+}
+
+interface MockRunner {
+  run: ReturnType<typeof vi.fn>;
+}
+
+function createMocks() {
+  const stateManager: MockStateManager = {
+    getTask: vi.fn(),
+    createTask: vi.fn(),
+    updateTask: vi.fn(),
+    getCandidatesByTaskId: vi.fn(),
+    getRunsByTask: vi.fn(),
+    getRetryPolicy: vi.fn(),
+  };
+
+  const runner: MockRunner = {
+    run: vi.fn(),
+  };
+
+  const intakeService = {};
+  const ledgerAdapter: LedgerAdapter = {
+    register: vi.fn(),
+    existsForCandidate: vi.fn(),
+    getEntries: vi.fn(),
+  } as unknown as LedgerAdapter;
+
+  return {
+    stateManager: stateManager as unknown as RuntimeStateManager,
+    runner: runner as unknown as DiagnosticianRunner,
+    intakeService: intakeService as unknown as CandidateIntakeService,
+    ledgerAdapter,
+    _stateManager: stateManager,
+    _runner: runner,
+  };
+}
+
+function makeRetriedResult(): RunnerResult {
+  return {
+    status: 'retried',
+    taskId: TASK_ID,
+    errorCategory: 'output_invalid',
+    failureReason: 'Validation failed: confidence must be between 0 and 1',
+    attemptCount: 1,
+  };
+}
+
+describe('PainSignalBridge retried with empty candidates', () => {
+  it('returns status=retried with empty candidateIds when runner returns retried', async () => {
+    const mocks = createMocks();
+    mocks._stateManager.getTask.mockResolvedValue(null);
+    mocks._stateManager.createTask.mockResolvedValue(undefined);
+    mocks._stateManager.updateTask.mockResolvedValue(undefined);
+    mocks._stateManager.getCandidatesByTaskId.mockResolvedValue([]);
+    mocks._stateManager.getRunsByTask.mockResolvedValue([]);
+    mocks._stateManager.getRetryPolicy.mockReturnValue({
+      calculateBackoff: () => 30000,
+      shouldRetry: () => true,
+    });
+    mocks._runner.run.mockResolvedValue(makeRetriedResult());
+
+    const bridge = new PainSignalBridge({
+      stateManager: mocks.stateManager,
+      runner: mocks.runner,
+      intakeService: mocks.intakeService,
+      ledgerAdapter: mocks.ledgerAdapter,
+    });
+
+    const result = await bridge.onPainDetected({
+      painId: PAIN_ID,
+      painType: 'tool_failure',
+      source: 'test',
+      reason: 'test',
+    });
+
+    expect(result.status).toBe('retried');
+    expect(result.candidateIds).toHaveLength(0);
+    expect(result.ledgerEntryIds).toHaveLength(0);
+    expect(result.errorCategory).toBe('output_invalid');
+    expect(result.message).toBe('Validation failed: confidence must be between 0 and 1');
+  });
+
+  it('does NOT query candidates or runs when runner returns retried', async () => {
+    const mocks = createMocks();
+    mocks._stateManager.getTask.mockResolvedValue(null);
+    mocks._stateManager.createTask.mockResolvedValue(undefined);
+    mocks._stateManager.updateTask.mockResolvedValue(undefined);
+    mocks._stateManager.getCandidatesByTaskId.mockResolvedValue([]);
+    mocks._stateManager.getRunsByTask.mockResolvedValue([]);
+    mocks._stateManager.getRetryPolicy.mockReturnValue({
+      calculateBackoff: () => 30000,
+      shouldRetry: () => true,
+    });
+    mocks._runner.run.mockResolvedValue(makeRetriedResult());
+
+    const bridge = new PainSignalBridge({
+      stateManager: mocks.stateManager,
+      runner: mocks.runner,
+      intakeService: mocks.intakeService,
+      ledgerAdapter: mocks.ledgerAdapter,
+    });
+
+    await bridge.onPainDetected({
+      painId: PAIN_ID,
+      painType: 'tool_failure',
+      source: 'test',
+      reason: 'test',
+    });
+
+    expect(mocks._stateManager.getCandidatesByTaskId).not.toHaveBeenCalled();
+    expect(mocks._stateManager.getRunsByTask).not.toHaveBeenCalled();
+  });
+
+  it('returns retried with empty candidates for existing task in retry_wait state', async () => {
+    const mocks = createMocks();
+    mocks._stateManager.getTask.mockResolvedValue({
+      taskId: TASK_ID,
+      taskKind: 'diagnostician',
+      status: 'retry_wait',
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: '2026-05-10T00:00:00Z',
+      attemptCount: 1,
+      maxAttempts: 3,
+      lastError: 'output_invalid',
+    });
+    mocks._stateManager.createTask.mockResolvedValue(undefined);
+    mocks._stateManager.updateTask.mockResolvedValue(undefined);
+    mocks._stateManager.getCandidatesByTaskId.mockResolvedValue([]);
+    mocks._stateManager.getRunsByTask.mockResolvedValue([]);
+    mocks._stateManager.getRetryPolicy.mockReturnValue({
+      calculateBackoff: () => 30000,
+      shouldRetry: () => true,
+    });
+    mocks._runner.run.mockResolvedValue(makeRetriedResult());
+
+    const bridge = new PainSignalBridge({
+      stateManager: mocks.stateManager,
+      runner: mocks.runner,
+      intakeService: mocks.intakeService,
+      ledgerAdapter: mocks.ledgerAdapter,
+    });
+
+    const result = await bridge.onPainDetected({
+      painId: PAIN_ID,
+      painType: 'tool_failure',
+      source: 'test',
+      reason: 'test',
+    });
+
+    expect(result.status).toBe('retried');
+    expect(result.candidateIds).toHaveLength(0);
+    expect(result.ledgerEntryIds).toHaveLength(0);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
@@ -157,8 +157,8 @@ const LEDGER_DEPRECATED: LedgerStore = {
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
 let mockLedgerData: LedgerStore = LEDGER_EMPTY;
-let mockCandidateRows: { candidate_id: string; created_at: string }[] = [];
-let mockAllCandidateRows: { candidate_id: string; status: string }[] = [];
+let _mockCandidateRows: { candidate_id: string; created_at: string }[] = [];
+let mockAllCandidateRows: { candidate_id: string; status: string; created_at?: string }[] = [];
 let mockDbExists = false;
 let mockDbShouldThrow = false;
 
@@ -173,11 +173,15 @@ vi.mock('better-sqlite3', () => ({
     }
     this.prepare = vi.fn((sql: string) => ({
       all: vi.fn(() => {
-        if (sql.includes('consumed')) {
-          return mockCandidateRows;
+        if (sql.includes('status') && sql.includes('created_at')) {
+          return mockAllCandidateRows.map(r => ({
+            candidate_id: r.candidate_id,
+            status: r.status,
+            created_at: r.created_at ?? '2026-01-15T00:00:00.000Z',
+          }));
         }
         if (sql.includes('FROM principle_candidates')) {
-          return mockAllCandidateRows;
+          return mockAllCandidateRows.map(r => ({ candidate_id: r.candidate_id }));
         }
         return [];
       }),
@@ -194,7 +198,7 @@ vi.mock('fs', () => ({
 
 function reset() {
   mockLedgerData = LEDGER_EMPTY;
-  mockCandidateRows = [];
+  _mockCandidateRows = [];
   mockAllCandidateRows = [];
   mockDbExists = false;
   mockDbShouldThrow = false;
@@ -297,8 +301,11 @@ describe('PruningReadModel', () => {
         },
       },
     };
-    mockCandidateRows = [
+    _mockCandidateRows = [
       { candidate_id: 'c_in_db', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockAllCandidateRows = [
+      { candidate_id: 'c_in_db', status: 'consumed', created_at: '2026-01-15T00:00:00.000Z' },
     ];
     mockDbExists = true;
 
@@ -340,7 +347,7 @@ describe('PruningReadModel', () => {
         },
       },
     };
-    mockCandidateRows = [];
+    _mockCandidateRows = [];
     mockDbExists = true;
 
     const model = new PruningReadModel({ workspaceDir: WORKSPACE });
@@ -381,7 +388,7 @@ describe('PruningReadModel', () => {
         },
       },
     };
-    mockCandidateRows = [];
+    _mockCandidateRows = [];
     mockDbExists = true;
 
     const model = new PruningReadModel({ workspaceDir: WORKSPACE });
@@ -459,8 +466,11 @@ describe('PruningReadModel', () => {
         },
       },
     };
-    mockCandidateRows = [
+    _mockCandidateRows = [
       { candidate_id: 'c_recent1', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockAllCandidateRows = [
+      { candidate_id: 'c_recent1', status: 'consumed', created_at: '2026-01-15T00:00:00.000Z' },
     ];
     mockDbExists = true;
 
@@ -571,7 +581,7 @@ describe('PruningReadModel', () => {
 
   it('getHealthSummary reuses signals without duplicate DB query', () => {
     mockLedgerData = LEDGER_MIXED;
-    mockCandidateRows = [];
+    _mockCandidateRows = [];
     mockDbExists = true;
 
     const model = new PruningReadModel({ workspaceDir: WORKSPACE });
@@ -579,6 +589,90 @@ describe('PruningReadModel', () => {
 
     expect(summary.totalPrinciples).toBe(4);
     expect(summary.orphanDerivedCandidateCount).toBe(1);
+  });
+
+  it('orphan count matches getOrphanDerivedCandidates for same data', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          p1: {
+            id: 'p1',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: ['c_consumed', 'c_pending', 'c_missing'],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    _mockCandidateRows = [
+      { candidate_id: 'c_consumed', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockAllCandidateRows = [
+      { candidate_id: 'c_consumed', status: 'consumed', created_at: '2026-01-15T00:00:00.000Z' },
+      { candidate_id: 'c_pending', status: 'pending', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const summary = model.getHealthSummary();
+    const orphanResult = model.getOrphanDerivedCandidates();
+
+    expect(summary.orphanDerivedCandidateCount).toBe(orphanResult.candidates.length);
+    expect(orphanResult.candidates.length).toBe(1);
+    expect(orphanResult.candidates[0]?.candidateId).toBe('c_missing');
+  });
+
+  it('pending candidate in DB is not counted as orphan', () => {
+    mockLedgerData = {
+      tree: {
+        principles: {
+          p1: {
+            id: 'p1',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            derivedFromPainIds: ['c_pending'],
+            ruleIds: [],
+            conflictsWithPrincipleIds: [],
+            version: 1,
+            text: '',
+            triggerPattern: '',
+            action: '',
+            priority: 'P1',
+            scope: 'general',
+            evaluability: 'deterministic',
+            valueScore: 0,
+            adherenceRate: 0,
+            painPreventedCount: 0,
+          } as LedgerPrinciple,
+        },
+      },
+    };
+    _mockCandidateRows = [];
+    mockAllCandidateRows = [
+      { candidate_id: 'c_pending', status: 'pending', created_at: '2026-01-15T00:00:00.000Z' },
+    ];
+    mockDbExists = true;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE });
+    const signals = model.getPrincipleSignals();
+    const summary = model.getHealthSummary();
+
+    expect(signals[0]?.orphanCandidateCount).toBe(0);
+    expect(summary.orphanDerivedCandidateCount).toBe(0);
   });
 
   describe('getOrphanDerivedCandidates', () => {
@@ -608,7 +702,7 @@ describe('PruningReadModel', () => {
           },
         },
       };
-      mockCandidateRows = [];
+      _mockCandidateRows = [];
       mockAllCandidateRows = [];
       mockDbExists = true;
 
@@ -650,11 +744,11 @@ describe('PruningReadModel', () => {
           },
         },
       };
-      mockCandidateRows = [
+      _mockCandidateRows = [
         { candidate_id: 'c_exists', created_at: '2026-01-15T00:00:00.000Z' },
       ];
       mockAllCandidateRows = [
-        { candidate_id: 'c_exists', status: 'consumed' },
+        { candidate_id: 'c_exists', status: 'consumed', created_at: '2026-01-15T00:00:00.000Z' },
       ];
       mockDbExists = true;
 
@@ -703,7 +797,7 @@ describe('PruningReadModel', () => {
           },
         },
       };
-      mockCandidateRows = [];
+      _mockCandidateRows = [];
       mockAllCandidateRows = [];
       mockDbExists = false;
 
@@ -741,7 +835,7 @@ describe('PruningReadModel', () => {
           },
         },
       };
-      mockCandidateRows = [];
+      _mockCandidateRows = [];
       mockAllCandidateRows = [];
       mockDbExists = true;
       mockDbShouldThrow = true;

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
@@ -297,15 +297,14 @@ describe('PiAiRuntimeAdapter', () => {
       }
     });
 
-    it('passes apiKey, timeoutMs from config, and maxRetries: 0 to complete options', async () => {
+    it('passes apiKey, effectiveTimeoutMs (input > config > default), and maxRetries: 0 to complete options', async () => {
       const adapter = makeAdapter({ maxRetries: 3, timeoutMs: 120_000 });
       await adapter.startRun(makeStartRunInput({ timeoutMs: 90_000 }));
 
       const [, , options] = mockComplete.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
       expect(options.apiKey).toBe('test-key-123');
       expect(options.maxRetries).toBe(0);
-      // completeWithRetry uses this.config.timeoutMs (120_000), not input.timeoutMs
-      expect(options.timeoutMs).toBe(120_000);
+      expect(options.timeoutMs).toBe(90_000);
     });
 
     it('returns RunHandle with runId, runtimeKind="pi-ai", and valid ISO startedAt', async () => {

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -335,7 +335,7 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
 
     // AbortSignal.timeout for clean timeout control
     // Priority: input.timeoutMs (runner) > config.timeoutMs (workflows.yaml) > 300_000 (default)
-    const effectiveTimeoutMs = input.timeoutMs || this.config.timeoutMs || 300_000;
+    const effectiveTimeoutMs = input.timeoutMs ?? this.config.timeoutMs ?? 300_000;
     const signal = AbortSignal.timeout(effectiveTimeoutMs);
 
     // Build pi-ai Context from inputPayload

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -306,6 +306,10 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
   /**
    * One-shot run: call LLM via pi-ai complete(), parse and validate output.
    * Blocks until LLM responds (or times out). Run is terminal on return.
+   *
+   * Timeout priority: input.timeoutMs (from runner) > this.config.timeoutMs (from workflows.yaml) > 300_000 (default)
+   * The resolved effectiveTimeoutMs is passed through to completeWithRetry and pi-ai complete()
+   * so that the provider request timeout always matches the runner's intent.
    */
   async startRun(input: StartRunInput): Promise<RunHandle> {
     const runId = crypto.randomUUID();
@@ -330,6 +334,7 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
     this.runs.set(runId, runState);
 
     // AbortSignal.timeout for clean timeout control
+    // Priority: input.timeoutMs (runner) > config.timeoutMs (workflows.yaml) > 300_000 (default)
     const effectiveTimeoutMs = input.timeoutMs || this.config.timeoutMs || 300_000;
     const signal = AbortSignal.timeout(effectiveTimeoutMs);
 
@@ -364,8 +369,8 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
     });
 
     try {
-      // Call LLM with retry
-      const response = await this.completeWithRetry(model, context, { signal, apiKey });
+      // Call LLM with retry — pass effectiveTimeoutMs so provider request uses runner timeout
+      const response = await this.completeWithRetry(model, context, { signal, apiKey, effectiveTimeoutMs });
 
       // extractAssistantTextOrThrow normalizes resolved-error responses
       // (e.g., stopReason:'error' + errorMessage:'401 Unauthorized')
@@ -470,7 +475,7 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
 
       if (isAbortError(err, signal)) {
         runState.status = 'timed_out';
-        runState.reason = `LLM request timed out after ${effectiveTimeoutMs}ms`;
+        runState.reason = `[timeout] LLM request timed out after ${effectiveTimeoutMs}ms (timeoutSource=runner_poll)`;
       } else if (err instanceof PDRuntimeError) {
         runState.status = 'failed';
         runState.reason = err.message;
@@ -606,10 +611,11 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
   private async completeWithRetry(
     model: ReturnType<typeof resolveModel>,
     context: Context,
-    options: { signal: AbortSignal; apiKey: string },
+    options: { signal: AbortSignal; apiKey: string; effectiveTimeoutMs?: number },
   ): Promise<AssistantMessage> {
     const maxRetries = this.config.maxRetries ?? 2;
-    const effectiveTimeoutMs = this.config.timeoutMs ?? 300_000;
+    // Use the timeout resolved in startRun (runner > config > default) — never re-derive from config alone
+    const effectiveTimeoutMs = options.effectiveTimeoutMs ?? this.config.timeoutMs ?? 300_000;
     let lastError: unknown = undefined;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -631,7 +637,7 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
             || /abort/i.test(rawMessage);
 
           if (isTimeout) {
-            throw new PDRuntimeError('timeout', `LLM request timed out after ${effectiveTimeoutMs}ms`);
+            throw new PDRuntimeError('timeout', `[timeout] LLM request timed out after ${effectiveTimeoutMs}ms (timeoutSource=provider_request)`);
           }
 
           // execution_failed — retryable if attempts remain

--- a/packages/principles-core/src/runtime-v2/gfi/gfi-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/gfi-read-model.ts
@@ -57,6 +57,51 @@ export interface GfiWorkspaceSnapshot {
 
 const DEFAULT_STALE_CUTOFF_MS = 2 * 60 * 60 * 1000; // 2 hours
 
+const DEFAULT_STALE_GFI_DEGRADED_THRESHOLD = 40;
+
+export interface GfiWorkspaceHealthAssessment {
+  status: 'healthy' | 'degraded';
+  reason: string;
+  staleGfiDegradedThreshold: number;
+}
+
+export function classifyGfiWorkspaceHealth(
+  snapshot: GfiWorkspaceSnapshot,
+  options?: { staleGfiDegradedThreshold?: number },
+): GfiWorkspaceHealthAssessment {
+  const staleGfiDegradedThreshold = options?.staleGfiDegradedThreshold ?? DEFAULT_STALE_GFI_DEGRADED_THRESHOLD;
+
+  if (snapshot.active !== null && snapshot.active.currentGfi >= staleGfiDegradedThreshold) {
+    return {
+      status: 'degraded',
+      reason: `Active session has elevated GFI (${snapshot.active.currentGfi})`,
+      staleGfiDegradedThreshold,
+    };
+  }
+
+  if (snapshot.activeSessionCount === 0 && snapshot.staleSessionCount > 0) {
+    const maxStaleGfi = snapshot.staleGfiRange?.max ?? 0;
+    if (maxStaleGfi >= staleGfiDegradedThreshold) {
+      return {
+        status: 'degraded',
+        reason: `No active sessions, ${snapshot.staleSessionCount} stale sessions with high GFI (max: ${maxStaleGfi})`,
+        staleGfiDegradedThreshold,
+      };
+    }
+    return {
+      status: 'healthy',
+      reason: `No active sessions, ${snapshot.staleSessionCount} stale sessions with low GFI (max: ${maxStaleGfi})`,
+      staleGfiDegradedThreshold,
+    };
+  }
+
+  return {
+    status: 'healthy',
+    reason: `${snapshot.activeSessionCount} active, ${snapshot.staleSessionCount} stale sessions`,
+    staleGfiDegradedThreshold,
+  };
+}
+
 /**
  * Convert a session's fields to a GfiState for snapshot creation.
  * Note: lastErrorHash is not persisted across sessions, so we omit it.

--- a/packages/principles-core/src/runtime-v2/gfi/index.ts
+++ b/packages/principles-core/src/runtime-v2/gfi/index.ts
@@ -8,7 +8,7 @@ export {
   createGfiSnapshot,
 } from './gfi-kernel.js';
 
-export { buildGfiWorkspaceSnapshot } from './gfi-read-model.js';
+export { buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from './gfi-read-model.js';
 
 export type {
   GfiState,
@@ -19,4 +19,4 @@ export type {
   GfiSnapshot,
 } from './gfi-types.js';
 
-export type { GfiReadModelInput, GfiWorkspaceSnapshot } from './gfi-read-model.js';
+export type { GfiReadModelInput, GfiWorkspaceSnapshot, GfiWorkspaceHealthAssessment } from './gfi-read-model.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -378,6 +378,7 @@ export {
 
 export {
   canAcquireLease,
+  canRetryNow,
   areDependenciesMet,
   canTransitionTo,
   isResultRefImmutable,
@@ -526,8 +527,8 @@ export type {
 
 // ── GFI Workspace Read Model (PRI-78) ──────────────────────────────────────
 
-export { buildGfiWorkspaceSnapshot } from './gfi/index.js';
-export type { GfiReadModelInput, GfiWorkspaceSnapshot } from './gfi/index.js';
+export { buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from './gfi/index.js';
+export type { GfiReadModelInput, GfiWorkspaceSnapshot, GfiWorkspaceHealthAssessment } from './gfi/index.js';
 
 // ── Schema Conformance Read Model (PRI-95) ──────────────────────────────────
 

--- a/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
@@ -42,11 +42,17 @@ export interface ReadyTask {
   channel: InternalizationChannel;
 }
 
-export type QueueNoReadyTasksReason = 'no_candidates' | 'all_hydration_failed' | 'all_blocked' | 'all_dependency_failed';
+export type QueueNoReadyTasksReason = 'no_candidates' | 'all_hydration_failed' | 'all_blocked' | 'all_dependency_failed' | 'all_retry_wait_pending';
 
 export interface NoReadyTasksDiagnosis {
   reason: QueueNoReadyTasksReason;
   inspectedCount: number;
+}
+
+export interface RetryWaitPendingSample {
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  retryAfter: string;
 }
 
 export interface InternalizationQueueSnapshot {
@@ -58,6 +64,7 @@ export interface InternalizationQueueSnapshot {
   sampleInvalidTaskIds: string[];
   blockedSummary: { count: number; samples: BlockedSample[] };
   dependencyFailedSummary: { count: number; samples: DependencyFailedSample[] };
+  retryWaitPendingSummary: { count: number; samples: RetryWaitPendingSample[] };
   readyTasks: ReadyTask[];
   noReadyTasks: NoReadyTasksDiagnosis | null;
 }
@@ -90,11 +97,15 @@ export class InternalizationQueueReadModel {
     const sampleInvalidTaskIds: string[] = [];
     const blockedSamples: BlockedSample[] = [];
     const dependencyFailedSamples: DependencyFailedSample[] = [];
+    const retryWaitPendingSamples: RetryWaitPendingSample[] = [];
     const readyTasks: ReadyTask[] = [];
 
     let hydrationFailures = 0;
     let blockedCount = 0;
     let dependencyFailures = 0;
+    let retryWaitPendingCount = 0;
+
+    const nowMs = Date.now();
 
     for (const rawTask of peerTasks) {
       const piTask = hydratePITaskRecord(rawTask);
@@ -114,7 +125,19 @@ export class InternalizationQueueReadModel {
 
       // Resolve dependencies for gate evaluation
       const dependencies = await this.resolveDependencies(piTask.dependencyTaskIds);
-      const gateResult = validateInternalizationTaskReady(piTask, dependencies);
+      const gateResult = validateInternalizationTaskReady(piTask, dependencies, nowMs);
+
+      if (gateResult.decision === 'retry_wait_pending') {
+        retryWaitPendingCount++;
+        if (retryWaitPendingSamples.length < MAX_SAMPLES) {
+          retryWaitPendingSamples.push({
+            taskId: piTask.taskId,
+            taskKind: piTask.taskKind,
+            retryAfter: gateResult.retryAfter ?? piTask.leaseExpiresAt ?? '',
+          });
+        }
+        continue;
+      }
 
       if (gateResult.decision === 'blocked') {
         blockedCount++;
@@ -150,11 +173,13 @@ export class InternalizationQueueReadModel {
         noReadyTasks = { reason: 'no_candidates', inspectedCount };
       } else {
         const reason: QueueNoReadyTasksReason =
-          hydrationFailures > 0 && hydrationFailures >= dependencyFailures && hydrationFailures >= blockedCount
-            ? 'all_hydration_failed'
-            : dependencyFailures >= blockedCount
-              ? 'all_dependency_failed'
-              : 'all_blocked';
+          retryWaitPendingCount > 0 && retryWaitPendingCount >= hydrationFailures && retryWaitPendingCount >= dependencyFailures && retryWaitPendingCount >= blockedCount
+            ? 'all_retry_wait_pending'
+            : hydrationFailures > 0 && hydrationFailures >= dependencyFailures && hydrationFailures >= blockedCount
+              ? 'all_hydration_failed'
+              : dependencyFailures >= blockedCount
+                ? 'all_dependency_failed'
+                : 'all_blocked';
         noReadyTasks = { reason, inspectedCount };
       }
     }
@@ -168,6 +193,7 @@ export class InternalizationQueueReadModel {
       sampleInvalidTaskIds,
       blockedSummary: { count: blockedCount, samples: blockedSamples },
       dependencyFailedSummary: { count: dependencyFailures, samples: dependencyFailedSamples },
+      retryWaitPendingSummary: { count: retryWaitPendingCount, samples: retryWaitPendingSamples },
       readyTasks,
       noReadyTasks,
     };

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -113,6 +113,7 @@ export {
 
 export {
   canAcquireLease,
+  canRetryNow,
   areDependenciesMet,
   canTransitionTo,
   isResultRefImmutable,

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -33,7 +33,7 @@ export interface NoReadyTasksResult {
   decision: 'no_ready_tasks';
   inspectedCount: number;
   /** Why no task could be leased: specific diagnosis */
-  reason: 'no_candidates' | 'all_hydration_failed' | 'all_blocked' | 'all_dependency_failed' | 'all_lease_conflict';
+  reason: 'no_candidates' | 'all_hydration_failed' | 'all_blocked' | 'all_dependency_failed' | 'all_lease_conflict' | 'all_retry_wait_pending';
 }
 
 export interface BlockedResult {
@@ -182,6 +182,7 @@ export class InternalizationOrchestrator {
     let hydrationFailures = 0;
     let blockedCount = 0;
     let dependencyFailures = 0;
+    let retryWaitPendingCount = 0;
     let leaseConflictCount = 0;
 
     for (const rawTask of candidates) {
@@ -208,6 +209,11 @@ export class InternalizationOrchestrator {
       if (gateResult.decision === 'dependency_failed') {
         // Non-terminal — skip and try next candidate
         dependencyFailures++;
+        continue;
+      }
+
+      if (gateResult.decision === 'retry_wait_pending') {
+        retryWaitPendingCount++;
         continue;
       }
 
@@ -255,15 +261,17 @@ export class InternalizationOrchestrator {
     // by specificity priority (hydration > dependency > blocked > lease).
     // Hydration participates when it is the highest count (not just 100%).
     const reason: NoReadyTasksResult['reason'] =
-      hydrationFailures > 0 && hydrationFailures >= dependencyFailures && hydrationFailures >= blockedCount && hydrationFailures >= leaseConflictCount
-        ? 'all_hydration_failed'
-        : dependencyFailures >= blockedCount && dependencyFailures >= leaseConflictCount
-          ? 'all_dependency_failed'
-          : blockedCount >= leaseConflictCount
-            ? 'all_blocked'
-            : leaseConflictCount > 0
-              ? 'all_lease_conflict'
-              : 'no_candidates';
+      retryWaitPendingCount > 0 && retryWaitPendingCount >= hydrationFailures && retryWaitPendingCount >= dependencyFailures && retryWaitPendingCount >= blockedCount && retryWaitPendingCount >= leaseConflictCount
+        ? 'all_retry_wait_pending'
+        : hydrationFailures > 0 && hydrationFailures >= dependencyFailures && hydrationFailures >= blockedCount && hydrationFailures >= leaseConflictCount
+          ? 'all_hydration_failed'
+          : dependencyFailures >= blockedCount && dependencyFailures >= leaseConflictCount
+            ? 'all_dependency_failed'
+            : blockedCount >= leaseConflictCount
+              ? 'all_blocked'
+              : leaseConflictCount > 0
+                ? 'all_lease_conflict'
+                : 'no_candidates';
 
     return {
       decision: 'no_ready_tasks',

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -29,6 +29,7 @@ import { getAllowedSuccessors, isAcyclic, validateEdge } from './internalization
 import {
   canAcquireLease,
   canTransitionTo,
+  canRetryNow,
 } from './internalization-task-guards.js';
 
 // ── Dependency Gate Types ─────────────────────────────────────────────────────
@@ -40,7 +41,7 @@ import {
  *   blocked:            Dependencies not yet satisfied — wait for them
  *   dependency_failed:   At least one dependency has failed — escalate policy needed
  */
-export type DependencyGateDecision = 'proceed' | 'blocked' | 'dependency_failed';
+export type DependencyGateDecision = 'proceed' | 'blocked' | 'dependency_failed' | 'retry_wait_pending';
 
 export interface DependencyGateResult {
   decision: DependencyGateDecision;
@@ -50,6 +51,8 @@ export interface DependencyGateResult {
   blockedBy: string[];
   /** Task IDs that have failed — for escalation policy decision */
   failedDependencies: string[];
+  /** For retry_wait_pending: ISO timestamp when the task can be retried */
+  retryAfter?: string;
 }
 
 // ── Transition Validation Types ───────────────────────────────────────────────
@@ -137,6 +140,7 @@ export interface GraphValidationResult {
 export function validateInternalizationTaskReady(
   task: PITaskRecord,
   dependencies: readonly TaskRecord[],
+  nowMs?: number,
 ): DependencyGateResult {
   const blockedBy: string[] = [];
   const failedDependencies: string[] = [];
@@ -149,6 +153,17 @@ export function validateInternalizationTaskReady(
       ready: false,
       blockedBy: [],
       failedDependencies: [],
+    };
+  }
+
+  // Check if retry_wait backoff period has expired
+  if (!canRetryNow(task, nowMs)) {
+    return {
+      decision: 'retry_wait_pending',
+      ready: false,
+      blockedBy: [],
+      failedDependencies: [],
+      retryAfter: task.leaseExpiresAt,
     };
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
@@ -34,7 +34,9 @@ import type { PITaskRecord, PIArtifact } from './peer-runner-contracts.js';
 export function canRetryNow(task: PITaskRecord, nowMs: number = Date.now()): boolean {
   if (task.status !== 'retry_wait') return true;
   if (!task.leaseExpiresAt) return true;
-  return new Date(task.leaseExpiresAt).getTime() <= nowMs;
+  const retryAfterMs = new Date(task.leaseExpiresAt).getTime();
+  if (Number.isNaN(retryAfterMs)) return true;
+  return retryAfterMs <= nowMs;
 }
 
 /**

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
@@ -19,6 +19,25 @@ import type { PITaskRecord, PIArtifact } from './peer-runner-contracts.js';
 // ── Lease Acquisition Guards ─────────────────────────────────────────────────
 
 /**
+ * Returns true if a retry_wait task's backoff period has expired and it can
+ * be re-leased now.
+ *
+ * When a task enters retry_wait, recovery-sweep sets leaseExpiresAt to
+ * now + backoffMs (the "retry-after" deadline). The task should NOT be
+ * re-leased until that deadline has passed.
+ *
+ * For non-retry_wait tasks, always returns true (no backoff gating needed).
+ *
+ * @param task - The task record to evaluate
+ * @param nowMs - Current time in milliseconds (default: Date.now())
+ */
+export function canRetryNow(task: PITaskRecord, nowMs: number = Date.now()): boolean {
+  if (task.status !== 'retry_wait') return true;
+  if (!task.leaseExpiresAt) return true;
+  return new Date(task.leaseExpiresAt).getTime() <= nowMs;
+}
+
+/**
  * Returns true if the task status allows acquiring a lease.
  *
  * Only `pending` and `retry_wait` can be leased:
@@ -27,6 +46,9 @@ import type { PITaskRecord, PIArtifact } from './peer-runner-contracts.js';
  *
  * Terminal states (succeeded/failed) are not leaseable.
  * `leased` tasks already have an active lease and cannot be re-leased.
+ *
+ * Note: This does NOT check backoff timing. Use canRetryNow() to gate
+ * retry_wait tasks whose backoff period has not yet expired.
  */
 export function canAcquireLease(task: PITaskRecord): boolean {
   return task.status === 'pending' || task.status === 'retry_wait';

--- a/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
@@ -13,14 +13,13 @@ import type { PainChainTrace } from './pain-chain-read-model.js';
 import { PruningReadModel } from './pruning-read-model.js';
 import { auditCandidateLedgerConsistency } from './candidate-audit.js';
 import type { CandidateAuditResult } from './candidate-audit.js';
-import { buildGfiWorkspaceSnapshot } from './gfi/gfi-read-model.js';
+import { buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from './gfi/gfi-read-model.js';
 import type { GfiWorkspaceSnapshot } from './gfi/gfi-read-model.js';
 import type { GfiSource } from './gfi/gfi-types.js';
 
 // ── Thresholds ────────────────────────────────────────────────────────────────
 
 const ORPHAN_DERIVED_CANDIDATE_COUNT_THRESHOLD = 10;
-const STALE_SESSION_COUNT_THRESHOLD = 20;
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -179,6 +178,7 @@ export class OperatorHealthReadModel {
     })();
 
     // ── Compute overallStatus ─────────────────────────────────────────────
+    const gfiHealth = classifyGfiWorkspaceHealth(gfi);
     let overallStatus: OverallHealthStatus = 'healthy';
 
     if (!dbExists || audit.status === 'error') {
@@ -188,7 +188,7 @@ export class OperatorHealthReadModel {
       || watchCount > 0
       || reviewCount > 0
       || orphanDerivedCandidateCount > ORPHAN_DERIVED_CANDIDATE_COUNT_THRESHOLD
-      || (gfi.staleSessionCount > STALE_SESSION_COUNT_THRESHOLD && gfi.activeSessionCount === 0)
+      || gfiHealth.status === 'degraded'
       || lastSuccessfulChain === null
     ) {
       overallStatus = 'degraded';
@@ -215,8 +215,8 @@ export class OperatorHealthReadModel {
       recommendedActions.push(`High orphan-derived-candidate count (${orphanDerivedCandidateCount}) — run pruning to clean up.`);
     }
 
-    if (gfi.staleSessionCount > STALE_SESSION_COUNT_THRESHOLD && gfi.activeSessionCount === 0) {
-      recommendedActions.push(`Many stale sessions (${gfi.staleSessionCount}) with no active sessions — run cleanup or investigate session lifecycle.`);
+    if (gfiHealth.status === 'degraded') {
+      recommendedActions.push(`GFI degraded: ${gfiHealth.reason} — run cleanup or investigate session lifecycle.`);
     }
 
     if (lastSuccessfulChain === null && dbExists) {

--- a/packages/principles-core/src/runtime-v2/pruning-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-read-model.ts
@@ -170,16 +170,20 @@ export class PruningReadModel {
     }
 
     const candidateCreatedAtMap = new Map<string, string>();
+    const allCandidateIdSet = new Set<string>();
     const pdDbPath = path.join(this.workspaceDir, '.pd', 'state.db');
     try {
       if (fs.existsSync(pdDbPath)) {
         const db = new Database(pdDbPath, { readonly: true });
         try {
-          const rows = db.prepare(
-            "SELECT candidate_id, created_at FROM principle_candidates WHERE status = 'consumed'"
-          ).all() as { candidate_id: string; created_at: string }[];
-          for (const r of rows) {
-            candidateCreatedAtMap.set(r.candidate_id, r.created_at);
+          const allRows = db.prepare(
+            'SELECT candidate_id, status, created_at FROM principle_candidates'
+          ).all() as { candidate_id: string; status: string; created_at: string }[];
+          for (const r of allRows) {
+            allCandidateIdSet.add(r.candidate_id);
+            if (r.status === 'consumed') {
+              candidateCreatedAtMap.set(r.candidate_id, r.created_at);
+            }
           }
         } finally {
           db.close();
@@ -199,10 +203,10 @@ export class PruningReadModel {
       let recentCandidateCount = 0;
       let orphanCandidateCount = 0;
       for (const cid of p.derivedFromPainIds ?? []) {
-        const cAt = candidateCreatedAtMap.get(cid);
-        if (cAt) {
+        if (allCandidateIdSet.has(cid)) {
           matchedCandidateCount++;
-          if (cAt >= recentCutoff) recentCandidateCount++;
+          const cAt = candidateCreatedAtMap.get(cid);
+          if (cAt && cAt >= recentCutoff) recentCandidateCount++;
         } else {
           orphanCandidateCount++;
         }

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
@@ -22,7 +22,7 @@ import type { TaskStore, TaskStoreFilter, TaskStoreUpdatePatch } from './task/ta
 import type { RunStore, RunRecord } from './run/run-store.js';
 import type { LeaseManager, AcquireLeaseOptions } from './lifecycle/lease-manager.js';
 import type { RetryPolicy, RetryPolicyConfig } from './lifecycle/retry-policy.js';
-import type { RecoverySweep } from './lifecycle/recovery-sweep.js';
+import type { RecoverySweep, RecoveryResult } from './lifecycle/recovery-sweep.js';
 import type { PDErrorCategory } from '../error-categories.js';
 import type { TaskRecord } from '../task-status.js';
 import { storeEmitter, type StoreEventEmitter } from './event-emitter.js';
@@ -297,15 +297,23 @@ export class RuntimeStateManager {
     return updated;
   }
 
-  /** Mark a task as retry_wait and emit task_retried event. Per D-03: retry with backoff. */
+  /** Mark a task as retry_wait and emit task_retried event. Per D-03: retry with backoff.
+   *  Sets leaseExpiresAt to now + backoffMs so that canRetryNow() gates correctly.
+   */
   async markTaskRetryWait(taskId: string, errorCategory: PDErrorCategory): Promise<TaskRecord> {
     this.assertInitialized();
     const now = new Date().toISOString();
 
+    // Fetch current task to compute backoff from attemptCount
+    const currentTask = await this._taskStore.getTask(taskId);
+    const attemptCount = currentTask?.attemptCount ?? 0;
+    const backoffMs = this.retryPolicy.calculateBackoff(attemptCount + 1);
+    const retryAfter = new Date(Date.now() + backoffMs).toISOString();
+
     const updated = await this._taskStore.updateTask(taskId, {
       status: 'retry_wait',
       leaseOwner: null,
-      leaseExpiresAt: null,
+      leaseExpiresAt: retryAfter,
       lastError: errorCategory,
     });
 
@@ -363,6 +371,21 @@ export class RuntimeStateManager {
   async runRecoverySweep(): Promise<{ recovered: number; errors: string[] }> {
     this.assertInitialized();
     return this.recoverySweep.recoverAll();
+  }
+
+  async detectExpiredLeases(): Promise<string[]> {
+    this.assertInitialized();
+    return this.recoverySweep.detectExpiredLeases();
+  }
+
+  async recoverTask(taskId: string): Promise<RecoveryResult | null> {
+    this.assertInitialized();
+    return this.recoverySweep.recoverTask(taskId);
+  }
+
+  async updateTaskDiagnosticJson(taskId: string, diagnosticJson: string): Promise<void> {
+    this.assertInitialized();
+    await this._taskStore.updateTask(taskId, { diagnosticJson });
   }
 
   getRetryPolicy(): RetryPolicy {


### PR DESCRIPTION
## Summary

Production baseline canary exposed 7 defects blocking the internalization pipeline and degrading observability. This PR fixes all 7 issues with TDD approach.

## Issues Fixed

### Issue 1 — Dreamer LLM timeout root-cause and configurable runner/provider timeout
**Root cause**: \PiAiRuntimeAdapter.completeWithRetry()\ used \	his.config.timeoutMs\ (120000 from workflows.yaml) instead of the \input.timeoutMs\ (300000) passed from DreamerRunner. The 120s timeout came from workflows.yaml config, not from the runner.

**Fix**:
- \completeWithRetry\ now accepts \ffectiveTimeoutMs\ from \startRun\
- Added \	imeoutSource\ to error messages: \provider_request\ vs \unner_poll\
- CLI supports \--timeout-ms\ flag: \pd runtime internalization run-once --runner dreamer --timeout-ms 300000\
- Priority: CLI flag > runner-specific workflow config > general workflow config > default 300000
- Output JSON includes \ffectiveTimeoutMs\ and \	imeoutSource\

### Issue 2 — retry_wait backoff gating in queue readiness
**Root cause**: \markTaskRetryWait\ set \leaseExpiresAt: null\, so \canRetryNow\ always returned true. retry_wait tasks immediately re-entered readyTasks causing rapid repeated failures.

**Fix**:
- \markTaskRetryWait\ now sets \leaseExpiresAt = now + backoffMs\
- Added \canRetryNow(task, nowMs)\ pure function
- Queue adds \ll_retry_wait_pending\ noReadyTasks reason and \etryWaitPendingSummary\

### Issue 3 — Runtime recovery sweep CLI for expired leases
**New command**: \pd runtime recovery sweep --workspace <path> --dry-run/--confirm\
- Default dry-run: lists expired leased tasks without modifying DB
- \--confirm\: calls \unRecoverySweep()\ to recover expired leases

### Issue 4 — Backfill pre-internalization consumed candidates
**New command**: \pd candidate internalization backfill --workspace <path> --dry-run/--confirm\
- Finds consumed candidates without corresponding dreamer tasks
- Creates root dreamer tasks using existing candidate internalize logic
- Idempotent: existing tasks get \candidateId\ injected into diagnosticJson

### Issue 5 — GFI stale session policy adjustment
**Root cause**: Canary marked degraded when staleSessionCount > 20 && activeSessionCount === 0, regardless of GFI values. 40 stale sessions with max GFI 4.6875 was incorrectly flagged as degraded.

**Fix**:
- Added \classifyGfiWorkspaceHealth()\ pure function with GFI-aware status classification
- 0 active + stale low GFI → healthy; 0 active + stale high GFI → degraded
- Configurable \staleGfiDegradedThreshold\ (default: 40)

### Issue 6 — Orphan count reconciliation
**Root cause**: \getPrincipleSignals()\ only queried \status = consumed\ candidates, while \getOrphanDerivedCandidates()\ queried all candidates. This caused canary to report 14 orphans while health snapshot reported 29.

**Fix**: Both methods now query all candidates uniformly. Canary details field renamed to \orphanDerivedCandidateCount\.

### Issue 7 — CLI UX: candidate show --candidate-id alias
**Fix**: \candidate show [candidateId]\ now supports \--candidate-id\ alias. Conflicting values fail closed.

## Test Results

- 92 vitest tests pass across all modified test files
- \
pm run build\ ✅, \
pm run typecheck:openclaw-plugin\ ✅
- Pre-push hook (lint + build + typecheck) ✅

## Real Workspace Verification

| Check | Before | After |
|-------|--------|-------|
| gfi_snapshot | degraded (40 stale, 0 active) | **healthy** |
| pruning_orphans count | canary: 14, health: 29 | **canary: 14, health: 14** |
| internalization integrity | 5 broken links | **ok** (0 broken links) |
| lease_stuck | 1 expired lease | **0** (recovered) |
| missing_dreamer_task | 4 consumed candidates | **0** (backfilled) |

## Not Included
- No \.trae/\ files committed
- No diagnostics bundle or temporary scripts committed
- No direct DB modifications
- No \pruning --confirm\ executed