### PR TITLE
fix(WORKFLOW): correct Linear project_slug and document shell fallback

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,7 +1,9 @@
 ---
 tracker:
   kind: linear
-  project_slug: "principles-d4d597b84d4d"
+  # project_slug must be a Linear Project.slugId (found in project URL: .../project/<slugId>).
+  # Using Project A slugId: d4fdb8223f27
+  project_slug: "d4fdb8223f27"
   active_states:
     - Todo
     - In Progress
@@ -18,6 +20,9 @@ polling:
 workspace:
   root: D:/code/principles-workspaces
 hooks:
+  # NOTE: after_create/before_remove hooks run via System.cmd("sh", ["-lc", command]).
+  # On Windows (where sh may not be in PATH), the Elixir runtime falls back to
+  # PowerShell or cmd automatically. Existing POSIX behavior is preserved when sh is available.
   after_create: |
     git clone --depth 1 https://github.com/csuzngjh/principles .
     npm install


### PR DESCRIPTION
## Summary

- Fix `project_slug` in WORKFLOW.md from wrong value `principles-d4d597b84d4d` to correct Project A `slugId` `d4fdb8223f27`
- Document that `project_slug` = Linear `Project.slugId` (found in project URL)
- Add note in hooks section about Windows shell fallback behavior

## Test plan

- [ ] Verify `./start-symphony.ps1 -DryRun` passes
- [ ] Confirm PRI-123 is now returned by Linear client with correct project_slug

## Notes

The Windows shell fallback (`pwsh` -> `powershell` -> `cmd`) is already implemented in `SymphonyElixir.ShellResolution` in the sibling `Symphony/elixir` directory. This PR only updates WORKFLOW.md with correct configuration and documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 添加了工作流钩子执行行为的说明文档
  * 补充了Windows系统上跨平台兼容性的相关说明

* **杂项**
  * 更新了工作流配置中的项目标识符

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/574)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->