### PR TITLE
feat(orchestrator): add taskKind filter to wakeOnce for --runner selectivity

### DIFF
--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -17,7 +17,7 @@ import {
   resolveRuntimeConfig,
   validateRuntimeConfig,
 } from '@principles/core/runtime-v2';
-import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, PDRuntimeAdapter } from '@principles/core/runtime-v2';
+import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 interface RunOnceOptions {
@@ -371,7 +371,7 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
 
     let wakeResult: WakeOnceResult = { decision: 'no_ready_tasks', reason: 'no_candidates', inspectedCount: 0 };
     try {
-      wakeResult = await orchestrator.wakeOnce();
+      wakeResult = await orchestrator.wakeOnce(runnerKind as PeerRunnerKind);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`Error: wake-once failed: ${message}`);
@@ -382,7 +382,7 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
     let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | undefined = undefined;
     let skipReason: string | undefined = undefined;
 
-    if (wakeResult.decision === 'would_lease' && wakeResult.taskKind === runnerKind) {
+    if (wakeResult.decision === 'would_lease') {
       const eventEmitter = new StoreEventEmitter();
       const artifactStore = stateManager.piArtifactStore;
       const runtimeAdapter = resolveRuntimeAdapter({ runtimeKind, taskId: wakeResult.taskId, workspaceDir, runnerKind, timeoutMs: cliTimeoutMs });
@@ -416,8 +416,6 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
         );
         runnerResult = await runner.run(wakeResult.taskId);
       }
-    } else if (wakeResult.decision === 'would_lease' && wakeResult.taskKind !== runnerKind) {
-      skipReason = 'unsupported_runner_kind';
     }
 
     const output = buildOutput(wakeResult, runnerResult, skipReason);

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -383,6 +383,10 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
     let skipReason: string | undefined = undefined;
 
     if (wakeResult.decision === 'would_lease') {
+      if (wakeResult.taskKind !== runnerKind) {
+        throw new Error(`Invariant violation: wakeOnce returned taskKind=${wakeResult.taskKind} but runnerKind=${runnerKind}`);
+      }
+
       const eventEmitter = new StoreEventEmitter();
       const artifactStore = stateManager.piArtifactStore;
       const runtimeAdapter = resolveRuntimeAdapter({ runtimeKind, taskId: wakeResult.taskId, workspaceDir, runnerKind, timeoutMs: cliTimeoutMs });
@@ -415,6 +419,8 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
           { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );
         runnerResult = await runner.run(wakeResult.taskId);
+      } else {
+        skipReason = 'no_runner_implemented';
       }
     }
 

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -260,24 +260,6 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.runnerResult.errorCategory).toBe('execution_failed');
   });
 
-  it('would_lease non-dreamer task: no lease acquired, reports unsupported (no stuck lease)', async () => {
-    mockWakeOnce.mockResolvedValue({
-      decision: 'would_lease',
-      taskId: 'task-phil-001',
-      taskKind: 'philosopher',
-    });
-
-    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'test-double', allowTestDouble: true, json: true });
-
-    expect(mockRun).not.toHaveBeenCalled();
-
-    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
-    expect(output.decision).toBe('would_lease');
-    expect(output.taskId).toBe('task-phil-001');
-    expect(output.runnerResult).toBeUndefined();
-    expect(output.skipReason).toBe('unsupported_runner_kind');
-  });
-
   it('text output for succeeded dreamer run includes runId/artifactId/resultRef', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
@@ -1020,5 +1002,42 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.enqueueDecision).toBe('successor_created');
     expect(output.successorTaskId).toBe('task-evaluator-enq-001');
     expect(output.successorKind).toBe('evaluator');
+  });
+
+  it('wakeOnce is called with runnerKind as taskKind filter', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-artificer-filter',
+      taskKind: 'artificer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-artificer-filter',
+      runId: 'run-filter',
+      artifactId: 'pi-art-filter',
+      resultRef: 'artificer://run-filter',
+      contextHash: 'ctx-filter',
+      output: {
+        taskId: 'task-artificer-filter',
+        sourceScribeArtifactId: 'pi-art-scribe-filter',
+        implementationPlan: {
+          summary: 'Test',
+          targetSurface: 'src/test.ts',
+          changes: [],
+          tests: [],
+          rolloutNotes: [],
+          confidence: 0.8,
+        },
+        sourceTrace: { scribeArtifactId: 'pi-art-scribe-filter' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'artificer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    expect(mockWakeOnce).toHaveBeenCalledWith('artificer');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
@@ -516,6 +516,111 @@ describe('InternalizationOrchestrator', () => {
       const clean = await moduleHasNoForbiddenImports('internalization/internalization-orchestrator.ts');
       expect(clean).toBe(true);
     });
+
+    // ── Test 9-13: wakeOnce taskKind filtering (PRI-110) ────────────────────
+
+    describe('wakeOnce — taskKind filtering', () => {
+      it('wakeOnce("artificer") skips dreamer candidates and leases artificer task', async () => {
+        const dreamerTask = makeRawTask({ taskId: 'dreamer-1', taskKind: 'dreamer', status: 'pending' });
+        const artificerTask = makeRawTask({ taskId: 'artificer-1', taskKind: 'artificer', status: 'pending' });
+        mockStateManager.listTasks
+          .mockResolvedValueOnce([dreamerTask, artificerTask])
+          .mockResolvedValueOnce([]);
+        mockStateManager.acquireLease.mockResolvedValue({ ...artificerTask, status: 'leased' });
+
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'artificer', dryRun: false },
+        );
+
+        const result = await orchestrator.wakeOnce('artificer');
+
+        expect(result.decision).toBe('leased');
+        expect((result as { taskId: string }).taskId).toBe('artificer-1');
+      });
+
+      it('wakeOnce("dreamer") with mixed candidates only returns dreamer task', async () => {
+        const dreamerTask = makeRawTask({ taskId: 'dreamer-1', taskKind: 'dreamer', status: 'pending' });
+        const artificerTask = makeRawTask({ taskId: 'artificer-1', taskKind: 'artificer', status: 'pending' });
+        mockStateManager.listTasks
+          .mockResolvedValueOnce([artificerTask, dreamerTask])
+          .mockResolvedValueOnce([]);
+        mockStateManager.acquireLease.mockResolvedValue({ ...dreamerTask, status: 'leased' });
+
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'dreamer', dryRun: false },
+        );
+
+        const result = await orchestrator.wakeOnce('dreamer');
+
+        expect(result.decision).toBe('leased');
+        expect((result as { taskId: string }).taskId).toBe('dreamer-1');
+      });
+
+      it('wakeOnce("evaluator") with no evaluator candidates returns no_ready_tasks', async () => {
+        const dreamerTask = makeRawTask({ taskId: 'dreamer-1', taskKind: 'dreamer', status: 'pending' });
+        mockStateManager.listTasks
+          .mockResolvedValueOnce([dreamerTask])
+          .mockResolvedValueOnce([]);
+
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'evaluator', dryRun: false },
+        );
+
+        const result = await orchestrator.wakeOnce('evaluator');
+
+        expect(result.decision).toBe('no_ready_tasks');
+        expect((result as { inspectedCount: number }).inspectedCount).toBe(0);
+      });
+
+      it('wakeOnce() without taskKind returns first leasable task regardless of kind (backward compat)', async () => {
+        const dreamerTask = makeRawTask({ taskId: 'dreamer-1', taskKind: 'dreamer', status: 'pending' });
+        const artificerTask = makeRawTask({ taskId: 'artificer-1', taskKind: 'artificer', status: 'pending' });
+        mockStateManager.listTasks
+          .mockResolvedValueOnce([dreamerTask, artificerTask])
+          .mockResolvedValueOnce([]);
+        mockStateManager.acquireLease.mockResolvedValue({ ...dreamerTask, status: 'leased' });
+
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'dreamer', dryRun: false },
+        );
+
+        const result = await orchestrator.wakeOnce();
+
+        expect(result.decision).toBe('leased');
+        expect((result as { taskId: string }).taskId).toBe('dreamer-1');
+      });
+
+      it('wakeOnce("artificer") skips blocked artificer and finds ready artificer', async () => {
+        const blockedArtificer = makeRawTask({
+          taskId: 'artificer-blocked',
+          taskKind: 'artificer',
+          status: 'pending',
+          dependencyTaskIds: ['dep-1'],
+        });
+        const readyArtificer = makeRawTask({ taskId: 'artificer-ready', taskKind: 'artificer', status: 'pending' });
+        const pendingDep = makeRawTask({ taskId: 'dep-1', status: 'pending', taskKind: 'scribe' });
+
+        mockStateManager.listTasks
+          .mockResolvedValueOnce([blockedArtificer, readyArtificer])
+          .mockResolvedValueOnce([]);
+        mockStateManager.getTask.mockResolvedValue(pendingDep);
+        mockStateManager.acquireLease.mockResolvedValue({ ...readyArtificer, status: 'leased' });
+
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'artificer', dryRun: false },
+        );
+
+        const result = await orchestrator.wakeOnce('artificer');
+
+        expect(result.decision).toBe('leased');
+        expect((result as { taskId: string }).taskId).toBe('artificer-ready');
+      });
+    });
   });
 
   // ── PRI-88: commitNextTaskProposal ──────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-orchestrator.test.ts
@@ -15,6 +15,7 @@ import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import type { TaskRecord } from '../task-status.js';
 import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PeerRunnerKind } from '../internalization/peer-runner-contracts.js';
 import { PDRuntimeError } from '../error-categories.js';
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
@@ -558,9 +559,13 @@ describe('InternalizationOrchestrator', () => {
         expect((result as { taskId: string }).taskId).toBe('dreamer-1');
       });
 
-      it('wakeOnce("evaluator") with no evaluator candidates returns no_ready_tasks', async () => {
+      it('wakeOnce("evaluator") with no evaluator candidates returns no_ready_tasks with filtered_out reason', async () => {
         const dreamerTask = makeRawTask({ taskId: 'dreamer-1', taskKind: 'dreamer', status: 'pending' });
         mockStateManager.listTasks
+          .mockResolvedValueOnce([dreamerTask])
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([dreamerTask])
+          .mockResolvedValueOnce([])
           .mockResolvedValueOnce([dreamerTask])
           .mockResolvedValueOnce([]);
 
@@ -573,6 +578,35 @@ describe('InternalizationOrchestrator', () => {
 
         expect(result.decision).toBe('no_ready_tasks');
         expect((result as { inspectedCount: number }).inspectedCount).toBe(0);
+        expect((result as { reason: string }).reason).toBe('filtered_out');
+      });
+
+      it('wakeOnce("evaluator") with completely empty queue returns no_ready_tasks with no_candidates reason', async () => {
+        mockStateManager.listTasks
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([]);
+
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'evaluator', dryRun: false },
+        );
+
+        const result = await orchestrator.wakeOnce('evaluator');
+
+        expect(result.decision).toBe('no_ready_tasks');
+        expect((result as { inspectedCount: number }).inspectedCount).toBe(0);
+        expect((result as { reason: string }).reason).toBe('no_candidates');
+      });
+
+      it('wakeOnce with invalid taskKind throws PDRuntimeError input_invalid', async () => {
+        const orchestrator = new OrchestratorClass(
+          { stateManager: mockStateManager as unknown as RuntimeStateManager },
+          { owner: 'test-owner', runtimeKind: 'dreamer', dryRun: false },
+        );
+
+        await expect(orchestrator.wakeOnce('diagnostician' as unknown as PeerRunnerKind)).rejects.toThrow('invalid taskKind filter');
       });
 
       it('wakeOnce() without taskKind returns first leasable task regardless of kind (backward compat)', async () => {

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -33,7 +33,7 @@ export interface NoReadyTasksResult {
   decision: 'no_ready_tasks';
   inspectedCount: number;
   /** Why no task could be leased: specific diagnosis */
-  reason: 'no_candidates' | 'all_hydration_failed' | 'all_blocked' | 'all_dependency_failed' | 'all_lease_conflict' | 'all_retry_wait_pending';
+  reason: 'no_candidates' | 'filtered_out' | 'all_hydration_failed' | 'all_blocked' | 'all_dependency_failed' | 'all_lease_conflict' | 'all_retry_wait_pending';
 }
 
 export interface BlockedResult {
@@ -172,10 +172,11 @@ export class InternalizationOrchestrator {
     const inspectedCount = candidates.length;
 
     if (inspectedCount === 0) {
+      const allPeerCount = taskKind ? (await this.findCandidates()).length : 0;
       return {
         decision: 'no_ready_tasks',
         inspectedCount: 0,
-        reason: 'no_candidates',
+        reason: allPeerCount > 0 ? 'filtered_out' : 'no_candidates',
       };
     }
 
@@ -459,6 +460,10 @@ export class InternalizationOrchestrator {
    * Filters to only PeerRunnerKind taskKinds and hydrates to PITaskRecord.
    */
   private async findCandidates(taskKind?: PeerRunnerKind): Promise<TaskRecord[]> {
+    if (taskKind && !isPeerRunnerKind(taskKind)) {
+      throw new PDRuntimeError('input_invalid', `findCandidates: invalid taskKind filter: ${taskKind}`);
+    }
+
     const allCandidates: TaskRecord[] = [];
     try {
       const pending = await this.stateManager.listTasks({ status: 'pending' });

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -167,8 +167,8 @@ export class InternalizationOrchestrator {
    *   5. On proceed + dryRun → would_lease; on proceed + !dryRun → acquireLease
    *   6. On lease_conflict PDRuntimeError → structured LeaseConflictResult
    */
-  async wakeOnce(): Promise<WakeOnceResult> {
-    const candidates = await this.findCandidates();
+  async wakeOnce(taskKind?: PeerRunnerKind): Promise<WakeOnceResult> {
+    const candidates = await this.findCandidates(taskKind);
     const inspectedCount = candidates.length;
 
     if (inspectedCount === 0) {
@@ -458,7 +458,7 @@ export class InternalizationOrchestrator {
    * Find candidate PI tasks by querying pending and retry_wait statuses.
    * Filters to only PeerRunnerKind taskKinds and hydrates to PITaskRecord.
    */
-  private async findCandidates(): Promise<TaskRecord[]> {
+  private async findCandidates(taskKind?: PeerRunnerKind): Promise<TaskRecord[]> {
     const allCandidates: TaskRecord[] = [];
     try {
       const pending = await this.stateManager.listTasks({ status: 'pending' });
@@ -469,8 +469,11 @@ export class InternalizationOrchestrator {
       throw new PDRuntimeError('runtime_unavailable', 'findCandidates failed', { cause: error });
     }
 
-    // Filter to PeerRunnerKind tasks only (skip diagnostician, etc.)
-    const peerTasks = allCandidates.filter(t => isPeerRunnerKind(t.taskKind));
+    let peerTasks = allCandidates.filter(t => isPeerRunnerKind(t.taskKind));
+
+    if (taskKind) {
+      peerTasks = peerTasks.filter(t => t.taskKind === taskKind);
+    }
 
     return peerTasks;
   }


### PR DESCRIPTION
## Summary

PR #540 合并后，`--runner artificer` 无法选中 artificer task，因为 `wakeOnce()` 返回队列中第一个可 lease 的任务（dreamer），不按 taskKind 过滤。

## Changes

### 核心修复
- `internalization-orchestrator.ts`: `wakeOnce(taskKind?: PeerRunnerKind)` 和 `findCandidates(taskKind?: PeerRunnerKind)` 添加可选 taskKind 过滤参数
- `runtime-internalization-run-once.ts`: 传入 `runnerKind as PeerRunnerKind` 给 `wakeOnce()`

### Review 加固 (commit 2)
- **F1**: 恢复 defense-in-depth — 添加 invariant assertion `if (wakeResult.taskKind !== runnerKind) throw new Error(...)`
- **F2**: 添加 `filtered_out` reason — 当 taskKind 过滤后无结果但队列有其他 kind 时，返回 `reason: 'filtered_out'` 而非 `no_candidates`，防止误诊
- **F3**: 运行时验证 taskKind — `findCandidates()` 顶部检查 `isPeerRunnerKind(taskKind)`，无效值抛 `input_invalid`
- **F4**: 添加 `no_runner_implemented` else 分支 — 防止未来新增 runner kind 时静默 no-op

### 测试
- 8 个新 orchestrator 测试 (taskKind 过滤 + filtered_out + no_candidates + invalid taskKind)
- 1 个新 CLI 测试 (验证 wakeOnce 被调用时传入正确的 taskKind)
- 移除 `unsupported_runner_kind` 测试 (场景不再存在)

## Production Validation

- Phase 1: canary=healthy, integrity=ok, queue=4 ready (3 dreamer + 1 artificer)
- Phase 2: `--runner artificer` 成功执行，artifactId=`pi-art-artificer-...`, successorKind=evaluator
- Phase 3: integrity=ok, queue=1 evaluator + 3 dreamer
- Phase 4: 3 dreamer chains failed (2 output_invalid, 1 timeout) — LLM provider issues
- Phase 5: Diagnostician UAT 70% (7/10) — below 90% threshold

## Next Blockers
1. **EvaluatorRunner vertical slice** — queue has 1 ready evaluator task
2. **Dreamer output_invalid** — 2/3 chains failed with schema validation errors
3. **Diagnostician flaky** — 70% success rate, needs hardening (PRI-109)

Linear: PRI-110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 运行时现已支持按运行程序类型筛选任务，提高任务调度的精确性和效率。

* **测试**
  * 增加了针对任务筛选行为的测试覆盖，包括多种场景验证和错误处理。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/541)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->