### PR TITLE
feat(pd-console): Phase 1 — 基础设施 + Server 骨架

### DIFF
--- a/.planning/phases/01-infrastructure-server-skeleton/01-04-SUMMARY.md
+++ b/.planning/phases/01-infrastructure-server-skeleton/01-04-SUMMARY.md
@@ -1,0 +1,81 @@
+---
+phase: "01"
+plan: "04"
+type: summary
+status: completed
+completed_at: "2026-05-11"
+---
+
+# Phase 1 Summary: Infrastructure + Server Skeleton
+
+## Success Criteria Results
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| SC1 | `packages/pd-console/` registered in npm workspace | PASS |
+| SC2 | `npm run dev` starts HTTP server, `GET /` returns frontend page | PASS |
+| SC3 | API request without Bearer Token returns 401 | PASS |
+| SC4 | server.ts successfully imports @principles/core function at runtime | PASS |
+
+## Wave Execution
+
+### Wave 1: Package Scaffolding (01-01)
+- Created `package.json` with `@principles/pd-console` name, scripts, dependencies
+- Created `tsconfig.json` with ES2022, NodeNext, react-jsx
+- Created `src/types.ts` with 8 shared types
+- `npx tsc --noEmit` passes
+- `npm ls @principles/pd-console` confirms workspace registration
+
+### Wave 2: Server + Frontend (01-02, 01-03 parallel)
+
+**01-02 Server:**
+- `src/server.ts` — 274 lines, native `http` module only
+- CLI arg parsing (`--workspace`, `--port`)
+- Token loading from `~/.openclaw/openclaw.json`
+- `crypto.timingSafeEqual` for auth
+- Route handler: static files, `/api/health`, `/api/status` with core import
+- Path traversal prevention via `safeStaticPath`
+
+**01-03 Frontend:**
+- `scripts/build-ui.mjs` — esbuild build script
+- `src/ui/main.tsx` — React entry point
+- `src/ui/App.tsx` — 3-page hash router (待办事项/系统状态/设置)
+- `src/ui/api.ts` — Centralized API client with 7 typed stubs
+- `src/ui/i18n.ts` — 11-term translation layer
+
+### Wave 3: Integration Verification (01-04)
+- `@principles/core` built successfully
+- `npm run build:ui` produces `dist/web/index.html` + `dist/web/assets/app.js`
+- Server starts, serves frontend, returns 401 without token
+- Core import verified in source and at runtime
+
+## Requirements Coverage
+
+| REQ-ID | Description | Status |
+|--------|-------------|--------|
+| INF-01 | npm workspace package config | DONE |
+| INF-02 | esbuild frontend build script | DONE |
+| INF-03 | TypeScript configuration | DONE |
+| INF-04 | i18n translation layer | DONE |
+| SRV-01 | HTTP server with static files + API routes | DONE |
+| SRV-02 | Bearer Token authentication | DONE |
+| SRV-03 | Workspace path via CLI arg | DONE |
+| SRV-04 | Direct @principles/core import | DONE |
+
+## Files Created
+
+```
+packages/pd-console/
+├── package.json
+├── tsconfig.json
+├── scripts/
+│   └── build-ui.mjs
+└── src/
+    ├── server.ts
+    ├── types.ts
+    └── ui/
+        ├── main.tsx
+        ├── App.tsx
+        ├── api.ts
+        └── i18n.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3210,6 +3210,10 @@
       "resolved": "packages/pd-cli",
       "link": true
     },
+    "node_modules/@principles/pd-console": {
+      "resolved": "packages/pd-console",
+      "link": true
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -7595,6 +7599,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -12787,6 +12804,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -14271,6 +14298,510 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -15076,6 +15607,520 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/pd-console": {
+      "name": "@principles/pd-console",
+      "version": "0.1.0",
+      "dependencies": {
+        "@principles/core": "*",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "esbuild": "^0.25.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pd-console/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "packages/pd-console/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/principles-core": {

--- a/packages/pd-console/package.json
+++ b/packages/pd-console/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@principles/pd-console",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:ui": "node scripts/build-ui.mjs",
+    "build": "npm run build:ui && npx tsc --noEmit",
+    "dev": "npx tsx src/server.ts --port 3100",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "@principles/core": "*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.7.0",
+    "esbuild": "^0.25.0",
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/pd-console/scripts/build-ui.mjs
+++ b/packages/pd-console/scripts/build-ui.mjs
@@ -1,0 +1,46 @@
+import { build } from "esbuild";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const isProduction = process.argv.includes("--production");
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = path.join(rootDir, "dist", "web");
+const assetsDir = path.join(outDir, "assets");
+
+mkdirSync(assetsDir, { recursive: true });
+
+await build({
+  entryPoints: [path.join(rootDir, "src", "ui", "main.tsx")],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  outfile: path.join(assetsDir, "app.js"),
+  sourcemap: isProduction ? false : "inline",
+  minify: isProduction,
+  jsx: "automatic",
+  loader: {
+    ".css": "css",
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify(isProduction ? "production" : "development"),
+  },
+});
+
+const html = `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PD Console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/assets/app.js"></script>
+  </body>
+</html>
+`;
+
+writeFileSync(path.join(outDir, "index.html"), html, "utf8");
+console.log("Built UI to dist/web/");

--- a/packages/pd-console/src/server.ts
+++ b/packages/pd-console/src/server.ts
@@ -1,0 +1,275 @@
+/**
+ * pd-console HTTP server — lightweight dashboard for Runtime V2 operator health.
+ *
+ * Uses ONLY Node.js built-in modules. No express/koa.
+ */
+
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+import { OperatorHealthReadModel } from '@principles/core/runtime-v2';
+
+// ── ESM __dirname equivalent ───────────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ── CLI arg parsing ──────────────────────────────────────────────────────────────────────
+
+interface ServerOptions {
+  workspace: string;
+  port: number;
+}
+
+function parseArgs(argv: string[]): ServerOptions {
+  const args = argv.slice(2);
+  let workspace = process.cwd();
+  let port = 3100;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--workspace' && i + 1 < args.length) {
+      workspace = path.resolve(args[i + 1]);
+      i++;
+    } else if (args[i] === '--port' && i + 1 < args.length) {
+      const parsed = parseInt(args[i + 1], 10);
+      if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+        console.error('Invalid port: ' + args[i + 1] + '. Must be 1-65535.');
+        process.exit(1);
+      }
+      port = parsed;
+      i++;
+    }
+  }
+
+  if (!fs.existsSync(workspace)) {
+    console.error('Workspace directory does not exist: ' + workspace);
+    process.exit(1);
+  }
+
+  return { workspace, port };
+}
+
+// ── Token loading ────────────────────────────────────────────────────────────────────────
+
+function loadGatewayToken(): string | null {
+  const configPath = path.join(os.homedir(), '.openclaw', 'openclaw.json');
+
+  if (!fs.existsSync(configPath)) {
+    console.warn('[auth] No openclaw config found at', configPath, '— skipping auth');
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const config = JSON.parse(raw) as Record<string, unknown>;
+    const gateway = config.gateway as Record<string, unknown> | undefined;
+    const auth = typeof gateway === "object" ? (gateway).auth as Record<string, unknown> | undefined : undefined;
+    const token = typeof auth === "object" ? (auth).token : undefined;
+
+    if (typeof token !== 'string' || token.length === 0) {
+      console.warn('[auth] No gateway.auth.token in config — skipping auth');
+      return null;
+    }
+
+    return token;
+  } catch {
+    console.warn('[auth] Failed to read/parse openclaw config — skipping auth');
+    return null;
+  }
+}
+
+// ── Auth middleware ──────────────────────────────────────────────────────────────────────
+
+const BEARER_REGEX = /^Bearer\s+(.+)$/i;
+
+function isAuthenticated(req: http.IncomingMessage, expectedToken: string | null): boolean {
+  if (expectedToken === null) {
+    return true;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader !== 'string') {
+    return false;
+  }
+
+  const match = BEARER_REGEX.exec(authHeader);
+  if (!match) {
+    return false;
+  }
+
+  const [, provided] = match;
+  const providedBuf = Buffer.from(provided, 'utf8');
+  const expectedBuf = Buffer.from(expectedToken, 'utf8');
+
+  if (providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(providedBuf, expectedBuf);
+}
+
+// ── MIME type helpers ──────────────────────────────────────────────────────────────────────
+
+const MIME_MAP: Readonly<Record<string, string>> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+function contentTypeFor(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_MAP[ext] ?? 'application/octet-stream';
+}
+
+// ── Security helpers ──────────────────────────────────────────────────────────────────
+
+function safeStaticPath(rootDir: string, requestPath: string): string | null {
+  const resolved = path.resolve(rootDir, requestPath);
+
+  if (!resolved.startsWith(rootDir + path.sep) && resolved !== rootDir) {
+    return null;
+  }
+
+  if (requestPath.includes('..')) {
+    return null;
+  }
+
+  return resolved;
+}
+
+function sendJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body, 'utf8'),
+  });
+  res.end(body);
+}
+
+function serveFile(res: http.ServerResponse, filePath: string): boolean {
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const contentType = contentTypeFor(filePath);
+  const data = fs.readFileSync(filePath);
+
+  res.writeHead(200, {
+    'Content-Type': contentType,
+    'Content-Length': data.length,
+  });
+  res.end(data);
+  return true;
+}
+
+// ── Route handler ───────────────────────────────────────────────────────────────────
+
+const WEB_ROOT = path.resolve(__dirname, '..', 'dist', 'web');
+
+function handleRequest(
+  expectedToken: string | null,
+  workspaceDir: string,
+): (req: http.IncomingMessage, res: http.ServerResponse) => void {
+  return (req: http.IncomingMessage, res: http.ServerResponse): void => {
+    const urlPath = req.url?.split('?')[0] ?? '/';
+
+    // GET /
+    if (urlPath === '/') {
+      const indexPath = path.join(WEB_ROOT, 'index.html');
+      if (!serveFile(res, indexPath)) {
+        sendJson(res, 404, { error: 'not_found', message: 'Run npm run build:ui first' });
+      }
+      return;
+    }
+
+    // GET /assets/*
+    if (urlPath.startsWith('/assets/')) {
+      const relativePath = urlPath.slice('/assets/'.length);
+      const safePath = safeStaticPath(path.join(WEB_ROOT, 'assets'), relativePath);
+      if (safePath === null) {
+        sendJson(res, 403, { error: 'forbidden' });
+        return;
+      }
+      if (!serveFile(res, safePath)) {
+        sendJson(res, 404, { error: 'not_found' });
+      }
+      return;
+    }
+
+    // GET /api/health
+    if (urlPath === '/api/health') {
+      if (!isAuthenticated(req, expectedToken)) {
+        sendJson(res, 401, { error: 'unauthorized' });
+        return;
+      }
+      sendJson(res, 200, { status: 'ok', timestamp: new Date().toISOString() });
+      return;
+    }
+
+    // GET /api/status
+    if (urlPath === '/api/status') {
+      if (!isAuthenticated(req, expectedToken)) {
+        sendJson(res, 401, { error: 'unauthorized' });
+        return;
+      }
+
+      (async (): Promise<void> => {
+        const readModel = new OperatorHealthReadModel({ workspaceDir });
+        try {
+          const snapshot = await readModel.getSnapshot();
+          sendJson(res, 200, snapshot);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          sendJson(res, 500, { status: 'error', message });
+        } finally {
+          try {
+            await readModel.close();
+          } catch (closeErr) {
+            console.error('[pd-console] Failed to close read model', closeErr);
+          }
+        }
+      })();
+
+      return;
+    }
+
+    // 404 fallback
+    sendJson(res, 404, { error: 'not_found' });
+  };
+}
+
+// ── Server startup ───────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const { workspace, port } = parseArgs(process.argv);
+  const expectedToken = loadGatewayToken();
+
+  const server = http.createServer(handleRequest(expectedToken, workspace));
+
+  server.listen(port, () => {
+    console.log('[pd-console] Listening on http://localhost:' + port);
+    console.log('[pd-console] Workspace: ' + workspace);
+    console.log('[pd-console] Auth: ' + (expectedToken ? 'enabled' : 'disabled (no token)'));
+  });
+}
+
+main();

--- a/packages/pd-console/src/types.ts
+++ b/packages/pd-console/src/types.ts
@@ -1,0 +1,49 @@
+export type TaskPriority = "needs_confirmation" | "suggested_attention" | "recent_activity";
+
+export type TaskKind = "approval" | "cleanup";
+
+export interface TaskItem {
+  id: string;
+  title: string;
+  sourceSummary: string;
+  priority: TaskPriority;
+  kind: TaskKind;
+  createdAt: string;
+  lastTriggeredAt?: string;
+  triggerCount?: number;
+}
+
+export interface EvidenceItem {
+  timestamp: string;
+  operation: string;
+  problem: string;
+}
+
+export interface TaskEvidence {
+  taskId: string;
+  summary: string;
+  why: string;
+  whatHappensIf: string;
+  evidence: EvidenceItem[];
+}
+
+export interface SystemStatus {
+  status: "healthy" | "attention" | "problem";
+  principleTotal: number;
+  principleActive: number;
+  principlePending: number;
+  weeklyChange: number;
+}
+
+export interface ActivityEvent {
+  id: string;
+  type: "error" | "learned" | "approved";
+  description: string;
+  timestamp: string;
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}

--- a/packages/pd-console/src/ui/App.tsx
+++ b/packages/pd-console/src/ui/App.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from "react";
+
+type Route = "tasks" | "status" | "settings";
+
+function routeFromHash(hash: string): Route {
+  if (hash === "#/status") return "status";
+  if (hash === "#/settings") return "settings";
+  return "tasks";
+}
+
+const NAV_ITEMS: { route: Route; href: string; label: string }[] = [
+  { route: "tasks", href: "#/", label: "待办事项" },
+  { route: "status", href: "#/status", label: "系统状态" },
+  { route: "settings", href: "#/settings", label: "设置" },
+];
+
+const NAV_STYLE: React.CSSProperties = {
+  display: "flex",
+  gap: "16px",
+  padding: "12px 24px",
+  borderBottom: "1px solid #e0e0e0",
+  backgroundColor: "#fafafa",
+};
+
+const LINK_STYLE: React.CSSProperties = {
+  textDecoration: "none",
+  color: "#333",
+  padding: "4px 8px",
+};
+
+const ACTIVE_LINK_STYLE: React.CSSProperties = {
+  ...LINK_STYLE,
+  fontWeight: "bold",
+  color: "#1677ff",
+  borderBottom: "2px solid #1677ff",
+};
+
+const CONTENT_STYLE: React.CSSProperties = {
+  padding: "24px",
+};
+
+function TasksPage() {
+  return (
+    <div>
+      <h1>待办事项</h1>
+      <p>任务列表将在此显示</p>
+    </div>
+  );
+}
+
+function StatusPage() {
+  return (
+    <div>
+      <h1>系统状态</h1>
+      <p>系统状态信息将在此显示</p>
+    </div>
+  );
+}
+
+function SettingsPage() {
+  return (
+    <div>
+      <h1>设置</h1>
+      <p>设置选项将在此显示</p>
+    </div>
+  );
+}
+
+const PAGE_MAP: Record<Route, () => React.JSX.Element> = {
+  tasks: TasksPage,
+  status: StatusPage,
+  settings: SettingsPage,
+};
+
+export function App() {
+  const [route, setRoute] = useState<Route>(
+    routeFromHash(window.location.hash),
+  );
+
+  useEffect(() => {
+    function handleHashChange() {
+      setRoute(routeFromHash(window.location.hash));
+    }
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  const PageComponent = PAGE_MAP[route];
+
+  return (
+    <div>
+      <nav style={NAV_STYLE}>
+        {NAV_ITEMS.map((item) => (
+          <a
+            key={item.route}
+            href={item.href}
+            style={item.route === route ? ACTIVE_LINK_STYLE : LINK_STYLE}
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+      <main style={CONTENT_STYLE}>
+        <PageComponent />
+      </main>
+    </div>
+  );
+}

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -1,0 +1,104 @@
+import type {
+  ApiResponse,
+  TaskItem,
+  TaskEvidence,
+  SystemStatus,
+  ActivityEvent,
+} from "../types.js";
+
+function getToken(): string | null {
+  return sessionStorage.getItem("pd_token");
+}
+
+function setToken(token: string): void {
+  sessionStorage.setItem("pd_token", token);
+}
+
+async function request<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<ApiResponse<T>> {
+  const token = getToken();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(path, {
+      ...options,
+      headers: {
+        ...headers,
+        ...(options?.headers as Record<string, string> | undefined),
+      },
+    });
+
+    if (!response.ok) {
+      return { success: false, error: `HTTP ${response.status}` };
+    }
+
+    const data: ApiResponse<T> = await response.json();
+    return data;
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Network error",
+    };
+  }
+}
+
+async function fetchTasks(): Promise<ApiResponse<TaskItem[]>> {
+  return request<TaskItem[]>("/api/tasks");
+}
+
+async function fetchTaskEvidence(id: string): Promise<ApiResponse<TaskEvidence>> {
+  return request<TaskEvidence>(`/api/tasks/${id}/evidence`);
+}
+
+async function approveTask(
+  id: string,
+): Promise<ApiResponse<{ success: boolean }>> {
+  return request<{ success: boolean }>(`/api/tasks/${id}/approve`, {
+    method: "POST",
+  });
+}
+
+async function rejectTask(
+  id: string,
+): Promise<ApiResponse<{ success: boolean }>> {
+  return request<{ success: boolean }>(`/api/tasks/${id}/reject`, {
+    method: "POST",
+  });
+}
+
+async function cleanupTask(
+  id: string,
+): Promise<ApiResponse<{ success: boolean }>> {
+  return request<{ success: boolean }>(`/api/tasks/${id}/cleanup`, {
+    method: "POST",
+  });
+}
+
+async function fetchStatus(): Promise<ApiResponse<SystemStatus>> {
+  return request<SystemStatus>("/api/status");
+}
+
+async function fetchActivity(): Promise<ApiResponse<ActivityEvent[]>> {
+  return request<ActivityEvent[]>("/api/activity");
+}
+
+export {
+  getToken,
+  setToken,
+  request,
+  fetchTasks,
+  fetchTaskEvidence,
+  approveTask,
+  rejectTask,
+  cleanupTask,
+  fetchStatus,
+  fetchActivity,
+};

--- a/packages/pd-console/src/ui/i18n.ts
+++ b/packages/pd-console/src/ui/i18n.ts
@@ -1,0 +1,30 @@
+const TERM_MAP: Record<string, string> = {
+  "Pain Signal": "错误记录",
+  GFI: "系统学习进度",
+  Principle: "经验",
+  Rule: "自动规则",
+  "Internalization Pipeline": "学习过程",
+  Candidate: "待确认的经验",
+  Pruning: "清理",
+  "Gate Block": "安全拦截",
+  "Trust Stage": "信任等级",
+  Lifecycle: "使用情况",
+  "Retry Wait": "等待重试",
+};
+
+function translate(term: string): string {
+  return TERM_MAP[term] ?? term;
+}
+
+function userFacingText(template: string): string {
+  let result = template;
+  const terms = Object.keys(TERM_MAP);
+
+  for (const term of terms) {
+    result = result.replaceAll(term, TERM_MAP[term]);
+  }
+
+  return result;
+}
+
+export { TERM_MAP, translate, userFacingText };

--- a/packages/pd-console/src/ui/main.tsx
+++ b/packages/pd-console/src/ui/main.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  throw new Error("Root element not found");
+}
+
+createRoot(rootEl).render(<App />);

--- a/packages/pd-console/tsconfig.json
+++ b/packages/pd-console/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## 摘要

Phase 1 完成：创建 `@principles/pd-console` 包，实现 HTTP 服务器骨架、Bearer Token 认证、前端构建脚手架和 @principles/core 集成。

## 变更内容

### 新增包
- `packages/pd-console/` — M11 PD Console 产品级控制台

### 创建的文件
- `package.json` — npm workspace 包配置
- `tsconfig.json` — ES2022 + NodeNext + react-jsx
- `src/server.ts` — 原生 http 模块服务器 + 认证 + 核心集成
- `src/types.ts` — 8 个共享类型定义
- `src/ui/main.tsx` — React 入口点
- `src/ui/App.tsx` — 3 页面哈希路由 (待办事项/系统状态/设置)
- `src/ui/api.ts` — 集中式 API 客户端（7 个端点存根）
- `src/ui/i18n.ts` — 技术术语 → 中文翻译层
- `scripts/build-ui.mjs` — esbuild 前端构建脚本
- `.planning/phases/01-infrastructure-server-skeleton/01-04-SUMMARY.md` — Phase 1 摘要

### 技术实现
- **服务器**: Node.js 原生 `http` 模块（无 express/koa）
- **认证**: Bearer Token，从 `~/.openclaw/openclaw.json` 读取，使用 `crypto.timingSafeEqual`
- **核心集成**: 直接 import `OperatorHealthReadModel` from `@principles/core/runtime-v2`
- **前端**: React 19 + esbuild + 哈希路由
- **构建**: esbuild 打包到 `dist/web/`

## 验证标准

| 标准 | 状态 |
|----------|--------|
| ✅ 包已在 npm workspace 中注册 | 通过 |
| ✅ `npm run dev` 启动服务器，`GET /` 返回前端页面 | 通过 |
| ✅ API 无 token 返回 401 | 通过 |
| ✅ server.ts 成功导入 @principles/core | 通过 |

## 需求覆盖

- INF-01, INF-02, INF-03, INF-04 ✅
- SRV-01, SRV-02, SRV-03, SRV-04 ✅

## 测试计划

- [ ] `npm run build:ui` 成功生成 `dist/web/`
- [ ] `npx tsc --noEmit` 通过
- [ ] `npm ls @principles/pd-console` 显示包已注册
- [ ] `npx tsx src/server.ts --workspace <path> --port 3100` 启动
- [ ] `curl http://localhost:3100/` 返回 HTML
- [ ] `curl http://localhost:3100/api/health` 返回 401（无 token）
- [ ] `curl -H "Authorization: Bearer <token>" http://localhost:3100/api/health` 返回 200

## 下一步

Phase 2 将实现全部 7 个 API 端点：
- GET /api/tasks — 待审批 + 待清理聚合列表
- GET /api/tasks/:id/evidence — 证据链路
- POST /api/tasks/:id/approve — 采纳经验
- POST /api/tasks/:id/reject — 拒绝经验
- POST /api/tasks/:id/cleanup — 清理过期经验
- GET /api/status — 系统状态
- GET /api/activity — 最近动态

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)