### PR TITLE
docs(runtime): add canary operator runbook

### DIFF
--- a/packages/pd-cli/README.md
+++ b/packages/pd-cli/README.md
@@ -23,6 +23,64 @@ Options:
 - `--score, -s` — Pain score 0-100 (default: 80)
 - `--session-id` — Session ID (default: auto-generated)
 
+## Production Canary Validation
+
+Operator-facing runbook for validating PD runtime health in production. All commands below are read-only and safe to run against a live workspace.
+
+### Validation Sequence
+
+Run these three commands in order to assess runtime health:
+
+```bash
+# 1. Full canary — runs 7 health checks across schema, candidates, GFI, queue, and runtime
+node packages/pd-cli/dist/index.js runtime canary --workspace "D:\.openclaw\workspace" --json
+
+# 2. Internalization queue snapshot — inspect PI task pipeline state
+node packages/pd-cli/dist/index.js runtime internalization queue --workspace "D:\.openclaw\workspace" --json
+
+# 3. Internalization chain integrity — verify candidate→dreamer→philosopher→artifact links
+node packages/pd-cli/dist/index.js runtime internalization integrity --workspace "D:\.openclaw\workspace" --json
+```
+
+Omit `--json` for human-readable text output.
+
+### Interpreting Canary Status
+
+The canary runs 7 checks and reports an `overallStatus`:
+
+| Status | Meaning |
+|--------|---------|
+| `healthy` | All checks pass. No action needed. |
+| `degraded` | Non-critical issues found (orphan candidates, queue blockers, stale GFI sessions). Review `checks` for details. |
+| `error` | Schema conformance failure or check threw an exception. Investigate before proceeding. |
+
+Each check in the `checks` array has its own `status` field. The `recommendedNextActions` array provides targeted remediation suggestions.
+
+### Identifying the Next Internalization Blocker
+
+After a healthy canary, check the queue and integrity for the next PI task to resolve:
+
+**Queue** — look at the `readyTasks` array. If empty, check `noReadyTasks.reason`:
+- `all_tasks_blocked` — examine `blockedSummary.samples` for dependency chains
+- `all_tasks_dependency_failed` — examine `dependencyFailedSummary.samples` for failed dependencies
+- `all_tasks_retry_wait` — tasks are in backoff; check `retryWaitPendingSummary.samples` for retry timers
+
+**Integrity** — look at `brokenLinks`:
+- `severity: "error"` — a broken link in the chain (e.g., missing artifact). This blocks internalization for that candidate.
+- `severity: "warning"` — a data quality issue that may need attention but doesn't block immediately.
+
+Each broken link includes a `recommendedAction` field. The `chainsWithBrokenLinks` count tells you how many candidate chains are affected.
+
+### Remediation
+
+Remediation commands (e.g., `pd candidate audit --repair`, `pd runtime pruning orphans`) should **always** be run with `--dry-run` first:
+
+```bash
+node packages/pd-cli/dist/index.js runtime pruning orphans --workspace "D:\.openclaw\workspace" --dry-run
+```
+
+Only add `--confirm` after reviewing the dry-run output. Never run remediation without understanding what it will change.
+
 ## Migration from openclaw tools
 
 The `pd pain record` CLI and the existing `write_pain_flag` tool write to the same pain flag file (`.state/.pain_flag`). They can coexist safely:


### PR DESCRIPTION
## Summary

- Added a Production Canary Validation section to the pd-cli README with the validation sequence, status interpretation, internalization blocker identification, and remediation guidance.

## Changed Files

- `packages/pd-cli/README.md` — added runbook section (+58 lines)

## Validation

- `git diff --check` — no whitespace errors
- `git status --short` — only `packages/pd-cli/README.md` modified
- Docs lint: no docs lint command found in this repo

## Notes

This PR was created as a Symphony trial (PRI-151).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* 新增生产环境运行时校验手册，提供只读验证流程。包含系统健康状态检查（正常/降级/异常三种状态）、检查结果与推荐操作的解读方式、故障排查指导，以及修复命令的验证流程（先用测试模式验证，确认后执行）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->