### PR TITLE
feat(runtime-v2): Trainer L2 runner vertical slice (PRI-116)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v2.9
 milestone_name: M10 — Nocturnal Artificer LLM Upgrade — IN PROGRESS
 status: completed
-last_updated: "2026-05-07T00:58:20.623Z"
+last_updated: "2026-05-12T07:15:03.515Z"
 last_activity: 2026-04-30 -- M10 Artificer LLM upgrade complete on fix/nocturnal-artificer-llm-upgrade
 progress:
-  total_phases: 81
-  completed_phases: 71
-  total_plans: 139
-  completed_plans: 148
-  percent: 100
+  total_phases: 1
+  completed_phases: 0
+  total_plans: 3
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State: Principles

--- a/packages/openclaw-plugin/src/core/event-log.ts
+++ b/packages/openclaw-plugin/src/core/event-log.ts
@@ -31,6 +31,7 @@ import type {
   RuleHostEvaluatedEventData,
   RuleHostBlockedEventData,
   RuleHostRequireApprovalEventData,
+  RuleHostAutoCorrectProposedEventData,
 } from '../types/event-types.js';
 import { createEmptyDailyStats } from '../types/event-types.js';
 import { atomicWriteFileSync } from '../utils/io.js';
@@ -242,6 +243,10 @@ export class EventLog {
 
   recordRuleHostRequireApproval(data: RuleHostRequireApprovalEventData): void {
     this.record('rulehost_requireApproval', 'requireApproval', undefined, data);
+  }
+
+  recordRuleHostAutoCorrectProposed(data: RuleHostAutoCorrectProposedEventData): void {
+    this.record('rulehost_auto_correct_proposed', 'auto_correct', undefined, data);
   }
 
   private record(

--- a/packages/openclaw-plugin/src/core/event-log.ts
+++ b/packages/openclaw-plugin/src/core/event-log.ts
@@ -454,6 +454,8 @@ export class EventLog {
       stats.evolution.rulehostBlocked++;
     } else if (entry.type === 'rulehost_requireApproval') {
       stats.evolution.rulehostRequireApproval++;
+    } else if (entry.type === 'rulehost_auto_correct_proposed') {
+      stats.evolution.rulehostAutoCorrectProposed++;
     }
   }
 

--- a/packages/openclaw-plugin/src/hooks/gate.ts
+++ b/packages/openclaw-plugin/src/hooks/gate.ts
@@ -16,6 +16,7 @@ import { WorkspaceContext } from '../core/workspace-context.js';
 import { recordGateBlockAndReturn } from './gate-block-helper.js';
 import { RuleHost } from '../core/rule-host.js';
 import type { RuleHostInput } from '@principles/core/runtime-v2';
+import { validateCorrectionProposal } from '@principles/core/runtime-v2';
 import type { PluginHookBeforeToolCallEvent, PluginHookToolContext, PluginHookBeforeToolCallResult, PluginLogger } from '../openclaw-sdk.js';
 import { AGENT_TOOLS, BASH_TOOLS_SET, WRITE_TOOLS } from '../constants/tools.js';
 import { getSession, hasRecentThinking } from '../core/session-tracker.js';
@@ -153,8 +154,36 @@ export function handleBeforeToolCall(
         logger?.warn?.(`[PD_GATE] Failed to record rule_enforced/rulehost_requireApproval: ${String(evErr)}`);
       }
     }
+
+    if (hostResult?.decision === 'auto_correct' && hostResult.correctionProposal) {
+      const proposal = hostResult.correctionProposal;
+      const validation = validateCorrectionProposal(proposal);
+
+      try {
+        const eventLog = EventLogService.get(wctx.stateDir, logger as PluginLogger | undefined);
+        const correctedFields = Array.isArray(proposal.correctedFields)
+          ? proposal.correctedFields.map((f: any) => typeof f === 'object' && f !== null ? String(f.field) : String(f))
+          : [];
+        eventLog.recordRuleHostAutoCorrectProposed({
+          toolName: event.toolName,
+          filePath: relPath,
+          ruleId: String(proposal.ruleId ?? 'unknown'),
+          principleId: proposal.principleId != null ? String(proposal.principleId) : undefined,
+          confidence: typeof proposal.confidence === 'number' ? proposal.confidence : 0,
+          reason: hostResult.reason,
+          applicationMode: proposal.applicationMode === 'live' ? 'live' : 'shadow',
+          correctedFields,
+          validationValid: validation.valid,
+        });
+      } catch (evErr) {
+        logger?.warn?.(`[PD_GATE] Failed to record rulehost_auto_correct_proposed: ${String(evErr)}`);
+      }
+
+      // SAFETY: Never modify event.params. Shadow mode is enforced at hook level.
+      // Even if applicationMode === 'live', current implementation is shadow-only.
+      // Live mutation requires a future feature gate (PRI-115+).
+    }
   } catch (hostError: unknown) {
-    // D-08: Conservative degradation — log and allow on Rule Host failure
     logger.warn?.(`[PD_GATE:RULE_HOST] Host evaluation failed, allowing conservatively: ${String(hostError)}`);
   }
 

--- a/packages/openclaw-plugin/src/hooks/gate.ts
+++ b/packages/openclaw-plugin/src/hooks/gate.ts
@@ -157,7 +157,12 @@ export function handleBeforeToolCall(
 
     if (hostResult?.decision === 'auto_correct' && hostResult.correctionProposal) {
       const proposal = hostResult.correctionProposal;
-      const validation = validateCorrectionProposal(proposal);
+      let validation: { valid: boolean; errors: string[] };
+      try {
+        validation = validateCorrectionProposal(proposal);
+      } catch (validationError: unknown) {
+        validation = { valid: false, errors: [`Validator threw: ${String(validationError)}`] };
+      }
 
       try {
         const eventLog = EventLogService.get(wctx.stateDir, logger as PluginLogger | undefined);
@@ -182,6 +187,23 @@ export function handleBeforeToolCall(
       // SAFETY: Never modify event.params. Shadow mode is enforced at hook level.
       // Even if applicationMode === 'live', current implementation is shadow-only.
       // Live mutation requires a future feature gate (PRI-115+).
+    } else if (hostResult?.decision === 'auto_correct') {
+      // auto_correct without correctionProposal — emit telemetry for observability
+      try {
+        const eventLog = EventLogService.get(wctx.stateDir, logger as PluginLogger | undefined);
+        eventLog.recordRuleHostAutoCorrectProposed({
+          toolName: event.toolName,
+          filePath: relPath,
+          ruleId: hostResult.ruleId ?? 'unknown',
+          confidence: 0,
+          reason: hostResult.reason ?? 'auto_correct without correctionProposal',
+          applicationMode: 'shadow',
+          correctedFields: [],
+          validationValid: false,
+        });
+      } catch (evErr) {
+        logger?.warn?.(`[PD_GATE] Failed to record rulehost_auto_correct_proposed (no proposal): ${String(evErr)}`);
+      }
     }
   } catch (hostError: unknown) {
     logger.warn?.(`[PD_GATE:RULE_HOST] Host evaluation failed, allowing conservatively: ${String(hostError)}`);

--- a/packages/openclaw-plugin/src/types/event-types.ts
+++ b/packages/openclaw-plugin/src/types/event-types.ts
@@ -30,7 +30,8 @@ export type EventType =
       // C: RuleHost funnel events (PD-FUNNEL-2.4)
       | 'rulehost_evaluated'
       | 'rulehost_blocked'
-      | 'rulehost_requireApproval';
+      | 'rulehost_requireApproval'
+      | 'rulehost_auto_correct_proposed';
 
 export type EventCategory =
   | 'success'
@@ -53,7 +54,8 @@ export type EventCategory =
       // C: New categories for RuleHost funnel (PD-FUNNEL-2.4) — completed/created already exist
       | 'evaluated'   // Used by: rulehost_evaluated
       | 'blocked'     // Used by: rulehost_blocked
-      | 'requireApproval';  // Used by: rulehost_requireApproval
+      | 'requireApproval'  // Used by: rulehost_requireApproval
+      | 'auto_correct';  // Used by: rulehost_auto_correct_proposed (PRI-114)
 
 /**
  * Base event structure for JSONL logging.
@@ -269,7 +271,7 @@ export interface RuleHostEvaluatedEventData {
   toolName: string;
   filePath: string;
   matched: boolean;
-  decision: 'allow' | 'block' | 'requireApproval';
+  decision: 'allow' | 'block' | 'requireApproval' | 'auto_correct';
   ruleId?: string;
 }
 
@@ -293,6 +295,23 @@ export interface RuleHostRequireApprovalEventData {
   filePath: string;
   reason: string;
   ruleId?: string;
+}
+
+/**
+ * rulehost_auto_correct_proposed — RuleHost proposed an auto-correction (PRI-114).
+ * Emitted from gate.ts when hostResult.decision === 'auto_correct'.
+ * Shadow mode only — params are never modified.
+ */
+export interface RuleHostAutoCorrectProposedEventData {
+  toolName: string;
+  filePath: string;
+  ruleId: string;
+  principleId?: string;
+  confidence: number;
+  reason: string;
+  applicationMode: 'shadow' | 'live';
+  correctedFields: string[];
+  validationValid: boolean;
 }
 
 // ============== Daily Statistics ==============

--- a/packages/openclaw-plugin/src/types/event-types.ts
+++ b/packages/openclaw-plugin/src/types/event-types.ts
@@ -423,6 +423,7 @@ export interface EvolutionStats {
   rulehostEvaluated: number;
   rulehostBlocked: number;
   rulehostRequireApproval: number;
+  rulehostAutoCorrectProposed: number;
 }
 
 export interface HookStats {
@@ -560,6 +561,7 @@ export function createEmptyDailyStats(date: string): DailyStats {
       rulehostEvaluated: 0,
       rulehostBlocked: 0,
       rulehostRequireApproval: 0,
+      rulehostAutoCorrectProposed: 0,
     },
     hooks: {
       total: 0,

--- a/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
@@ -54,6 +54,13 @@ vi.mock('../../src/core/principle-tree-ledger.js', () => ({
   listImplementationsByLifecycleState: vi.fn(() => []),
 }));
 
+vi.mock('../../src/hooks/gate-block-helper.js', () => ({
+  recordGateBlockAndReturn: vi.fn(() => ({
+    block: true as const,
+    reason: 'mocked block',
+  })),
+}));
+
 function makeValidProposal(overrides: Record<string, unknown> = {}) {
   return {
     proposedParams: { content: 'fixed content' },

--- a/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
@@ -246,4 +246,24 @@ describe('PRI-114: Gate auto_correct shadow mode', () => {
     expect(result).toBeUndefined();
     expect(event.params).toEqual(paramsCopy);
   });
+
+
+  // PRI-114 review: auto_correct without correctionProposal still emits telemetry
+  it('auto_correct without correctionProposal emits telemetry with validationValid false', () => {
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix but no proposal',
+      ruleId: 'R_no_prop',
+    });
+
+    const result = handleBeforeToolCall(makeWriteEvent(), makeCtx());
+
+    expect(result).toBeUndefined();
+    expect(mockEventLogInstance.recordRuleHostAutoCorrectProposed).toHaveBeenCalledTimes(1);
+    const call = mockEventLogInstance.recordRuleHostAutoCorrectProposed.mock.calls[0][0];
+    expect(call.validationValid).toBe(false);
+    expect(call.reason).toContain('no proposal');
+  });
+
 });

--- a/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
@@ -1,0 +1,249 @@
+/**
+ * PRI-114: Gate auto_correct shadow mode tests
+ *
+ * Verify that auto_correct decision in gate.ts:
+ * - Never modifies event.params (shadow enforced)
+ * - Emits rulehost_auto_correct_proposed telemetry
+ * - Invalid proposals still emit telemetry (validationValid: false)
+ * - Existing allow/block/requireApproval unchanged
+ * - Config gate defaults to shadow even when live configured
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleBeforeToolCall } from '../../src/hooks/gate.js';
+import * as sessionTracker from '../../src/core/session-tracker.js';
+import * as evolutionEngine from '../../src/core/evolution-engine.js';
+
+const workspaceDir = '/mock/workspace';
+const sessionId = 'test-ac-shadow';
+
+const mockEvolution = {
+  getTier: vi.fn().mockReturnValue(3),
+  getPoints: vi.fn().mockReturnValue(200),
+};
+
+vi.mock('../../src/core/session-tracker.js', () => ({
+  getSession: vi.fn(() => ({ currentGfi: 0 })),
+  trackBlock: vi.fn(),
+  hasRecentThinking: vi.fn(() => false),
+}));
+
+vi.mock('../../src/core/evolution-engine.js', () => ({
+  getEvolutionEngine: vi.fn(() => mockEvolution),
+}));
+
+const mockEventLogInstance = {
+  recordRuleHostEvaluated: vi.fn(),
+  recordRuleEnforced: vi.fn(),
+  recordRuleHostBlocked: vi.fn(),
+  recordRuleHostRequireApproval: vi.fn(),
+  recordRuleHostAutoCorrectProposed: vi.fn(),
+};
+vi.mock('../../src/core/event-log.js', () => ({
+  EventLogService: { get: vi.fn(() => mockEventLogInstance) },
+}));
+
+let _mockEvaluate = vi.fn().mockReturnValue(undefined);
+vi.mock('../../src/core/rule-host.js', () => ({
+  RuleHost: vi.fn(function(this: any, _stateDir: string, _logger: any) {
+    this.evaluate = _mockEvaluate;
+  }),
+}));
+
+vi.mock('../../src/core/principle-tree-ledger.js', () => ({
+  loadLedger: vi.fn(),
+  listImplementationsByLifecycleState: vi.fn(() => []),
+}));
+
+function makeValidProposal(overrides: Record<string, unknown> = {}) {
+  return {
+    proposedParams: { content: 'fixed content' },
+    correctedFields: [
+      { field: 'content', original: 'broken', proposed: 'fixed content', reason: 'typo' },
+    ],
+    applicationMode: 'shadow' as const,
+    confidence: 0.9,
+    ruleId: 'R_ac_test',
+    principleId: 'P_ac_test',
+    notifyAgent: true,
+    ...overrides,
+  };
+}
+
+function makeWriteEvent(params: Record<string, unknown> = {}) {
+  return {
+    toolName: 'write',
+    params: { file_path: '/mock/workspace/src/foo.ts', content: 'broken', ...params },
+  };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    workspaceDir,
+    sessionId,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe('PRI-114: Gate auto_correct shadow mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _mockEvaluate = vi.fn().mockReturnValue(undefined);
+  });
+
+  it('auto_correct does NOT modify event.params', () => {
+    const originalParams = { file_path: '/mock/workspace/src/foo.ts', content: 'broken' };
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix typo in content',
+      ruleId: 'R_ac_001',
+      correctionProposal: makeValidProposal(),
+    });
+
+    const event = makeWriteEvent(originalParams);
+    const paramsCopy = { ...event.params };
+    const result = handleBeforeToolCall(event, makeCtx());
+
+    // Shadow mode: returns undefined (allow), params unchanged
+    expect(result).toBeUndefined();
+    expect(event.params).toEqual(paramsCopy);
+  });
+
+  it('auto_correct with applicationMode live still does NOT modify params', () => {
+    const originalParams = { file_path: '/mock/workspace/src/foo.ts', content: 'broken' };
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix typo',
+      ruleId: 'R_ac_live',
+      correctionProposal: makeValidProposal({ applicationMode: 'live' }),
+    });
+
+    const event = makeWriteEvent(originalParams);
+    const paramsCopy = { ...event.params };
+    const result = handleBeforeToolCall(event, makeCtx());
+
+    expect(result).toBeUndefined();
+    expect(event.params).toEqual(paramsCopy);
+  });
+
+  it('auto_correct emits rulehost_auto_correct_proposed telemetry', () => {
+    const proposal = makeValidProposal();
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix typo in content',
+      ruleId: proposal.ruleId,
+      correctionProposal: proposal,
+    });
+
+    handleBeforeToolCall(makeWriteEvent(), makeCtx());
+
+    expect(mockEventLogInstance.recordRuleHostAutoCorrectProposed).toHaveBeenCalledTimes(1);
+    const call = mockEventLogInstance.recordRuleHostAutoCorrectProposed.mock.calls[0][0];
+    expect(call.toolName).toBe('write');
+    expect(call.ruleId).toBe(proposal.ruleId);
+    expect(call.principleId).toBe(proposal.principleId);
+    expect(call.confidence).toBe(0.9);
+    expect(call.reason).toBe('fix typo in content');
+    expect(call.applicationMode).toBe('shadow');
+    expect(call.correctedFields).toEqual(['content']);
+    expect(call.validationValid).toBe(true);
+  });
+
+  it('auto_correct with invalid proposal still emits telemetry with validationValid false', () => {
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        // Invalid: proposedParams is a string, missing fields
+        proposedParams: 'not-an-object',
+      },
+    });
+
+    handleBeforeToolCall(makeWriteEvent(), makeCtx());
+
+    expect(mockEventLogInstance.recordRuleHostAutoCorrectProposed).toHaveBeenCalledTimes(1);
+    const call = mockEventLogInstance.recordRuleHostAutoCorrectProposed.mock.calls[0][0];
+    expect(call.validationValid).toBe(false);
+  });
+
+  it('block still takes precedence over auto_correct', () => {
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'block',
+      matched: true,
+      reason: 'dangerous operation',
+      ruleId: 'R_block',
+    });
+
+    const event = makeWriteEvent();
+    const result = handleBeforeToolCall(event, makeCtx());
+
+    expect(result).toBeDefined();
+    expect(mockEventLogInstance.recordRuleHostBlocked).toHaveBeenCalled();
+    expect(mockEventLogInstance.recordRuleHostAutoCorrectProposed).not.toHaveBeenCalled();
+  });
+
+  it('requireApproval still works unchanged', () => {
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'requireApproval',
+      matched: true,
+      reason: 'sensitive write',
+      ruleId: 'R_approval',
+    });
+
+    const result = handleBeforeToolCall(makeWriteEvent(), makeCtx());
+    expect(result).toBeUndefined();
+    expect(mockEventLogInstance.recordRuleHostRequireApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('allow still works unchanged', () => {
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'allow',
+      matched: true,
+      reason: 'safe',
+    });
+
+    const result = handleBeforeToolCall(makeWriteEvent(), makeCtx());
+    expect(result).toBeUndefined();
+    expect(mockEventLogInstance.recordRuleHostEvaluated).toHaveBeenCalledTimes(1);
+  });
+
+  it('missing pluginConfig defaults to shadow (no crash)', () => {
+    const proposal = makeValidProposal();
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: proposal,
+    });
+
+    const event = makeWriteEvent();
+    const paramsCopy = { ...event.params };
+    const result = handleBeforeToolCall(event, makeCtx({ pluginConfig: undefined }));
+
+    expect(result).toBeUndefined();
+    expect(event.params).toEqual(paramsCopy);
+  });
+
+  it('pluginConfig.autoCorrectLive true still shadow (current impl)', () => {
+    const proposal = makeValidProposal({ applicationMode: 'live' });
+    _mockEvaluate = vi.fn().mockReturnValue({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: proposal,
+    });
+
+    const event = makeWriteEvent();
+    const paramsCopy = { ...event.params };
+    const result = handleBeforeToolCall(event, makeCtx({
+      pluginConfig: { autoCorrectLive: true },
+    }));
+
+    expect(result).toBeUndefined();
+    expect(event.params).toEqual(paramsCopy);
+  });
+});

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -8,6 +8,7 @@ import {
   ArtificerRunner,
   EvaluatorRunner,
   RolloutReviewerRunner,
+  TrainerRunner,
   StoreEventEmitter,
   DefaultDreamerValidator,
   DefaultPhilosopherValidator,
@@ -15,13 +16,14 @@ import {
   DefaultArtificerValidator,
   DefaultEvaluatorValidator,
   DefaultRolloutReviewerValidator,
+  DefaultTrainerValidator,
   TestDoubleRuntimeAdapter,
   PiAiRuntimeAdapter,
   OpenClawCliRuntimeAdapter,
   resolveRuntimeConfig,
   validateRuntimeConfig,
 } from '@principles/core/runtime-v2';
-import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, EvaluatorRunnerResult, RolloutReviewerRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
+import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, EvaluatorRunnerResult, RolloutReviewerRunnerResult, TrainerRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 interface RunOnceOptions {
@@ -37,7 +39,7 @@ interface RunOnceOptions {
 const OWNER = 'pd-cli-internalization-run-once';
 const RUNTIME_KIND = 'local-worker';
 
-const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer']);
+const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer', 'trainer']);
 
 interface RunOnceOutput {
   decision: string;
@@ -48,7 +50,7 @@ interface RunOnceOutput {
   runId?: string;
   artifactId?: string;
   resultRef?: string;
-  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult;
+  runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult | TrainerRunnerResult;
   skipReason?: string;
   conflictReason?: string;
   reason?: string;
@@ -60,7 +62,7 @@ interface RunOnceOutput {
   timeoutSource?: string;
 }
 
-function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult, skipReason?: string): RunOnceOutput {
+function buildOutput(wakeResult: WakeOnceResult, runnerResult?: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult | TrainerRunnerResult, skipReason?: string): RunOnceOutput {
   const base: RunOnceOutput = { decision: wakeResult.decision };
 
   switch (wakeResult.decision) {
@@ -361,6 +363,56 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
         }),
       });
     }
+    if (opts.runnerKind === 'trainer') {
+      let capturedSourceRolloutReviewerArtifactId = 'pi-art-test-rollout-reviewer';
+      return new TestDoubleRuntimeAdapter({
+        onStartRun: (input) => {
+          try {
+            const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+            const parsed = JSON.parse(payloadStr);
+            if (typeof parsed.sourceRolloutReviewerArtifactId === 'string' && parsed.sourceRolloutReviewerArtifactId.trim() !== '') {
+              capturedSourceRolloutReviewerArtifactId = parsed.sourceRolloutReviewerArtifactId;
+            }
+          } catch { /* use default */ }
+          return { runId: `td-trainer-${Date.now()}`, runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+        },
+        onPollRun: (_runId: string) => ({
+          runId: _runId,
+          status: 'succeeded',
+          startedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+        }),
+        onFetchOutput: (_runId: string) => ({
+          runId: _runId,
+          payload: {
+            taskId: opts.taskId,
+            sourceRolloutReviewerArtifactId: capturedSourceRolloutReviewerArtifactId,
+            ruleCandidate: {
+              toolScope: 'src/**/*.ts',
+              triggerCondition: 'TypeScript file edit with schema mismatch',
+              proposedDecision: 'auto_correct',
+              proposedCorrection: {
+                type: 'add_validation',
+                action: 'prepend',
+                snippet: 'const validated = schema.parse(input); if (!validated.success) throw new ValidationError(validated.error);',
+              },
+              rationale: 'Auto-correct validates input before processing to prevent downstream errors',
+              confidence: 0.88,
+            },
+            safety: {
+              limitations: ['Requires schema definition for all input types', 'May not handle complex nested structures'],
+              falsePositiveRisks: ['Could over-correct on intentional dynamic patterns'],
+              requiredReplayCases: ['Schema validation edge case', 'Nested object validation'],
+            },
+            sourceTrace: {
+              rolloutReviewerArtifactId: capturedSourceRolloutReviewerArtifactId,
+            },
+            risks: [],
+            generatedAt: new Date().toISOString(),
+          },
+        }),
+      });
+    }
     return new TestDoubleRuntimeAdapter({
       onPollRun: (_runId: string) => ({
         runId: _runId,
@@ -465,7 +517,7 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       return;
     }
 
-    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult | undefined = undefined;
+    let runnerResult: DreamerRunnerResult | PhilosopherRunnerResult | ScribeRunnerResult | ArtificerRunnerResult | EvaluatorRunnerResult | RolloutReviewerRunnerResult | TrainerRunnerResult | undefined = undefined;
     let skipReason: string | undefined = undefined;
 
     if (wakeResult.decision === 'would_lease') {
@@ -515,6 +567,13 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       } else if (runnerKind === 'rollout_reviewer') {
         const validator = new DefaultRolloutReviewerValidator();
         const runner = new RolloutReviewerRunner(
+          { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
+          { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
+        );
+        runnerResult = await runner.run(wakeResult.taskId);
+      } else if (runnerKind === 'trainer') {
+        const validator = new DefaultTrainerValidator();
+        const runner = new TrainerRunner(
           { stateManager, runtimeAdapter, eventEmitter, validator, artifactStore },
           { owner: OWNER, runtimeKind: RUNTIME_KIND, pollIntervalMs: 100, timeoutMs: effectiveTimeoutMs },
         );

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -199,7 +199,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
   });
 
   it('unsupported runner kind: exits 1 with error', async () => {
-    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'trainer', runtime: 'test-double', allowTestDouble: true });
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'invalid-runner', runtime: 'test-double', allowTestDouble: true });
 
     expect(process.exitCode).toBe(1);
     expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('unsupported runner kind'))).toBe(true);

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -1804,6 +1804,79 @@ describe('PRI-RR RolloutReviewerRunner boundary', () => {
   });
 });
 
+// ── PRI-116: TrainerRunner boundary guards ──────────────────────────────────
+
+describe('PRI-116 TrainerRunner boundary', () => {
+  it('trainer source files exist in internalization directory', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'trainer-runner.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'trainer-output.ts'))).toBe(true);
+    expect(existsSync(resolve(__dirname, '..', 'internalization', 'trainer-prompt-builder.ts'))).toBe(true);
+  });
+
+  it('trainer test file exists', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(resolve(__dirname, 'trainer-runner-vslice.test.ts'))).toBe(true);
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: trainer-output.ts has no openclaw-plugin, fs, path imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'trainer-output.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+  });
+
+  it('CORE_NO_FORBIDDEN_IMPORTS: trainer-runner.ts has no openclaw-plugin, RolloutReviewerRunner, nocturnal-trinity imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'trainer-runner.ts'), 'utf-8');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('RolloutReviewerRunner');
+    expect(src).not.toContain('nocturnal-trinity');
+    expect(src).not.toContain('InternalizationOrchestrator');
+    expect(src).not.toContain('createTask');
+    expect(src).not.toContain('enqueueTask');
+  });
+
+  it('CORE_NO_SCHEDULING: trainer-runner.ts has no node:fs, node:cron imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'trainer-runner.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('BARREL_EXPORTS: internalization/index.ts exports TrainerRunner and TrainerOutput', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).toContain('TrainerRunner');
+    expect(src).toContain('TrainerOutput');
+    expect(src).toContain('DefaultTrainerValidator');
+  });
+
+  it('BARREL_EXPORTS: runtime-v2/index.ts exports TrainerRunner and TrainerOutput', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('TrainerRunner');
+    expect(src).toContain('TrainerOutput');
+    expect(src).toContain('DefaultTrainerValidator');
+  });
+
+  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers trainer-output-v1 schema', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    expect(src).toContain('trainer-output-v1');
+    expect(src).toContain('TrainerOutputV1Schema');
+  });
+});
+
 describe('PRI-114: correction-proposal boundary', () => {
   it('CORE_PURE: correction-proposal.ts has zero infrastructure imports', async () => {
     const { readFileSync } = await import('node:fs');

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -90,6 +90,8 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/pi-artifact-store.ts',
   // PRI-113
   'golden-trace.ts',
+  // PRI-114
+  'internalization/correction-proposal.ts',
   // PRI-105
   'remediation-contract.ts',
 ] as const;
@@ -130,6 +132,8 @@ const REQUIRED_TEST_FILES = [
   '../gfi/__tests__/gfi-kernel.test.ts',
   // PRI-113
   'golden-trace.test.ts',
+  // PRI-114
+  'correction-proposal.test.ts',
   // PRI-105
   'remediation-contract.test.ts',
 ];
@@ -1797,5 +1801,42 @@ describe('PRI-RR RolloutReviewerRunner boundary', () => {
     const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
     expect(src).toContain('rollout-reviewer-output-v1');
     expect(src).toContain('RolloutReviewerOutputV1Schema');
+  });
+});
+
+describe('PRI-114: correction-proposal boundary', () => {
+  it('CORE_PURE: correction-proposal.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'correction-proposal.ts'), 'utf-8');
+    expect(src).not.toContain('node:vm');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('require(');
+  });
+
+  it('CONTRACT_IMPORT: rule-host-contracts.ts imports CorrectionProposal from same directory', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'rule-host-contracts.ts'), 'utf-8');
+    expect(src).toContain("from './correction-proposal.js'");
+  });
+
+  it('EVALUATOR_IMPORT: rule-host-evaluator.ts imports validateCorrectionProposal from same directory', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'rule-host-evaluator.ts'), 'utf-8');
+    expect(src).toContain("from './correction-proposal.js'");
+    expect(src).toContain('validateCorrectionProposal');
+  });
+
+  it('BARREL_EXPORTS: runtime-v2/index.ts exports CorrectionProposal and validators', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('CorrectionProposal');
+    expect(src).toContain('validateProposedParams');
+    expect(src).toContain('validateCorrectionProposal');
+    expect(src).toContain("from './internalization/correction-proposal.js'");
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
@@ -273,4 +273,80 @@ describe('validateCorrectionProposal', () => {
     const result = validateCorrectionProposal(proposal);
     expect(result.valid).toBe(true);
   });
+
+
+  // PRI-114 review: throwing getter does not crash validateCorrectionProposal
+  it('validateCorrectionProposal handles throwing getter gracefully', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = {
+      proposedParams: new Proxy({}, {
+        get(_target, prop) { if (prop === 'something') throw new Error('boom'); return undefined; }
+      }),
+      correctedFields: [{ field: 'x', original: 'a', proposed: 'b', reason: 'fix' }],
+      applicationMode: 'shadow',
+      confidence: 0.8,
+      ruleId: 'R_throw',
+      notifyAgent: false,
+    };
+    const result = validateCorrectionProposal(proposal);
+    expect(result).toBeDefined();
+    expect(typeof result.valid).toBe('boolean');
+  });
+
+  // PRI-114 review: NaN confidence
+  it('rejects NaN confidence', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: {},
+      correctedFields: [],
+      applicationMode: 'shadow',
+      confidence: NaN,
+      ruleId: 'R_nan',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('confidence'))).toBe(true);
+  });
+
+  // PRI-114 review: Infinity confidence
+  it('rejects Infinity confidence', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: {},
+      correctedFields: [],
+      applicationMode: 'shadow',
+      confidence: Infinity,
+      ruleId: 'R_inf',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('confidence'))).toBe(true);
+  });
+
+  // PRI-114 review: Negative infinity confidence
+  it('rejects -Infinity confidence', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: {},
+      correctedFields: [],
+      applicationMode: 'shadow',
+      confidence: -Infinity,
+      ruleId: 'R_ninf',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('confidence'))).toBe(true);
+  });
+
+  // PRI-114 review: sessionId in proposedParams identity protection
+  it('validateProposedParams rejects sessionId modification', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { content: 'old', sessionId: 's1' },
+      { content: 'old', sessionId: 's1' },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('sessionId'))).toBe(true);
+  });
+
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
@@ -1,0 +1,276 @@
+/**
+ * PRI-114: CorrectionProposal contract + validators
+ *
+ * TDD tests for validateProposedParams and validateCorrectionProposal.
+ */
+import { describe, it, expect } from 'vitest';
+
+describe('validateProposedParams', () => {
+  async function getModule() {
+    return import('../internalization/correction-proposal.js');
+  }
+
+  it('accepts valid proposed params that are a subset of original keys', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { content: 'fixed' },
+      { content: 'broken', path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('accepts valid proposed params with nested serializable objects', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { options: { encoding: 'utf-8' } },
+      { options: { encoding: 'ascii' }, path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects null', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(null, { path: '/foo.ts' });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects undefined', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(undefined, { path: '/foo.ts' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects arrays', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams([1, 2, 3], { path: '/foo.ts' });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('plain object'))).toBe(true);
+  });
+
+  it('rejects string', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams('not an object', { path: '/foo.ts' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects function values', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { callback: (() => null) as unknown as Function },
+      { callback: null, path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('function') || e.includes('Function'))).toBe(true);
+  });
+
+  it('rejects undefined values', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { content: undefined },
+      { content: 'original', path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('undefined'))).toBe(true);
+  });
+
+  it('rejects Symbol values', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { tag: Symbol('test') },
+      { tag: 'original', path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('symbol') || e.includes('Symbol'))).toBe(true);
+  });
+
+  it('rejects circular references', async () => {
+    const { validateProposedParams } = await getModule();
+    const original: Record<string, unknown> = { path: '/bar.ts', self: null };
+    const circular: Record<string, unknown> = { path: '/foo.ts' };
+    circular.self = circular;
+    const result = validateProposedParams(circular, original);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('circular') || e.includes('JSON'))).toBe(true);
+  });
+
+  it('rejects keys absent from original params', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { unknown_key: 'value' },
+      { path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('unknown_key') || e.includes('not present'))).toBe(true);
+  });
+
+  it('rejects proposed toolName modification', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { toolName: 'dangerous_tool' },
+      { toolName: 'write', path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('toolName') || e.includes('identity'))).toBe(true);
+  });
+
+  it('accepts empty proposed params (no-op correction)', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams({}, { path: '/foo.ts' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects BigInt values', async () => {
+    const { validateProposedParams } = await getModule();
+    const result = validateProposedParams(
+      { size: BigInt(9007199254740991) },
+      { size: 100, path: '/foo.ts' },
+    );
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateCorrectionProposal', () => {
+  async function getModule() {
+    return import('../internalization/correction-proposal.js');
+  }
+
+  function makeValidProposal() {
+    return {
+      proposedParams: { content: 'fixed' },
+      correctedFields: [
+        { field: 'content', original: 'broken', proposed: 'fixed', reason: 'typo fix' },
+      ],
+      applicationMode: 'shadow' as const,
+      confidence: 0.85,
+      ruleId: 'R_test_001',
+      principleId: 'P_001',
+      notifyAgent: true,
+    };
+  }
+
+  it('accepts valid complete proposal', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal(makeValidProposal());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects null', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal(null);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects missing proposedParams', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = makeValidProposal();
+    delete (proposal as Record<string, unknown>).proposedParams;
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('proposedParams'))).toBe(true);
+  });
+
+  it('rejects missing correctedFields', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = makeValidProposal();
+    delete (proposal as Record<string, unknown>).correctedFields;
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('correctedFields'))).toBe(true);
+  });
+
+  it('rejects missing applicationMode', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = makeValidProposal();
+    delete (proposal as Record<string, unknown>).applicationMode;
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('applicationMode'))).toBe(true);
+  });
+
+  it('rejects invalid applicationMode', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = { ...makeValidProposal(), applicationMode: 'maybe' };
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('applicationMode'))).toBe(true);
+  });
+
+  it('rejects confidence below 0', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = { ...makeValidProposal(), confidence: -0.1 };
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence'))).toBe(true);
+  });
+
+  it('rejects confidence above 1', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = { ...makeValidProposal(), confidence: 1.5 };
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence'))).toBe(true);
+  });
+
+  it('accepts confidence at boundaries (0 and 1)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const r0 = validateCorrectionProposal({ ...makeValidProposal(), confidence: 0 });
+    expect(r0.valid).toBe(true);
+    const r1 = validateCorrectionProposal({ ...makeValidProposal(), confidence: 1 });
+    expect(r1.valid).toBe(true);
+  });
+
+  it('rejects missing ruleId', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = makeValidProposal();
+    delete (proposal as Record<string, unknown>).ruleId;
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('ruleId'))).toBe(true);
+  });
+
+  it('rejects empty ruleId', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = { ...makeValidProposal(), ruleId: '' };
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('ruleId'))).toBe(true);
+  });
+
+  it('rejects missing notifyAgent', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = makeValidProposal();
+    delete (proposal as Record<string, unknown>).notifyAgent;
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('notifyAgent'))).toBe(true);
+  });
+
+  it('rejects non-boolean notifyAgent', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = { ...makeValidProposal(), notifyAgent: 'yes' };
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('notifyAgent'))).toBe(true);
+  });
+
+  it('rejects non-JSON-serializable proposedParams', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const circular: Record<string, unknown> = { content: 'test' };
+    circular.self = circular;
+    const proposal = { ...makeValidProposal(), proposedParams: circular };
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('proposedParams') || e.includes('serializable'))).toBe(true);
+  });
+
+  it('accepts proposal without principleId (optional)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const proposal = makeValidProposal();
+    delete (proposal as Record<string, unknown>).principleId;
+    const result = validateCorrectionProposal(proposal);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/rule-host-evaluator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/rule-host-evaluator.test.ts
@@ -232,3 +232,287 @@ describe('mergeDecisions', () => {
     expect(mergeDecisions(impls, makeInput())).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// PRI-114: auto_correct merge tests
+// ---------------------------------------------------------------------------
+
+describe('mergeDecisions — auto_correct (PRI-114)', () => {
+  async function getModule() {
+    return import('../internalization/rule-host-evaluator.js');
+  }
+
+  function makeInput114(): RuleHostInput {
+    return {
+      action: { toolName: 'write', normalizedPath: '/foo.ts', paramsSummary: {} },
+      workspace: { isRiskPath: false, planStatus: 'NONE', hasPlanFile: false },
+      session: { sessionId: 's1', currentGfi: 0, recentThinking: false },
+      evolution: { epTier: 0 },
+      derived: { estimatedLineChanges: 1, bashRisk: 'unknown' },
+    };
+  }
+
+  function makeImpl114(overrides: {
+    implId?: string;
+    ruleId?: string;
+    evaluate: (_input: RuleHostInput) => RuleHostResult;
+  }): LoadedImplementation {
+    return {
+      implId: overrides.implId ?? 'impl-1',
+      ruleId: overrides.ruleId ?? 'R_001',
+      meta: { name: 'Test', version: '1.0.0', ruleId: 'R_001', coversCondition: 'test' },
+      evaluate: overrides.evaluate,
+    };
+  }
+
+  // 13. Single auto_correct returns the proposal
+  it('returns auto_correct result when single impl returns auto_correct', async () => {
+    const { mergeDecisions } = await getModule();
+    const proposal = {
+      proposedParams: { content: 'fixed' },
+      correctedFields: [{ field: 'content', original: 'broken', proposed: 'fixed', reason: 'fix' }],
+      applicationMode: 'shadow' as const,
+      confidence: 0.9,
+      ruleId: 'R_auto_001',
+      notifyAgent: true,
+    };
+    const impls = [
+      makeImpl114({
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix typo',
+          correctionProposal: proposal,
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114());
+    expect(result?.decision).toBe('auto_correct');
+    expect(result?.correctionProposal).toEqual(proposal);
+  });
+
+  // 14. auto_correct + allow -> auto_correct wins
+  it('auto_correct takes precedence over allow', async () => {
+    const { mergeDecisions } = await getModule();
+    const proposal = {
+      proposedParams: { content: 'fixed' },
+      correctedFields: [{ field: 'content', original: 'bad', proposed: 'fixed', reason: 'fix' }],
+      applicationMode: 'shadow' as const,
+      confidence: 0.8,
+      ruleId: 'R_auto_002',
+      notifyAgent: false,
+    };
+    const impls = [
+      makeImpl114({
+        implId: 'allow-1',
+        evaluate: () => ({ decision: 'allow' as const, matched: true, reason: 'ok' }),
+      }),
+      makeImpl114({
+        implId: 'ac-1',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix content',
+          correctionProposal: proposal,
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114());
+    expect(result?.decision).toBe('auto_correct');
+  });
+
+  // 15. auto_correct + requireApproval -> auto_correct wins
+  it('auto_correct takes precedence over requireApproval', async () => {
+    const { mergeDecisions } = await getModule();
+    const proposal = {
+      proposedParams: { content: 'fixed' },
+      correctedFields: [{ field: 'content', original: 'bad', proposed: 'fixed', reason: 'fix' }],
+      applicationMode: 'shadow' as const,
+      confidence: 0.8,
+      ruleId: 'R_auto_003',
+      notifyAgent: false,
+    };
+    const impls = [
+      makeImpl114({
+        implId: 'approval-1',
+        evaluate: () => ({ decision: 'requireApproval' as const, matched: true, reason: 'needs review' }),
+      }),
+      makeImpl114({
+        implId: 'ac-1',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix it',
+          correctionProposal: proposal,
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114());
+    expect(result?.decision).toBe('auto_correct');
+  });
+
+  // 16. block + auto_correct -> block short-circuits
+  it('block short-circuits before auto_correct is evaluated', async () => {
+    const { mergeDecisions } = await getModule();
+    let acCalled = false;
+    const impls = [
+      makeImpl114({
+        implId: 'blocker',
+        evaluate: () => ({ decision: 'block' as const, matched: true, reason: 'dangerous' }),
+      }),
+      makeImpl114({
+        implId: 'ac-never',
+        evaluate: () => {
+          acCalled = true;
+          return {
+            decision: 'auto_correct' as const,
+            matched: true,
+            reason: 'fix',
+            correctionProposal: {
+              proposedParams: {},
+              correctedFields: [],
+              applicationMode: 'shadow',
+              confidence: 0.5,
+              ruleId: 'R_x',
+              notifyAgent: false,
+            },
+          };
+        },
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114());
+    expect(result?.decision).toBe('block');
+    expect(acCalled).toBe(false);
+  });
+
+  // 17. auto_correct with invalid proposal -> skipped, falls through
+  it('invalid auto_correct proposal is skipped with warning', async () => {
+    const { mergeDecisions } = await getModule();
+    const logger = { warn: vi.fn() };
+    const impls = [
+      makeImpl114({
+        implId: 'bad-ac',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix',
+          correctionProposal: {
+            proposedParams: 'not-an-object' as unknown as Record<string, unknown>,
+          } as RuleHostResult['correctionProposal'],
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114(), logger);
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  // 18. auto_correct with missing correctionProposal -> skipped
+  it('auto_correct without correctionProposal is skipped with warning', async () => {
+    const { mergeDecisions } = await getModule();
+    const logger = { warn: vi.fn() };
+    const impls = [
+      makeImpl114({
+        implId: 'no-proposal',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix but no proposal',
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114(), logger);
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  // 19. Multiple auto_correct -> first valid one wins
+  it('first valid auto_correct proposal wins among multiple', async () => {
+    const { mergeDecisions } = await getModule();
+    const proposal1 = {
+      proposedParams: { content: 'fix1' },
+      correctedFields: [{ field: 'content', original: 'bad', proposed: 'fix1', reason: 'first' }],
+      applicationMode: 'shadow' as const,
+      confidence: 0.7,
+      ruleId: 'R_first',
+      notifyAgent: false,
+    };
+    const proposal2 = {
+      proposedParams: { content: 'fix2' },
+      correctedFields: [{ field: 'content', original: 'bad', proposed: 'fix2', reason: 'second' }],
+      applicationMode: 'shadow' as const,
+      confidence: 0.8,
+      ruleId: 'R_second',
+      notifyAgent: true,
+    };
+    const impls = [
+      makeImpl114({
+        implId: 'ac-first',
+        ruleId: 'R_first',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'first fix',
+          correctionProposal: proposal1,
+        }),
+      }),
+      makeImpl114({
+        implId: 'ac-second',
+        ruleId: 'R_second',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'second fix',
+          correctionProposal: proposal2,
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114());
+    expect(result?.decision).toBe('auto_correct');
+    expect(result?.correctionProposal?.ruleId).toBe('R_first');
+  });
+
+  // 20. auto_correct with matched:false -> ignored
+  it('auto_correct with matched:false is ignored', async () => {
+    const { mergeDecisions } = await getModule();
+    const impls = [
+      makeImpl114({
+        implId: 'unmatched-ac',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: false,
+          reason: 'not applicable',
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114());
+    expect(result).toBeUndefined();
+  });
+
+  // 21. All auto_correct invalid -> falls through to requireApproval
+  it('all auto_correct invalid falls through to requireApproval', async () => {
+    const { mergeDecisions } = await getModule();
+    const logger = { warn: vi.fn() };
+    const impls = [
+      makeImpl114({
+        implId: 'bad-ac',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix',
+          correctionProposal: { proposedParams: null } as unknown as RuleHostResult['correctionProposal'],
+        }),
+      }),
+      makeImpl114({
+        implId: 'approval',
+        evaluate: () => ({
+          decision: 'requireApproval' as const,
+          matched: true,
+          reason: 'needs review',
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114(), logger);
+    expect(result?.decision).toBe('requireApproval');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/rule-host-evaluator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/rule-host-evaluator.test.ts
@@ -515,4 +515,38 @@ describe('mergeDecisions — auto_correct (PRI-114)', () => {
     const result = mergeDecisions(impls, makeInput114(), logger);
     expect(result?.decision).toBe('requireApproval');
   });
+
+
+  // 22. auto_correct with throwing getter proposal — does not crash merge
+  it('auto_correct with throwing getter proposal does not crash mergeDecisions', async () => {
+    const { mergeDecisions } = await getModule();
+    const logger = { warn: vi.fn() };
+    const maliciousProposal = new Proxy({}, {
+      get(_target, prop) { if (prop === 'proposedParams') throw new Error('getter boom'); return undefined; }
+    });
+    const impls = [
+      makeImpl114({
+        implId: 'malicious',
+        evaluate: () => ({
+          decision: 'auto_correct' as const,
+          matched: true,
+          reason: 'fix',
+          correctionProposal: maliciousProposal as unknown as RuleHostResult['correctionProposal'],
+        }),
+      }),
+      makeImpl114({
+        implId: 'approval-fallback',
+        evaluate: () => ({
+          decision: 'requireApproval' as const,
+          matched: true,
+          reason: 'needs review',
+        }),
+      }),
+    ];
+    const result = mergeDecisions(impls, makeInput114(), logger);
+    // Should not throw, falls through to requireApproval (fail-closed)
+    expect(result?.decision).toBe('requireApproval');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/trainer-output-validator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/trainer-output-validator.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest';
+import { DefaultTrainerValidator } from '../internalization/trainer-output.js';
+import type { TrainerOutputV1 } from '../internalization/trainer-output.js';
+
+const TRAINER_TASK_ID = 'trainer-001';
+const ROLLOUT_REVIEWER_ARTIFACT_ID = 'pi-art-rollout-reviewer-001';
+
+function makeTrainerOutput(overrides: Partial<TrainerOutputV1> = {}): TrainerOutputV1 {
+  return {
+    taskId: TRAINER_TASK_ID,
+    sourceRolloutReviewerArtifactId: ROLLOUT_REVIEWER_ARTIFACT_ID,
+    ruleCandidate: {
+      toolScope: 'tool_call',
+      triggerCondition: 'When a tool is called',
+      proposedDecision: 'allow',
+      rationale: 'Standard safe operation pattern',
+      confidence: 0.85,
+    },
+    safety: {
+      limitations: ['Requires feature flag'],
+      falsePositiveRisks: ['May block legitimate edge cases'],
+      requiredReplayCases: ['tool_call with empty params', 'tool_call with null toolName'],
+    },
+    sourceTrace: {
+      rolloutReviewerArtifactId: ROLLOUT_REVIEWER_ARTIFACT_ID,
+    },
+    generatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('DefaultTrainerValidator (vertical slice)', () => {
+  const validator = new DefaultTrainerValidator();
+
+  it('accepts valid Trainer output', async () => {
+    const result = await validator.validate(makeTrainerOutput(), TRAINER_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects taskId mismatch', async () => {
+    const output = makeTrainerOutput();
+    (output as unknown as Record<string, unknown>).taskId = 'wrong';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('taskId mismatch'))).toBe(true);
+  });
+
+  it('rejects missing sourceRolloutReviewerArtifactId', async () => {
+    const output = makeTrainerOutput();
+    (output as unknown as Record<string, unknown>).sourceRolloutReviewerArtifactId = '';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceRolloutReviewerArtifactId'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceRolloutReviewerArtifactId when expected is provided', async () => {
+    const output = makeTrainerOutput();
+    (output as unknown as Record<string, unknown>).sourceRolloutReviewerArtifactId = 'wrong-artifact-id';
+    const result = await validator.validate(output, TRAINER_TASK_ID, ROLLOUT_REVIEWER_ARTIFACT_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sourceRolloutReviewerArtifactId mismatch'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceTrace.rolloutReviewerArtifactId vs sourceRolloutReviewerArtifactId', async () => {
+    const output = makeTrainerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).rolloutReviewerArtifactId = 'wrong-trace-id';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('must match'))).toBe(true);
+  });
+
+  it('rejects invalid proposedDecision value', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).proposedDecision = 'invalid';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('proposedDecision'))).toBe(true);
+  });
+
+  it('rejects confidence as string', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).confidence = '0.85';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be number'))).toBe(true);
+  });
+
+  it('rejects confidence > 1', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).confidence = 1.5;
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be in [0, 1]'))).toBe(true);
+  });
+
+  it('rejects NaN confidence', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).confidence = NaN;
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be number'))).toBe(true);
+  });
+
+  it('rejects Infinity confidence', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).confidence = Infinity;
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('confidence must be number'))).toBe(true);
+  });
+
+  it('rejects null output', async () => {
+    const result = await validator.validate(null as unknown as TrainerOutputV1, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects missing toolScope', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).toolScope = '';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('toolScope'))).toBe(true);
+  });
+
+  it('rejects missing triggerCondition', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).triggerCondition = '';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('triggerCondition'))).toBe(true);
+  });
+
+  it('rejects missing rationale', async () => {
+    const output = makeTrainerOutput();
+    (output.ruleCandidate as unknown as Record<string, unknown>).rationale = '';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('rationale'))).toBe(true);
+  });
+
+  it('accepts auto_correct with proposedCorrection', async () => {
+    const output = makeTrainerOutput({
+      ruleCandidate: {
+        toolScope: 'tool_call',
+        triggerCondition: 'When a tool is called with invalid params',
+        proposedDecision: 'auto_correct',
+        proposedCorrection: {
+          description: 'Use default params instead',
+          proposedParams: { defaultTimeout: 5000 },
+        },
+        rationale: 'Safe to auto-correct with defaults',
+        confidence: 0.9,
+      },
+    });
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects auto_correct without proposedCorrection', async () => {
+    const output = makeTrainerOutput({
+      ruleCandidate: {
+        toolScope: 'tool_call',
+        triggerCondition: 'When a tool is called',
+        proposedDecision: 'auto_correct',
+        rationale: 'Safe to auto-correct',
+        confidence: 0.9,
+      },
+    } as TrainerOutputV1);
+    // TypeScript allows this structurally, but validator should reject
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('proposedCorrection'))).toBe(true);
+  });
+
+  it('rejects non-auto_correct decision with proposedCorrection', async () => {
+    const output = makeTrainerOutput({
+      ruleCandidate: {
+        toolScope: 'tool_call',
+        triggerCondition: 'When a tool is called',
+        proposedDecision: 'allow',
+        proposedCorrection: {
+          description: 'Should not exist for allow decision',
+          proposedParams: {},
+        },
+        rationale: 'This should be invalid',
+        confidence: 0.85,
+      },
+    } as TrainerOutputV1);
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('proposedCorrection'))).toBe(true);
+  });
+
+  it('rejects safety.limitations with non-string elements', async () => {
+    const output = makeTrainerOutput();
+    (output.safety as unknown as Record<string, unknown>).limitations = [42];
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('limitations must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects safety.falsePositiveRisks with non-string elements', async () => {
+    const output = makeTrainerOutput();
+    (output.safety as unknown as Record<string, unknown>).falsePositiveRisks = [true];
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('falsePositiveRisks must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects safety.requiredReplayCases with non-string elements', async () => {
+    const output = makeTrainerOutput();
+    (output.safety as unknown as Record<string, unknown>).requiredReplayCases = [{}];
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('requiredReplayCases must be an array of strings'))).toBe(true);
+  });
+
+  it('accepts output with optional goldenTraceRefs', async () => {
+    const output = makeTrainerOutput({
+      goldenTraceRefs: ['gt-case-001', 'gt-case-002'],
+    });
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects goldenTraceRefs with non-string elements', async () => {
+    const output = makeTrainerOutput();
+    (output as unknown as Record<string, unknown>).goldenTraceRefs = [42];
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('goldenTraceRefs must be an array of strings'))).toBe(true);
+  });
+
+  it('rejects missing generatedAt', async () => {
+    const output = makeTrainerOutput();
+    (output as unknown as Record<string, unknown>).generatedAt = '';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('generatedAt'))).toBe(true);
+  });
+
+  it('rejects unparseable generatedAt', async () => {
+    const output = makeTrainerOutput();
+    (output as unknown as Record<string, unknown>).generatedAt = 'not-a-date';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('generatedAt'))).toBe(true);
+  });
+
+  it('rejects mismatched sourceRolloutReviewerArtifactId vs sourceTrace.rolloutReviewerArtifactId', async () => {
+    const output = makeTrainerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).rolloutReviewerArtifactId = 'different-id';
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('must match'))).toBe(true);
+  });
+
+  it('accepts valid output with all optional fields', async () => {
+    const output = makeTrainerOutput({
+      goldenTraceRefs: ['gt-001'],
+      inlineGoldenTraceCases: [
+        {
+          caseId: 'case-001',
+          kind: 'positive',
+          toolName: 'tool_call',
+          params: { name: 'test' },
+          expectedDecision: 'allow',
+          sourceRefs: [],
+        },
+      ],
+      sourceTrace: {
+        rolloutReviewerArtifactId: ROLLOUT_REVIEWER_ARTIFACT_ID,
+        evaluatorArtifactId: 'pi-art-evaluator-001',
+      },
+    });
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects non-string rolloutReviewerArtifactId in sourceTrace', async () => {
+    const output = makeTrainerOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).rolloutReviewerArtifactId = 42;
+    const result = await validator.validate(output, TRAINER_TASK_ID);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('rolloutReviewerArtifactId'))).toBe(true);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/trainer-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/trainer-runner-vslice.test.ts
@@ -1,0 +1,575 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TrainerRunner } from '../internalization/trainer-runner.js';
+import type { TrainerRunnerDeps } from '../internalization/trainer-runner.js';
+import type { PIArtifactStore, PIArtifactRecord } from '../internalization/pi-artifact.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { TrainerOutputV1 } from '../internalization/trainer-output.js';
+import { DefaultTrainerValidator } from '../internalization/trainer-output.js';
+import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
+import type { TaskRecord } from '../task-status.js';
+import { TestDoubleRuntimeAdapter } from '../adapter/test-double-runtime-adapter.js';
+
+const ROLLOUT_REVIEWER_TASK_ID = 'rollout-reviewer-001';
+const TRAINER_TASK_ID = 'trainer-001';
+
+function makeRolloutReviewerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ROLLOUT_REVIEWER_TASK_ID,
+    taskKind: 'rollout_reviewer',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'rollout-reviewer://run-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'model_training',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-rollout-reviewer-001-run-001' }],
+    }),
+    ...overrides,
+  };
+}
+
+function makeTrainerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: TRAINER_TASK_ID,
+    taskKind: 'trainer',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [ROLLOUT_REVIEWER_TASK_ID],
+      channel: 'model_training',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-rollout-reviewer-001-run-001' }],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeTrainerOutput(sourceRolloutReviewerArtifactId: string): TrainerOutputV1 {
+  return {
+    taskId: TRAINER_TASK_ID,
+    sourceRolloutReviewerArtifactId,
+    ruleCandidate: {
+      toolScope: 'tool_call',
+      triggerCondition: 'When a tool is called with invalid parameters',
+      proposedDecision: 'auto_correct',
+      proposedCorrection: {
+        description: 'Use default parameters instead',
+        proposedParams: { defaultTimeout: 5000 },
+      },
+      rationale: 'Safe to auto-correct with sensible defaults',
+      confidence: 0.88,
+    },
+    safety: {
+      limitations: ['Requires feature flag enabled'],
+      falsePositiveRisks: ['May incorrectly auto-correct edge case inputs'],
+      requiredReplayCases: ['tool_call with null params', 'tool_call with empty toolName'],
+    },
+    sourceTrace: {
+      rolloutReviewerArtifactId: sourceRolloutReviewerArtifactId,
+    },
+    goldenTraceRefs: ['gt-case-001'],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function makeRolloutReviewerArtifact(): PIArtifactRecord {
+  return {
+    artifactId: 'pi-art-rollout-reviewer-001-run-001',
+    artifactKind: 'principle',
+    sourceTaskId: ROLLOUT_REVIEWER_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify({
+      taskId: ROLLOUT_REVIEWER_TASK_ID,
+      sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+      review: {
+        decision: 'approve_rollout',
+        summary: 'The rollout plan is safe to proceed',
+        confidence: 0.9,
+        requiredChanges: [],
+        rolloutRisks: ['Feature flag configuration may need adjustment'],
+        safetyChecks: ['Verify feature flag is properly configured'],
+      },
+      sourceTrace: {
+        evaluatorArtifactId: 'pi-art-evaluator-001',
+      },
+      risks: ['Rollback plan should be tested before deployment'],
+      generatedAt: '2026-05-11T12:00:00.000Z',
+    }),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('TrainerRunner (vertical slice)', () => {
+  function createMockDeps(overrides: Partial<TrainerRunnerDeps> = {}): TrainerRunnerDeps {
+    const artifactStore = overrides.artifactStore ?? new MemoryPIArtifactStore();
+    const trainerTask = makeTrainerTask();
+    const rolloutReviewerTask = makeRolloutReviewerTask();
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(trainerTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === TRAINER_TASK_ID) return Promise.resolve(trainerTask);
+        if (id === ROLLOUT_REVIEWER_TASK_ID) return Promise.resolve(rolloutReviewerTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-trainer-001',
+        taskId: TRAINER_TASK_ID,
+        runtimeKind: 'trainer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const runHandle: RunHandle = { runId: 'run-trainer-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+    const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-trainer-001' };
+
+    const runtimeAdapter = {
+      startRun: vi.fn().mockResolvedValue(runHandle),
+      pollRun: vi.fn().mockResolvedValue(succeededStatus),
+      fetchOutput: vi.fn().mockResolvedValue({
+        payload: makeTrainerOutput('pi-art-rollout-reviewer-001-run-001'),
+      }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PDRuntimeAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const validator = new DefaultTrainerValidator();
+
+    return {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator,
+      artifactStore,
+      ...overrides,
+    };
+  }
+
+  it('taskKind not trainer fails closed and releases lease', async () => {
+    const wrongKindTask = makeTrainerTask({ taskKind: 'dreamer' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(wrongKindTask);
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+    expect(result.failureReason).toContain("must be 'trainer'");
+    expect(deps.stateManager.markTaskFailed).toHaveBeenCalledWith(
+      TRAINER_TASK_ID,
+      'input_invalid',
+    );
+  });
+
+  it('missing rollout_reviewer dependency blocked/failure', async () => {
+    const noDepTask = makeTrainerTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'model_training',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockResolvedValue(noDepTask);
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockResolvedValue(noDepTask);
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('rollout_reviewer dependency not succeeded cannot execute', async () => {
+    const pendingRolloutReviewer = makeRolloutReviewerTask({ status: 'pending' });
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).getTask = vi.fn().mockImplementation((id: string) => {
+      if (id === TRAINER_TASK_ID) return Promise.resolve(makeTrainerTask());
+      if (id === ROLLOUT_REVIEWER_TASK_ID) return Promise.resolve(pendingRolloutReviewer);
+      return Promise.resolve(null);
+    });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('rollout_reviewer artifact missing goes to retry/fail', async () => {
+    const emptyArtifactStore = new MemoryPIArtifactStore();
+    const deps = createMockDeps({ artifactStore: emptyArtifactStore });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('input_invalid');
+  });
+
+  it('valid runtime output writes trainer PIArtifact with artifactKind rule', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeRolloutReviewerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(result.artifactId).toBeDefined();
+
+    const artifacts = await store.listBySourceTaskId(TRAINER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('rule');
+  });
+
+  it('valid runtime output marks task succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeRolloutReviewerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
+      TRAINER_TASK_ID,
+      expect.stringContaining('trainer://'),
+    );
+  });
+
+  it('invalid output does not write artifact', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeRolloutReviewerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const invalidOutput: TrainerOutputV1 = {
+      taskId: 'wrong-task-id',
+      sourceRolloutReviewerArtifactId: '',
+      ruleCandidate: {
+        toolScope: '',
+        triggerCondition: '',
+        proposedDecision: 'invalid' as 'allow',
+        rationale: '',
+        confidence: 1.5,
+      },
+      safety: {
+        limitations: [],
+        falsePositiveRisks: [],
+        requiredReplayCases: [],
+      },
+      sourceTrace: {
+        rolloutReviewerArtifactId: '',
+      },
+      generatedAt: '',
+    };
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+
+    const artifacts = await store.listBySourceTaskId(TRAINER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('artifact write failure goes to retry/fail, not mark succeeded', async () => {
+    const failingStore = {
+      listBySourceTaskId: vi.fn().mockResolvedValue([makeRolloutReviewerArtifact()]),
+      upsertArtifact: vi.fn().mockRejectedValue(new Error('Disk full')),
+    } as unknown as PIArtifactStore;
+
+    const deps = createMockDeps({ artifactStore: failingStore });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('mismatched sourceRolloutReviewerArtifactId does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeRolloutReviewerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeTrainerOutput('wrong-artifact-id');
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(TRAINER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('sourceTrace.rolloutReviewerArtifactId mismatch does not write artifact or mark succeeded', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeRolloutReviewerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const mismatchedOutput = makeTrainerOutput('pi-art-rollout-reviewer-001-run-001');
+    (mismatchedOutput.sourceTrace as unknown as Record<string, unknown>).rolloutReviewerArtifactId = 'wrong-trace-id';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    const artifacts = await store.listBySourceTaskId(TRAINER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('output_invalid is permanent failure', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeRolloutReviewerArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const invalidOutput = makeTrainerOutput('pi-art-rollout-reviewer-001-run-001');
+    (invalidOutput.ruleCandidate as unknown as Record<string, unknown>).proposedDecision = 'invalid';
+
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+    expect(deps.stateManager.markTaskFailed).toHaveBeenCalledWith(TRAINER_TASK_ID, 'output_invalid');
+  });
+});
+
+describe('TrainerRunner integration: test-double captures sourceRolloutReviewerArtifactId from prompt', () => {
+  it('seed rollout_reviewer artifact -> run trainer with test-double -> succeeded with correct sourceRolloutReviewerArtifactId', async () => {
+    const ROLLOUT_REVIEWER_ART_ID = 'pi-art-rollout-reviewer-real-001';
+    const artifactStore = new MemoryPIArtifactStore();
+
+    const rolloutReviewerArtifact: PIArtifactRecord = {
+      artifactId: ROLLOUT_REVIEWER_ART_ID,
+      artifactKind: 'principle',
+      sourceTaskId: ROLLOUT_REVIEWER_TASK_ID,
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: JSON.stringify({
+        taskId: ROLLOUT_REVIEWER_TASK_ID,
+        sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+        review: {
+          decision: 'approve_rollout',
+          summary: 'The rollout plan is safe to proceed',
+          confidence: 0.9,
+          requiredChanges: [],
+          rolloutRisks: [],
+          safetyChecks: [],
+        },
+        sourceTrace: {
+          evaluatorArtifactId: 'pi-art-evaluator-001',
+        },
+        risks: [],
+        generatedAt: new Date().toISOString(),
+      }),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await artifactStore.upsertArtifact(rolloutReviewerArtifact);
+
+    const trainerTask = makeTrainerTask();
+
+    let capturedSourceRolloutReviewerArtifactId: string | undefined = undefined;
+    const runtimeAdapter = new TestDoubleRuntimeAdapter({
+      onStartRun: (input) => {
+        try {
+          const payloadStr = typeof input.inputPayload === 'string' ? input.inputPayload : JSON.stringify(input.inputPayload);
+          const parsed = JSON.parse(payloadStr);
+          if (typeof parsed.sourceRolloutReviewerArtifactId === 'string' && parsed.sourceRolloutReviewerArtifactId.trim() !== '') {
+            capturedSourceRolloutReviewerArtifactId = parsed.sourceRolloutReviewerArtifactId;
+          }
+        } catch { /* ignore */ }
+        return { runId: 'run-integration-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+      },
+      onPollRun: (_runId: string) => ({
+        runId: _runId,
+        status: 'succeeded',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }),
+      onFetchOutput: (_runId: string) => ({
+        runId: _runId,
+        payload: {
+          taskId: TRAINER_TASK_ID,
+          sourceRolloutReviewerArtifactId: capturedSourceRolloutReviewerArtifactId ?? ROLLOUT_REVIEWER_ART_ID,
+          ruleCandidate: {
+            toolScope: 'tool_call',
+            triggerCondition: 'When a tool is called',
+            proposedDecision: 'allow',
+            rationale: 'Safe operation',
+            confidence: 0.85,
+          },
+          safety: {
+            limitations: [],
+            falsePositiveRisks: [],
+            requiredReplayCases: [],
+          },
+          sourceTrace: {
+            rolloutReviewerArtifactId: capturedSourceRolloutReviewerArtifactId ?? ROLLOUT_REVIEWER_ART_ID,
+          },
+          generatedAt: new Date().toISOString(),
+        },
+      }),
+    });
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(trainerTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === TRAINER_TASK_ID) return Promise.resolve(trainerTask);
+        if (id === ROLLOUT_REVIEWER_TASK_ID) return Promise.resolve(makeRolloutReviewerTask());
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-integration-001',
+        taskId: TRAINER_TASK_ID,
+        runtimeKind: 'trainer',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const deps: TrainerRunnerDeps = {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator: new DefaultTrainerValidator(),
+      artifactStore,
+    };
+
+    const runner = new TrainerRunner(deps, {
+      owner: 'test-integration',
+      runtimeKind: 'trainer',
+      pollIntervalMs: 10,
+      timeoutMs: 5000,
+    });
+
+    const result = await runner.run(TRAINER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+    expect(capturedSourceRolloutReviewerArtifactId).toBe(ROLLOUT_REVIEWER_ART_ID);
+    expect(result.output?.sourceRolloutReviewerArtifactId).toBe(ROLLOUT_REVIEWER_ART_ID);
+    expect(result.output?.sourceTrace.rolloutReviewerArtifactId).toBe(ROLLOUT_REVIEWER_ART_ID);
+
+    const artifacts = await artifactStore.listBySourceTaskId(TRAINER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('rule');
+
+    const [storedArtifact] = artifacts;
+    expect(storedArtifact).toBeDefined();
+    if (!storedArtifact) return;
+    const storedOutput = JSON.parse(storedArtifact.contentJson) as TrainerOutputV1;
+    expect(storedOutput.sourceRolloutReviewerArtifactId).toBe(ROLLOUT_REVIEWER_ART_ID);
+    expect(storedOutput.sourceTrace.rolloutReviewerArtifactId).toBe(ROLLOUT_REVIEWER_ART_ID);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -27,6 +27,7 @@ import { ScribeOutputV1Schema } from '../internalization/scribe-output.js';
 import { ArtificerOutputV1Schema } from '../internalization/artificer-output.js';
 import { EvaluatorOutputV1Schema } from '../internalization/evaluator-output.js';
 import { RolloutReviewerOutputV1Schema } from '../internalization/rollout-reviewer-output.js';
+import { TrainerOutputV1Schema } from '../internalization/trainer-output.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair } from './structured-output-repair.js';
@@ -196,6 +197,7 @@ const OUTPUT_SCHEMA_REGISTRY = new Map<string, TSchema>([
   ['artificer-output-v1', ArtificerOutputV1Schema as TSchema],
   ['evaluator-output-v1', EvaluatorOutputV1Schema as TSchema],
   ['rollout-reviewer-output-v1', RolloutReviewerOutputV1Schema as TSchema],
+  ['trainer-output-v1', TrainerOutputV1Schema as TSchema],
 ]);
 
 export class PiAiRuntimeAdapter implements PDRuntimeAdapter {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -639,6 +639,52 @@ export type {
   RolloutReviewerPromptBuildResult,
 } from './internalization/rollout-reviewer-prompt-builder.js';
 
+// ── Trainer Runner (PRI-116) ────────────────────────────────────────────────
+
+export type {
+  TrainerRuleCandidate,
+  TrainerSafety,
+  TrainerSourceTrace,
+  TrainerOutputV1,
+  TrainerValidationResult,
+  TrainerValidator,
+} from './internalization/trainer-output.js';
+
+export {
+  DefaultTrainerValidator,
+  TrainerOutputV1Schema,
+  TrainerRuleCandidateSchema,
+  TrainerSafetySchema,
+  TrainerSourceTraceSchema,
+  TRAINER_DECISIONS,
+} from './internalization/trainer-output.js';
+
+export type {
+  TrainerRunnerResultStatus,
+  TrainerRunnerResult,
+  TrainerRunnerOptions,
+  ResolvedTrainerRunnerOptions,
+  TrainerRunnerDeps,
+} from './internalization/trainer-runner.js';
+
+export {
+  TrainerRunner,
+  resolveTrainerRunnerOptions,
+  DEFAULT_TRAINER_RUNNER_OPTIONS,
+} from './internalization/trainer-runner.js';
+
+export {
+  TrainerPromptBuilder,
+  TRAINER_PROTOCOL_INSTRUCTION,
+  TRAINER_PROMPT_CONTRACT_VERSION,
+} from './internalization/trainer-prompt-builder.js';
+
+export type {
+  TrainerPromptBuilderInput,
+  TrainerPromptInput,
+  TrainerPromptBuildResult,
+} from './internalization/trainer-prompt-builder.js';
+
 // ── PIArtifact Durable Store (PRI-84) ────────────────────────────────────────
 
 export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -265,6 +265,9 @@ export type {
 } from './internalization/rule-host-contracts.js';
 export type { RuleHostHelpers } from './internalization/rule-host-helpers.js';
 export { createRuleHostHelpers } from './internalization/rule-host-helpers.js';
+// Correction proposal (PRI-114)
+export type { CorrectionProposal, CorrectionProposalValidationResult } from './internalization/correction-proposal.js';
+export { validateProposedParams, validateCorrectionProposal } from './internalization/correction-proposal.js';
 
 // Internalization route model (PRI-43)
 export type { InternalizationRouteKind, InternalizationRouteDecision } from './internalization/internalization-route.js';

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/trainer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/trainer-prompt-builder.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { TrainerPromptBuilder, TRAINER_PROTOCOL_INSTRUCTION, TRAINER_PROMPT_CONTRACT_VERSION } from '../trainer-prompt-builder.js';
+
+const TASK_ID = 'trainer-001';
+const CONTEXT_HASH = 'ctx-abc123';
+const SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID = 'pi-art-rollout-reviewer-001';
+
+const ROLLOUT_REVIEWER_ARTIFACT = {
+  taskId: 'rollout-reviewer-001',
+  sourceEvaluatorArtifactId: 'pi-art-evaluator-001',
+  review: {
+    decision: 'approve_rollout',
+    summary: 'The rollout plan is safe to proceed',
+    confidence: 0.9,
+    requiredChanges: [],
+    rolloutRisks: ['Feature flag configuration may need adjustment'],
+    safetyChecks: ['Verify feature flag is properly configured'],
+  },
+  sourceTrace: {
+    evaluatorArtifactId: 'pi-art-evaluator-001',
+  },
+  risks: ['Rollback plan should be tested before deployment'],
+  generatedAt: '2026-05-11T12:00:00.000Z',
+};
+
+describe('TrainerPromptBuilder (vertical slice)', () => {
+  it('buildPrompt returns a message string', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(typeof result.message).toBe('string');
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+
+  it('promptInput includes taskId', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(result.promptInput.taskId).toBe(TASK_ID);
+  });
+
+  it('promptInput includes contextHash', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(result.promptInput.contextHash).toBe(CONTEXT_HASH);
+  });
+
+  it('promptInput includes sourceRolloutReviewerArtifactId', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(result.promptInput.sourceRolloutReviewerArtifactId).toBe(SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID);
+  });
+
+  it('promptInput includes rolloutReviewerArtifact', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(result.promptInput.rolloutReviewerArtifact).toBe(ROLLOUT_REVIEWER_ARTIFACT);
+  });
+
+  it('promptInput includes trainerInstruction', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(typeof result.promptInput.trainerInstruction).toBe('string');
+    expect(result.promptInput.trainerInstruction.length).toBeGreaterThan(0);
+  });
+
+  it('promptInput includes promptContractVersion', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(result.promptInput.promptContractVersion).toBe('trainer-output-v1.prompt.v1');
+  });
+
+  it('message is valid JSON parseable', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(() => JSON.parse(result.message)).not.toThrow();
+  });
+
+  it('parsed message contains all required fields', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    const parsed = JSON.parse(result.message);
+    expect(parsed.taskId).toBe(TASK_ID);
+    expect(parsed.contextHash).toBe(CONTEXT_HASH);
+    expect(parsed.sourceRolloutReviewerArtifactId).toBe(SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID);
+    expect(parsed.rolloutReviewerArtifact).toBeDefined();
+    expect(parsed.trainerInstruction).toBeDefined();
+    expect(parsed.promptContractVersion).toBe('trainer-output-v1.prompt.v1');
+  });
+
+  it('message does not include markdown code fences', () => {
+    const builder = new TrainerPromptBuilder();
+    const result = builder.buildPrompt({
+      taskId: TASK_ID,
+      contextHash: CONTEXT_HASH,
+      sourceRolloutReviewerArtifactId: SOURCE_ROLLOUT_REVIEWER_ARTIFACT_ID,
+      rolloutReviewerArtifact: ROLLOUT_REVIEWER_ARTIFACT,
+    });
+
+    expect(result.message).not.toMatch(/^```/);
+    expect(result.message).not.toMatch(/```$/);
+  });
+
+  it('trainerInstruction contains JSON-only directive', () => {
+    expect(TRAINER_PROTOCOL_INSTRUCTION).toContain('JSON');
+    expect(TRAINER_PROTOCOL_INSTRUCTION).toContain('only');
+  });
+
+  it('promptContractVersion constant is trainer-output-v1.prompt.v1', () => {
+    expect(TRAINER_PROMPT_CONTRACT_VERSION).toBe('trainer-output-v1.prompt.v1');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts
@@ -1,0 +1,180 @@
+/**
+ * CorrectionProposal — Pure domain types and validators for auto-correction
+ *
+ * PRI-114: Extends RuleHost with auto_correct decision support.
+ * Proposes parameter corrections but never applies them directly.
+ *
+ * TRUST BOUNDARY:
+ *   - Pure functions only, zero side effects
+ *   - No filesystem, VM, process, or network access
+ *   - All validation is fail-closed (invalid -> rejected, never applied)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CorrectionProposal {
+  proposedParams: Record<string, unknown>;
+  correctedFields: {
+    field: string;
+    original: unknown;
+    proposed: unknown;
+    reason: string;
+  }[];
+  applicationMode: 'shadow' | 'live';
+  confidence: number;
+  ruleId: string;
+  principleId?: string;
+  notifyAgent: boolean;
+}
+
+export interface CorrectionProposalValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const IDENTITY_FIELDS = new Set(['toolName', 'sessionId']);
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isJsonSerializable(value: unknown, seen: Set<unknown> = new Set()): boolean {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+  if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'undefined' || typeof value === 'bigint') {
+    return false;
+  }
+  if (typeof value !== 'object') {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.every(item => isJsonSerializable(item, seen));
+  }
+  return Object.values(value as Record<string, unknown>).every(v => isJsonSerializable(v, seen));
+}
+
+// ---------------------------------------------------------------------------
+// validateProposedParams
+// ---------------------------------------------------------------------------
+
+export function validateProposedParams(
+  proposedParams: unknown,
+  originalParams: Record<string, unknown>,
+): CorrectionProposalValidationResult {
+  const errors: string[] = [];
+
+  if (!isPlainObject(proposedParams)) {
+    const type = proposedParams === null ? 'null'
+      : Array.isArray(proposedParams) ? 'array'
+      : typeof proposedParams;
+    errors.push(`proposedParams must be a plain object, got ${type}`);
+    return { valid: false, errors };
+  }
+
+  for (const key of Object.keys(proposedParams)) {
+    const value = proposedParams[key];
+
+    if (IDENTITY_FIELDS.has(key)) {
+      errors.push(`proposedParams must not modify identity field "${key}"`);
+      continue;
+    }
+
+    if (!(key in originalParams)) {
+      errors.push(`proposedParams key "${key}" is not present in original params`);
+      continue;
+    }
+
+    if (typeof value === 'function') {
+      errors.push(`proposedParams["${key}"] contains a Function value (not JSON-serializable)`);
+    } else if (typeof value === 'undefined') {
+      errors.push(`proposedParams["${key}"] contains undefined (not JSON-serializable)`);
+    } else if (typeof value === 'symbol') {
+      errors.push(`proposedParams["${key}"] contains a Symbol value (not JSON-serializable)`);
+    } else if (typeof value === 'bigint') {
+      errors.push(`proposedParams["${key}"] contains a BigInt value (not JSON-serializable)`);
+    }
+  }
+
+  // Always check serializability regardless of other errors
+  if (!isJsonSerializable(proposedParams)) {
+    errors.push('proposedParams contains a circular reference (not JSON-serializable)');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// validateCorrectionProposal
+// ---------------------------------------------------------------------------
+
+export function validateCorrectionProposal(
+  proposal: unknown,
+): CorrectionProposalValidationResult {
+  const errors: string[] = [];
+
+  if (!isPlainObject(proposal)) {
+    errors.push('proposal must be a plain object');
+    return { valid: false, errors };
+  }
+
+  // proposedParams — required, must be a plain object
+  if (!('proposedParams' in proposal)) {
+    errors.push('proposedParams is required');
+  } else if (!isPlainObject(proposal.proposedParams)) {
+    errors.push('proposedParams must be a plain object');
+  } else if (!isJsonSerializable(proposal.proposedParams)) {
+    errors.push('proposedParams is not JSON-serializable');
+  }
+
+  // correctedFields — required, must be array
+  if (!('correctedFields' in proposal)) {
+    errors.push('correctedFields is required');
+  } else if (!Array.isArray(proposal.correctedFields)) {
+    errors.push('correctedFields must be an array');
+  }
+
+  // applicationMode — required, must be 'shadow' or 'live'
+  if (!('applicationMode' in proposal)) {
+    errors.push('applicationMode is required');
+  } else if (proposal.applicationMode !== 'shadow' && proposal.applicationMode !== 'live') {
+    errors.push(`applicationMode must be "shadow" or "live", got "${String(proposal.applicationMode)}"`);
+  }
+
+  // confidence — required, number in [0, 1]
+  if (!('confidence' in proposal)) {
+    errors.push('confidence is required');
+  } else if (typeof proposal.confidence !== 'number' || !Number.isFinite(proposal.confidence) || proposal.confidence < 0 || proposal.confidence > 1) {
+    errors.push(`confidence must be a number in [0, 1], got ${String(proposal.confidence)}`);
+  }
+
+  // ruleId — required, non-empty string
+  if (!('ruleId' in proposal)) {
+    errors.push('ruleId is required');
+  } else if (typeof proposal.ruleId !== 'string' || proposal.ruleId.length === 0) {
+    errors.push('ruleId must be a non-empty string');
+  }
+
+  // notifyAgent — required, boolean
+  if (!('notifyAgent' in proposal)) {
+    errors.push('notifyAgent is required');
+  } else if (typeof proposal.notifyAgent !== 'boolean') {
+    errors.push(`notifyAgent must be a boolean, got ${typeof proposal.notifyAgent}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -351,6 +351,52 @@ export type {
   RolloutReviewerPromptBuildResult,
 } from './rollout-reviewer-prompt-builder.js';
 
+// ── Trainer Runner (PRI-116) ────────────────────────────────────────────────
+
+export type {
+  TrainerRuleCandidate,
+  TrainerSafety,
+  TrainerSourceTrace,
+  TrainerOutputV1,
+  TrainerValidationResult,
+  TrainerValidator,
+} from './trainer-output.js';
+
+export {
+  DefaultTrainerValidator,
+  TrainerOutputV1Schema,
+  TrainerRuleCandidateSchema,
+  TrainerSafetySchema,
+  TrainerSourceTraceSchema,
+  TRAINER_DECISIONS,
+} from './trainer-output.js';
+
+export type {
+  TrainerRunnerResultStatus,
+  TrainerRunnerResult,
+  TrainerRunnerOptions,
+  ResolvedTrainerRunnerOptions,
+  TrainerRunnerDeps,
+} from './trainer-runner.js';
+
+export {
+  TrainerRunner,
+  resolveTrainerRunnerOptions,
+  DEFAULT_TRAINER_RUNNER_OPTIONS,
+} from './trainer-runner.js';
+
+export {
+  TrainerPromptBuilder,
+  TRAINER_PROTOCOL_INSTRUCTION,
+  TRAINER_PROMPT_CONTRACT_VERSION,
+} from './trainer-prompt-builder.js';
+
+export type {
+  TrainerPromptBuilderInput,
+  TrainerPromptInput,
+  TrainerPromptBuildResult,
+} from './trainer-prompt-builder.js';
+
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 
 export type {

--- a/packages/principles-core/src/runtime-v2/internalization/rule-host-contracts.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-host-contracts.ts
@@ -3,13 +3,15 @@
  *
  * PURPOSE: Define the constrained interface through which active code
  * implementations are executed. Implementations receive a frozen snapshot
- * of context and return one of three decisions.
+ * of context and return one of four decisions.
  *
  * TRUST BOUNDARY:
  *   - RuleHostInput is a frozen snapshot — no live workspace handles
  *   - Implementations execute in a constrained vm context with minimal helpers
  *   - No filesystem, process, require, dynamic import, eval, or network access
  */
+
+import type { CorrectionProposal } from './correction-proposal.js';
 
 // ---------------------------------------------------------------------------
 // Input: Frozen snapshot provided to implementations
@@ -41,10 +43,10 @@ export interface RuleHostInput {
 }
 
 // ---------------------------------------------------------------------------
-// Decision: Limited to three outcomes
+// Decision: Four outcomes (PRI-114 adds auto_correct)
 // ---------------------------------------------------------------------------
 
-export type RuleHostDecision = 'allow' | 'block' | 'requireApproval';
+export type RuleHostDecision = 'allow' | 'block' | 'requireApproval' | 'auto_correct';
 
 // ---------------------------------------------------------------------------
 // Meta: Exported by each implementation for identification
@@ -68,6 +70,8 @@ export interface RuleHostResult {
   diagnostics?: Record<string, unknown>;
   ruleId?: string;
   principleId?: string;
+  /** Present when decision is 'auto_correct'. Must pass validateCorrectionProposal(). */
+  correctionProposal?: CorrectionProposal;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/principles-core/src/runtime-v2/internalization/rule-host-evaluator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-host-evaluator.ts
@@ -2,9 +2,13 @@
  * Rule Host Evaluator — Pure decision merge logic
  *
  * PURPOSE: Iterate loaded code implementations and merge their decisions.
- * Block short-circuits, requireApproval collects, allow is implicit.
+ * Block short-circuits, auto_correct collects (validated), requireApproval
+ * collects, allow is implicit.
+ *
+ * Precedence: block > auto_correct > requireApproval > allow
  *
  * PRI-45: Pure function extracted from the plugin's RuleHost.evaluate().
+ * PRI-114: Added auto_correct handling with fail-closed validation.
  * No filesystem, no VM, no side effects.
  */
 
@@ -13,6 +17,7 @@ import type {
   RuleHostResult,
   LoadedImplementation,
 } from './rule-host-contracts.js';
+import { validateCorrectionProposal } from './correction-proposal.js';
 
 export interface DecisionMergeLogger {
   warn?: (_message: string) => void;
@@ -29,6 +34,8 @@ export type RuleHostLogger = DecisionMergeLogger;
  *
  * Rules:
  *   - If any implementation returns `block`, short-circuit and return block.
+ *   - `auto_correct` proposals are collected and validated.
+ *     First valid proposal wins. Invalid proposals are logged and skipped.
  *   - Collect all `requireApproval` results and merge their reasons/diagnostics.
  *   - `allow` results are ignored (no opinion).
  *   - Individual implementation errors are logged and skipped.
@@ -46,6 +53,7 @@ export function mergeDecisions(
   try {
 
     let blocked: RuleHostResult | undefined = undefined;
+    const autoCorrects: RuleHostResult[] = [];
     const approvals: RuleHostResult[] = [];
 
     for (const impl of implementations) {
@@ -61,7 +69,9 @@ export function mergeDecisions(
           break;
         }
 
-        if (result.decision === 'requireApproval') {
+        if (result.decision === 'auto_correct') {
+          autoCorrects.push(result);
+        } else if (result.decision === 'requireApproval') {
           approvals.push(result);
         }
         // 'allow' is implicit — no action needed
@@ -74,6 +84,26 @@ export function mergeDecisions(
 
     if (blocked) {
       return blocked;
+    }
+
+    // auto_correct takes precedence over requireApproval
+    if (autoCorrects.length > 0) {
+      for (const ac of autoCorrects) {
+        if (ac.correctionProposal) {
+          const validation = validateCorrectionProposal(ac.correctionProposal);
+          if (validation.valid) {
+            return ac;
+          }
+          logger?.warn?.(
+            `[RuleHost] auto_correct proposal from ${ac.ruleId ?? 'unknown'} failed validation: ${validation.errors.join('; ')}`
+          );
+        } else {
+          logger?.warn?.(
+            `[RuleHost] auto_correct decision from ${ac.ruleId ?? 'unknown'} missing correctionProposal`
+          );
+        }
+      }
+      // All auto_correct proposals invalid — fall through to requireApproval
     }
 
     if (approvals.length > 0) {

--- a/packages/principles-core/src/runtime-v2/internalization/rule-host-evaluator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-host-evaluator.ts
@@ -1,5 +1,5 @@
 /**
- * Rule Host Evaluator — Pure decision merge logic
+ * Rule Host Evaluator �?Pure decision merge logic
  *
  * PURPOSE: Iterate loaded code implementations and merge their decisions.
  * Block short-circuits, auto_correct collects (validated), requireApproval
@@ -74,7 +74,7 @@ export function mergeDecisions(
         } else if (result.decision === 'requireApproval') {
           approvals.push(result);
         }
-        // 'allow' is implicit — no action needed
+        // 'allow' is implicit �?no action needed
       } catch (evalError: unknown) {
         logger?.warn?.(
           `[RuleHost] Implementation ${impl.implId} evaluation failed: ${String(evalError)}`
@@ -90,20 +90,26 @@ export function mergeDecisions(
     if (autoCorrects.length > 0) {
       for (const ac of autoCorrects) {
         if (ac.correctionProposal) {
-          const validation = validateCorrectionProposal(ac.correctionProposal);
-          if (validation.valid) {
-            return ac;
+          try {
+            const validation = validateCorrectionProposal(ac.correctionProposal);
+            if (validation.valid) {
+              return ac;
+            }
+            logger?.warn?.(
+              `[RuleHost] auto_correct proposal from ${ac.ruleId ?? 'unknown'} failed validation: ${validation.errors.join('; ')}`
+            );
+          } catch (validationError: unknown) {
+            logger?.warn?.(
+              `[RuleHost] auto_correct proposal from ${ac.ruleId ?? 'unknown'} threw during validation (fail-closed): ${String(validationError)}`
+            );
           }
-          logger?.warn?.(
-            `[RuleHost] auto_correct proposal from ${ac.ruleId ?? 'unknown'} failed validation: ${validation.errors.join('; ')}`
-          );
         } else {
           logger?.warn?.(
             `[RuleHost] auto_correct decision from ${ac.ruleId ?? 'unknown'} missing correctionProposal`
           );
         }
       }
-      // All auto_correct proposals invalid — fall through to requireApproval
+      // All auto_correct proposals invalid �?fall through to requireApproval
     }
 
     if (approvals.length > 0) {

--- a/packages/principles-core/src/runtime-v2/internalization/trainer-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/trainer-output.ts
@@ -1,0 +1,255 @@
+import { Type, type Static } from '@sinclair/typebox';
+
+export interface TrainerRuleCandidate {
+  readonly toolScope: string;
+  readonly triggerCondition: string;
+  readonly proposedDecision: 'allow' | 'block' | 'require_approval' | 'auto_correct';
+  readonly proposedCorrection?: {
+    readonly description: string;
+    readonly proposedParams: unknown;
+  };
+  readonly rationale: string;
+  readonly confidence: number;
+}
+
+export interface TrainerSafety {
+  readonly limitations: readonly string[];
+  readonly falsePositiveRisks: readonly string[];
+  readonly requiredReplayCases: readonly string[];
+}
+
+export interface TrainerSourceTrace {
+  readonly rolloutReviewerArtifactId: string;
+  readonly evaluatorArtifactId?: string;
+  readonly artificerArtifactId?: string;
+  readonly scribeArtifactId?: string;
+  readonly philosopherArtifactId?: string;
+  readonly dreamerArtifactId?: string;
+}
+
+export interface TrainerOutputV1 {
+  readonly taskId: string;
+  readonly sourceRolloutReviewerArtifactId: string;
+  readonly ruleCandidate: TrainerRuleCandidate;
+  readonly goldenTraceRefs?: readonly string[];
+  readonly inlineGoldenTraceCases?: readonly {
+    readonly caseId: string;
+    readonly kind: 'negative' | 'positive';
+    readonly toolName: string;
+    readonly params: unknown;
+    readonly expectedDecision: 'allow' | 'block' | 'propose_correction';
+    readonly expectedProposedParams?: unknown;
+    readonly expectedApplicationMode?: 'shadow' | 'live';
+    readonly sourceRefs?: readonly string[];
+  }[];
+  readonly safety: TrainerSafety;
+  readonly sourceTrace: TrainerSourceTrace;
+  readonly generatedAt: string;
+}
+
+export const TRAINER_DECISIONS = ['allow', 'block', 'require_approval', 'auto_correct'] as const;
+
+export const TrainerRuleCandidateSchema = Type.Object({
+  toolScope: Type.String({ minLength: 1 }),
+  triggerCondition: Type.String({ minLength: 1 }),
+  proposedDecision: Type.Union([
+    Type.Literal('allow'),
+    Type.Literal('block'),
+    Type.Literal('require_approval'),
+    Type.Literal('auto_correct'),
+  ]),
+  proposedCorrection: Type.Optional(Type.Object({
+    description: Type.String({ minLength: 1 }),
+    proposedParams: Type.Any(),
+  })),
+  rationale: Type.String({ minLength: 1 }),
+  confidence: Type.Number({ minimum: 0, maximum: 1 }),
+});
+
+export const TrainerSafetySchema = Type.Object({
+  limitations: Type.Array(Type.String()),
+  falsePositiveRisks: Type.Array(Type.String()),
+  requiredReplayCases: Type.Array(Type.String()),
+});
+
+export const TrainerSourceTraceSchema = Type.Object({
+  rolloutReviewerArtifactId: Type.String({ minLength: 1 }),
+  evaluatorArtifactId: Type.Optional(Type.String()),
+  artificerArtifactId: Type.Optional(Type.String()),
+  scribeArtifactId: Type.Optional(Type.String()),
+  philosopherArtifactId: Type.Optional(Type.String()),
+  dreamerArtifactId: Type.Optional(Type.String()),
+});
+
+export const TrainerOutputV1Schema = Type.Object({
+  taskId: Type.String({ minLength: 1 }),
+  sourceRolloutReviewerArtifactId: Type.String({ minLength: 1 }),
+  ruleCandidate: TrainerRuleCandidateSchema,
+  goldenTraceRefs: Type.Optional(Type.Array(Type.String())),
+  inlineGoldenTraceCases: Type.Optional(Type.Array(Type.Object({
+    caseId: Type.String({ minLength: 1 }),
+    kind: Type.Union([Type.Literal('negative'), Type.Literal('positive')]),
+    toolName: Type.String({ minLength: 1 }),
+    params: Type.Any(),
+    expectedDecision: Type.Union([
+      Type.Literal('allow'),
+      Type.Literal('block'),
+      Type.Literal('propose_correction'),
+    ]),
+    expectedProposedParams: Type.Optional(Type.Any()),
+    expectedApplicationMode: Type.Optional(Type.Union([
+      Type.Literal('shadow'),
+      Type.Literal('live'),
+    ])),
+    sourceRefs: Type.Optional(Type.Array(Type.String())),
+  }))),
+  safety: TrainerSafetySchema,
+  sourceTrace: TrainerSourceTraceSchema,
+  generatedAt: Type.String({ minLength: 1 }),
+});
+
+export type TrainerOutputV1TB = Static<typeof TrainerOutputV1Schema>;
+
+export interface TrainerValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+export interface TrainerValidator {
+  validate(output: TrainerOutputV1, taskId: string, expectedSourceRolloutReviewerArtifactId?: string): Promise<TrainerValidationResult>;
+}
+
+export class DefaultTrainerValidator implements TrainerValidator {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async validate(output: TrainerOutputV1, taskId: string, expectedSourceRolloutReviewerArtifactId?: string): Promise<TrainerValidationResult> {
+    const errors: string[] = [];
+
+    if (typeof output !== 'object' || output === null) {
+      return { valid: false, errors: ['Output is not an object'], errorCategory: 'output_invalid' };
+    }
+
+    if (output.taskId !== taskId) {
+      errors.push(`taskId mismatch: expected ${taskId}, got ${String(output.taskId)}`);
+    }
+
+    if (typeof output.sourceRolloutReviewerArtifactId !== 'string' || output.sourceRolloutReviewerArtifactId.trim() === '') {
+      errors.push('sourceRolloutReviewerArtifactId must be non-empty string');
+    } else if (expectedSourceRolloutReviewerArtifactId && output.sourceRolloutReviewerArtifactId !== expectedSourceRolloutReviewerArtifactId) {
+      errors.push(`sourceRolloutReviewerArtifactId mismatch: expected ${expectedSourceRolloutReviewerArtifactId}, got ${output.sourceRolloutReviewerArtifactId}`);
+    }
+
+    if (typeof output.ruleCandidate !== 'object' || output.ruleCandidate === null) {
+      errors.push('ruleCandidate must be an object');
+    } else {
+      const rc = output.ruleCandidate as unknown as Record<string, unknown>;
+      if (typeof rc.toolScope !== 'string' || (rc.toolScope as string).trim() === '') {
+        errors.push('ruleCandidate.toolScope must be non-empty string');
+      }
+      if (typeof rc.triggerCondition !== 'string' || (rc.triggerCondition as string).trim() === '') {
+        errors.push('ruleCandidate.triggerCondition must be non-empty string');
+      }
+      if (!TRAINER_DECISIONS.includes(rc.proposedDecision as 'allow' | 'block' | 'require_approval' | 'auto_correct')) {
+        errors.push(`ruleCandidate.proposedDecision must be one of ${TRAINER_DECISIONS.join('/')}, got ${String(rc.proposedDecision)}`);
+      }
+      if (typeof rc.rationale !== 'string' || (rc.rationale as string).trim() === '') {
+        errors.push('ruleCandidate.rationale must be non-empty string');
+      }
+      if (typeof rc.confidence !== 'number' || !Number.isFinite(rc.confidence)) {
+        errors.push('ruleCandidate.confidence must be number');
+      } else if (rc.confidence < 0 || rc.confidence > 1) {
+        errors.push('ruleCandidate.confidence must be in [0, 1]');
+      }
+
+      const isAutoCorrect = rc.proposedDecision === 'auto_correct';
+      const hasProposedCorrection = rc.proposedCorrection !== undefined && rc.proposedCorrection !== null;
+      if (isAutoCorrect && !hasProposedCorrection) {
+        errors.push('ruleCandidate.proposedCorrection is required when proposedDecision is auto_correct');
+      }
+      if (!isAutoCorrect && hasProposedCorrection) {
+        errors.push('ruleCandidate.proposedCorrection must not exist when proposedDecision is not auto_correct');
+      }
+    }
+
+    if (typeof output.safety !== 'object' || output.safety === null) {
+      errors.push('safety must be an object');
+    } else {
+      const s = output.safety as unknown as Record<string, unknown>;
+      if (!Array.isArray(s.limitations)) {
+        errors.push('safety.limitations must be an array');
+      } else if (!(s.limitations as unknown[]).every(e => typeof e === 'string')) {
+        errors.push('safety.limitations must be an array of strings');
+      }
+      if (!Array.isArray(s.falsePositiveRisks)) {
+        errors.push('safety.falsePositiveRisks must be an array');
+      } else if (!(s.falsePositiveRisks as unknown[]).every(e => typeof e === 'string')) {
+        errors.push('safety.falsePositiveRisks must be an array of strings');
+      }
+      if (!Array.isArray(s.requiredReplayCases)) {
+        errors.push('safety.requiredReplayCases must be an array');
+      } else if (!(s.requiredReplayCases as unknown[]).every(e => typeof e === 'string')) {
+        errors.push('safety.requiredReplayCases must be an array of strings');
+      }
+    }
+
+    if (typeof output.sourceTrace !== 'object' || output.sourceTrace === null) {
+      errors.push('sourceTrace must be an object');
+    } else {
+      const st = output.sourceTrace as unknown as Record<string, unknown>;
+      if (typeof st.rolloutReviewerArtifactId !== 'string' || (st.rolloutReviewerArtifactId as string).trim() === '') {
+        errors.push('sourceTrace.rolloutReviewerArtifactId must be non-empty string');
+      } else if (expectedSourceRolloutReviewerArtifactId && st.rolloutReviewerArtifactId !== expectedSourceRolloutReviewerArtifactId) {
+        errors.push(`sourceTrace.rolloutReviewerArtifactId mismatch: expected ${expectedSourceRolloutReviewerArtifactId}, got ${st.rolloutReviewerArtifactId}`);
+      }
+      if (st.evaluatorArtifactId !== undefined && typeof st.evaluatorArtifactId !== 'string') {
+        errors.push('sourceTrace.evaluatorArtifactId must be string if present');
+      }
+      if (st.artificerArtifactId !== undefined && typeof st.artificerArtifactId !== 'string') {
+        errors.push('sourceTrace.artificerArtifactId must be string if present');
+      }
+      if (st.scribeArtifactId !== undefined && typeof st.scribeArtifactId !== 'string') {
+        errors.push('sourceTrace.scribeArtifactId must be string if present');
+      }
+      if (st.philosopherArtifactId !== undefined && typeof st.philosopherArtifactId !== 'string') {
+        errors.push('sourceTrace.philosopherArtifactId must be string if present');
+      }
+      if (st.dreamerArtifactId !== undefined && typeof st.dreamerArtifactId !== 'string') {
+        errors.push('sourceTrace.dreamerArtifactId must be string if present');
+      }
+    }
+
+    if (typeof output.sourceRolloutReviewerArtifactId === 'string' && output.sourceRolloutReviewerArtifactId.trim() !== ''
+      && typeof output.sourceTrace === 'object' && output.sourceTrace !== null
+      && typeof (output.sourceTrace as unknown as Record<string, unknown>).rolloutReviewerArtifactId === 'string'
+      && output.sourceRolloutReviewerArtifactId !== (output.sourceTrace as unknown as Record<string, unknown>).rolloutReviewerArtifactId) {
+      errors.push('sourceRolloutReviewerArtifactId and sourceTrace.rolloutReviewerArtifactId must match');
+    }
+
+    if (output.goldenTraceRefs !== undefined) {
+      if (!Array.isArray(output.goldenTraceRefs)) {
+        errors.push('goldenTraceRefs must be an array');
+      } else if (!(output.goldenTraceRefs as unknown[]).every(e => typeof e === 'string')) {
+        errors.push('goldenTraceRefs must be an array of strings');
+      }
+    }
+
+    if (output.inlineGoldenTraceCases !== undefined) {
+      if (!Array.isArray(output.inlineGoldenTraceCases)) {
+        errors.push('inlineGoldenTraceCases must be an array');
+      }
+    }
+
+    if (typeof output.generatedAt !== 'string' || output.generatedAt.trim() === '') {
+      errors.push('generatedAt must be non-empty string');
+    } else {
+      const date = new Date(output.generatedAt);
+      if (isNaN(date.getTime())) {
+        errors.push('generatedAt must be a parseable ISO-8601 timestamp');
+      }
+    }
+
+    return errors.length > 0
+      ? { valid: false, errors, errorCategory: 'output_invalid' }
+      : { valid: true, errors: [] };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/trainer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/trainer-prompt-builder.ts
@@ -1,0 +1,81 @@
+export interface TrainerPromptBuilderInput {
+  taskId: string;
+  contextHash: string;
+  sourceRolloutReviewerArtifactId: string;
+  rolloutReviewerArtifact: unknown;
+}
+
+export interface TrainerPromptInput {
+  taskId: string;
+  contextHash: string;
+  sourceRolloutReviewerArtifactId: string;
+  rolloutReviewerArtifact: unknown;
+  trainerInstruction: string;
+  promptContractVersion: string;
+}
+
+export interface TrainerPromptBuildResult {
+  readonly message: string;
+  readonly promptInput: TrainerPromptInput;
+}
+
+export const TRAINER_PROTOCOL_INSTRUCTION = `You are a Trainer agent in a principle internalization pipeline. Your role is to generate an L2 rule candidate from the RolloutReviewer's assessment, producing a structured decision, safety constraints, and test cases for replay.
+
+PROTOCOL:
+1. Review the rolloutReviewerArtifact to understand the rollout decision, safety checks, and risks
+2. Extract the tool scope and trigger condition for the rule candidate
+3. Produce a decision: allow (safe to use), block (unsafe), require_approval (needs human review), or auto_correct (safe to self-correct)
+4. If decision is auto_correct, provide a proposed correction with description and params
+5. Provide a confidence score from 0.0 to 1.0 reflecting certainty in the decision
+6. Identify safety limitations, false positive risks, and required replay test cases
+7. Preserve the lineage trace from evaluator, artificer, scribe, philosopher, and dreamer artifacts
+8. Reference golden trace cases if available
+
+CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
+
+COMPLETE EXAMPLE OUTPUT (follow this exact structure):
+{"taskId":"task-123","sourceRolloutReviewerArtifactId":"pi-art-rollout-reviewer-001","ruleCandidate":{"toolScope":"tool_call","triggerCondition":"When a tool is called with invalid parameters","proposedDecision":"auto_correct","proposedCorrection":{"description":"Use default parameters instead","proposedParams":{"defaultTimeout":5000}},"rationale":"Safe to auto-correct with sensible defaults","confidence":0.88},"safety":{"limitations":["Requires feature flag enabled"],"falsePositiveRisks":["May incorrectly auto-correct edge case inputs"],"requiredReplayCases":["tool_call with null params","tool_call with empty toolName"]},"sourceTrace":{"rolloutReviewerArtifactId":"pi-art-rollout-reviewer-001"},"goldenTraceRefs":["gt-case-001","gt-case-002"],"generatedAt":"2026-05-11T12:00:00.000Z"}
+
+CONSTRAINTS:
+- Output ONLY valid JSON — no markdown, no explanatory text, no code fences, no prose before or after
+- ruleCandidate.toolScope MUST be a non-empty string
+- ruleCandidate.triggerCondition MUST be a non-empty string
+- ruleCandidate.proposedDecision MUST be one of: allow, block, require_approval, auto_correct
+- ruleCandidate.rationale MUST be a non-empty string
+- ruleCandidate.confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- ruleCandidate.proposedCorrection is ONLY allowed when proposedDecision is auto_correct — it must be omitted otherwise
+- ruleCandidate.proposedCorrection.description MUST be a non-empty string if present
+- safety.limitations MUST be an array of strings (can be empty)
+- safety.falsePositiveRisks MUST be an array of strings (can be empty)
+- safety.requiredReplayCases MUST be an array of strings (can be empty)
+- sourceRolloutReviewerArtifactId MUST be copied exactly from input.sourceRolloutReviewerArtifactId (non-empty string)
+- sourceTrace.rolloutReviewerArtifactId MUST be copied exactly from input.sourceRolloutReviewerArtifactId
+- sourceTrace.evaluatorArtifactId is optional — include only if available from rollout reviewer artifact
+- sourceTrace.artificerArtifactId is optional — include only if available from rollout reviewer artifact
+- sourceTrace.scribeArtifactId is optional — include only if available from rollout reviewer artifact
+- sourceTrace.philosopherArtifactId is optional — include only if available from rollout reviewer artifact
+- sourceTrace.dreamerArtifactId is optional — include only if available from rollout reviewer artifact
+- goldenTraceRefs is optional — array of strings if present
+- inlineGoldenTraceCases is optional — array of case objects if present
+- generatedAt MUST be an ISO-8601 timestamp string
+`;
+
+export const TRAINER_PROMPT_CONTRACT_VERSION = 'trainer-output-v1.prompt.v1';
+
+export class TrainerPromptBuilder {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildPrompt(input: TrainerPromptBuilderInput): TrainerPromptBuildResult {
+    const promptInput: TrainerPromptInput = {
+      taskId: input.taskId,
+      contextHash: input.contextHash,
+      sourceRolloutReviewerArtifactId: input.sourceRolloutReviewerArtifactId,
+      rolloutReviewerArtifact: input.rolloutReviewerArtifact,
+      trainerInstruction: TRAINER_PROTOCOL_INSTRUCTION,
+      promptContractVersion: TRAINER_PROMPT_CONTRACT_VERSION,
+    };
+
+    const message = JSON.stringify(promptInput);
+
+    return { message, promptInput };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/trainer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/trainer-runner.ts
@@ -1,0 +1,686 @@
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type {
+  PDRuntimeAdapter,
+  RunHandle,
+  RunStatus,
+  StartRunInput,
+} from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { TrainerOutputV1, TrainerValidator } from './trainer-output.js';
+import type { PIArtifactStore } from './pi-artifact.js';
+import type { TaskRecord } from '../task-status.js';
+import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
+import type { TelemetryEvent } from '../../telemetry-event.js';
+import { hydratePITaskRecord } from './pitask-metadata.js';
+import { RunnerPhase } from '../runner/runner-phase.js';
+import { TrainerPromptBuilder } from './trainer-prompt-builder.js';
+
+export type TrainerRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
+
+export interface TrainerRunnerResult {
+  readonly status: TrainerRunnerResultStatus;
+  readonly taskId: string;
+  readonly runId?: string;
+  readonly artifactId?: string;
+  readonly resultRef?: string;
+  readonly contextHash?: string;
+  readonly output?: TrainerOutputV1;
+  readonly errorCategory?: PDErrorCategory;
+  readonly failureReason?: string;
+  readonly attemptCount: number;
+}
+
+export interface TrainerRunnerOptions {
+  readonly pollIntervalMs?: number;
+  readonly timeoutMs?: number;
+  readonly defaultMaxAttempts?: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId?: string;
+}
+
+export interface ResolvedTrainerRunnerOptions {
+  readonly pollIntervalMs: number;
+  readonly timeoutMs: number;
+  readonly defaultMaxAttempts: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId: string;
+}
+
+const DEFAULT_TRAINER_RUNNER_OPTIONS: Readonly<Omit<ResolvedTrainerRunnerOptions, 'owner' | 'runtimeKind'>> = {
+  pollIntervalMs: 5_000,
+  timeoutMs: 300_000,
+  defaultMaxAttempts: 3,
+  agentId: 'trainer',
+} as const;
+
+export function resolveTrainerRunnerOptions(options: TrainerRunnerOptions): ResolvedTrainerRunnerOptions {
+  return {
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_TRAINER_RUNNER_OPTIONS.pollIntervalMs,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TRAINER_RUNNER_OPTIONS.timeoutMs,
+    defaultMaxAttempts: options.defaultMaxAttempts ?? DEFAULT_TRAINER_RUNNER_OPTIONS.defaultMaxAttempts,
+    owner: options.owner,
+    runtimeKind: options.runtimeKind,
+    agentId: options.agentId ?? DEFAULT_TRAINER_RUNNER_OPTIONS.agentId,
+  };
+}
+
+export interface TrainerRunnerDeps {
+  readonly stateManager: RuntimeStateManager;
+  readonly runtimeAdapter: PDRuntimeAdapter;
+  readonly eventEmitter: StoreEventEmitter;
+  readonly validator: TrainerValidator;
+  readonly artifactStore: PIArtifactStore;
+}
+
+interface FailureContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errorCategory: PDErrorCategory;
+  readonly failureReason: string;
+}
+
+interface SucceedContext {
+  readonly taskId: string;
+  readonly runId: string;
+  readonly output: TrainerOutputV1;
+  readonly task: TaskRecord;
+  readonly contextHash: string;
+}
+
+interface ValidationErrorContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errors: readonly string[];
+  readonly errorCategory?: string;
+}
+
+const TRAINER_PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set<PDErrorCategory>([
+  'storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid',
+]);
+
+export class TrainerRunner {
+  private phase: RunnerPhase = RunnerPhase.Idle;
+  private readonly resolvedOptions: ResolvedTrainerRunnerOptions;
+  private readonly stateManager: RuntimeStateManager;
+  private readonly runtimeAdapter: PDRuntimeAdapter;
+  private readonly eventEmitter: StoreEventEmitter;
+  private readonly validator: TrainerValidator;
+  private readonly artifactStore: PIArtifactStore;
+
+  constructor(deps: TrainerRunnerDeps, options: TrainerRunnerOptions) {
+    this.stateManager = deps.stateManager;
+    this.runtimeAdapter = deps.runtimeAdapter;
+    this.eventEmitter = deps.eventEmitter;
+    this.validator = deps.validator;
+    this.artifactStore = deps.artifactStore;
+    this.resolvedOptions = resolveTrainerRunnerOptions(options);
+  }
+
+  get currentPhase(): RunnerPhase {
+    return this.phase;
+  }
+
+  private emitTrainerEvent(
+    eventType: string,
+    taskId: string,
+    payload: Record<string, unknown>,
+  ): void {
+    this.eventEmitter.emitTelemetry({
+      eventType: eventType as TelemetryEvent['eventType'],
+      traceId: taskId,
+      timestamp: new Date().toISOString(),
+      sessionId: this.resolvedOptions.owner,
+      agentId: this.resolvedOptions.agentId,
+      payload,
+    });
+  }
+
+  async run(taskId: string): Promise<TrainerRunnerResult> {
+    this.phase = RunnerPhase.Idle;
+
+    // eslint-disable-next-line @typescript-eslint/init-declarations
+    let leasedTask: TaskRecord;
+    try {
+      leasedTask = await this.stateManager.acquireLease({
+        taskId,
+        owner: this.resolvedOptions.owner,
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+    } catch (error) {
+      return await this.handleLeaseOrPhaseError(taskId, error);
+    }
+
+    if (leasedTask.taskKind !== 'trainer') {
+      this.emitTrainerEvent('trainer_wrong_task_kind', taskId, {
+        expectedKind: 'trainer',
+        actualKind: leasedTask.taskKind,
+      });
+      return this.retryOrFail({
+        taskId,
+        task: leasedTask,
+        errorCategory: 'input_invalid',
+        failureReason: `Task kind must be 'trainer', got '${leasedTask.taskKind}'`,
+      });
+    }
+
+    this.emitTrainerEvent('trainer_task_leased', taskId, {
+      taskKind: 'trainer',
+      attemptCount: leasedTask.attemptCount,
+    });
+
+    try {
+      const storeRunId = await this.resolveStoreRunId(taskId);
+
+      this.phase = RunnerPhase.BuildingContext;
+      const { contextHash, rolloutReviewerArtifact, sourceRolloutReviewerArtifactId } = await this.buildContext(taskId);
+
+      if (!rolloutReviewerArtifact || !sourceRolloutReviewerArtifactId) {
+        return this.retryOrFail({
+          taskId,
+          task: leasedTask,
+          errorCategory: 'input_invalid',
+          failureReason: sourceRolloutReviewerArtifactId ? 'RolloutReviewer dependency artifact not found' : 'RolloutReviewer dependency artifact ID not resolved',
+        });
+      }
+
+      this.emitTrainerEvent('trainer_context_built', taskId, { contextHash });
+
+      this.phase = RunnerPhase.Invoking;
+      const runHandle = await this.invokeRuntime({ taskId, contextHash, rolloutReviewerArtifact, sourceRolloutReviewerArtifactId });
+
+      this.emitTrainerEvent('trainer_run_started', taskId, {
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+
+      this.phase = RunnerPhase.Polling;
+      const finalStatus = await this.pollUntilTerminal(runHandle);
+
+      if (finalStatus.status !== 'succeeded') {
+        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
+      }
+
+      this.phase = RunnerPhase.FetchingOutput;
+      const output = await this.fetchAndParseOutput(runHandle.runId);
+
+      this.phase = RunnerPhase.Validating;
+      const validationResult = await this.validator.validate(output, taskId, sourceRolloutReviewerArtifactId ?? undefined);
+      if (!validationResult.valid) {
+        return await this.handleValidationError({
+          taskId,
+          task: leasedTask,
+          errors: validationResult.errors,
+          errorCategory: validationResult.errorCategory,
+        });
+      }
+
+      this.emitTrainerEvent('trainer_output_validated', taskId, {
+        decision: output.ruleCandidate.proposedDecision,
+        confidence: output.ruleCandidate.confidence,
+      });
+
+      return await this.succeedTask({
+        taskId,
+        runId: storeRunId,
+        output,
+        task: leasedTask,
+        contextHash,
+      });
+    } catch (error) {
+      return await this.handlePostLeaseError(taskId, leasedTask, error);
+    }
+  }
+
+  private async buildContext(taskId: string): Promise<{ contextHash: string; rolloutReviewerArtifact: string | null; sourceRolloutReviewerArtifactId: string | null }> {
+    const task = await this.stateManager.getTask(taskId);
+    if (!task) {
+      throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
+    }
+
+    const piTask = hydratePITaskRecord(task);
+    const deps = piTask?.dependencyTaskIds ?? [];
+
+    if (deps.length === 0) {
+      this.emitTrainerEvent('trainer_no_dependencies', taskId, {});
+      return { contextHash: 'empty', rolloutReviewerArtifact: null, sourceRolloutReviewerArtifactId: null };
+    }
+
+    for (const depId of deps) {
+      const depTask = await this.stateManager.getTask(depId);
+      if (!depTask) continue;
+      if (depTask.taskKind !== 'rollout_reviewer') continue;
+      if (depTask.status !== 'succeeded') {
+        this.emitTrainerEvent('trainer_dependency_not_succeeded', taskId, {
+          depTaskId: depId,
+          depStatus: depTask.status,
+        });
+        continue;
+      }
+
+      const artifacts = await this.artifactStore.listBySourceTaskId(depId);
+      if (artifacts.length > 0) {
+        const [firstArtifact] = artifacts;
+        if (!firstArtifact) continue;
+        const artifactRef = firstArtifact.artifactId;
+        this.emitTrainerEvent('trainer_rollout_reviewer_dep_selected', taskId, {
+          depTaskId: depId,
+          artifactId: firstArtifact.artifactId,
+        });
+        return {
+          contextHash: TrainerRunner.hashContextRefs([artifactRef]),
+          rolloutReviewerArtifact: firstArtifact.contentJson,
+          sourceRolloutReviewerArtifactId: firstArtifact.artifactId,
+        };
+      }
+    }
+
+    this.emitTrainerEvent('trainer_no_rollout_reviewer_artifact', taskId, {});
+    return { contextHash: 'empty', rolloutReviewerArtifact: null, sourceRolloutReviewerArtifactId: null };
+  }
+
+  private static hashContextRefs(refs: readonly string[]): string {
+    if (refs.length === 0) return 'empty';
+    const str = refs.join('|');
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+    }
+    return `ctx-${Math.abs(hash).toString(16)}`;
+  }
+
+  private async resolveStoreRunId(taskId: string): Promise<string> {
+    const runs = await this.stateManager.getRunsByTask(taskId);
+    const latestRun = runs[runs.length - 1];
+    if (!latestRun) {
+      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
+    }
+    return latestRun.runId;
+  }
+
+  private async invokeRuntime(params: {
+    taskId: string;
+    contextHash: string;
+    rolloutReviewerArtifact: string | null;
+    sourceRolloutReviewerArtifactId: string;
+  }): Promise<RunHandle> {
+    let parsedRolloutReviewerArtifact: unknown = null;
+    if (params.rolloutReviewerArtifact) {
+      try {
+        parsedRolloutReviewerArtifact = JSON.parse(params.rolloutReviewerArtifact);
+      } catch {
+        parsedRolloutReviewerArtifact = params.rolloutReviewerArtifact;
+      }
+    }
+
+    const builder = new TrainerPromptBuilder();
+    const { message } = builder.buildPrompt({
+      taskId: params.taskId,
+      contextHash: params.contextHash,
+      sourceRolloutReviewerArtifactId: params.sourceRolloutReviewerArtifactId,
+      rolloutReviewerArtifact: parsedRolloutReviewerArtifact,
+    });
+
+    const startInput: StartRunInput = {
+      agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
+      taskRef: { taskId: params.taskId },
+      inputPayload: message,
+      contextItems: [],
+      outputSchemaRef: 'trainer-output-v1',
+      timeoutMs: this.resolvedOptions.timeoutMs,
+    };
+
+    return this.runtimeAdapter.startRun(startInput);
+  }
+
+  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
+    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
+
+    while (Date.now() < deadline) {
+      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(status.status)) {
+        return status;
+      }
+      await this.sleep(this.resolvedOptions.pollIntervalMs);
+    }
+
+    try {
+      const finalPoll = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(finalPoll.status)) {
+        return finalPoll;
+      }
+    } catch { /* fall through to cancel/timeout */ }
+
+    let cancelFailed = false;
+    try {
+      await this.runtimeAdapter.cancelRun(runHandle.runId);
+    } catch (cancelErr) {
+      cancelFailed = true;
+      this.emitTrainerEvent('trainer_cancel_run_failed', runHandle.runId, {
+        runId: runHandle.runId,
+        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
+      });
+    }
+    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
+    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
+  }
+
+  private async fetchAndParseOutput(runId: string): Promise<TrainerOutputV1> {
+    const result = await this.runtimeAdapter.fetchOutput(runId);
+    if (!result || !result.payload) {
+      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
+    }
+    const payload = result.payload as Record<string, unknown>;
+    if (typeof payload !== 'object' || payload === null) {
+      throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
+    }
+    if (typeof payload.ruleCandidate !== 'object' || payload.ruleCandidate === null) {
+      throw new PDRuntimeError('output_invalid', `Output payload missing ruleCandidate object for run ${runId}`);
+    }
+    return result.payload as TrainerOutputV1;
+  }
+
+  private async succeedTask(ctx: SucceedContext): Promise<TrainerRunnerResult> {
+    try {
+      await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));
+    } catch (updateErr) {
+      this.emitTrainerEvent('trainer_update_output_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
+      });
+      throw updateErr;
+    }
+
+    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
+    const now = new Date().toISOString();
+
+    let lineageArtifactIds: string[] = [];
+    try {
+      const piTask = hydratePITaskRecord(ctx.task);
+      const deps = piTask?.dependencyTaskIds ?? [];
+      const results = await Promise.allSettled(
+        deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          for (const artifact of result.value) {
+            lineageArtifactIds.push(artifact.artifactId);
+          }
+        }
+      }
+    } catch { /* lineage resolution failure is non-fatal */ }
+
+    try {
+      await this.artifactStore.upsertArtifact({
+        artifactId,
+        artifactKind: 'rule',
+        sourceTaskId: ctx.taskId,
+        lineageArtifactIds,
+        validationStatus: 'pending',
+        contentJson: JSON.stringify(ctx.output),
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (artifactErr) {
+      this.emitTrainerEvent('trainer_artifact_write_failed', ctx.taskId, {
+        runId: ctx.runId,
+        errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
+      });
+      return this.retryOrFail({
+        taskId: ctx.taskId,
+        task: ctx.task,
+        errorCategory: 'artifact_commit_failed',
+        failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
+      });
+    }
+
+    const resultRef = `trainer://${ctx.runId}`;
+    try {
+      await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
+    } catch (stateErr) {
+      this.emitTrainerEvent('trainer_mark_succeeded_failed', ctx.taskId, {
+        taskId: ctx.taskId,
+        runId: ctx.runId,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      throw stateErr;
+    }
+
+    this.emitTrainerEvent('trainer_task_succeeded', ctx.taskId, {
+      attemptCount: ctx.task.attemptCount,
+      resultRef,
+      decision: ctx.output.ruleCandidate.proposedDecision,
+      confidence: ctx.output.ruleCandidate.confidence,
+    });
+
+    this.phase = RunnerPhase.Completed;
+    return {
+      status: 'succeeded',
+      taskId: ctx.taskId,
+      runId: ctx.runId,
+      artifactId,
+      resultRef,
+      contextHash: ctx.contextHash,
+      output: ctx.output,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  private async handleRuntimeFailure(
+    taskId: string,
+    task: TaskRecord,
+    runStatus: RunStatus,
+  ): Promise<TrainerRunnerResult> {
+    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status);
+
+    this.emitTrainerEvent('trainer_run_failed', taskId, {
+      runStatus: runStatus.status,
+      errorCategory,
+    });
+
+    return this.retryOrFail({
+      taskId,
+      task,
+      errorCategory,
+      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
+    });
+  }
+
+  private async handleValidationError(ctx: ValidationErrorContext): Promise<TrainerRunnerResult> {
+    const category = (ctx.errorCategory ?? 'output_invalid') as PDErrorCategory;
+
+    this.emitTrainerEvent('trainer_output_invalid', ctx.taskId, {
+      errorCount: ctx.errors.length,
+      errorCategory: category,
+    });
+
+    return this.retryOrFail({
+      taskId: ctx.taskId,
+      task: ctx.task,
+      errorCategory: category,
+      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
+    });
+  }
+
+  private async handleLeaseOrPhaseError(
+    taskId: string,
+    error: unknown,
+  ): Promise<TrainerRunnerResult> {
+    const classified = this.classifyError(error);
+
+    if (classified.category === 'lease_conflict') {
+      this.emitTrainerEvent('trainer_run_failed', taskId, {
+        errorCategory: 'lease_conflict',
+        errorMessage: classified.message,
+      });
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'lease_conflict',
+        failureReason: classified.message,
+        attemptCount: 1,
+      };
+    }
+
+    this.emitTrainerEvent('trainer_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    const task: TaskRecord = {
+      taskId,
+      taskKind: 'trainer',
+      status: 'leased',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      attemptCount: 1,
+      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
+    };
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async handlePostLeaseError(
+    taskId: string,
+    task: TaskRecord,
+    error: unknown,
+  ): Promise<TrainerRunnerResult> {
+    const classified = this.classifyError(error);
+
+    this.emitTrainerEvent('trainer_run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async retryOrFail(ctx: FailureContext): Promise<TrainerRunnerResult> {
+    if (this.isPermanentError(ctx.errorCategory)) {
+      try {
+        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitTrainerEvent('trainer_mark_failed_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitTrainerEvent('trainer_task_failed', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+        failureReason: ctx.failureReason,
+      });
+      this.phase = RunnerPhase.Failed;
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
+    if (shouldRetry) {
+      try {
+        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitTrainerEvent('trainer_mark_retry_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitTrainerEvent('trainer_task_retried', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+      });
+      this.phase = RunnerPhase.RetryWaiting;
+      return {
+        status: 'retried',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    try {
+      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
+    } catch (stateErr) {
+      this.emitTrainerEvent('trainer_mark_failed_error', ctx.taskId, {
+        errorCategory: 'storage_unavailable',
+        attemptCount: ctx.task.attemptCount,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `State manager error: ${ctx.failureReason}`,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+    this.emitTrainerEvent('trainer_task_failed', ctx.taskId, {
+      errorCategory: 'max_attempts_exceeded',
+      attemptCount: ctx.task.attemptCount,
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+    });
+    this.phase = RunnerPhase.Failed;
+    return {
+      status: 'failed',
+      taskId: ctx.taskId,
+      errorCategory: 'max_attempts_exceeded',
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private isPermanentError(category: PDErrorCategory): boolean {
+    return TRAINER_PERMANENT_ERROR_CATEGORIES.has(category);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
+    if (error instanceof PDRuntimeError) {
+      return { category: error.category, message: error.message };
+    }
+    if (error instanceof Error) {
+      return { category: 'execution_failed', message: error.message };
+    }
+    return { category: 'execution_failed', message: String(error) };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private mapRunStatusToErrorCategory(status: string): PDErrorCategory {
+    switch (status) {
+      case 'failed': return 'execution_failed';
+      case 'timed_out': return 'timeout';
+      case 'cancelled': return 'cancelled';
+      default: return 'execution_failed';
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+export { DEFAULT_TRAINER_RUNNER_OPTIONS };


### PR DESCRIPTION
## Summary

Trainer is the terminal L2 runner that reads a rollout_reviewer artifact and produces a validated rule candidate artifact — without installing rules, mutating ledgers, or writing code patches.

### Files Created

| File | Purpose |
|------|---------|
| `trainer-output.ts` | TrainerOutputV1 type + TypeBox schemas + DefaultTrainerValidator (27 validation rules) |
| `trainer-prompt-builder.ts` | TrainerPromptBuilder with JSON-only instruction |
| `trainer-runner.ts` | TrainerRunner following rollout-reviewer pattern, artifactKind='rule' |

### Files Modified

| File | Change |
|------|--------|
| `pi-ai-runtime-adapter.ts` | Register `trainer-output-v1` schema |
| `internalization/index.ts` | Barrel exports for Trainer types/values |
| `runtime-v2/index.ts` | Barrel exports for Trainer types/values |
| `runtime-internalization-run-once.ts` | trainer test-double block + dispatch branch |
| `architecture-regression.test.ts` | 8 new PRI-116 boundary guards |

## Test Plan

- [x] `npm run build --workspace=@principles/core` ✅
- [x] `npm run build --workspace=@principles/pd-cli` ✅
- [x] 51 Trainer专项测试全部通过 (27 validator + 12 prompt-builder + 13 runner) ✅
- [x] 8 architecture regression guards ✅
- [x] 234 CLI run-once tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增自动纠正建议功能，支持系统自动识别和提议参数调整
  * 新增培训师任务运行器，支持端到端的智能模型驱动任务执行与验证

* **测试**
  * 新增自动纠正行为的影子模式测试
  * 新增培训师输出验证及运行器垂直切片测试
  * 新增架构回归测试套件，覆盖纠正提议及培训师运行器边界

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->