### PR TITLE
feat(runtime-v2): PrincipleCompiler GoldenTrace replay validator (PRI-115)

### DIFF
--- a/packages/openclaw-plugin/src/core/principle-compiler/__tests__/compiler-replay-gate.test.ts
+++ b/packages/openclaw-plugin/src/core/principle-compiler/__tests__/compiler-replay-gate.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mocks (hoisted for vi.mock compatibility) ---
+
+const {
+  mockCollect, mockRegister, mockCreateAssetDir,
+  mockLoadModule, mockValidate, mockGenerate,
+} = vi.hoisted(() => ({
+  mockCollect: vi.fn(),
+  mockRegister: vi.fn(),
+  mockCreateAssetDir: vi.fn(),
+  mockLoadModule: vi.fn(),
+  mockValidate: vi.fn(),
+  mockGenerate: vi.fn(),
+}));
+
+vi.mock('../code-validator.js', () => ({
+  validateGeneratedCode: mockValidate,
+}));
+
+vi.mock('../template-generator.js', () => ({
+  generateFromTemplate: mockGenerate,
+}));
+
+vi.mock('../ledger-registrar.js', () => ({
+  registerCompiledRule: mockRegister,
+}));
+
+vi.mock('../../code-implementation-storage.js', () => ({
+  createImplementationAssetDir: mockCreateAssetDir,
+}));
+
+vi.mock('../../rule-implementation-runtime.js', () => ({
+  loadRuleImplementationModule: mockLoadModule,
+}));
+
+import { PrincipleCompiler } from '../compiler.js';
+
+// --- Fixtures ---
+
+const PRINCIPLE_ID = 'P_test_001';
+
+function makeContext(overrides?: { reason?: string }) {
+  return {
+    principle: {
+      id: PRINCIPLE_ID,
+      version: 1,
+      text: 'Never delete system files via bash',
+      triggerPattern: 'bash rm',
+      action: 'block dangerous bash commands',
+      status: 'active' as const,
+      priority: 'high' as const,
+      scope: 'global' as const,
+      evaluability: 'deterministic' as const,
+      valueScore: 0.9,
+      adherenceRate: 0.8,
+      painPreventedCount: 5,
+      derivedFromPainIds: ['pain_001'],
+      ruleIds: [] as string[],
+      conflictsWithPrincipleIds: [] as string[],
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-01T00:00:00Z',
+    },
+    painEvents: [
+      {
+        reason: overrides?.reason ?? 'bash command failed on /etc/important.conf',
+        source: 'tool_failure',
+      },
+    ],
+    sessionSnapshot: null,
+    lineage: { sourcePainIds: ['pain_001'], sessionId: null as string | null },
+  };
+}
+
+// --- Tests ---
+
+describe('PrincipleCompiler replay gate (PRI-115)', () => {
+  let compiler: PrincipleCompiler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock collector.collect directly on the instance
+    mockCollect.mockReturnValue(makeContext());
+
+    mockValidate.mockReturnValue({ valid: true, errors: [], warnings: [] });
+    mockGenerate.mockReturnValue(
+      'export function evaluate() { return { decision: "block", matched: true, reason: "test", confidence: 0.95 }; }',
+    );
+    mockRegister.mockReturnValue({ ruleId: 'R_test_auto', implementationId: 'IMPL_test_auto' });
+
+    compiler = new PrincipleCompiler('/tmp/test-state', {} as any);
+    // Override collector after construction to avoid module resolution issues
+    (compiler as any).collector = { collect: mockCollect, collectBatch: vi.fn() };
+  });
+
+  it('failing replay returns degraded=true and blocks registration', () => {
+    mockCollect.mockReturnValue(makeContext());
+
+    mockLoadModule.mockReturnValue({
+      evaluate: () => ({ decision: 'allow', matched: false, reason: 'pass', confidence: 1.0 }),
+    });
+
+    const result = compiler.compileOne(PRINCIPLE_ID);
+
+    expect(result.success).toBe(false);
+    expect(result.degraded).toBe(true);
+    expect(result.reason).toBe('replay_validation_failed');
+    expect(result.replayResult).toBeDefined();
+    expect(result.replayResult!.passed).toBe(false);
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('no asset dir created on replay failure', () => {
+    mockCollect.mockReturnValue(makeContext());
+
+    mockLoadModule.mockReturnValue({
+      evaluate: () => ({ decision: 'allow', matched: false, reason: 'pass', confidence: 1.0 }),
+    });
+
+    compiler.compileOne(PRINCIPLE_ID);
+
+    expect(mockCreateAssetDir).not.toHaveBeenCalled();
+  });
+
+  it('passing replay registers normally', () => {
+    mockCollect.mockReturnValue(makeContext());
+
+    mockLoadModule.mockReturnValue({
+      evaluate: (input: any) => {
+        const path = input?.action?.paramsSummary?.path;
+        if (path && path.includes('passwd')) {
+          return { decision: 'block', matched: true, reason: 'dangerous', confidence: 0.95 };
+        }
+        return { decision: 'allow', matched: false, reason: 'safe', confidence: 1.0 };
+      },
+    });
+
+    const result = compiler.compileOne(PRINCIPLE_ID);
+
+    expect(result.success).toBe(true);
+    expect(result.degraded).toBeUndefined();
+    expect(mockRegister).toHaveBeenCalledOnce();
+    expect(mockCreateAssetDir).toHaveBeenCalledOnce();
+  });
+
+  it('no cases (no regex qualifier) skips replay gate and registers', () => {
+    mockCollect.mockReturnValue(makeContext({ reason: 'bash failed unexpectedly' }));
+
+    mockLoadModule.mockReturnValue({
+      evaluate: () => ({ decision: 'block', matched: true, reason: 'test', confidence: 0.95 }),
+    });
+
+    const result = compiler.compileOne(PRINCIPLE_ID);
+
+    expect(result.success).toBe(true);
+    expect(result.degraded).toBeUndefined();
+    expect(mockRegister).toHaveBeenCalledOnce();
+    expect(mockLoadModule).not.toHaveBeenCalled();
+  });
+
+  it('no evaluate export returns degraded', () => {
+    mockCollect.mockReturnValue(makeContext());
+
+    mockLoadModule.mockReturnValue({});
+
+    const result = compiler.compileOne(PRINCIPLE_ID);
+
+    expect(result.success).toBe(false);
+    expect(result.degraded).toBe(true);
+    expect(result.reason).toContain('no evaluate export');
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openclaw-plugin/src/core/principle-compiler/compiler.ts
+++ b/packages/openclaw-plugin/src/core/principle-compiler/compiler.ts
@@ -3,12 +3,13 @@
  *
  * Orchestrates the full compilation flow:
  *   ReflectionContextCollector.collect() → extract patterns → generateFromTemplate()
- *   → validateGeneratedCode() → registerCompiledRule()
+ *   → validateGeneratedCode() → [replay validation] → registerCompiledRule()
  *
  * DESIGN DECISIONS:
  * - extractPatterns infers toolName from pain event reasons and session tool calls
  * - Groups by toolName into PainPattern objects
  * - If no patterns can be extracted, returns a 'no patterns' failure
+ * - PRI-115: Replay validation gate runs after code validation, before registration
  */
 
 import { ReflectionContextCollector } from '../reflection/reflection-context.js';
@@ -18,6 +19,9 @@ import { registerCompiledRule } from './ledger-registrar.js';
 import { createImplementationAssetDir } from '../code-implementation-storage.js';
 import type { TrajectoryDatabase } from '../trajectory.js';
 import type { CompileResult } from '@principles/core/runtime-v2';
+import { loadRuleImplementationModule } from '../rule-implementation-runtime.js';
+import { createGoldenTraceFixture, type GoldenTraceCase } from '@principles/core/runtime-v2';
+import { replayGoldenTrace, type ReplayEvaluateFn } from '@principles/core/runtime-v2';
 
 // Re-export CompileResult from core
 export type { CompileResult } from '@principles/core/runtime-v2';
@@ -171,6 +175,7 @@ export class PrincipleCompiler {
    * 2. Extract pain patterns
    * 3. Generate code from template
    * 4. Validate generated code
+   * 4.5. Replay validation against GoldenTrace (PRI-115)
    * 5. Register in ledger
    */
   compileOne(principleId: string): CompileResult {
@@ -203,6 +208,35 @@ export class PrincipleCompiler {
       };
     }
 
+    // Step 4.5: Replay validation against GoldenTrace (PRI-115)
+    const replayCases = this.buildGoldenTraceCases(patterns, context);
+    if (replayCases.length > 0) {
+      try {
+        const moduleExports = loadRuleImplementationModule(code, `replay-${principleId}.js`);
+        if (typeof moduleExports.evaluate !== 'function') {
+          return { success: false, principleId, reason: 'replay: no evaluate export', degraded: true };
+        }
+        const evaluateFn = moduleExports.evaluate as ReplayEvaluateFn;
+        const replayResult = replayGoldenTrace(evaluateFn, replayCases);
+        if (!replayResult.passed) {
+          return {
+            success: false,
+            principleId,
+            reason: 'replay_validation_failed',
+            code,
+            replayResult,
+            degraded: true,
+          };
+        }
+      } catch (err) {
+        return {
+          success: false,
+          principleId,
+          reason: `replay_error: ${(err as Error).message}`,
+          degraded: true,
+        };
+      }
+    }
     // Step 5: Register
     const registration = registerCompiledRule(this.stateDir, {
       principleId,
@@ -222,6 +256,42 @@ export class PrincipleCompiler {
       implementationId: registration.implementationId,
       code,
     };
+  }
+
+  /**
+   * Build GoldenTrace test cases from extracted pain patterns.
+   *
+   * Generates synthetic negative/positive parameter pairs based on whether
+   * the pattern targets commands (commandRegex) or paths (pathRegex).
+   * Returns an empty array when no patterns are available.
+   */
+  private buildGoldenTraceCases(
+    patterns: PainPattern[],
+    _context: { painEvents: Array<{ reason: string | null; source: string }> },
+  ): GoldenTraceCase[] {
+    if (patterns.length === 0) return [];
+
+    const pattern = patterns[0];
+    // Skip replay when the pattern has no regex qualifier -- the generated template
+    // blocks ALL calls to the tool, making it impossible to construct a passing
+    // positive case. Replay is only meaningful when the template is selective.
+    if (!pattern.commandRegex && !pattern.pathRegex && !pattern.contentRegex) return [];
+    const negativeParams: Record<string, unknown> = {};
+    if (pattern.commandRegex) negativeParams.command = 'rm -rf /';
+    else negativeParams.path = '/etc/passwd';
+
+    const positiveParams: Record<string, unknown> = {};
+    if (pattern.commandRegex) positiveParams.command = 'echo hello';
+    else positiveParams.path = '/tmp/safe.txt';
+
+    const fixture = createGoldenTraceFixture({
+      toolName: pattern.toolName,
+      negativeParams,
+      positiveParams,
+      expectedDecision: 'block',
+    });
+
+    return fixture.cases;
   }
 
   /**

--- a/packages/openclaw-plugin/src/core/principle-compiler/compiler.ts
+++ b/packages/openclaw-plugin/src/core/principle-compiler/compiler.ts
@@ -211,11 +211,24 @@ export class PrincipleCompiler {
     // Step 4.5: Replay validation against GoldenTrace (PRI-115)
     const replayCases = this.buildGoldenTraceCases(patterns, context);
     if (replayCases.length > 0) {
+      let moduleExports: { evaluate?: unknown };
       try {
-        const moduleExports = loadRuleImplementationModule(code, `replay-${principleId}.js`);
-        if (typeof moduleExports.evaluate !== 'function') {
-          return { success: false, principleId, reason: 'replay: no evaluate export', degraded: true };
-        }
+        moduleExports = loadRuleImplementationModule(code, `replay-${principleId}.js`);
+      } catch (err) {
+        return {
+          success: false,
+          principleId,
+          reason: `module_load_error: ${(err as Error).message}`,
+          code,
+          degraded: true,
+        };
+      }
+
+      if (typeof moduleExports.evaluate !== 'function') {
+        return { success: false, principleId, reason: 'replay: no evaluate export', degraded: true };
+      }
+
+      try {
         const evaluateFn = moduleExports.evaluate as ReplayEvaluateFn;
         const replayResult = replayGoldenTrace(evaluateFn, replayCases);
         if (!replayResult.passed) {
@@ -233,6 +246,7 @@ export class PrincipleCompiler {
           success: false,
           principleId,
           reason: `replay_error: ${(err as Error).message}`,
+          code,
           degraded: true,
         };
       }
@@ -275,7 +289,8 @@ export class PrincipleCompiler {
     // Skip replay when the pattern has no regex qualifier -- the generated template
     // blocks ALL calls to the tool, making it impossible to construct a passing
     // positive case. Replay is only meaningful when the template is selective.
-    if (!pattern.commandRegex && !pattern.pathRegex && !pattern.contentRegex) return [];
+    // Also skip contentRegex-only patterns: synthetic content params are not meaningful.
+    if (!pattern.commandRegex && !pattern.pathRegex) return [];
     const negativeParams: Record<string, unknown> = {};
     if (pattern.commandRegex) negativeParams.command = 'rm -rf /';
     else negativeParams.path = '/etc/passwd';

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -88,6 +88,9 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-84
   'internalization/pi-artifact.ts',
   'internalization/pi-artifact-store.ts',
+  // PRI-115
+  'golden-trace-replay-validator.ts',
+  'golden-trace-replay-adapter.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -122,6 +125,8 @@ const REQUIRED_TEST_FILES = [
   '../../prompt-builder/__tests__/focus-compression.test.ts',
   // PRI-76
   '../gfi/__tests__/gfi-kernel.test.ts',
+  // PRI-115
+  'golden-trace-replay-validator.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [
@@ -1876,3 +1881,4 @@ describe('PRI-114: correction-proposal boundary', () => {
     expect(src).toContain("from './internalization/correction-proposal.js'");
   });
 });
+

--- a/packages/principles-core/src/runtime-v2/__tests__/golden-trace-replay-validator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/golden-trace-replay-validator.test.ts
@@ -189,4 +189,59 @@ describe('replayGoldenTrace', () => {
     const failed = result.perCaseResults.find(c => !c.passed);
     expect(failed?.caseId).toBe('neg-bash-force');
   });
+  it('requireApproval accepted as valid block decision', () => {
+    const requireApprovalEvaluate: ReplayEvaluateFn = () => ({
+      decision: 'requireApproval' as const,
+      matched: true,
+      reason: 'requires manual approval',
+      confidence: 0.9,
+    });
+    const cases: GoldenTraceCase[] = [
+      {
+        caseId: 'block-ra',
+        kind: 'negative',
+        toolName: 'bash',
+        params: { command: 'rm -rf /' },
+        expectedDecision: 'block',
+      },
+    ];
+    const result = replayGoldenTrace(requireApprovalEvaluate, cases);
+    expect(result.passed).toBe(true);
+    expect(result.perCaseResults[0]?.actualDecision).toBe('requireApproval');
+  });
+
+  it('applicationMode mismatch fails with repair hint', () => {
+    const liveModeEvaluate: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct' as const,
+      matched: true,
+      reason: 'auto-corrected params',
+      confidence: 0.9,
+      correctionProposal: {
+        proposedParams: { command: 'rm -i /tmp/safe' },
+        correctedFields: [{ field: 'command', original: null, proposed: 'rm -i /tmp/safe', reason: 'corrected' }],
+        applicationMode: 'live' as const,
+        confidence: 0.9,
+        ruleId: 'test-rule',
+        notifyAgent: true,
+      },
+    });
+    const cases: GoldenTraceCase[] = [
+      {
+        caseId: 'ac-mode-mismatch',
+        kind: 'negative',
+        toolName: 'bash',
+        params: { command: 'rm -rf /' },
+        expectedDecision: 'propose_correction',
+        expectedProposedParams: { command: 'rm -i /tmp/safe' },
+        expectedApplicationMode: 'shadow',
+      },
+    ];
+    const result = replayGoldenTrace(liveModeEvaluate, cases);
+    expect(result.passed).toBe(false);
+    const [caseResult] = result.perCaseResults;
+    expect(caseResult?.applicationModeMatch).toBe(false);
+    expect(caseResult?.failureReason).toContain('applicationMode mismatch');
+    expect(caseResult?.repairHint).toContain('applicationMode');
+  });
+
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/golden-trace-replay-validator.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/golden-trace-replay-validator.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { replayGoldenTrace } from '../golden-trace-replay-validator.js';
+import type { ReplayEvaluateFn } from '../golden-trace-replay-validator.js';
+import type { GoldenTraceCase } from '../golden-trace.js';
+
+// --- Helpers ---
+
+function createBlockBashEvaluate(): ReplayEvaluateFn {
+  return () => ({
+    decision: 'block' as const,
+    matched: true,
+    reason: 'bash command blocked',
+    confidence: 0.95,
+  });
+}
+
+function createAlwaysAllowEvaluate(): ReplayEvaluateFn {
+  return () => ({
+    decision: 'allow' as const,
+    matched: false,
+    reason: 'no match',
+    confidence: 1.0,
+  });
+}
+
+function createAutoCorrectEvaluate(expectedParams: Record<string, unknown>): ReplayEvaluateFn {
+  return () => ({
+    decision: 'auto_correct' as const,
+    matched: true,
+    reason: 'auto-corrected params',
+    confidence: 0.9,
+    correctionProposal: {
+      proposedParams: expectedParams,
+      correctedFields: Object.keys(expectedParams).map(k => ({ field: k, original: null, proposed: expectedParams[k], reason: "corrected" })),
+      applicationMode: 'shadow' as const,
+      confidence: 0.9,
+      ruleId: 'test-rule',
+      notifyAgent: true,
+    },
+  });
+}
+
+function createBashBlockCases(): GoldenTraceCase[] {
+  return [
+    {
+      caseId: 'neg-bash-rm',
+      kind: 'negative',
+      toolName: 'bash',
+      params: { command: 'rm -rf /' },
+      expectedDecision: 'block',
+    },
+    {
+      caseId: 'neg-bash-force',
+      kind: 'negative',
+      toolName: 'bash',
+      params: { command: 'git push --force' },
+      expectedDecision: 'block',
+    },
+    {
+      caseId: 'pos-bash-ls',
+      kind: 'positive',
+      toolName: 'bash',
+      params: { command: 'ls -la' },
+      expectedDecision: 'allow',
+    },
+    {
+      caseId: 'pos-bash-git-status',
+      kind: 'positive',
+      toolName: 'bash',
+      params: { command: 'git status' },
+      expectedDecision: 'allow',
+    },
+  ];
+}
+
+// --- Tests ---
+
+describe('replayGoldenTrace', () => {
+  it('valid rule passes all positive and negative cases', () => {
+    const _evaluate = createBlockBashEvaluate();
+    const cases = createBashBlockCases();
+    // For positive cases, block evaluate returns block, but positive expects allow.
+    // Need an evaluate that allows safe commands and blocks dangerous ones.
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      const cmd = input?.action?.toolName === 'bash'
+        ? (input.action.paramsSummary)?.command as string
+        : '';
+      if (cmd.includes('rm') || cmd.includes('force')) {
+        return { decision: 'block', matched: true, reason: 'dangerous', confidence: 0.95 };
+      }
+      return { decision: 'allow', matched: false, reason: 'safe', confidence: 1.0 };
+    };
+    const result = replayGoldenTrace(smartEvaluate, cases);
+    expect(result.passed).toBe(true);
+    expect(result.totalCases).toBe(4);
+    expect(result.passedCases).toBe(4);
+    expect(result.failedCases).toBe(0);
+  });
+
+  it('false positive blocked: rule that allows negative case fails', () => {
+    const evaluate = createAlwaysAllowEvaluate();
+    const cases = createBashBlockCases();
+    const result = replayGoldenTrace(evaluate, cases);
+    expect(result.passed).toBe(false);
+    expect(result.failedCases).toBe(2);
+    const failedIds = result.perCaseResults.filter(c => !c.passed).map(c => c.caseId);
+    expect(failedIds).toContain('neg-bash-rm');
+    expect(failedIds).toContain('neg-bash-force');
+  });
+
+  it('auto_correct case validates expected proposedParams', () => {
+    const expectedParams = { command: 'rm -i /tmp/safe' };
+    const evaluate = createAutoCorrectEvaluate(expectedParams);
+    const cases: GoldenTraceCase[] = [
+      {
+        caseId: 'ac-bash-rm',
+        kind: 'negative',
+        toolName: 'bash',
+        params: { command: 'rm -rf /' },
+        expectedDecision: 'propose_correction',
+        expectedProposedParams: expectedParams,
+        expectedApplicationMode: 'shadow',
+      },
+    ];
+    const result = replayGoldenTrace(evaluate, cases);
+    expect(result.passed).toBe(true);
+    expect(result.perCaseResults[0]?.proposedParamsMatch).toBe(true);
+  });
+
+  it('invalid rule returns structured failure with repair hints', () => {
+    const badEvaluate: ReplayEvaluateFn = () => {
+      throw new Error('rule execution failed');
+    };
+    const cases = createBashBlockCases();
+    const result = replayGoldenTrace(badEvaluate, cases);
+    expect(result.passed).toBe(false);
+    expect(result.failedCases).toBe(4);
+    for (const cr of result.perCaseResults) {
+      expect(cr.passed).toBe(false);
+      expect(cr.failureReason).toBeTruthy();
+    }
+  });
+
+  it('mismatched proposedParams fails with diff', () => {
+    const expectedParams = { command: 'rm -i /tmp/safe' };
+    const wrongParams = { command: 'rm -rf /' };
+    const evaluate = createAutoCorrectEvaluate(wrongParams);
+    const cases: GoldenTraceCase[] = [
+      {
+        caseId: 'ac-mismatch',
+        kind: 'negative',
+        toolName: 'bash',
+        params: { command: 'rm -rf /' },
+        expectedDecision: 'propose_correction',
+        expectedProposedParams: expectedParams,
+        expectedApplicationMode: 'shadow',
+      },
+    ];
+    const result = replayGoldenTrace(evaluate, cases);
+    expect(result.passed).toBe(false);
+    expect(result.perCaseResults[0]?.proposedParamsMatch).toBe(false);
+    expect(result.perCaseResults[0]?.proposedParamsDiff).toBeTruthy();
+  });
+
+  it('empty cases returns passed=true (backward compat)', () => {
+    const evaluate = createBlockBashEvaluate();
+    const result = replayGoldenTrace(evaluate, []);
+    expect(result.passed).toBe(true);
+    expect(result.totalCases).toBe(0);
+    expect(result.perCaseResults).toEqual([]);
+  });
+
+  it('partial pass reports individual failures', () => {
+    const partialEvaluate: ReplayEvaluateFn = (input) => {
+      const cmd = input?.action?.toolName === 'bash'
+        ? (input.action.paramsSummary)?.command as string
+        : '';
+      // Blocks rm but allows force push (false negative for force)
+      if (cmd.includes('rm')) {
+        return { decision: 'block', matched: true, reason: 'dangerous', confidence: 0.95 };
+      }
+      return { decision: 'allow', matched: false, reason: 'safe', confidence: 1.0 };
+    };
+    const cases = createBashBlockCases();
+    const result = replayGoldenTrace(partialEvaluate, cases);
+    expect(result.passed).toBe(false);
+    expect(result.passedCases).toBe(3);
+    expect(result.failedCases).toBe(1);
+    const failed = result.perCaseResults.find(c => !c.passed);
+    expect(failed?.caseId).toBe('neg-bash-force');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/golden-trace-replay-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-replay-adapter.ts
@@ -37,19 +37,6 @@ export function replayValidateCode(
   loadEvaluate: SandboxEvaluateLoader,
 ): ReplayValidatorResult {
   const config = { ...DEFAULT_REPLAY_VALIDATOR_CONFIG, ...input.config };
-
-  if (input.cases.length === 0) {
-    return {
-      passed: true,
-      totalCases: 0,
-      passedCases: 0,
-      failedCases: 0,
-      perCaseResults: [],
-      failureReasons: [],
-      repairHints: [],
-    };
-  }
-
   const evaluateFn = loadEvaluate(input.code);
   return replayGoldenTrace(evaluateFn, input.cases, config);
 }

--- a/packages/principles-core/src/runtime-v2/golden-trace-replay-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-replay-adapter.ts
@@ -1,0 +1,55 @@
+/**
+ * GoldenTrace Replay Adapter - Code-to-validator bridge with injected sandbox
+ *
+ * PRI-115: Provides a convenience function that loads raw code string
+ * into a sandbox and runs the replay validator against GoldenTrace cases.
+ *
+ * The sandbox loader is injected to keep core free of node:vm imports.
+ */
+
+import type { GoldenTraceCase } from './golden-trace.js';
+import {
+  replayGoldenTrace,
+  DEFAULT_REPLAY_VALIDATOR_CONFIG,
+  type ReplayValidatorResult,
+  type ReplayValidatorConfig,
+  type ReplayEvaluateFn,
+} from './golden-trace-replay-validator.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReplayCodeInput {
+  code: string;
+  cases: readonly GoldenTraceCase[];
+  config?: Partial<ReplayValidatorConfig>;
+}
+
+export type SandboxEvaluateLoader = (code: string) => ReplayEvaluateFn;
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export function replayValidateCode(
+  input: ReplayCodeInput,
+  loadEvaluate: SandboxEvaluateLoader,
+): ReplayValidatorResult {
+  const config = { ...DEFAULT_REPLAY_VALIDATOR_CONFIG, ...input.config };
+
+  if (input.cases.length === 0) {
+    return {
+      passed: true,
+      totalCases: 0,
+      passedCases: 0,
+      failedCases: 0,
+      perCaseResults: [],
+      failureReasons: [],
+      repairHints: [],
+    };
+  }
+
+  const evaluateFn = loadEvaluate(input.code);
+  return replayGoldenTrace(evaluateFn, input.cases, config);
+}

--- a/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
@@ -205,15 +205,18 @@ function validateCase(
   }
 
   const result = evalOutcome.value;
-  baseResult.actualDecision = result.decision;
+  const caseResult = {
+    ...baseResult,
+    actualDecision: result.decision,
+  };
 
   switch (traceCase.expectedDecision) {
     case 'allow':
-      return validateAllowCase(baseResult, result);
+      return validateAllowCase(caseResult, result);
     case 'block':
-      return validateBlockCase(baseResult, result);
+      return validateBlockCase(caseResult, result);
     case 'propose_correction':
-      return validateProposeCorrectionCase(baseResult, result, traceCase);
+      return validateProposeCorrectionCase(caseResult, result, traceCase);
     default:
       return {
         ...baseResult,

--- a/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
@@ -1,0 +1,272 @@
+/**
+ * GoldenTrace Replay Validator - Pure replay validation for generated L2 rules
+ *
+ * PRI-115: Before L2 registration, generated rule code must pass replay
+ * against GoldenTrace cases. This module provides the pure validation logic.
+ *
+ * TRUST BOUNDARY:
+ *   - Pure functions only, zero side effects
+ *   - No filesystem, VM, process, or network access
+ *   - Sandbox loading is injected via the adapter layer
+ */
+
+import type { GoldenTraceCase, GoldenTraceDecision } from './golden-trace.js';
+import type { RuleHostDecision, RuleHostInput, RuleHostResult } from './internalization/rule-host-contracts.js';
+import type { RuleHostHelpers } from './internalization/rule-host-helpers.js';
+import { createSyntheticRuleHostInput } from './golden-trace.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReplayValidatorCaseResult {
+  caseId: string;
+  passed: boolean;
+  expectedDecision: GoldenTraceDecision;
+  actualDecision: RuleHostDecision | 'error' | 'non_deterministic';
+  failureReason?: string;
+  repairHint?: string;
+  proposedParamsMatch?: boolean;
+  proposedParamsDiff?: string[];
+  applicationModeMatch?: boolean;
+}
+
+export interface ReplayValidatorResult {
+  passed: boolean;
+  totalCases: number;
+  passedCases: number;
+  failedCases: number;
+  perCaseResults: readonly ReplayValidatorCaseResult[];
+  failureReasons: readonly string[];
+  repairHints: readonly string[];
+}
+
+export interface ReplayValidatorConfig {
+  maxRepairAttempts: number;
+}
+
+export const DEFAULT_REPLAY_VALIDATOR_CONFIG: ReplayValidatorConfig = {
+  maxRepairAttempts: 0,
+};
+
+export type ReplayEvaluateFn = (
+  input: RuleHostInput,
+  helpers: RuleHostHelpers,
+) => RuleHostResult;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const GOLDEN_TO_HOST_BLOCK_ACCEPT: ReadonlySet<RuleHostDecision> = new Set(['block', 'requireApproval']);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function diffParams(
+  expected: Record<string, unknown>,
+  actual: Record<string, unknown>,
+): string[] {
+  const diffs: string[] = [];
+  const allKeys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  for (const key of allKeys) {
+    if (!(key in actual)) {
+      diffs.push(`missing field "${key}"`);
+    } else if (!(key in expected)) {
+      diffs.push(`unexpected field "${key}"`);
+    } else if (JSON.stringify(expected[key]) !== JSON.stringify(actual[key])) {
+      diffs.push(`field "${key}": expected ${JSON.stringify(expected[key])}, got ${JSON.stringify(actual[key])}`);
+    }
+  }
+  return diffs;
+}
+
+// ---------------------------------------------------------------------------
+// Per-case validation
+// ---------------------------------------------------------------------------
+
+function validateAllowCase(
+  base: ReplayValidatorCaseResult,
+  result: RuleHostResult,
+): ReplayValidatorCaseResult {
+  const passed = result.decision === 'allow' || result.matched === false;
+  return {
+    ...base,
+    passed,
+    failureReason: passed ? undefined : `Expected allow but got ${result.decision}`,
+    repairHint: passed ? undefined : 'Rule incorrectly blocks or intervenes on benign input',
+  };
+}
+function validateBlockCase(
+  base: ReplayValidatorCaseResult,
+  result: RuleHostResult,
+): ReplayValidatorCaseResult {
+  const passed = GOLDEN_TO_HOST_BLOCK_ACCEPT.has(result.decision);
+  return {
+    ...base,
+    passed,
+    failureReason: passed ? undefined : `Expected block but got ${result.decision}`,
+    repairHint: passed ? undefined : 'Rule failed to block harmful input -- check condition matching',
+  };
+}
+function validateProposeCorrectionCase(
+  base: ReplayValidatorCaseResult,
+  result: RuleHostResult,
+  traceCase: GoldenTraceCase,
+): ReplayValidatorCaseResult {
+  if (result.decision !== 'auto_correct') {
+    return {
+      ...base,
+      passed: false,
+      failureReason: `Expected auto_correct (propose_correction) but got ${result.decision}`,
+      repairHint: 'Rule must return auto_correct decision with correctionProposal',
+    };
+  }
+
+  const proposal = result.correctionProposal;
+  if (!proposal) {
+    return {
+      ...base,
+      passed: false,
+      failureReason: 'auto_correct decision missing correctionProposal',
+      repairHint: 'Return correctionProposal with proposedParams when decision is auto_correct',
+    };
+  }
+
+  const perCase: ReplayValidatorCaseResult = { ...base, passed: true };
+
+  if (traceCase.expectedProposedParams) {
+    const diffs = diffParams(
+      traceCase.expectedProposedParams,
+      proposal.proposedParams,
+    );
+    perCase.proposedParamsMatch = diffs.length === 0;
+    perCase.proposedParamsDiff = diffs.length > 0 ? diffs : undefined;
+    if (diffs.length > 0) {
+      perCase.passed = false;
+      perCase.failureReason = `proposedParams mismatch: ${diffs.join('; ')}`;
+      perCase.repairHint = 'Ensure correctionProposal.proposedParams matches expected corrected params';
+    }
+  }
+
+  if (traceCase.expectedApplicationMode) {
+    perCase.applicationModeMatch = proposal.applicationMode === traceCase.expectedApplicationMode;
+    if (!perCase.applicationModeMatch) {
+      perCase.passed = false;
+      perCase.failureReason = (perCase.failureReason ? perCase.failureReason + '; ' : '') +
+        `applicationMode mismatch: expected ${traceCase.expectedApplicationMode}, got ${proposal.applicationMode}`;
+      perCase.repairHint = (perCase.repairHint ? perCase.repairHint + '; ' : '') +
+        'Set correctionProposal.applicationMode to match expected mode';
+    }
+  }
+
+  return perCase;
+}
+function validateCase(
+  evaluateFn: ReplayEvaluateFn,
+  traceCase: GoldenTraceCase,
+): ReplayValidatorCaseResult {
+  const input = createSyntheticRuleHostInput(
+    { toolName: traceCase.toolName, params: traceCase.params },
+  );
+
+  const baseResult: ReplayValidatorCaseResult = {
+    caseId: traceCase.caseId,
+    passed: false,
+    expectedDecision: traceCase.expectedDecision,
+    actualDecision: 'error',
+  };
+
+  const evalOutcome = (() => {
+    const helpers: RuleHostHelpers = {
+      isRiskPath: () => input.workspace.isRiskPath,
+      getToolName: () => input.action.toolName,
+      getEstimatedLineChanges: () => input.derived.estimatedLineChanges,
+      getBashRisk: () => input.derived.bashRisk,
+      hasPlanFile: () => input.workspace.hasPlanFile,
+      getPlanStatus: () => input.workspace.planStatus,
+      getEpTier: () => input.evolution.epTier,
+    };
+    try {
+      return { ok: true as const, value: evaluateFn(input, helpers) };
+    } catch (err) {
+      return { ok: false as const, error: (err as Error).message };
+    }
+  })();
+
+  if (!evalOutcome.ok) {
+    return {
+      ...baseResult,
+      actualDecision: 'error',
+      failureReason: `evaluate() threw: ${evalOutcome.error}`,
+      repairHint: 'Ensure evaluate() handles all input shapes without throwing',
+    };
+  }
+
+  const result = evalOutcome.value;
+  baseResult.actualDecision = result.decision;
+
+  switch (traceCase.expectedDecision) {
+    case 'allow':
+      return validateAllowCase(baseResult, result);
+    case 'block':
+      return validateBlockCase(baseResult, result);
+    case 'propose_correction':
+      return validateProposeCorrectionCase(baseResult, result, traceCase);
+    default:
+      return {
+        ...baseResult,
+        failureReason: `Unknown expectedDecision: ${String(traceCase.expectedDecision)}`,
+      };
+  }
+}
+
+
+
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+export function replayGoldenTrace(
+  evaluateFn: ReplayEvaluateFn,
+  cases: readonly GoldenTraceCase[],
+  config?: Partial<ReplayValidatorConfig>,
+): ReplayValidatorResult {
+  const _config = { ...DEFAULT_REPLAY_VALIDATOR_CONFIG, ...config };
+
+  if (cases.length === 0) {
+    return {
+      passed: true,
+      totalCases: 0,
+      passedCases: 0,
+      failedCases: 0,
+      perCaseResults: [],
+      failureReasons: [],
+      repairHints: [],
+    };
+  }
+
+  const perCaseResults = cases.map((traceCase) => validateCase(evaluateFn, traceCase));
+  const passedCases = perCaseResults.filter((r) => r.passed).length;
+  const failedCases = perCaseResults.length - passedCases;
+  const failureReasons = perCaseResults
+    .filter((r) => !r.passed && r.failureReason)
+    .map((r) => `[${r.caseId}] ${r.failureReason ?? ''}`);
+  const repairHints = perCaseResults
+    .filter((r) => !r.passed && r.repairHint)
+    .map((r) => r.repairHint ?? '');
+
+  void _config.maxRepairAttempts;
+
+  return {
+    passed: failedCases === 0,
+    totalCases: perCaseResults.length,
+    passedCases,
+    failedCases,
+    perCaseResults,
+    failureReasons,
+    repairHints,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -784,3 +784,26 @@ export type {
   SyntheticRuleHostInputOverrides,
   GoldenTraceFixtureInput,
 } from './golden-trace.js';
+// ── GoldenTrace Replay Validator (PRI-115) ────────────────────────────────
+
+export {
+  replayGoldenTrace,
+  DEFAULT_REPLAY_VALIDATOR_CONFIG,
+} from './golden-trace-replay-validator.js';
+
+export type {
+  ReplayValidatorCaseResult,
+  ReplayValidatorResult,
+  ReplayValidatorConfig,
+  ReplayEvaluateFn,
+} from './golden-trace-replay-validator.js';
+
+export {
+  replayValidateCode,
+} from './golden-trace-replay-adapter.js';
+
+export type {
+  ReplayCodeInput,
+  SandboxEvaluateLoader,
+} from './golden-trace-replay-adapter.js';
+

--- a/packages/principles-core/src/runtime-v2/internalization/compile-result.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/compile-result.ts
@@ -1,8 +1,11 @@
 /**
- * Compile Result — Pure type for principle compilation outcomes
+ * Compile Result - Pure type for principle compilation outcomes
  *
  * PRI-44: Pure type, zero infrastructure dependency.
+ * PRI-115: Extended with replay validation result and degradation flag.
  */
+
+import type { ReplayValidatorResult } from '../golden-trace-replay-validator.js';
 
 export interface CompileResult {
   success: boolean;
@@ -11,4 +14,8 @@ export interface CompileResult {
   implementationId?: string;
   code?: string;
   reason?: string;
+  /** PRI-115: Structured replay validation result when GoldenTrace gate runs */
+  replayResult?: ReplayValidatorResult;
+  /** PRI-115: True when replay failed and compiler degraded to L1 artifact */
+  degraded?: boolean;
 }


### PR DESCRIPTION
## Summary

- **Replay validation gate**: Before L2 registration, generated rule code now runs `evaluate(input, helpers)` against GoldenTrace cases in the same sandbox contract RuleHost uses
- **Fail-closed degradation**: On replay failure, the compiler returns `degraded: true` and skips registration entirely — the caller falls back to L1 prompt artifacts
- **Safety guarantee**: Rules that compile but make wrong decisions never reach `registerCompiledRule()` or `createImplementationAssetDir()`

## Replay Contract

| GoldenTrace Expected | RuleHost Acceptable | Validation |
|---------------------|--------------------|------------|
| `allow` | `decision === 'allow'` OR `matched === false` | Positive case passes |
| `block` | `decision === 'block'` OR `decision === 'requireApproval'` | Negative case blocked |
| `propose_correction` | `decision === 'auto_correct'` + validate `correctionProposal` | Params + mode match |

## Fail/Degrade Behavior

1. Replay passes → register L2 normally
2. Replay fails → return `{ success: false, degraded: true, replayResult }`, no registration
3. No cases (blanket block template) → skip replay gate, backward compatible
4. No `evaluate` export → degrade with reason
5. Evaluate throws → degrade with reason

## Test Results

- **7 core validator tests**: valid rule pass, false positive blocked, auto_correct params validation, invalid rule structured failure, mismatched params diff, empty cases backward compat, partial pass reporting
- **5 compiler integration tests**: failing replay blocks registration, no asset dir on failure, passing replay registers, no-cases skip gate, missing evaluate export

## Files

### New
- `principles-core/src/runtime-v2/golden-trace-replay-validator.ts` — Pure replay validator (zero I/O)
- `principles-core/src/runtime-v2/golden-trace-replay-adapter.ts` — Code-to-validator adapter with injected sandbox loader
- `principles-core/src/runtime-v2/__tests__/golden-trace-replay-validator.test.ts` — 7 unit tests
- `openclaw-plugin/src/core/principle-compiler/__tests__/compiler-replay-gate.test.ts` — 5 integration tests

### Modified
- `compile-result.ts` — `replayResult?: ReplayValidatorResult` + `degraded?: boolean`
- `compiler.ts` — Step 4.5 replay gate + `buildGoldenTraceCases()` with regex-qualifier guard
- `index.ts` — Barrel exports for all replay validator types
- `architecture-regression.test.ts` — Source + test file existence guards

## Non-goals

- No live auto-correction (maxRepairAttempts field only)
- No ledger mutation changes
- No PrincipleCompiler rewrite
- No Trainer runner integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在编译流程中新增 GoldenTrace 重放验证门，基于生成的重放用例验证规则行为，失败时会标记为降级并跳过注册/持久化。
  * 编译结果现在可返回重放验证摘要和降级标识，便于诊断与回退决策。

* **测试**
  * 新增多套重放验证相关单元与端到端测试，覆盖通过/失败、异常、自动修正和边界情况。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/568)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->