### PR TITLE
feat(runtime): unify remediation result contract (PRI-105)

### DIFF
--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -26,6 +26,8 @@ import {
 } from '@principles/core/runtime-v2';
 import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import { createRemediationResult, remediationAction } from './remediation-output.js';
+import type { RemediationResult } from './remediation-output.js';
 
 // ── Interfaces ────────────────────────────────────────────────────────────────
 
@@ -713,7 +715,34 @@ interface BackfillOutput {
   results: BackfillCandidateResult[];
 }
 
+function createBackfillRemediationResult(output: BackfillOutput): RemediationResult {
+  const actions = output.results
+    .filter((result) => result.status === 'would_create' || result.status === 'created')
+    .map((result) => remediationAction({
+      action: result.status === 'created' ? 'create_dreamer_task' : 'would_create_dreamer_task',
+      targetId: result.candidateId,
+      previousState: 'consumed_candidate_without_dreamer',
+      nextState: result.status === 'created' ? 'dreamer_task_created' : 'dreamer_task_would_be_created',
+      reason: result.reason ?? `Backfill ${result.status === 'created' ? 'created' : 'would create'} dreamer task${result.taskId ? ` ${result.taskId}` : ''}`,
+    }));
+
+  return createRemediationResult({
+    mode: output.mode === 'confirm' ? 'confirm' : 'dry_run',
+    repairedCount: output.created,
+    skippedCount: output.alreadyHaveTask + output.deferred + output.errors,
+    actions,
+    warnings: output.errors > 0 ? [`${output.errors} candidate(s) could not be backfilled.`] : [],
+    status: output.errors > 0 && output.created === 0 ? 'error' : undefined,
+    safeToConfirm: output.mode === 'dry-run' && output.missingDreamerTask > 0 && output.errors === 0,
+  });
+}
+
 export async function handleCandidateInternalizationBackfill(opts: CandidateBackfillOptions): Promise<void> {
+  if (opts.dryRun && opts.confirm) {
+    console.error('Error: --dry-run and --confirm are mutually exclusive');
+    process.exit(1);
+  }
+
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
   const stateManager = new RuntimeStateManager({ workspaceDir });
   const isConfirm = opts.confirm ?? false;
@@ -816,9 +845,12 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
     }
 
     if (opts.json) {
-      console.log(JSON.stringify(output, null, 2));
+      console.log(JSON.stringify({ ...createBackfillRemediationResult(output), details: output }, null, 2));
     } else {
+      const remediation = createBackfillRemediationResult(output);
       console.log(`\nCandidate Internalization Backfill (${output.mode})\n`);
+      console.log(`  status:              ${remediation.status}`);
+      console.log(`  safe_to_confirm:     ${remediation.safeToConfirm}`);
       console.log(`  total_consumed:      ${output.totalConsumed}`);
       console.log(`  missing_dreamer:     ${output.missingDreamerTask}`);
       console.log(`  already_have_task:   ${output.alreadyHaveTask}`);

--- a/packages/pd-cli/src/commands/remediation-output.ts
+++ b/packages/pd-cli/src/commands/remediation-output.ts
@@ -1,0 +1,66 @@
+export type RemediationMode = 'dry_run' | 'confirm';
+export type RemediationStatus = 'would_change' | 'changed' | 'no_op' | 'refused' | 'error';
+
+export interface RemediationAction {
+  action: string;
+  targetId: string;
+  previousState?: string;
+  nextState?: string;
+  reason: string;
+  taskId?: string;
+  type?: string;
+  severity?: 'error' | 'warning';
+  previousStatus?: string;
+  newStatus?: string;
+  recommendedAction?: string;
+  successorTaskId?: string;
+}
+
+export interface RemediationResult {
+  mode: RemediationMode;
+  status: RemediationStatus;
+  safeToConfirm: boolean;
+  repairedCount: number;
+  skippedCount: number;
+  actions: RemediationAction[];
+  warnings: string[];
+  generatedAt?: string;
+  dryRun?: boolean;
+}
+
+export function createRemediationResult(input: {
+  mode: RemediationMode;
+  repairedCount?: number;
+  skippedCount?: number;
+  actions?: RemediationAction[];
+  warnings?: string[];
+  status?: RemediationStatus;
+  safeToConfirm?: boolean;
+  generatedAt?: string;
+  includeLegacyDryRun?: boolean;
+}): RemediationResult {
+  const actions = input.actions ?? [];
+  const warnings = input.warnings ?? [];
+  const repairedCount = input.repairedCount ?? 0;
+  const status = input.status ?? (input.mode === 'dry_run'
+    ? (actions.length > 0 ? 'would_change' : 'no_op')
+    : (repairedCount > 0 ? 'changed' : 'no_op'));
+
+  return {
+    mode: input.mode,
+    status,
+    safeToConfirm: input.safeToConfirm ?? (
+      input.mode === 'dry_run' && status === 'would_change' && warnings.length === 0
+    ),
+    repairedCount,
+    skippedCount: input.skippedCount ?? 0,
+    actions,
+    warnings,
+    ...(input.generatedAt ? { generatedAt: input.generatedAt } : {}),
+    ...(input.includeLegacyDryRun ? { dryRun: input.mode === 'dry_run' } : {}),
+  };
+}
+
+export function remediationAction(input: RemediationAction): RemediationAction {
+  return input;
+}

--- a/packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { InternalizationIntegrityRemediation } from '@principles/core/runtime-v2';
-import type { RemediationResult } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import type { RemediationResult } from './remediation-output.js';
 
 interface InternalizationIntegrityRepairOptions {
   workspace?: string;
@@ -15,7 +15,9 @@ function formatTextOutput(result: RemediationResult): string {
 
   lines.push('Internalization Integrity Repair Report');
   lines.push(`generatedAt: ${result.generatedAt}`);
-  lines.push(`mode: ${result.dryRun ? 'DRY-RUN' : 'CONFIRM'}`);
+  lines.push(`mode: ${result.mode === 'dry_run' ? 'DRY-RUN' : 'CONFIRM'}`);
+  lines.push(`status: ${result.status}`);
+  lines.push(`safeToConfirm: ${result.safeToConfirm}`);
   lines.push(`repairedCount: ${result.repairedCount}`);
   lines.push(`skippedCount: ${result.skippedCount}`);
   lines.push('');
@@ -26,9 +28,9 @@ function formatTextOutput(result: RemediationResult): string {
     lines.push(`Actions (${result.actions.length}):`);
     for (const action of result.actions) {
       const icon = action.severity === 'error' ? '✗' : '⚠';
-      lines.push(`  ${icon} [${action.type}] ${action.taskId}`);
-      lines.push(`    ${action.previousStatus} → ${action.newStatus}`);
-      lines.push(`    action: ${action.recommendedAction}`);
+      lines.push(`  ${icon} [${action.type ?? action.action}] ${action.taskId ?? action.targetId}`);
+      lines.push(`    ${action.previousState ?? action.previousStatus ?? '(unknown)'} → ${action.nextState ?? action.newStatus ?? '(unknown)'}`);
+      lines.push(`    action: ${action.action}`);
       lines.push(`    reason: ${action.reason}`);
       if (action.successorTaskId) {
         lines.push(`    successorTaskId: ${action.successorTaskId}`);
@@ -52,7 +54,7 @@ export async function handleRuntimeInternalizationIntegrityRepair(opts: Internal
   const isDryRun = !opts.confirm;
 
   const remediation = new InternalizationIntegrityRemediation({ workspaceDir });
-  const result = remediation.repair({ dryRun: isDryRun });
+  const result = remediation.repair({ dryRun: isDryRun }) as unknown as RemediationResult;
 
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));

--- a/packages/pd-cli/src/commands/runtime-pruning.ts
+++ b/packages/pd-cli/src/commands/runtime-pruning.ts
@@ -10,6 +10,8 @@ import * as path from 'path';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import { PruningReadModel, appendPruningReview, listPruningReviews, buildMaskedPrincipleSet, loadLedger, saveLedger } from '@principles/core/runtime-v2';
 import type { PruningReviewDecision, OrphanDerivedCandidate, OrphanDetectionResult } from '@principles/core/runtime-v2';
+import { createRemediationResult, remediationAction } from './remediation-output.js';
+import type { RemediationResult } from './remediation-output.js';
 
 interface PruningReportOptions {
   workspace?: string;
@@ -287,15 +289,22 @@ export interface PruningOrphansOptions {
   json?: boolean;
 }
 
-export interface OrphanCleanupResult {
-  orphanDerivedCandidateCount: number;
-  candidates: OrphanDerivedCandidate[];
-  dryRun: boolean;
-  dbReadable: boolean;
-  removedFromPrinciples?: { principleId: string; removedIds: string[] }[];
+function orphanActions(orphans: OrphanDerivedCandidate[]) {
+  return orphans.map((orphan) => remediationAction({
+    action: 'remove_orphan_reference',
+    targetId: orphan.candidateId,
+    previousState: orphan.status ?? 'unknown',
+    nextState: 'removed_from_ledger_reference',
+    reason: `${orphan.reason} (principle: ${orphan.principleId})`,
+  }));
 }
 
 export function handlePruningOrphans(opts: PruningOrphansOptions): void {
+  if (opts.dryRun && opts.confirm) {
+    console.error('Error: --dry-run and --confirm are mutually exclusive');
+    process.exit(1);
+  }
+
   const workspaceDir = opts.workspace
     ? path.resolve(opts.workspace)
     : resolveWorkspaceDir();
@@ -306,15 +315,23 @@ export function handlePruningOrphans(opts: PruningOrphansOptions): void {
   const isDryRun = !opts.confirm;
 
   if (isDryRun) {
-    const result: OrphanCleanupResult = {
-      orphanDerivedCandidateCount: orphans.length,
-      candidates: orphans,
-      dryRun: true,
-      dbReadable: detection.dbReadable,
-    };
+    const result: RemediationResult = createRemediationResult({
+      mode: 'dry_run',
+      repairedCount: 0,
+      skippedCount: 0,
+      actions: orphanActions(orphans),
+      warnings: detection.dbReadable ? [] : ['state.db is unreadable; --confirm will be refused until DB access is restored.'],
+      safeToConfirm: detection.dbReadable && orphans.length > 0,
+      includeLegacyDryRun: true,
+    });
 
     if (opts.json) {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(JSON.stringify({
+        ...result,
+        orphanDerivedCandidateCount: orphans.length,
+        candidates: orphans,
+        dbReadable: detection.dbReadable,
+      }, null, 2));
       return;
     }
 
@@ -342,15 +359,24 @@ export function handlePruningOrphans(opts: PruningOrphansOptions): void {
   }
 
   if (!detection.dbReadable) {
-    const result: OrphanCleanupResult = {
-      orphanDerivedCandidateCount: orphans.length,
-      candidates: orphans,
-      dryRun: false,
-      dbReadable: false,
-    };
+    const result: RemediationResult = createRemediationResult({
+      mode: 'confirm',
+      status: 'refused',
+      safeToConfirm: false,
+      repairedCount: 0,
+      skippedCount: orphans.length,
+      actions: orphanActions(orphans),
+      warnings: ['state.db is unreadable; refusing orphan cleanup because candidates cannot be verified.'],
+      includeLegacyDryRun: true,
+    });
 
     if (opts.json) {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(JSON.stringify({
+        ...result,
+        orphanDerivedCandidateCount: orphans.length,
+        candidates: orphans,
+        dbReadable: false,
+      }, null, 2));
     } else {
       console.error('❌ REFUSED: state.db is unreadable — cannot safely confirm orphan cleanup.');
       console.error('   All derivedFromPainIds would appear as orphans when the DB is inaccessible.');
@@ -402,16 +428,24 @@ export function handlePruningOrphans(opts: PruningOrphansOptions): void {
     }
   }
 
-  const result: OrphanCleanupResult = {
-    orphanDerivedCandidateCount: orphans.length,
-    candidates: orphans,
-    dryRun: false,
-    dbReadable: true,
-    removedFromPrinciples,
-  };
+  const removedCount = removedFromPrinciples.reduce((sum, item) => sum + item.removedIds.length, 0);
+  const result: RemediationResult = createRemediationResult({
+    mode: 'confirm',
+    repairedCount: removedCount,
+    skippedCount: Math.max(0, orphans.length - removedCount),
+    actions: orphanActions(orphans),
+    warnings: [],
+    includeLegacyDryRun: true,
+  });
 
   if (opts.json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify({
+      ...result,
+      orphanDerivedCandidateCount: orphans.length,
+      candidates: orphans,
+      dbReadable: true,
+      removedFromPrinciples,
+    }, null, 2));
     return;
   }
 

--- a/packages/pd-cli/src/commands/runtime-recovery.ts
+++ b/packages/pd-cli/src/commands/runtime-recovery.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
 import { RuntimeStateManager } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import { createRemediationResult, remediationAction } from './remediation-output.js';
+import type { RemediationResult } from './remediation-output.js';
 
 interface RecoverySweepOptions {
   workspace?: string;
@@ -9,45 +11,28 @@ interface RecoverySweepOptions {
   json?: boolean;
 }
 
-interface RecoverySweepOutput {
-  mode: 'dry-run' | 'confirm';
-  expiredLeaseCount: number;
-  expiredLeaseTaskIds: string[];
-  recoveredCount: number;
-  failedCount: number;
-  errors: string[];
-  samples: {
-    taskId: string;
-    previousStatus: string;
-    newStatus: string;
-    wasLeaseExpired: boolean;
-  }[];
-}
-
-function formatTextOutput(output: RecoverySweepOutput): string {
+function formatTextOutput(output: RemediationResult): string {
   const lines: string[] = [];
 
   lines.push(`Recovery Sweep (${output.mode})`);
-  lines.push(`  expired_leases: ${output.expiredLeaseCount}`);
+  lines.push(`  status: ${output.status}`);
+  lines.push(`  safeToConfirm: ${output.safeToConfirm}`);
+  lines.push(`  repairedCount: ${output.repairedCount}`);
+  lines.push(`  skippedCount: ${output.skippedCount}`);
 
-  if (output.expiredLeaseCount > 0) {
-    lines.push(`  task_ids: ${output.expiredLeaseTaskIds.join(', ')}`);
+  if (output.warnings.length > 0) {
+    lines.push(`  warnings:`);
+    for (const warning of output.warnings) lines.push(`    - ${warning}`);
   }
-
-  if (output.mode === 'confirm') {
-    lines.push(`  recovered: ${output.recoveredCount}`);
-    lines.push(`  failed: ${output.failedCount}`);
-    if (output.errors.length > 0) {
-      lines.push(`  errors:`);
-      for (const err of output.errors) {
-        lines.push(`    - ${err}`);
-      }
-    }
-    for (const sample of output.samples.slice(0, 5)) {
-      lines.push(`  ${sample.taskId}: ${sample.previousStatus} → ${sample.newStatus}`);
-    }
-  } else {
+  for (const action of output.actions.slice(0, 5)) {
+    lines.push(`  ${action.targetId}: ${action.previousState ?? '(unknown)'} → ${action.nextState ?? '(unknown)'}`);
+    lines.push(`    action: ${action.action}`);
+    lines.push(`    reason: ${action.reason}`);
+  }
+  if (output.mode === 'dry_run' && output.actions.length > 0) {
     lines.push(`  (use --confirm to recover expired leases)`);
+  } else if (output.actions.length === 0) {
+    lines.push(`  no expired leases found`);
   }
 
   return lines.join('\n');
@@ -69,35 +54,44 @@ export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Pr
   try {
     const expiredLeaseTaskIds = await stateManager.detectExpiredLeases();
 
-    const output: RecoverySweepOutput = {
-      mode: isDryRun ? 'dry-run' : 'confirm',
-      expiredLeaseCount: expiredLeaseTaskIds.length,
-      expiredLeaseTaskIds,
-      recoveredCount: 0,
-      failedCount: 0,
-      errors: [],
-      samples: [],
-    };
+    const actions = expiredLeaseTaskIds.map((taskId) => remediationAction({
+      action: 'recover_expired_lease',
+      targetId: taskId,
+      previousState: 'leased',
+      nextState: 'retry_wait',
+      reason: 'Task lease is expired and can be recovered by the operator sweep.',
+    }));
+    const warnings: string[] = [];
+    let repairedCount = 0;
+    let failedCount = 0;
 
     if (isConfirm && expiredLeaseTaskIds.length > 0) {
       for (const taskId of expiredLeaseTaskIds) {
         try {
           const result = await stateManager.recoverTask(taskId);
           if (result) {
-            output.recoveredCount++;
-            output.samples.push({
-              taskId,
-              previousStatus: result.previousStatus,
-              newStatus: result.newStatus,
-              wasLeaseExpired: true,
-            });
+            repairedCount++;
+            const action = actions.find((a) => a.targetId === taskId);
+            if (action) {
+              action.previousState = result.previousStatus;
+              action.nextState = result.newStatus;
+            }
           }
         } catch (err) {
-          output.failedCount++;
-          output.errors.push(`${taskId}: ${err instanceof Error ? err.message : String(err)}`);
+          failedCount++;
+          warnings.push(`${taskId}: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     }
+    const output = createRemediationResult({
+      mode: isDryRun ? 'dry_run' : 'confirm',
+      repairedCount,
+      skippedCount: failedCount,
+      actions,
+      warnings,
+      status: failedCount > 0 && repairedCount === 0 ? 'error' : undefined,
+      safeToConfirm: isDryRun && expiredLeaseTaskIds.length > 0,
+    });
 
     if (opts.json) {
       console.log(JSON.stringify(output, null, 2));

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -463,11 +463,11 @@ recoveryCmd
   .command('sweep')
   .description('Detect and optionally recover expired leases')
   .option('-w, --workspace <path>', 'Workspace directory')
-  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--dry-run', 'Report only, no modifications (default)')
   .option('--confirm', 'Actually recover expired leases')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
-    await handleRuntimeRecoverySweep({ workspace: opts.workspace, dryRun: !opts.confirm, confirm: opts.confirm, json: opts.json });
+    await handleRuntimeRecoverySweep({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, json: opts.json });
   });
 
 diagnosticsCmd
@@ -545,13 +545,13 @@ pruningCmd
   .command('orphans')
   .description('List orphan derived candidates not found in state.db')
   .option('-w, --workspace <path>', 'Workspace directory')
-  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--dry-run', 'Report only, no modifications (default)')
   .option('--confirm', 'Actually remove orphan references from ledger')
   .option('--json', 'Output raw JSON')
   .action((opts) => {
     handlePruningOrphans({
       workspace: opts.workspace,
-      dryRun: !opts.confirm,
+      dryRun: opts.dryRun,
       confirm: opts.confirm,
       json: opts.json,
     });
@@ -653,11 +653,11 @@ candidateInternalizationCmd
   .command('backfill')
   .description('Backfill dreamer tasks for consumed candidates created before Internalization Engine')
   .option('-w, --workspace <path>', 'Workspace directory')
-  .option('--dry-run', 'Report only, no modifications (default)', true)
+  .option('--dry-run', 'Report only, no modifications (default)')
   .option('--confirm', 'Actually create missing dreamer tasks')
   .option('--json', 'Output as JSON')
   .action(async (opts) => {
-    await handleCandidateInternalizationBackfill({ workspace: opts.workspace, dryRun: !opts.confirm, confirm: opts.confirm, json: opts.json });
+    await handleCandidateInternalizationBackfill({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, json: opts.json });
   });
 
 // ── Artifact inspection commands ────────────────────────────────────────────

--- a/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockInitialize = vi.hoisted(() => vi.fn());
+const mockClose = vi.hoisted(() => vi.fn());
+const mockGetCandidate = vi.hoisted(() => vi.fn());
+const mockGetTask = vi.hoisted(() => vi.fn());
+const mockCreateTask = vi.hoisted(() => vi.fn());
+const mockUpdateTaskDiagnosticJson = vi.hoisted(() => vi.fn());
+const mockAll = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn((workspace?: string) => workspace ?? '/fake/workspace'),
+}));
+
+vi.mock('../../src/principle-tree-ledger-adapter.js', () => ({
+  PrincipleTreeLedgerAdapter: vi.fn(),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  RuntimeStateManager: vi.fn().mockImplementation(function () {
+    return {
+      initialize: mockInitialize,
+      close: mockClose,
+      getCandidate: mockGetCandidate,
+      getTask: mockGetTask,
+      createTask: mockCreateTask,
+      updateTaskDiagnosticJson: mockUpdateTaskDiagnosticJson,
+      connection: {
+        getDb: () => ({
+          prepare: () => ({ all: mockAll, get: vi.fn(), run: vi.fn() }),
+        }),
+      },
+    };
+  }),
+  SqliteConnection: vi.fn(),
+  candidateList: vi.fn(),
+  candidateShow: vi.fn(),
+  CandidateIntakeService: vi.fn(),
+  CandidateIntakeError: class CandidateIntakeError extends Error {},
+  loadLedger: vi.fn(),
+  getLedgerFilePathPublic: vi.fn(),
+  decideInternalizationRoute: vi.fn(() => ({
+    ready: true,
+    route: 'principle-ledger',
+    reason: 'ready',
+    missingFields: [],
+    nextAction: 'internalize',
+  })),
+  createPITaskDiagnosticJson: vi.fn(() => JSON.stringify({ pi_metadata: { channel: 'prompt' } })),
+  createRemediationResult: vi.fn((input) => ({
+    mode: input.mode,
+    status: input.status ?? (input.mode === 'dry_run'
+      ? (input.actions?.length > 0 ? 'would_change' : 'no_op')
+      : (input.repairedCount > 0 ? 'changed' : 'no_op')),
+    safeToConfirm: input.safeToConfirm ?? false,
+    repairedCount: input.repairedCount ?? 0,
+    skippedCount: input.skippedCount ?? 0,
+    actions: input.actions ?? [],
+    warnings: input.warnings ?? [],
+  })),
+  remediationAction: vi.fn((input) => input),
+}));
+
+import { handleCandidateInternalizationBackfill } from '../../src/commands/candidate.js';
+
+describe('pd candidate internalization backfill remediation contract', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialize.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+    mockAll.mockReturnValue([{ candidate_id: 'cand-1' }]);
+    mockGetCandidate.mockResolvedValue({
+      candidateId: 'cand-1',
+      description: 'candidate',
+      sourceRecommendationJson: JSON.stringify({ kind: 'principle', description: 'candidate' }),
+    });
+    mockGetTask.mockResolvedValue(null);
+    mockCreateTask.mockResolvedValue({ taskId: 'dreamer-cand-1-prompt' });
+    process.exitCode = 0;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('dry-run JSON uses shared remediation contract and does not create tasks', async () => {
+    await handleCandidateInternalizationBackfill({ workspace: '/fake/workspace', dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output).toMatchObject({
+      mode: 'dry_run',
+      status: 'would_change',
+      safeToConfirm: true,
+      repairedCount: 0,
+    });
+    expect(output.actions[0]).toMatchObject({ action: 'would_create_dreamer_task', targetId: 'cand-1' });
+    expect(output.details.missingDreamerTask).toBe(1);
+    expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('confirm JSON reports changed after creating missing dreamer task', async () => {
+    await handleCandidateInternalizationBackfill({ workspace: '/fake/workspace', confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.mode).toBe('confirm');
+    expect(output.status).toBe('changed');
+    expect(output.repairedCount).toBe(1);
+    expect(mockCreateTask).toHaveBeenCalled();
+  });
+
+  it('rejects --dry-run and --confirm together before writing', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
+
+    await expect(
+      handleCandidateInternalizationBackfill({ workspace: '/fake/workspace', dryRun: true, confirm: true, json: true }),
+    ).rejects.toThrow('process.exit:1');
+
+    expect(mockCreateTask).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+    exitSpy.mockRestore();
+  });
+});
+

--- a/packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts
@@ -18,11 +18,16 @@ import { handleRuntimeInternalizationIntegrityRepair } from '../../src/commands/
 const WS = '/fake/workspace';
 
 function makeResult(overrides: Partial<{ dryRun: boolean; repairedCount: number; skippedCount: number; actions: unknown[] }> = {}) {
+  const dryRun = overrides.dryRun ?? true;
   return {
-    dryRun: overrides.dryRun ?? true,
+    mode: dryRun ? 'dry_run' : 'confirm',
+    status: dryRun ? 'no_op' : (overrides.repairedCount ?? 0) > 0 ? 'changed' : 'no_op',
+    safeToConfirm: false,
+    dryRun,
     repairedCount: overrides.repairedCount ?? 0,
     skippedCount: overrides.skippedCount ?? 0,
     actions: overrides.actions ?? [],
+    warnings: [],
     generatedAt: new Date().toISOString(),
   };
 }

--- a/packages/pd-cli/tests/commands/runtime-pruning.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-pruning.test.ts
@@ -71,6 +71,19 @@ vi.mock('@principles/core/runtime-v2', () => ({
   PruningReadModel: vi.fn().mockImplementation(function () {
     return new MockPruningReadModel();
   }),
+  createRemediationResult: vi.fn((input) => ({
+    mode: input.mode,
+    status: input.status ?? (input.mode === 'dry_run'
+      ? (input.actions?.length > 0 ? 'would_change' : 'no_op')
+      : (input.repairedCount > 0 ? 'changed' : 'no_op')),
+    safeToConfirm: input.safeToConfirm ?? false,
+    repairedCount: input.repairedCount ?? 0,
+    skippedCount: input.skippedCount ?? 0,
+    actions: input.actions ?? [],
+    warnings: input.warnings ?? [],
+    ...(input.includeLegacyDryRun ? { dryRun: input.mode === 'dry_run' } : {}),
+  })),
+  remediationAction: vi.fn((input) => input),
   appendPruningReview: mockAppendPruningReview,
   listPruningReviews: mockListPruningReviews,
   buildMaskedPrincipleSet: mockBuildMaskedPrincipleSet,
@@ -513,6 +526,9 @@ describe('pd runtime pruning orphans', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     handlePruningOrphans({ json: true, dryRun: true, confirm: false });
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.mode).toBe('dry_run');
+    expect(output.status).toBe('would_change');
+    expect(output.safeToConfirm).toBe(true);
     expect(output.orphanDerivedCandidateCount).toBe(2);
     expect(output.dryRun).toBe(true);
     expect(output.dbReadable).toBe(true);
@@ -525,6 +541,8 @@ describe('pd runtime pruning orphans', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     handlePruningOrphans({ json: true });
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.mode).toBe('dry_run');
+    expect(output.status).toBe('no_op');
     expect(output.dryRun).toBe(true);
     expect(mockSaveLedger).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
@@ -565,6 +583,9 @@ describe('pd runtime pruning orphans', () => {
     const savedLedgerArg = mockSaveLedger.mock.calls[0]![1];
     expect(savedLedgerArg.tree.principles.p1.derivedFromPainIds).toEqual(['c_valid1']);
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.mode).toBe('confirm');
+    expect(output.status).toBe('changed');
+    expect(output.repairedCount).toBe(1);
     expect(output.dryRun).toBe(false);
     expect(output.dbReadable).toBe(true);
     expect(output.removedFromPrinciples).toHaveLength(1);
@@ -663,6 +684,8 @@ describe('pd runtime pruning orphans', () => {
     expect(processSpy).toHaveBeenCalledWith(1);
     expect(mockSaveLedger).not.toHaveBeenCalled();
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.status).toBe('refused');
+    expect(output.safeToConfirm).toBe(false);
     expect(output.dbReadable).toBe(false);
     expect(output.dryRun).toBe(false); // operation was refused, not a dry-run
     consoleSpy.mockRestore();

--- a/packages/pd-cli/tests/commands/runtime-recovery.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-recovery.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDetectExpiredLeases = vi.hoisted(() => vi.fn());
+const mockRecoverTask = vi.hoisted(() => vi.fn());
+const mockClose = vi.hoisted(() => vi.fn());
+const mockInitialize = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  RuntimeStateManager: vi.fn().mockImplementation(function () {
+    return {
+      initialize: mockInitialize,
+      close: mockClose,
+      detectExpiredLeases: mockDetectExpiredLeases,
+      recoverTask: mockRecoverTask,
+    };
+  }),
+  createRemediationResult: vi.fn((input) => ({
+    mode: input.mode,
+    status: input.status ?? (input.mode === 'dry_run'
+      ? (input.actions?.length > 0 ? 'would_change' : 'no_op')
+      : (input.repairedCount > 0 ? 'changed' : 'no_op')),
+    safeToConfirm: input.safeToConfirm ?? false,
+    repairedCount: input.repairedCount ?? 0,
+    skippedCount: input.skippedCount ?? 0,
+    actions: input.actions ?? [],
+    warnings: input.warnings ?? [],
+  })),
+  remediationAction: vi.fn((input) => input),
+}));
+
+import { handleRuntimeRecoverySweep } from '../../src/commands/runtime-recovery.js';
+
+describe('pd runtime recovery sweep remediation contract', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialize.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+    mockDetectExpiredLeases.mockResolvedValue([]);
+    mockRecoverTask.mockResolvedValue(null);
+    process.exitCode = 0;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('dry-run JSON uses shared remediation contract and does not recover tasks', async () => {
+    mockDetectExpiredLeases.mockResolvedValue(['task-1']);
+
+    await handleRuntimeRecoverySweep({ workspace: '/fake/workspace', dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output).toMatchObject({
+      mode: 'dry_run',
+      status: 'would_change',
+      safeToConfirm: true,
+      repairedCount: 0,
+      skippedCount: 0,
+    });
+    expect(output.actions[0]).toMatchObject({ action: 'recover_expired_lease', targetId: 'task-1' });
+    expect(mockRecoverTask).not.toHaveBeenCalled();
+  });
+
+  it('confirm JSON reports changed after recovering expired leases', async () => {
+    mockDetectExpiredLeases.mockResolvedValue(['task-1']);
+    mockRecoverTask.mockResolvedValue({ previousStatus: 'leased', newStatus: 'retry_wait' });
+
+    await handleRuntimeRecoverySweep({ workspace: '/fake/workspace', confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.mode).toBe('confirm');
+    expect(output.status).toBe('changed');
+    expect(output.repairedCount).toBe(1);
+    expect(mockRecoverTask).toHaveBeenCalledWith('task-1');
+  });
+
+  it('rejects --dry-run and --confirm together before writing', async () => {
+    await handleRuntimeRecoverySweep({ workspace: '/fake/workspace', dryRun: true, confirm: true, json: true });
+
+    expect(mockRecoverTask).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -90,6 +90,8 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/pi-artifact-store.ts',
   // PRI-113
   'golden-trace.ts',
+  // PRI-105
+  'remediation-contract.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -128,6 +130,8 @@ const REQUIRED_TEST_FILES = [
   '../gfi/__tests__/gfi-kernel.test.ts',
   // PRI-113
   'golden-trace.test.ts',
+  // PRI-105
+  'remediation-contract.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-integrity-remediation.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-integrity-remediation.test.ts
@@ -3,7 +3,8 @@ import Database from 'better-sqlite3';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { InternalizationIntegrityRemediation, type RemediationAction } from '../internalization-integrity-remediation.js';
+import { InternalizationIntegrityRemediation } from '../internalization-integrity-remediation.js';
+import type { RemediationAction } from '../remediation-contract.js';
 
 describe('InternalizationIntegrityRemediation', () => {
   let tmpDir = '';

--- a/packages/principles-core/src/runtime-v2/__tests__/remediation-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/remediation-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createRemediationResult, remediationAction } from '../remediation-contract.js';
+
+describe('RemediationResult contract', () => {
+  it('dry-run with actions reports would_change and safeToConfirm', () => {
+    const result = createRemediationResult({
+      mode: 'dry_run',
+      actions: [remediationAction({ action: 'repair', targetId: 'task-1', reason: 'expired lease' })],
+    });
+
+    expect(result).toMatchObject({
+      mode: 'dry_run',
+      status: 'would_change',
+      safeToConfirm: true,
+      repairedCount: 0,
+      skippedCount: 0,
+      warnings: [],
+    });
+  });
+
+  it('confirm with repaired items reports changed and is not safeToConfirm', () => {
+    const result = createRemediationResult({
+      mode: 'confirm',
+      repairedCount: 1,
+      actions: [remediationAction({ action: 'repair', targetId: 'task-1', reason: 'expired lease' })],
+    });
+
+    expect(result.status).toBe('changed');
+    expect(result.safeToConfirm).toBe(false);
+  });
+
+  it('explicit refused status is preserved', () => {
+    const result = createRemediationResult({
+      mode: 'confirm',
+      status: 'refused',
+      safeToConfirm: false,
+      warnings: ['state.db unreadable'],
+    });
+
+    expect(result.status).toBe('refused');
+    expect(result.safeToConfirm).toBe(false);
+    expect(result.warnings).toEqual(['state.db unreadable']);
+  });
+});
+

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -690,7 +690,20 @@ export { InternalizationChainIntegrityReadModel, extractPIMetadata } from './int
 export type { BrokenLink, ChainIntegrityResult, InternalizationChainIntegrityReadModelOptions } from './internalization-chain-integrity-read-model.js';
 
 export { InternalizationIntegrityRemediation } from './internalization-integrity-remediation.js';
-export type { RemediationAction, RemediationResult, InternalizationIntegrityRemediationOptions } from './internalization-integrity-remediation.js';
+export type { InternalizationIntegrityRemediationOptions } from './internalization-integrity-remediation.js';
+
+export {
+  createRemediationResult,
+  remediationAction,
+} from './remediation-contract.js';
+
+export type {
+  RemediationAction,
+  RemediationMode,
+  RemediationResult,
+  RemediationStatus,
+  CreateRemediationResultInput,
+} from './remediation-contract.js';
 
 // ── Control Plane Triage (PRI-99) ───────────────────────────────────────────
 

--- a/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
@@ -2,25 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
 import { extractPIMetadata } from './internalization-chain-integrity-read-model.js';
-
-export interface RemediationAction {
-  taskId: string;
-  type: string;
-  severity: 'error' | 'warning';
-  previousStatus: string;
-  newStatus: string;
-  recommendedAction: string;
-  reason: string;
-  successorTaskId?: string;
-}
-
-export interface RemediationResult {
-  dryRun: boolean;
-  repairedCount: number;
-  skippedCount: number;
-  actions: RemediationAction[];
-  generatedAt: string;
-}
+import { createRemediationResult, remediationAction } from './remediation-contract.js';
+import type { RemediationAction, RemediationResult } from './remediation-contract.js';
 
 export interface InternalizationIntegrityRemediationOptions {
   workspaceDir: string;
@@ -56,27 +39,35 @@ export class InternalizationIntegrityRemediation {
     for (const bd of brokenDreamers) {
       if (bd.missingArtifact) {
         if (params.dryRun) {
-          actions.push({
+          actions.push(remediationAction({
+            action: 'requeue',
+            targetId: bd.taskId,
             taskId: bd.taskId,
             type: 'missing_dreamer_pi_artifact',
             severity: 'error',
+            previousState: 'succeeded',
+            nextState: 'retry_wait',
             previousStatus: 'succeeded',
             newStatus: 'retry_wait',
             recommendedAction: 'requeue',
             reason: 'Succeeded dreamer missing dreamer_pi artifact — operator repair: requeue to retry_wait for re-execution',
-          });
+          }));
         } else {
           const currentStatus = this.getTaskStatus(bd.taskId);
           if (currentStatus !== 'succeeded') {
-            actions.push({
+            actions.push(remediationAction({
+              action: 'already_repaired',
+              targetId: bd.taskId,
               taskId: bd.taskId,
               type: 'missing_dreamer_pi_artifact',
               severity: 'error',
+              previousState: currentStatus,
+              nextState: currentStatus,
               previousStatus: currentStatus,
               newStatus: currentStatus,
               recommendedAction: 'already_repaired',
               reason: `Task already in ${currentStatus} — no repair needed`,
-            });
+            }));
             skippedCount++;
             continue;
           }
@@ -84,80 +75,101 @@ export class InternalizationIntegrityRemediation {
           this.requeueTask(bd.taskId);
           repairedCount++;
 
-          actions.push({
+          actions.push(remediationAction({
+            action: 'requeue',
+            targetId: bd.taskId,
             taskId: bd.taskId,
             type: 'missing_dreamer_pi_artifact',
             severity: 'error',
+            previousState: 'succeeded',
+            nextState: 'retry_wait',
             previousStatus: 'succeeded',
             newStatus: 'retry_wait',
             recommendedAction: 'requeue',
             reason: 'Succeeded dreamer missing dreamer_pi artifact — operator repair: requeue to retry_wait for re-execution',
-          });
+          }));
         }
       }
 
       if (bd.missingSuccessor) {
         if (!bd.hasArtifact) {
-          actions.push({
+          actions.push(remediationAction({
+            action: 'skip_missing_artifact',
+            targetId: bd.taskId,
             taskId: bd.taskId,
             type: 'missing_philosopher_successor',
             severity: 'warning',
+            previousState: this.getTaskStatus(bd.taskId),
+            nextState: this.getTaskStatus(bd.taskId),
             previousStatus: this.getTaskStatus(bd.taskId),
             newStatus: this.getTaskStatus(bd.taskId),
             recommendedAction: 'skip_missing_artifact',
             reason: 'Cannot create philosopher successor — dreamer has no dreamer_pi artifact. Fix artifact first.',
-          });
+          }));
           skippedCount++;
         } else if (params.dryRun) {
-          actions.push({
+          actions.push(remediationAction({
+            action: 'enqueue_successor',
+            targetId: bd.taskId,
             taskId: bd.taskId,
             type: 'missing_philosopher_successor',
             severity: 'warning',
+            previousState: 'succeeded',
+            nextState: 'succeeded',
             previousStatus: 'succeeded',
             newStatus: 'succeeded',
             recommendedAction: 'enqueue_successor',
             reason: 'Dreamer has artifact but no philosopher successor — would create philosopher task',
-          });
+          }));
         } else {
           const existingSuccessor = this.findExistingSuccessor(bd.taskId);
           if (existingSuccessor) {
-            actions.push({
+            actions.push(remediationAction({
+              action: 'successor_exists',
+              targetId: bd.taskId,
               taskId: bd.taskId,
               type: 'missing_philosopher_successor',
               severity: 'warning',
+              previousState: 'succeeded',
+              nextState: 'succeeded',
               previousStatus: 'succeeded',
               newStatus: 'succeeded',
               recommendedAction: 'successor_exists',
               reason: `Philosopher successor already exists: ${existingSuccessor}`,
               successorTaskId: existingSuccessor,
-            });
+            }));
             skippedCount++;
           } else {
             const successorTaskId = this.createPhilosopherSuccessor(bd.taskId);
             repairedCount++;
 
-            actions.push({
+            actions.push(remediationAction({
+              action: 'enqueue_successor',
+              targetId: bd.taskId,
               taskId: bd.taskId,
               type: 'missing_philosopher_successor',
               severity: 'warning',
+              previousState: 'succeeded',
+              nextState: 'succeeded',
               previousStatus: 'succeeded',
               newStatus: 'succeeded',
               recommendedAction: 'enqueue_successor',
               reason: 'Created philosopher successor task',
               successorTaskId,
-            });
+            }));
           }
         }
       }
     }
 
-    return {
-      dryRun: params.dryRun,
+    return createRemediationResult({
+      mode: params.dryRun ? 'dry_run' : 'confirm',
       repairedCount,
       skippedCount,
       actions,
       generatedAt,
-    };
+      includeLegacyDryRun: true,
+    });
   }
 
   private detectBrokenDreamers(): BrokenDreamer[] {

--- a/packages/principles-core/src/runtime-v2/remediation-contract.ts
+++ b/packages/principles-core/src/runtime-v2/remediation-contract.ts
@@ -1,0 +1,87 @@
+export type RemediationMode = 'dry_run' | 'confirm';
+
+export type RemediationStatus = 'would_change' | 'changed' | 'no_op' | 'refused' | 'error';
+
+export interface RemediationAction {
+  action: string;
+  targetId: string;
+  previousState?: string;
+  nextState?: string;
+  reason: string;
+
+  /**
+   * Legacy command-specific fields are retained during PRI-105 migration so
+   * existing operator consumers do not lose detail while the shared contract
+   * becomes the canonical top-level shape.
+   */
+  taskId?: string;
+  type?: string;
+  severity?: 'error' | 'warning';
+  previousStatus?: string;
+  newStatus?: string;
+  recommendedAction?: string;
+  successorTaskId?: string;
+}
+
+export interface RemediationResult {
+  mode: RemediationMode;
+  status: RemediationStatus;
+  safeToConfirm: boolean;
+  repairedCount: number;
+  skippedCount: number;
+  actions: RemediationAction[];
+  warnings: string[];
+
+  generatedAt?: string;
+  dryRun?: boolean;
+}
+
+export interface CreateRemediationResultInput {
+  mode: RemediationMode;
+  repairedCount?: number;
+  skippedCount?: number;
+  actions?: RemediationAction[];
+  warnings?: string[];
+  status?: RemediationStatus;
+  safeToConfirm?: boolean;
+  generatedAt?: string;
+  includeLegacyDryRun?: boolean;
+}
+
+function deriveRemediationStatus(
+  mode: RemediationMode,
+  repairedCount: number,
+  actions: RemediationAction[],
+): RemediationStatus {
+  if (mode === 'dry_run') {
+    return actions.length > 0 ? 'would_change' : 'no_op';
+  }
+  return repairedCount > 0 ? 'changed' : 'no_op';
+}
+
+export function createRemediationResult(input: CreateRemediationResultInput): RemediationResult {
+  const actions = input.actions ?? [];
+  const warnings = input.warnings ?? [];
+  const repairedCount = input.repairedCount ?? 0;
+  const skippedCount = input.skippedCount ?? 0;
+  const status = input.status ?? deriveRemediationStatus(input.mode, repairedCount, actions);
+  const safeToConfirm = input.safeToConfirm ?? (
+    input.mode === 'dry_run' && status === 'would_change' && warnings.length === 0
+  );
+
+  return {
+    mode: input.mode,
+    status,
+    safeToConfirm,
+    repairedCount,
+    skippedCount,
+    actions,
+    warnings,
+    ...(input.generatedAt ? { generatedAt: input.generatedAt } : {}),
+    ...(input.includeLegacyDryRun ? { dryRun: input.mode === 'dry_run' } : {}),
+  };
+}
+
+export function remediationAction(input: RemediationAction): RemediationAction {
+  return input;
+}


### PR DESCRIPTION
## Summary

Implements PRI-105: a shared remediation dry-run/confirm output contract for control-plane repair commands.

## Changes

- Added canonical core `RemediationResult` / `RemediationAction` helpers in `@principles/core/runtime-v2`.
- Aligned these commands to expose the shared JSON shape:
  - `pd runtime recovery sweep`
  - `pd runtime pruning orphans`
  - `pd candidate internalization backfill`
  - `pd runtime internalization integrity repair`
- Standardized `mode`, `status`, `safeToConfirm`, `repairedCount`, `skippedCount`, `actions[]`, and `warnings[]` while preserving command-specific details during migration.
- Enforced `--dry-run` / `--confirm` mutual exclusion across the touched commands.
- Added architecture regression coverage for the new core contract.

## Verification

- `npx eslint packages/principles-core/src/runtime-v2/remediation-contract.ts packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts packages/pd-cli/src/commands/remediation-output.ts packages/pd-cli/src/commands/runtime-recovery.ts packages/pd-cli/src/commands/runtime-pruning.ts packages/pd-cli/src/commands/candidate.ts packages/pd-cli/src/commands/runtime-internalization-integrity-repair.ts` ✅
- `npx vitest run packages/principles-core/src/runtime-v2/__tests__/remediation-contract.test.ts packages/principles-core/src/runtime-v2/__tests__/internalization-integrity-remediation.test.ts packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts packages/pd-cli/tests/commands/runtime-recovery.test.ts packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts packages/pd-cli/tests/commands/runtime-pruning.test.ts packages/pd-cli/tests/commands/runtime-internalization-integrity-repair.test.ts` ✅ — 304 passed, 1 skipped
- `npm run build --workspace=@principles/core` ✅
- `npm run build --workspace=@principles/pd-cli` ✅
- `npm run typecheck:openclaw-plugin` ✅
- `git diff --check` ✅

## Notes

The normal pre-push hook runs repo-wide lint and is currently blocked by pre-existing `@typescript-eslint/no-unnecessary-type-assertion` findings outside this PR. The changed files were linted directly and passed.

## Non-goals

- No new repair behavior.
- No production `--confirm` execution.
- No Principle ledger mutation changes.