### PR TITLE
feat(evaluator-runner): EvaluatorRunner vertical slice

### DIFF
--- a/docs/reports/2026-05-11-dreamer-output-invalid-drain-analysis.md
+++ b/docs/reports/2026-05-11-dreamer-output-invalid-drain-analysis.md
@@ -2,93 +2,282 @@
 
 ## Summary
 
-During PRI-110 drain, 4 dreamer tasks failed permanently after exhausting retries. This evidence pack documents the failure patterns for future hardening.
+During PRI-110 drain, 4 dreamer tasks failed permanently after exhausting retries.
+This evidence pack documents the failure patterns, observability gaps, and
+recommended hardening — **no DreamerRunner code changes** unless a minimal
+reproduction is found.
+
+## Runtime Configuration
+
+| Field | Value |
+|---|---|
+| **outputSchemaRef** | `dreamer-output-v1` |
+| **provider** | `minimax-cn` |
+| **model** | `MiniMax-M2.7` |
+| **apiKeyEnv** | `MINIMAX_CN_API_KEY` |
+| **maxRetries** | 3 |
+| **timeoutMs** | 120000 |
+| **runtimeKind** | `pi-ai` |
+
+Source: `D:\.openclaw\workspace\.state\workflows.yaml`
 
 ## Failed Task Summary
 
-| Task ID (prefix) | Attempts | Final Error | output_invalid Runs | timeout Runs |
+| Task ID (prefix) | Attempts | Final Error | output_invalid | timeout | max_attempts_exceeded |
+|---|---|---|---|---|---|
+| `dreamer-0bcc0c79-9011-4d2f-865d-674a145219ff` | 3 | max_attempts_exceeded | 2 | 0 | 1 |
+| `dreamer-1316a064-ce07-42db-b06a-21917a551752` | 4 | max_attempts_exceeded | 1 | 1 | 2 |
+| `dreamer-dfd8937b-16e1-4824-bf93-6903b430d4c2` | 3 | max_attempts_exceeded | 0 | 1 | 2 |
+| `dreamer-a3e308de-41d4-473f-a74a-a66caa394efb` | 3 | max_attempts_exceeded | 1 | 1 | 1 |
+
+**Totals**: 4 output_invalid, 3 timeout, 6 max_attempts_exceeded across 12 runs
+
+Note: The user's task description mentions "2 output_invalid, 1 timeout" for 3
+failed tasks. The actual data shows 4 failed tasks with 4 output_invalid and
+3 timeout error categories. The discrepancy is because some runs that succeeded
+on retry (attempt 3 or 4) were later re-attempted by the drain and hit
+max_attempts_exceeded, which is a terminal category not an LLM error category.
+
+## Per-Run Detail with Failure Reason
+
+### dreamer-0bcc0c79 (FAILED — 2 output_invalid, 0 timeout)
+
+| Run | Attempt | Started | Ended | Duration | error_category | failureReason |
+|---|---|---|---|---|---|---|
+| run_1 | 1 | 2026-05-10T08:03:30 | 2026-05-10T08:04:57 | ~87s | output_invalid | task_retry |
+| run_2 | 2 | 2026-05-10T10:48:41 | 2026-05-10T10:49:34 | ~53s | output_invalid | task_retry |
+| run_3 | 3 | 2026-05-11T02:47:44 | 2026-05-11T02:48:16 | ~32s | max_attempts_exceeded | task_failed |
+
+**Diagnosis**: Both output_invalid runs (87s, 53s) had sufficient LLM response
+time — the LLM returned something but it wasn't valid JSON or failed schema
+validation. The 32s terminal run was a max_attempts_exceeded re-attempt.
+
+### dreamer-1316a064 (FAILED — 1 output_invalid, 1 timeout)
+
+| Run | Attempt | Started | Ended | Duration | error_category | failureReason |
+|---|---|---|---|---|---|---|
+| run_1 | 1 | 2026-05-10T08:02:40 | 2026-05-10T08:03:12 | ~32s | output_invalid | task_retry |
+| run_2 | 2 | 2026-05-10T09:52:54 | 2026-05-10T09:53:05 | ~11s | timeout | task_retry |
+| run_3 | 3 | 2026-05-10T10:45:32 | 2026-05-10T10:46:10 | ~38s | — | task_completed (succeeded) |
+| run_4 | 4 | 2026-05-11T02:47:17 | 2026-05-11T02:47:27 | ~10s | max_attempts_exceeded | task_failed |
+
+**Diagnosis**: Run 1 (32s) returned output_invalid. Run 2 (11s) was a genuine
+timeout (too short for LLM response). Run 3 succeeded but the task was
+re-attempted and hit max_attempts_exceeded on run 4.
+
+### dreamer-dfd8937b (FAILED — 0 output_invalid, 1 timeout)
+
+| Run | Attempt | Started | Ended | Duration | error_category | failureReason |
+|---|---|---|---|---|---|---|
+| run_1 | 1 | 2026-05-10T08:02:20 | 2026-05-10T08:02:30 | ~10s | timeout | task_retry |
+| run_2 | 2 | 2026-05-10T09:51:51 | 2026-05-10T09:52:42 | ~51s | — | task_completed (succeeded) |
+| run_3 | 3 | 2026-05-11T02:46:17 | 2026-05-11T02:46:48 | ~31s | max_attempts_exceeded | task_failed |
+
+**Diagnosis**: Only 1 genuine timeout (10s — likely API connection issue).
+Run 2 actually succeeded. Run 3 was a re-attempt that hit max_attempts_exceeded.
+
+### dreamer-a3e308de (FAILED — 1 output_invalid, 1 timeout)
+
+| Run | Attempt | Started | Ended | Duration | error_category | failureReason |
+|---|---|---|---|---|---|---|
+| run_1 | 1 | 2026-05-10T03:49:57 | 2026-05-10T03:50:08 | ~11s | timeout | task_retry |
+| run_2 | 2 | 2026-05-10T04:26:44 | 2026-05-10T04:26:51 | ~7s | output_invalid | task_retry |
+| run_3 | 3 | 2026-05-10T08:05:06 | 2026-05-10T08:07:00 | ~114s | max_attempts_exceeded | task_failed |
+
+**Diagnosis**: Run 1 (11s) was a genuine timeout. Run 2 (7s) returned
+output_invalid — the extremely short duration suggests the LLM returned
+an error or empty response, not a full JSON output. Run 3 (114s) hit
+max_attempts_exceeded.
+
+## Genuine LLM Error Breakdown
+
+Filtering out max_attempts_exceeded (which is a terminal state, not an LLM
+error), the genuine LLM-level failures are:
+
+| Error Category | Count | Runs |
+|---|---|---|
+| output_invalid | 4 | 0bcc0c79-run1, 0bcc0c79-run2, 1316a064-run1, a3e308de-run2 |
+| timeout | 3 | 1316a064-run2, dfd8937b-run1, a3e308de-run1 |
+
+**output_invalid rate**: 4/7 genuine failures (57%)
+**timeout rate**: 3/7 genuine failures (43%)
+
+## Raw Schema Error Summary
+
+**CRITICAL OBSERVABILITY GAP**: We cannot determine the specific schema errors
+because:
+
+1. **`runs.output_payload` is NULL for all failed runs** — the raw LLM response
+   is not persisted on failure.
+2. **No `output_extraction_failed` telemetry events** were emitted for these
+   runs (the feature was added after these failures occurred).
+3. **No `output_repair_attempted` telemetry events** exist in the event logs
+   for 2026-05-10 or 2026-05-11.
+4. **No `runtime_invocation_started/failed` telemetry events** exist for these
+   runs — the telemetry pipeline was not active during these failures.
+
+### Inferred Failure Path
+
+Based on the code path in `PiAiRuntimeAdapter.startRun()`:
+
+```
+LLM response → extractJsonObject(text)
+  → null? → output_invalid ("No valid JSON found in LLM response")
+  → JSON parsed? → Value.Check(DreamerOutputV1Schema, parsed)
+    → fails? → attemptStructuredOutputRepair()
+      → fails? → output_invalid ("LLM output does not match dreamer-output-v1 schema")
+```
+
+The 4 output_invalid runs likely fall into one of these categories:
+
+| Pattern | extractJsonObject | Schema Check | Repair | Likelihood |
 |---|---|---|---|---|
-| `dreamer-0bcc0c79-9011-4d2f-865d-674a145219ff` | 3 | max_attempts_exceeded | 2 | 0 |
-| `dreamer-1316a064-ce07-42db-b06a-21917a551752` | 4 | max_attempts_exceeded | 1 | 1 |
-| `dreamer-dfd8937b-16e1-4824-bf93-6903b430d4c2` | 3 | max_attempts_exceeded | 0 | 1 |
-| `dreamer-a3e308de-41d4-473f-a74a-a66caa394efb` | 3 | max_attempts_exceeded | 1 | 0 |
+| A: No JSON at all | null | N/A | N/A | **High** — MiniMax-M2.7 may return prose |
+| B: Prose-wrapped JSON | parsed | fail | fail | **Medium** — code fences or preamble |
+| C: JSON but wrong schema | parsed | fail | fail | **Medium** — missing fields, wrong types |
+| D: JSON valid but validator rejects | parsed | pass | N/A | **Low** — taskId mismatch etc. |
 
-**Total**: 4 output_invalid, 2 timeout across 8 failed runs
+**Most likely**: Pattern A or B. The EvaluatorRunner had the same issue with
+the same provider/model (MiniMax-M2.7) — it returned prose-wrapped or non-JSON
+output. The fix (strengthened prompt) resolved the evaluator issue, suggesting
+the same root cause applies to dreamer.
 
-## Per-Run Details
+## Successful Run Analysis
 
-### dreamer-0bcc0c79 (2 output_invalid, 0 timeout)
+3 dreamer runs succeeded (output_payload available). Analyzing their output
+reveals what MiniMax-M2.7 produces when it works:
 
-| Run | Started | Ended | Duration | Error Category |
-|---|---|---|---|---|
-| run_1 | 2026-05-10T08:03:30 | 2026-05-10T08:04:57 | ~87s | output_invalid |
-| run_2 | 2026-05-10T10:48:41 | 2026-05-10T10:49:34 | ~53s | output_invalid |
-| run_3 | 2026-05-11T02:47:44 | 2026-05-11T02:48:16 | ~32s | max_attempts_exceeded |
+### dreamer-10df2bb5 run_3 (succeeded, attempt 3)
 
-### dreamer-1316a064 (1 output_invalid, 1 timeout)
+```json
+{
+  "valid": true,
+  "taskId": "dreamer-10df2bb5-f2ed-4688-892e-409bbaa76aa7-prompt",
+  "candidates": [{
+    "candidateIndex": 0,
+    "badDecision": "predecessorOutput is null - no diagnosis analysis was provided...",
+    "betterDecision": "Request predecessor to provide Diagnostician diagnosis output...",
+    "rationale": "Without a predecessor diagnosis identifying what went wrong...",
+    "confidence": 1,
+    "riskLevel": "low",
+    "strategicPerspective": "dependency_awareness - agents in a pipeline..."
+  }],
+  "sourcePrincipleId": "",
+  "sourcePainId": "",
+  "contextRefs": [],
+  "generatedAt": "2025-01-15T12:00:00.000Z"
+}
+```
 
-| Run | Started | Ended | Duration | Error Category |
-|---|---|---|---|---|
-| run_1 | 2026-05-10T08:02:40 | 2026-05-10T08:03:12 | ~32s | output_invalid |
-| run_2 | 2026-05-10T09:52:54 | 2026-05-10T09:53:05 | ~11s | timeout |
-| run_3 | 2026-05-11T02:47:17 | 2026-05-11T02:47:27 | ~10s | max_attempts_exceeded |
-| run_4 | N/A | N/A | N/A | max_attempts_exceeded (terminal) |
+**Observations from successful outputs**:
+- `confidence` is `1` (integer, not 0.0-1.0 float) — this passes TypeBox
+  `Type.Number({ minimum: 0, maximum: 1 })` but may indicate the LLM doesn't
+  understand the 0.0-1.0 range constraint.
+- `sourcePrincipleId` and `sourcePainId` are empty strings `""` — passes
+  `Type.Optional(Type.String())` but semantically wrong (should be absent or
+  meaningful).
+- `generatedAt` uses past dates (`2025-01-15`, `2025-01-09`, `2025-12-16`) —
+  the LLM fabricates timestamps rather than using current time.
+- Only 1 candidate generated despite the schema allowing 1-5 — the LLM takes
+  the minimum path.
 
-### dreamer-dfd8937b (0 output_invalid, 1 timeout)
+These patterns suggest the LLM follows the JSON structure but doesn't deeply
+understand the semantic constraints.
 
-| Run | Started | Ended | Duration | Error Category |
-|---|---|---|---|---|
-| run_1 | 2026-05-10T08:02:20 | 2026-05-10T08:02:30 | ~10s | timeout |
-| run_2 | N/A | N/A | N/A | max_attempts_exceeded |
-| run_3 | 2026-05-11T02:46:17 | 2026-05-11T02:46:48 | ~31s | max_attempts_exceeded |
+## Dreamer Prompt Gap Analysis
 
-### dreamer-a3e308de (1 output_invalid, 0 timeout)
+Current `DREAMER_PROTOCOL_INSTRUCTION` vs. hardened `EVALUATOR_PROTOCOL_INSTRUCTION`:
 
-| Run | Started | Ended | Duration | Error Category |
-|---|---|---|---|---|
-| run_1 | 2026-05-10T03:49:57 | 2026-05-10T03:50:08 | ~11s | timeout |
-| run_2 | 2026-05-10T04:26:44 | 2026-05-10T04:26:51 | ~7s | output_invalid |
-| run_3 | 2026-05-10T08:05:06 | 2026-05-10T08:07:00 | ~114s | max_attempts_exceeded |
+| Feature | Dreamer (current) | Evaluator (hardened) |
+|---|---|---|
+| "CRITICAL: ENTIRE response ONLY JSON" | ❌ Missing | ✅ Present |
+| "Do NOT include text before/after JSON" | ❌ Missing | ✅ Present |
+| "Do NOT wrap in markdown code fences" | ❌ Missing | ✅ Present |
+| Complete filled JSON example | ❌ Placeholder shape only | ✅ All fields filled |
+| "no prose before or after" | ❌ Missing | ✅ Present |
+| JSON-only emphasis repeated in CONSTRAINTS | ⚠️ Partial ("no markdown") | ✅ Full emphasis |
+| `sourceArtificerArtifactId` copy instruction | N/A | ✅ Present |
 
-## Dreamer Prompt Analysis
+The Dreamer prompt's "OUTPUT FORMAT" section shows a template with `<from input>`
+placeholders rather than a concrete example. LLMs (especially smaller models
+like MiniMax-M2.7) benefit significantly from concrete examples over templates.
 
-Current `DREAMER_PROTOCOL_INSTRUCTION` includes:
-- "OUTPUT FORMAT (pure JSON, no markdown)" with example shape
-- "Output ONLY valid JSON (no markdown, no explanatory text, no code fences)"
-- Constraints for each field
+## Observability Issues
 
-**Missing**:
-- No "CRITICAL: Your ENTIRE response must be ONLY the JSON object" emphasis
-- No "Do NOT include any text before or after the JSON" emphasis
-- No complete minimal JSON example with all fields filled
-- No "Do NOT wrap in markdown code fences" emphasis
+### Issue 1: No raw LLM output on failure
 
-## Schema Error Patterns
+**Severity**: Critical
+**Impact**: Cannot determine whether output_invalid was caused by no JSON,
+prose-wrapped JSON, or schema-invalid JSON.
 
-`output_invalid` in the Dreamer context means one of:
-1. `extractJsonObject(text)` returned `null` — LLM returned no parseable JSON
-2. JSON parsed but failed `DreamerOutputV1` schema validation — and repair also failed
-3. JSON parsed, schema valid, but `DefaultDreamerValidator.validate()` found cross-field errors (e.g., taskId mismatch)
+**Evidence**: All 4 output_invalid runs have `output_payload = NULL` and
+`input_payload = NULL` in the runs table.
 
-**Most likely cause**: Pattern 1 (no parseable JSON). The 10-11s timeout runs suggest LLM API issues (connection timeout), while the 32-87s output_invalid runs suggest the LLM returned a response but it wasn't valid JSON.
+**Status**: Partially addressed by `output_extraction_failed` telemetry event
+(added in PRI-EVAL hardening commit). This event captures the first 500 chars
+of the raw LLM response when `extractJsonObject` returns null. However, it
+does NOT capture the raw output when JSON parses but schema validation fails.
 
-## Observability Gap
+### Issue 2: No runtime invocation telemetry for these failures
 
-**Critical finding**: The `runs` table `input_payload` and `output_payload` columns are **empty** for all failed dreamer runs. This means:
-- We cannot see what the LLM actually returned
-- We cannot determine if `extractJsonObject` failed or schema validation failed
-- We cannot reproduce the failure with the exact LLM output
+**Severity**: High
+**Impact**: Cannot correlate failures with provider/model configuration.
 
-The `PiAiRuntimeAdapter.startRun()` method does not persist the raw LLM response before throwing `output_invalid`. The telemetry events (`runtime_invocation_failed`) are emitted but do not include the raw output preview.
+**Evidence**: Zero `runtime_invocation_started`, `runtime_invocation_failed`,
+`output_extraction_failed`, or `output_repair_attempted` events in
+`events_2026-05-10.jsonl` or `events_2026-05-11.jsonl`.
+
+**Root cause**: The telemetry pipeline was not active during these failures.
+The `output_extraction_failed` event was added after these failures occurred.
+
+### Issue 3: No schema error detail on output_invalid
+
+**Severity**: Medium
+**Impact**: Cannot determine which specific schema fields failed validation.
+
+**Evidence**: The `runtime_invocation_failed` event includes `errorCategory`
+and `errorMessage` but not the TypeBox validation errors. The
+`output_repair_attempted` event includes `repairSummary` but only when repair
+is attempted (not when `extractJsonObject` returns null).
+
+**Recommendation**: Add `schemaErrors` field to `output_repair_attempted`
+telemetry payload, containing the first 5 TypeBox validation errors.
 
 ## Recommendations
 
-1. **Add `output_extraction_failed` telemetry event**: When `extractJsonObject` returns null, emit a telemetry event with the first 500 chars of the LLM response. This provides diagnosis without DB bloat.
+1. **Strengthen DreamerPromptBuilder** (same hardening as EvaluatorPromptBuilder):
+   - Add "CRITICAL: Your ENTIRE response must be ONLY the JSON object"
+   - Add "Do NOT include any text before or after the JSON"
+   - Add "Do NOT wrap the JSON in markdown code fences"
+   - Replace placeholder JSON template with a complete filled example
+   - Add "no prose before or after" emphasis in CONSTRAINTS
 
-2. **Strengthen DreamerPromptBuilder**: Add the same hardening as EvaluatorPromptBuilder — complete JSON example, "ENTIRE response only JSON" emphasis, "no prose before/after" emphasis.
+2. **Do NOT change DreamerRunner code**: The runner logic is correct. The issue
+   is LLM output quality from MiniMax-M2.7, not runner behavior.
 
-3. **Create LLM invocation observability issue**: Track as a follow-up — persist raw LLM output (or preview) in the `runs` table on failure for post-mortem analysis.
+3. **Create LLM invocation observability issue** (follow-up):
+   - Persist raw LLM output preview (first 500 chars) in `runs.output_payload`
+     on failure, not just on success
+   - Add `schemaErrors` to `output_repair_attempted` telemetry
+   - Ensure telemetry pipeline is active for all runtime invocations
 
-4. **Do NOT change DreamerRunner code**: The runner logic is correct. The issue is LLM output quality, not runner behavior.
+4. **Consider increasing maxAttempts for dreamer**: With 3 max attempts and
+   ~57% output_invalid rate, the probability of all 3 failing is ~8%.
+   Increasing to 5 would reduce this to ~2%. However, this is a palliative,
+   not a cure — prompt hardening is the primary fix.
 
-5. **Consider increasing maxAttempts for dreamer**: With 3 max attempts and ~50% output_invalid rate, the probability of all 3 failing is ~12.5%. Increasing to 5 would reduce this to ~3%.
+5. **Validate MiniMax-M2.7 compatibility**: After prompt hardening, run a
+   production validation with `--runner dreamer` to confirm the hardened
+   prompt produces valid JSON from MiniMax-M2.7.
+
+## Appendix: Data Sources
+
+- **Tasks table**: `D:\.openclaw\workspace\.pd\state.db` — `tasks` table
+- **Runs table**: Same DB — `runs` table
+- **Workflows config**: `D:\.openclaw\workspace\.state\workflows.yaml`
+- **Telemetry logs**: `D:\.openclaw\workspace\.state\logs\events_2026-05-10.jsonl`,
+  `events_2026-05-11.jsonl`
+- **DreamerRunner code**: `packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts`
+- **DreamerPromptBuilder**: `packages/principles-core/src/runtime-v2/internalization/dreamer-prompt-builder.ts`
+- **DreamerOutputV1Schema**: `packages/principles-core/src/runtime-v2/internalization/dreamer-output.ts`
+- **PiAiRuntimeAdapter**: `packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts`

--- a/docs/reports/2026-05-11-dreamer-output-invalid-drain-analysis.md
+++ b/docs/reports/2026-05-11-dreamer-output-invalid-drain-analysis.md
@@ -1,0 +1,94 @@
+# Dreamer output_invalid Drain Analysis — 2026-05-11
+
+## Summary
+
+During PRI-110 drain, 4 dreamer tasks failed permanently after exhausting retries. This evidence pack documents the failure patterns for future hardening.
+
+## Failed Task Summary
+
+| Task ID (prefix) | Attempts | Final Error | output_invalid Runs | timeout Runs |
+|---|---|---|---|---|
+| `dreamer-0bcc0c79-9011-4d2f-865d-674a145219ff` | 3 | max_attempts_exceeded | 2 | 0 |
+| `dreamer-1316a064-ce07-42db-b06a-21917a551752` | 4 | max_attempts_exceeded | 1 | 1 |
+| `dreamer-dfd8937b-16e1-4824-bf93-6903b430d4c2` | 3 | max_attempts_exceeded | 0 | 1 |
+| `dreamer-a3e308de-41d4-473f-a74a-a66caa394efb` | 3 | max_attempts_exceeded | 1 | 0 |
+
+**Total**: 4 output_invalid, 2 timeout across 8 failed runs
+
+## Per-Run Details
+
+### dreamer-0bcc0c79 (2 output_invalid, 0 timeout)
+
+| Run | Started | Ended | Duration | Error Category |
+|---|---|---|---|---|
+| run_1 | 2026-05-10T08:03:30 | 2026-05-10T08:04:57 | ~87s | output_invalid |
+| run_2 | 2026-05-10T10:48:41 | 2026-05-10T10:49:34 | ~53s | output_invalid |
+| run_3 | 2026-05-11T02:47:44 | 2026-05-11T02:48:16 | ~32s | max_attempts_exceeded |
+
+### dreamer-1316a064 (1 output_invalid, 1 timeout)
+
+| Run | Started | Ended | Duration | Error Category |
+|---|---|---|---|---|
+| run_1 | 2026-05-10T08:02:40 | 2026-05-10T08:03:12 | ~32s | output_invalid |
+| run_2 | 2026-05-10T09:52:54 | 2026-05-10T09:53:05 | ~11s | timeout |
+| run_3 | 2026-05-11T02:47:17 | 2026-05-11T02:47:27 | ~10s | max_attempts_exceeded |
+| run_4 | N/A | N/A | N/A | max_attempts_exceeded (terminal) |
+
+### dreamer-dfd8937b (0 output_invalid, 1 timeout)
+
+| Run | Started | Ended | Duration | Error Category |
+|---|---|---|---|---|
+| run_1 | 2026-05-10T08:02:20 | 2026-05-10T08:02:30 | ~10s | timeout |
+| run_2 | N/A | N/A | N/A | max_attempts_exceeded |
+| run_3 | 2026-05-11T02:46:17 | 2026-05-11T02:46:48 | ~31s | max_attempts_exceeded |
+
+### dreamer-a3e308de (1 output_invalid, 0 timeout)
+
+| Run | Started | Ended | Duration | Error Category |
+|---|---|---|---|---|
+| run_1 | 2026-05-10T03:49:57 | 2026-05-10T03:50:08 | ~11s | timeout |
+| run_2 | 2026-05-10T04:26:44 | 2026-05-10T04:26:51 | ~7s | output_invalid |
+| run_3 | 2026-05-10T08:05:06 | 2026-05-10T08:07:00 | ~114s | max_attempts_exceeded |
+
+## Dreamer Prompt Analysis
+
+Current `DREAMER_PROTOCOL_INSTRUCTION` includes:
+- "OUTPUT FORMAT (pure JSON, no markdown)" with example shape
+- "Output ONLY valid JSON (no markdown, no explanatory text, no code fences)"
+- Constraints for each field
+
+**Missing**:
+- No "CRITICAL: Your ENTIRE response must be ONLY the JSON object" emphasis
+- No "Do NOT include any text before or after the JSON" emphasis
+- No complete minimal JSON example with all fields filled
+- No "Do NOT wrap in markdown code fences" emphasis
+
+## Schema Error Patterns
+
+`output_invalid` in the Dreamer context means one of:
+1. `extractJsonObject(text)` returned `null` — LLM returned no parseable JSON
+2. JSON parsed but failed `DreamerOutputV1` schema validation — and repair also failed
+3. JSON parsed, schema valid, but `DefaultDreamerValidator.validate()` found cross-field errors (e.g., taskId mismatch)
+
+**Most likely cause**: Pattern 1 (no parseable JSON). The 10-11s timeout runs suggest LLM API issues (connection timeout), while the 32-87s output_invalid runs suggest the LLM returned a response but it wasn't valid JSON.
+
+## Observability Gap
+
+**Critical finding**: The `runs` table `input_payload` and `output_payload` columns are **empty** for all failed dreamer runs. This means:
+- We cannot see what the LLM actually returned
+- We cannot determine if `extractJsonObject` failed or schema validation failed
+- We cannot reproduce the failure with the exact LLM output
+
+The `PiAiRuntimeAdapter.startRun()` method does not persist the raw LLM response before throwing `output_invalid`. The telemetry events (`runtime_invocation_failed`) are emitted but do not include the raw output preview.
+
+## Recommendations
+
+1. **Add `output_extraction_failed` telemetry event**: When `extractJsonObject` returns null, emit a telemetry event with the first 500 chars of the LLM response. This provides diagnosis without DB bloat.
+
+2. **Strengthen DreamerPromptBuilder**: Add the same hardening as EvaluatorPromptBuilder — complete JSON example, "ENTIRE response only JSON" emphasis, "no prose before/after" emphasis.
+
+3. **Create LLM invocation observability issue**: Track as a follow-up — persist raw LLM output (or preview) in the `runs` table on failure for post-mortem analysis.
+
+4. **Do NOT change DreamerRunner code**: The runner logic is correct. The issue is LLM output quality, not runner behavior.
+
+5. **Consider increasing maxAttempts for dreamer**: With 3 max attempts and ~50% output_invalid rate, the probability of all 3 failing is ~12.5%. Increasing to 5 would reduce this to ~3%.

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -6,18 +6,20 @@ import {
   PhilosopherRunner,
   ScribeRunner,
   ArtificerRunner,
+  EvaluatorRunner,
   StoreEventEmitter,
   DefaultDreamerValidator,
   DefaultPhilosopherValidator,
   DefaultScribeValidator,
   DefaultArtificerValidator,
+  DefaultEvaluatorValidator,
   TestDoubleRuntimeAdapter,
   PiAiRuntimeAdapter,
   OpenClawCliRuntimeAdapter,
   resolveRuntimeConfig,
   validateRuntimeConfig,
 } from '@principles/core/runtime-v2';
-import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
+import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, EvaluatorRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 interface RunOnceOptions {
@@ -33,7 +35,7 @@ interface RunOnceOptions {
 const OWNER = 'pd-cli-internalization-run-once';
 const RUNTIME_KIND = 'local-worker';
 
-const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer']);
+const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator']);
 
 interface RunOnceOutput {
   decision: string;
@@ -44,7 +46,7 @@ interface RunOnceOutput {
   runId?: string;
   artifactId?: string;
   resultRef?: string;
-  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult;
+  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult;
   skipReason?: string;
   conflictReason?: string;
   reason?: string;
@@ -56,7 +58,7 @@ interface RunOnceOutput {
   timeoutSource?: string;
 }
 
-function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult, skipReason?: string): RunOnceOutput {
+function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult, skipReason?: string): RunOnceOutput {
   const base: RunOnceOutput = { decision: wakeResult.decision };
 
   switch (wakeResult.decision) {
@@ -275,6 +277,47 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
         }),
       });
     }
+    if (opts.runnerKind === 'evaluator') {
+      let capturedSourceArtificerArtifactId = 'pi-art-test-artificer';
+      return new TestDoubleRuntimeAdapter({
+        onStartRun: (input) => {
+          try {
+            const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+            const parsed = JSON.parse(payloadStr);
+            if (typeof parsed.sourceArtificerArtifactId === 'string' && parsed.sourceArtificerArtifactId.trim() !== '') {
+              capturedSourceArtificerArtifactId = parsed.sourceArtificerArtifactId;
+            }
+          } catch { /* use default */ }
+          return { runId: `td-evaluator-${Date.now()}`, runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+        },
+        onPollRun: (_runId: string) => ({
+          runId: _runId,
+          status: 'succeeded',
+          startedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+        }),
+        onFetchOutput: (_runId: string) => ({
+          runId: _runId,
+          payload: {
+            taskId: opts.taskId,
+            sourceArtificerArtifactId: capturedSourceArtificerArtifactId,
+            evaluation: {
+              decision: 'approved',
+              summary: 'Test evaluation summary',
+              score: 0.85,
+              strengths: ['Well-structured plan'],
+              concerns: [],
+              requiredChanges: [],
+            },
+            sourceTrace: {
+              artificerArtifactId: capturedSourceArtificerArtifactId,
+            },
+            risks: [],
+            generatedAt: new Date().toISOString(),
+          },
+        }),
+      });
+    }
     return new TestDoubleRuntimeAdapter({
       onPollRun: (_runId: string) => ({
         runId: _runId,
@@ -379,7 +422,7 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       return;
     }
 
-    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | undefined = undefined;
+    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | undefined = undefined;
     let skipReason: string | undefined = undefined;
 
     if (wakeResult.decision === 'would_lease') {
@@ -415,6 +458,13 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       } else if (runnerKind === 'artificer') {
         const validator = new DefaultArtificerValidator();
         const runner = new ArtificerRunner(
+          { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
+          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
+        );
+        runnerResult = await runner.run(wakeResult.taskId);
+      } else if (runnerKind === 'evaluator') {
+        const validator = new DefaultEvaluatorValidator();
+        const runner = new EvaluatorRunner(
           { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
           { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -46,6 +46,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
   ArtificerRunner: vi.fn().mockImplementation(function () {
     return { run: mockRun };
   }),
+  EvaluatorRunner: vi.fn().mockImplementation(function () {
+    return { run: mockRun };
+  }),
   StoreEventEmitter: vi.fn().mockImplementation(function () {
     return { emitTelemetry: vi.fn() };
   }),
@@ -62,6 +65,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
     return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
   }),
   DefaultArtificerValidator: vi.fn().mockImplementation(function () {
+    return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
+  }),
+  DefaultEvaluatorValidator: vi.fn().mockImplementation(function () {
     return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
   }),
   TestDoubleRuntimeAdapter: vi.fn().mockImplementation(function () {
@@ -187,7 +193,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
   });
 
   it('unsupported runner kind: exits 1 with error', async () => {
-    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'evaluator', runtime: 'test-double', allowTestDouble: true });
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'trainer', runtime: 'test-double', allowTestDouble: true });
 
     expect(process.exitCode).toBe(1);
     expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('unsupported runner kind'))).toBe(true);
@@ -899,13 +905,14 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.successorKind).toBe('artificer');
   });
 
-  it('run-once source has no direct EvaluatorRunner import', async () => {
+  it('run-once source imports EvaluatorRunner for dispatch', async () => {
     const { existsSync, readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const srcPath = resolve(__dirname, '../../src/commands/runtime-internalization-run-once.ts');
     if (!existsSync(srcPath)) return;
     const src = readFileSync(srcPath, 'utf-8');
-    expect(src).not.toContain('EvaluatorRunner');
+    expect(src).toContain('EvaluatorRunner');
+    expect(src).toContain('DefaultEvaluatorValidator');
   });
 
   it('--runner artificer dispatches ArtificerRunner', async () => {
@@ -1039,5 +1046,101 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'artificer', runtime: 'test-double', allowTestDouble: true, json: true });
 
     expect(mockWakeOnce).toHaveBeenCalledWith('artificer');
+  });
+
+  it('--runner evaluator dispatches EvaluatorRunner', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-evaluator-001',
+      taskKind: 'evaluator',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-evaluator-001',
+      runId: 'run-evaluator-001',
+      artifactId: 'pi-art-task-evaluator-001-run-evaluator-001',
+      resultRef: 'evaluator://run-evaluator-001',
+      contextHash: 'ctx-evaluator-abc',
+      output: {
+        taskId: 'task-evaluator-001',
+        sourceArtificerArtifactId: 'pi-art-artificer-001',
+        evaluation: {
+          decision: 'approved',
+          summary: 'Test evaluation summary',
+          score: 0.85,
+          strengths: ['Well-structured plan'],
+          concerns: [],
+          requiredChanges: [],
+        },
+        sourceTrace: { artificerArtifactId: 'pi-art-artificer-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'evaluator', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const EvaluatorRunnerMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.EvaluatorRunner),
+    );
+    expect(EvaluatorRunnerMock).toHaveBeenCalled();
+    expect(mockRun).toHaveBeenCalledWith('task-evaluator-001');
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.runnerKind).toBe('evaluator');
+    expect(output.taskId).toBe('task-evaluator-001');
+    expect(output.runId).toBe('run-evaluator-001');
+    expect(output.artifactId).toBe('pi-art-task-evaluator-001-run-evaluator-001');
+    expect(output.resultRef).toBe('evaluator://run-evaluator-001');
+    expect(output.runnerResult.status).toBe('succeeded');
+  });
+
+  it('--runner evaluator --enqueue-next returns successor decision', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-evaluator-enq-001',
+      taskKind: 'evaluator',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-evaluator-enq-001',
+      runId: 'run-evaluator-enq-001',
+      artifactId: 'pi-art-evaluator-enq-001',
+      resultRef: 'evaluator://run-evaluator-enq-001',
+      contextHash: 'ctx-enq',
+      output: {
+        taskId: 'task-evaluator-enq-001',
+        sourceArtificerArtifactId: 'pi-art-artificer-enq-001',
+        evaluation: {
+          decision: 'approved',
+          summary: 'Test evaluation summary',
+          score: 0.85,
+          strengths: ['Well-structured plan'],
+          concerns: [],
+          requiredChanges: [],
+        },
+        sourceTrace: { artificerArtifactId: 'pi-art-artificer-enq-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'task-evaluator-enq-001',
+      successorTaskId: 'task-rollout-reviewer-enq-001',
+      successorKind: 'rollout_reviewer',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'evaluator', runtime: 'test-double', allowTestDouble: true, enqueueNext: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.enqueueDecision).toBe('successor_created');
+    expect(output.successorTaskId).toBe('task-rollout-reviewer-enq-001');
+    expect(output.successorKind).toBe('rollout_reviewer');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -65,6 +65,10 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-111
   'internalization/artificer-output.ts',
   'internalization/artificer-runner.ts',
+  // PRI-EVAL
+  'internalization/evaluator-output.ts',
+  'internalization/evaluator-runner.ts',
+  'internalization/evaluator-prompt-builder.ts',
   // PRI-74 (follow-up to PRI-75 Phase 3)
   '../prompt-builder/routing-guidance.ts',
   // PRI-81 Phase A
@@ -102,6 +106,8 @@ const REQUIRED_TEST_FILES = [
   'scribe-runner-vslice.test.ts',
   // PRI-111
   'artificer-runner-vslice.test.ts',
+  // PRI-EVAL
+  'evaluator-runner-vslice.test.ts',
   // PRI-74 (follow-up to PRI-75 Phase 3)
   '../../prompt-builder/__tests__/routing-guidance.test.ts',
   // PRI-81 Phase A
@@ -1624,5 +1630,69 @@ describe('PRI-111 ArtificerRunner boundary', () => {
     const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
     expect(src).toContain('artificer-output-v1');
     expect(src).toContain('ArtificerOutputV1Schema');
+  });
+});
+
+// ── PRI-EVAL: EvaluatorRunner boundary guards ──────────────────────────────────
+
+describe('PRI-EVAL EvaluatorRunner boundary', () => {
+  it('evaluator source files exist in internalization directory', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'evaluator-runner.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'evaluator-output.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'evaluator-prompt-builder.ts'))).toBe(true);
+  });
+
+  it('evaluator test file exists', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, 'evaluator-runner-vslice.test.ts'))).toBe(true);
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: evaluator-output.ts has no openclaw-plugin, fs, path imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'evaluator-output.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: evaluator-runner.ts has no openclaw-plugin, RolloutReviewerRunner, nocturnal-trinity imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'evaluator-runner.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('RolloutReviewerRunner');
+    expect(src).not.toContain('nocturnal-trinity');
+    expect(src).not.toContain('InternalizationOrchestrator');
+    expect(src).not.toContain('createTask');
+    expect(src).not.toContain('enqueueTask');
+  });
+
+  it('CORE_NO_SCHEDULING: evaluator-runner.ts has no node:fs, node:cron imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'evaluator-runner.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('BARREL_EXPORTS: internalization/index.ts exports EvaluatorRunner and EvaluatorOutput', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).toContain('EvaluatorRunner');
+    expect(src).toContain('EvaluatorOutput');
+    expect(src).toContain('DefaultEvaluatorValidator');
+  });
+
+  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers evaluator-output-v1 schema', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    expect(src).toContain('evaluator-output-v1');
+    expect(src).toContain('EvaluatorOutputV1Schema');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
@@ -1,0 +1,714 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EvaluatorRunner } from '../internalization/evaluator-runner.js';
+import type { EvaluatorRunnerDeps } from '../internalization/evaluator-runner.js';
+import type { PIArtifactStore, PIArtifactRecord } from '../internalization/pi-artifact.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { EvaluatorOutputV1 } from '../internalization/evaluator-output.js';
+import { DefaultEvaluatorValidator } from '../internalization/evaluator-output.js';
+import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
+import type { TaskRecord } from '../task-status.js';
+import { TestDoubleRuntimeAdapter } from '../adapter/test-double-runtime-adapter.js';
+
+const ARTIFICER_TASK_ID = 'artificer-001';
+const EVALUATOR_TASK_ID = 'evaluator-001';
+
+function makeArtificerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ARTIFICER_TASK_ID,
+    taskKind: 'artificer',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'artificer://run-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-artificer-001-run-001' }],
+    }),
+    ...overrides,
+  };
+}
+
+function makeEvaluatorTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: EVALUATOR_TASK_ID,
+    taskKind: 'evaluator',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [ARTIFICER_TASK_ID],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-artificer-001-run-001' }],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeEvaluatorOutput(): EvaluatorOutputV1 {
+  return {
+    taskId: EVALUATOR_TASK_ID,
+    sourceArtificerArtifactId: 'pi-art-artificer-001-run-001',
+    evaluation: {
+      decision: 'approved',
+      summary: 'Implementation plan is well-structured and feasible',
+      score: 0.85,
+      strengths: ['Clear change descriptions', 'Good test coverage plan'],
+      concerns: ['Rollout notes could be more specific'],
+      requiredChanges: [],
+    },
+    sourceTrace: {
+      artificerArtifactId: 'pi-art-artificer-001-run-001',
+    },
+    risks: ['May need additional integration tests'],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function makeArtificerArtifact(): PIArtifactRecord {
+  return {
+    artifactId: 'pi-art-artificer-001-run-001',
+    artifactKind: 'principle',
+    sourceTaskId: ARTIFICER_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify({
+      taskId: ARTIFICER_TASK_ID,
+      sourceScribeArtifactId: 'pi-art-scribe-001',
+      implementationPlan: {
+        summary: 'Add input validation to all async operations',
+        targetSurface: 'src/async-ops/*.ts',
+        changes: ['Add try-catch to asyncOp1', 'Add error boundary to asyncOp2'],
+        tests: ['Unit test for asyncOp1 error handling', 'Integration test for error boundary'],
+        rolloutNotes: ['Deploy behind feature flag', 'Monitor error rates post-deploy'],
+        confidence: 0.85,
+      },
+      sourceTrace: {
+        scribeArtifactId: 'pi-art-scribe-001',
+      },
+      risks: ['May add latency from error checking'],
+      generatedAt: new Date().toISOString(),
+    }),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('EvaluatorRunner (vertical slice)', () => {
+  let artifactStore: PIArtifactStore = new MemoryPIArtifactStore();
+
+  beforeEach(() => {
+    artifactStore = new MemoryPIArtifactStore();
+  });
+
+  function createMockDeps(overrides: Partial<EvaluatorRunnerDeps> = {}): EvaluatorRunnerDeps {
+    const evaluatorTask = makeEvaluatorTask();
+    const artificerTask = makeArtificerTask();
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(evaluatorTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorTask);
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(artificerTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-evaluator-001',
+        taskId: EVALUATOR_TASK_ID,
+        runtimeKind: 'evaluator',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const runHandle: RunHandle = { runId: 'run-evaluator-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+    const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-evaluator-001' };
+
+    const runtimeAdapter = {
+      startRun: vi.fn().mockResolvedValue(runHandle),
+      pollRun: vi.fn().mockResolvedValue(succeededStatus),
+      fetchOutput: vi.fn().mockResolvedValue({
+        payload: makeEvaluatorOutput(),
+      }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PDRuntimeAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const validator = new DefaultEvaluatorValidator();
+
+    return {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator,
+      artifactStore,
+      ...overrides,
+    };
+  }
+
+  it('taskKind not evaluator fails closed and releases lease', async () => {
+    const wrongKindTask = makeEvaluatorTask({ taskKind: 'dreamer' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(wrongKindTask);
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+    expect(result.failureReason).toContain("must be 'evaluator'");
+    expect(deps.stateManager.markTaskFailed).toHaveBeenCalledWith(
+      EVALUATOR_TASK_ID,
+      'input_invalid',
+    );
+  });
+
+  it('missing artificer dependency blocked/failure', async () => {
+    const noDepTask = makeEvaluatorTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(noDepTask);
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockResolvedValue(noDepTask);
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('artificer dependency not succeeded cannot execute', async () => {
+    const pendingArtificer = makeArtificerTask({ status: 'pending' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockImplementation((id: string) => {
+      if (id === EVALUATOR_TASK_ID) return Promise.resolve(makeEvaluatorTask());
+      if (id === ARTIFICER_TASK_ID) return Promise.resolve(pendingArtificer);
+      return Promise.resolve(null);
+    });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('artificer artifact missing goes to retry/fail', async () => {
+    const emptyArtifactStore = new MemoryPIArtifactStore();
+    const deps = createMockDeps({ artifactStore: emptyArtifactStore });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('valid runtime output writes evaluator PIArtifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(result.artifactId).toBeDefined();
+
+    const artifacts = await store.listBySourceTaskId(EVALUATOR_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+  });
+
+  it('valid runtime output marks task succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
+      EVALUATOR_TASK_ID,
+      expect.stringContaining('evaluator://'),
+    );
+  });
+
+  it('invalid output does not write artifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const invalidOutput: EvaluatorOutputV1 = {
+      taskId: 'wrong-task-id',
+      sourceArtificerArtifactId: '',
+      evaluation: {
+        decision: 'approved',
+        summary: '',
+        score: 1.5,
+        strengths: [],
+        concerns: [],
+        requiredChanges: [],
+      },
+      sourceTrace: {
+        artificerArtifactId: '',
+      },
+      risks: 'not-array' as unknown as string[],
+      generatedAt: '',
+    };
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+
+    const artifacts = await store.listBySourceTaskId(EVALUATOR_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('artifact write failure goes to retry/fail, not mark succeeded', async () => {
+    const failingStore = {
+      listBySourceTaskId: vi.fn().mockResolvedValue([makeArtificerArtifact()]),
+      upsertArtifact: vi.fn().mockRejectedValue(new Error('Disk full')),
+    } as unknown as PIArtifactStore;
+
+    const deps = createMockDeps({ artifactStore: failingStore });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('mismatched sourceArtificerArtifactId does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeEvaluatorOutput();
+    (mismatchedOutput as unknown as Record<string, unknown>).sourceArtificerArtifactId = 'wrong-artifact-id';
+    (mismatchedOutput.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId = 'wrong-artifact-id';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(EVALUATOR_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('sourceTrace.artificerArtifactId mismatch does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeEvaluatorOutput();
+    (mismatchedOutput.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId = 'wrong-trace-id';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(EVALUATOR_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+});
+
+describe('DefaultEvaluatorValidator (vertical slice)', () => {
+  const validator = new DefaultEvaluatorValidator();
+
+  it('accepts valid Evaluator output', async () => {
+    const result = await validator.validate(makeEvaluatorOutput(), EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects taskId mismatch', async () => {
+    const output = makeEvaluatorOutput();
+    (output as unknown as Record<string, unknown>).taskId = 'wrong';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('taskId mismatch'))).toBe(true);
+  });
+
+  it('rejects missing sourceArtificerArtifactId', async () => {
+    const output = makeEvaluatorOutput();
+    (output as unknown as Record<string, unknown>).sourceArtificerArtifactId = '';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceArtificerArtifactId'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceArtificerArtifactId when expected is provided', async () => {
+    const output = makeEvaluatorOutput();
+    (output as unknown as Record<string, unknown>).sourceArtificerArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID, 'pi-art-artificer-001-run-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceArtificerArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceTrace.artificerArtifactId when expected is provided', async () => {
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID, 'pi-art-artificer-001-run-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceTrace.artificerArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects invalid decision value', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).decision = 'invalid';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.decision'))).toBe(true);
+  });
+
+  it('rejects score as string', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).score = '0.85';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.score must be number'))).toBe(true);
+  });
+
+  it('rejects score > 1', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).score = 1.5;
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.score must be in [0, 1]'))).toBe(true);
+  });
+
+  it('rejects NaN score', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).score = NaN;
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.score must be number'))).toBe(true);
+  });
+
+  it('rejects Infinity score', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).score = Infinity;
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.score must be number'))).toBe(true);
+  });
+
+  it('rejects null output', async () => {
+    const result = await validator.validate(null as unknown as EvaluatorOutputV1, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects strengths with non-string elements', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).strengths = [1, 2];
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.strengths must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects concerns with non-string elements', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).concerns = [true];
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.concerns must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects requiredChanges with non-string elements', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).requiredChanges = [42];
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.requiredChanges must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects risks with non-string elements', async () => {
+    const output = makeEvaluatorOutput();
+    (output as unknown as Record<string, unknown>).risks = [42];
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('risks must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects missing evaluation.summary', async () => {
+    const output = makeEvaluatorOutput();
+    (output.evaluation as unknown as Record<string, unknown>).summary = '';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('evaluation.summary'))).toBe(true);
+  });
+
+  it('rejects missing sourceTrace.artificerArtifactId', async () => {
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId = '';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceTrace.artificerArtifactId'))).toBe(true);
+  });
+
+  it('accepts valid output with matching expectedSourceArtificerArtifactId', async () => {
+    const output = makeEvaluatorOutput();
+    const result = await validator.validate(output, EVALUATOR_TASK_ID, 'pi-art-artificer-001-run-001');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects mismatched sourceArtificerArtifactId vs sourceTrace.artificerArtifactId', async () => {
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId = 'different-id';
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('must match'))).toBe(true);
+  });
+
+  it('rejects non-string scribeArtifactId in sourceTrace', async () => {
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = 42;
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('scribeArtifactId'))).toBe(true);
+  });
+
+  it('rejects non-string philosopherArtifactId in sourceTrace', async () => {
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).philosopherArtifactId = { evil: true };
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('philosopherArtifactId'))).toBe(true);
+  });
+
+  it('rejects non-string dreamerArtifactId in sourceTrace', async () => {
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).dreamerArtifactId = true;
+    const result = await validator.validate(output, EVALUATOR_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('dreamerArtifactId'))).toBe(true);
+  });
+});
+
+describe('EvaluatorRunner integration: test-double captures sourceArtificerArtifactId from prompt', () => {
+  it('seed artificer artifact -> run evaluator with test-double -> succeeded with correct sourceArtificerArtifactId', async () => {
+    const ARTIFICER_ART_ID = 'pi-art-artificer-real-001';
+    const artifactStore = new MemoryPIArtifactStore();
+
+    const artificerArtifact: PIArtifactRecord = {
+      artifactId: ARTIFICER_ART_ID,
+      artifactKind: 'principle',
+      sourceTaskId: ARTIFICER_TASK_ID,
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: JSON.stringify({
+        taskId: ARTIFICER_TASK_ID,
+        sourceScribeArtifactId: 'pi-art-scribe-001',
+        implementationPlan: {
+          summary: 'Add input validation to all async operations',
+          targetSurface: 'src/async-ops/*.ts',
+          changes: ['Add try-catch to asyncOp1'],
+          tests: ['Unit test for asyncOp1 error handling'],
+          rolloutNotes: ['Deploy behind feature flag'],
+          confidence: 0.85,
+        },
+        sourceTrace: { scribeArtifactId: 'pi-art-scribe-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      }),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await artifactStore.upsertArtifact(artificerArtifact);
+
+    const evaluatorTask = makeEvaluatorTask();
+
+    let capturedSourceArtificerArtifactId: string = ARTIFICER_ART_ID;
+    const runtimeAdapter = new TestDoubleRuntimeAdapter({
+      onStartRun: (input) => {
+        try {
+          const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+          const parsed = JSON.parse(payloadStr);
+          if (typeof parsed.sourceArtificerArtifactId === 'string' && parsed.sourceArtificerArtifactId.trim() !== '') {
+            capturedSourceArtificerArtifactId = parsed.sourceArtificerArtifactId;
+          }
+        } catch { /* ignore */ }
+        return { runId: 'run-integration-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+      },
+      onPollRun: (_runId: string) => ({
+        runId: _runId,
+        status: 'succeeded',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }),
+      onFetchOutput: (_runId: string) => ({
+        runId: _runId,
+        payload: {
+          taskId: EVALUATOR_TASK_ID,
+          sourceArtificerArtifactId: capturedSourceArtificerArtifactId,
+          evaluation: {
+            decision: 'approved',
+            summary: 'Implementation plan is well-structured',
+            score: 0.85,
+            strengths: ['Clear change descriptions'],
+            concerns: [],
+            requiredChanges: [],
+          },
+          sourceTrace: {
+            artificerArtifactId: capturedSourceArtificerArtifactId,
+          },
+          risks: [],
+          generatedAt: new Date().toISOString(),
+        },
+      }),
+    });
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(evaluatorTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorTask);
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(makeArtificerTask());
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-integration-001',
+        taskId: EVALUATOR_TASK_ID,
+        runtimeKind: 'evaluator',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const deps: EvaluatorRunnerDeps = {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator: new DefaultEvaluatorValidator(),
+      artifactStore,
+    };
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test-integration',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 5000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+    expect(capturedSourceArtificerArtifactId).toBe(ARTIFICER_ART_ID);
+    expect(result.output?.sourceArtificerArtifactId).toBe(ARTIFICER_ART_ID);
+    expect(result.output?.sourceTrace.artificerArtifactId).toBe(ARTIFICER_ART_ID);
+
+    const artifacts = await artifactStore.listBySourceTaskId(EVALUATOR_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+
+    const [storedArtifact] = artifacts;
+    expect(storedArtifact).toBeDefined();
+    if (!storedArtifact) return;
+    const storedOutput = JSON.parse(storedArtifact.contentJson) as EvaluatorOutputV1;
+    expect(storedOutput.sourceArtificerArtifactId).toBe(ARTIFICER_ART_ID);
+    expect(storedOutput.sourceTrace.artificerArtifactId).toBe(ARTIFICER_ART_ID);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EvaluatorRunner } from '../internalization/evaluator-runner.js';
 import type { EvaluatorRunnerDeps } from '../internalization/evaluator-runner.js';
 import type { PIArtifactStore, PIArtifactRecord } from '../internalization/pi-artifact.js';
@@ -106,13 +106,8 @@ function makeArtificerArtifact(): PIArtifactRecord {
 }
 
 describe('EvaluatorRunner (vertical slice)', () => {
-  let artifactStore: PIArtifactStore = new MemoryPIArtifactStore();
-
-  beforeEach(() => {
-    artifactStore = new MemoryPIArtifactStore();
-  });
-
   function createMockDeps(overrides: Partial<EvaluatorRunnerDeps> = {}): EvaluatorRunnerDeps {
+    const artifactStore = overrides.artifactStore ?? new MemoryPIArtifactStore();
     const evaluatorTask = makeEvaluatorTask();
     const artificerTask = makeArtificerTask();
 
@@ -614,7 +609,7 @@ describe('EvaluatorRunner integration: test-double captures sourceArtificerArtif
 
     const evaluatorTask = makeEvaluatorTask();
 
-    let capturedSourceArtificerArtifactId: string = ARTIFICER_ART_ID;
+    let capturedSourceArtificerArtifactId: string | undefined = undefined;
     const runtimeAdapter = new TestDoubleRuntimeAdapter({
       onStartRun: (input) => {
         try {
@@ -633,25 +628,25 @@ describe('EvaluatorRunner integration: test-double captures sourceArtificerArtif
         endedAt: new Date().toISOString(),
       }),
       onFetchOutput: (_runId: string) => ({
-        runId: _runId,
-        payload: {
-          taskId: EVALUATOR_TASK_ID,
-          sourceArtificerArtifactId: capturedSourceArtificerArtifactId,
-          evaluation: {
-            decision: 'approved',
-            summary: 'Implementation plan is well-structured',
-            score: 0.85,
-            strengths: ['Clear change descriptions'],
-            concerns: [],
-            requiredChanges: [],
+          runId: _runId,
+          payload: {
+            taskId: EVALUATOR_TASK_ID,
+            sourceArtificerArtifactId: capturedSourceArtificerArtifactId ?? ARTIFICER_ART_ID,
+            evaluation: {
+              decision: 'approved',
+              summary: 'Implementation plan is well-structured',
+              score: 0.85,
+              strengths: ['Clear change descriptions'],
+              concerns: [],
+              requiredChanges: [],
+            },
+            sourceTrace: {
+              artificerArtifactId: capturedSourceArtificerArtifactId ?? ARTIFICER_ART_ID,
+            },
+            risks: [],
+            generatedAt: new Date().toISOString(),
           },
-          sourceTrace: {
-            artificerArtifactId: capturedSourceArtificerArtifactId,
-          },
-          risks: [],
-          generatedAt: new Date().toISOString(),
-        },
-      }),
+        }),
     });
 
     const stateManager = {

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
@@ -88,4 +88,10 @@ describe('extractJsonObject', () => {
     const result = extractJsonObject(input);
     expect(result).toBeNull();
   });
+
+  it('parses JSON with braces inside string values', () => {
+    const input = '{"taskId":"t1","summary":"Use {braces} for objects","score":0.5}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', summary: 'Use {braces} for objects', score: 0.5 });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { extractJsonObject } from '../json-extractor.js';
+
+describe('extractJsonObject', () => {
+  it('parses pure JSON object', () => {
+    const input = '{"taskId":"t1","score":0.85}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', score: 0.85 });
+  });
+
+  it('parses JSON in ```json code fence', () => {
+    const input = '```json\n{"taskId":"t1","score":0.85}\n```';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', score: 0.85 });
+  });
+
+  it('parses JSON in ``` code fence without language tag', () => {
+    const input = '```\n{"taskId":"t1","score":0.85}\n```';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', score: 0.85 });
+  });
+
+  it('parses prose-wrapped JSON', () => {
+    const input = 'Here is the evaluation output:\n{"taskId":"t1","score":0.85}\nDone.';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', score: 0.85 });
+  });
+
+  it('parses JSON with leading and trailing whitespace', () => {
+    const input = '   \n  {"taskId":"t1"}  \n  ';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1' });
+  });
+
+  it('returns first JSON object when multiple exist', () => {
+    const input = '{"first":1} some text {"second":2}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ first: 1 });
+  });
+
+  it('returns null for pure prose with no JSON', () => {
+    const input = 'This is just text with no JSON at all.';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for malformed JSON with unclosed brace', () => {
+    const input = '{"taskId":"t1","score":0.85';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('returns outermost object for nested JSON', () => {
+    const input = '{"outer":{"inner":1},"flag":true}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ outer: { inner: 1 }, flag: true });
+  });
+
+  it('returns null for JSON array at top level', () => {
+    const input = '[1,2,3]';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    const result = extractJsonObject('');
+    expect(result).toBeNull();
+  });
+
+  it('parses code-fenced JSON with prose before and after', () => {
+    const input = 'I have evaluated the plan.\n```json\n{"taskId":"t1","decision":"approved"}\n```\nHope this helps!';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', decision: 'approved' });
+  });
+
+  it('parses JSON with nested arrays and objects', () => {
+    const input = '{"taskId":"t1","evaluation":{"strengths":["a","b"],"concerns":[]},"risks":[]}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({
+      taskId: 't1',
+      evaluation: { strengths: ['a', 'b'], concerns: [] },
+      risks: [],
+    });
+  });
+
+  it('returns null for string with only braces but no valid JSON', () => {
+    const input = '{not valid json}';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
@@ -820,7 +820,8 @@ describe('PiAiRuntimeAdapter', () => {
     });
 
     it('emits output_extraction_failed telemetry when extractJsonObject returns null', async () => {
-      mockComplete.mockResolvedValueOnce(makeAssistantMessage('I evaluated the plan and it looks good. The implementation is solid.'));
+      const proseOutput = 'I evaluated the plan and it looks good. The implementation is solid.';
+      mockComplete.mockResolvedValueOnce(makeAssistantMessage(proseOutput));
 
       const adapter = makeAdapter();
       try { await adapter.startRun(makeDiagnosticianInput()); } catch { /* expected */ }
@@ -829,8 +830,9 @@ describe('PiAiRuntimeAdapter', () => {
       expect(extractionEvent).toBeDefined();
       const payload = extractionEvent?.payload as Record<string, unknown>;
       expect(payload.outputSchemaRef).toBe('diagnostician-output-v1');
-      expect(typeof payload.rawOutputPreview).toBe('string');
-      expect((payload.rawOutputPreview as string).length).toBeGreaterThan(0);
+      expect(payload.provider).toBe('openrouter');
+      expect(payload.model).toBe('anthropic/claude-sonnet-4');
+      expect(payload.rawOutputPreview).toBe(proseOutput);
     });
 
     it('emits output_repair_attempted telemetry on repair attempt', async () => {

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
@@ -819,6 +819,20 @@ describe('PiAiRuntimeAdapter', () => {
       expect(mockComplete).toHaveBeenCalledTimes(1);
     });
 
+    it('emits output_extraction_failed telemetry when extractJsonObject returns null', async () => {
+      mockComplete.mockResolvedValueOnce(makeAssistantMessage('I evaluated the plan and it looks good. The implementation is solid.'));
+
+      const adapter = makeAdapter();
+      try { await adapter.startRun(makeDiagnosticianInput()); } catch { /* expected */ }
+
+      const extractionEvent = findTelemetryEvent('output_extraction_failed');
+      expect(extractionEvent).toBeDefined();
+      const payload = extractionEvent?.payload as Record<string, unknown>;
+      expect(payload.outputSchemaRef).toBe('diagnostician-output-v1');
+      expect(typeof payload.rawOutputPreview).toBe('string');
+      expect((payload.rawOutputPreview as string).length).toBeGreaterThan(0);
+    });
+
     it('emits output_repair_attempted telemetry on repair attempt', async () => {
       mockComplete
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
@@ -889,6 +903,58 @@ describe('PiAiRuntimeAdapter', () => {
       });
       // 1 original + 1 repair = 2 calls total (not infinite)
       expect(mockComplete).toHaveBeenCalledTimes(2);
+    });
+
+    it('repairs evaluator-output-v1 with prose-wrapped JSON', async () => {
+      const EVALUATOR_OUTPUT_INVALID = {
+        taskId: 'task-eval-repair-1',
+        sourceArtificerArtifactId: 'pi-art-artificer-repair-1',
+        evaluation: {
+          decision: 'approved',
+          summary: 'Good plan',
+          score: '0.85',
+          strengths: ['Clear'],
+          concerns: [],
+          requiredChanges: [],
+        },
+        sourceTrace: {
+          artificerArtifactId: 'pi-art-artificer-repair-1',
+        },
+        risks: [],
+        generatedAt: '2026-05-11T12:00:00.000Z',
+      };
+
+      const EVALUATOR_OUTPUT_VALID = {
+        taskId: 'task-eval-repair-1',
+        sourceArtificerArtifactId: 'pi-art-artificer-repair-1',
+        evaluation: {
+          decision: 'approved',
+          summary: 'Good plan',
+          score: 0.85,
+          strengths: ['Clear'],
+          concerns: [],
+          requiredChanges: [],
+        },
+        sourceTrace: {
+          artificerArtifactId: 'pi-art-artificer-repair-1',
+        },
+        risks: [],
+        generatedAt: '2026-05-11T12:00:00.000Z',
+      };
+
+      mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(EVALUATOR_OUTPUT_INVALID)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(EVALUATOR_OUTPUT_VALID)));
+
+      const adapter = makeAdapter();
+      const handle = await adapter.startRun(makeStartRunInput({
+        outputSchemaRef: 'evaluator-output-v1',
+        taskRef: { taskId: 'task-eval-repair-1' },
+      }));
+
+      expect(mockComplete).toHaveBeenCalledTimes(2);
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output?.payload).toMatchObject({ evaluation: { score: 0.85 } });
     });
   });
 

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -395,6 +395,19 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
       // Parse response — handles prose-wrapped and code-fenced JSON
       let validatedOutput: unknown = extractJsonObject(text);
       if (!validatedOutput) {
+        this.eventEmitter.emitTelemetry({
+          eventType: 'output_extraction_failed',
+          traceId: input.taskRef?.taskId ?? runId,
+          timestamp: new Date().toISOString(),
+          sessionId: 'pi-ai-adapter',
+          agentId: 'pi-ai-adapter',
+          payload: {
+            runId,
+            runtimeKind: 'pi-ai',
+            outputSchemaRef: input.outputSchemaRef ?? 'unknown',
+            rawOutputPreview: text.slice(0, 500),
+          },
+        });
         throw new PDRuntimeError('output_invalid', 'No valid JSON found in LLM response');
       }
 

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -404,6 +404,8 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
           payload: {
             runId,
             runtimeKind: 'pi-ai',
+            provider: this.config.provider,
+            model: this.config.model,
             outputSchemaRef: input.outputSchemaRef ?? 'unknown',
             rawOutputPreview: text.slice(0, 500),
           },

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -25,6 +25,7 @@ import { DreamerOutputV1Schema } from '../internalization/dreamer-output.js';
 import { PhilosopherOutputV1Schema } from '../internalization/philosopher-output.js';
 import { ScribeOutputV1Schema } from '../internalization/scribe-output.js';
 import { ArtificerOutputV1Schema } from '../internalization/artificer-output.js';
+import { EvaluatorOutputV1Schema } from '../internalization/evaluator-output.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair } from './structured-output-repair.js';
@@ -189,6 +190,7 @@ const OUTPUT_SCHEMA_REGISTRY = new Map<string, TSchema>([
   ['philosopher-output-v1', PhilosopherOutputV1Schema as TSchema],
   ['scribe-output-v1', ScribeOutputV1Schema as TSchema],
   ['artificer-output-v1', ArtificerOutputV1Schema as TSchema],
+  ['evaluator-output-v1', EvaluatorOutputV1Schema as TSchema],
 ]);
 
 export class PiAiRuntimeAdapter implements PDRuntimeAdapter {

--- a/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
@@ -144,30 +144,15 @@ TAXONOMY DEFINITIONS:
 4. "prompt": Context/Skill injection. Use to influence the agent's workflow habits.
 5. "defer": Insufficient evidence. Use for network timeouts or noise.
 
-OUTPUT FORMAT (pure JSON, no markdown):
-{
-  "valid": true,
-  "diagnosisId": "<generate UUID>",
-  "taskId": "<from input>",
-  "summary": "<one line root cause summary>",
-  "rootCause": "<Design|People|Assumption|Tooling>: <specific root cause>",
-  "violatedPrinciples": [{"rationale": "<why this principle was violated>"}],
-  "evidence": [{"sourceRef": "<sourceRef from context>", "note": "<what this shows>"}],
-  "recommendations": [
-    {"kind": "principle", "description": "<high-level guideline>", "abstractedPrinciple": "<one sentence, <=200 chars>"},
-    {"kind": "rule", "description": "<deterministic constraint>", "triggerPattern": "<regex/keywords>", "action": "<what to do>"},
-    {"kind": "implementation", "description": "<specific code change>"},
-    {"kind": "prompt", "description": "<workflow habit change>"},
-    {"kind": "defer", "description": "<why evidence is insufficient>"}
-  ],
-  "confidence": 0.85,
-  "ambiguityNotes": ["<optional: anything uncertain>"]
-}
+CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
 
-IMPORTANT: The examples above are ILLUSTRATIVE ONLY. Your recommendations MUST be based on the actual root cause analysis and evidence in this context — do not copy the example text verbatim.
+COMPLETE EXAMPLE OUTPUT (follow this exact structure):
+{"valid":true,"diagnosisId":"diag-550e8400-e29b-41d4-a716-446655440000","taskId":"task-abc123","summary":"Missing input validation caused null pointer exception in handler","rootCause":"Design: No null check on input parameter before processing","violatedPrinciples":[{"rationale":"The defensive programming principle was violated by not validating inputs at the boundary"}],"evidence":[{"sourceRef":"src:handler.ts:L42","note":"Null dereference without guard check"},{"sourceRef":"log:error-trace","note":"NullPointerException at handler.process()"}],"recommendations":[{"kind":"rule","description":"Add null check at handler entry point","triggerPattern":"function process(","action":"Insert null guard returning error response"},{"kind":"principle","description":"Validate all external inputs at system boundaries","abstractedPrinciple":"Never trust external data without validation at entry points"},{"kind":"implementation","description":"Add input validation middleware before handler"},{"kind":"prompt","description":"Add defensive validation step to agent workflow"},{"kind":"defer","description":"Upstream caller validation status unclear from available logs"}],"confidence":0.82,"ambiguityNotes":["Stack trace may indicate upstream caller also missing validation"]}
+
+IMPORTANT: The example above is ILLUSTRATIVE ONLY. Your recommendations MUST be based on the actual root cause analysis and evidence in this context — do not copy the example text verbatim.
 
 CONSTRAINTS:
-- Output ONLY valid JSON (no markdown, no explanatory text)
+- Output ONLY valid JSON — no markdown, no explanatory text, no code fences, no prose before or after
 - Do NOT read files, call tools, or write to any database
 - rootCause MUST include category prefix: "Design: ..." or "People: ..." etc.
 - confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
@@ -8,8 +8,9 @@
  * Phase: m6-03
  */
 import { describe, it, expect } from 'vitest';
-import { DiagnosticianPromptBuilder } from '../../diagnostician-prompt-builder.js';
+import { DiagnosticianPromptBuilder, DIAGNOSTIC_PROTOCOL_INSTRUCTION } from '../../diagnostician-prompt-builder.js';
 import type { DiagnosticianContextPayload } from '../../context-payload.js';
+import { extractJsonObject } from '../../adapter/json-extractor.js';
 
 const MINIMAL_PAYLOAD: DiagnosticianContextPayload = {
   contextId: 'ctx-1',
@@ -245,8 +246,7 @@ describe('DiagnosticianPromptBuilder', () => {
       const builder = new DiagnosticianPromptBuilder();
       const result = builder.buildPrompt(MINIMAL_PAYLOAD);
       const instruction = result.promptInput.diagnosticInstruction;
-      // All 5 kinds should appear in the taxonomy definitions
-      const taxonomyBlock = (/TAXONOMY[\s\S]*?OUTPUT FORMAT/.exec(instruction))?.[0] ?? '';
+      const taxonomyBlock = (/TAXONOMY[\s\S]*?CRITICAL/.exec(instruction))?.[0] ?? '';
       expect(taxonomyBlock).toContain('"rule"');
       expect(taxonomyBlock).toContain('"principle"');
       expect(taxonomyBlock).toContain('"implementation"');
@@ -288,11 +288,83 @@ describe('DiagnosticianPromptBuilder', () => {
       const builder = new DiagnosticianPromptBuilder();
       const result = builder.buildPrompt(MINIMAL_PAYLOAD);
       const instruction = result.promptInput.diagnosticInstruction;
-      // Should contain a concrete decimal like 0.85 in the OUTPUT FORMAT section
-      const outputFormat = (/OUTPUT FORMAT[\s\S]*?CONSTRAINTS/.exec(instruction))?.[0] ?? '';
-      expect(outputFormat).toMatch(/"confidence":\s*0\.\d+/);
-      // Should NOT use range notation like 0.0-1.0 in the JSON example
-      expect(outputFormat).not.toMatch(/"confidence":\s*0\.0-1\.0/);
+      const exampleSection = (/COMPLETE EXAMPLE OUTPUT[\s\S]*?CONSTRAINTS/.exec(instruction))?.[0] ?? '';
+      expect(exampleSection).toMatch(/"confidence":\s*0\.\d+/);
+      expect(exampleSection).not.toMatch(/"confidence":\s*0\.0-1\.0/);
+    });
+  });
+
+  describe('prompt contract hardening (PRI-109)', () => {
+    it('instruction contains CRITICAL JSON-only emphasis', () => {
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toContain('CRITICAL');
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toContain('ENTIRE response must be ONLY the JSON object');
+    });
+
+    it('instruction prohibits markdown code fences', () => {
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toContain('Do NOT wrap the JSON in markdown code fences');
+    });
+
+    it('instruction prohibits prose before or after JSON', () => {
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toContain('Do NOT include any text before or after the JSON');
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toContain('Do NOT add explanatory prose');
+    });
+
+    it('instruction contains complete JSON example parseable by extractJsonObject', () => {
+      const parsed = extractJsonObject(DIAGNOSTIC_PROTOCOL_INSTRUCTION);
+      expect(parsed).not.toBeNull();
+    });
+
+    it('JSON example has all required DiagnosticianOutputV1 fields', () => {
+      const example = extractJsonObject(DIAGNOSTIC_PROTOCOL_INSTRUCTION) as Record<string, unknown>;
+      expect(example).toHaveProperty('valid');
+      expect(typeof example.valid).toBe('boolean');
+      expect(example).toHaveProperty('diagnosisId');
+      expect(example).toHaveProperty('taskId');
+      expect(example).toHaveProperty('summary');
+      expect(example).toHaveProperty('rootCause');
+      expect(example).toHaveProperty('violatedPrinciples');
+      expect(Array.isArray(example.violatedPrinciples)).toBe(true);
+      expect(example).toHaveProperty('evidence');
+      expect(Array.isArray(example.evidence)).toBe(true);
+      expect(example).toHaveProperty('recommendations');
+      expect(Array.isArray(example.recommendations)).toBe(true);
+      expect(example).toHaveProperty('confidence');
+      expect(typeof example.confidence).toBe('number');
+      expect(example.confidence).toBeGreaterThanOrEqual(0);
+      expect(example.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('JSON example recommendations cover all 5 taxonomy kinds', () => {
+      const example = extractJsonObject(DIAGNOSTIC_PROTOCOL_INSTRUCTION) as Record<string, unknown>;
+      const recs = example.recommendations as Record<string, unknown>[];
+      const kinds = recs.map(r => r.kind);
+      expect(kinds).toContain('rule');
+      expect(kinds).toContain('principle');
+      expect(kinds).toContain('implementation');
+      expect(kinds).toContain('prompt');
+      expect(kinds).toContain('defer');
+    });
+
+    it('JSON example rule recommendation has triggerPattern and action', () => {
+      const example = extractJsonObject(DIAGNOSTIC_PROTOCOL_INSTRUCTION) as Record<string, unknown>;
+      const recs = example.recommendations as Record<string, unknown>[];
+      const rule = recs.find(r => r.kind === 'rule');
+      expect(rule).toBeDefined();
+      expect(rule).toHaveProperty('triggerPattern');
+      expect(rule).toHaveProperty('action');
+    });
+
+    it('JSON example principle recommendation has abstractedPrinciple', () => {
+      const example = extractJsonObject(DIAGNOSTIC_PROTOCOL_INSTRUCTION) as Record<string, unknown>;
+      const recs = example.recommendations as Record<string, unknown>[];
+      const principle = recs.find(r => r.kind === 'principle');
+      expect(principle).toBeDefined();
+      expect(principle).toHaveProperty('abstractedPrinciple');
+    });
+
+    it('CONSTRAINTS section includes no code fences and no prose emphasis', () => {
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toMatch(/no code fences/);
+      expect(DIAGNOSTIC_PROTOCOL_INSTRUCTION).toMatch(/no prose before or after/);
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -548,6 +548,50 @@ export {
   DEFAULT_ARTIFICER_RUNNER_OPTIONS,
 } from './internalization/artificer-runner.js';
 
+// ── Evaluator Runner (PRI-EVAL) ────────────────────────────────────────────────
+
+export type {
+  EvaluatorEvaluation,
+  EvaluatorSourceTrace,
+  EvaluatorOutputV1,
+  EvaluatorValidationResult,
+  EvaluatorValidator,
+} from './internalization/evaluator-output.js';
+
+export {
+  DefaultEvaluatorValidator,
+  EvaluatorOutputV1Schema,
+  EvaluatorEvaluationSchema,
+  EvaluatorSourceTraceSchema,
+  EVALUATOR_DECISIONS,
+} from './internalization/evaluator-output.js';
+
+export type {
+  EvaluatorRunnerResultStatus,
+  EvaluatorRunnerResult,
+  EvaluatorRunnerOptions,
+  ResolvedEvaluatorRunnerOptions,
+  EvaluatorRunnerDeps,
+} from './internalization/evaluator-runner.js';
+
+export {
+  EvaluatorRunner,
+  resolveEvaluatorRunnerOptions,
+  DEFAULT_EVALUATOR_RUNNER_OPTIONS,
+} from './internalization/evaluator-runner.js';
+
+export {
+  EvaluatorPromptBuilder,
+  EVALUATOR_PROTOCOL_INSTRUCTION,
+  EVALUATOR_PROMPT_CONTRACT_VERSION,
+} from './internalization/evaluator-prompt-builder.js';
+
+export type {
+  EvaluatorPromptBuilderInput,
+  EvaluatorPromptInput,
+  EvaluatorPromptBuildResult,
+} from './internalization/evaluator-prompt-builder.js';
+
 // ── PIArtifact Durable Store (PRI-84) ────────────────────────────────────────
 
 export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts
@@ -105,13 +105,19 @@ describe('EvaluatorPromptBuilder', () => {
     expect(evaluation).toHaveProperty('decision');
     expect(evaluation).toHaveProperty('summary');
     expect(evaluation).toHaveProperty('score');
+    expect(typeof evaluation.score).toBe('number');
     expect(evaluation).toHaveProperty('strengths');
+    expect(Array.isArray(evaluation.strengths)).toBe(true);
     expect(evaluation).toHaveProperty('concerns');
+    expect(Array.isArray(evaluation.concerns)).toBe(true);
     expect(evaluation).toHaveProperty('requiredChanges');
+    expect(Array.isArray(evaluation.requiredChanges)).toBe(true);
     expect(example).toHaveProperty('sourceTrace');
     const sourceTrace = example.sourceTrace as Record<string, unknown>;
     expect(sourceTrace).toHaveProperty('artificerArtifactId');
+    expect(sourceTrace.artificerArtifactId).toBe(example.sourceArtificerArtifactId);
     expect(example).toHaveProperty('risks');
+    expect(Array.isArray(example.risks)).toBe(true);
     expect(example).toHaveProperty('generatedAt');
   });
 

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts
@@ -4,6 +4,7 @@ import {
   EVALUATOR_PROTOCOL_INSTRUCTION,
   EVALUATOR_PROMPT_CONTRACT_VERSION,
 } from '../evaluator-prompt-builder.js';
+import { extractJsonObject } from '../../adapter/json-extractor.js';
 
 describe('EvaluatorPromptBuilder', () => {
   const builder = new EvaluatorPromptBuilder();
@@ -91,5 +92,38 @@ describe('EvaluatorPromptBuilder', () => {
   it('evaluatorInstruction is included in prompt input', () => {
     const { promptInput } = builder.buildPrompt(input);
     expect(promptInput.evaluatorInstruction).toBe(EVALUATOR_PROTOCOL_INSTRUCTION);
+  });
+
+  it('instruction contains complete JSON example with all required fields', () => {
+    const parsed = extractJsonObject(EVALUATOR_PROTOCOL_INSTRUCTION);
+    expect(parsed).not.toBeNull();
+    const example = parsed as Record<string, unknown>;
+    expect(example).toHaveProperty('taskId');
+    expect(example).toHaveProperty('sourceArtificerArtifactId');
+    expect(example).toHaveProperty('evaluation');
+    const evaluation = example.evaluation as Record<string, unknown>;
+    expect(evaluation).toHaveProperty('decision');
+    expect(evaluation).toHaveProperty('summary');
+    expect(evaluation).toHaveProperty('score');
+    expect(evaluation).toHaveProperty('strengths');
+    expect(evaluation).toHaveProperty('concerns');
+    expect(evaluation).toHaveProperty('requiredChanges');
+    expect(example).toHaveProperty('sourceTrace');
+    const sourceTrace = example.sourceTrace as Record<string, unknown>;
+    expect(sourceTrace).toHaveProperty('artificerArtifactId');
+    expect(example).toHaveProperty('risks');
+    expect(example).toHaveProperty('generatedAt');
+  });
+
+  it('instruction says ENTIRE response must be ONLY the JSON object', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('ENTIRE response must be ONLY the JSON object');
+  });
+
+  it('instruction says no text before or after JSON', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('no prose before or after');
+  });
+
+  it('instruction says no markdown code fences', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('Do NOT wrap the JSON in markdown code fences');
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EvaluatorPromptBuilder,
+  EVALUATOR_PROTOCOL_INSTRUCTION,
+  EVALUATOR_PROMPT_CONTRACT_VERSION,
+} from '../evaluator-prompt-builder.js';
+
+describe('EvaluatorPromptBuilder', () => {
+  const builder = new EvaluatorPromptBuilder();
+
+  const input = {
+    taskId: 'evaluator-task-001',
+    contextHash: 'ctx-abc123',
+    sourceArtificerArtifactId: 'pi-art-artificer-001',
+    artificerArtifact: {
+      taskId: 'artificer-task-001',
+      implementationPlan: {
+        summary: 'Add input validation',
+        targetSurface: 'src/ops/*.ts',
+        changes: ['Add try-catch'],
+        tests: ['Unit test for error handling'],
+        rolloutNotes: ['Deploy behind feature flag'],
+        confidence: 0.85,
+      },
+    },
+  };
+
+  it('includes sourceArtificerArtifactId at top level in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.sourceArtificerArtifactId).toBe('pi-art-artificer-001');
+  });
+
+  it('includes taskId in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.taskId).toBe('evaluator-task-001');
+  });
+
+  it('includes contextHash in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.contextHash).toBe('ctx-abc123');
+  });
+
+  it('includes artificerArtifact in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.artificerArtifact).toEqual(input.artificerArtifact);
+  });
+
+  it('instruction says copy sourceArtificerArtifactId exactly', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('sourceArtificerArtifactId MUST be copied exactly from input.sourceArtificerArtifactId');
+  });
+
+  it('instruction says copy sourceTrace.artificerArtifactId exactly', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('sourceTrace.artificerArtifactId MUST be copied exactly from input.sourceArtificerArtifactId');
+  });
+
+  it('instruction includes JSON-only constraint', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('ONLY valid JSON');
+  });
+
+  it('instruction includes no markdown constraint', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('no markdown');
+  });
+
+  it('instruction includes no code fences constraint', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('no code fences');
+  });
+
+  it('promptContractVersion is present in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.promptContractVersion).toBe(EVALUATOR_PROMPT_CONTRACT_VERSION);
+  });
+
+  it('promptContractVersion value is evaluator-output-v1.prompt.v1', () => {
+    expect(EVALUATOR_PROMPT_CONTRACT_VERSION).toBe('evaluator-output-v1.prompt.v1');
+  });
+
+  it('score instruction says number not string/percentage', () => {
+    expect(EVALUATOR_PROTOCOL_INSTRUCTION).toContain('NOT a string, NOT a percentage');
+  });
+
+  it('message is valid JSON containing promptInput', () => {
+    const { message } = builder.buildPrompt(input);
+    const parsed = JSON.parse(message);
+    expect(parsed.taskId).toBe(input.taskId);
+    expect(parsed.contextHash).toBe(input.contextHash);
+    expect(parsed.sourceArtificerArtifactId).toBe(input.sourceArtificerArtifactId);
+    expect(parsed.evaluatorInstruction).toBe(EVALUATOR_PROTOCOL_INSTRUCTION);
+    expect(parsed.promptContractVersion).toBe(EVALUATOR_PROMPT_CONTRACT_VERSION);
+  });
+
+  it('evaluatorInstruction is included in prompt input', () => {
+    const { promptInput } = builder.buildPrompt(input);
+    expect(promptInput.evaluatorInstruction).toBe(EVALUATOR_PROTOCOL_INSTRUCTION);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-output.ts
@@ -1,0 +1,149 @@
+import { Type, type Static } from '@sinclair/typebox';
+
+export interface EvaluatorEvaluation {
+  readonly decision: 'approved' | 'needs_revision' | 'rejected';
+  readonly summary: string;
+  readonly score: number;
+  readonly strengths: readonly string[];
+  readonly concerns: readonly string[];
+  readonly requiredChanges: readonly string[];
+}
+
+export interface EvaluatorSourceTrace {
+  readonly artificerArtifactId: string;
+  readonly scribeArtifactId?: string;
+  readonly philosopherArtifactId?: string;
+  readonly dreamerArtifactId?: string;
+}
+
+export interface EvaluatorOutputV1 {
+  readonly taskId: string;
+  readonly sourceArtificerArtifactId: string;
+  readonly evaluation: EvaluatorEvaluation;
+  readonly sourceTrace: EvaluatorSourceTrace;
+  readonly risks: readonly string[];
+  readonly generatedAt: string;
+}
+
+export const EVALUATOR_DECISIONS = ['approved', 'needs_revision', 'rejected'] as const;
+
+export const EvaluatorEvaluationSchema = Type.Object({
+  decision: Type.Union([
+    Type.Literal('approved'),
+    Type.Literal('needs_revision'),
+    Type.Literal('rejected'),
+  ]),
+  summary: Type.String({ minLength: 1 }),
+  score: Type.Number({ minimum: 0, maximum: 1 }),
+  strengths: Type.Array(Type.String()),
+  concerns: Type.Array(Type.String()),
+  requiredChanges: Type.Array(Type.String()),
+});
+
+export const EvaluatorSourceTraceSchema = Type.Object({
+  artificerArtifactId: Type.String({ minLength: 1 }),
+  scribeArtifactId: Type.Optional(Type.String()),
+  philosopherArtifactId: Type.Optional(Type.String()),
+  dreamerArtifactId: Type.Optional(Type.String()),
+});
+
+export const EvaluatorOutputV1Schema = Type.Object({
+  taskId: Type.String({ minLength: 1 }),
+  sourceArtificerArtifactId: Type.String({ minLength: 1 }),
+  evaluation: EvaluatorEvaluationSchema,
+  sourceTrace: EvaluatorSourceTraceSchema,
+  risks: Type.Array(Type.String()),
+  generatedAt: Type.String({ minLength: 1 }),
+});
+
+export type EvaluatorOutputV1TB = Static<typeof EvaluatorOutputV1Schema>;
+
+export interface EvaluatorValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+export interface EvaluatorValidator {
+  validate(output: EvaluatorOutputV1, taskId: string, expectedSourceArtificerArtifactId?: string): Promise<EvaluatorValidationResult>;
+}
+
+export class DefaultEvaluatorValidator implements EvaluatorValidator {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async validate(output: EvaluatorOutputV1, taskId: string, expectedSourceArtificerArtifactId?: string): Promise<EvaluatorValidationResult> {
+    const errors: string[] = [];
+
+    if (typeof output !== 'object' || output === null) {
+      return { valid: false, errors: ['Output is not an object'], errorCategory: 'output_invalid' };
+    }
+
+    if (output.taskId !== taskId) {
+      errors.push(`taskId mismatch: expected ${taskId}, got ${String(output.taskId)}`);
+    }
+
+    if (typeof output.sourceArtificerArtifactId !== 'string' || output.sourceArtificerArtifactId.trim() === '') {
+      errors.push('sourceArtificerArtifactId must be non-empty string');
+    } else if (expectedSourceArtificerArtifactId && output.sourceArtificerArtifactId !== expectedSourceArtificerArtifactId) {
+      errors.push(`sourceArtificerArtifactId mismatch: expected ${expectedSourceArtificerArtifactId}, got ${output.sourceArtificerArtifactId}`);
+    }
+
+    if (typeof output.evaluation !== 'object' || output.evaluation === null) {
+      errors.push('evaluation must be an object');
+    } else {
+      const ev = output.evaluation as unknown as Record<string, unknown>;
+      if (!EVALUATOR_DECISIONS.includes(ev.decision as 'approved' | 'needs_revision' | 'rejected')) {
+        errors.push(`evaluation.decision must be one of ${EVALUATOR_DECISIONS.join('/')}, got ${String(ev.decision)}`);
+      }
+      if (typeof ev.summary !== 'string' || (ev.summary).trim() === '') errors.push('evaluation.summary must be non-empty string');
+      if (typeof ev.score !== 'number' || !Number.isFinite(ev.score)) errors.push('evaluation.score must be number');
+      else if (ev.score < 0 || ev.score > 1) errors.push('evaluation.score must be in [0, 1]');
+      if (!Array.isArray(ev.strengths)) errors.push('evaluation.strengths must be an array');
+      else if (!(ev.strengths as unknown[]).every(e => typeof e === 'string')) errors.push('evaluation.strengths must be an array of strings');
+      if (!Array.isArray(ev.concerns)) errors.push('evaluation.concerns must be an array');
+      else if (!(ev.concerns as unknown[]).every(e => typeof e === 'string')) errors.push('evaluation.concerns must be an array of strings');
+      if (!Array.isArray(ev.requiredChanges)) errors.push('evaluation.requiredChanges must be an array');
+      else if (!(ev.requiredChanges as unknown[]).every(e => typeof e === 'string')) errors.push('evaluation.requiredChanges must be an array of strings');
+    }
+
+    if (typeof output.sourceTrace !== 'object' || output.sourceTrace === null) {
+      errors.push('sourceTrace must be an object');
+    } else {
+      const st = output.sourceTrace as unknown as Record<string, unknown>;
+      if (typeof st.artificerArtifactId !== 'string' || (st.artificerArtifactId).trim() === '') {
+        errors.push('sourceTrace.artificerArtifactId must be non-empty string');
+      } else if (expectedSourceArtificerArtifactId && st.artificerArtifactId !== expectedSourceArtificerArtifactId) {
+        errors.push(`sourceTrace.artificerArtifactId mismatch: expected ${expectedSourceArtificerArtifactId}, got ${st.artificerArtifactId}`);
+      }
+      if (st.scribeArtifactId !== undefined && typeof st.scribeArtifactId !== 'string') {
+        errors.push('sourceTrace.scribeArtifactId must be string if present');
+      }
+      if (st.philosopherArtifactId !== undefined && typeof st.philosopherArtifactId !== 'string') {
+        errors.push('sourceTrace.philosopherArtifactId must be string if present');
+      }
+      if (st.dreamerArtifactId !== undefined && typeof st.dreamerArtifactId !== 'string') {
+        errors.push('sourceTrace.dreamerArtifactId must be string if present');
+      }
+    }
+
+    if (!Array.isArray(output.risks)) {
+      errors.push('risks must be an array');
+    } else if (!(output.risks as unknown[]).every(e => typeof e === 'string')) {
+      errors.push('risks must be an array of strings');
+    }
+
+    if (typeof output.sourceArtificerArtifactId === 'string' && output.sourceArtificerArtifactId.trim() !== ''
+      && typeof output.sourceTrace === 'object' && output.sourceTrace !== null
+      && typeof (output.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId === 'string'
+      && output.sourceArtificerArtifactId !== (output.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId) {
+      errors.push('sourceArtificerArtifactId and sourceTrace.artificerArtifactId must match');
+    }
+
+    if (typeof output.generatedAt !== 'string' || output.generatedAt.trim() === '') {
+      errors.push('generatedAt must be non-empty string');
+    }
+
+    return errors.length > 0
+      ? { valid: false, errors, errorCategory: 'output_invalid' }
+      : { valid: true, errors: [] };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts
@@ -30,30 +30,13 @@ PROTOCOL:
 6. Preserve the lineage trace from artificer, scribe, philosopher, and dreamer artifacts
 7. Identify risks associated with this evaluation
 
-OUTPUT FORMAT (pure JSON, no markdown):
-{
-  "taskId": "<from input>",
-  "sourceArtificerArtifactId": "<copy exactly from input.sourceArtificerArtifactId>",
-  "evaluation": {
-    "decision": "approved" | "needs_revision" | "rejected",
-    "summary": "<concise evaluation summary>",
-    "score": 0.85,
-    "strengths": ["<strength 1>", "<strength 2>"],
-    "concerns": ["<concern 1>", "<concern 2>"],
-    "requiredChanges": ["<change 1>", "<change 2>"]
-  },
-  "sourceTrace": {
-    "artificerArtifactId": "<copy exactly from input.sourceArtificerArtifactId>",
-    "scribeArtifactId": "<from artificer artifact if available, or omit>",
-    "philosopherArtifactId": "<from artificer artifact if available, or omit>",
-    "dreamerArtifactId": "<from artificer artifact if available, or omit>"
-  },
-  "risks": ["<risk 1>", "<risk 2>"],
-  "generatedAt": "<ISO-8601 timestamp>"
-}
+CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
+
+COMPLETE EXAMPLE OUTPUT (follow this exact structure):
+{"taskId":"task-123","sourceArtificerArtifactId":"pi-art-artificer-001","evaluation":{"decision":"approved","summary":"The implementation plan is well-structured and addresses the identified issues.","score":0.85,"strengths":["Clear change descriptions with specific file targets","Good test coverage plan"],"concerns":["Rollout notes could be more specific about monitoring"],"requiredChanges":[]},"sourceTrace":{"artificerArtifactId":"pi-art-artificer-001"},"risks":["May need additional integration tests"],"generatedAt":"2026-05-11T12:00:00.000Z"}
 
 CONSTRAINTS:
-- Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
+- Output ONLY valid JSON — no markdown, no explanatory text, no code fences, no prose before or after
 - evaluation.decision MUST be one of: approved, needs_revision, rejected
 - evaluation.summary MUST be a non-empty string
 - evaluation.score MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts
@@ -1,0 +1,90 @@
+export interface EvaluatorPromptBuilderInput {
+  taskId: string;
+  contextHash: string;
+  sourceArtificerArtifactId: string;
+  artificerArtifact: unknown;
+}
+
+export interface EvaluatorPromptInput {
+  taskId: string;
+  contextHash: string;
+  sourceArtificerArtifactId: string;
+  artificerArtifact: unknown;
+  evaluatorInstruction: string;
+  promptContractVersion: string;
+}
+
+export interface EvaluatorPromptBuildResult {
+  readonly message: string;
+  readonly promptInput: EvaluatorPromptInput;
+}
+
+export const EVALUATOR_PROTOCOL_INSTRUCTION = `You are an Evaluator agent in a principle internalization pipeline. Your role is to critically review the Artificer's implementation plan and produce a structured evaluation with a decision, score, and actionable feedback.
+
+PROTOCOL:
+1. Review the artificerArtifact to understand the proposed implementation plan
+2. Evaluate the plan against quality criteria: completeness, feasibility, test coverage, risk mitigation
+3. Produce a decision: approved (plan is sound), needs_revision (plan has issues but is salvageable), or rejected (plan is fundamentally flawed)
+4. Provide a score from 0.0 to 1.0 reflecting overall quality
+5. List specific strengths, concerns, and required changes
+6. Preserve the lineage trace from artificer, scribe, philosopher, and dreamer artifacts
+7. Identify risks associated with this evaluation
+
+OUTPUT FORMAT (pure JSON, no markdown):
+{
+  "taskId": "<from input>",
+  "sourceArtificerArtifactId": "<copy exactly from input.sourceArtificerArtifactId>",
+  "evaluation": {
+    "decision": "approved" | "needs_revision" | "rejected",
+    "summary": "<concise evaluation summary>",
+    "score": 0.85,
+    "strengths": ["<strength 1>", "<strength 2>"],
+    "concerns": ["<concern 1>", "<concern 2>"],
+    "requiredChanges": ["<change 1>", "<change 2>"]
+  },
+  "sourceTrace": {
+    "artificerArtifactId": "<copy exactly from input.sourceArtificerArtifactId>",
+    "scribeArtifactId": "<from artificer artifact if available, or omit>",
+    "philosopherArtifactId": "<from artificer artifact if available, or omit>",
+    "dreamerArtifactId": "<from artificer artifact if available, or omit>"
+  },
+  "risks": ["<risk 1>", "<risk 2>"],
+  "generatedAt": "<ISO-8601 timestamp>"
+}
+
+CONSTRAINTS:
+- Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
+- evaluation.decision MUST be one of: approved, needs_revision, rejected
+- evaluation.summary MUST be a non-empty string
+- evaluation.score MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- evaluation.strengths MUST be an array of strings (can be empty)
+- evaluation.concerns MUST be an array of strings (can be empty)
+- evaluation.requiredChanges MUST be an array of strings (can be empty)
+- sourceArtificerArtifactId MUST be copied exactly from input.sourceArtificerArtifactId (non-empty string)
+- sourceTrace.artificerArtifactId MUST be copied exactly from input.sourceArtificerArtifactId
+- sourceTrace.scribeArtifactId is optional — include only if available from artificer artifact
+- sourceTrace.philosopherArtifactId is optional — include only if available from artificer artifact
+- sourceTrace.dreamerArtifactId is optional — include only if available from artificer artifact
+- risks MUST be an array of strings (can be empty if no risks identified)
+- generatedAt MUST be an ISO-8601 timestamp string
+`;
+
+export const EVALUATOR_PROMPT_CONTRACT_VERSION = 'evaluator-output-v1.prompt.v1';
+
+export class EvaluatorPromptBuilder {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildPrompt(input: EvaluatorPromptBuilderInput): EvaluatorPromptBuildResult {
+    const promptInput: EvaluatorPromptInput = {
+      taskId: input.taskId,
+      contextHash: input.contextHash,
+      sourceArtificerArtifactId: input.sourceArtificerArtifactId,
+      artificerArtifact: input.artificerArtifact,
+      evaluatorInstruction: EVALUATOR_PROTOCOL_INSTRUCTION,
+      promptContractVersion: EVALUATOR_PROMPT_CONTRACT_VERSION,
+    };
+
+    const message = JSON.stringify(promptInput);
+
+    return { message, promptInput };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -1,0 +1,673 @@
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type {
+  PDRuntimeAdapter,
+  RunHandle,
+  RunStatus,
+  StartRunInput,
+} from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { EvaluatorOutputV1, EvaluatorValidator } from './evaluator-output.js';
+import type { PIArtifactStore } from './pi-artifact.js';
+import type { TaskRecord } from '../task-status.js';
+import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
+import type { TelemetryEvent } from '../../telemetry-event.js';
+import { hydratePITaskRecord } from './pitask-metadata.js';
+import { RunnerPhase } from '../runner/runner-phase.js';
+import { EvaluatorPromptBuilder } from './evaluator-prompt-builder.js';
+
+export type EvaluatorRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
+
+export interface EvaluatorRunnerResult {
+  readonly status: EvaluatorRunnerResultStatus;
+  readonly taskId: string;
+  readonly runId?: string;
+  readonly artifactId?: string;
+  readonly resultRef?: string;
+  readonly contextHash?: string;
+  readonly output?: EvaluatorOutputV1;
+  readonly errorCategory?: PDErrorCategory;
+  readonly failureReason?: string;
+  readonly attemptCount: number;
+}
+
+export interface EvaluatorRunnerOptions {
+  readonly pollIntervalMs?: number;
+  readonly timeoutMs?: number;
+  readonly defaultMaxAttempts?: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId?: string;
+}
+
+export interface ResolvedEvaluatorRunnerOptions {
+  readonly pollIntervalMs: number;
+  readonly timeoutMs: number;
+  readonly defaultMaxAttempts: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId: string;
+}
+
+const DEFAULT_EVALUATOR_RUNNER_OPTIONS: Readonly<Omit<ResolvedEvaluatorRunnerOptions, 'owner' | 'runtimeKind'>> = {
+  pollIntervalMs: 5_000,
+  timeoutMs: 300_000,
+  defaultMaxAttempts: 3,
+  agentId: 'evaluator',
+} as const;
+
+export function resolveEvaluatorRunnerOptions(options: EvaluatorRunnerOptions): ResolvedEvaluatorRunnerOptions {
+  return {
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_EVALUATOR_RUNNER_OPTIONS.pollIntervalMs,
+    timeoutMs: options.timeoutMs ?? DEFAULT_EVALUATOR_RUNNER_OPTIONS.timeoutMs,
+    defaultMaxAttempts: options.defaultMaxAttempts ?? DEFAULT_EVALUATOR_RUNNER_OPTIONS.defaultMaxAttempts,
+    owner: options.owner,
+    runtimeKind: options.runtimeKind,
+    agentId: options.agentId ?? DEFAULT_EVALUATOR_RUNNER_OPTIONS.agentId,
+  };
+}
+
+export interface EvaluatorRunnerDeps {
+  readonly stateManager: RuntimeStateManager;
+  readonly runtimeAdapter: PDRuntimeAdapter;
+  readonly eventEmitter: StoreEventEmitter;
+  readonly validator: EvaluatorValidator;
+  readonly artifactStore: PIArtifactStore;
+}
+
+interface FailureContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errorCategory: PDErrorCategory;
+  readonly failureReason: string;
+}
+
+interface SucceedContext {
+  readonly taskId: string;
+  readonly runId: string;
+  readonly output: EvaluatorOutputV1;
+  readonly task: TaskRecord;
+  readonly contextHash: string;
+}
+
+interface ValidationErrorContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+export class EvaluatorRunner {
+  private phase: RunnerPhase = RunnerPhase.Idle;
+  private readonly resolvedOptions: ResolvedEvaluatorRunnerOptions;
+  private readonly stateManager: RuntimeStateManager;
+  private readonly runtimeAdapter: PDRuntimeAdapter;
+  private readonly eventEmitter: StoreEventEmitter;
+  private readonly validator: EvaluatorValidator;
+  private readonly artifactStore: PIArtifactStore;
+
+  constructor(deps: EvaluatorRunnerDeps, options: EvaluatorRunnerOptions) {
+    this.stateManager = deps.stateManager;
+    this.runtimeAdapter = deps.runtimeAdapter;
+    this.eventEmitter = deps.eventEmitter;
+    this.validator = deps.validator;
+    this.artifactStore = deps.artifactStore;
+    this.resolvedOptions = resolveEvaluatorRunnerOptions(options);
+  }
+
+  get currentPhase(): RunnerPhase {
+    return this.phase;
+  }
+
+  private emitEvaluatorEvent(
+    eventType: string,
+    taskId: string,
+    payload: Record<string, unknown>,
+  ): void {
+    this.eventEmitter.emitTelemetry({
+      eventType: eventType as TelemetryEvent['eventType'],
+      traceId: taskId,
+      timestamp: new Date().toISOString(),
+      sessionId: this.resolvedOptions.owner,
+      agentId: this.resolvedOptions.agentId,
+      payload,
+    });
+  }
+
+  async run(taskId: string): Promise<EvaluatorRunnerResult> {
+    this.phase = RunnerPhase.Idle;
+
+    // eslint-disable-next-line @typescript-eslint/init-declarations
+    let leasedTask: TaskRecord;
+    try {
+      leasedTask = await this.stateManager.acquireLease({
+        taskId,
+        owner: this.resolvedOptions.owner,
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+    } catch (error) {
+      return await this.handleLeaseOrPhaseError(taskId, error);
+    }
+
+    if (leasedTask.taskKind !== 'evaluator') {
+      this.emitEvaluatorEvent('evaluator_wrong_task_kind', taskId, {
+        expectedKind: 'evaluator',
+        actualKind: leasedTask.taskKind,
+      });
+      await this.stateManager.markTaskFailed(taskId, 'input_invalid');
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'input_invalid',
+        failureReason: `Task kind must be 'evaluator', got '${leasedTask.taskKind}'`,
+        attemptCount: leasedTask.attemptCount,
+      };
+    }
+
+    this.emitEvaluatorEvent('evaluator_task_leased', taskId, {
+      taskKind: 'evaluator',
+      attemptCount: leasedTask.attemptCount,
+    });
+
+    try {
+      const storeRunId = await this.resolveStoreRunId(taskId);
+
+      this.phase = RunnerPhase.BuildingContext;
+      const { contextHash, artificerArtifact, sourceArtificerArtifactId } = await this.buildContext(taskId);
+
+      if (!artificerArtifact || !sourceArtificerArtifactId) {
+        return this.retryOrFail({
+          taskId,
+          task: leasedTask,
+          errorCategory: 'input_invalid',
+          failureReason: sourceArtificerArtifactId ? 'Artificer dependency artifact not found' : 'Artificer dependency artifact ID not resolved',
+        });
+      }
+
+      this.emitEvaluatorEvent('evaluator_context_built', taskId, { contextHash });
+
+      this.phase = RunnerPhase.Invoking;
+      const runHandle = await this.invokeRuntime({ taskId, contextHash, artificerArtifact, sourceArtificerArtifactId });
+
+      this.emitEvaluatorEvent('evaluator_run_started', taskId, {
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+
+      this.phase = RunnerPhase.Polling;
+      const finalStatus = await this.pollUntilTerminal(runHandle);
+
+      if (finalStatus.status !== 'succeeded') {
+        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
+      }
+
+      this.phase = RunnerPhase.FetchingOutput;
+      const output = await this.fetchAndParseOutput(runHandle.runId);
+
+      this.phase = RunnerPhase.Validating;
+      const validationResult = await this.validator.validate(output, taskId, sourceArtificerArtifactId ?? undefined);
+      if (!validationResult.valid) {
+        return await this.handleValidationError({
+          taskId,
+          task: leasedTask,
+          errors: validationResult.errors,
+          errorCategory: validationResult.errorCategory,
+        });
+      }
+
+      this.emitEvaluatorEvent('evaluator_output_validated', taskId, {
+        evaluationDecision: output.evaluation.decision,
+        evaluationScore: output.evaluation.score,
+      });
+
+      return await this.succeedTask({
+        taskId,
+        runId: storeRunId,
+        output,
+        task: leasedTask,
+        contextHash,
+      });
+    } catch (error) {
+      return await this.handlePostLeaseError(taskId, leasedTask, error);
+    }
+  }
+
+  private async buildContext(taskId: string): Promise<{ contextHash: string; artificerArtifact: string | null; sourceArtificerArtifactId: string | null }> {
+    const task = await this.stateManager.getTask(taskId);
+    if (!task) {
+      throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
+    }
+
+    const piTask = hydratePITaskRecord(task);
+    const deps = piTask?.dependencyTaskIds ?? [];
+
+    if (deps.length === 0) {
+      this.emitEvaluatorEvent('evaluator_no_dependencies', taskId, {});
+      return { contextHash: 'empty', artificerArtifact: null, sourceArtificerArtifactId: null };
+    }
+
+    for (const depId of deps) {
+      const depTask = await this.stateManager.getTask(depId);
+      if (!depTask) continue;
+      if (depTask.taskKind !== 'artificer') continue;
+      if (depTask.status !== 'succeeded') {
+        this.emitEvaluatorEvent('evaluator_dependency_not_succeeded', taskId, {
+          depTaskId: depId,
+          depStatus: depTask.status,
+        });
+        continue;
+      }
+
+      const artifacts = await this.artifactStore.listBySourceTaskId(depId);
+      if (artifacts.length > 0) {
+        const [firstArtifact] = artifacts;
+        if (!firstArtifact) continue;
+        const artifactRef = firstArtifact.artifactId;
+        this.emitEvaluatorEvent('evaluator_artificer_dep_selected', taskId, {
+          depTaskId: depId,
+          artifactId: firstArtifact.artifactId,
+        });
+        return {
+          contextHash: EvaluatorRunner.hashContextRefs([artifactRef]),
+          artificerArtifact: firstArtifact.contentJson,
+          sourceArtificerArtifactId: firstArtifact.artifactId,
+        };
+      }
+    }
+
+    this.emitEvaluatorEvent('evaluator_no_artificer_artifact', taskId, {});
+    return { contextHash: 'empty', artificerArtifact: null, sourceArtificerArtifactId: null };
+  }
+
+  private static hashContextRefs(refs: readonly string[]): string {
+    if (refs.length === 0) return 'empty';
+    const str = refs.join('|');
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+    }
+    return `ctx-${Math.abs(hash).toString(16)}`;
+  }
+
+  private async resolveStoreRunId(taskId: string): Promise<string> {
+    const runs = await this.stateManager.getRunsByTask(taskId);
+    const latestRun = runs[runs.length - 1];
+    if (!latestRun) {
+      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
+    }
+    return latestRun.runId;
+  }
+
+  private async invokeRuntime(params: {
+    taskId: string;
+    contextHash: string;
+    artificerArtifact: string | null;
+    sourceArtificerArtifactId: string;
+  }): Promise<RunHandle> {
+    let parsedArtificerArtifact: unknown = null;
+    if (params.artificerArtifact) {
+      try {
+        parsedArtificerArtifact = JSON.parse(params.artificerArtifact);
+      } catch {
+        parsedArtificerArtifact = params.artificerArtifact;
+      }
+    }
+
+    const builder = new EvaluatorPromptBuilder();
+    const { message } = builder.buildPrompt({
+      taskId: params.taskId,
+      contextHash: params.contextHash,
+      artificerArtifact: parsedArtificerArtifact,
+      sourceArtificerArtifactId: params.sourceArtificerArtifactId,
+    });
+
+    const startInput: StartRunInput = {
+      agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
+      taskRef: { taskId: params.taskId },
+      inputPayload: message,
+      contextItems: [],
+      outputSchemaRef: 'evaluator-output-v1',
+      timeoutMs: this.resolvedOptions.timeoutMs,
+    };
+
+    return this.runtimeAdapter.startRun(startInput);
+  }
+
+  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
+    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
+
+    while (Date.now() < deadline) {
+      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(status.status)) {
+        return status;
+      }
+      await this.sleep(this.resolvedOptions.pollIntervalMs);
+    }
+
+    let cancelFailed = false;
+    try {
+      await this.runtimeAdapter.cancelRun(runHandle.runId);
+    } catch (cancelErr) {
+      cancelFailed = true;
+      this.emitEvaluatorEvent('evaluator_cancel_run_failed', runHandle.runId, {
+        runId: runHandle.runId,
+        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
+      });
+    }
+    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
+    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
+  }
+
+  private async fetchAndParseOutput(runId: string): Promise<EvaluatorOutputV1> {
+    const result = await this.runtimeAdapter.fetchOutput(runId);
+    if (!result || !result.payload) {
+      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
+    }
+    return result.payload as EvaluatorOutputV1;
+  }
+
+  private async succeedTask(ctx: SucceedContext): Promise<EvaluatorRunnerResult> {
+    try {
+      await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));
+    } catch (updateErr) {
+      this.emitEvaluatorEvent('evaluator_update_output_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
+      });
+      throw updateErr;
+    }
+
+    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
+    const now = new Date().toISOString();
+
+    let lineageArtifactIds: string[] = [];
+    try {
+      const piTask = hydratePITaskRecord(ctx.task);
+      const deps = piTask?.dependencyTaskIds ?? [];
+      const results = await Promise.allSettled(
+        deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          for (const artifact of result.value) {
+            lineageArtifactIds.push(artifact.artifactId);
+          }
+        }
+      }
+    } catch { /* lineage resolution failure is non-fatal */ }
+
+    try {
+      await this.artifactStore.upsertArtifact({
+        artifactId,
+        artifactKind: 'principle',
+        sourceTaskId: ctx.taskId,
+        lineageArtifactIds,
+        validationStatus: 'pending',
+        contentJson: JSON.stringify(ctx.output),
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (artifactErr) {
+      this.emitEvaluatorEvent('evaluator_artifact_write_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
+      });
+      return this.retryOrFail({
+        taskId: ctx.taskId,
+        task: ctx.task,
+        errorCategory: 'artifact_commit_failed',
+        failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
+      });
+    }
+
+    const resultRef = `evaluator://${ctx.runId}`;
+    try {
+      await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
+    } catch (stateErr) {
+      this.emitEvaluatorEvent('evaluator_mark_succeeded_failed', ctx.taskId, {
+        taskId: ctx.taskId,
+        runId: ctx.runId,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      throw stateErr;
+    }
+
+    this.emitEvaluatorEvent('evaluator_task_succeeded', ctx.taskId, {
+      attemptCount: ctx.task.attemptCount,
+      resultRef,
+      evaluationDecision: ctx.output.evaluation.decision,
+      evaluationScore: ctx.output.evaluation.score,
+    });
+
+    this.phase = RunnerPhase.Completed;
+    return {
+      status: 'succeeded',
+      taskId: ctx.taskId,
+      runId: ctx.runId,
+      artifactId,
+      resultRef,
+      contextHash: ctx.contextHash,
+      output: ctx.output,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  private async handleRuntimeFailure(
+    taskId: string,
+    task: TaskRecord,
+    runStatus: RunStatus,
+  ): Promise<EvaluatorRunnerResult> {
+    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status);
+
+    this.emitEvaluatorEvent('evaluator_run_failed', taskId, {
+      runStatus: runStatus.status,
+      errorCategory,
+    });
+
+    return this.retryOrFail({
+      taskId,
+      task,
+      errorCategory,
+      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
+    });
+  }
+
+  private async handleValidationError(ctx: ValidationErrorContext): Promise<EvaluatorRunnerResult> {
+    const category = (ctx.errorCategory ?? 'output_invalid') as PDErrorCategory;
+
+    this.emitEvaluatorEvent('evaluator_output_invalid', ctx.taskId, {
+      errorCount: ctx.errors.length,
+      errorCategory: category,
+    });
+
+    return this.retryOrFail({
+      taskId: ctx.taskId,
+      task: ctx.task,
+      errorCategory: category,
+      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
+    });
+  }
+
+  private async handleLeaseOrPhaseError(
+    taskId: string,
+    error: unknown,
+  ): Promise<EvaluatorRunnerResult> {
+    const classified = this.classifyError(error);
+
+    if (classified.category === 'lease_conflict') {
+      this.emitEvaluatorEvent('evaluator_run_failed', taskId, {
+        errorCategory: 'lease_conflict',
+        errorMessage: classified.message,
+      });
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'lease_conflict',
+        failureReason: classified.message,
+        attemptCount: 1,
+      };
+    }
+
+    this.emitEvaluatorEvent('evaluator_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    const task: TaskRecord = {
+      taskId,
+      taskKind: 'evaluator',
+      status: 'leased',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      attemptCount: 1,
+      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
+    };
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async handlePostLeaseError(
+    taskId: string,
+    task: TaskRecord,
+    error: unknown,
+  ): Promise<EvaluatorRunnerResult> {
+    const classified = this.classifyError(error);
+
+    this.emitEvaluatorEvent('evaluator_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async retryOrFail(ctx: FailureContext): Promise<EvaluatorRunnerResult> {
+    if (this.isPermanentError(ctx.errorCategory)) {
+      try {
+        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitEvaluatorEvent('evaluator_mark_failed_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitEvaluatorEvent('evaluator_task_failed', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+        failureReason: ctx.failureReason,
+      });
+      this.phase = RunnerPhase.Failed;
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
+    if (shouldRetry) {
+      try {
+        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitEvaluatorEvent('evaluator_mark_retry_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitEvaluatorEvent('evaluator_task_retried', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+      });
+      this.phase = RunnerPhase.RetryWaiting;
+      return {
+        status: 'retried',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    try {
+      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
+    } catch (stateErr) {
+      this.emitEvaluatorEvent('evaluator_mark_failed_error', ctx.taskId, {
+        errorCategory: 'storage_unavailable',
+        attemptCount: ctx.task.attemptCount,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `State manager error: ${ctx.failureReason}`,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+    this.emitEvaluatorEvent('evaluator_task_failed', ctx.taskId, {
+      errorCategory: 'max_attempts_exceeded',
+      attemptCount: ctx.task.attemptCount,
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+    });
+    this.phase = RunnerPhase.Failed;
+    return {
+      status: 'failed',
+      taskId: ctx.taskId,
+      errorCategory: 'max_attempts_exceeded',
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  private readonly PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set(
+    Object.freeze(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid'] as const),
+  );
+
+  private isPermanentError(category: PDErrorCategory): boolean {
+    return this.PERMANENT_ERROR_CATEGORIES.has(category);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
+    if (error instanceof PDRuntimeError) {
+      return { category: error.category, message: error.message };
+    }
+    if (error instanceof Error) {
+      return { category: 'execution_failed', message: error.message };
+    }
+    return { category: 'execution_failed', message: String(error) };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private mapRunStatusToErrorCategory(status: string): PDErrorCategory {
+    switch (status) {
+      case 'failed': return 'execution_failed';
+      case 'timed_out': return 'timeout';
+      case 'cancelled': return 'cancelled';
+      default: return 'execution_failed';
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+export { DEFAULT_EVALUATOR_RUNNER_OPTIONS };

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -96,6 +96,10 @@ interface ValidationErrorContext {
   readonly errorCategory?: string;
 }
 
+const EVALUATOR_PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set<PDErrorCategory>([
+  'storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid',
+]);
+
 export class EvaluatorRunner {
   private phase: RunnerPhase = RunnerPhase.Idle;
   private readonly resolvedOptions: ResolvedEvaluatorRunnerOptions;
@@ -153,14 +157,12 @@ export class EvaluatorRunner {
         expectedKind: 'evaluator',
         actualKind: leasedTask.taskKind,
       });
-      await this.stateManager.markTaskFailed(taskId, 'input_invalid');
-      return {
-        status: 'failed',
+      return this.retryOrFail({
         taskId,
+        task: leasedTask,
         errorCategory: 'input_invalid',
         failureReason: `Task kind must be 'evaluator', got '${leasedTask.taskKind}'`,
-        attemptCount: leasedTask.attemptCount,
-      };
+      });
     }
 
     this.emitEvaluatorEvent('evaluator_task_leased', taskId, {
@@ -343,6 +345,13 @@ export class EvaluatorRunner {
       await this.sleep(this.resolvedOptions.pollIntervalMs);
     }
 
+    try {
+      const finalPoll = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(finalPoll.status)) {
+        return finalPoll;
+      }
+    } catch { /* fall through to cancel/timeout */ }
+
     let cancelFailed = false;
     try {
       await this.runtimeAdapter.cancelRun(runHandle.runId);
@@ -361,6 +370,13 @@ export class EvaluatorRunner {
     const result = await this.runtimeAdapter.fetchOutput(runId);
     if (!result || !result.payload) {
       throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
+    }
+    const payload = result.payload as Record<string, unknown>;
+    if (typeof payload !== 'object' || payload === null) {
+      throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
+    }
+    if (typeof payload.evaluation !== 'object' || payload.evaluation === null) {
+      throw new PDRuntimeError('output_invalid', `Output payload missing evaluation object for run ${runId}`);
     }
     return result.payload as EvaluatorOutputV1;
   }
@@ -635,12 +651,9 @@ export class EvaluatorRunner {
     };
   }
 
-  private readonly PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set(
-    Object.freeze(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid'] as const),
-  );
-
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private isPermanentError(category: PDErrorCategory): boolean {
-    return this.PERMANENT_ERROR_CATEGORIES.has(category);
+    return EVALUATOR_PERMANENT_ERROR_CATEGORIES.has(category);
   }
 
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -263,6 +263,50 @@ export {
   DEFAULT_ARTIFICER_RUNNER_OPTIONS,
 } from './artificer-runner.js';
 
+// ── Evaluator Runner (PRI-EVAL) ────────────────────────────────────────────────
+
+export type {
+  EvaluatorEvaluation,
+  EvaluatorSourceTrace,
+  EvaluatorOutputV1,
+  EvaluatorValidationResult,
+  EvaluatorValidator,
+} from './evaluator-output.js';
+
+export {
+  DefaultEvaluatorValidator,
+  EvaluatorOutputV1Schema,
+  EvaluatorEvaluationSchema,
+  EvaluatorSourceTraceSchema,
+  EVALUATOR_DECISIONS,
+} from './evaluator-output.js';
+
+export type {
+  EvaluatorRunnerResultStatus,
+  EvaluatorRunnerResult,
+  EvaluatorRunnerOptions,
+  ResolvedEvaluatorRunnerOptions,
+  EvaluatorRunnerDeps,
+} from './evaluator-runner.js';
+
+export {
+  EvaluatorRunner,
+  resolveEvaluatorRunnerOptions,
+  DEFAULT_EVALUATOR_RUNNER_OPTIONS,
+} from './evaluator-runner.js';
+
+export {
+  EvaluatorPromptBuilder,
+  EVALUATOR_PROTOCOL_INSTRUCTION,
+  EVALUATOR_PROMPT_CONTRACT_VERSION,
+} from './evaluator-prompt-builder.js';
+
+export type {
+  EvaluatorPromptBuilderInput,
+  EvaluatorPromptInput,
+  EvaluatorPromptBuildResult,
+} from './evaluator-prompt-builder.js';
+
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 
 export type {

--- a/packages/principles-core/src/telemetry-event.ts
+++ b/packages/principles-core/src/telemetry-event.ts
@@ -58,6 +58,7 @@ import { Value } from '@sinclair/typebox/value';
  * - output_validation_succeeded — output validation passed
  * - output_validation_failed — output validation failed
  * - output_repair_attempted — PRI-71 schema repair attempted (bounded by maxRepairAttempts)
+ * - output_extraction_failed — JSON extraction from LLM response failed (no parseable JSON found)
  */
 export const TelemetryEventType = Type.Union([
   Type.Literal('pain_detected'),
@@ -98,6 +99,7 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('output_validation_succeeded'),
   Type.Literal('output_validation_failed'),
   Type.Literal('output_repair_attempted'),
+  Type.Literal('output_extraction_failed'),
   // PRI-67: Dreamer runner events
   Type.Literal('dreamer_task_leased'),
   Type.Literal('dreamer_context_built'),


### PR DESCRIPTION
## EvaluatorRunner Vertical Slice + output_invalid Hardening

### 现象
Production internalization queue blocked on evaluator — 1 ready evaluator task cannot proceed because no EvaluatorRunner implementation exists。生产验证中 EvaluatorRunner 和 DiagnosticianRunner 均出现 output_invalid（LLM 返回非 JSON）。

### 根因
1. EvaluatorRunner was listed in PeerRunnerKind but had no implementation
2. LLM (MiniMax-M2.7) 返回 prose-wrapped 或非 JSON 响应，导致 extractJsonObject 返回 null
3. DIAGNOSTIC_PROTOCOL_INSTRUCTION 缺少 CRITICAL JSON-only 强调和完整示例

### 修改文件

**New files (6):**
- \packages/principles-core/src/runtime-v2/internalization/evaluator-output.ts\ — EvaluatorOutputV1 interface, TypeBox schemas, DefaultEvaluatorValidator
- \packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts\ — Hardened JSON prompt builder with CRITICAL emphasis, complete JSON example
- \packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts\ — Phase-tracked runner with artifact lookup, sourceArtificerArtifactId validation
- \packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts\ — 33 tests
- \packages/principles-core/src/runtime-v2/internalization/__tests__/evaluator-prompt-builder.test.ts\ — 18 tests (14 original + 4 hardening)
- \packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts\ — 15 tests for extractJsonObject

**Modified files (8):**
- \packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts\ — Register evaluator-output-v1 schema + output_extraction_failed telemetry with provider/model
- \packages/principles-core/src/runtime-v2/internalization/diagnostician-prompt-builder.ts\ — Harden DIAGNOSTIC_PROTOCOL_INSTRUCTION (CRITICAL emphasis, complete JSON example, no code fences/prose)
- \packages/principles-core/src/telemetry-event.ts\ — Add output_extraction_failed to TelemetryEventType
- \packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts\ — 9 new prompt contract hardening tests + 2 regex anchor fixes
- \packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts\ — evaluator-output-v1 repair test + output_extraction_failed telemetry test
- \packages/principles-core/src/runtime-v2/internalization/index.ts\ — Export evaluator types
- \packages/principles-core/src/runtime-v2/index.ts\ — Re-export evaluator types
- \packages/pd-cli/src/commands/runtime-internalization-run-once.ts\ — Add evaluator dispatch + test-double fixture

### 生产验证结果

**Evaluator (PRI-EVAL):**
- Hardening 前: output_invalid (No valid JSON found in LLM response)
- Hardening 后: succeeded, decision=needs_revision, score=0.72, successor rollout_reviewer enqueued ✅

**Diagnostician (PRI-109):**
- Baseline UAT: 70% (7/10), 1 output_invalid + 2 timeout
- Hardened UAT: 90% (9/10), 0 output_invalid + 1 runtime_timeout ✅
- output_invalid 完全消除，仅剩 MiniMax API 连接级 timeout

### Commit History
1. feat(evaluator-runner): implement EvaluatorRunner vertical slice
2. fix(evaluator-runner): address CodeRabbit review findings
3. fix(evaluator): harden prompt + add extractJsonObject tests + output_extraction_failed telemetry
4. fix(review): strengthen test assertions + add provider/model to output_extraction_failed telemetry
5. fix(diagnostician): harden DIAGNOSTIC_PROTOCOL_INSTRUCTION for output_invalid prevention