### PR TITLE
feat(pd-cli): integrity-repair command + fix artifact_kind mismatch (PRI-108)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts
@@ -1,0 +1,62 @@
+import * as path from 'path';
+import { InternalizationIntegrityRemediation } from '@principles/core/runtime-v2';
+import type { RemediationResult } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface InternalizationIntegrityRepairOptions {
+  workspace?: string;
+  dryRun?: boolean;
+  confirm?: boolean;
+  json?: boolean;
+}
+
+function formatTextOutput(result: RemediationResult): string {
+  const lines: string[] = [];
+
+  lines.push('Internalization Integrity Repair Report');
+  lines.push(`generatedAt: ${result.generatedAt}`);
+  lines.push(`mode: ${result.dryRun ? 'DRY-RUN' : 'CONFIRM'}`);
+  lines.push(`repairedCount: ${result.repairedCount}`);
+  lines.push(`skippedCount: ${result.skippedCount}`);
+  lines.push('');
+
+  if (result.actions.length === 0) {
+    lines.push('No broken links found. Nothing to repair.');
+  } else {
+    lines.push(`Actions (${result.actions.length}):`);
+    for (const action of result.actions) {
+      const icon = action.severity === 'error' ? '✗' : '⚠';
+      lines.push(`  ${icon} [${action.type}] ${action.taskId}`);
+      lines.push(`    ${action.previousStatus} → ${action.newStatus}`);
+      lines.push(`    action: ${action.recommendedAction}`);
+      lines.push(`    reason: ${action.reason}`);
+      if (action.successorTaskId) {
+        lines.push(`    successorTaskId: ${action.successorTaskId}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleRuntimeInternalizationIntegrityRepair(opts: InternalizationIntegrityRepairOptions): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const isDryRun = !opts.confirm;
+
+  const remediation = new InternalizationIntegrityRemediation({ workspaceDir });
+  const result = remediation.repair({ dryRun: isDryRun });
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatTextOutput(result));
+  }
+
+  if (!isDryRun && result.repairedCount === 0 && result.actions.length > 0) {
+    console.error('');
+    console.error('NOTE: No repairs were made. All issues were already resolved or skipped.');
+  }
+}

--- a/packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts
@@ -44,6 +44,11 @@ export async function handleRuntimeInternalizationIntegrityRepair(opts: Internal
     ? path.resolve(opts.workspace)
     : resolveWorkspaceDir();
 
+  if (opts.dryRun && opts.confirm) {
+    console.error('Error: --dry-run and --confirm are mutually exclusive. Specify one or the other.');
+    process.exit(1);
+  }
+
   const isDryRun = !opts.confirm;
 
   const remediation = new InternalizationIntegrityRemediation({ workspaceDir });

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -444,11 +444,11 @@ internalizationCmd
   .command('integrity-repair')
   .description('Repair broken internalization chain links (operator repair path)')
   .option('-w, --workspace <path>', 'Workspace directory')
-  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--dry-run', 'Report only, no modifications')
   .option('--confirm', 'Actually repair broken links')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
-    await handleRuntimeInternalizationIntegrityRepair({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, json: opts.json });
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: opts.workspace, confirm: opts.confirm, dryRun: opts.dryRun, json: opts.json });
   });
 
 const diagnosticsCmd = runtimeCmd

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -36,6 +36,7 @@ import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handle
 import { handleArtifactShow } from './commands/artifact.js';
 import { handleRuntimeCanary } from './commands/runtime-canary.js';
 import { handleRuntimeInternalizationIntegrity } from './commands/runtime-internalization-integrity.js';
+import { handleRuntimeInternalizationIntegrityRepair } from './commands/runtime-internalization-integrity-repair.js';
 import { handleRuntimeDiagnosticsExport } from './commands/runtime-diagnostics-export.js';
 import { handleRuntimeRecoverySweep } from './commands/runtime-recovery.js';
 
@@ -437,6 +438,17 @@ internalizationCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleRuntimeInternalizationIntegrity({ workspace: opts.workspace, json: opts.json });
+  });
+
+internalizationCmd
+  .command('integrity-repair')
+  .description('Repair broken internalization chain links (operator repair path)')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--confirm', 'Actually repair broken links')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, json: opts.json });
   });
 
 const diagnosticsCmd = runtimeCmd

--- a/packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts
@@ -12,6 +12,7 @@ vi.mock('@principles/core/runtime-v2', () => ({
   }),
 }));
 
+import { Command } from 'commander';
 import { handleRuntimeInternalizationIntegrityRepair } from '../../src/commands/runtime-internalization-integrity-repair.js';
 
 const WS = '/fake/workspace';
@@ -24,6 +25,26 @@ function makeResult(overrides: Partial<{ dryRun: boolean; repairedCount: number;
     actions: overrides.actions ?? [],
     generatedAt: new Date().toISOString(),
   };
+}
+
+function createTestProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+
+  const internalizationCmd = program.command('internalization');
+
+  internalizationCmd
+    .command('integrity-repair')
+    .description('Repair broken internalization chain links (operator repair path)')
+    .option('-w, --workspace <path>', 'Workspace directory')
+    .option('--dry-run', 'Report only, no modifications')
+    .option('--confirm', 'Actually repair broken links')
+    .option('--json', 'Output raw JSON')
+    .action(async (opts) => {
+      await handleRuntimeInternalizationIntegrityRepair({ workspace: opts.workspace, confirm: opts.confirm, dryRun: opts.dryRun, json: opts.json });
+    });
+
+  return program;
 }
 
 describe('handleRuntimeInternalizationIntegrityRepair', () => {
@@ -48,7 +69,7 @@ describe('handleRuntimeInternalizationIntegrityRepair', () => {
   it('outputs JSON result on confirm', async () => {
     mockRepair.mockReturnValue(makeResult({ dryRun: false, repairedCount: 1 }));
 
-    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: false, confirm: true, json: true });
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, confirm: true, json: true });
 
     const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(jsonOutput.dryRun).toBe(false);
@@ -68,16 +89,76 @@ describe('handleRuntimeInternalizationIntegrityRepair', () => {
   it('defaults to dry-run when --confirm not specified', async () => {
     mockRepair.mockReturnValue(makeResult({ dryRun: true }));
 
-    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: true, confirm: false, json: true });
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, json: true });
 
     expect(mockRepair).toHaveBeenCalledWith({ dryRun: true });
   });
 
-  it('passes confirm=false when --confirm is set', async () => {
+  it('enters confirm mode when only --confirm is passed', async () => {
     mockRepair.mockReturnValue(makeResult({ dryRun: false }));
 
-    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: false, confirm: true, json: true });
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, confirm: true, json: true });
 
     expect(mockRepair).toHaveBeenCalledWith({ dryRun: false });
+  });
+
+  it('rejects --dry-run and --confirm together', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
+
+    await expect(
+      handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: true, confirm: true, json: true }),
+    ).rejects.toThrow('process.exit:1');
+
+    exitSpy.mockRestore();
+  });
+});
+
+describe('Commander wiring for integrity-repair', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('no flags → dry-run mode (confirm=undefined, dryRun=undefined)', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: true }));
+
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'integrity-repair', '--workspace', WS, '--json']);
+
+    expect(mockRepair).toHaveBeenCalledWith({ dryRun: true });
+  });
+
+  it('--confirm alone → confirm mode (not blocked by dryRun default)', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: false }));
+
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'integrity-repair', '--workspace', WS, '--confirm', '--json']);
+
+    expect(mockRepair).toHaveBeenCalledWith({ dryRun: false });
+  });
+
+  it('--dry-run alone → dry-run mode', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: true }));
+
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'integrity-repair', '--workspace', WS, '--dry-run', '--json']);
+
+    expect(mockRepair).toHaveBeenCalledWith({ dryRun: true });
+  });
+
+  it('--dry-run --confirm together → rejected', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: true }));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
+
+    const program = createTestProgram();
+    await expect(
+      program.parseAsync(['node', 'pd', 'internalization', 'integrity-repair', '--workspace', WS, '--dry-run', '--confirm', '--json']),
+    ).rejects.toThrow('process.exit:1');
+
+    exitSpy.mockRestore();
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRepair = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  InternalizationIntegrityRemediation: vi.fn().mockImplementation(function () {
+    return { repair: mockRepair };
+  }),
+}));
+
+import { handleRuntimeInternalizationIntegrityRepair } from '../../src/commands/runtime-internalization-integrity-repair.js';
+
+const WS = '/fake/workspace';
+
+function makeResult(overrides: Partial<{ dryRun: boolean; repairedCount: number; skippedCount: number; actions: unknown[] }> = {}) {
+  return {
+    dryRun: overrides.dryRun ?? true,
+    repairedCount: overrides.repairedCount ?? 0,
+    skippedCount: overrides.skippedCount ?? 0,
+    actions: overrides.actions ?? [],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+describe('handleRuntimeInternalizationIntegrityRepair', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('outputs JSON result on dry-run', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: true }));
+
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: true, confirm: false, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.dryRun).toBe(true);
+  });
+
+  it('outputs JSON result on confirm', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: false, repairedCount: 1 }));
+
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: false, confirm: true, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.dryRun).toBe(false);
+    expect(jsonOutput.repairedCount).toBe(1);
+  });
+
+  it('outputs text format when --json not specified', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: true }));
+
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: true, confirm: false, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Integrity Repair');
+    expect(allOutput).toContain('DRY-RUN');
+  });
+
+  it('defaults to dry-run when --confirm not specified', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: true }));
+
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: true, confirm: false, json: true });
+
+    expect(mockRepair).toHaveBeenCalledWith({ dryRun: true });
+  });
+
+  it('passes confirm=false when --confirm is set', async () => {
+    mockRepair.mockReturnValue(makeResult({ dryRun: false }));
+
+    await handleRuntimeInternalizationIntegrityRepair({ workspace: WS, dryRun: false, confirm: true, json: true });
+
+    expect(mockRepair).toHaveBeenCalledWith({ dryRun: false });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts
@@ -89,7 +89,7 @@ describe('InternalizationChainIntegrityReadModel', () => {
         return { all: vi.fn(() => [{ run_id: 'run1', task_id: 't1', execution_status: 'succeeded' }]), get: vi.fn(() => undefined) };
       }
       if (sql.includes('FROM pi_artifacts') && !sql.includes('WHERE')) {
-        return { all: vi.fn(() => [{ artifact_id: 'pia1', artifact_kind: 'dreamer_pi', source_task_id: 't1' }]), get: vi.fn(() => undefined) };
+        return { all: vi.fn(() => [{ artifact_id: 'pia1', artifact_kind: 'principle', source_task_id: 't1' }]), get: vi.fn(() => undefined) };
       }
       return { all: vi.fn(() => []), get: vi.fn(() => undefined) };
     });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-integrity-remediation.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-integrity-remediation.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { InternalizationIntegrityRemediation, type RemediationAction } from '../internalization-integrity-remediation.js';
+
+describe('InternalizationIntegrityRemediation', () => {
+  let tmpDir = '';
+  let dbPath = '';
+  let db: Database.Database = null as unknown as Database.Database;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pri108-test-'));
+    fs.mkdirSync(path.join(tmpDir, '.pd'), { recursive: true });
+    dbPath = path.join(tmpDir, '.pd', 'state.db');
+    db = new Database(dbPath);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS tasks (
+        task_id TEXT PRIMARY KEY,
+        task_kind TEXT NOT NULL,
+        status TEXT NOT NULL,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        max_attempts INTEGER NOT NULL DEFAULT 3,
+        input_ref TEXT,
+        result_ref TEXT,
+        last_error TEXT,
+        lease_owner TEXT,
+        lease_expires_at TEXT,
+        diagnostic_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS pi_artifacts (
+        artifact_id TEXT PRIMARY KEY,
+        source_task_id TEXT NOT NULL,
+        artifact_kind TEXT NOT NULL,
+        content_json TEXT NOT NULL,
+        validation_status TEXT NOT NULL DEFAULT 'pending',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS runs (
+        run_id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        started_at TEXT,
+        completed_at TEXT,
+        output_json TEXT,
+        error_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.close();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  });
+
+  interface TaskInsertOpts {
+    taskId: string;
+    taskKind: string;
+    status: string;
+    diagnosticJson?: string;
+    attemptCount?: number;
+  }
+
+  function insertTask(opts: TaskInsertOpts): void {
+    const d = new Database(dbPath);
+    d.prepare(
+      `INSERT OR REPLACE INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json)
+       VALUES (?, ?, ?, ?, 3, ?)`,
+    ).run(opts.taskId, opts.taskKind, opts.status, opts.attemptCount ?? 1, opts.diagnosticJson ?? null);
+    d.close();
+  }
+
+  interface ArtifactInsertOpts {
+    artifactId: string;
+    sourceTaskId: string;
+    kind: string;
+    content: string;
+  }
+
+  function insertArtifact(opts: ArtifactInsertOpts): void {
+    const d = new Database(dbPath);
+    d.prepare(
+      `INSERT OR REPLACE INTO pi_artifacts (artifact_id, source_task_id, artifact_kind, content_json)
+       VALUES (?, ?, ?, ?)`,
+    ).run(opts.artifactId, opts.sourceTaskId, opts.kind, opts.content);
+    d.close();
+  }
+
+  function getTaskField(taskId: string, field: string): string | number | null {
+    const d = new Database(dbPath);
+    const row = d.prepare(`SELECT ${field} FROM tasks WHERE task_id = ?`).get(taskId) as Record<string, unknown> | undefined;
+    d.close();
+    return (row?.[field] as string | number | null) ?? null;
+  }
+
+  function findAction(actions: RemediationAction[], taskId: string, type: string): RemediationAction | undefined {
+    return actions.find(a => a.taskId === taskId && a.type === type);
+  }
+
+  describe('dry-run', () => {
+    it('does not modify DB on dry-run', () => {
+      insertTask({ taskId: 'dreamer-001', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(getTaskField('dreamer-001', 'status')).toBe('succeeded');
+    });
+
+    it('reports missing_dreamer_pi_artifact as requeue action', () => {
+      insertTask({ taskId: 'dreamer-001', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: true });
+
+      const action = findAction(result.actions, 'dreamer-001', 'missing_dreamer_pi_artifact');
+      expect(action).toBeDefined();
+      expect(action?.recommendedAction).toBe('requeue');
+      expect(action?.previousStatus).toBe('succeeded');
+      expect(action?.newStatus).toBe('retry_wait');
+    });
+
+    it('reports missing_philosopher_successor with artifact present as enqueue_successor action', () => {
+      insertTask({ taskId: 'dreamer-002', taskKind: 'dreamer', status: 'succeeded' });
+      insertArtifact({ artifactId: 'art-002', sourceTaskId: 'dreamer-002', kind: 'principle', content: '{"valid":true}' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: true });
+
+      const action = findAction(result.actions, 'dreamer-002', 'missing_philosopher_successor');
+      expect(action).toBeDefined();
+      expect(action?.recommendedAction).toBe('enqueue_successor');
+    });
+
+    it('reports missing_philosopher_successor without artifact as skip (Case C)', () => {
+      insertTask({ taskId: 'dreamer-003', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: true });
+
+      const action = findAction(result.actions, 'dreamer-003', 'missing_philosopher_successor');
+      expect(action).toBeDefined();
+      expect(action?.recommendedAction).toBe('skip_missing_artifact');
+    });
+
+    it('returns repairedCount=0 and skippedCount on dry-run', () => {
+      insertTask({ taskId: 'dreamer-001', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: true });
+
+      expect(result.repairedCount).toBe(0);
+      expect(result.skippedCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('confirm', () => {
+    it('requeues succeeded dreamer with missing artifact to retry_wait', () => {
+      insertTask({ taskId: 'dreamer-001', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      expect(result.dryRun).toBe(false);
+      expect(getTaskField('dreamer-001', 'status')).toBe('retry_wait');
+      expect(getTaskField('dreamer-001', 'lease_owner')).toBeNull();
+
+      const action = findAction(result.actions, 'dreamer-001', 'missing_dreamer_pi_artifact');
+      expect(action?.previousStatus).toBe('succeeded');
+      expect(action?.newStatus).toBe('retry_wait');
+      expect(action?.reason).toContain('operator repair');
+    });
+
+    it('creates philosopher successor when dreamer has artifact but no successor', () => {
+      insertTask({ taskId: 'dreamer-002', taskKind: 'dreamer', status: 'succeeded' });
+      insertArtifact({ artifactId: 'art-002', sourceTaskId: 'dreamer-002', kind: 'principle', content: '{"valid":true}' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      const action = findAction(result.actions, 'dreamer-002', 'missing_philosopher_successor');
+      expect(action?.recommendedAction).toBe('enqueue_successor');
+      expect(action?.successorTaskId).toBeDefined();
+    });
+
+    it('skips philosopher successor creation when dreamer has no artifact (Case C)', () => {
+      insertTask({ taskId: 'dreamer-003', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      const action = findAction(result.actions, 'dreamer-003', 'missing_philosopher_successor');
+      expect(action?.recommendedAction).toBe('skip_missing_artifact');
+    });
+
+    it('is idempotent — second confirm does not re-requeue or create duplicate successor', () => {
+      insertTask({ taskId: 'dreamer-002', taskKind: 'dreamer', status: 'succeeded' });
+      insertArtifact({ artifactId: 'art-002', sourceTaskId: 'dreamer-002', kind: 'principle', content: '{"valid":true}' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result1 = remediation.repair({ dryRun: false });
+      const result2 = remediation.repair({ dryRun: false });
+
+      expect(result1.repairedCount).toBeGreaterThan(0);
+      expect(result2.repairedCount).toBe(0);
+      expect(result2.actions.every(a => a.recommendedAction === 'already_repaired' || a.recommendedAction === 'successor_exists')).toBe(true);
+    });
+
+    it('increments repairedCount for each repaired action', () => {
+      insertTask({ taskId: 'dreamer-a', taskKind: 'dreamer', status: 'succeeded' });
+      insertTask({ taskId: 'dreamer-b', taskKind: 'dreamer', status: 'succeeded' });
+      insertArtifact({ artifactId: 'art-b', sourceTaskId: 'dreamer-b', kind: 'principle', content: '{"valid":true}' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      expect(result.repairedCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it('fails closed when DB is not readable', () => {
+      const badDir = path.join(os.tmpdir(), 'nonexistent-' + Date.now());
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: badDir });
+
+      expect(() => remediation.repair({ dryRun: false })).toThrow();
+    });
+
+    it('JSON output includes repairedCount, skippedCount, actions', () => {
+      insertTask({ taskId: 'dreamer-001', taskKind: 'dreamer', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      expect(result).toHaveProperty('repairedCount');
+      expect(result).toHaveProperty('skippedCount');
+      expect(result).toHaveProperty('actions');
+      expect(Array.isArray(result.actions)).toBe(true);
+    });
+
+    it('does not touch non-dreamer tasks', () => {
+      insertTask({ taskId: 'diagnostician-001', taskKind: 'diagnostician', status: 'succeeded' });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      expect(getTaskField('diagnostician-001', 'status')).toBe('succeeded');
+      expect(result.actions.find(a => a.taskId === 'diagnostician-001')).toBeUndefined();
+    });
+
+    it('does not touch dreamer tasks with artifact and successor', () => {
+      insertTask({ taskId: 'dreamer-ok', taskKind: 'dreamer', status: 'succeeded' });
+      insertArtifact({ artifactId: 'art-ok', sourceTaskId: 'dreamer-ok', kind: 'principle', content: '{"valid":true}' });
+      insertTask({
+        taskId: 'philosopher-ok',
+        taskKind: 'philosopher',
+        status: 'pending',
+        diagnosticJson: JSON.stringify({ dependencyTaskIds: ['dreamer-ok'], channel: 'prompt' }),
+      });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      const action = result.actions.find(a => a.taskId === 'dreamer-ok');
+      expect(action).toBeUndefined();
+    });
+
+    it('resets attempt_count to 0 when requeuing succeeded dreamer', () => {
+      insertTask({ taskId: 'dreamer-maxed', taskKind: 'dreamer', status: 'succeeded', attemptCount: 3 });
+
+      const remediation = new InternalizationIntegrityRemediation({ workspaceDir: tmpDir });
+      const result = remediation.repair({ dryRun: false });
+
+      expect(getTaskField('dreamer-maxed', 'status')).toBe('retry_wait');
+      expect(getTaskField('dreamer-maxed', 'attempt_count')).toBe(0);
+
+      const action = findAction(result.actions, 'dreamer-maxed', 'missing_dreamer_pi_artifact');
+      expect(action?.newStatus).toBe('retry_wait');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -537,7 +537,7 @@ export type { SchemaConformanceResult, SchemaConformanceTableResult, SchemaConfo
 
 // ── Internalization Chain Integrity Read Model (PRI-97) ─────────────────────
 
-export { InternalizationChainIntegrityReadModel } from './internalization-chain-integrity-read-model.js';
+export { InternalizationChainIntegrityReadModel, extractPIMetadata } from './internalization-chain-integrity-read-model.js';
 export type { BrokenLink, ChainIntegrityResult, InternalizationChainIntegrityReadModelOptions } from './internalization-chain-integrity-read-model.js';
 
 export { InternalizationIntegrityRemediation } from './internalization-integrity-remediation.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -540,6 +540,9 @@ export type { SchemaConformanceResult, SchemaConformanceTableResult, SchemaConfo
 export { InternalizationChainIntegrityReadModel } from './internalization-chain-integrity-read-model.js';
 export type { BrokenLink, ChainIntegrityResult, InternalizationChainIntegrityReadModelOptions } from './internalization-chain-integrity-read-model.js';
 
+export { InternalizationIntegrityRemediation } from './internalization-integrity-remediation.js';
+export type { RemediationAction, RemediationResult, InternalizationIntegrityRemediationOptions } from './internalization-integrity-remediation.js';
+
 // ── Control Plane Triage (PRI-99) ───────────────────────────────────────────
 
 export { classifyCanaryFindings } from './control-plane-triage.js';

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -29,6 +29,20 @@ export interface InternalizationChainIntegrityReadModelOptions {
   workspaceDir: string;
 }
 
+function extractPIMetadata(diagJson: string | null): { parentTaskId?: string; dependencyTaskIds?: string[] } {
+  if (!diagJson) return {};
+  try {
+    const parsed = JSON.parse(diagJson);
+    const meta = parsed?.pi_metadata ?? parsed;
+    return {
+      parentTaskId: meta?.parentTaskId,
+      dependencyTaskIds: meta?.dependencyTaskIds,
+    };
+  } catch {
+    return {};
+  }
+}
+
 export class InternalizationChainIntegrityReadModel {
   private readonly dbPath: string;
 
@@ -116,25 +130,21 @@ export class InternalizationChainIntegrityReadModel {
         if (dreamerTask.status !== 'succeeded') continue;
 
         const hasDreamerArtifact = piArtifacts.some(
-          a => a.source_task_id === dreamerTask.task_id && a.artifact_kind === 'dreamer_pi'
+          a => a.source_task_id === dreamerTask.task_id && a.artifact_kind === 'principle'
         );
         if (!hasDreamerArtifact) {
           brokenLinks.push({
             type: 'missing_dreamer_pi_artifact',
             severity: 'error',
             taskId: dreamerTask.task_id,
-            reason: `Succeeded dreamer task ${dreamerTask.task_id} has no dreamer_pi artifact`,
+            reason: `Succeeded dreamer task ${dreamerTask.task_id} has no principle artifact`,
             recommendedAction: 'Re-run the dreamer task or investigate artifact commit failure.',
           });
         }
 
         const hasPhilosopherSuccessor = philosopherTasks.some(pt => {
-          try {
-            const diag = pt.diagnostic_json ? JSON.parse(pt.diagnostic_json) : null;
-            return diag?.parentTaskId === dreamerTask.task_id || diag?.dependencyTaskIds?.includes(dreamerTask.task_id);
-          } catch {
-            return false;
-          }
+          const meta = extractPIMetadata(pt.diagnostic_json);
+          return meta.parentTaskId === dreamerTask.task_id || meta.dependencyTaskIds?.includes(dreamerTask.task_id);
         });
         if (!hasPhilosopherSuccessor) {
           brokenLinks.push({
@@ -150,12 +160,10 @@ export class InternalizationChainIntegrityReadModel {
       for (const philosopherTask of philosopherTasks) {
         if (philosopherTask.status === 'pending' || philosopherTask.status === 'leased') {
           let hasDreamerDependency = false;
-          try {
-            const diag = philosopherTask.diagnostic_json ? JSON.parse(philosopherTask.diagnostic_json) : null;
-            if (diag?.dependencyTaskIds?.length > 0) {
-              hasDreamerDependency = diag.dependencyTaskIds.some((id: string) => taskMap.has(id) && taskMap.get(id)?.task_kind === 'dreamer');
-            }
-          } catch { /* skip */ }
+          const philMeta = extractPIMetadata(philosopherTask.diagnostic_json);
+          if (philMeta.dependencyTaskIds && philMeta.dependencyTaskIds.length > 0) {
+            hasDreamerDependency = philMeta.dependencyTaskIds.some((id: string) => taskMap.has(id) && taskMap.get(id)?.task_kind === 'dreamer');
+          }
 
           if (!hasDreamerDependency) {
             const candidateForPhilosopher = consumedCandidates.find(c => c.task_id === philosopherTask.task_id);
@@ -170,14 +178,14 @@ export class InternalizationChainIntegrityReadModel {
               });
               if (dreamerForCandidate) {
                 const hasDreamerPi = piArtifacts.some(
-                  a => a.source_task_id === dreamerForCandidate.task_id && a.artifact_kind === 'dreamer_pi'
+                  a => a.source_task_id === dreamerForCandidate.task_id && a.artifact_kind === 'principle'
                 );
                 if (!hasDreamerPi) {
                   brokenLinks.push({
                     type: 'philosopher_missing_dreamer_artifact',
                     severity: 'warning',
                     taskId: philosopherTask.task_id,
-                    reason: `Philosopher task ${philosopherTask.task_id} depends on dreamer task ${dreamerForCandidate.task_id} which has no dreamer_pi artifact`,
+                    reason: `Philosopher task ${philosopherTask.task_id} depends on dreamer task ${dreamerForCandidate.task_id} which has no principle artifact`,
                     recommendedAction: 'Ensure dreamer task has completed and committed artifacts before philosopher runs.',
                   });
                 }

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -29,7 +29,7 @@ export interface InternalizationChainIntegrityReadModelOptions {
   workspaceDir: string;
 }
 
-function extractPIMetadata(diagJson: string | null): { parentTaskId?: string; dependencyTaskIds?: string[] } {
+export function extractPIMetadata(diagJson: string | null): { parentTaskId?: string; dependencyTaskIds?: string[] } {
   if (!diagJson) return {};
   try {
     const parsed = JSON.parse(diagJson);

--- a/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
@@ -1,0 +1,294 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+
+export interface RemediationAction {
+  taskId: string;
+  type: string;
+  severity: 'error' | 'warning';
+  previousStatus: string;
+  newStatus: string;
+  recommendedAction: string;
+  reason: string;
+  successorTaskId?: string;
+}
+
+export interface RemediationResult {
+  dryRun: boolean;
+  repairedCount: number;
+  skippedCount: number;
+  actions: RemediationAction[];
+  generatedAt: string;
+}
+
+export interface InternalizationIntegrityRemediationOptions {
+  workspaceDir: string;
+}
+
+interface BrokenDreamer {
+  taskId: string;
+  missingArtifact: boolean;
+  missingSuccessor: boolean;
+  hasArtifact: boolean;
+}
+
+export class InternalizationIntegrityRemediation {
+  private readonly dbPath: string;
+
+  constructor(opts: InternalizationIntegrityRemediationOptions) {
+    this.dbPath = path.join(opts.workspaceDir, '.pd', 'state.db');
+  }
+
+  repair(params: { dryRun: boolean }): RemediationResult {
+    const generatedAt = new Date().toISOString();
+
+    if (!fs.existsSync(this.dbPath)) {
+      throw new Error(`state.db not found at ${this.dbPath} — cannot remediate`);
+    }
+
+    const brokenDreamers = this.detectBrokenDreamers();
+
+    const actions: RemediationAction[] = [];
+    let repairedCount = 0;
+    let skippedCount = 0;
+
+    for (const bd of brokenDreamers) {
+      if (bd.missingArtifact) {
+        if (params.dryRun) {
+          actions.push({
+            taskId: bd.taskId,
+            type: 'missing_dreamer_pi_artifact',
+            severity: 'error',
+            previousStatus: 'succeeded',
+            newStatus: 'retry_wait',
+            recommendedAction: 'requeue',
+            reason: 'Succeeded dreamer missing dreamer_pi artifact — operator repair: requeue to retry_wait for re-execution',
+          });
+        } else {
+          const currentStatus = this.getTaskStatus(bd.taskId);
+          if (currentStatus !== 'succeeded') {
+            actions.push({
+              taskId: bd.taskId,
+              type: 'missing_dreamer_pi_artifact',
+              severity: 'error',
+              previousStatus: currentStatus,
+              newStatus: currentStatus,
+              recommendedAction: 'already_repaired',
+              reason: `Task already in ${currentStatus} — no repair needed`,
+            });
+            skippedCount++;
+            continue;
+          }
+
+          this.requeueTask(bd.taskId);
+          repairedCount++;
+
+          actions.push({
+            taskId: bd.taskId,
+            type: 'missing_dreamer_pi_artifact',
+            severity: 'error',
+            previousStatus: 'succeeded',
+            newStatus: 'retry_wait',
+            recommendedAction: 'requeue',
+            reason: 'Succeeded dreamer missing dreamer_pi artifact — operator repair: requeue to retry_wait for re-execution',
+          });
+        }
+      }
+
+      if (bd.missingSuccessor) {
+        if (!bd.hasArtifact) {
+          actions.push({
+            taskId: bd.taskId,
+            type: 'missing_philosopher_successor',
+            severity: 'warning',
+            previousStatus: this.getTaskStatus(bd.taskId),
+            newStatus: this.getTaskStatus(bd.taskId),
+            recommendedAction: 'skip_missing_artifact',
+            reason: 'Cannot create philosopher successor — dreamer has no dreamer_pi artifact. Fix artifact first.',
+          });
+          skippedCount++;
+        } else if (params.dryRun) {
+          actions.push({
+            taskId: bd.taskId,
+            type: 'missing_philosopher_successor',
+            severity: 'warning',
+            previousStatus: 'succeeded',
+            newStatus: 'succeeded',
+            recommendedAction: 'enqueue_successor',
+            reason: 'Dreamer has artifact but no philosopher successor — would create philosopher task',
+          });
+        } else {
+          const existingSuccessor = this.findExistingSuccessor(bd.taskId);
+          if (existingSuccessor) {
+            actions.push({
+              taskId: bd.taskId,
+              type: 'missing_philosopher_successor',
+              severity: 'warning',
+              previousStatus: 'succeeded',
+              newStatus: 'succeeded',
+              recommendedAction: 'successor_exists',
+              reason: `Philosopher successor already exists: ${existingSuccessor}`,
+              successorTaskId: existingSuccessor,
+            });
+            skippedCount++;
+          } else {
+            const successorTaskId = this.createPhilosopherSuccessor(bd.taskId);
+            repairedCount++;
+
+            actions.push({
+              taskId: bd.taskId,
+              type: 'missing_philosopher_successor',
+              severity: 'warning',
+              previousStatus: 'succeeded',
+              newStatus: 'succeeded',
+              recommendedAction: 'enqueue_successor',
+              reason: 'Created philosopher successor task',
+              successorTaskId,
+            });
+          }
+        }
+      }
+    }
+
+    return {
+      dryRun: params.dryRun,
+      repairedCount,
+      skippedCount,
+      actions,
+      generatedAt,
+    };
+  }
+
+  private detectBrokenDreamers(): BrokenDreamer[] {
+    const db = new Database(this.dbPath, { readonly: true });
+    try {
+      const dreamerTasks = db.prepare(
+        "SELECT task_id, diagnostic_json FROM tasks WHERE task_kind = 'dreamer' AND status = 'succeeded'",
+      ).all() as { task_id: string; diagnostic_json: string | null }[];
+
+      const piArtifacts = db.prepare(
+        "SELECT source_task_id, artifact_kind FROM pi_artifacts WHERE artifact_kind = 'principle'",
+      ).all() as { source_task_id: string; artifact_kind: string }[];
+
+      const philosopherTasks = db.prepare(
+        "SELECT task_id, diagnostic_json FROM tasks WHERE task_kind = 'philosopher'",
+      ).all() as { task_id: string; diagnostic_json: string | null }[];
+
+      const artifactTaskIds = new Set(piArtifacts.map(a => a.source_task_id));
+
+      const philosopherParentIds = new Set<string>();
+      for (const pt of philosopherTasks) {
+        try {
+          const parsed = pt.diagnostic_json ? JSON.parse(pt.diagnostic_json) : null;
+          const meta = parsed?.pi_metadata ?? parsed;
+          if (meta?.dependencyTaskIds) {
+            for (const depId of meta.dependencyTaskIds) {
+              philosopherParentIds.add(depId);
+            }
+          }
+          if (meta?.parentTaskId) {
+            philosopherParentIds.add(meta.parentTaskId);
+          }
+        } catch { /* skip */ }
+      }
+
+      const results: BrokenDreamer[] = [];
+
+      for (const dt of dreamerTasks) {
+        const hasArtifact = artifactTaskIds.has(dt.task_id);
+        const missingArtifact = !hasArtifact;
+        const missingSuccessor = !philosopherParentIds.has(dt.task_id);
+
+        if (missingArtifact || missingSuccessor) {
+          results.push({
+            taskId: dt.task_id,
+            missingArtifact,
+            missingSuccessor,
+            hasArtifact,
+          });
+        }
+      }
+
+      return results;
+    } finally {
+      db.close();
+    }
+  }
+
+  private getTaskStatus(taskId: string): string {
+    const db = new Database(this.dbPath, { readonly: true });
+    try {
+      const row = db.prepare('SELECT status FROM tasks WHERE task_id = ?').get(taskId) as { status: string } | undefined;
+      return row?.status ?? 'unknown';
+    } finally {
+      db.close();
+    }
+  }
+
+  private requeueTask(taskId: string): void {
+    const db = new Database(this.dbPath);
+    try {
+      const now = new Date();
+      const retryAfter = new Date(now.getTime() + 60_000);
+
+      db.prepare(
+        `UPDATE tasks SET status = 'retry_wait', attempt_count = 0, lease_owner = NULL, lease_expires_at = ?, result_ref = NULL, updated_at = datetime('now') WHERE task_id = ?`,
+      ).run(retryAfter.toISOString(), taskId);
+    } finally {
+      db.close();
+    }
+  }
+
+  private findExistingSuccessor(dreamerTaskId: string): string | null {
+    const db = new Database(this.dbPath, { readonly: true });
+    try {
+      const philosopherTasks = db.prepare(
+        "SELECT task_id, diagnostic_json FROM tasks WHERE task_kind = 'philosopher'",
+      ).all() as { task_id: string; diagnostic_json: string | null }[];
+
+      for (const pt of philosopherTasks) {
+        try {
+          const parsed = pt.diagnostic_json ? JSON.parse(pt.diagnostic_json) : null;
+          const meta = parsed?.pi_metadata ?? parsed;
+          if (meta?.dependencyTaskIds?.includes(dreamerTaskId) || meta?.parentTaskId === dreamerTaskId) {
+            return pt.task_id;
+          }
+        } catch { /* skip */ }
+      }
+
+      const successorTaskId = `philosopher-${dreamerTaskId}-prompt`;
+      const existing = db.prepare('SELECT task_id FROM tasks WHERE task_id = ?').get(successorTaskId) as { task_id: string } | undefined;
+      if (existing) {
+        return existing.task_id;
+      }
+
+      return null;
+    } finally {
+      db.close();
+    }
+  }
+
+  private createPhilosopherSuccessor(dreamerTaskId: string): string {
+    const db = new Database(this.dbPath);
+    try {
+      const successorTaskId = `philosopher-${dreamerTaskId}-prompt`;
+      const metadata = {
+        dependencyTaskIds: [dreamerTaskId],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+        parentTaskId: dreamerTaskId,
+      };
+
+      db.prepare(
+        `INSERT OR IGNORE INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json)
+         VALUES (?, 'philosopher', 'pending', 0, 3, ?)`,
+      ).run(successorTaskId, JSON.stringify(metadata));
+
+      return successorTaskId;
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
+import { extractPIMetadata } from './internalization-chain-integrity-read-model.js';
 
 export interface RemediationAction {
   taskId: string;
@@ -178,18 +179,15 @@ export class InternalizationIntegrityRemediation {
 
       const philosopherParentIds = new Set<string>();
       for (const pt of philosopherTasks) {
-        try {
-          const parsed = pt.diagnostic_json ? JSON.parse(pt.diagnostic_json) : null;
-          const meta = parsed?.pi_metadata ?? parsed;
-          if (meta?.dependencyTaskIds) {
-            for (const depId of meta.dependencyTaskIds) {
-              philosopherParentIds.add(depId);
-            }
+        const meta = extractPIMetadata(pt.diagnostic_json);
+        if (meta.dependencyTaskIds) {
+          for (const depId of meta.dependencyTaskIds) {
+            philosopherParentIds.add(depId);
           }
-          if (meta?.parentTaskId) {
-            philosopherParentIds.add(meta.parentTaskId);
-          }
-        } catch { /* skip */ }
+        }
+        if (meta.parentTaskId) {
+          philosopherParentIds.add(meta.parentTaskId);
+        }
       }
 
       const results: BrokenDreamer[] = [];
@@ -228,12 +226,9 @@ export class InternalizationIntegrityRemediation {
   private requeueTask(taskId: string): void {
     const db = new Database(this.dbPath);
     try {
-      const now = new Date();
-      const retryAfter = new Date(now.getTime() + 60_000);
-
       db.prepare(
-        `UPDATE tasks SET status = 'retry_wait', attempt_count = 0, lease_owner = NULL, lease_expires_at = ?, result_ref = NULL, updated_at = datetime('now') WHERE task_id = ?`,
-      ).run(retryAfter.toISOString(), taskId);
+        `UPDATE tasks SET status = 'retry_wait', attempt_count = 0, lease_owner = NULL, lease_expires_at = NULL, result_ref = NULL, updated_at = datetime('now') WHERE task_id = ?`,
+      ).run(taskId);
     } finally {
       db.close();
     }
@@ -247,13 +242,10 @@ export class InternalizationIntegrityRemediation {
       ).all() as { task_id: string; diagnostic_json: string | null }[];
 
       for (const pt of philosopherTasks) {
-        try {
-          const parsed = pt.diagnostic_json ? JSON.parse(pt.diagnostic_json) : null;
-          const meta = parsed?.pi_metadata ?? parsed;
-          if (meta?.dependencyTaskIds?.includes(dreamerTaskId) || meta?.parentTaskId === dreamerTaskId) {
-            return pt.task_id;
-          }
-        } catch { /* skip */ }
+        const meta = extractPIMetadata(pt.diagnostic_json);
+        if (meta.dependencyTaskIds?.includes(dreamerTaskId) || meta.parentTaskId === dreamerTaskId) {
+          return pt.task_id;
+        }
       }
 
       const successorTaskId = `philosopher-${dreamerTaskId}-prompt`;
@@ -272,19 +264,24 @@ export class InternalizationIntegrityRemediation {
     const db = new Database(this.dbPath);
     try {
       const successorTaskId = `philosopher-${dreamerTaskId}-prompt`;
+
+      const artifactRow = db.prepare(
+        "SELECT artifact_id FROM pi_artifacts WHERE source_task_id = ? AND artifact_kind = 'principle' LIMIT 1",
+      ).get(dreamerTaskId) as { artifact_id: string } | undefined;
+
       const metadata = {
         dependencyTaskIds: [dreamerTaskId],
         channel: 'prompt',
         timeoutMs: 300_000,
-        inputArtifactRefs: [],
+        inputArtifactRefs: artifactRow ? [{ artifactId: artifactRow.artifact_id, kind: 'principle' }] : [],
         outputArtifactRefs: [],
         parentTaskId: dreamerTaskId,
       };
 
       db.prepare(
-        `INSERT OR IGNORE INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json)
-         VALUES (?, 'philosopher', 'pending', 0, 3, ?)`,
-      ).run(successorTaskId, JSON.stringify(metadata));
+        `INSERT OR IGNORE INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, input_ref, diagnostic_json, created_at, updated_at)
+         VALUES (?, 'philosopher', 'pending', 0, 3, ?, ?, datetime('now'), datetime('now'))`,
+      ).run(successorTaskId, artifactRow?.artifact_id ?? null, JSON.stringify(metadata));
 
       return successorTaskId;
     } finally {


### PR DESCRIPTION
## 现象

- 3 historical dreamer tasks in succeeded status missing dreamer_pi artifact
- Integrity check reported brokenLinks (missing_dreamer_pi_artifact, missing_philosopher_successor)
- Canary overallStatus=degraded, runtime_health degraded (lastSuccessfulChain=null)

## 根因

1. Historical dreamer tasks were marked succeeded without committing artifacts (pre-PRI-107)
2. Integrity read model queried artifact_kind='dreamer_pi' but actual runners use 'principle'
3. Integrity read model parsed diagnostic_json at top level, but orchestrator stores under pi_metadata key
4. No operator repair path existed for requeuing succeeded tasks back to retry_wait

## 修复策略

1. Add InternalizationIntegrityRemediation class with dry-run/confirm pattern
   - Case A: succeeded dreamer missing artifact -> requeue to retry_wait (operator repair, resets attempt_count)
   - Case B: succeeded dreamer has artifact but no philosopher -> create philosopher successor
   - Case C: no artifact and no successor -> skip successor creation, fix artifact first
2. Add CLI command: pd runtime internalization integrity-repair --dry-run/--confirm
3. Fix artifact_kind query: 'dreamer_pi' -> 'principle' in integrity read model + remediation
4. Fix diagnostic_json parsing: support both top-level and pi_metadata-nested formats

## 修改文件

- internalization-integrity-remediation.ts (new)
- internalization-integrity-remediation.test.ts (new, 15 tests)
- internalization-chain-integrity-read-model.ts (fix artifact_kind + extractPIMetadata)
- internalization-chain-integrity-read-model.test.ts (fix mock)
- index.ts (export remediation)
- runtime-internalization-integrity-repair.ts (new)
- runtime-internalization-integrity-repair.test.ts (new, 5 tests)
- pd-cli index.ts (register command)

## 测试命令和结果

- npx vitest run packages/principles-core/src/runtime-v2/__tests__/internalization-integrity-remediation.test.ts -> 15/15 passed
- npx vitest run packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts -> 7/7 passed
- npx vitest run packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts -> 5/5 passed

## 真实 workspace dry-run/confirm 输出摘要

- dry-run: detected 3 broken dreamer tasks with missing_dreamer_pi_artifact + missing_philosopher_successor
- confirm: repairedCount=3, all 3 requeued from succeeded -> retry_wait
- Post-repair E2E: dreamer succeeded -> philosopher succeeded -> scribe enqueued
- Post-repair integrity: overallStatus=ok, brokenLinks=[]
- Post-repair canary: overallStatus=healthy

## 剩余风险

- UAT success rate 67% (Diagnostician output_invalid on 1/3 runs) - known flaky issue
- ScribeRunner not yet implemented - next blocker for full pipeline drain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 新增 CLI 命令用于检测和修复断裂的国际化链路。支持模拟运行模式预览更改，以及确认后应用实际修复。可生成 JSON 或文本格式的修复报告，包含修复和跳过的数量统计。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->