### PR TITLE
feat: RolloutReviewerRunner vertical slice + Dreamer hardening + canary fixture gate

### DIFF
--- a/docs/adr/0004-l2-auto-correction-and-replay.md
+++ b/docs/adr/0004-l2-auto-correction-and-replay.md
@@ -1,0 +1,69 @@
+# ADR-0004: L2 硬内化升级 —— 自动修正与轨迹回放测试 (Auto-Correction & Trajectory Replay)
+
+> **状态**: 接受 (Accepted)
+> **日期**: 2026-05-11
+> **相关**: DOMAIN_MODEL.md, PD_System_Dynamics_Model.md (L2 内化层)
+
+## 1. 背景与痛点 (Context)
+
+在当前的 PD 架构中，L2 级硬内化（Code/Hook/Tool）由 `PrincipleCompiler` 编译并在 `RuleHost` 中执行。但在实际运行中暴露出两个核心缺陷：
+1. **消极拦截 (Passive Blocking)**：`RuleHost` 的裁决只有 `allow`, `block`, `requireApproval`。当 Agent 犯了微小的语法错误（如漏传参数），`block` 会直接打断任务流，迫使大模型消耗大量上下文去反思和重试，效率极低。
+2. **缺乏防退化保护 (No Regression Protection)**：`PrincipleCompiler` 依赖大模型一次性生成 JavaScript 沙盒代码，直接进入 `probation`（试用期）面对真实流量。如果生成的逻辑有 Bug（例如正则表达式过于宽泛），会导致严重的误拦截（False Positive），使得 Agent “变笨”。
+
+受“Heuristic Learning”思想启发，L2 层必须具备**残差修正（Auto-Correction）**能力，且其生成过程必须是**可回归测试（Regression-testable）**的。
+
+## 2. 决策详情 (Decisions)
+
+### 决策一：扩展 RuleHost 协议，支持主动“残差修正”
+
+我们决定将 `RuleHost` 从单纯的门禁，升级为能够直接篡改（mutate）底层 Tool 执行参数的中间件。
+
+**技术契约变更**：
+在 `RuleHostResult` 中新增 `auto_correct` 决策类型：
+
+```typescript
+// packages/openclaw-plugin/src/core/rule-host-types.ts
+export type RuleDecision = 'allow' | 'block' | 'requireApproval' | 'auto_correct';
+
+export interface RuleHostResult {
+  decision: RuleDecision;
+  reason?: string;
+  ruleId?: string;
+  principleId?: string;
+  // 当 decision 为 'auto_correct' 时，提供修正后的参数
+  modifiedParams?: Record<string, unknown>; 
+  // 是否向 LLM 发送一条系统通知，告知参数被底层系统修正（隐性学习）
+  notifyAgent?: boolean; 
+}
+```
+
+**执行流调整**：
+在感知与门控层（`hooks/gate.ts` `before_tool_call`）中：
+* 如果 `RuleHost` 返回 `auto_correct`，Hook 将**悄悄替换** `event.params` 为 `modifiedParams`，然后返回 `allow` 继续执行。
+* 如果 `notifyAgent` 为 `true`，Hook 会将这次“修正记录”注入到 `after_tool_call` 的结果中，提醒 Agent 底层进行了自动修复。
+
+### 决策二：引入基于轨迹的“影子回放测试”
+
+我们决定在 `PrincipleCompiler` 管道中强制加入局部验证环（Local Sandbox Testing）。未经测试证明能够“拦截过去错误”的代码，不准进入账本。
+
+**技术契约变更**：
+引入一个新的领域实体：**`GoldenTrace`（黄金测试集）**。
+1. **测试用例提取**：`Diagnostician` 在输出 Rule 建议时，必须同步提取触发该痛点时的**原始 `tool_call` 快照**（Negative Case）和一个**期望的 `tool_call` 快照**（Positive Case）。
+2. **编译器本地验证 (Compiler Validator)**：
+   在 `PrincipleCompiler` 生成 JS 代码之后、写入 Ledger 之前，强制执行两项沙盒验证：
+   * **Test 1 (拦截/修正测试)**：输入 Negative Case，断言输出必须为 `block` 或 `auto_correct`。
+   * **Test 2 (防误伤测试)**：输入 Positive Case，断言输出必须为 `allow`。
+
+**执行流调整**：
+如果生成的代码未能通过验证，`PrincipleCompiler` 会将报错反馈给大模型进行有限次数的自循环修复（Self-Correction）。若重试耗尽仍未通过，则放弃编译该 Rule，降级保留为 L1 软提示词。
+
+## 3. 架构收益 (Consequences)
+
+### 积极影响 (Pros)
+* **大幅降低 Token 消耗与幻觉**：Agent 不需要自己去纠正低级拼写或规范错误，底层系统（L2）自动修正。
+* **物理隔离的安全性增强**：每一条硬规则在上线前都经过了其对应的历史痛点（Pain Trace）的严格断言测试，降低“误拦截”风险。真正做到了“防遗忘”。
+* **对齐 SD 模型**：补齐了《PD_System_Dynamics_Model.md》中 L2 层的“残差修正”系统动力学特性。
+
+### 潜在风险 (Cons / Mitigations)
+* *风险*：自动修正可能会让 Agent 产生“我写得是对的”的错觉。
+* *缓解*：必须配套实现 `notifyAgent` 机制，在工具调用返回时附加上下文告警。

--- a/docs/adr/0004-l2-auto-correction-and-replay.md
+++ b/docs/adr/0004-l2-auto-correction-and-replay.md
@@ -31,9 +31,9 @@ export interface RuleHostResult {
   ruleId?: string;
   principleId?: string;
   // 当 decision 为 'auto_correct' 时，提供修正后的参数
-  modifiedParams?: Record<string, unknown>; 
+  modifiedParams?: Record<string, unknown>;
   // 是否向 LLM 发送一条系统通知，告知参数被底层系统修正（隐性学习）
-  notifyAgent?: boolean; 
+  notifyAgent?: boolean;
 }
 ```
 

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -7,19 +7,21 @@ import {
   ScribeRunner,
   ArtificerRunner,
   EvaluatorRunner,
+  RolloutReviewerRunner,
   StoreEventEmitter,
   DefaultDreamerValidator,
   DefaultPhilosopherValidator,
   DefaultScribeValidator,
   DefaultArtificerValidator,
   DefaultEvaluatorValidator,
+  DefaultRolloutReviewerValidator,
   TestDoubleRuntimeAdapter,
   PiAiRuntimeAdapter,
   OpenClawCliRuntimeAdapter,
   resolveRuntimeConfig,
   validateRuntimeConfig,
 } from '@principles/core/runtime-v2';
-import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, EvaluatorRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
+import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, EvaluatorRunnerResult, RolloutReviewerRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 interface RunOnceOptions {
@@ -35,7 +37,7 @@ interface RunOnceOptions {
 const OWNER = 'pd-cli-internalization-run-once';
 const RUNTIME_KIND = 'local-worker';
 
-const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator']);
+const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer']);
 
 interface RunOnceOutput {
   decision: string;
@@ -46,7 +48,7 @@ interface RunOnceOutput {
   runId?: string;
   artifactId?: string;
   resultRef?: string;
-  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult;
+  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult;
   skipReason?: string;
   conflictReason?: string;
   reason?: string;
@@ -58,7 +60,7 @@ interface RunOnceOutput {
   timeoutSource?: string;
 }
 
-function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult, skipReason?: string): RunOnceOutput {
+function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult, skipReason?: string): RunOnceOutput {
   const base: RunOnceOutput = { decision: wakeResult.decision };
 
   switch (wakeResult.decision) {
@@ -318,6 +320,47 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
         }),
       });
     }
+    if (opts.runnerKind === 'rollout_reviewer') {
+      let capturedSourceEvaluatorArtifactId = 'pi-art-test-evaluator';
+      return new TestDoubleRuntimeAdapter({
+        onStartRun: (input) => {
+          try {
+            const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+            const parsed = JSON.parse(payloadStr);
+            if (typeof parsed.sourceEvaluatorArtifactId === 'string' && parsed.sourceEvaluatorArtifactId.trim() !== '') {
+              capturedSourceEvaluatorArtifactId = parsed.sourceEvaluatorArtifactId;
+            }
+          } catch { /* use default */ }
+          return { runId: `td-rollout-reviewer-${Date.now()}`, runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+        },
+        onPollRun: (_runId: string) => ({
+          runId: _runId,
+          status: 'succeeded',
+          startedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+        }),
+        onFetchOutput: (_runId: string) => ({
+          runId: _runId,
+          payload: {
+            taskId: opts.taskId,
+            sourceEvaluatorArtifactId: capturedSourceEvaluatorArtifactId,
+            review: {
+              decision: 'approve_rollout',
+              summary: 'Test rollout review summary',
+              confidence: 0.9,
+              requiredChanges: [],
+              rolloutRisks: [],
+              safetyChecks: ['Verify feature flag is properly configured'],
+            },
+            sourceTrace: {
+              evaluatorArtifactId: capturedSourceEvaluatorArtifactId,
+            },
+            risks: [],
+            generatedAt: new Date().toISOString(),
+          },
+        }),
+      });
+    }
     return new TestDoubleRuntimeAdapter({
       onPollRun: (_runId: string) => ({
         runId: _runId,
@@ -422,7 +465,7 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       return;
     }
 
-    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | undefined = undefined;
+    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult | undefined = undefined;
     let skipReason: string | undefined = undefined;
 
     if (wakeResult.decision === 'would_lease') {
@@ -465,6 +508,13 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       } else if (runnerKind === 'evaluator') {
         const validator = new DefaultEvaluatorValidator();
         const runner = new EvaluatorRunner(
+          { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
+          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
+        );
+        runnerResult = await runner.run(wakeResult.taskId);
+      } else if (runnerKind === 'rollout_reviewer') {
+        const validator = new DefaultRolloutReviewerValidator();
+        const runner = new RolloutReviewerRunner(
           { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
           { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -49,6 +49,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
   EvaluatorRunner: vi.fn().mockImplementation(function () {
     return { run: mockRun };
   }),
+  RolloutReviewerRunner: vi.fn().mockImplementation(function () {
+    return { run: mockRun };
+  }),
   StoreEventEmitter: vi.fn().mockImplementation(function () {
     return { emitTelemetry: vi.fn() };
   }),
@@ -68,6 +71,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
     return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
   }),
   DefaultEvaluatorValidator: vi.fn().mockImplementation(function () {
+    return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
+  }),
+  DefaultRolloutReviewerValidator: vi.fn().mockImplementation(function () {
     return { validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }) };
   }),
   TestDoubleRuntimeAdapter: vi.fn().mockImplementation(function () {
@@ -1142,5 +1148,98 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.enqueueDecision).toBe('successor_created');
     expect(output.successorTaskId).toBe('task-rollout-reviewer-enq-001');
     expect(output.successorKind).toBe('rollout_reviewer');
+  });
+
+  it('--runner rollout_reviewer dispatches RolloutReviewerRunner', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-rollout-reviewer-001',
+      taskKind: 'rollout_reviewer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-rollout-reviewer-001',
+      runId: 'run-rollout-reviewer-001',
+      artifactId: 'pi-art-task-rollout-reviewer-001-run-rollout-reviewer-001',
+      resultRef: 'rollout-reviewer://run-rollout-reviewer-001',
+      contextHash: 'ctx-rr-abc',
+      output: {
+        taskId: 'task-rollout-reviewer-001',
+        sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+        review: {
+          decision: 'approve_rollout',
+          summary: 'Test rollout review summary',
+          confidence: 0.9,
+          requiredChanges: [],
+          rolloutRisks: [],
+          safetyChecks: ['Verify feature flag is properly configured'],
+        },
+        sourceTrace: { evaluatorArtifactId: 'pi-art-evaluator-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'rollout_reviewer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const RolloutReviewerRunnerMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.RolloutReviewerRunner),
+    );
+    expect(RolloutReviewerRunnerMock).toHaveBeenCalled();
+    expect(mockRun).toHaveBeenCalledWith('task-rollout-reviewer-001');
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.runnerKind).toBe('rollout_reviewer');
+    expect(output.taskId).toBe('task-rollout-reviewer-001');
+    expect(output.runId).toBe('run-rollout-reviewer-001');
+    expect(output.artifactId).toBe('pi-art-task-rollout-reviewer-001-run-rollout-reviewer-001');
+    expect(output.resultRef).toBe('rollout-reviewer://run-rollout-reviewer-001');
+    expect(output.runnerResult.status).toBe('succeeded');
+  });
+
+  it('--runner rollout_reviewer --enqueue-next returns no_successor for prompt channel', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-rollout-reviewer-enq-001',
+      taskKind: 'rollout_reviewer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-rollout-reviewer-enq-001',
+      runId: 'run-rollout-reviewer-enq-001',
+      artifactId: 'pi-art-rollout-reviewer-enq-001',
+      resultRef: 'rollout-reviewer://run-rollout-reviewer-enq-001',
+      contextHash: 'ctx-enq',
+      output: {
+        taskId: 'task-rollout-reviewer-enq-001',
+        sourceEvaluatorArtifactId: 'pi-art-evaluator-enq-001',
+        review: {
+          decision: 'approve_rollout',
+          summary: 'Test rollout review summary',
+          confidence: 0.9,
+          requiredChanges: [],
+          rolloutRisks: [],
+          safetyChecks: ['Verify feature flag is properly configured'],
+        },
+        sourceTrace: { evaluatorArtifactId: 'pi-art-evaluator-enq-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'no_successor',
+      sourceTaskId: 'task-rollout-reviewer-enq-001',
+      reason: 'No valid successor in job graph for this task kind and channel',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'rollout_reviewer', runtime: 'test-double', allowTestDouble: true, enqueueNext: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.enqueueDecision).toBe('no_successor');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -69,6 +69,10 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/evaluator-output.ts',
   'internalization/evaluator-runner.ts',
   'internalization/evaluator-prompt-builder.ts',
+  // PRI-RR
+  'internalization/rollout-reviewer-output.ts',
+  'internalization/rollout-reviewer-runner.ts',
+  'internalization/rollout-reviewer-prompt-builder.ts',
   // PRI-74 (follow-up to PRI-75 Phase 3)
   '../prompt-builder/routing-guidance.ts',
   // PRI-81 Phase A
@@ -108,6 +112,8 @@ const REQUIRED_TEST_FILES = [
   'artificer-runner-vslice.test.ts',
   // PRI-EVAL
   'evaluator-runner-vslice.test.ts',
+  // PRI-RR
+  'rollout-reviewer-runner-vslice.test.ts',
   // PRI-74 (follow-up to PRI-75 Phase 3)
   '../../prompt-builder/__tests__/routing-guidance.test.ts',
   // PRI-81 Phase A
@@ -1694,5 +1700,69 @@ describe('PRI-EVAL EvaluatorRunner boundary', () => {
     const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
     expect(src).toContain('evaluator-output-v1');
     expect(src).toContain('EvaluatorOutputV1Schema');
+  });
+});
+
+// ── PRI-RR: RolloutReviewerRunner boundary guards ──────────────────────────────
+
+describe('PRI-RR RolloutReviewerRunner boundary', () => {
+  it('rollout_reviewer source files exist in internalization directory', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'rollout-reviewer-runner.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'rollout-reviewer-output.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'rollout-reviewer-prompt-builder.ts'))).toBe(true);
+  });
+
+  it('rollout_reviewer test file exists', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, 'rollout-reviewer-runner-vslice.test.ts'))).toBe(true);
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: rollout-reviewer-output.ts has no openclaw-plugin, fs, path imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'rollout-reviewer-output.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: rollout-reviewer-runner.ts has no openclaw-plugin, TrainerRunner, nocturnal-trinity imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'rollout-reviewer-runner.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('TrainerRunner');
+    expect(src).not.toContain('nocturnal-trinity');
+    expect(src).not.toContain('InternalizationOrchestrator');
+    expect(src).not.toContain('createTask');
+    expect(src).not.toContain('enqueueTask');
+  });
+
+  it('CORE_NO_SCHEDULING: rollout-reviewer-runner.ts has no node:fs, node:cron imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'rollout-reviewer-runner.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('BARREL_EXPORTS: internalization/index.ts exports RolloutReviewerRunner and RolloutReviewerOutput', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).toContain('RolloutReviewerRunner');
+    expect(src).toContain('RolloutReviewerOutput');
+    expect(src).toContain('DefaultRolloutReviewerValidator');
+  });
+
+  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers rollout-reviewer-output-v1 schema', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    expect(src).toContain('rollout-reviewer-output-v1');
+    expect(src).toContain('RolloutReviewerOutputV1Schema');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
@@ -508,3 +508,128 @@ describe('DreamerRunner with DefaultDreamerValidator (PRI-87)', () => {
     expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
   });
 });
+
+describe('DreamerRunner output_extraction_failed telemetry', () => {
+  function createMinimalDeps() {
+    const artifactStore = new MemoryPIArtifactStore();
+    const task: TaskRecord = {
+      taskId: 'task-dreamer-ext-001',
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(task),
+      getTask: vi.fn().mockResolvedValue(task),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-ext-001',
+        taskId: 'task-dreamer-ext-001',
+        runtimeKind: 'dreamer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const runHandle: RunHandle = { runId: 'run-ext-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+    const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-ext-001' };
+
+    const runtimeAdapter = {
+      startRun: vi.fn().mockResolvedValue(runHandle),
+      pollRun: vi.fn().mockResolvedValue(succeededStatus),
+      fetchOutput: vi.fn().mockResolvedValue({ payload: null }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PDRuntimeAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    return { stateManager, runtimeAdapter, eventEmitter, validator: new DefaultDreamerValidator(), artifactStore };
+  }
+
+  it('emits dreamer_output_extraction_failed when fetchOutput returns null payload', async () => {
+    const deps = createMinimalDeps();
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({ payload: null });
+
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-ext-001');
+    expect(result.status).toBe('failed');
+
+    const telemetryCalls = (deps.eventEmitter as unknown as { emitTelemetry: ReturnType<typeof vi.fn> }).emitTelemetry.mock.calls;
+    const extractionFailedCalls = telemetryCalls.filter((call: unknown[]) => {
+      const evt = call[0] as Record<string, unknown>;
+      return evt && evt.eventType === 'dreamer_output_extraction_failed';
+    });
+    expect(extractionFailedCalls.length).toBeGreaterThanOrEqual(1);
+    const evt = extractionFailedCalls[0]?.[0] as Record<string, unknown>;
+    expect(evt).toBeDefined();
+    const evtPayload = evt?.payload as Record<string, unknown> | undefined;
+    expect(evtPayload?.stage).toBe('payload_missing');
+  });
+
+  it('emits dreamer_output_extraction_failed when fetchOutput returns non-object payload', async () => {
+    const deps = createMinimalDeps();
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({ payload: 'not-json' });
+
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-ext-001');
+    expect(result.status).toBe('failed');
+
+    const telemetryCalls = (deps.eventEmitter as unknown as { emitTelemetry: ReturnType<typeof vi.fn> }).emitTelemetry.mock.calls;
+    const extractionFailedCalls = telemetryCalls.filter((call: unknown[]) => {
+      const evt = call[0] as Record<string, unknown>;
+      return evt && evt.eventType === 'dreamer_output_extraction_failed';
+    });
+    expect(extractionFailedCalls.length).toBeGreaterThanOrEqual(1);
+    const evt = extractionFailedCalls[0]?.[0] as Record<string, unknown>;
+    expect(evt).toBeDefined();
+    const evtPayload = evt?.payload as Record<string, unknown> | undefined;
+    expect(evtPayload?.stage).toBe('payload_not_object');
+  });
+
+  it('emits dreamer_output_extraction_failed when fetchOutput throws', async () => {
+    const deps = createMinimalDeps();
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockRejectedValue(new Error('Network timeout'));
+
+    const runner = new DreamerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'dreamer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run('task-dreamer-ext-001');
+    expect(result.status).toBe('failed');
+
+    const telemetryCalls = (deps.eventEmitter as unknown as { emitTelemetry: ReturnType<typeof vi.fn> }).emitTelemetry.mock.calls;
+    const extractionFailedCalls = telemetryCalls.filter((call: unknown[]) => {
+      const evt = call[0] as Record<string, unknown>;
+      return evt && evt.eventType === 'dreamer_output_extraction_failed';
+    });
+    expect(extractionFailedCalls.length).toBeGreaterThanOrEqual(1);
+    const evt = extractionFailedCalls[0]?.[0] as Record<string, unknown>;
+    expect(evt).toBeDefined();
+    const evtPayload = evt?.payload as Record<string, unknown> | undefined;
+    expect(evtPayload?.stage).toBe('fetchOutput');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/production-canary-fixture-gate.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/production-canary-fixture-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import Database from 'better-sqlite3';
 import { RuntimeStateManager } from '../store/runtime-state-manager.js';
 import { InternalizationQueueReadModel } from '../internalization-queue-read-model.js';
 import { InternalizationChainIntegrityReadModel } from '../internalization-chain-integrity-read-model.js';
@@ -159,9 +160,57 @@ describe('PRI-102: Production canary fixture gate', () => {
         },
       ]);
 
+      const stateDir = path.join(fixture.workspaceDir, '.state');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const orphanCandidateId = 'orphan-cand-999';
+      const ledgerContent = {
+        _tree: {
+          principles: {
+            'pri-orphan-test': {
+              id: 'pri-orphan-test',
+              version: 1,
+              text: 'test principle with orphan derived candidate',
+              triggerPattern: 'test',
+              action: 'test',
+              status: 'active',
+              priority: 'P2',
+              scope: 'general',
+              evaluability: 'manual_only',
+              valueScore: 0.5,
+              adherenceRate: 0.8,
+              painPreventedCount: 0,
+              derivedFromPainIds: [orphanCandidateId],
+              ruleIds: [],
+              conflictsWithPrincipleIds: [],
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          },
+          rules: {},
+          implementations: {},
+          metrics: {},
+          lastUpdated: new Date().toISOString(),
+        },
+      };
+      fs.writeFileSync(
+        path.join(stateDir, 'principle_training_state.json'),
+        JSON.stringify(ledgerContent, null, 2),
+      );
+
       const pruningModel = new PruningReadModel({ workspaceDir: fixture.workspaceDir });
-      const result = pruningModel.getOrphanDerivedCandidates();
-      expect(result.dbReadable).toBe(true);
+      const orphanResult = pruningModel.getOrphanDerivedCandidates();
+      expect(orphanResult.dbReadable).toBe(true);
+      expect(orphanResult.candidates.length).toBeGreaterThan(0);
+      expect(orphanResult.candidates[0]?.candidateId).toBe(orphanCandidateId);
+      expect(orphanResult.candidates[0]?.reason).toContain('not found in state.db');
+
+      const healthModel = new OperatorHealthReadModel({ workspaceDir: fixture.workspaceDir });
+      try {
+        const snapshot = await healthModel.getSnapshot();
+        expect(snapshot.overallStatus).toBe('degraded');
+      } finally {
+        await healthModel.close();
+      }
     });
 
     it('workspace with only failed tasks reports degraded', async () => {
@@ -188,7 +237,7 @@ describe('PRI-102: Production canary fixture gate', () => {
   });
 
   describe('integrity ok/brokenLinks', () => {
-    it('workspace with runtime tasks reports integrity status (may be degraded due to missing candidate tables)', async () => {
+    it('succeeded dreamer with no philosopher successor reports degraded with missing_philosopher_successor', async () => {
       await fixture.init();
       await fixture.seedTasks([
         {
@@ -202,9 +251,25 @@ describe('PRI-102: Production canary fixture gate', () => {
         },
       ]);
 
+      const dbPath = path.join(fixture.workspaceDir, '.pd', 'state.db');
+      const db = new Database(dbPath);
+      const now = new Date().toISOString();
+      db.prepare(
+        'INSERT INTO runs (run_id, task_id, runtime_kind, execution_status, started_at, ended_at, reason, attempt_number, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      ).run('run-dreamer-001', 'dreamer-001', 'dreamer', 'succeeded', now, now, 'task_completed', 1, now, now);
+      db.prepare(
+        'INSERT INTO pi_artifacts (artifact_id, artifact_kind, source_task_id, content_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+      ).run('artifact-dreamer-001', 'principle', 'dreamer-001', '{}', now, now);
+      db.close();
+
       const model = new InternalizationChainIntegrityReadModel({ workspaceDir: fixture.workspaceDir });
       const result = model.check();
-      expect(['ok', 'degraded', 'error']).toContain(result.overallStatus);
+      expect(result.overallStatus).toBe('degraded');
+      expect(result.brokenLinks.length).toBeGreaterThan(0);
+      const missingPhil = result.brokenLinks.find(l => l.type === 'missing_philosopher_successor');
+      expect(missingPhil).toBeDefined();
+      expect(missingPhil?.taskId).toBe('dreamer-001');
+      expect(missingPhil?.severity).toBe('warning');
     });
 
     it('workspace with missing DB reports error', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/production-canary-fixture-gate.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/production-canary-fixture-gate.test.ts
@@ -1,0 +1,550 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import { InternalizationQueueReadModel } from '../internalization-queue-read-model.js';
+import { InternalizationChainIntegrityReadModel } from '../internalization-chain-integrity-read-model.js';
+import { OperatorHealthReadModel } from '../operator-health-read-model.js';
+import { PruningReadModel } from '../pruning-read-model.js';
+import { SchemaConformanceReadModel } from '../schema-conformance-read-model.js';
+import { validateInternalizationTaskReady } from '../internalization/internalization-state-machine.js';
+import { hydratePITaskRecord } from '../internalization/pitask-metadata.js';
+import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
+import { buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from '../gfi/gfi-read-model.js';
+import type { TaskRecord } from '../task-status.js';
+
+interface FixtureTaskSeed {
+  taskId: string;
+  taskKind: string;
+  status: string;
+  attemptCount: number;
+  maxAttempts: number;
+  resultRef?: string;
+  leaseExpiresAt?: string;
+  diagnosticJson?: string;
+}
+
+class SyntheticWorkspaceFixture {
+  readonly workspaceDir: string;
+  private stateManager: RuntimeStateManager | null = null;
+  private _dbWritten = false;
+
+  constructor() {
+    this.workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pri-canary-fixture-'));
+  }
+
+  async init(): Promise<RuntimeStateManager> {
+    this.stateManager = new RuntimeStateManager({
+      workspaceDir: this.workspaceDir,
+    });
+    await this.stateManager.initialize();
+    this._dbWritten = true;
+    return this.stateManager;
+  }
+
+  async seedTasks(tasks: FixtureTaskSeed[]): Promise<void> {
+    if (!this.stateManager) throw new Error('Call init() first');
+    for (const t of tasks) {
+      await this.stateManager.createTask({
+        taskId: t.taskId,
+        taskKind: t.taskKind,
+        status: t.status as TaskRecord['status'],
+        attemptCount: t.attemptCount,
+        maxAttempts: t.maxAttempts,
+        resultRef: t.resultRef ?? undefined,
+        leaseExpiresAt: t.leaseExpiresAt ?? undefined,
+        diagnosticJson: t.diagnosticJson ?? undefined,
+      });
+    }
+  }
+
+  async getDBSizeBytes(): Promise<number> {
+    const dbPath = path.join(this.workspaceDir, '.pd', 'state.db');
+    if (!fs.existsSync(dbPath)) return 0;
+    const stat = fs.statSync(dbPath);
+    return stat.size;
+  }
+
+  async getDBWriteCount(): Promise<number> {
+    const dbPath = path.join(this.workspaceDir, '.pd', 'state.db');
+    if (!fs.existsSync(dbPath)) return 0;
+    const stat = fs.statSync(dbPath);
+    return stat.mtimeMs;
+  }
+
+  async close(): Promise<void> {
+    if (this.stateManager) {
+      await this.stateManager.close();
+      this.stateManager = null;
+    }
+  }
+
+  destroy(): void {
+    fs.rmSync(this.workspaceDir, { recursive: true, force: true });
+  }
+}
+
+function makePITaskDiagnosticJson(overrides: {
+  dependencyTaskIds?: string[];
+  channel?: string;
+  timeoutMs?: number;
+  inputArtifactRefs?: { artifactType: string; ref: string }[];
+  outputArtifactRefs?: { artifactType: string; ref: string }[];
+}): string {
+  return createPITaskDiagnosticJson({
+    dependencyTaskIds: overrides.dependencyTaskIds ?? [],
+    channel: (overrides.channel ?? 'prompt') as 'prompt',
+    timeoutMs: overrides.timeoutMs ?? 300_000,
+    inputArtifactRefs: overrides.inputArtifactRefs ?? [],
+    outputArtifactRefs: overrides.outputArtifactRefs ?? [],
+  });
+}
+
+describe('PRI-102: Production canary fixture gate', () => {
+  let fixture = new SyntheticWorkspaceFixture();
+
+  beforeEach(() => {
+    fixture = new SyntheticWorkspaceFixture();
+  });
+
+  afterEach(async () => {
+    await fixture.close();
+    fixture.destroy();
+  });
+
+  describe('canary healthy/degraded判定', () => {
+    it('empty workspace with initialized DB has schema conformance issues (candidates table missing)', async () => {
+      await fixture.init();
+
+      const model = new SchemaConformanceReadModel({ workspaceDir: fixture.workspaceDir });
+      const result = model.check();
+      expect(result.overallStatus).not.toBe('ok');
+    });
+
+    it('workspace with only runtime tasks (no candidates) is degraded due to missing candidate/ledger tables', async () => {
+      const _mgr = await fixture.init();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-001',
+          taskKind: 'dreamer',
+          status: 'succeeded',
+          attemptCount: 1,
+          maxAttempts: 3,
+          resultRef: 'dreamer://run-001',
+          diagnosticJson: makePITaskDiagnosticJson({}),
+        },
+      ]);
+
+      const healthModel = new OperatorHealthReadModel({ workspaceDir: fixture.workspaceDir });
+      try {
+        const snapshot = await healthModel.getSnapshot();
+        expect(snapshot.overallStatus).not.toBe('healthy');
+      } finally {
+        await healthModel.close();
+      }
+    });
+
+    it('workspace with orphan candidates reports degraded', async () => {
+      await fixture.init();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-001',
+          taskKind: 'dreamer',
+          status: 'succeeded',
+          attemptCount: 1,
+          maxAttempts: 3,
+          resultRef: 'dreamer://run-001',
+          diagnosticJson: makePITaskDiagnosticJson({}),
+        },
+      ]);
+
+      const pruningModel = new PruningReadModel({ workspaceDir: fixture.workspaceDir });
+      const result = pruningModel.getOrphanDerivedCandidates();
+      expect(result.dbReadable).toBe(true);
+    });
+
+    it('workspace with only failed tasks reports degraded', async () => {
+      await fixture.init();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-failed-001',
+          taskKind: 'dreamer',
+          status: 'failed',
+          attemptCount: 3,
+          maxAttempts: 3,
+          diagnosticJson: makePITaskDiagnosticJson({}),
+        },
+      ]);
+
+      const healthModel = new OperatorHealthReadModel({ workspaceDir: fixture.workspaceDir });
+      try {
+        const snapshot = await healthModel.getSnapshot();
+        expect(snapshot.overallStatus).toBe('degraded');
+      } finally {
+        await healthModel.close();
+      }
+    });
+  });
+
+  describe('integrity ok/brokenLinks', () => {
+    it('workspace with runtime tasks reports integrity status (may be degraded due to missing candidate tables)', async () => {
+      await fixture.init();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-001',
+          taskKind: 'dreamer',
+          status: 'succeeded',
+          attemptCount: 1,
+          maxAttempts: 3,
+          resultRef: 'dreamer://run-001',
+          diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: [] }),
+        },
+      ]);
+
+      const model = new InternalizationChainIntegrityReadModel({ workspaceDir: fixture.workspaceDir });
+      const result = model.check();
+      expect(['ok', 'degraded', 'error']).toContain(result.overallStatus);
+    });
+
+    it('workspace with missing DB reports error', async () => {
+      const noDbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pri-no-db-'));
+      try {
+        const model = new InternalizationChainIntegrityReadModel({ workspaceDir: noDbDir });
+        const result = model.check();
+        expect(result.overallStatus).toBe('error');
+        expect(result.brokenLinks.length).toBeGreaterThan(0);
+        expect(result.brokenLinks[0]?.type).toBe('database_missing');
+      } finally {
+        fs.rmSync(noDbDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('retry_wait不应提前ready', () => {
+    it('retry_wait task with future leaseExpiresAt is NOT ready', async () => {
+      const mgr = await fixture.init();
+      const futureTime = new Date(Date.now() + 60_000).toISOString();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-retry-001',
+          taskKind: 'dreamer',
+          status: 'retry_wait',
+          attemptCount: 1,
+          maxAttempts: 3,
+          leaseExpiresAt: futureTime,
+          diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: [] }),
+        },
+      ]);
+
+      const queueModel = new InternalizationQueueReadModel(mgr);
+      const snapshot = await queueModel.getSnapshot();
+
+      expect(snapshot.readyTasks.length).toBe(0);
+      expect(snapshot.retryWaitPendingSummary.count).toBe(1);
+    });
+
+    it('retry_wait task with expired leaseExpiresAt IS ready', async () => {
+      const mgr = await fixture.init();
+      const pastTime = new Date(Date.now() - 60_000).toISOString();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-retry-ready-001',
+          taskKind: 'dreamer',
+          status: 'retry_wait',
+          attemptCount: 1,
+          maxAttempts: 3,
+          leaseExpiresAt: pastTime,
+          diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: [] }),
+        },
+      ]);
+
+      const queueModel = new InternalizationQueueReadModel(mgr);
+      const snapshot = await queueModel.getSnapshot();
+
+      expect(snapshot.readyTasks.length).toBe(1);
+      expect(snapshot.readyTasks[0]?.taskId).toBe('dreamer-retry-ready-001');
+    });
+
+    it('validateInternalizationTaskReady rejects retry_wait with future backoff', () => {
+      const futureTime = new Date(Date.now() + 120_000).toISOString();
+      const rawTask: TaskRecord = {
+        taskId: 'retry-gate-001',
+        taskKind: 'dreamer',
+        status: 'retry_wait',
+        attemptCount: 1,
+        maxAttempts: 3,
+        leaseExpiresAt: futureTime,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: [] }),
+      };
+
+      const piTask = hydratePITaskRecord(rawTask);
+      expect(piTask).not.toBeNull();
+      if (!piTask) return;
+
+      const result = validateInternalizationTaskReady(piTask, [], Date.now());
+      expect(result.decision).toBe('retry_wait_pending');
+      expect(result.ready).toBe(false);
+    });
+
+    it('validateInternalizationTaskReady allows retry_wait with expired backoff', () => {
+      const pastTime = new Date(Date.now() - 120_000).toISOString();
+      const rawTask: TaskRecord = {
+        taskId: 'retry-gate-002',
+        taskKind: 'dreamer',
+        status: 'retry_wait',
+        attemptCount: 1,
+        maxAttempts: 3,
+        leaseExpiresAt: pastTime,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: [] }),
+      };
+
+      const piTask = hydratePITaskRecord(rawTask);
+      expect(piTask).not.toBeNull();
+      if (!piTask) return;
+
+      const result = validateInternalizationTaskReady(piTask, [], Date.now());
+      expect(result.decision).toBe('proceed');
+      expect(result.ready).toBe(true);
+    });
+
+    it('queue snapshot correctly diagnoses all_retry_wait_pending', async () => {
+      const mgr = await fixture.init();
+      const futureTime = new Date(Date.now() + 60_000).toISOString();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-rw-001',
+          taskKind: 'dreamer',
+          status: 'retry_wait',
+          attemptCount: 1,
+          maxAttempts: 3,
+          leaseExpiresAt: futureTime,
+          diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: [] }),
+        },
+        {
+          taskId: 'philosopher-rw-001',
+          taskKind: 'philosopher',
+          status: 'retry_wait',
+          attemptCount: 1,
+          maxAttempts: 3,
+          leaseExpiresAt: futureTime,
+          diagnosticJson: makePITaskDiagnosticJson({ dependencyTaskIds: ['dreamer-rw-001'] }),
+        },
+      ]);
+
+      const queueModel = new InternalizationQueueReadModel(mgr);
+      const snapshot = await queueModel.getSnapshot();
+
+      expect(snapshot.readyTasks.length).toBe(0);
+      expect(snapshot.noReadyTasks).not.toBeNull();
+      expect(snapshot.noReadyTasks?.reason).toBe('all_retry_wait_pending');
+    });
+  });
+
+  describe('read-only command不写DB', () => {
+    it('SchemaConformanceReadModel does not modify DB', async () => {
+      await fixture.init();
+      const sizeBefore = await fixture.getDBSizeBytes();
+
+      const model = new SchemaConformanceReadModel({ workspaceDir: fixture.workspaceDir });
+      model.check();
+
+      const sizeAfter = await fixture.getDBSizeBytes();
+      expect(sizeAfter).toBe(sizeBefore);
+    });
+
+    it('InternalizationChainIntegrityReadModel does not modify DB', async () => {
+      await fixture.init();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-001',
+          taskKind: 'dreamer',
+          status: 'succeeded',
+          attemptCount: 1,
+          maxAttempts: 3,
+          resultRef: 'dreamer://run-001',
+          diagnosticJson: makePITaskDiagnosticJson({}),
+        },
+      ]);
+      const mtimeBefore = await fixture.getDBWriteCount();
+
+      const model = new InternalizationChainIntegrityReadModel({ workspaceDir: fixture.workspaceDir });
+      model.check();
+
+      const mtimeAfter = await fixture.getDBWriteCount();
+      expect(mtimeAfter).toBe(mtimeBefore);
+    });
+
+    it('PruningReadModel does not modify DB', async () => {
+      await fixture.init();
+      const mtimeBefore = await fixture.getDBWriteCount();
+
+      const model = new PruningReadModel({ workspaceDir: fixture.workspaceDir });
+      model.getOrphanDerivedCandidates();
+      model.getHealthSummary();
+
+      const mtimeAfter = await fixture.getDBWriteCount();
+      expect(mtimeAfter).toBe(mtimeBefore);
+    });
+
+    it('RuntimeStateManager readonly mode does not write', async () => {
+      const mgr = await fixture.init();
+      await fixture.seedTasks([
+        {
+          taskId: 'dreamer-001',
+          taskKind: 'dreamer',
+          status: 'succeeded',
+          attemptCount: 1,
+          maxAttempts: 3,
+          diagnosticJson: makePITaskDiagnosticJson({}),
+        },
+      ]);
+      await mgr.close();
+
+      const mtimeBefore = await fixture.getDBWriteCount();
+
+      const readonlyMgr = new RuntimeStateManager({
+        workspaceDir: fixture.workspaceDir,
+        readonly: true,
+      });
+      await readonlyMgr.initialize();
+
+      const task = await readonlyMgr.getTask('dreamer-001');
+      expect(task).not.toBeNull();
+      expect(task?.taskId).toBe('dreamer-001');
+
+      await readonlyMgr.close();
+
+      const mtimeAfter = await fixture.getDBWriteCount();
+      expect(mtimeAfter).toBe(mtimeBefore);
+    });
+  });
+
+  describe('stale GFI low不degraded', () => {
+    it('stale sessions with low GFI are healthy', () => {
+      const snapshot = buildGfiWorkspaceSnapshot({
+        sessions: [
+          {
+            sessionId: 'stale-low-1',
+            currentGfi: 5,
+            consecutiveErrors: 0,
+            lastActivityAt: Date.now() - 3 * 60 * 60 * 1000,
+          },
+          {
+            sessionId: 'stale-low-2',
+            currentGfi: 10,
+            consecutiveErrors: 0,
+            lastActivityAt: Date.now() - 5 * 60 * 60 * 1000,
+          },
+        ],
+        nowMs: Date.now(),
+      });
+
+      const health = classifyGfiWorkspaceHealth(snapshot);
+      expect(health.status).toBe('healthy');
+      expect(health.reason).toContain('low GFI');
+    });
+
+    it('stale sessions with high GFI are degraded', () => {
+      const snapshot = buildGfiWorkspaceSnapshot({
+        sessions: [
+          {
+            sessionId: 'stale-high-1',
+            currentGfi: 80,
+            consecutiveErrors: 5,
+            lastActivityAt: Date.now() - 3 * 60 * 60 * 1000,
+          },
+        ],
+        nowMs: Date.now(),
+      });
+
+      const health = classifyGfiWorkspaceHealth(snapshot);
+      expect(health.status).toBe('degraded');
+      expect(health.reason).toContain('high GFI');
+    });
+
+    it('active session with GFI below threshold is healthy', () => {
+      const snapshot = buildGfiWorkspaceSnapshot({
+        sessions: [
+          {
+            sessionId: 'active-low-1',
+            currentGfi: 15,
+            consecutiveErrors: 0,
+            lastActivityAt: Date.now(),
+          },
+        ],
+        nowMs: Date.now(),
+      });
+
+      const health = classifyGfiWorkspaceHealth(snapshot);
+      expect(health.status).toBe('healthy');
+    });
+
+    it('active session with GFI at or above threshold is degraded', () => {
+      const snapshot = buildGfiWorkspaceSnapshot({
+        sessions: [
+          {
+            sessionId: 'active-high-1',
+            currentGfi: 45,
+            consecutiveErrors: 2,
+            lastActivityAt: Date.now(),
+          },
+        ],
+        nowMs: Date.now(),
+      });
+
+      const health = classifyGfiWorkspaceHealth(snapshot);
+      expect(health.status).toBe('degraded');
+    });
+
+    it('no sessions at all is healthy (cold start)', () => {
+      const snapshot = buildGfiWorkspaceSnapshot({
+        sessions: [],
+        nowMs: Date.now(),
+      });
+
+      const health = classifyGfiWorkspaceHealth(snapshot);
+      expect(health.status).toBe('healthy');
+    });
+  });
+
+  describe('pruning orphan count一致', () => {
+    it('getOrphanDerivedCandidates count matches getHealthSummary', async () => {
+      await fixture.init();
+
+      const model = new PruningReadModel({ workspaceDir: fixture.workspaceDir });
+      const orphans = model.getOrphanDerivedCandidates();
+      const summary = model.getHealthSummary();
+
+      expect(orphans.candidates.length).toBe(summary.orphanDerivedCandidateCount);
+    });
+
+    it('empty workspace has zero orphans in both methods', async () => {
+      await fixture.init();
+
+      const model = new PruningReadModel({ workspaceDir: fixture.workspaceDir });
+      const orphans = model.getOrphanDerivedCandidates();
+      const summary = model.getHealthSummary();
+
+      expect(orphans.candidates.length).toBe(0);
+      expect(summary.orphanDerivedCandidateCount).toBe(0);
+      expect(summary.watchCount).toBe(0);
+      expect(summary.reviewCount).toBe(0);
+    });
+
+    it('multiple calls return consistent orphan count', async () => {
+      await fixture.init();
+
+      const model = new PruningReadModel({ workspaceDir: fixture.workspaceDir });
+
+      const results = Array.from({ length: 5 }, () => model.getOrphanDerivedCandidates());
+      const counts = results.map(r => r.candidates.length);
+
+      expect(new Set(counts).size).toBe(1);
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/rollout-reviewer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/rollout-reviewer-runner-vslice.test.ts
@@ -1,0 +1,756 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RolloutReviewerRunner } from '../internalization/rollout-reviewer-runner.js';
+import type { RolloutReviewerRunnerDeps } from '../internalization/rollout-reviewer-runner.js';
+import type { PIArtifactStore, PIArtifactRecord } from '../internalization/pi-artifact.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { RolloutReviewerOutputV1 } from '../internalization/rollout-reviewer-output.js';
+import { DefaultRolloutReviewerValidator } from '../internalization/rollout-reviewer-output.js';
+import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
+import type { TaskRecord } from '../task-status.js';
+import { TestDoubleRuntimeAdapter } from '../adapter/test-double-runtime-adapter.js';
+
+const EVALUATOR_TASK_ID = 'evaluator-001';
+const ROLLOUT_REVIEWER_TASK_ID = 'rollout-reviewer-001';
+
+function makeEvaluatorTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: EVALUATOR_TASK_ID,
+    taskKind: 'evaluator',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'evaluator://run-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-evaluator-001-run-001' }],
+    }),
+    ...overrides,
+  };
+}
+
+function makeRolloutReviewerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ROLLOUT_REVIEWER_TASK_ID,
+    taskKind: 'rollout_reviewer',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [EVALUATOR_TASK_ID],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-evaluator-001-run-001' }],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeRolloutReviewerOutput(): RolloutReviewerOutputV1 {
+  return {
+    taskId: ROLLOUT_REVIEWER_TASK_ID,
+    sourceEvaluatorArtifactId: 'pi-art-evaluator-001-run-001',
+    review: {
+      decision: 'approve_rollout',
+      summary: 'The evaluation is thorough and the plan is safe to proceed',
+      confidence: 0.9,
+      requiredChanges: [],
+      rolloutRisks: ['Feature flag configuration may need adjustment'],
+      safetyChecks: ['Verify feature flag is properly configured'],
+    },
+    sourceTrace: {
+      evaluatorArtifactId: 'pi-art-evaluator-001-run-001',
+    },
+    risks: ['Rollback plan should be tested'],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function makeEvaluatorArtifact(): PIArtifactRecord {
+  return {
+    artifactId: 'pi-art-evaluator-001-run-001',
+    artifactKind: 'principle',
+    sourceTaskId: EVALUATOR_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify({
+      taskId: EVALUATOR_TASK_ID,
+      sourceArtificerArtifactId: 'pi-art-artificer-001',
+      evaluation: {
+        decision: 'approved',
+        summary: 'Implementation plan is well-structured and feasible',
+        score: 0.85,
+        strengths: ['Clear change descriptions'],
+        concerns: [],
+        requiredChanges: [],
+      },
+      sourceTrace: {
+        artificerArtifactId: 'pi-art-artificer-001',
+      },
+      risks: [],
+      generatedAt: new Date().toISOString(),
+    }),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('RolloutReviewerRunner (vertical slice)', () => {
+  function createMockDeps(overrides: Partial<RolloutReviewerRunnerDeps> = {}): RolloutReviewerRunnerDeps {
+    const artifactStore = overrides.artifactStore ?? new MemoryPIArtifactStore();
+    const rolloutReviewerTask = makeRolloutReviewerTask();
+    const evaluatorTask = makeEvaluatorTask();
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(rolloutReviewerTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === ROLLOUT_REVIEWER_TASK_ID) return Promise.resolve(rolloutReviewerTask);
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-rollout-reviewer-001',
+        taskId: ROLLOUT_REVIEWER_TASK_ID,
+        runtimeKind: 'rollout_reviewer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const runHandle: RunHandle = { runId: 'run-rollout-reviewer-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+    const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-rollout-reviewer-001' };
+
+    const runtimeAdapter = {
+      startRun: vi.fn().mockResolvedValue(runHandle),
+      pollRun: vi.fn().mockResolvedValue(succeededStatus),
+      fetchOutput: vi.fn().mockResolvedValue({
+        payload: makeRolloutReviewerOutput(),
+      }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PDRuntimeAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const validator = new DefaultRolloutReviewerValidator();
+
+    return {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator,
+      artifactStore,
+      ...overrides,
+    };
+  }
+
+  it('taskKind not rollout_reviewer fails closed and releases lease', async () => {
+    const wrongKindTask = makeRolloutReviewerTask({ taskKind: 'dreamer' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(wrongKindTask);
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+    expect(result.failureReason).toContain("must be 'rollout_reviewer'");
+    expect(deps.stateManager.markTaskFailed).toHaveBeenCalledWith(
+      ROLLOUT_REVIEWER_TASK_ID,
+      'input_invalid',
+    );
+  });
+
+  it('missing evaluator dependency blocked/failure', async () => {
+    const noDepTask = makeRolloutReviewerTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(noDepTask);
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockResolvedValue(noDepTask);
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('evaluator dependency not succeeded cannot execute', async () => {
+    const pendingEvaluator = makeEvaluatorTask({ status: 'pending' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockImplementation((id: string) => {
+      if (id === ROLLOUT_REVIEWER_TASK_ID) return Promise.resolve(makeRolloutReviewerTask());
+      if (id === EVALUATOR_TASK_ID) return Promise.resolve(pendingEvaluator);
+      return Promise.resolve(null);
+    });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('evaluator artifact missing goes to retry/fail', async () => {
+    const emptyArtifactStore = new MemoryPIArtifactStore();
+    const deps = createMockDeps({ artifactStore: emptyArtifactStore });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('valid runtime output writes rollout_reviewer PIArtifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeEvaluatorArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(result.artifactId).toBeDefined();
+
+    const artifacts = await store.listBySourceTaskId(ROLLOUT_REVIEWER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+  });
+
+  it('valid runtime output marks task succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeEvaluatorArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
+      ROLLOUT_REVIEWER_TASK_ID,
+      expect.stringContaining('rollout-reviewer://'),
+    );
+  });
+
+  it('invalid output does not write artifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeEvaluatorArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const invalidOutput: RolloutReviewerOutputV1 = {
+      taskId: 'wrong-task-id',
+      sourceEvaluatorArtifactId: '',
+      review: {
+        decision: 'approve_rollout',
+        summary: '',
+        confidence: 1.5,
+        requiredChanges: [],
+        rolloutRisks: [],
+        safetyChecks: [],
+      },
+      sourceTrace: {
+        evaluatorArtifactId: '',
+      },
+      risks: 'not-array' as unknown as string[],
+      generatedAt: '',
+    };
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+
+    const artifacts = await store.listBySourceTaskId(ROLLOUT_REVIEWER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('artifact write failure goes to retry/fail, not mark succeeded', async () => {
+    const failingStore = {
+      listBySourceTaskId: vi.fn().mockResolvedValue([makeEvaluatorArtifact()]),
+      upsertArtifact: vi.fn().mockRejectedValue(new Error('Disk full')),
+    } as unknown as PIArtifactStore;
+
+    const deps = createMockDeps({ artifactStore: failingStore });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('output_invalid results in permanent failure', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeEvaluatorArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const invalidOutput: RolloutReviewerOutputV1 = {
+      taskId: ROLLOUT_REVIEWER_TASK_ID,
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001-run-001',
+      review: {
+        decision: 'invalid_decision' as 'approve_rollout',
+        summary: 'Test',
+        confidence: 0.5,
+        requiredChanges: [],
+        rolloutRisks: [],
+        safetyChecks: [],
+      },
+      sourceTrace: {
+        evaluatorArtifactId: 'pi-art-evaluator-001-run-001',
+      },
+      risks: [],
+      generatedAt: new Date().toISOString(),
+    };
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+  });
+
+  it('mismatched sourceEvaluatorArtifactId does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeEvaluatorArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeRolloutReviewerOutput();
+    (mismatchedOutput as unknown as Record<string, unknown>).sourceEvaluatorArtifactId = 'wrong-artifact-id';
+    (mismatchedOutput.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId = 'wrong-artifact-id';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(ROLLOUT_REVIEWER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('sourceTrace.evaluatorArtifactId mismatch does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeEvaluatorArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeRolloutReviewerOutput();
+    (mismatchedOutput.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId = 'wrong-trace-id';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(ROLLOUT_REVIEWER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+});
+
+describe('DefaultRolloutReviewerValidator (vertical slice)', () => {
+  const validator = new DefaultRolloutReviewerValidator();
+
+  it('accepts valid RolloutReviewer output', async () => {
+    const result = await validator.validate(makeRolloutReviewerOutput(), ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects taskId mismatch', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output as unknown as Record<string, unknown>).taskId = 'wrong';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('taskId mismatch'))).toBe(true);
+  });
+
+  it('rejects missing sourceEvaluatorArtifactId', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output as unknown as Record<string, unknown>).sourceEvaluatorArtifactId = '';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceEvaluatorArtifactId'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceEvaluatorArtifactId when expected is provided', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output as unknown as Record<string, unknown>).sourceEvaluatorArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID, 'pi-art-evaluator-001-run-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceEvaluatorArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceTrace.evaluatorArtifactId when expected is provided', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID, 'pi-art-evaluator-001-run-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceTrace.evaluatorArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects invalid decision value', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).decision = 'invalid';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.decision'))).toBe(true);
+  });
+
+  it('rejects confidence as string', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).confidence = '0.9';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.confidence must be number'))).toBe(true);
+  });
+
+  it('rejects confidence > 1', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).confidence = 1.5;
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.confidence must be in [0, 1]'))).toBe(true);
+  });
+
+  it('rejects NaN confidence', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).confidence = NaN;
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.confidence must be number'))).toBe(true);
+  });
+
+  it('rejects Infinity confidence', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).confidence = Infinity;
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.confidence must be number'))).toBe(true);
+  });
+
+  it('rejects null output', async () => {
+    const result = await validator.validate(null as unknown as RolloutReviewerOutputV1, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects requiredChanges with non-string elements', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).requiredChanges = [42];
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.requiredChanges must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects rolloutRisks with non-string elements', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).rolloutRisks = [1];
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.rolloutRisks must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects safetyChecks with non-string elements', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).safetyChecks = [true];
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.safetyChecks must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects risks with non-string elements', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output as unknown as Record<string, unknown>).risks = [42];
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('risks must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects missing review.summary', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.review as unknown as Record<string, unknown>).summary = '';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('review.summary'))).toBe(true);
+  });
+
+  it('rejects missing sourceTrace.evaluatorArtifactId', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId = '';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceTrace.evaluatorArtifactId'))).toBe(true);
+  });
+
+  it('accepts valid output with matching expectedSourceEvaluatorArtifactId', async () => {
+    const output = makeRolloutReviewerOutput();
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID, 'pi-art-evaluator-001-run-001');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects mismatched sourceEvaluatorArtifactId vs sourceTrace.evaluatorArtifactId', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId = 'different-id';
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('must match'))).toBe(true);
+  });
+
+  it('rejects non-string artificerArtifactId in sourceTrace', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).artificerArtifactId = 42;
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('artificerArtifactId'))).toBe(true);
+  });
+
+  it('rejects non-string scribeArtifactId in sourceTrace', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = 42;
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('scribeArtifactId'))).toBe(true);
+  });
+
+  it('rejects non-string philosopherArtifactId in sourceTrace', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).philosopherArtifactId = { evil: true };
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('philosopherArtifactId'))).toBe(true);
+  });
+
+  it('rejects non-string dreamerArtifactId in sourceTrace', async () => {
+    const output = makeRolloutReviewerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).dreamerArtifactId = true;
+    const result = await validator.validate(output, ROLLOUT_REVIEWER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('dreamerArtifactId'))).toBe(true);
+  });
+});
+
+describe('RolloutReviewerRunner integration: test-double captures sourceEvaluatorArtifactId from prompt', () => {
+  it('seed evaluator artifact -> run rollout_reviewer with test-double -> succeeded with correct sourceEvaluatorArtifactId', async () => {
+    const EVALUATOR_ART_ID = 'pi-art-evaluator-real-001';
+    const artifactStore = new MemoryPIArtifactStore();
+
+    const evaluatorArtifact: PIArtifactRecord = {
+      artifactId: EVALUATOR_ART_ID,
+      artifactKind: 'principle',
+      sourceTaskId: EVALUATOR_TASK_ID,
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: JSON.stringify({
+        taskId: EVALUATOR_TASK_ID,
+        sourceArtificerArtifactId: 'pi-art-artificer-001',
+        evaluation: {
+          decision: 'approved',
+          summary: 'Implementation plan is well-structured',
+          score: 0.85,
+          strengths: ['Clear change descriptions'],
+          concerns: [],
+          requiredChanges: [],
+        },
+        sourceTrace: { artificerArtifactId: 'pi-art-artificer-001' },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      }),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await artifactStore.upsertArtifact(evaluatorArtifact);
+
+    const rolloutReviewerTask = makeRolloutReviewerTask();
+
+    let capturedSourceEvaluatorArtifactId: string | undefined = undefined;
+    const runtimeAdapter = new TestDoubleRuntimeAdapter({
+      onStartRun: (input) => {
+        try {
+          const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+          const parsed = JSON.parse(payloadStr);
+          if (typeof parsed.sourceEvaluatorArtifactId === 'string' && parsed.sourceEvaluatorArtifactId.trim() !== '') {
+            capturedSourceEvaluatorArtifactId = parsed.sourceEvaluatorArtifactId;
+          }
+        } catch { /* ignore */ }
+        return { runId: 'run-integration-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+      },
+      onPollRun: (_runId: string) => ({
+        runId: _runId,
+        status: 'succeeded',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }),
+      onFetchOutput: (_runId: string) => ({
+          runId: _runId,
+          payload: {
+            taskId: ROLLOUT_REVIEWER_TASK_ID,
+            sourceEvaluatorArtifactId: capturedSourceEvaluatorArtifactId ?? EVALUATOR_ART_ID,
+            review: {
+              decision: 'approve_rollout',
+              summary: 'The evaluation is thorough and the plan is safe to proceed',
+              confidence: 0.9,
+              requiredChanges: [],
+              rolloutRisks: [],
+              safetyChecks: ['Verify feature flag is properly configured'],
+            },
+            sourceTrace: {
+              evaluatorArtifactId: capturedSourceEvaluatorArtifactId ?? EVALUATOR_ART_ID,
+            },
+            risks: [],
+            generatedAt: new Date().toISOString(),
+          },
+        }),
+    });
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(rolloutReviewerTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === ROLLOUT_REVIEWER_TASK_ID) return Promise.resolve(rolloutReviewerTask);
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(makeEvaluatorTask());
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-integration-001',
+        taskId: ROLLOUT_REVIEWER_TASK_ID,
+        runtimeKind: 'rollout_reviewer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const deps: RolloutReviewerRunnerDeps = {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator: new DefaultRolloutReviewerValidator(),
+      artifactStore,
+    };
+
+    const runner = new RolloutReviewerRunner(deps, {
+      owner: 'test-integration',
+      runtimeKind: 'rollout_reviewer',
+      pollIntervalMs: 10,
+      timeoutMs: 5000,
+    });
+
+    const result = await runner.run(ROLLOUT_REVIEWER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+    expect(capturedSourceEvaluatorArtifactId).toBe(EVALUATOR_ART_ID);
+    expect(result.output?.sourceEvaluatorArtifactId).toBe(EVALUATOR_ART_ID);
+    expect(result.output?.sourceTrace.evaluatorArtifactId).toBe(EVALUATOR_ART_ID);
+
+    const artifacts = await artifactStore.listBySourceTaskId(ROLLOUT_REVIEWER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+
+    const [storedArtifact] = artifacts;
+    expect(storedArtifact).toBeDefined();
+    if (!storedArtifact) return;
+    const storedOutput = JSON.parse(storedArtifact.contentJson) as RolloutReviewerOutputV1;
+    expect(storedOutput.sourceEvaluatorArtifactId).toBe(EVALUATOR_ART_ID);
+    expect(storedOutput.sourceTrace.evaluatorArtifactId).toBe(EVALUATOR_ART_ID);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -26,6 +26,7 @@ import { PhilosopherOutputV1Schema } from '../internalization/philosopher-output
 import { ScribeOutputV1Schema } from '../internalization/scribe-output.js';
 import { ArtificerOutputV1Schema } from '../internalization/artificer-output.js';
 import { EvaluatorOutputV1Schema } from '../internalization/evaluator-output.js';
+import { RolloutReviewerOutputV1Schema } from '../internalization/rollout-reviewer-output.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair } from './structured-output-repair.js';
@@ -191,6 +192,7 @@ const OUTPUT_SCHEMA_REGISTRY = new Map<string, TSchema>([
   ['scribe-output-v1', ScribeOutputV1Schema as TSchema],
   ['artificer-output-v1', ArtificerOutputV1Schema as TSchema],
   ['evaluator-output-v1', EvaluatorOutputV1Schema as TSchema],
+  ['rollout-reviewer-output-v1', RolloutReviewerOutputV1Schema as TSchema],
 ]);
 
 export class PiAiRuntimeAdapter implements PDRuntimeAdapter {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -592,6 +592,50 @@ export type {
   EvaluatorPromptBuildResult,
 } from './internalization/evaluator-prompt-builder.js';
 
+// ── Rollout Reviewer Runner (PRI-RR) ────────────────────────────────────────
+
+export type {
+  RolloutReviewerReview,
+  RolloutReviewerSourceTrace,
+  RolloutReviewerOutputV1,
+  RolloutReviewerValidationResult,
+  RolloutReviewerValidator,
+} from './internalization/rollout-reviewer-output.js';
+
+export {
+  DefaultRolloutReviewerValidator,
+  RolloutReviewerOutputV1Schema,
+  RolloutReviewerReviewSchema,
+  RolloutReviewerSourceTraceSchema,
+  ROLLOUT_REVIEWER_DECISIONS,
+} from './internalization/rollout-reviewer-output.js';
+
+export type {
+  RolloutReviewerRunnerResultStatus,
+  RolloutReviewerRunnerResult,
+  RolloutReviewerRunnerOptions,
+  ResolvedRolloutReviewerRunnerOptions,
+  RolloutReviewerRunnerDeps,
+} from './internalization/rollout-reviewer-runner.js';
+
+export {
+  RolloutReviewerRunner,
+  resolveRolloutReviewerRunnerOptions,
+  DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS,
+} from './internalization/rollout-reviewer-runner.js';
+
+export {
+  RolloutReviewerPromptBuilder,
+  ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION,
+  ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION,
+} from './internalization/rollout-reviewer-prompt-builder.js';
+
+export type {
+  RolloutReviewerPromptBuilderInput,
+  RolloutReviewerPromptInput,
+  RolloutReviewerPromptBuildResult,
+} from './internalization/rollout-reviewer-prompt-builder.js';
+
 // ── PIArtifact Durable Store (PRI-84) ────────────────────────────────────────
 
 export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/dreamer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/dreamer-prompt-builder.test.ts
@@ -134,6 +134,51 @@ describe('DreamerPromptBuilder', () => {
       expect(instruction).toMatch(/no markdown/i);
     });
 
+    it('dreamerInstruction contains CRITICAL JSON-only directive', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toContain('CRITICAL');
+      expect(instruction).toContain('ONLY valid JSON');
+      expect(instruction).toContain('no code fences');
+      expect(instruction).toContain('no prose');
+    });
+
+    it('dreamerInstruction contains COMPLETE EXAMPLE OUTPUT with concrete values', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toContain('COMPLETE EXAMPLE OUTPUT');
+      expect(instruction).toContain('"valid":true');
+      expect(instruction).toContain('"taskId":"task-dreamer-001"');
+      expect(instruction).toContain('"badDecision"');
+      expect(instruction).toContain('"betterDecision"');
+      expect(instruction).toContain('"rationale"');
+      expect(instruction).toContain('"strategicPerspective"');
+    });
+
+    it('dreamerInstruction example output is parseable JSON', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      const exampleMatch = /\{"valid":true[^}]+generatedAt":"[^"]+"\}/s.exec(instruction);
+      expect(exampleMatch).toBeDefined();
+      if (exampleMatch) {
+        expect(() => JSON.parse(exampleMatch[0])).not.toThrow();
+      }
+    });
+
+    it('dreamerInstruction explicitly prohibits code fences', () => {
+      const builder = new DreamerPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_INPUT);
+
+      const instruction = result.promptInput.dreamerInstruction;
+      expect(instruction).toMatch(/Do NOT wrap.*code fence/);
+    });
+
     it('buildPrompt() is a pure function — same input produces same output', () => {
       const builder = new DreamerPromptBuilder();
       const result1 = builder.buildPrompt(MINIMAL_INPUT);

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/rollout-reviewer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/rollout-reviewer-prompt-builder.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RolloutReviewerPromptBuilder,
+  ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION,
+  ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION,
+} from '../rollout-reviewer-prompt-builder.js';
+
+describe('RolloutReviewerPromptBuilder', () => {
+  const builder = new RolloutReviewerPromptBuilder();
+
+  it('buildPrompt produces valid JSON message', () => {
+    const result = builder.buildPrompt({
+      taskId: 'task-rr-001',
+      contextHash: 'ctx-abc123',
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      evaluatorArtifact: { taskId: 'eval-001', evaluation: { decision: 'approved' } },
+    });
+
+    expect(result.message).toBeDefined();
+    const parsed = JSON.parse(result.message);
+    expect(parsed).toBeDefined();
+    expect(typeof parsed).toBe('object');
+  });
+
+  it('promptInput contains correct sourceEvaluatorArtifactId', () => {
+    const result = builder.buildPrompt({
+      taskId: 'task-rr-001',
+      contextHash: 'ctx-abc123',
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      evaluatorArtifact: { taskId: 'eval-001' },
+    });
+
+    expect(result.promptInput.sourceEvaluatorArtifactId).toBe('pi-art-evaluator-001');
+  });
+
+  it('promptInput contains rolloutReviewerInstruction', () => {
+    const result = builder.buildPrompt({
+      taskId: 'task-rr-001',
+      contextHash: 'ctx-abc123',
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      evaluatorArtifact: null,
+    });
+
+    expect(result.promptInput.rolloutReviewerInstruction).toBe(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION);
+  });
+
+  it('promptContractVersion is set correctly', () => {
+    const result = builder.buildPrompt({
+      taskId: 'task-rr-001',
+      contextHash: 'ctx-abc123',
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      evaluatorArtifact: null,
+    });
+
+    expect(result.promptInput.promptContractVersion).toBe(ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION);
+  });
+
+  it('promptInput contains taskId and contextHash', () => {
+    const result = builder.buildPrompt({
+      taskId: 'task-rr-001',
+      contextHash: 'ctx-abc123',
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      evaluatorArtifact: null,
+    });
+
+    expect(result.promptInput.taskId).toBe('task-rr-001');
+    expect(result.promptInput.contextHash).toBe('ctx-abc123');
+  });
+
+  it('promptInput contains evaluatorArtifact', () => {
+    const evaluatorArtifact = { taskId: 'eval-001', evaluation: { decision: 'approved' } };
+    const result = builder.buildPrompt({
+      taskId: 'task-rr-001',
+      contextHash: 'ctx-abc123',
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      evaluatorArtifact,
+    });
+
+    expect(result.promptInput.evaluatorArtifact).toBe(evaluatorArtifact);
+  });
+
+  it('protocol instruction contains CRITICAL JSON-only directive', () => {
+    expect(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION).toContain('CRITICAL');
+    expect(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION).toContain('ONLY valid JSON');
+    expect(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION).toContain('no markdown');
+    expect(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION).toContain('no code fences');
+  });
+
+  it('protocol instruction contains complete example output', () => {
+    expect(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION).toContain('COMPLETE EXAMPLE OUTPUT');
+    expect(ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION).toContain('approve_rollout');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-prompt-builder.ts
@@ -46,29 +46,15 @@ PROTOCOL:
 4. Assign a confidence score (0.0 to 1.0) and risk level (low, medium, or high) to each candidate
 5. Provide a strategic perspective for each candidate
 
-OUTPUT FORMAT (pure JSON, no markdown):
-{
-  "valid": true,
-  "taskId": "<from input>",
-  "candidates": [
-    {
-      "candidateIndex": 0,
-      "badDecision": "<what the agent did wrong>",
-      "betterDecision": "<what the agent should have done>",
-      "rationale": "<why the better decision is superior>",
-      "confidence": 0.85,
-      "riskLevel": "low",
-      "strategicPerspective": "<strategic lens: e.g., defensive_programming, fail_fast, graceful_degradation>"
-    }
-  ],
-  "sourcePrincipleId": "<optional: principle ID if applicable>",
-  "sourcePainId": "<optional: pain signal ID if applicable>",
-  "contextRefs": ["<from input contextRefs>"],
-  "generatedAt": "<ISO-8601 timestamp>"
-}
+CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
+
+COMPLETE EXAMPLE OUTPUT (follow this exact structure):
+{"valid":true,"taskId":"task-dreamer-001","candidates":[{"candidateIndex":0,"badDecision":"Ignored null check on user input before processing","betterDecision":"Add null/undefined guard before accessing user input properties","rationale":"Defensive programming prevents runtime crashes from unexpected null values","confidence":0.9,"riskLevel":"low","strategicPerspective":"defensive_programming"},{"candidateIndex":1,"badDecision":"Used synchronous file read in request handler","betterDecision":"Replace with async fs.readFile to avoid blocking the event loop","rationale":"Non-blocking I/O preserves server responsiveness under load","confidence":0.85,"riskLevel":"medium","strategicPerspective":"fail_fast"}],"sourcePrincipleId":"pri-042","sourcePainId":"pain-null-crash","contextRefs":["pi-art-diag-001"],"generatedAt":"2026-05-11T12:00:00.000Z"}
 
 CONSTRAINTS:
-- Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
+- Output ONLY valid JSON — no markdown, no explanatory text, no code fences, no prose before or after
+- Do NOT wrap the JSON in \`\`\`json or any other code fence markers
+- Do NOT add any commentary or explanation outside the JSON object
 - candidates MUST have 1-5 items
 - candidateIndex MUST be a number (0-based)
 - badDecision, betterDecision, rationale, strategicPerspective MUST be non-empty strings
@@ -77,6 +63,7 @@ CONSTRAINTS:
 - contextRefs MUST be copied from the input contextRefs array
 - generatedAt MUST be an ISO-8601 timestamp string
 - valid MUST be true on success
+- sourcePrincipleId and sourcePainId are optional strings
 `;
 
 export class DreamerPromptBuilder {

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -242,7 +242,7 @@ export class DreamerRunner {
 
       // 6. Fetch output
       this.phase = RunnerPhase.FetchingOutput;
-      const output = await this.fetchAndParseOutput(runHandle.runId);
+      const output = await this.fetchAndParseOutput(runHandle.runId, taskId);
 
       // 7. Validate
       this.phase = RunnerPhase.Validating;
@@ -454,12 +454,39 @@ export class DreamerRunner {
     throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
   }
 
-  private async fetchAndParseOutput(runId: string): Promise<DreamerOutput> {
-    const result = await this.runtimeAdapter.fetchOutput(runId);
+  private async fetchAndParseOutput(runId: string, taskId: string): Promise<DreamerOutput> {
+    const result = await this.fetchOutputWithTelemetry(runId, taskId);
     if (!result || !result.payload) {
+      this.emitDreamerEvent('dreamer_output_extraction_failed', taskId, {
+        runId,
+        stage: 'payload_missing',
+        errorMessage: `No output available for run ${runId}`,
+      });
       throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
     }
+    const payload = result.payload as Record<string, unknown>;
+    if (typeof payload !== 'object' || payload === null) {
+      this.emitDreamerEvent('dreamer_output_extraction_failed', taskId, {
+        runId,
+        stage: 'payload_not_object',
+        errorMessage: `Output payload is not an object for run ${runId}`,
+      });
+      throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
+    }
     return result.payload as DreamerOutput;
+  }
+
+  private async fetchOutputWithTelemetry(runId: string, taskId: string): Promise<Awaited<ReturnType<PDRuntimeAdapter['fetchOutput']>>> {
+    try {
+      return await this.runtimeAdapter.fetchOutput(runId);
+    } catch (fetchErr) {
+      this.emitDreamerEvent('dreamer_output_extraction_failed', taskId, {
+        runId,
+        stage: 'fetchOutput',
+        errorMessage: fetchErr instanceof Error ? fetchErr.message : String(fetchErr),
+      });
+      throw fetchErr;
+    }
   }
 
   private async succeedTask(ctx: SucceedContext): Promise<DreamerRunnerResult> {

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -307,6 +307,50 @@ export type {
   EvaluatorPromptBuildResult,
 } from './evaluator-prompt-builder.js';
 
+// ── Rollout Reviewer Runner (PRI-RR) ────────────────────────────────────────
+
+export type {
+  RolloutReviewerReview,
+  RolloutReviewerSourceTrace,
+  RolloutReviewerOutputV1,
+  RolloutReviewerValidationResult,
+  RolloutReviewerValidator,
+} from './rollout-reviewer-output.js';
+
+export {
+  DefaultRolloutReviewerValidator,
+  RolloutReviewerOutputV1Schema,
+  RolloutReviewerReviewSchema,
+  RolloutReviewerSourceTraceSchema,
+  ROLLOUT_REVIEWER_DECISIONS,
+} from './rollout-reviewer-output.js';
+
+export type {
+  RolloutReviewerRunnerResultStatus,
+  RolloutReviewerRunnerResult,
+  RolloutReviewerRunnerOptions,
+  ResolvedRolloutReviewerRunnerOptions,
+  RolloutReviewerRunnerDeps,
+} from './rollout-reviewer-runner.js';
+
+export {
+  RolloutReviewerRunner,
+  resolveRolloutReviewerRunnerOptions,
+  DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS,
+} from './rollout-reviewer-runner.js';
+
+export {
+  RolloutReviewerPromptBuilder,
+  ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION,
+  ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION,
+} from './rollout-reviewer-prompt-builder.js';
+
+export type {
+  RolloutReviewerPromptBuilderInput,
+  RolloutReviewerPromptInput,
+  RolloutReviewerPromptBuildResult,
+} from './rollout-reviewer-prompt-builder.js';
+
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 
 export type {

--- a/packages/principles-core/src/runtime-v2/internalization/rollout-reviewer-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rollout-reviewer-output.ts
@@ -1,0 +1,154 @@
+import { Type, type Static } from '@sinclair/typebox';
+
+export interface RolloutReviewerReview {
+  readonly decision: 'approve_rollout' | 'needs_revision' | 'reject';
+  readonly summary: string;
+  readonly confidence: number;
+  readonly requiredChanges: readonly string[];
+  readonly rolloutRisks: readonly string[];
+  readonly safetyChecks: readonly string[];
+}
+
+export interface RolloutReviewerSourceTrace {
+  readonly evaluatorArtifactId: string;
+  readonly artificerArtifactId?: string;
+  readonly scribeArtifactId?: string;
+  readonly philosopherArtifactId?: string;
+  readonly dreamerArtifactId?: string;
+}
+
+export interface RolloutReviewerOutputV1 {
+  readonly taskId: string;
+  readonly sourceEvaluatorArtifactId: string;
+  readonly review: RolloutReviewerReview;
+  readonly sourceTrace: RolloutReviewerSourceTrace;
+  readonly risks: readonly string[];
+  readonly generatedAt: string;
+}
+
+export const ROLLOUT_REVIEWER_DECISIONS = ['approve_rollout', 'needs_revision', 'reject'] as const;
+
+export const RolloutReviewerReviewSchema = Type.Object({
+  decision: Type.Union([
+    Type.Literal('approve_rollout'),
+    Type.Literal('needs_revision'),
+    Type.Literal('reject'),
+  ]),
+  summary: Type.String({ minLength: 1 }),
+  confidence: Type.Number({ minimum: 0, maximum: 1 }),
+  requiredChanges: Type.Array(Type.String()),
+  rolloutRisks: Type.Array(Type.String()),
+  safetyChecks: Type.Array(Type.String()),
+});
+
+export const RolloutReviewerSourceTraceSchema = Type.Object({
+  evaluatorArtifactId: Type.String({ minLength: 1 }),
+  artificerArtifactId: Type.Optional(Type.String()),
+  scribeArtifactId: Type.Optional(Type.String()),
+  philosopherArtifactId: Type.Optional(Type.String()),
+  dreamerArtifactId: Type.Optional(Type.String()),
+});
+
+export const RolloutReviewerOutputV1Schema = Type.Object({
+  taskId: Type.String({ minLength: 1 }),
+  sourceEvaluatorArtifactId: Type.String({ minLength: 1 }),
+  review: RolloutReviewerReviewSchema,
+  sourceTrace: RolloutReviewerSourceTraceSchema,
+  risks: Type.Array(Type.String()),
+  generatedAt: Type.String({ minLength: 1 }),
+});
+
+export type RolloutReviewerOutputV1TB = Static<typeof RolloutReviewerOutputV1Schema>;
+
+export interface RolloutReviewerValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+export interface RolloutReviewerValidator {
+  validate(output: RolloutReviewerOutputV1, taskId: string, expectedSourceEvaluatorArtifactId?: string): Promise<RolloutReviewerValidationResult>;
+}
+
+export class DefaultRolloutReviewerValidator implements RolloutReviewerValidator {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async validate(output: RolloutReviewerOutputV1, taskId: string, expectedSourceEvaluatorArtifactId?: string): Promise<RolloutReviewerValidationResult> {
+    const errors: string[] = [];
+
+    if (typeof output !== 'object' || output === null) {
+      return { valid: false, errors: ['Output is not an object'], errorCategory: 'output_invalid' };
+    }
+
+    if (output.taskId !== taskId) {
+      errors.push(`taskId mismatch: expected ${taskId}, got ${String(output.taskId)}`);
+    }
+
+    if (typeof output.sourceEvaluatorArtifactId !== 'string' || output.sourceEvaluatorArtifactId.trim() === '') {
+      errors.push('sourceEvaluatorArtifactId must be non-empty string');
+    } else if (expectedSourceEvaluatorArtifactId && output.sourceEvaluatorArtifactId !== expectedSourceEvaluatorArtifactId) {
+      errors.push(`sourceEvaluatorArtifactId mismatch: expected ${expectedSourceEvaluatorArtifactId}, got ${output.sourceEvaluatorArtifactId}`);
+    }
+
+    if (typeof output.review !== 'object' || output.review === null) {
+      errors.push('review must be an object');
+    } else {
+      const rv = output.review as unknown as Record<string, unknown>;
+      if (!ROLLOUT_REVIEWER_DECISIONS.includes(rv.decision as 'approve_rollout' | 'needs_revision' | 'reject')) {
+        errors.push(`review.decision must be one of ${ROLLOUT_REVIEWER_DECISIONS.join('/')}, got ${String(rv.decision)}`);
+      }
+      if (typeof rv.summary !== 'string' || (rv.summary).trim() === '') errors.push('review.summary must be non-empty string');
+      if (typeof rv.confidence !== 'number' || !Number.isFinite(rv.confidence)) errors.push('review.confidence must be number');
+      else if (rv.confidence < 0 || rv.confidence > 1) errors.push('review.confidence must be in [0, 1]');
+      if (!Array.isArray(rv.requiredChanges)) errors.push('review.requiredChanges must be an array');
+      else if (!(rv.requiredChanges as unknown[]).every(e => typeof e === 'string')) errors.push('review.requiredChanges must be an array of strings');
+      if (!Array.isArray(rv.rolloutRisks)) errors.push('review.rolloutRisks must be an array');
+      else if (!(rv.rolloutRisks as unknown[]).every(e => typeof e === 'string')) errors.push('review.rolloutRisks must be an array of strings');
+      if (!Array.isArray(rv.safetyChecks)) errors.push('review.safetyChecks must be an array');
+      else if (!(rv.safetyChecks as unknown[]).every(e => typeof e === 'string')) errors.push('review.safetyChecks must be an array of strings');
+    }
+
+    if (typeof output.sourceTrace !== 'object' || output.sourceTrace === null) {
+      errors.push('sourceTrace must be an object');
+    } else {
+      const st = output.sourceTrace as unknown as Record<string, unknown>;
+      if (typeof st.evaluatorArtifactId !== 'string' || (st.evaluatorArtifactId).trim() === '') {
+        errors.push('sourceTrace.evaluatorArtifactId must be non-empty string');
+      } else if (expectedSourceEvaluatorArtifactId && st.evaluatorArtifactId !== expectedSourceEvaluatorArtifactId) {
+        errors.push(`sourceTrace.evaluatorArtifactId mismatch: expected ${expectedSourceEvaluatorArtifactId}, got ${st.evaluatorArtifactId}`);
+      }
+      if (st.artificerArtifactId !== undefined && typeof st.artificerArtifactId !== 'string') {
+        errors.push('sourceTrace.artificerArtifactId must be string if present');
+      }
+      if (st.scribeArtifactId !== undefined && typeof st.scribeArtifactId !== 'string') {
+        errors.push('sourceTrace.scribeArtifactId must be string if present');
+      }
+      if (st.philosopherArtifactId !== undefined && typeof st.philosopherArtifactId !== 'string') {
+        errors.push('sourceTrace.philosopherArtifactId must be string if present');
+      }
+      if (st.dreamerArtifactId !== undefined && typeof st.dreamerArtifactId !== 'string') {
+        errors.push('sourceTrace.dreamerArtifactId must be string if present');
+      }
+    }
+
+    if (!Array.isArray(output.risks)) {
+      errors.push('risks must be an array');
+    } else if (!(output.risks as unknown[]).every(e => typeof e === 'string')) {
+      errors.push('risks must be an array of strings');
+    }
+
+    if (typeof output.sourceEvaluatorArtifactId === 'string' && output.sourceEvaluatorArtifactId.trim() !== ''
+      && typeof output.sourceTrace === 'object' && output.sourceTrace !== null
+      && typeof (output.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId === 'string'
+      && output.sourceEvaluatorArtifactId !== (output.sourceTrace as unknown as Record<string, unknown>).evaluatorArtifactId) {
+      errors.push('sourceEvaluatorArtifactId and sourceTrace.evaluatorArtifactId must match');
+    }
+
+    if (typeof output.generatedAt !== 'string' || output.generatedAt.trim() === '') {
+      errors.push('generatedAt must be non-empty string');
+    }
+
+    return errors.length > 0
+      ? { valid: false, errors, errorCategory: 'output_invalid' }
+      : { valid: true, errors: [] };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/rollout-reviewer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rollout-reviewer-prompt-builder.ts
@@ -1,0 +1,76 @@
+export interface RolloutReviewerPromptBuilderInput {
+  taskId: string;
+  contextHash: string;
+  sourceEvaluatorArtifactId: string;
+  evaluatorArtifact: unknown;
+}
+
+export interface RolloutReviewerPromptInput {
+  taskId: string;
+  contextHash: string;
+  sourceEvaluatorArtifactId: string;
+  evaluatorArtifact: unknown;
+  rolloutReviewerInstruction: string;
+  promptContractVersion: string;
+}
+
+export interface RolloutReviewerPromptBuildResult {
+  readonly message: string;
+  readonly promptInput: RolloutReviewerPromptInput;
+}
+
+export const ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION = `You are a Rollout Reviewer agent in a principle internalization pipeline. Your role is to review the Evaluator's assessment and produce a rollout review decision with safety checks and risk analysis.
+
+PROTOCOL:
+1. Review the evaluatorArtifact to understand the evaluation decision, score, and feedback
+2. Assess whether the evaluated plan is safe to proceed with rollout
+3. Produce a decision: approve_rollout (safe to proceed), needs_revision (issues found but salvageable), or reject (fundamental safety or quality concerns)
+4. Provide a confidence score from 0.0 to 1.0 reflecting your assessment certainty
+5. List specific required changes if any
+6. Identify rollout-specific risks
+7. List safety checks that should be performed before/during rollout
+8. Preserve the lineage trace from evaluator, artificer, scribe, philosopher, and dreamer artifacts
+9. Identify risks associated with this review
+
+CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
+
+COMPLETE EXAMPLE OUTPUT (follow this exact structure):
+{"taskId":"task-123","sourceEvaluatorArtifactId":"pi-art-evaluator-001","review":{"decision":"approve_rollout","summary":"The evaluation is thorough and the plan is safe to proceed with rollout.","confidence":0.9,"requiredChanges":[],"rolloutRisks":["Feature flag configuration may need adjustment"],"safetyChecks":["Verify feature flag is properly configured","Monitor error rates for 24h post-deploy"]},"sourceTrace":{"evaluatorArtifactId":"pi-art-evaluator-001"},"risks":["Rollback plan should be tested before deployment"],"generatedAt":"2026-05-11T12:00:00.000Z"}
+
+CONSTRAINTS:
+- Output ONLY valid JSON — no markdown, no explanatory text, no code fences, no prose before or after
+- review.decision MUST be one of: approve_rollout, needs_revision, reject
+- review.summary MUST be a non-empty string
+- review.confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- review.requiredChanges MUST be an array of strings (can be empty)
+- review.rolloutRisks MUST be an array of strings (can be empty)
+- review.safetyChecks MUST be an array of strings (can be empty)
+- sourceEvaluatorArtifactId MUST be copied exactly from input.sourceEvaluatorArtifactId (non-empty string)
+- sourceTrace.evaluatorArtifactId MUST be copied exactly from input.sourceEvaluatorArtifactId
+- sourceTrace.artificerArtifactId is optional — include only if available from evaluator artifact
+- sourceTrace.scribeArtifactId is optional — include only if available from evaluator artifact
+- sourceTrace.philosopherArtifactId is optional — include only if available from evaluator artifact
+- sourceTrace.dreamerArtifactId is optional — include only if available from evaluator artifact
+- risks MUST be an array of strings (can be empty if no risks identified)
+- generatedAt MUST be an ISO-8601 timestamp string
+`;
+
+export const ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION = 'rollout-reviewer-output-v1.prompt.v1';
+
+export class RolloutReviewerPromptBuilder {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildPrompt(input: RolloutReviewerPromptBuilderInput): RolloutReviewerPromptBuildResult {
+    const promptInput: RolloutReviewerPromptInput = {
+      taskId: input.taskId,
+      contextHash: input.contextHash,
+      sourceEvaluatorArtifactId: input.sourceEvaluatorArtifactId,
+      evaluatorArtifact: input.evaluatorArtifact,
+      rolloutReviewerInstruction: ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION,
+      promptContractVersion: ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION,
+    };
+
+    const message = JSON.stringify(promptInput);
+
+    return { message, promptInput };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/rollout-reviewer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rollout-reviewer-runner.ts
@@ -1,0 +1,686 @@
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type {
+  PDRuntimeAdapter,
+  RunHandle,
+  RunStatus,
+  StartRunInput,
+} from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { RolloutReviewerOutputV1, RolloutReviewerValidator } from './rollout-reviewer-output.js';
+import type { PIArtifactStore } from './pi-artifact.js';
+import type { TaskRecord } from '../task-status.js';
+import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
+import type { TelemetryEvent } from '../../telemetry-event.js';
+import { hydratePITaskRecord } from './pitask-metadata.js';
+import { RunnerPhase } from '../runner/runner-phase.js';
+import { RolloutReviewerPromptBuilder } from './rollout-reviewer-prompt-builder.js';
+
+export type RolloutReviewerRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
+
+export interface RolloutReviewerRunnerResult {
+  readonly status: RolloutReviewerRunnerResultStatus;
+  readonly taskId: string;
+  readonly runId?: string;
+  readonly artifactId?: string;
+  readonly resultRef?: string;
+  readonly contextHash?: string;
+  readonly output?: RolloutReviewerOutputV1;
+  readonly errorCategory?: PDErrorCategory;
+  readonly failureReason?: string;
+  readonly attemptCount: number;
+}
+
+export interface RolloutReviewerRunnerOptions {
+  readonly pollIntervalMs?: number;
+  readonly timeoutMs?: number;
+  readonly defaultMaxAttempts?: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId?: string;
+}
+
+export interface ResolvedRolloutReviewerRunnerOptions {
+  readonly pollIntervalMs: number;
+  readonly timeoutMs: number;
+  readonly defaultMaxAttempts: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId: string;
+}
+
+const DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS: Readonly<Omit<ResolvedRolloutReviewerRunnerOptions, 'owner' | 'runtimeKind'>> = {
+  pollIntervalMs: 5_000,
+  timeoutMs: 300_000,
+  defaultMaxAttempts: 3,
+  agentId: 'rollout_reviewer',
+} as const;
+
+export function resolveRolloutReviewerRunnerOptions(options: RolloutReviewerRunnerOptions): ResolvedRolloutReviewerRunnerOptions {
+  return {
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS.pollIntervalMs,
+    timeoutMs: options.timeoutMs ?? DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS.timeoutMs,
+    defaultMaxAttempts: options.defaultMaxAttempts ?? DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS.defaultMaxAttempts,
+    owner: options.owner,
+    runtimeKind: options.runtimeKind,
+    agentId: options.agentId ?? DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS.agentId,
+  };
+}
+
+export interface RolloutReviewerRunnerDeps {
+  readonly stateManager: RuntimeStateManager;
+  readonly runtimeAdapter: PDRuntimeAdapter;
+  readonly eventEmitter: StoreEventEmitter;
+  readonly validator: RolloutReviewerValidator;
+  readonly artifactStore: PIArtifactStore;
+}
+
+interface FailureContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errorCategory: PDErrorCategory;
+  readonly failureReason: string;
+}
+
+interface SucceedContext {
+  readonly taskId: string;
+  readonly runId: string;
+  readonly output: RolloutReviewerOutputV1;
+  readonly task: TaskRecord;
+  readonly contextHash: string;
+}
+
+interface ValidationErrorContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+const ROLLOUT_REVIEWER_PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set<PDErrorCategory>([
+  'storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid',
+]);
+
+export class RolloutReviewerRunner {
+  private phase: RunnerPhase = RunnerPhase.Idle;
+  private readonly resolvedOptions: ResolvedRolloutReviewerRunnerOptions;
+  private readonly stateManager: RuntimeStateManager;
+  private readonly runtimeAdapter: PDRuntimeAdapter;
+  private readonly eventEmitter: StoreEventEmitter;
+  private readonly validator: RolloutReviewerValidator;
+  private readonly artifactStore: PIArtifactStore;
+
+  constructor(deps: RolloutReviewerRunnerDeps, options: RolloutReviewerRunnerOptions) {
+    this.stateManager = deps.stateManager;
+    this.runtimeAdapter = deps.runtimeAdapter;
+    this.eventEmitter = deps.eventEmitter;
+    this.validator = deps.validator;
+    this.artifactStore = deps.artifactStore;
+    this.resolvedOptions = resolveRolloutReviewerRunnerOptions(options);
+  }
+
+  get currentPhase(): RunnerPhase {
+    return this.phase;
+  }
+
+  private emitRolloutReviewerEvent(
+    eventType: string,
+    taskId: string,
+    payload: Record<string, unknown>,
+  ): void {
+    this.eventEmitter.emitTelemetry({
+      eventType: eventType as TelemetryEvent['eventType'],
+      traceId: taskId,
+      timestamp: new Date().toISOString(),
+      sessionId: this.resolvedOptions.owner,
+      agentId: this.resolvedOptions.agentId,
+      payload,
+    });
+  }
+
+  async run(taskId: string): Promise<RolloutReviewerRunnerResult> {
+    this.phase = RunnerPhase.Idle;
+
+    // eslint-disable-next-line @typescript-eslint/init-declarations
+    let leasedTask: TaskRecord;
+    try {
+      leasedTask = await this.stateManager.acquireLease({
+        taskId,
+        owner: this.resolvedOptions.owner,
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+    } catch (error) {
+      return await this.handleLeaseOrPhaseError(taskId, error);
+    }
+
+    if (leasedTask.taskKind !== 'rollout_reviewer') {
+      this.emitRolloutReviewerEvent('rollout_reviewer_wrong_task_kind', taskId, {
+        expectedKind: 'rollout_reviewer',
+        actualKind: leasedTask.taskKind,
+      });
+      return this.retryOrFail({
+        taskId,
+        task: leasedTask,
+        errorCategory: 'input_invalid',
+        failureReason: `Task kind must be 'rollout_reviewer', got '${leasedTask.taskKind}'`,
+      });
+    }
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_task_leased', taskId, {
+      taskKind: 'rollout_reviewer',
+      attemptCount: leasedTask.attemptCount,
+    });
+
+    try {
+      const storeRunId = await this.resolveStoreRunId(taskId);
+
+      this.phase = RunnerPhase.BuildingContext;
+      const { contextHash, evaluatorArtifact, sourceEvaluatorArtifactId } = await this.buildContext(taskId);
+
+      if (!evaluatorArtifact || !sourceEvaluatorArtifactId) {
+        return this.retryOrFail({
+          taskId,
+          task: leasedTask,
+          errorCategory: 'input_invalid',
+          failureReason: sourceEvaluatorArtifactId ? 'Evaluator dependency artifact not found' : 'Evaluator dependency artifact ID not resolved',
+        });
+      }
+
+      this.emitRolloutReviewerEvent('rollout_reviewer_context_built', taskId, { contextHash });
+
+      this.phase = RunnerPhase.Invoking;
+      const runHandle = await this.invokeRuntime({ taskId, contextHash, evaluatorArtifact, sourceEvaluatorArtifactId });
+
+      this.emitRolloutReviewerEvent('rollout_reviewer_run_started', taskId, {
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+
+      this.phase = RunnerPhase.Polling;
+      const finalStatus = await this.pollUntilTerminal(runHandle);
+
+      if (finalStatus.status !== 'succeeded') {
+        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
+      }
+
+      this.phase = RunnerPhase.FetchingOutput;
+      const output = await this.fetchAndParseOutput(runHandle.runId);
+
+      this.phase = RunnerPhase.Validating;
+      const validationResult = await this.validator.validate(output, taskId, sourceEvaluatorArtifactId ?? undefined);
+      if (!validationResult.valid) {
+        return await this.handleValidationError({
+          taskId,
+          task: leasedTask,
+          errors: validationResult.errors,
+          errorCategory: validationResult.errorCategory,
+        });
+      }
+
+      this.emitRolloutReviewerEvent('rollout_reviewer_output_validated', taskId, {
+        reviewDecision: output.review.decision,
+        reviewConfidence: output.review.confidence,
+      });
+
+      return await this.succeedTask({
+        taskId,
+        runId: storeRunId,
+        output,
+        task: leasedTask,
+        contextHash,
+      });
+    } catch (error) {
+      return await this.handlePostLeaseError(taskId, leasedTask, error);
+    }
+  }
+
+  private async buildContext(taskId: string): Promise<{ contextHash: string; evaluatorArtifact: string | null; sourceEvaluatorArtifactId: string | null }> {
+    const task = await this.stateManager.getTask(taskId);
+    if (!task) {
+      throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
+    }
+
+    const piTask = hydratePITaskRecord(task);
+    const deps = piTask?.dependencyTaskIds ?? [];
+
+    if (deps.length === 0) {
+      this.emitRolloutReviewerEvent('rollout_reviewer_no_dependencies', taskId, {});
+      return { contextHash: 'empty', evaluatorArtifact: null, sourceEvaluatorArtifactId: null };
+    }
+
+    for (const depId of deps) {
+      const depTask = await this.stateManager.getTask(depId);
+      if (!depTask) continue;
+      if (depTask.taskKind !== 'evaluator') continue;
+      if (depTask.status !== 'succeeded') {
+        this.emitRolloutReviewerEvent('rollout_reviewer_dependency_not_succeeded', taskId, {
+          depTaskId: depId,
+          depStatus: depTask.status,
+        });
+        continue;
+      }
+
+      const artifacts = await this.artifactStore.listBySourceTaskId(depId);
+      if (artifacts.length > 0) {
+        const [firstArtifact] = artifacts;
+        if (!firstArtifact) continue;
+        const artifactRef = firstArtifact.artifactId;
+        this.emitRolloutReviewerEvent('rollout_reviewer_evaluator_dep_selected', taskId, {
+          depTaskId: depId,
+          artifactId: firstArtifact.artifactId,
+        });
+        return {
+          contextHash: RolloutReviewerRunner.hashContextRefs([artifactRef]),
+          evaluatorArtifact: firstArtifact.contentJson,
+          sourceEvaluatorArtifactId: firstArtifact.artifactId,
+        };
+      }
+    }
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_no_evaluator_artifact', taskId, {});
+    return { contextHash: 'empty', evaluatorArtifact: null, sourceEvaluatorArtifactId: null };
+  }
+
+  private static hashContextRefs(refs: readonly string[]): string {
+    if (refs.length === 0) return 'empty';
+    const str = refs.join('|');
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+    }
+    return `ctx-${Math.abs(hash).toString(16)}`;
+  }
+
+  private async resolveStoreRunId(taskId: string): Promise<string> {
+    const runs = await this.stateManager.getRunsByTask(taskId);
+    const latestRun = runs[runs.length - 1];
+    if (!latestRun) {
+      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
+    }
+    return latestRun.runId;
+  }
+
+  private async invokeRuntime(params: {
+    taskId: string;
+    contextHash: string;
+    evaluatorArtifact: string | null;
+    sourceEvaluatorArtifactId: string;
+  }): Promise<RunHandle> {
+    let parsedEvaluatorArtifact: unknown = null;
+    if (params.evaluatorArtifact) {
+      try {
+        parsedEvaluatorArtifact = JSON.parse(params.evaluatorArtifact);
+      } catch {
+        parsedEvaluatorArtifact = params.evaluatorArtifact;
+      }
+    }
+
+    const builder = new RolloutReviewerPromptBuilder();
+    const { message } = builder.buildPrompt({
+      taskId: params.taskId,
+      contextHash: params.contextHash,
+      evaluatorArtifact: parsedEvaluatorArtifact,
+      sourceEvaluatorArtifactId: params.sourceEvaluatorArtifactId,
+    });
+
+    const startInput: StartRunInput = {
+      agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
+      taskRef: { taskId: params.taskId },
+      inputPayload: message,
+      contextItems: [],
+      outputSchemaRef: 'rollout-reviewer-output-v1',
+      timeoutMs: this.resolvedOptions.timeoutMs,
+    };
+
+    return this.runtimeAdapter.startRun(startInput);
+  }
+
+  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
+    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
+
+    while (Date.now() < deadline) {
+      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(status.status)) {
+        return status;
+      }
+      await this.sleep(this.resolvedOptions.pollIntervalMs);
+    }
+
+    try {
+      const finalPoll = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(finalPoll.status)) {
+        return finalPoll;
+      }
+    } catch { /* fall through to cancel/timeout */ }
+
+    let cancelFailed = false;
+    try {
+      await this.runtimeAdapter.cancelRun(runHandle.runId);
+    } catch (cancelErr) {
+      cancelFailed = true;
+      this.emitRolloutReviewerEvent('rollout_reviewer_cancel_run_failed', runHandle.runId, {
+        runId: runHandle.runId,
+        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
+      });
+    }
+    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
+    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
+  }
+
+  private async fetchAndParseOutput(runId: string): Promise<RolloutReviewerOutputV1> {
+    const result = await this.runtimeAdapter.fetchOutput(runId);
+    if (!result || !result.payload) {
+      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
+    }
+    const payload = result.payload as Record<string, unknown>;
+    if (typeof payload !== 'object' || payload === null) {
+      throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
+    }
+    if (typeof payload.review !== 'object' || payload.review === null) {
+      throw new PDRuntimeError('output_invalid', `Output payload missing review object for run ${runId}`);
+    }
+    return result.payload as RolloutReviewerOutputV1;
+  }
+
+  private async succeedTask(ctx: SucceedContext): Promise<RolloutReviewerRunnerResult> {
+    try {
+      await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));
+    } catch (updateErr) {
+      this.emitRolloutReviewerEvent('rollout_reviewer_update_output_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
+      });
+      throw updateErr;
+    }
+
+    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
+    const now = new Date().toISOString();
+
+    let lineageArtifactIds: string[] = [];
+    try {
+      const piTask = hydratePITaskRecord(ctx.task);
+      const deps = piTask?.dependencyTaskIds ?? [];
+      const results = await Promise.allSettled(
+        deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          for (const artifact of result.value) {
+            lineageArtifactIds.push(artifact.artifactId);
+          }
+        }
+      }
+    } catch { /* lineage resolution failure is non-fatal */ }
+
+    try {
+      await this.artifactStore.upsertArtifact({
+        artifactId,
+        artifactKind: 'principle',
+        sourceTaskId: ctx.taskId,
+        lineageArtifactIds,
+        validationStatus: 'pending',
+        contentJson: JSON.stringify(ctx.output),
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (artifactErr) {
+      this.emitRolloutReviewerEvent('rollout_reviewer_artifact_write_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
+      });
+      return this.retryOrFail({
+        taskId: ctx.taskId,
+        task: ctx.task,
+        errorCategory: 'artifact_commit_failed',
+        failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
+      });
+    }
+
+    const resultRef = `rollout-reviewer://${ctx.runId}`;
+    try {
+      await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
+    } catch (stateErr) {
+      this.emitRolloutReviewerEvent('rollout_reviewer_mark_succeeded_failed', ctx.taskId, {
+        taskId: ctx.taskId,
+        runId: ctx.runId,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      throw stateErr;
+    }
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_task_succeeded', ctx.taskId, {
+      attemptCount: ctx.task.attemptCount,
+      resultRef,
+      reviewDecision: ctx.output.review.decision,
+      reviewConfidence: ctx.output.review.confidence,
+    });
+
+    this.phase = RunnerPhase.Completed;
+    return {
+      status: 'succeeded',
+      taskId: ctx.taskId,
+      runId: ctx.runId,
+      artifactId,
+      resultRef,
+      contextHash: ctx.contextHash,
+      output: ctx.output,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  private async handleRuntimeFailure(
+    taskId: string,
+    task: TaskRecord,
+    runStatus: RunStatus,
+  ): Promise<RolloutReviewerRunnerResult> {
+    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status);
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_run_failed', taskId, {
+      runStatus: runStatus.status,
+      errorCategory,
+    });
+
+    return this.retryOrFail({
+      taskId,
+      task,
+      errorCategory,
+      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
+    });
+  }
+
+  private async handleValidationError(ctx: ValidationErrorContext): Promise<RolloutReviewerRunnerResult> {
+    const category = (ctx.errorCategory ?? 'output_invalid') as PDErrorCategory;
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_output_invalid', ctx.taskId, {
+      errorCount: ctx.errors.length,
+      errorCategory: category,
+    });
+
+    return this.retryOrFail({
+      taskId: ctx.taskId,
+      task: ctx.task,
+      errorCategory: category,
+      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
+    });
+  }
+
+  private async handleLeaseOrPhaseError(
+    taskId: string,
+    error: unknown,
+  ): Promise<RolloutReviewerRunnerResult> {
+    const classified = this.classifyError(error);
+
+    if (classified.category === 'lease_conflict') {
+      this.emitRolloutReviewerEvent('rollout_reviewer_run_failed', taskId, {
+        errorCategory: 'lease_conflict',
+        errorMessage: classified.message,
+      });
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'lease_conflict',
+        failureReason: classified.message,
+        attemptCount: 1,
+      };
+    }
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    const task: TaskRecord = {
+      taskId,
+      taskKind: 'rollout_reviewer',
+      status: 'leased',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      attemptCount: 1,
+      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
+    };
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async handlePostLeaseError(
+    taskId: string,
+    task: TaskRecord,
+    error: unknown,
+  ): Promise<RolloutReviewerRunnerResult> {
+    const classified = this.classifyError(error);
+
+    this.emitRolloutReviewerEvent('rollout_reviewer_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async retryOrFail(ctx: FailureContext): Promise<RolloutReviewerRunnerResult> {
+    if (this.isPermanentError(ctx.errorCategory)) {
+      try {
+        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitRolloutReviewerEvent('rollout_reviewer_mark_failed_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitRolloutReviewerEvent('rollout_reviewer_task_failed', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+        failureReason: ctx.failureReason,
+      });
+      this.phase = RunnerPhase.Failed;
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
+    if (shouldRetry) {
+      try {
+        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitRolloutReviewerEvent('rollout_reviewer_mark_retry_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitRolloutReviewerEvent('rollout_reviewer_task_retried', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+      });
+      this.phase = RunnerPhase.RetryWaiting;
+      return {
+        status: 'retried',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    try {
+      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
+    } catch (stateErr) {
+      this.emitRolloutReviewerEvent('rollout_reviewer_mark_failed_error', ctx.taskId, {
+        errorCategory: 'storage_unavailable',
+        attemptCount: ctx.task.attemptCount,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `State manager error: ${ctx.failureReason}`,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+    this.emitRolloutReviewerEvent('rollout_reviewer_task_failed', ctx.taskId, {
+      errorCategory: 'max_attempts_exceeded',
+      attemptCount: ctx.task.attemptCount,
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+    });
+    this.phase = RunnerPhase.Failed;
+    return {
+      status: 'failed',
+      taskId: ctx.taskId,
+      errorCategory: 'max_attempts_exceeded',
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private isPermanentError(category: PDErrorCategory): boolean {
+    return ROLLOUT_REVIEWER_PERMANENT_ERROR_CATEGORIES.has(category);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
+    if (error instanceof PDRuntimeError) {
+      return { category: error.category, message: error.message };
+    }
+    if (error instanceof Error) {
+      return { category: 'execution_failed', message: error.message };
+    }
+    return { category: 'execution_failed', message: String(error) };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private mapRunStatusToErrorCategory(status: string): PDErrorCategory {
+    switch (status) {
+      case 'failed': return 'execution_failed';
+      case 'timed_out': return 'timeout';
+      case 'cancelled': return 'cancelled';
+      default: return 'execution_failed';
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+export { DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS };


### PR DESCRIPTION
## Summary

Three vertical slices advancing PD internalization reliability:

### PRI-RR: RolloutReviewerRunner vertical slice
- New \ollout-reviewer-output.ts\ — RolloutReviewerOutputV1 interface, TypeBox schema, DefaultRolloutReviewerValidator
- New \ollout-reviewer-prompt-builder.ts\ — CRITICAL JSON-only instruction, complete example output
- New \ollout-reviewer-runner.ts\ — lease→buildContext→invoke→poll→validate→succeed/fail flow
- Registered \ollout-reviewer-output-v1\ schema in PiAiRuntimeAdapter
- Added \ollout_reviewer\ to SUPPORTED_RUNNERS, test-double dispatch, CLI branch
- 35 runner vslice + 8 prompt builder + 2 CLI + architecture regression tests

### Dreamer output_invalid hardening
- Replaced template-style OUTPUT FORMAT with **COMPLETE EXAMPLE OUTPUT** (concrete JSON)
- Added **CRITICAL JSON-only directive** (no prose, no code fences)
- Added \dreamer_output_extraction_failed\ telemetry with stage: fetchOutput | payload_missing | payload_not_object
- 4 prompt builder hardening + 3 telemetry tests

### PRI-102: Production canary fixture gate
- New \SyntheticWorkspaceFixture\ factory (temp dir + SQLite state.db)
- 23 tests covering: canary healthy/degraded, integrity ok/brokenLinks, retry_wait not early-ready, read-only no DB writes, stale GFI low not degraded, pruning orphan count consistency

## Verification
- [x] All builds pass (core + pd-cli + typecheck)
- [x] 755+ tests pass including all new suites
- [x] Pre-push hooks (lint, build, typecheck) pass
- [ ] Production: run-once --runner rollout_reviewer --enqueue-next verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 Rollout Reviewer Runner，支持运行时内化任务的评审和验证
  * 引入 L2 自动纠正机制，支持参数无声修改和可选的代理通知
  * 运行时 CLI 现支持 rollout reviewer 工作流

* **测试**
  * 为 Rollout Reviewer 功能新增全面测试覆盖
  * 扩展回归和垂直切片测试套件

* **文档**
  * 新增 L2 自动纠正和重放机制的架构决策记录

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/545)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->