### PR TITLE
fix(installer): replace console.exit with process.exit

### DIFF
--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -222,7 +222,7 @@ function buildCoreAndCli() {
     console.log('✅ @principles/core and @principles/pd-cli built');
   } catch (error) {
     console.error('\n❌ Core/CLI build failed');
-    console.exit(1);
+    process.exit(1);
   }
 }
 
@@ -237,7 +237,7 @@ function buildPdConsole() {
       console.log('✅ pd-console built');
     } catch (error) {
       console.error('\n❌ pd-console build failed');
-      console.exit(1);
+      process.exit(1);
     }
   } else {
     console.log('⏭️  pd-console dist already exists (skip build)');
@@ -273,7 +273,7 @@ function installPlugin(args) {
     console.log('✅ Plugin installed');
   } catch (error) {
     console.error('\n❌ Plugin installation failed');
-    console.exit(1);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- `console.exit()` is not a standard Node.js API — `TypeError: console.exit is not a function` on Node 24
- All 3 occurrences replaced with `process.exit(1)`

## Test plan
- [ ] `node scripts/install.mjs` exits correctly with error code on failure paths (no TypeError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)