### PR TITLE
feat(internalization): add Dreamer/Philosopher prompt contracts (PRI-107)

### DIFF
--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/dreamer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/dreamer-prompt-builder.test.ts
@@ -1,0 +1,177 @@
+/**
+ * DreamerPromptBuilder unit tests (PRI-107).
+ *
+ * Tests that the prompt builder produces a valid JSON message containing
+ * both context data and an instruction telling the LLM to produce
+ * DreamerOutputV1 JSON.
+ */
+import { describe, it, expect } from 'vitest';
+import { DreamerPromptBuilder } from '../dreamer-prompt-builder.js';
+
+const MINIMAL_INPUT = {
+  taskId: 'task-dreamer-001',
+  contextHash: 'ctx-abc123',
+  contextRefs: ['ref-diag-001', 'ref-artifact-001'],
+  predecessorOutput: {
+    valid: true,
+    diagnosisId: 'diag-001',
+    taskId: 'task-diag-001',
+    summary: 'Agent failed to validate input',
+    rootCause: 'Design: missing input validation gate',
+    violatedPrinciples: [{ rationale: 'No pre-condition check' }],
+    evidence: [{ sourceRef: 'ref-1', note: 'Missing validation' }],
+    recommendations: [
+      { kind: 'rule', description: 'Add input validation', triggerPattern: 'user_input', action: 'validate before processing' },
+    ],
+    confidence: 0.85,
+    ambiguityNotes: [],
+  },
+};
+
+describe('DreamerPromptBuilder', () => {
+  describe('buildPrompt()', () => {
+    it('returns PromptBuildResult with message and promptInput fields', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result).toHaveProperty('message');
+      expect(result).toHaveProperty('promptInput');
+      expect(typeof result.message).toBe('string');
+    });
+
+    it('maps taskId from input to top-level promptInput.taskId', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.taskId).toBe('task-dreamer-001');
+    });
+
+    it('maps contextHash from input to top-level promptInput.contextHash', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.contextHash).toBe('ctx-abc123');
+    });
+
+    it('maps contextRefs from input to top-level promptInput.contextRefs', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.contextRefs).toEqual(['ref-diag-001', 'ref-artifact-001']);
+    });
+
+    it('maps predecessorOutput from input to top-level promptInput.predecessorOutput', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.predecessorOutput).toEqual(MINIMAL_INPUT.predecessorOutput);
+    });
+
+    it('message field is valid JSON (JSON.parse succeeds)', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(() => JSON.parse(result.message)).not.toThrow();
+    });
+
+    it('taskId appears at top level of serialized JSON message', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const parsed = JSON.parse(result.message);
+      expect(parsed.taskId).toBe('task-dreamer-001');
+    });
+
+    it('dreamerInstruction is present and contains key protocol keywords', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.dreamerInstruction).toBeDefined();
+      expect(result.promptInput.dreamerInstruction.length).toBeGreaterThan(100);
+      expect(result.promptInput.dreamerInstruction).toContain('Dreamer');
+      expect(result.promptInput.dreamerInstruction).toContain('candidate');
+      expect(result.promptInput.dreamerInstruction).toContain('badDecision');
+      expect(result.promptInput.dreamerInstruction).toContain('betterDecision');
+      expect(result.promptInput.dreamerInstruction).toContain('confidence');
+    });
+
+    it('dreamerInstruction contains the output JSON schema format', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toContain('"valid"');
+      expect(instruction).toContain('"taskId"');
+      expect(instruction).toContain('"candidates"');
+      expect(instruction).toContain('"candidateIndex"');
+      expect(instruction).toContain('"riskLevel"');
+      expect(instruction).toContain('"generatedAt"');
+    });
+
+    it('dreamerInstruction specifies riskLevel must be low|medium|high', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toMatch(/low.*medium.*high|riskLevel.*low.*medium.*high/s);
+    });
+
+    it('dreamerInstruction specifies confidence must be a number between 0 and 1', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toMatch(/confidence.*number/i);
+      expect(instruction).toMatch(/0.*1/);
+    });
+
+    it('dreamerInstruction specifies output must be pure JSON only', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toMatch(/only.*JSON|JSON.*only|pure JSON/i);
+      expect(instruction).toMatch(/no markdown/i);
+    });
+
+    it('buildPrompt() is a pure function — same input produces same output', () => {
+      const builder = new DreamerPromptBuilder();
+      const result1 = builder.buildPrompt(MINIMAL_INPUT);
+      const result2 = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result1.message).toBe(result2.message);
+      expect(result1.promptInput).toEqual(result2.promptInput);
+    });
+
+    it('handles null predecessorOutput gracefully', () => {
+      const input = { ...MINIMAL_INPUT, predecessorOutput: null };
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(input);
+
+      expect(result.promptInput.predecessorOutput).toBeNull();
+      expect(() => JSON.parse(result.message)).not.toThrow();
+    });
+
+    it('handles empty contextRefs array', () => {
+      const input = { ...MINIMAL_INPUT, contextRefs: [] };
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(input);
+
+      expect(result.promptInput.contextRefs).toEqual([]);
+      const parsed = JSON.parse(result.message);
+      expect(parsed.contextRefs).toEqual([]);
+    });
+
+    it('message JSON contains all required DreamerPromptInput fields at top level', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const parsed = JSON.parse(result.message);
+      expect(parsed).toHaveProperty('taskId');
+      expect(parsed).toHaveProperty('contextHash');
+      expect(parsed).toHaveProperty('contextRefs');
+      expect(parsed).toHaveProperty('predecessorOutput');
+      expect(parsed).toHaveProperty('dreamerInstruction');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-prompt-builder.test.ts
@@ -28,6 +28,7 @@ const MINIMAL_INPUT = {
     contextRefs: ['ref-diag-001'],
     generatedAt: '2026-05-01T00:00:00Z',
   },
+  sourceDreamerArtifactId: 'pi-art-dreamer-001-run-001',
 };
 
 describe('PhilosopherPromptBuilder', () => {
@@ -60,6 +61,13 @@ describe('PhilosopherPromptBuilder', () => {
       const result = builder.buildPrompt(MINIMAL_INPUT);
 
       expect(result.promptInput.dreamerArtifact).toEqual(MINIMAL_INPUT.dreamerArtifact);
+    });
+
+    it('maps sourceDreamerArtifactId from input to top-level promptInput.sourceDreamerArtifactId', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.sourceDreamerArtifactId).toBe('pi-art-dreamer-001-run-001');
     });
 
     it('message field is valid JSON (JSON.parse succeeds)', () => {
@@ -123,6 +131,22 @@ describe('PhilosopherPromptBuilder', () => {
       expect(instruction).toMatch(/no markdown/i);
     });
 
+    it('philosopherInstruction tells LLM to copy sourceDreamerArtifactId from input', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.philosopherInstruction;
+      expect(instruction).toContain('input.sourceDreamerArtifactId');
+    });
+
+    it('sourceDreamerArtifactId appears at top level of serialized JSON message', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const parsed = JSON.parse(result.message);
+      expect(parsed.sourceDreamerArtifactId).toBe('pi-art-dreamer-001-run-001');
+    });
+
     it('buildPrompt() is a pure function — same input produces same output', () => {
       const builder = new PhilosopherPromptBuilder();
       const result1 = builder.buildPrompt(MINIMAL_INPUT);
@@ -133,11 +157,12 @@ describe('PhilosopherPromptBuilder', () => {
     });
 
     it('handles null dreamerArtifact gracefully', () => {
-      const input = { ...MINIMAL_INPUT, dreamerArtifact: null };
+      const input = { ...MINIMAL_INPUT, dreamerArtifact: null, sourceDreamerArtifactId: '' };
       const builder = new PhilosopherPromptBuilder();
       const result = builder.buildPrompt(input);
 
       expect(result.promptInput.dreamerArtifact).toBeNull();
+      expect(result.promptInput.sourceDreamerArtifactId).toBe('');
       expect(() => JSON.parse(result.message)).not.toThrow();
     });
 
@@ -149,6 +174,7 @@ describe('PhilosopherPromptBuilder', () => {
       expect(parsed).toHaveProperty('taskId');
       expect(parsed).toHaveProperty('contextHash');
       expect(parsed).toHaveProperty('dreamerArtifact');
+      expect(parsed).toHaveProperty('sourceDreamerArtifactId');
       expect(parsed).toHaveProperty('philosopherInstruction');
     });
   });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-prompt-builder.test.ts
@@ -1,0 +1,155 @@
+/**
+ * PhilosopherPromptBuilder unit tests (PRI-107).
+ *
+ * Tests that the prompt builder produces a valid JSON message containing
+ * both context data (including dreamer artifact) and an instruction telling
+ * the LLM to produce PhilosopherOutputV1 JSON.
+ */
+import { describe, it, expect } from 'vitest';
+import { PhilosopherPromptBuilder } from '../philosopher-prompt-builder.js';
+
+const MINIMAL_INPUT = {
+  taskId: 'task-philosopher-001',
+  contextHash: 'ctx-def456',
+  dreamerArtifact: {
+    valid: true,
+    taskId: 'task-dreamer-001',
+    candidates: [
+      {
+        candidateIndex: 0,
+        badDecision: 'Skipped input validation',
+        betterDecision: 'Add pre-condition check before processing',
+        rationale: 'Validation prevents downstream errors',
+        confidence: 0.85,
+        riskLevel: 'low',
+        strategicPerspective: 'defensive_programming',
+      },
+    ],
+    contextRefs: ['ref-diag-001'],
+    generatedAt: '2026-05-01T00:00:00Z',
+  },
+};
+
+describe('PhilosopherPromptBuilder', () => {
+  describe('buildPrompt()', () => {
+    it('returns PromptBuildResult with message and promptInput fields', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result).toHaveProperty('message');
+      expect(result).toHaveProperty('promptInput');
+      expect(typeof result.message).toBe('string');
+    });
+
+    it('maps taskId from input to top-level promptInput.taskId', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.taskId).toBe('task-philosopher-001');
+    });
+
+    it('maps contextHash from input to top-level promptInput.contextHash', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.contextHash).toBe('ctx-def456');
+    });
+
+    it('maps dreamerArtifact from input to top-level promptInput.dreamerArtifact', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.dreamerArtifact).toEqual(MINIMAL_INPUT.dreamerArtifact);
+    });
+
+    it('message field is valid JSON (JSON.parse succeeds)', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(() => JSON.parse(result.message)).not.toThrow();
+    });
+
+    it('taskId appears at top level of serialized JSON message', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const parsed = JSON.parse(result.message);
+      expect(parsed.taskId).toBe('task-philosopher-001');
+    });
+
+    it('philosopherInstruction is present and contains key protocol keywords', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result.promptInput.philosopherInstruction).toBeDefined();
+      expect(result.promptInput.philosopherInstruction.length).toBeGreaterThan(100);
+      expect(result.promptInput.philosopherInstruction).toContain('Philosopher');
+      expect(result.promptInput.philosopherInstruction).toContain('principle');
+      expect(result.promptInput.philosopherInstruction).toContain('thesis');
+    });
+
+    it('philosopherInstruction contains the output JSON schema format', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.philosopherInstruction;
+      expect(instruction).toContain('"taskId"');
+      expect(instruction).toContain('"sourceDreamerArtifactId"');
+      expect(instruction).toContain('"thesis"');
+      expect(instruction).toContain('"principleCandidate"');
+      expect(instruction).toContain('"title"');
+      expect(instruction).toContain('"rationale"');
+      expect(instruction).toContain('"scope"');
+      expect(instruction).toContain('"confidence"');
+      expect(instruction).toContain('"risks"');
+      expect(instruction).toContain('"generatedAt"');
+    });
+
+    it('philosopherInstruction specifies confidence must be a number between 0 and 1', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.philosopherInstruction;
+      expect(instruction).toMatch(/confidence.*number/i);
+      expect(instruction).toMatch(/0.*1/);
+    });
+
+    it('philosopherInstruction specifies output must be pure JSON only', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.philosopherInstruction;
+      expect(instruction).toMatch(/only.*JSON|JSON.*only|pure JSON/i);
+      expect(instruction).toMatch(/no markdown/i);
+    });
+
+    it('buildPrompt() is a pure function — same input produces same output', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result1 = builder.buildPrompt(MINIMAL_INPUT);
+      const result2 = builder.buildPrompt(MINIMAL_INPUT);
+
+      expect(result1.message).toBe(result2.message);
+      expect(result1.promptInput).toEqual(result2.promptInput);
+    });
+
+    it('handles null dreamerArtifact gracefully', () => {
+      const input = { ...MINIMAL_INPUT, dreamerArtifact: null };
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(input);
+
+      expect(result.promptInput.dreamerArtifact).toBeNull();
+      expect(() => JSON.parse(result.message)).not.toThrow();
+    });
+
+    it('message JSON contains all required PhilosopherPromptInput fields at top level', () => {
+      const builder = new PhilosopherPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const parsed = JSON.parse(result.message);
+      expect(parsed).toHaveProperty('taskId');
+      expect(parsed).toHaveProperty('contextHash');
+      expect(parsed).toHaveProperty('dreamerArtifact');
+      expect(parsed).toHaveProperty('philosopherInstruction');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-prompt-builder.ts
@@ -1,0 +1,97 @@
+/**
+ * DreamerPromptBuilder — transforms Dreamer context into a prompt for the LLM.
+ *
+ * PRI-107: The Dreamer runner previously sent only `{ taskId, contextHash }` as
+ * inputPayload, giving the LLM no instructions about what to produce. This builder
+ * follows the DiagnosticianPromptBuilder pattern: it packages context data + an
+ * explicit instruction telling the LLM to produce DreamerOutputV1 JSON.
+ *
+ * ## Contract
+ *
+ * buildPrompt() takes DreamerPromptBuilderInput and returns a JSON string
+ * to be passed as `inputPayload` in StartRunInput.
+ *
+ * ## Constraints
+ *
+ * - Output is ONLY JSON — no markdown, no file ops, no tool calls
+ * - NO extraSystemPrompt field — system prompt is agent profile's responsibility
+ * - buildPrompt() is a pure function — no DB calls, no side effects
+ */
+export interface DreamerPromptBuilderInput {
+  taskId: string;
+  contextHash: string;
+  contextRefs: readonly string[];
+  predecessorOutput: unknown;
+}
+
+export interface DreamerPromptInput {
+  taskId: string;
+  contextHash: string;
+  contextRefs: readonly string[];
+  predecessorOutput: unknown;
+  dreamerInstruction: string;
+}
+
+export interface DreamerPromptBuildResult {
+  readonly message: string;
+  readonly promptInput: DreamerPromptInput;
+}
+
+export const DREAMER_PROTOCOL_INSTRUCTION = `You are a Dreamer agent in a principle internalization pipeline. Your role is to generate alternative decision candidates based on the predecessor's diagnosis analysis.
+
+PROTOCOL:
+1. Review the predecessorOutput (typically a Diagnostician diagnosis) to understand what went wrong
+2. For each identified root cause, generate 1-5 alternative decision candidates
+3. Each candidate must describe: what was done wrong (badDecision), what should have been done instead (betterDecision), and why (rationale)
+4. Assign a confidence score (0.0 to 1.0) and risk level (low, medium, or high) to each candidate
+5. Provide a strategic perspective for each candidate
+
+OUTPUT FORMAT (pure JSON, no markdown):
+{
+  "valid": true,
+  "taskId": "<from input>",
+  "candidates": [
+    {
+      "candidateIndex": 0,
+      "badDecision": "<what the agent did wrong>",
+      "betterDecision": "<what the agent should have done>",
+      "rationale": "<why the better decision is superior>",
+      "confidence": 0.85,
+      "riskLevel": "low",
+      "strategicPerspective": "<strategic lens: e.g., defensive_programming, fail_fast, graceful_degradation>"
+    }
+  ],
+  "sourcePrincipleId": "<optional: principle ID if applicable>",
+  "sourcePainId": "<optional: pain signal ID if applicable>",
+  "contextRefs": ["<from input contextRefs>"],
+  "generatedAt": "<ISO-8601 timestamp>"
+}
+
+CONSTRAINTS:
+- Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
+- candidates MUST have 1-5 items
+- candidateIndex MUST be a number (0-based)
+- badDecision, betterDecision, rationale, strategicPerspective MUST be non-empty strings
+- confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- riskLevel MUST be exactly one of: "low", "medium", "high" (lowercase only)
+- contextRefs MUST be copied from the input contextRefs array
+- generatedAt MUST be an ISO-8601 timestamp string
+- valid MUST be true on success
+`;
+
+export class DreamerPromptBuilder {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildPrompt(input: DreamerPromptBuilderInput): DreamerPromptBuildResult {
+    const promptInput: DreamerPromptInput = {
+      taskId: input.taskId,
+      contextHash: input.contextHash,
+      contextRefs: input.contextRefs,
+      predecessorOutput: input.predecessorOutput,
+      dreamerInstruction: DREAMER_PROTOCOL_INSTRUCTION,
+    };
+
+    const message = JSON.stringify(promptInput);
+
+    return { message, promptInput };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -39,6 +39,7 @@ import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
 import type { TelemetryEvent } from '../../telemetry-event.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
 import { RunnerPhase } from '../runner/runner-phase.js';
+import { DreamerPromptBuilder } from './dreamer-prompt-builder.js';
 
 // ── Result Types ─────────────────────────────────────────────────────────────
 
@@ -218,13 +219,13 @@ export class DreamerRunner {
 
       // 2. Build context from predecessor task outputs (no ContextAssembler)
       this.phase = RunnerPhase.BuildingContext;
-      const { contextHash } = await this.buildContext(taskId);
+      const { contextHash, contextRefs, predecessorOutput } = await this.buildContext(taskId);
 
       this.emitDreamerEvent('dreamer_context_built', taskId, { contextHash });
 
       // 3. Invoke runtime
       this.phase = RunnerPhase.Invoking;
-      const runHandle = await this.invokeRuntime(taskId, contextHash);
+      const runHandle = await this.invokeRuntime({ taskId, contextHash, contextRefs, predecessorOutput });
 
       this.emitDreamerEvent('dreamer_run_started', taskId, {
         runtimeKind: this.resolvedOptions.runtimeKind,
@@ -294,8 +295,7 @@ export class DreamerRunner {
    *
    * @see hydratePITaskRecord (PRI-65) for fail-closed PI metadata access
    */
-  private async buildContext(taskId: string): Promise<{ contextHash: string }> {
-    // Get the task to read dependencyTaskIds
+  private async buildContext(taskId: string): Promise<{ contextHash: string; contextRefs: string[]; predecessorOutput: unknown }> {
     const task = await this.stateManager.getTask(taskId);
     if (!task) {
       throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
@@ -304,9 +304,9 @@ export class DreamerRunner {
     const piTask = hydratePITaskRecord(task);
     const deps = piTask?.dependencyTaskIds ?? [];
 
-    // Resolve each dependency and collect result refs
     const contextRefs: string[] = [];
     const rejectedDeps: string[] = [];
+    let predecessorOutput: unknown = null;
     if (deps.length > 0) {
       const results = await Promise.allSettled(
         deps.map((depId) => this.stateManager.getTask(depId)),
@@ -325,6 +325,16 @@ export class DreamerRunner {
           if (depPiTask?.outputArtifactRefs) {
             contextRefs.push(...depPiTask.outputArtifactRefs.map((a) => a.ref));
           }
+          if (result.value.status === 'succeeded' && predecessorOutput === null) {
+            const artifacts = await this.artifactStore.listBySourceTaskId(depId);
+            if (artifacts.length > 0 && artifacts[0]) {
+              try {
+                predecessorOutput = JSON.parse(artifacts[0].contentJson);
+              } catch {
+                predecessorOutput = artifacts[0].contentJson;
+              }
+            }
+          }
         }
       }
     }
@@ -336,10 +346,9 @@ export class DreamerRunner {
       });
     }
 
-    // Compute context hash from collected refs
     const contextHash = DreamerRunner.hashContextRefs(contextRefs);
 
-    return { contextHash };
+    return { contextHash, contextRefs, predecessorOutput };
   }
 
   /**
@@ -392,11 +401,24 @@ export class DreamerRunner {
     return { ids: lineageIds, hasRejected };
   }
 
-  private async invokeRuntime(taskId: string, contextHash: string): Promise<RunHandle> {
+  private async invokeRuntime(params: {
+    taskId: string;
+    contextHash: string;
+    contextRefs: readonly string[];
+    predecessorOutput: unknown;
+  }): Promise<RunHandle> {
+    const builder = new DreamerPromptBuilder();
+    const { message } = builder.buildPrompt({
+      taskId: params.taskId,
+      contextHash: params.contextHash,
+      contextRefs: params.contextRefs,
+      predecessorOutput: params.predecessorOutput,
+    });
+
     const startInput: StartRunInput = {
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
-      taskRef: { taskId },
-      inputPayload: JSON.stringify({ taskId, contextHash }),
+      taskRef: { taskId: params.taskId },
+      inputPayload: message,
       contextItems: [],
       outputSchemaRef: 'dreamer-output-v1',
       timeoutMs: this.resolvedOptions.timeoutMs,

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-prompt-builder.ts
@@ -21,12 +21,14 @@ export interface PhilosopherPromptBuilderInput {
   taskId: string;
   contextHash: string;
   dreamerArtifact: unknown;
+  sourceDreamerArtifactId: string;
 }
 
 export interface PhilosopherPromptInput {
   taskId: string;
   contextHash: string;
   dreamerArtifact: unknown;
+  sourceDreamerArtifactId: string;
   philosopherInstruction: string;
 }
 
@@ -47,7 +49,7 @@ PROTOCOL:
 OUTPUT FORMAT (pure JSON, no markdown):
 {
   "taskId": "<from input>",
-  "sourceDreamerArtifactId": "<ID of the dreamer artifact you analyzed>",
+  "sourceDreamerArtifactId": "<copy exactly from input.sourceDreamerArtifactId>",
   "thesis": "<philosophical thesis synthesizing the Dreamer's analysis>",
   "principleCandidate": {
     "title": "<concise principle title, <=100 chars>",
@@ -67,7 +69,7 @@ CONSTRAINTS:
 - principleCandidate.scope MUST be a non-empty string describing applicability
 - principleCandidate.confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
 - risks MUST be an array of strings (can be empty if no risks identified)
-- sourceDreamerArtifactId MUST be a non-empty string referencing the dreamer artifact
+- sourceDreamerArtifactId MUST be copied exactly from input.sourceDreamerArtifactId (non-empty string)
 - generatedAt MUST be an ISO-8601 timestamp string
 `;
 
@@ -78,6 +80,7 @@ export class PhilosopherPromptBuilder {
       taskId: input.taskId,
       contextHash: input.contextHash,
       dreamerArtifact: input.dreamerArtifact,
+      sourceDreamerArtifactId: input.sourceDreamerArtifactId,
       philosopherInstruction: PHILOSOPHER_PROTOCOL_INSTRUCTION,
     };
 

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-prompt-builder.ts
@@ -1,0 +1,88 @@
+/**
+ * PhilosopherPromptBuilder — transforms Philosopher context into a prompt for the LLM.
+ *
+ * PRI-107: The Philosopher runner previously sent only `{ taskId, contextHash, dreamerArtifact }`
+ * as inputPayload, giving the LLM no instructions about what to produce. This builder
+ * follows the DiagnosticianPromptBuilder pattern: it packages context data + an
+ * explicit instruction telling the LLM to produce PhilosopherOutputV1 JSON.
+ *
+ * ## Contract
+ *
+ * buildPrompt() takes PhilosopherPromptBuilderInput and returns a JSON string
+ * to be passed as `inputPayload` in StartRunInput.
+ *
+ * ## Constraints
+ *
+ * - Output is ONLY JSON — no markdown, no file ops, no tool calls
+ * - NO extraSystemPrompt field — system prompt is agent profile's responsibility
+ * - buildPrompt() is a pure function — no DB calls, no side effects
+ */
+export interface PhilosopherPromptBuilderInput {
+  taskId: string;
+  contextHash: string;
+  dreamerArtifact: unknown;
+}
+
+export interface PhilosopherPromptInput {
+  taskId: string;
+  contextHash: string;
+  dreamerArtifact: unknown;
+  philosopherInstruction: string;
+}
+
+export interface PhilosopherPromptBuildResult {
+  readonly message: string;
+  readonly promptInput: PhilosopherPromptInput;
+}
+
+export const PHILOSOPHER_PROTOCOL_INSTRUCTION = `You are a Philosopher agent in a principle internalization pipeline. Your role is to distill a principle candidate from the Dreamer's alternative decision analysis.
+
+PROTOCOL:
+1. Review the dreamerArtifact to understand the alternative decisions proposed by the Dreamer
+2. Synthesize the Dreamer's candidates into a single philosophical thesis
+3. Extract a principle candidate with title, rationale, scope, and confidence
+4. Identify risks associated with applying this principle
+5. The principle should be abstract and reusable, not tied to a specific instance
+
+OUTPUT FORMAT (pure JSON, no markdown):
+{
+  "taskId": "<from input>",
+  "sourceDreamerArtifactId": "<ID of the dreamer artifact you analyzed>",
+  "thesis": "<philosophical thesis synthesizing the Dreamer's analysis>",
+  "principleCandidate": {
+    "title": "<concise principle title, <=100 chars>",
+    "rationale": "<why this principle addresses the root cause>",
+    "scope": "<when/where this principle applies>",
+    "confidence": 0.8
+  },
+  "risks": ["<risk 1>", "<risk 2>"],
+  "generatedAt": "<ISO-8601 timestamp>"
+}
+
+CONSTRAINTS:
+- Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
+- thesis MUST be a non-empty string summarizing the philosophical insight
+- principleCandidate.title MUST be a non-empty string (concise, <=100 chars)
+- principleCandidate.rationale MUST be a non-empty string
+- principleCandidate.scope MUST be a non-empty string describing applicability
+- principleCandidate.confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- risks MUST be an array of strings (can be empty if no risks identified)
+- sourceDreamerArtifactId MUST be a non-empty string referencing the dreamer artifact
+- generatedAt MUST be an ISO-8601 timestamp string
+`;
+
+export class PhilosopherPromptBuilder {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildPrompt(input: PhilosopherPromptBuilderInput): PhilosopherPromptBuildResult {
+    const promptInput: PhilosopherPromptInput = {
+      taskId: input.taskId,
+      contextHash: input.contextHash,
+      dreamerArtifact: input.dreamerArtifact,
+      philosopherInstruction: PHILOSOPHER_PROTOCOL_INSTRUCTION,
+    };
+
+    const message = JSON.stringify(promptInput);
+
+    return { message, promptInput };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
@@ -39,6 +39,7 @@ import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
 import type { TelemetryEvent } from '../../telemetry-event.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
 import { RunnerPhase } from '../runner/runner-phase.js';
+import { PhilosopherPromptBuilder } from './philosopher-prompt-builder.js';
 
 // ── Result Types ──────────────────────────────────────────────────────────────
 
@@ -327,11 +328,27 @@ export class PhilosopherRunner {
     return latestRun.runId;
   }
 
-  private async invokeRuntime(taskId: string, contextHash: string, dreamerArtifact: string): Promise<RunHandle> {
+  private async invokeRuntime(taskId: string, contextHash: string, dreamerArtifact: string | null): Promise<RunHandle> {
+    let parsedDreamerArtifact: unknown = null;
+    if (dreamerArtifact) {
+      try {
+        parsedDreamerArtifact = JSON.parse(dreamerArtifact);
+      } catch {
+        parsedDreamerArtifact = dreamerArtifact;
+      }
+    }
+
+    const builder = new PhilosopherPromptBuilder();
+    const { message } = builder.buildPrompt({
+      taskId,
+      contextHash,
+      dreamerArtifact: parsedDreamerArtifact,
+    });
+
     const startInput: StartRunInput = {
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
       taskRef: { taskId },
-      inputPayload: JSON.stringify({ taskId, contextHash, dreamerArtifact }),
+      inputPayload: message,
       contextItems: [],
       outputSchemaRef: 'philosopher-output-v1',
       timeoutMs: this.resolvedOptions.timeoutMs,

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
@@ -208,7 +208,7 @@ export class PhilosopherRunner {
       const storeRunId = await this.resolveStoreRunId(taskId);
 
       this.phase = RunnerPhase.BuildingContext;
-      const { contextHash, dreamerArtifact } = await this.buildContext(taskId);
+      const { contextHash, dreamerArtifact, sourceDreamerArtifactId } = await this.buildContext(taskId);
 
       if (!dreamerArtifact) {
         return this.retryOrFail({
@@ -222,7 +222,7 @@ export class PhilosopherRunner {
       this.emitPhilosopherEvent('philosopher_context_built', taskId, { contextHash });
 
       this.phase = RunnerPhase.Invoking;
-      const runHandle = await this.invokeRuntime(taskId, contextHash, dreamerArtifact);
+      const runHandle = await this.invokeRuntime({ taskId, contextHash, dreamerArtifact, sourceDreamerArtifactId });
 
       this.emitPhilosopherEvent('philosopher_run_started', taskId, {
         runtimeKind: this.resolvedOptions.runtimeKind,
@@ -267,7 +267,7 @@ export class PhilosopherRunner {
 
   // ── Phase methods ─────────────────────────────────────────────────────────
 
-  private async buildContext(taskId: string): Promise<{ contextHash: string; dreamerArtifact: string | null }> {
+  private async buildContext(taskId: string): Promise<{ contextHash: string; dreamerArtifact: string | null; sourceDreamerArtifactId: string | null }> {
     const task = await this.stateManager.getTask(taskId);
     if (!task) {
       throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
@@ -278,7 +278,7 @@ export class PhilosopherRunner {
 
     if (deps.length === 0) {
       this.emitPhilosopherEvent('philosopher_no_dependencies', taskId, {});
-      return { contextHash: 'empty', dreamerArtifact: null };
+      return { contextHash: 'empty', dreamerArtifact: null, sourceDreamerArtifactId: null };
     }
 
     for (const depId of deps) {
@@ -301,12 +301,13 @@ export class PhilosopherRunner {
         return {
           contextHash: PhilosopherRunner.hashContextRefs([artifactRef]),
           dreamerArtifact: firstArtifact.contentJson,
+          sourceDreamerArtifactId: firstArtifact.artifactId,
         };
       }
     }
 
     this.emitPhilosopherEvent('philosopher_no_dreamer_artifact', taskId, {});
-    return { contextHash: 'empty', dreamerArtifact: null };
+    return { contextHash: 'empty', dreamerArtifact: null, sourceDreamerArtifactId: null };
   }
 
   private static hashContextRefs(refs: readonly string[]): string {
@@ -328,26 +329,32 @@ export class PhilosopherRunner {
     return latestRun.runId;
   }
 
-  private async invokeRuntime(taskId: string, contextHash: string, dreamerArtifact: string | null): Promise<RunHandle> {
+  private async invokeRuntime(params: {
+    taskId: string;
+    contextHash: string;
+    dreamerArtifact: string | null;
+    sourceDreamerArtifactId: string | null;
+  }): Promise<RunHandle> {
     let parsedDreamerArtifact: unknown = null;
-    if (dreamerArtifact) {
+    if (params.dreamerArtifact) {
       try {
-        parsedDreamerArtifact = JSON.parse(dreamerArtifact);
+        parsedDreamerArtifact = JSON.parse(params.dreamerArtifact);
       } catch {
-        parsedDreamerArtifact = dreamerArtifact;
+        parsedDreamerArtifact = params.dreamerArtifact;
       }
     }
 
     const builder = new PhilosopherPromptBuilder();
     const { message } = builder.buildPrompt({
-      taskId,
-      contextHash,
+      taskId: params.taskId,
+      contextHash: params.contextHash,
       dreamerArtifact: parsedDreamerArtifact,
+      sourceDreamerArtifactId: params.sourceDreamerArtifactId ?? '',
     });
 
     const startInput: StartRunInput = {
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
-      taskRef: { taskId },
+      taskRef: { taskId: params.taskId },
       inputPayload: message,
       contextItems: [],
       outputSchemaRef: 'philosopher-output-v1',


### PR DESCRIPTION
## Summary

Fixes the root cause of persistent Dreamer \output_invalid\ failures: the runner sent only \{ taskId, contextHash }\ as inputPayload, giving the LLM zero instructions about what structured output to produce.

## Problem

Before this PR, both DreamerRunner and PhilosopherRunner sent minimal JSON as inputPayload:
- Dreamer: \JSON.stringify({ taskId, contextHash })\
- Philosopher: \JSON.stringify({ taskId, contextHash, dreamerArtifact })\

The LLM had no idea it should produce DreamerOutputV1/PhilosopherOutputV1 structured JSON, resulting in 100% output_invalid failure rate.

## Solution

Follow the existing \DiagnosticianPromptBuilder\ pattern:

1. **DreamerPromptBuilder** — packages context data + explicit instruction into inputPayload
   - Instruction tells LLM to produce DreamerOutputV1 JSON with candidates (badDecision, betterDecision, rationale, confidence, riskLevel, strategicPerspective)
   - Includes predecessorOutput (diagnostician's diagnosis) so LLM has context to dream about

2. **PhilosopherPromptBuilder** — same pattern
   - Instruction tells LLM to produce PhilosopherOutputV1 JSON with thesis, principleCandidate, risks
   - Includes dreamerArtifact so LLM has the dreamer's candidates to philosophize about

3. **DreamerRunner.buildContext** — now also returns \contextRefs\ and \predecessorOutput\ (fetched from artifact store)

4. **DreamerRunner.invokeRuntime** — uses DreamerPromptBuilder instead of raw JSON

5. **PhilosopherRunner.invokeRuntime** — uses PhilosopherPromptBuilder, parses dreamerArtifact JSON before passing to builder

## Production Verification

- \pd runtime internalization run-once dreamer\: **succeeded** (previously always \output_invalid\)
- 2 consecutive dreamer runs both succeeded
- Canary: all checks pass (runtime_health degraded only due to missing UAT baseline)

## Test Coverage

- 29 new prompt builder tests (16 Dreamer + 13 Philosopher)
- All existing runner tests continue to pass (12 dreamer + 14 philosopher)
- 125 adapter tests pass
- Build + typecheck pass

## Scope

This PR ONLY adds prompt contracts. It does NOT:
- Add system message support to PiAiRuntimeAdapter
- Modify the adapter's message construction
- Change any schema validation logic

Follow-up items (non-blocking):
- Extract OUTPUT_SCHEMA_REGISTRY from adapter file (P2 from PR #536 review)
- Add telemetry warning when unknown outputSchemaRef skips validation (P2)
- Enrich dreamer context with full predecessor artifact content (currently only first artifact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 新增单元测试，验证提示构建流程的正确性和一致性

* **Refactor**
  * 优化内部提示构建机制，增强上下文和参数的传递
  * 改进运行时调用流程，支持更丰富的管道信息

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/537)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->