### PR TITLE
fix: update OpenClaw badge link from nicepkg/openclaw to openclaw/openclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/nicepkg/openclaw">
+  <a href="https://github.com/openclaw/openclaw">
     <img src="https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35" alt="OpenClaw Plugin">
   </a>
   <img src="https://img.shields.io/github/v/release/csuzngjh/principles?style=flat-square&color=5865F2" alt="Release">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -25,7 +25,7 @@ Principles Disciple 是一个 OpenClaw 插件，用来帮助编程智能体保�
 智能体是日常用户。
 人类是安装者、监督者和风险承担者。
 
-[![OpenClaw Plugin](https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35)](https://github.com/nicepkg/openclaw)
+[![OpenClaw Plugin](https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35)](https://github.com/openclaw/openclaw)
 
 [English](README.md) | [中文](README_ZH.md)
 


### PR DESCRIPTION
## Summary

- OpenClaw 仓库已从 `nicepkg/openclaw` 迁移到 `openclaw/openclaw`
- 更新 README.md 和 README_ZH.md 中的 badge 链接

## Test plan

- [ ] README badge 链接可访问: https://github.com/openclaw/openclaw

Closes N/A — small fix, no issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新项目文档中的仓库链接指向新的项目地址，确保用户可以正确访问项目源代码和相关资源。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->