### PR TITLE
feat(internalization): ArtificerRunner vertical slice (PRI-111)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -5,17 +5,19 @@ import {
   DreamerRunner,
   PhilosopherRunner,
   ScribeRunner,
+  ArtificerRunner,
   StoreEventEmitter,
   DefaultDreamerValidator,
   DefaultPhilosopherValidator,
   DefaultScribeValidator,
+  DefaultArtificerValidator,
   TestDoubleRuntimeAdapter,
   PiAiRuntimeAdapter,
   OpenClawCliRuntimeAdapter,
   resolveRuntimeConfig,
   validateRuntimeConfig,
 } from '@principles/core/runtime-v2';
-import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, PDRuntimeAdapter } from '@principles/core/runtime-v2';
+import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, PDRuntimeAdapter } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 interface RunOnceOptions {
@@ -31,7 +33,7 @@ interface RunOnceOptions {
 const OWNER = 'pd-cli-internalization-run-once';
 const RUNTIME_KIND = 'local-worker';
 
-const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe']);
+const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer']);
 
 interface RunOnceOutput {
   decision: string;
@@ -42,7 +44,7 @@ interface RunOnceOutput {
   runId?: string;
   artifactId?: string;
   resultRef?: string;
-  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult;
+  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult;
   skipReason?: string;
   conflictReason?: string;
   reason?: string;
@@ -54,7 +56,7 @@ interface RunOnceOutput {
   timeoutSource?: string;
 }
 
-function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult, skipReason?: string): RunOnceOutput {
+function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult, skipReason?: string): RunOnceOutput {
   const base: RunOnceOutput = { decision: wakeResult.decision };
 
   switch (wakeResult.decision) {
@@ -232,6 +234,47 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
         }),
       });
     }
+    if (opts.runnerKind === 'artificer') {
+      let capturedSourceScribeArtifactId = 'pi-art-test-scribe';
+      return new TestDoubleRuntimeAdapter({
+        onStartRun: (input) => {
+          try {
+            const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+            const parsed = JSON.parse(payloadStr);
+            if (typeof parsed.sourceScribeArtifactId === 'string' && parsed.sourceScribeArtifactId.trim() !== '') {
+              capturedSourceScribeArtifactId = parsed.sourceScribeArtifactId;
+            }
+          } catch { /* use default */ }
+          return { runId: `td-artificer-${Date.now()}`, runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+        },
+        onPollRun: (_runId: string) => ({
+          runId: _runId,
+          status: 'succeeded',
+          startedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+        }),
+        onFetchOutput: (_runId: string) => ({
+          runId: _runId,
+          payload: {
+            taskId: opts.taskId,
+            sourceScribeArtifactId: capturedSourceScribeArtifactId,
+            implementationPlan: {
+              summary: 'Test implementation summary',
+              targetSurface: 'src/test/*.ts',
+              changes: ['Add validation to test module'],
+              tests: ['Unit test for validation'],
+              rolloutNotes: ['Deploy behind feature flag'],
+              confidence: 0.8,
+            },
+            sourceTrace: {
+              scribeArtifactId: capturedSourceScribeArtifactId,
+            },
+            risks: [],
+            generatedAt: new Date().toISOString(),
+          },
+        }),
+      });
+    }
     return new TestDoubleRuntimeAdapter({
       onPollRun: (_runId: string) => ({
         runId: _runId,
@@ -336,7 +379,7 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       return;
     }
 
-    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | undefined = undefined;
+    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | undefined = undefined;
     let skipReason: string | undefined = undefined;
 
     if (wakeResult.decision === 'would_lease' && wakeResult.taskKind === runnerKind) {
@@ -361,6 +404,13 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       } else if (runnerKind === 'scribe') {
         const validator = new DefaultScribeValidator();
         const runner = new ScribeRunner(
+          { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
+          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
+        );
+        runnerResult = await runner.run(wakeResult.taskId);
+      } else if (runnerKind === 'artificer') {
+        const validator = new DefaultArtificerValidator();
+        const runner = new ArtificerRunner(
           { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
           { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -43,6 +43,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
   ScribeRunner: vi.fn().mockImplementation(function () {
     return { run: mockRun };
   }),
+  ArtificerRunner: vi.fn().mockImplementation(function () {
+    return { run: mockRun };
+  }),
   StoreEventEmitter: vi.fn().mockImplementation(function () {
     return { emitTelemetry: vi.fn() };
   }),
@@ -56,6 +59,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
     return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
   }),
   DefaultScribeValidator: vi.fn().mockImplementation(function () {
+    return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
+  }),
+  DefaultArtificerValidator: vi.fn().mockImplementation(function () {
     return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
   }),
   TestDoubleRuntimeAdapter: vi.fn().mockImplementation(function () {
@@ -181,7 +187,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
   });
 
   it('unsupported runner kind: exits 1 with error', async () => {
-    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'artificer', runtime: 'test-double', allowTestDouble: true });
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'evaluator', runtime: 'test-double', allowTestDouble: true });
 
     expect(process.exitCode).toBe(1);
     expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('unsupported runner kind'))).toBe(true);
@@ -911,12 +917,108 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.successorKind).toBe('artificer');
   });
 
-  it('run-once source has no direct ScribeRunner to ArtificerRunner import', async () => {
+  it('run-once source has no direct EvaluatorRunner import', async () => {
     const { existsSync, readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const srcPath = resolve(__dirname, '../../src/commands/runtime-internalization-run-once.ts');
     if (!existsSync(srcPath)) return;
     const src = readFileSync(srcPath, 'utf-8');
-    expect(src).not.toContain('ArtificerRunner');
+    expect(src).not.toContain('EvaluatorRunner');
+  });
+
+  it('--runner artificer dispatches ArtificerRunner', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-artificer-001',
+      taskKind: 'artificer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-artificer-001',
+      runId: 'run-artificer-001',
+      artifactId: 'pi-art-task-artificer-001-run-artificer-001',
+      resultRef: 'artificer://run-artificer-001',
+      contextHash: 'ctx-artificer-abc',
+      output: {
+        taskId: 'task-artificer-001',
+        sourceScribeArtifactId: 'pi-art-scribe-001',
+        implementationPlan: {
+          summary: 'Test implementation summary',
+          targetSurface: 'src/test/*.ts',
+          changes: ['Add validation'],
+          tests: ['Unit test for validation'],
+          rolloutNotes: ['Deploy behind feature flag'],
+          confidence: 0.8,
+        },
+        sourceTrace: { scribeArtifactId: 'pi-art-scribe-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'artificer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const ArtificerRunnerMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.ArtificerRunner),
+    );
+    expect(ArtificerRunnerMock).toHaveBeenCalled();
+    expect(mockRun).toHaveBeenCalledWith('task-artificer-001');
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.runnerKind).toBe('artificer');
+    expect(output.taskId).toBe('task-artificer-001');
+    expect(output.runId).toBe('run-artificer-001');
+    expect(output.artifactId).toBe('pi-art-task-artificer-001-run-artificer-001');
+    expect(output.resultRef).toBe('artificer://run-artificer-001');
+    expect(output.runnerResult.status).toBe('succeeded');
+  });
+
+  it('--runner artificer --enqueue-next returns successor decision', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-artificer-enq-001',
+      taskKind: 'artificer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-artificer-enq-001',
+      runId: 'run-artificer-enq-001',
+      artifactId: 'pi-art-artificer-enq-001',
+      resultRef: 'artificer://run-artificer-enq-001',
+      contextHash: 'ctx-enq',
+      output: {
+        taskId: 'task-artificer-enq-001',
+        sourceScribeArtifactId: 'pi-art-scribe-enq-001',
+        implementationPlan: {
+          summary: 'Test implementation summary',
+          targetSurface: 'src/test/*.ts',
+          changes: ['Add validation'],
+          tests: ['Unit test for validation'],
+          rolloutNotes: ['Deploy behind feature flag'],
+          confidence: 0.8,
+        },
+        sourceTrace: { scribeArtifactId: 'pi-art-scribe-enq-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'task-artificer-enq-001',
+      successorTaskId: 'task-evaluator-enq-001',
+      successorKind: 'evaluator',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'artificer', runtime: 'test-double', allowTestDouble: true, enqueueNext: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.enqueueDecision).toBe('successor_created');
+    expect(output.successorTaskId).toBe('task-evaluator-enq-001');
+    expect(output.successorKind).toBe('evaluator');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -62,6 +62,9 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-109
   'internalization/scribe-output.ts',
   'internalization/scribe-runner.ts',
+  // PRI-111
+  'internalization/artificer-output.ts',
+  'internalization/artificer-runner.ts',
   // PRI-74 (follow-up to PRI-75 Phase 3)
   '../prompt-builder/routing-guidance.ts',
   // PRI-81 Phase A
@@ -97,6 +100,8 @@ const REQUIRED_TEST_FILES = [
   'dreamer-runner.test.ts',
   // PRI-109
   'scribe-runner-vslice.test.ts',
+  // PRI-111
+  'artificer-runner-vslice.test.ts',
   // PRI-74 (follow-up to PRI-75 Phase 3)
   '../../prompt-builder/__tests__/routing-guidance.test.ts',
   // PRI-81 Phase A
@@ -1556,5 +1561,68 @@ describe('PRI-78 GFI observability boundary', () => {
       'utf-8'
     );
     expect(src).toContain("from '@principles/core/runtime-v2'");
+  });
+});
+
+// ── PRI-111: ArtificerRunner boundary guards ──────────────────────────────────
+
+describe('PRI-111 ArtificerRunner boundary', () => {
+  it('artificer source files exist in internalization directory', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'artificer-runner.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'artificer-output.ts'))).toBe(true);
+  });
+
+  it('artificer test file exists', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, 'artificer-runner-vslice.test.ts'))).toBe(true);
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: artificer-runner.ts has no openclaw-plugin, evaluator, nocturnal-trinity imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'artificer-runner.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('EvaluatorRunner');
+    expect(src).not.toContain('nocturnal-trinity');
+    expect(src).not.toContain('InternalizationOrchestrator');
+    expect(src).not.toContain('createTask');
+    expect(src).not.toContain('enqueueTask');
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: artificer-output.ts has no openclaw-plugin, fs, path imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'artificer-output.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+  });
+
+  it('CORE_NO_SCHEDULING: artificer-runner.ts has no node:fs, node:cron, or cron-style scheduling', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'artificer-runner.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('BARREL_EXPORTS: internalization/index.ts exports ArtificerRunner and ArtificerOutput', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).toContain('ArtificerRunner');
+    expect(src).toContain('ArtificerOutput');
+    expect(src).toContain('DefaultArtificerValidator');
+  });
+
+  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers artificer-output-v1 schema', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    expect(src).toContain('artificer-output-v1');
+    expect(src).toContain('ArtificerOutputV1Schema');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/artificer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/artificer-runner-vslice.test.ts
@@ -1,0 +1,699 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ArtificerRunner } from '../internalization/artificer-runner.js';
+import type { ArtificerRunnerDeps } from '../internalization/artificer-runner.js';
+import type { PIArtifactStore, PIArtifactRecord } from '../internalization/pi-artifact.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { ArtificerOutputV1 } from '../internalization/artificer-output.js';
+import { DefaultArtificerValidator } from '../internalization/artificer-output.js';
+import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
+import type { TaskRecord } from '../task-status.js';
+import { TestDoubleRuntimeAdapter } from '../adapter/test-double-runtime-adapter.js';
+
+import { PDRuntimeError } from '../error-categories.js';
+
+const SCRIBE_TASK_ID = 'scribe-001';
+const ARTIFICER_TASK_ID = 'artificer-001';
+
+function makeScribeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: SCRIBE_TASK_ID,
+    taskKind: 'scribe',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'scribe://run-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-scribe-001-run-001' }],
+    }),
+    ...overrides,
+  };
+}
+
+function makeArtificerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ARTIFICER_TASK_ID,
+    taskKind: 'artificer',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [SCRIBE_TASK_ID],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-scribe-001-run-001' }],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeArtificerOutput(): ArtificerOutputV1 {
+  return {
+    taskId: ARTIFICER_TASK_ID,
+    sourceScribeArtifactId: 'pi-art-scribe-001-run-001',
+    implementationPlan: {
+      summary: 'Add input validation to all async operations',
+      targetSurface: 'src/async-ops/*.ts',
+      changes: ['Add try-catch to asyncOp1', 'Add error boundary to asyncOp2'],
+      tests: ['Unit test for asyncOp1 error handling', 'Integration test for error boundary'],
+      rolloutNotes: ['Deploy behind feature flag', 'Monitor error rates post-deploy'],
+      confidence: 0.85,
+    },
+    sourceTrace: {
+      scribeArtifactId: 'pi-art-scribe-001-run-001',
+    },
+    risks: ['May add latency from error checking'],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function makeScribeArtifact(): PIArtifactRecord {
+  return {
+    artifactId: 'pi-art-scribe-001-run-001',
+    artifactKind: 'principle',
+    sourceTaskId: SCRIBE_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify({
+      taskId: SCRIBE_TASK_ID,
+      sourcePhilosopherArtifactId: 'pi-art-philosopher-001',
+      principleDraft: {
+        title: 'Systematic Error Handling',
+        statement: 'All async operations must include explicit error handling',
+        rationale: 'Uncaught errors cascade into system instability',
+        applicability: ['All async operations'],
+        antiPatterns: ['Ignoring promise rejections'],
+        confidence: 0.9,
+      },
+      sourceTrace: {
+        philosopherArtifactId: 'pi-art-philosopher-001',
+      },
+      risks: [],
+      generatedAt: new Date().toISOString(),
+    }),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('ArtificerRunner (PRI-111)', () => {
+  let artifactStore: PIArtifactStore = new MemoryPIArtifactStore();
+
+  beforeEach(() => {
+    artifactStore = new MemoryPIArtifactStore();
+  });
+
+  function createMockDeps(overrides: Partial<ArtificerRunnerDeps> = {}): ArtificerRunnerDeps {
+    const artificerTask = makeArtificerTask();
+    const scribeTask = makeScribeTask();
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(artificerTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(artificerTask);
+        if (id === SCRIBE_TASK_ID) return Promise.resolve(scribeTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-artificer-001',
+        taskId: ARTIFICER_TASK_ID,
+        runtimeKind: 'artificer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const runHandle: RunHandle = { runId: 'run-artificer-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+    const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-artificer-001' };
+
+    const runtimeAdapter = {
+      startRun: vi.fn().mockResolvedValue(runHandle),
+      pollRun: vi.fn().mockResolvedValue(succeededStatus),
+      fetchOutput: vi.fn().mockResolvedValue({
+        payload: makeArtificerOutput(),
+      }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PDRuntimeAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const validator = new DefaultArtificerValidator();
+
+    return {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator,
+      artifactStore,
+      ...overrides,
+    };
+  }
+
+  it('taskKind not artificer fails closed and releases lease', async () => {
+    const wrongKindTask = makeArtificerTask({ taskKind: 'dreamer' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(wrongKindTask);
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+    expect(result.failureReason).toContain("must be 'artificer'");
+    expect(deps.stateManager.markTaskFailed).toHaveBeenCalledWith(
+      ARTIFICER_TASK_ID,
+      'input_invalid',
+    );
+  });
+
+  it('lease conflict is non-mutating', async () => {
+    const deps = createMockDeps();
+    const leaseError = new PDRuntimeError('lease_conflict', 'Another runner holds the lease');
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockRejectedValue(leaseError);
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('lease_conflict');
+    expect(deps.stateManager.markTaskFailed).not.toHaveBeenCalled();
+    expect(deps.stateManager.markTaskRetryWait).not.toHaveBeenCalled();
+  });
+
+  it('missing scribe dependency blocked/failure', async () => {
+    const noDepTask = makeArtificerTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(noDepTask);
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockResolvedValue(noDepTask);
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('scribe dependency not succeeded cannot execute', async () => {
+    const pendingScribe = makeScribeTask({ status: 'pending' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockImplementation((id: string) => {
+      if (id === ARTIFICER_TASK_ID) return Promise.resolve(makeArtificerTask());
+      if (id === SCRIBE_TASK_ID) return Promise.resolve(pendingScribe);
+      return Promise.resolve(null);
+    });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('scribe artifact missing goes to retry/fail', async () => {
+    const emptyArtifactStore = new MemoryPIArtifactStore();
+    const deps = createMockDeps({ artifactStore: emptyArtifactStore });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('valid runtime output writes artificer PIArtifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeScribeArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(result.artifactId).toBeDefined();
+
+    const artifacts = await store.listBySourceTaskId(ARTIFICER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+  });
+
+  it('valid runtime output marks task succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeScribeArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
+      ARTIFICER_TASK_ID,
+      expect.stringContaining('artificer://'),
+    );
+  });
+
+  it('invalid output does not write artifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeScribeArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const invalidOutput: ArtificerOutputV1 = {
+      taskId: 'wrong-task-id',
+      sourceScribeArtifactId: '',
+      implementationPlan: {
+        summary: '',
+        targetSurface: '',
+        changes: [],
+        tests: [],
+        rolloutNotes: [],
+        confidence: 1.5,
+      },
+      sourceTrace: {
+        scribeArtifactId: '',
+      },
+      risks: 'not-array' as unknown as string[],
+      generatedAt: '',
+    };
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+
+    const artifacts = await store.listBySourceTaskId(ARTIFICER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('artifact write failure goes to retry/fail, not mark succeeded', async () => {
+    const failingStore = {
+      listBySourceTaskId: vi.fn().mockResolvedValue([makeScribeArtifact()]),
+      upsertArtifact: vi.fn().mockRejectedValue(new Error('Disk full')),
+    } as unknown as PIArtifactStore;
+
+    const deps = createMockDeps({ artifactStore: failingStore });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('mismatched sourceScribeArtifactId does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeScribeArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeArtificerOutput();
+    (mismatchedOutput as unknown as Record<string, unknown>).sourceScribeArtifactId = 'wrong-artifact-id';
+    (mismatchedOutput.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = 'wrong-artifact-id';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(ARTIFICER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+});
+
+describe('DefaultArtificerValidator (PRI-111)', () => {
+  const validator = new DefaultArtificerValidator();
+
+  it('accepts valid Artificer output', async () => {
+    const result = await validator.validate(makeArtificerOutput(), ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects taskId mismatch', async () => {
+    const output = makeArtificerOutput();
+    (output as unknown as Record<string, unknown>).taskId = 'wrong';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('taskId mismatch'))).toBe(true);
+  });
+
+  it('rejects missing sourceScribeArtifactId', async () => {
+    const output = makeArtificerOutput();
+    (output as unknown as Record<string, unknown>).sourceScribeArtifactId = '';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceScribeArtifactId'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceScribeArtifactId when expected is provided', async () => {
+    const output = makeArtificerOutput();
+    (output as unknown as Record<string, unknown>).sourceScribeArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID, 'pi-art-scribe-001-run-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceScribeArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceTrace.scribeArtifactId when expected is provided', async () => {
+    const output = makeArtificerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID, 'pi-art-scribe-001-run-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceTrace.scribeArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects confidence as string', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).confidence = '0.85';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be number'))).toBe(true);
+  });
+
+  it('rejects confidence > 1', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).confidence = 1.5;
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be in [0, 1]'))).toBe(true);
+  });
+
+  it('rejects NaN confidence', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).confidence = NaN;
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be number'))).toBe(true);
+  });
+
+  it('rejects Infinity confidence', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).confidence = Infinity;
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be number'))).toBe(true);
+  });
+
+  it('rejects null output', async () => {
+    const result = await validator.validate(null as unknown as ArtificerOutputV1, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects changes with non-string elements', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).changes = [1, 2];
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('changes must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects tests with non-string elements', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).tests = [true];
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('tests must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects rolloutNotes with non-string elements', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).rolloutNotes = [42];
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('rolloutNotes must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects risks with non-string elements', async () => {
+    const output = makeArtificerOutput();
+    (output as unknown as Record<string, unknown>).risks = [42];
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('risks must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects missing implementationPlan.summary', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).summary = '';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('implementationPlan.summary'))).toBe(true);
+  });
+
+  it('rejects missing implementationPlan.targetSurface', async () => {
+    const output = makeArtificerOutput();
+    (output.implementationPlan as unknown as Record<string, unknown>).targetSurface = '';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('implementationPlan.targetSurface'))).toBe(true);
+  });
+
+  it('rejects missing sourceTrace.scribeArtifactId', async () => {
+    const output = makeArtificerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = '';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceTrace.scribeArtifactId'))).toBe(true);
+  });
+
+  it('accepts valid output with matching expectedSourceScribeArtifactId', async () => {
+    const output = makeArtificerOutput();
+    const result = await validator.validate(output, ARTIFICER_TASK_ID, 'pi-art-scribe-001-run-001');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects non-string philosopherArtifactId in sourceTrace', async () => {
+    const output = makeArtificerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).philosopherArtifactId = 42;
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('philosopherArtifactId'))).toBe(true);
+  });
+
+  it('rejects non-string dreamerArtifactId in sourceTrace', async () => {
+    const output = makeArtificerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).dreamerArtifactId = { evil: true };
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('dreamerArtifactId'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceScribeArtifactId vs sourceTrace.scribeArtifactId', async () => {
+    const output = makeArtificerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = 'different-id';
+    const result = await validator.validate(output, ARTIFICER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('must match'))).toBe(true);
+  });
+});
+
+describe('ArtificerRunner integration: test-double captures sourceScribeArtifactId from prompt', () => {
+  it('seed scribe artifact -> run artificer with test-double -> succeeded with correct sourceScribeArtifactId', async () => {
+    const SCRIBE_ART_ID = 'pi-art-scribe-real-001';
+    const artifactStore = new MemoryPIArtifactStore();
+
+    const scribeArtifact: PIArtifactRecord = {
+      artifactId: SCRIBE_ART_ID,
+      artifactKind: 'principle',
+      sourceTaskId: SCRIBE_TASK_ID,
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: JSON.stringify({
+        taskId: SCRIBE_TASK_ID,
+        sourcePhilosopherArtifactId: 'pi-art-philosopher-001',
+        principleDraft: {
+          title: 'Systematic Error Handling',
+          statement: 'All async operations must include explicit error handling',
+          rationale: 'Uncaught errors cascade into system instability',
+          applicability: ['All async operations'],
+          antiPatterns: ['Ignoring promise rejections'],
+          confidence: 0.9,
+        },
+        sourceTrace: { philosopherArtifactId: 'pi-art-philosopher-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      }),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await artifactStore.upsertArtifact(scribeArtifact);
+
+    const artificerTask = makeArtificerTask();
+
+    let capturedSourceScribeArtifactId: string = SCRIBE_ART_ID;
+    const runtimeAdapter = new TestDoubleRuntimeAdapter({
+      onStartRun: (input) => {
+        try {
+          const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+          const parsed = JSON.parse(payloadStr);
+          if (typeof parsed.sourceScribeArtifactId === 'string' && parsed.sourceScribeArtifactId.trim() !== '') {
+            capturedSourceScribeArtifactId = parsed.sourceScribeArtifactId;
+          }
+        } catch { /* ignore */ }
+        return { runId: 'run-integration-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+      },
+      onPollRun: (_runId: string) => ({
+        runId: _runId,
+        status: 'succeeded',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }),
+      onFetchOutput: (_runId: string) => ({
+        runId: _runId,
+        payload: {
+          taskId: ARTIFICER_TASK_ID,
+          sourceScribeArtifactId: capturedSourceScribeArtifactId,
+          implementationPlan: {
+            summary: 'Add input validation to all async operations',
+            targetSurface: 'src/async-ops/*.ts',
+            changes: ['Add try-catch to asyncOp1'],
+            tests: ['Unit test for asyncOp1 error handling'],
+            rolloutNotes: ['Deploy behind feature flag'],
+            confidence: 0.85,
+          },
+          sourceTrace: {
+            scribeArtifactId: capturedSourceScribeArtifactId,
+          },
+          risks: ['May add latency from error checking'],
+          generatedAt: new Date().toISOString(),
+        },
+      }),
+    });
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(artificerTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(artificerTask);
+        if (id === SCRIBE_TASK_ID) return Promise.resolve(makeScribeTask());
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-integration-001',
+        taskId: ARTIFICER_TASK_ID,
+        runtimeKind: 'artificer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const deps: ArtificerRunnerDeps = {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator: new DefaultArtificerValidator(),
+      artifactStore,
+    };
+
+    const runner = new ArtificerRunner(deps, {
+      owner: 'test-integration',
+      runtimeKind: 'artificer',
+      pollIntervalMs: 10,
+      timeoutMs: 5000,
+    });
+
+    const result = await runner.run(ARTIFICER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+    expect(capturedSourceScribeArtifactId).toBe(SCRIBE_ART_ID);
+    expect(result.output?.sourceScribeArtifactId).toBe(SCRIBE_ART_ID);
+    expect(result.output?.sourceTrace.scribeArtifactId).toBe(SCRIBE_ART_ID);
+
+    const artifacts = await artifactStore.listBySourceTaskId(ARTIFICER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+
+    const [storedArtifact] = artifacts;
+    expect(storedArtifact).toBeDefined();
+    if (!storedArtifact) return;
+    const storedOutput = JSON.parse(storedArtifact.contentJson) as ArtificerOutputV1;
+    expect(storedOutput.sourceScribeArtifactId).toBe(SCRIBE_ART_ID);
+    expect(storedOutput.sourceTrace.scribeArtifactId).toBe(SCRIBE_ART_ID);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -24,6 +24,7 @@ import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
 import { DreamerOutputV1Schema } from '../internalization/dreamer-output.js';
 import { PhilosopherOutputV1Schema } from '../internalization/philosopher-output.js';
 import { ScribeOutputV1Schema } from '../internalization/scribe-output.js';
+import { ArtificerOutputV1Schema } from '../internalization/artificer-output.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair } from './structured-output-repair.js';
@@ -187,6 +188,7 @@ const OUTPUT_SCHEMA_REGISTRY = new Map<string, TSchema>([
   ['dreamer-output-v1', DreamerOutputV1Schema as TSchema],
   ['philosopher-output-v1', PhilosopherOutputV1Schema as TSchema],
   ['scribe-output-v1', ScribeOutputV1Schema as TSchema],
+  ['artificer-output-v1', ArtificerOutputV1Schema as TSchema],
 ]);
 
 export class PiAiRuntimeAdapter implements PDRuntimeAdapter {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -517,6 +517,37 @@ export {
   DEFAULT_SCRIBE_RUNNER_OPTIONS,
 } from './internalization/scribe-runner.js';
 
+// ── Artificer Runner (PRI-111) ────────────────────────────────────────────────
+
+export type {
+  ArtificerOutputV1,
+  ArtificerImplementationPlan,
+  ArtificerSourceTrace,
+  ArtificerValidationResult,
+  ArtificerValidator,
+} from './internalization/artificer-output.js';
+
+export {
+  DefaultArtificerValidator,
+  ArtificerOutputV1Schema,
+  ArtificerImplementationPlanSchema,
+  ArtificerSourceTraceSchema,
+} from './internalization/artificer-output.js';
+
+export type {
+  ArtificerRunnerResultStatus,
+  ArtificerRunnerResult,
+  ArtificerRunnerOptions,
+  ResolvedArtificerRunnerOptions,
+  ArtificerRunnerDeps,
+} from './internalization/artificer-runner.js';
+
+export {
+  ArtificerRunner,
+  resolveArtificerRunnerOptions,
+  DEFAULT_ARTIFICER_RUNNER_OPTIONS,
+} from './internalization/artificer-runner.js';
+
 // ── PIArtifact Durable Store (PRI-84) ────────────────────────────────────────
 
 export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ArtificerPromptBuilder,
+  ARTIFICER_PROTOCOL_INSTRUCTION,
+  ARTIFICER_PROMPT_CONTRACT_VERSION,
+} from '../artificer-prompt-builder.js';
+
+describe('ArtificerPromptBuilder', () => {
+  const builder = new ArtificerPromptBuilder();
+
+  const input = {
+    taskId: 'artificer-task-001',
+    contextHash: 'ctx-abc123',
+    sourceScribeArtifactId: 'pi-art-scribe-001',
+    scribeArtifact: {
+      taskId: 'scribe-task-001',
+      principleDraft: { title: 'Test', statement: 'S', rationale: 'R', applicability: [], antiPatterns: [], confidence: 0.9 },
+    },
+  };
+
+  it('includes sourceScribeArtifactId at top level in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.sourceScribeArtifactId).toBe('pi-art-scribe-001');
+  });
+
+  it('instruction says copy sourceScribeArtifactId exactly', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('sourceScribeArtifactId MUST be copied exactly from input.sourceScribeArtifactId');
+  });
+
+  it('instruction says copy sourceTrace.scribeArtifactId exactly', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('sourceTrace.scribeArtifactId MUST be copied exactly from input.sourceScribeArtifactId');
+  });
+
+  it('instruction includes JSON-only constraint', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('ONLY valid JSON');
+  });
+
+  it('instruction includes no markdown constraint', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('no markdown');
+  });
+
+  it('instruction includes no code fences constraint', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('no code fences');
+  });
+
+  it('promptContractVersion is present in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.promptContractVersion).toBe(ARTIFICER_PROMPT_CONTRACT_VERSION);
+  });
+
+  it('promptContractVersion value is artificer-output-v1.prompt.v1', () => {
+    expect(ARTIFICER_PROMPT_CONTRACT_VERSION).toBe('artificer-output-v1.prompt.v1');
+  });
+
+  it('confidence instruction says number not string/percentage', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('NOT a string, NOT a percentage');
+  });
+
+  it('message is valid JSON containing promptInput', () => {
+    const { message } = builder.buildPrompt(input);
+    const parsed = JSON.parse(message);
+    expect(parsed.taskId).toBe(input.taskId);
+    expect(parsed.contextHash).toBe(input.contextHash);
+    expect(parsed.sourceScribeArtifactId).toBe(input.sourceScribeArtifactId);
+    expect(parsed.artificerInstruction).toBe(ARTIFICER_PROTOCOL_INSTRUCTION);
+    expect(parsed.promptContractVersion).toBe(ARTIFICER_PROMPT_CONTRACT_VERSION);
+  });
+
+  it('artificerInstruction is included in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.artificerInstruction).toBe(ARTIFICER_PROTOCOL_INSTRUCTION);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-output.ts
@@ -1,0 +1,136 @@
+import { Type, type Static } from '@sinclair/typebox';
+
+export interface ArtificerImplementationPlan {
+  readonly summary: string;
+  readonly targetSurface: string;
+  readonly changes: readonly string[];
+  readonly tests: readonly string[];
+  readonly rolloutNotes: readonly string[];
+  readonly confidence: number;
+}
+
+export interface ArtificerSourceTrace {
+  readonly scribeArtifactId: string;
+  readonly philosopherArtifactId?: string;
+  readonly dreamerArtifactId?: string;
+}
+
+export interface ArtificerOutputV1 {
+  readonly taskId: string;
+  readonly sourceScribeArtifactId: string;
+  readonly implementationPlan: ArtificerImplementationPlan;
+  readonly sourceTrace: ArtificerSourceTrace;
+  readonly risks: readonly string[];
+  readonly generatedAt: string;
+}
+
+export const ArtificerImplementationPlanSchema = Type.Object({
+  summary: Type.String({ minLength: 1 }),
+  targetSurface: Type.String({ minLength: 1 }),
+  changes: Type.Array(Type.String()),
+  tests: Type.Array(Type.String()),
+  rolloutNotes: Type.Array(Type.String()),
+  confidence: Type.Number({ minimum: 0, maximum: 1 }),
+});
+
+export const ArtificerSourceTraceSchema = Type.Object({
+  scribeArtifactId: Type.String({ minLength: 1 }),
+  philosopherArtifactId: Type.Optional(Type.String()),
+  dreamerArtifactId: Type.Optional(Type.String()),
+});
+
+export const ArtificerOutputV1Schema = Type.Object({
+  taskId: Type.String({ minLength: 1 }),
+  sourceScribeArtifactId: Type.String({ minLength: 1 }),
+  implementationPlan: ArtificerImplementationPlanSchema,
+  sourceTrace: ArtificerSourceTraceSchema,
+  risks: Type.Array(Type.String()),
+  generatedAt: Type.String({ minLength: 1 }),
+});
+
+export type ArtificerOutputV1TB = Static<typeof ArtificerOutputV1Schema>;
+
+export interface ArtificerValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+export interface ArtificerValidator {
+  validate(output: ArtificerOutputV1, taskId: string, expectedSourceScribeArtifactId?: string): Promise<ArtificerValidationResult>;
+}
+
+export class DefaultArtificerValidator implements ArtificerValidator {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async validate(output: ArtificerOutputV1, taskId: string, expectedSourceScribeArtifactId?: string): Promise<ArtificerValidationResult> {
+    const errors: string[] = [];
+
+    if (typeof output !== 'object' || output === null) {
+      return { valid: false, errors: ['Output is not an object'], errorCategory: 'output_invalid' };
+    }
+
+    if (output.taskId !== taskId) {
+      errors.push(`taskId mismatch: expected ${taskId}, got ${String(output.taskId)}`);
+    }
+
+    if (typeof output.sourceScribeArtifactId !== 'string' || output.sourceScribeArtifactId.trim() === '') {
+      errors.push('sourceScribeArtifactId must be non-empty string');
+    } else if (expectedSourceScribeArtifactId && output.sourceScribeArtifactId !== expectedSourceScribeArtifactId) {
+      errors.push(`sourceScribeArtifactId mismatch: expected ${expectedSourceScribeArtifactId}, got ${output.sourceScribeArtifactId}`);
+    }
+
+    if (typeof output.implementationPlan !== 'object' || output.implementationPlan === null) {
+      errors.push('implementationPlan must be an object');
+    } else {
+      const ip = output.implementationPlan as unknown as Record<string, unknown>;
+      if (typeof ip.summary !== 'string' || (ip.summary).trim() === '') errors.push('implementationPlan.summary must be non-empty string');
+      if (typeof ip.targetSurface !== 'string' || (ip.targetSurface).trim() === '') errors.push('implementationPlan.targetSurface must be non-empty string');
+      if (!Array.isArray(ip.changes)) errors.push('implementationPlan.changes must be an array');
+      else if (!(ip.changes as unknown[]).every(e => typeof e === 'string')) errors.push('implementationPlan.changes must be an array of strings');
+      if (!Array.isArray(ip.tests)) errors.push('implementationPlan.tests must be an array');
+      else if (!(ip.tests as unknown[]).every(e => typeof e === 'string')) errors.push('implementationPlan.tests must be an array of strings');
+      if (!Array.isArray(ip.rolloutNotes)) errors.push('implementationPlan.rolloutNotes must be an array');
+      else if (!(ip.rolloutNotes as unknown[]).every(e => typeof e === 'string')) errors.push('implementationPlan.rolloutNotes must be an array of strings');
+      if (typeof ip.confidence !== 'number' || !Number.isFinite(ip.confidence)) errors.push('implementationPlan.confidence must be number');
+      else if (ip.confidence < 0 || ip.confidence > 1) errors.push('implementationPlan.confidence must be in [0, 1]');
+    }
+
+    if (typeof output.sourceTrace !== 'object' || output.sourceTrace === null) {
+      errors.push('sourceTrace must be an object');
+    } else {
+      const st = output.sourceTrace as unknown as Record<string, unknown>;
+      if (typeof st.scribeArtifactId !== 'string' || (st.scribeArtifactId).trim() === '') {
+        errors.push('sourceTrace.scribeArtifactId must be non-empty string');
+      } else if (expectedSourceScribeArtifactId && st.scribeArtifactId !== expectedSourceScribeArtifactId) {
+        errors.push(`sourceTrace.scribeArtifactId mismatch: expected ${expectedSourceScribeArtifactId}, got ${st.scribeArtifactId}`);
+      }
+      if (st.philosopherArtifactId !== undefined && typeof st.philosopherArtifactId !== 'string') {
+        errors.push('sourceTrace.philosopherArtifactId must be string if present');
+      }
+      if (st.dreamerArtifactId !== undefined && typeof st.dreamerArtifactId !== 'string') {
+        errors.push('sourceTrace.dreamerArtifactId must be string if present');
+      }
+    }
+
+    if (!Array.isArray(output.risks)) {
+      errors.push('risks must be an array');
+    } else if (!(output.risks as unknown[]).every(e => typeof e === 'string')) {
+      errors.push('risks must be an array of strings');
+    }
+
+    if (typeof output.sourceScribeArtifactId === 'string' && output.sourceScribeArtifactId.trim() !== ''
+      && typeof output.sourceTrace === 'object' && output.sourceTrace !== null
+      && typeof (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId === 'string'
+      && output.sourceScribeArtifactId !== (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId) {
+      errors.push('sourceScribeArtifactId and sourceTrace.scribeArtifactId must match');
+    }
+
+    if (typeof output.generatedAt !== 'string' || output.generatedAt.trim() === '') {
+      errors.push('generatedAt must be non-empty string');
+    }
+
+    return errors.length > 0
+      ? { valid: false, errors, errorCategory: 'output_invalid' }
+      : { valid: true, errors: [] };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
@@ -1,0 +1,86 @@
+export interface ArtificerPromptBuilderInput {
+  taskId: string;
+  contextHash: string;
+  sourceScribeArtifactId: string;
+  scribeArtifact: unknown;
+}
+
+export interface ArtificerPromptInput {
+  taskId: string;
+  contextHash: string;
+  sourceScribeArtifactId: string;
+  scribeArtifact: unknown;
+  artificerInstruction: string;
+  promptContractVersion: string;
+}
+
+export interface ArtificerPromptBuildResult {
+  readonly message: string;
+  readonly promptInput: ArtificerPromptInput;
+}
+
+export const ARTIFICER_PROTOCOL_INSTRUCTION = `You are an Artificer agent in a principle internalization pipeline. Your role is to transform the Scribe's formal principle draft into an implementation-oriented plan with concrete changes, tests, and rollout notes.
+
+PROTOCOL:
+1. Review the scribeArtifact to understand the formal principle draft
+2. Transform the principle draft into an implementation plan with summary, target surface, specific changes, test requirements, and rollout notes
+3. Preserve the lineage trace from scribe, philosopher, and dreamer artifacts
+4. Identify risks associated with implementing this principle
+5. The implementation plan should be concrete enough to guide code changes, not just philosophical
+
+OUTPUT FORMAT (pure JSON, no markdown):
+{
+  "taskId": "<from input>",
+  "sourceScribeArtifactId": "<copy exactly from input.sourceScribeArtifactId>",
+  "implementationPlan": {
+    "summary": "<concise summary of the implementation approach>",
+    "targetSurface": "<specific code/module/surface area to modify>",
+    "changes": ["<specific change 1>", "<specific change 2>"],
+    "tests": ["<test requirement 1>", "<test requirement 2>"],
+    "rolloutNotes": ["<rollout consideration 1>", "<rollout consideration 2>"],
+    "confidence": 0.8
+  },
+  "sourceTrace": {
+    "scribeArtifactId": "<copy exactly from input.sourceScribeArtifactId>",
+    "philosopherArtifactId": "<from scribe artifact if available, or omit>",
+    "dreamerArtifactId": "<from scribe artifact if available, or omit>"
+  },
+  "risks": ["<risk 1>", "<risk 2>"],
+  "generatedAt": "<ISO-8601 timestamp>"
+}
+
+CONSTRAINTS:
+- Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
+- implementationPlan.summary MUST be a non-empty string
+- implementationPlan.targetSurface MUST be a non-empty string
+- implementationPlan.changes MUST be an array of strings
+- implementationPlan.tests MUST be an array of strings
+- implementationPlan.rolloutNotes MUST be an array of strings
+- implementationPlan.confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- sourceScribeArtifactId MUST be copied exactly from input.sourceScribeArtifactId (non-empty string)
+- sourceTrace.scribeArtifactId MUST be copied exactly from input.sourceScribeArtifactId
+- sourceTrace.philosopherArtifactId is optional — include only if available from scribe artifact
+- sourceTrace.dreamerArtifactId is optional — include only if available from scribe artifact
+- risks MUST be an array of strings (can be empty if no risks identified)
+- generatedAt MUST be an ISO-8601 timestamp string
+`;
+
+export const ARTIFICER_PROMPT_CONTRACT_VERSION = 'artificer-output-v1.prompt.v1';
+
+export class ArtificerPromptBuilder {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildPrompt(input: ArtificerPromptBuilderInput): ArtificerPromptBuildResult {
+    const promptInput: ArtificerPromptInput = {
+      taskId: input.taskId,
+      contextHash: input.contextHash,
+      sourceScribeArtifactId: input.sourceScribeArtifactId,
+      scribeArtifact: input.scribeArtifact,
+      artificerInstruction: ARTIFICER_PROTOCOL_INSTRUCTION,
+      promptContractVersion: ARTIFICER_PROMPT_CONTRACT_VERSION,
+    };
+
+    const message = JSON.stringify(promptInput);
+
+    return { message, promptInput };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-runner.ts
@@ -1,0 +1,671 @@
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type {
+  PDRuntimeAdapter,
+  RunHandle,
+  RunStatus,
+  StartRunInput,
+} from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { ArtificerOutputV1, ArtificerValidator } from './artificer-output.js';
+import type { PIArtifactStore } from './pi-artifact.js';
+import type { TaskRecord } from '../task-status.js';
+import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
+import type { TelemetryEvent } from '../../telemetry-event.js';
+import { hydratePITaskRecord } from './pitask-metadata.js';
+import { RunnerPhase } from '../runner/runner-phase.js';
+import { ArtificerPromptBuilder } from './artificer-prompt-builder.js';
+
+export type ArtificerRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
+
+export interface ArtificerRunnerResult {
+  readonly status: ArtificerRunnerResultStatus;
+  readonly taskId: string;
+  readonly runId?: string;
+  readonly artifactId?: string;
+  readonly resultRef?: string;
+  readonly contextHash?: string;
+  readonly output?: ArtificerOutputV1;
+  readonly errorCategory?: PDErrorCategory;
+  readonly failureReason?: string;
+  readonly attemptCount: number;
+}
+
+export interface ArtificerRunnerOptions {
+  readonly pollIntervalMs?: number;
+  readonly timeoutMs?: number;
+  readonly defaultMaxAttempts?: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId?: string;
+}
+
+export interface ResolvedArtificerRunnerOptions {
+  readonly pollIntervalMs: number;
+  readonly timeoutMs: number;
+  readonly defaultMaxAttempts: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId: string;
+}
+
+const DEFAULT_ARTIFICER_RUNNER_OPTIONS: Readonly<Omit<ResolvedArtificerRunnerOptions, 'owner' | 'runtimeKind'>> = {
+  pollIntervalMs: 5_000,
+  timeoutMs: 300_000,
+  defaultMaxAttempts: 3,
+  agentId: 'artificer',
+} as const;
+
+export function resolveArtificerRunnerOptions(options: ArtificerRunnerOptions): ResolvedArtificerRunnerOptions {
+  return {
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_ARTIFICER_RUNNER_OPTIONS.pollIntervalMs,
+    timeoutMs: options.timeoutMs ?? DEFAULT_ARTIFICER_RUNNER_OPTIONS.timeoutMs,
+    defaultMaxAttempts: options.defaultMaxAttempts ?? DEFAULT_ARTIFICER_RUNNER_OPTIONS.defaultMaxAttempts,
+    owner: options.owner,
+    runtimeKind: options.runtimeKind,
+    agentId: options.agentId ?? DEFAULT_ARTIFICER_RUNNER_OPTIONS.agentId,
+  };
+}
+
+export interface ArtificerRunnerDeps {
+  readonly stateManager: RuntimeStateManager;
+  readonly runtimeAdapter: PDRuntimeAdapter;
+  readonly eventEmitter: StoreEventEmitter;
+  readonly validator: ArtificerValidator;
+  readonly artifactStore: PIArtifactStore;
+}
+
+interface FailureContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errorCategory: PDErrorCategory;
+  readonly failureReason: string;
+}
+
+interface SucceedContext {
+  readonly taskId: string;
+  readonly runId: string;
+  readonly output: ArtificerOutputV1;
+  readonly task: TaskRecord;
+  readonly contextHash: string;
+}
+
+interface ValidationErrorContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+export class ArtificerRunner {
+  private phase: RunnerPhase = RunnerPhase.Idle;
+  private readonly resolvedOptions: ResolvedArtificerRunnerOptions;
+  private readonly stateManager: RuntimeStateManager;
+  private readonly runtimeAdapter: PDRuntimeAdapter;
+  private readonly eventEmitter: StoreEventEmitter;
+  private readonly validator: ArtificerValidator;
+  private readonly artifactStore: PIArtifactStore;
+
+  constructor(deps: ArtificerRunnerDeps, options: ArtificerRunnerOptions) {
+    this.stateManager = deps.stateManager;
+    this.runtimeAdapter = deps.runtimeAdapter;
+    this.eventEmitter = deps.eventEmitter;
+    this.validator = deps.validator;
+    this.artifactStore = deps.artifactStore;
+    this.resolvedOptions = resolveArtificerRunnerOptions(options);
+  }
+
+  get currentPhase(): RunnerPhase {
+    return this.phase;
+  }
+
+  private emitArtificerEvent(
+    eventType: string,
+    taskId: string,
+    payload: Record<string, unknown>,
+  ): void {
+    this.eventEmitter.emitTelemetry({
+      eventType: eventType as TelemetryEvent['eventType'],
+      traceId: taskId,
+      timestamp: new Date().toISOString(),
+      sessionId: this.resolvedOptions.owner,
+      agentId: this.resolvedOptions.agentId,
+      payload,
+    });
+  }
+
+  async run(taskId: string): Promise<ArtificerRunnerResult> {
+    this.phase = RunnerPhase.Idle;
+
+    // eslint-disable-next-line @typescript-eslint/init-declarations
+    let leasedTask: TaskRecord;
+    try {
+      leasedTask = await this.stateManager.acquireLease({
+        taskId,
+        owner: this.resolvedOptions.owner,
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+    } catch (error) {
+      return await this.handleLeaseOrPhaseError(taskId, error);
+    }
+
+    if (leasedTask.taskKind !== 'artificer') {
+      this.emitArtificerEvent('artificer_wrong_task_kind', taskId, {
+        expectedKind: 'artificer',
+        actualKind: leasedTask.taskKind,
+      });
+      await this.stateManager.markTaskFailed(taskId, 'input_invalid');
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'input_invalid',
+        failureReason: `Task kind must be 'artificer', got '${leasedTask.taskKind}'`,
+        attemptCount: leasedTask.attemptCount,
+      };
+    }
+
+    this.emitArtificerEvent('artificer_task_leased', taskId, {
+      taskKind: 'artificer',
+      attemptCount: leasedTask.attemptCount,
+    });
+
+    try {
+      const storeRunId = await this.resolveStoreRunId(taskId);
+
+      this.phase = RunnerPhase.BuildingContext;
+      const { contextHash, scribeArtifact, sourceScribeArtifactId } = await this.buildContext(taskId);
+
+      if (!scribeArtifact || !sourceScribeArtifactId) {
+        return this.retryOrFail({
+          taskId,
+          task: leasedTask,
+          errorCategory: 'input_invalid',
+          failureReason: sourceScribeArtifactId ? 'Scribe dependency artifact not found' : 'Scribe dependency artifact ID not resolved',
+        });
+      }
+
+      this.emitArtificerEvent('artificer_context_built', taskId, { contextHash });
+
+      this.phase = RunnerPhase.Invoking;
+      const runHandle = await this.invokeRuntime({ taskId, contextHash, scribeArtifact, sourceScribeArtifactId });
+
+      this.emitArtificerEvent('artificer_run_started', taskId, {
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+
+      this.phase = RunnerPhase.Polling;
+      const finalStatus = await this.pollUntilTerminal(runHandle);
+
+      if (finalStatus.status !== 'succeeded') {
+        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
+      }
+
+      this.phase = RunnerPhase.FetchingOutput;
+      const output = await this.fetchAndParseOutput(runHandle.runId);
+
+      this.phase = RunnerPhase.Validating;
+      const validationResult = await this.validator.validate(output, taskId, sourceScribeArtifactId ?? undefined);
+      if (!validationResult.valid) {
+        return await this.handleValidationError({
+          taskId,
+          task: leasedTask,
+          errors: validationResult.errors,
+          errorCategory: validationResult.errorCategory,
+        });
+      }
+
+      this.emitArtificerEvent('artificer_output_validated', taskId, {
+        implementationSummary: output.implementationPlan.summary,
+      });
+
+      return await this.succeedTask({
+        taskId,
+        runId: storeRunId,
+        output,
+        task: leasedTask,
+        contextHash,
+      });
+    } catch (error) {
+      return await this.handlePostLeaseError(taskId, leasedTask, error);
+    }
+  }
+
+  private async buildContext(taskId: string): Promise<{ contextHash: string; scribeArtifact: string | null; sourceScribeArtifactId: string | null }> {
+    const task = await this.stateManager.getTask(taskId);
+    if (!task) {
+      throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
+    }
+
+    const piTask = hydratePITaskRecord(task);
+    const deps = piTask?.dependencyTaskIds ?? [];
+
+    if (deps.length === 0) {
+      this.emitArtificerEvent('artificer_no_dependencies', taskId, {});
+      return { contextHash: 'empty', scribeArtifact: null, sourceScribeArtifactId: null };
+    }
+
+    for (const depId of deps) {
+      const depTask = await this.stateManager.getTask(depId);
+      if (!depTask) continue;
+      if (depTask.taskKind !== 'scribe') continue;
+      if (depTask.status !== 'succeeded') {
+        this.emitArtificerEvent('artificer_dependency_not_succeeded', taskId, {
+          depTaskId: depId,
+          depStatus: depTask.status,
+        });
+        continue;
+      }
+
+      const artifacts = await this.artifactStore.listBySourceTaskId(depId);
+      if (artifacts.length > 0) {
+        const [firstArtifact] = artifacts;
+        if (!firstArtifact) continue;
+        const artifactRef = firstArtifact.artifactId;
+        this.emitArtificerEvent('artificer_scribe_dep_selected', taskId, {
+          depTaskId: depId,
+          artifactId: firstArtifact.artifactId,
+        });
+        return {
+          contextHash: ArtificerRunner.hashContextRefs([artifactRef]),
+          scribeArtifact: firstArtifact.contentJson,
+          sourceScribeArtifactId: firstArtifact.artifactId,
+        };
+      }
+    }
+
+    this.emitArtificerEvent('artificer_no_scribe_artifact', taskId, {});
+    return { contextHash: 'empty', scribeArtifact: null, sourceScribeArtifactId: null };
+  }
+
+  private static hashContextRefs(refs: readonly string[]): string {
+    if (refs.length === 0) return 'empty';
+    const str = refs.join('|');
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+    }
+    return `ctx-${Math.abs(hash).toString(16)}`;
+  }
+
+  private async resolveStoreRunId(taskId: string): Promise<string> {
+    const runs = await this.stateManager.getRunsByTask(taskId);
+    const latestRun = runs[runs.length - 1];
+    if (!latestRun) {
+      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
+    }
+    return latestRun.runId;
+  }
+
+  private async invokeRuntime(params: {
+    taskId: string;
+    contextHash: string;
+    scribeArtifact: string | null;
+    sourceScribeArtifactId: string;
+  }): Promise<RunHandle> {
+    let parsedScribeArtifact: unknown = null;
+    if (params.scribeArtifact) {
+      try {
+        parsedScribeArtifact = JSON.parse(params.scribeArtifact);
+      } catch {
+        parsedScribeArtifact = params.scribeArtifact;
+      }
+    }
+
+    const builder = new ArtificerPromptBuilder();
+    const { message } = builder.buildPrompt({
+      taskId: params.taskId,
+      contextHash: params.contextHash,
+      scribeArtifact: parsedScribeArtifact,
+      sourceScribeArtifactId: params.sourceScribeArtifactId,
+    });
+
+    const startInput: StartRunInput = {
+      agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
+      taskRef: { taskId: params.taskId },
+      inputPayload: message,
+      contextItems: [],
+      outputSchemaRef: 'artificer-output-v1',
+      timeoutMs: this.resolvedOptions.timeoutMs,
+    };
+
+    return this.runtimeAdapter.startRun(startInput);
+  }
+
+  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
+    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
+
+    while (Date.now() < deadline) {
+      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(status.status)) {
+        return status;
+      }
+      await this.sleep(this.resolvedOptions.pollIntervalMs);
+    }
+
+    let cancelFailed = false;
+    try {
+      await this.runtimeAdapter.cancelRun(runHandle.runId);
+    } catch (cancelErr) {
+      cancelFailed = true;
+      this.emitArtificerEvent('artificer_cancel_run_failed', runHandle.runId, {
+        runId: runHandle.runId,
+        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
+      });
+    }
+    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
+    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
+  }
+
+  private async fetchAndParseOutput(runId: string): Promise<ArtificerOutputV1> {
+    const result = await this.runtimeAdapter.fetchOutput(runId);
+    if (!result || !result.payload) {
+      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
+    }
+    return result.payload as ArtificerOutputV1;
+  }
+
+  private async succeedTask(ctx: SucceedContext): Promise<ArtificerRunnerResult> {
+    try {
+      await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));
+    } catch (updateErr) {
+      this.emitArtificerEvent('artificer_update_output_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
+      });
+      throw updateErr;
+    }
+
+    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
+    const now = new Date().toISOString();
+
+    let lineageArtifactIds: string[] = [];
+    try {
+      const piTask = hydratePITaskRecord(ctx.task);
+      const deps = piTask?.dependencyTaskIds ?? [];
+      const results = await Promise.allSettled(
+        deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          for (const artifact of result.value) {
+            lineageArtifactIds.push(artifact.artifactId);
+          }
+        }
+      }
+    } catch { /* lineage resolution failure is non-fatal */ }
+
+    try {
+      await this.artifactStore.upsertArtifact({
+        artifactId,
+        artifactKind: 'principle',
+        sourceTaskId: ctx.taskId,
+        lineageArtifactIds,
+        validationStatus: 'pending',
+        contentJson: JSON.stringify(ctx.output),
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (artifactErr) {
+      this.emitArtificerEvent('artificer_artifact_write_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
+      });
+      return this.retryOrFail({
+        taskId: ctx.taskId,
+        task: ctx.task,
+        errorCategory: 'artifact_commit_failed',
+        failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
+      });
+    }
+
+    const resultRef = `artificer://${ctx.runId}`;
+    try {
+      await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
+    } catch (stateErr) {
+      this.emitArtificerEvent('artificer_mark_succeeded_failed', ctx.taskId, {
+        taskId: ctx.taskId,
+        runId: ctx.runId,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      throw stateErr;
+    }
+
+    this.emitArtificerEvent('artificer_task_succeeded', ctx.taskId, {
+      attemptCount: ctx.task.attemptCount,
+      resultRef,
+      implementationSummary: ctx.output.implementationPlan.summary,
+    });
+
+    this.phase = RunnerPhase.Completed;
+    return {
+      status: 'succeeded',
+      taskId: ctx.taskId,
+      runId: ctx.runId,
+      artifactId,
+      resultRef,
+      contextHash: ctx.contextHash,
+      output: ctx.output,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  private async handleRuntimeFailure(
+    taskId: string,
+    task: TaskRecord,
+    runStatus: RunStatus,
+  ): Promise<ArtificerRunnerResult> {
+    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status);
+
+    this.emitArtificerEvent('artificer_run_failed', taskId, {
+      runStatus: runStatus.status,
+      errorCategory,
+    });
+
+    return this.retryOrFail({
+      taskId,
+      task,
+      errorCategory,
+      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
+    });
+  }
+
+  private async handleValidationError(ctx: ValidationErrorContext): Promise<ArtificerRunnerResult> {
+    const category = (ctx.errorCategory ?? 'output_invalid') as PDErrorCategory;
+
+    this.emitArtificerEvent('artificer_output_invalid', ctx.taskId, {
+      errorCount: ctx.errors.length,
+      errorCategory: category,
+    });
+
+    return this.retryOrFail({
+      taskId: ctx.taskId,
+      task: ctx.task,
+      errorCategory: category,
+      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
+    });
+  }
+
+  private async handleLeaseOrPhaseError(
+    taskId: string,
+    error: unknown,
+  ): Promise<ArtificerRunnerResult> {
+    const classified = this.classifyError(error);
+
+    if (classified.category === 'lease_conflict') {
+      this.emitArtificerEvent('artificer_run_failed', taskId, {
+        errorCategory: 'lease_conflict',
+        errorMessage: classified.message,
+      });
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'lease_conflict',
+        failureReason: classified.message,
+        attemptCount: 1,
+      };
+    }
+
+    this.emitArtificerEvent('artificer_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    const task: TaskRecord = {
+      taskId,
+      taskKind: 'artificer',
+      status: 'leased',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      attemptCount: 1,
+      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
+    };
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async handlePostLeaseError(
+    taskId: string,
+    task: TaskRecord,
+    error: unknown,
+  ): Promise<ArtificerRunnerResult> {
+    const classified = this.classifyError(error);
+
+    this.emitArtificerEvent('artificer_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async retryOrFail(ctx: FailureContext): Promise<ArtificerRunnerResult> {
+    if (this.isPermanentError(ctx.errorCategory)) {
+      try {
+        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitArtificerEvent('artificer_mark_failed_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitArtificerEvent('artificer_task_failed', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+        failureReason: ctx.failureReason,
+      });
+      this.phase = RunnerPhase.Failed;
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
+    if (shouldRetry) {
+      try {
+        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitArtificerEvent('artificer_mark_retry_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitArtificerEvent('artificer_task_retried', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+      });
+      this.phase = RunnerPhase.RetryWaiting;
+      return {
+        status: 'retried',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    try {
+      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
+    } catch (stateErr) {
+      this.emitArtificerEvent('artificer_mark_failed_error', ctx.taskId, {
+        errorCategory: 'storage_unavailable',
+        attemptCount: ctx.task.attemptCount,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `State manager error: ${ctx.failureReason}`,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+    this.emitArtificerEvent('artificer_task_failed', ctx.taskId, {
+      errorCategory: 'max_attempts_exceeded',
+      attemptCount: ctx.task.attemptCount,
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+    });
+    this.phase = RunnerPhase.Failed;
+    return {
+      status: 'failed',
+      taskId: ctx.taskId,
+      errorCategory: 'max_attempts_exceeded',
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  private readonly PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set(
+    Object.freeze(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid'] as const),
+  );
+
+  private isPermanentError(category: PDErrorCategory): boolean {
+    return this.PERMANENT_ERROR_CATEGORIES.has(category);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
+    if (error instanceof PDRuntimeError) {
+      return { category: error.category, message: error.message };
+    }
+    if (error instanceof Error) {
+      return { category: 'execution_failed', message: error.message };
+    }
+    return { category: 'execution_failed', message: String(error) };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private mapRunStatusToErrorCategory(status: string): PDErrorCategory {
+    switch (status) {
+      case 'failed': return 'execution_failed';
+      case 'timed_out': return 'timeout';
+      case 'cancelled': return 'cancelled';
+      default: return 'execution_failed';
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+export { DEFAULT_ARTIFICER_RUNNER_OPTIONS };

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -232,6 +232,37 @@ export {
   DEFAULT_SCRIBE_RUNNER_OPTIONS,
 } from './scribe-runner.js';
 
+// ── Artificer Runner (PRI-111) ────────────────────────────────────────────────
+
+export type {
+  ArtificerOutputV1,
+  ArtificerImplementationPlan,
+  ArtificerSourceTrace,
+  ArtificerValidationResult,
+  ArtificerValidator,
+} from './artificer-output.js';
+
+export {
+  DefaultArtificerValidator,
+  ArtificerOutputV1Schema,
+  ArtificerImplementationPlanSchema,
+  ArtificerSourceTraceSchema,
+} from './artificer-output.js';
+
+export type {
+  ArtificerRunnerResultStatus,
+  ArtificerRunnerResult,
+  ArtificerRunnerOptions,
+  ResolvedArtificerRunnerOptions,
+  ArtificerRunnerDeps,
+} from './artificer-runner.js';
+
+export {
+  ArtificerRunner,
+  resolveArtificerRunnerOptions,
+  DEFAULT_ARTIFICER_RUNNER_OPTIONS,
+} from './artificer-runner.js';
+
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 
 export type {


### PR DESCRIPTION
## Summary

Implements ArtificerRunner vertical slice, enabling the current ready artificer task to execute successfully and produce an implementation-oriented PI artifact.

Refs: PRI-111

## Files Created

- \rtificer-output.ts\ — ArtificerOutputV1 interface + TypeBox schema + DefaultArtificerValidator
- \rtificer-prompt-builder.ts\ — ArtificerPromptBuilder with promptContractVersion = artificer-output-v1.prompt.v1
- \rtificer-runner.ts\ — Full ArtificerRunner following ScribeRunner pattern (taskKind=artificer)
- \rtificer-prompt-builder.test.ts\ — 11 tests
- \rtificer-runner-vslice.test.ts\ — 32 tests (including integration test)

## Files Modified

- \internalization/index.ts\ + \untime-v2/index.ts\ — Artificer exports
- \pi-ai-runtime-adapter.ts\ — artificer-output-v1 schema registered
- \untime-internalization-run-once.ts\ — artificer runner dispatch + test-double
- \untime-internalization-run-once.test.ts\ — 2 new artificer tests
- \rchitecture-regression.test.ts\ — PRI-111 boundary guards

## Validator Security Fixes (Adversarial Review)

- F-02: Reject NaN/Infinity confidence via \Number.isFinite()\
- F-03: Type-validate optional sourceTrace fields
- F-05: Cross-field consistency check between sourceScribeArtifactId and sourceTrace.scribeArtifactId
- F-08: Telemetry event for scribe dep selection in buildContext
- F-09: Context hash uses actual artifactId instead of synthetic fallback
- F-12: sourceScribeArtifactId non-nullable in invokeRuntime with explicit null check

## Test-Double Fix

- Artificer test-double captures sourceScribeArtifactId from startRun input and replays in fetchOutput
- Non-mock integration test: seed scribe artifact -> run artificer with test-double -> succeeded

## Test Results

- 78 tests pass (32 runner + 11 prompt-builder + 35 run-once)
- Architecture regression: all PRI-111 guards pass
- Build + typecheck: clean
- Pre-push hook: lint + build + typecheck all green

## Production Validation

- Queue: 1 artificer task correctly leased and dispatched
- Runtime result: LLM provider timeout (transient) -> task correctly retried
- Integrity: ok, brokenLinks=[]
- Canary: healthy

## Next Blocker

- EvaluatorRunner (not yet implemented)
- If --enqueue-next succeeds, it creates evaluator successor per job graph edge [artificer, evaluator]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在命令行工具和运行时环境中添加了Artificer运行器支持

* **测试**
  * 新增Artificer运行器功能的全面测试覆盖

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/540)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->