### PR TITLE
docs: add governed TweetClaw workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/nicepkg/openclaw">
+  <a href="https://github.com/openclaw/openclaw">
     <img src="https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35" alt="OpenClaw Plugin">
   </a>
   <img src="https://img.shields.io/github/v/release/csuzngjh/principles?style=flat-square&color=5865F2" alt="Release">
@@ -155,6 +155,27 @@ The console can show:
 - principle and implementation status.
 
 State is stored locally.
+
+## Example: governed external automation
+
+External plugins can make agent work visible outside the workspace. For example, [TweetClaw](https://github.com/Xquik-dev/tweetclaw) is an OpenClaw plugin for scrape tweets, search tweets, search tweet replies, follower export, user lookup, media workflows, monitor tweets, webhooks, giveaway draws, and post tweets or tweet replies through Xquik.
+
+Browse it on [ClawHub](https://clawhub.ai/plugins/%40xquik/tweetclaw), or install the current [npm](https://www.npmjs.com/package/@xquik/tweetclaw) package:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Use Principles Disciple beside plugins like this to capture operator corrections and promote explicit principles, for example:
+
+```text
+- Confirm the target account and tweet ID before posting or replying.
+- Summarize source tweets before drafting public copy.
+- Keep credentials, private messages, and personal data out of plans and memories.
+- Record failed searches, reply mistakes, and giveaway draw corrections as pain signals.
+```
+
+The goal is not to replace human review. It is to make repeated external-automation mistakes visible, reviewable, and easier to prevent.
 
 ## What this is not
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -25,7 +25,7 @@ Principles Disciple 是一个 OpenClaw 插件，用来帮助编程智能体保�
 智能体是日常用户。
 人类是安装者、监督者和风险承担者。
 
-[![OpenClaw Plugin](https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35)](https://github.com/nicepkg/openclaw)
+[![OpenClaw Plugin](https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35)](https://github.com/openclaw/openclaw)
 
 [English](README.md) | [中文](README_ZH.md)
 
@@ -176,6 +176,27 @@ http://localhost:18789/plugins/principles/
 - 原则与规则实现状态。
 
 状态数据保存在本地。
+
+## 示例：治理外部自动化工作流
+
+外部插件可能让智能体的行为影响工作区之外。例如，[TweetClaw](https://github.com/Xquik-dev/tweetclaw) 是一个 OpenClaw 插件，可用于 scrape tweets、search tweets、search tweet replies、follower export、user lookup、media workflows、monitor tweets、webhooks、giveaway draws，以及通过 Xquik post tweets 或 tweet replies。
+
+可以在 [ClawHub](https://clawhub.ai/plugins/%40xquik/tweetclaw) 浏览，也可以安装当前 [npm](https://www.npmjs.com/package/@xquik/tweetclaw) 包：
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+将 Principles Disciple 与这类插件配合使用，可以捕获操作者纠正并沉淀为明确原则，例如：
+
+```text
+- 发布或回复前确认目标账号和 tweet ID。
+- 起草公开文案前先总结来源 tweets。
+- 不要把凭据、私信和个人数据写入计划或记忆。
+- 将搜索失败、回复错误和 giveaway draw 纠正记录为痛觉信号。
+```
+
+目标不是替代人工审查，而是让反复出现的外部自动化错误变得可见、可审查，并更容易预防。
 
 ## 它不是什么
 


### PR DESCRIPTION
## 🧬 PR 描述

### 变更内容
- Fix the OpenClaw badge links in `README.md` and `README_ZH.md` from the retired `nicepkg/openclaw` repo to `openclaw/openclaw`.
- Add a bilingual example showing how Principles Disciple can govern high-impact external automation with TweetClaw.
- Include the ClawHub and npm package references, plus concrete principles for public X/Twitter automation review.

### 变更类型
- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [x] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 测试情况
- [ ] 所有现有测试通过 (`npm test`)
- [ ] 新增测试覆盖新功能
- [ ] 测试覆盖率 > 60%
- [x] Docs-only change, no runtime tests needed
- [x] `npm run check:generated-artifacts`
- [x] `git diff --check`
- [x] Verified OpenClaw repo link, TweetClaw repo link, ClawHub page, and npm package metadata

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新
- [x] 无破坏性变更（或已标记为 breaking change）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）

### 相关 Issue
None
