### PR TITLE
feat(core): PRI-141 Task Three Strikes Out Mechanism

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -153,6 +153,8 @@ const REQUIRED_TEST_FILES = [
   'golden-trace-replay-validator.test.ts',
   // PRI-140
   '../store/sqlite-connection-pragma.test.ts',
+  // PRI-141
+  'task-three-strikes.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [
@@ -2423,6 +2425,56 @@ describe('Phase 2.6 principle-tree data structures migration', () => {
     ), 'utf-8');
     expect(src).not.toMatch(/^export interface PrincipleDependency/m);
     expect(src).not.toMatch(/^export interface PrincipleTreeStore/m);
+  });
+});
+
+// ── PRI-141: Task Three Strikes Out Mechanism ──────────────────────────────────
+
+describe('PRI-141 Task Three Strikes Out Mechanism', () => {
+  it('core barrel exports isUnresolvable, recordRejection, DEFAULT_UNRESOLVABLE_THRESHOLD', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('isUnresolvable');
+    expect(src).toContain('recordRejection');
+    expect(src).toContain('DEFAULT_UNRESOLVABLE_THRESHOLD');
+  });
+
+  it('core barrel exports UnresolvableSample type', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('UnresolvableSample');
+  });
+
+  it('internalization-task-guards.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '..', 'internalization', 'internalization-task-guards.ts'
+    ), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('node:cron');
+  });
+
+  it('PITaskRecord includes rejectionCount field', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '..', 'internalization', 'peer-runner-contracts.ts'
+    ), 'utf-8');
+    expect(src).toContain('rejectionCount');
+  });
+
+  it('PITaskMetadata includes rejectionCount field', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(
+      __dirname, '..', 'internalization', 'pitask-metadata.ts'
+    ), 'utf-8');
+    expect(src).toContain('rejectionCount');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-queue-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-queue-read-model.test.ts
@@ -34,6 +34,7 @@ type MakeTaskOptions = {
   outputArtifactRefs?: { artifactType: string; ref: string }[];
   attemptCount?: number;
   maxAttempts?: number;
+  rejectionCount?: number;
 };
 
 function makeTask(overrides: MakeTaskOptions & { taskId: string; taskKind: string; status: 'pending' | 'retry_wait' | 'failed' }): TaskRecord {
@@ -47,6 +48,7 @@ function makeTask(overrides: MakeTaskOptions & { taskId: string; taskKind: strin
   const outputArtifactRefs = overrides.outputArtifactRefs ?? [];
   const attemptCount = overrides.attemptCount ?? 0;
   const maxAttempts = overrides.maxAttempts ?? 3;
+  const rejectionCount = overrides.rejectionCount ?? 0;
 
   let {diagnosticJson} = overrides;
   if (diagnosticJson === undefined) {
@@ -57,6 +59,7 @@ function makeTask(overrides: MakeTaskOptions & { taskId: string; taskKind: strin
         timeoutMs,
         inputArtifactRefs,
         outputArtifactRefs,
+        rejectionCount,
       },
     });
   }
@@ -365,6 +368,74 @@ describe('InternalizationQueueReadModel.getSnapshot', () => {
     expect(snap.dependencyFailedSummary.count).toBe(1);
     expect(snap.blockedSummary.count).toBe(1);
     expect(snap.noReadyTasks?.reason).toBe('all_dependency_failed');
+  });
+
+  // ── P8: Unresolvable tasks (PRI-141) ────────────────────────────────────
+
+  it('unresolvable task (rejectionCount >= 3) excluded from readyTasks', async () => {
+    const sm = createSm(
+      [
+        makeTask({ taskId: 'unresolvable_1', taskKind: 'scribe', status: 'pending', rejectionCount: 3 }),
+      ],
+      [],
+      () => null,
+    );
+    model = new InternalizationQueueReadModel(sm);
+    const snap = await model.getSnapshot();
+
+    expect(snap.readyTasks).toEqual([]);
+    expect(snap.unresolvableSummary.count).toBe(1);
+    expect(snap.unresolvableSummary.samples[0]?.taskId).toBe('unresolvable_1');
+    expect(snap.unresolvableSummary.samples[0]?.rejectionCount).toBe(3);
+  });
+
+  it('all unresolvable tasks → all_unresolvable reason', async () => {
+    const sm = createSm(
+      [
+        makeTask({ taskId: 'u1', taskKind: 'scribe', status: 'pending', rejectionCount: 3 }),
+        makeTask({ taskId: 'u2', taskKind: 'artificer', status: 'pending', rejectionCount: 5 }),
+      ],
+      [],
+      () => null,
+    );
+    model = new InternalizationQueueReadModel(sm);
+    const snap = await model.getSnapshot();
+
+    expect(snap.readyTasks).toEqual([]);
+    expect(snap.unresolvableSummary.count).toBe(2);
+    expect(snap.noReadyTasks?.reason).toBe('all_unresolvable');
+  });
+
+  it('unresolvable task mixed with ready task: ready task still available', async () => {
+    const sm = createSm(
+      [
+        makeTask({ taskId: 'u1', taskKind: 'scribe', status: 'pending', rejectionCount: 3 }),
+        makeTask({ taskId: 'r1', taskKind: 'dreamer', status: 'pending', rejectionCount: 0 }),
+      ],
+      [],
+      () => null,
+    );
+    model = new InternalizationQueueReadModel(sm);
+    const snap = await model.getSnapshot();
+
+    expect(snap.readyTasks).toContainEqual({ taskId: 'r1', taskKind: 'dreamer', channel: 'prompt' });
+    expect(snap.unresolvableSummary.count).toBe(1);
+    expect(snap.noReadyTasks).toBeNull();
+  });
+
+  it('task with rejectionCount < 3 is NOT unresolvable', async () => {
+    const sm = createSm(
+      [
+        makeTask({ taskId: 'retry_1', taskKind: 'scribe', status: 'pending', rejectionCount: 2 }),
+      ],
+      [],
+      () => null,
+    );
+    model = new InternalizationQueueReadModel(sm);
+    const snap = await model.getSnapshot();
+
+    expect(snap.readyTasks).toContainEqual({ taskId: 'retry_1', taskKind: 'scribe', channel: 'prompt' });
+    expect(snap.unresolvableSummary.count).toBe(0);
   });
 
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-state-machine.test.ts
@@ -26,6 +26,7 @@ function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
     timeoutMs = 60000,
     inputArtifactRefs = [],
     outputArtifactRefs = [],
+    rejectionCount = 0,
   } = overrides;
   return {
     taskId,
@@ -40,6 +41,7 @@ function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
     timeoutMs,
     inputArtifactRefs,
     outputArtifactRefs,
+    rejectionCount,
   } as PITaskRecord;
 }
 

--- a/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
@@ -63,6 +63,7 @@ function makeMetadata(overrides?: Partial<PITaskMetadata>) {
     outputArtifactRefs: overrides?.outputArtifactRefs ?? ([] as ArtifactRef[]),
     parentTaskId: overrides?.parentTaskId,
     correlationId: overrides?.correlationId,
+    rejectionCount: overrides?.rejectionCount,
   };
 }
 

--- a/packages/principles-core/src/runtime-v2/__tests__/task-three-strikes.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/task-three-strikes.test.ts
@@ -255,4 +255,45 @@ describe('PRI-141: Task Three Strikes Out Mechanism', () => {
       expect(src).not.toContain('openclaw-plugin');
     });
   });
+
+  describe('isValidPITaskRecord validates rejectionCount', () => {
+    it('record with valid rejectionCount passes validation', async () => {
+      const { isValidPITaskRecord } = await import('../internalization/peer-runner-contracts.js');
+      const task = makePITask({ rejectionCount: 0 });
+      expect(isValidPITaskRecord(task)).toBe(true);
+    });
+
+    it('record with undefined rejectionCount fails validation', async () => {
+      const { isValidPITaskRecord } = await import('../internalization/peer-runner-contracts.js');
+      const { rejectionCount: _rc, ...taskWithoutRejectionCount } = makePITask({ rejectionCount: 0 });
+      expect(isValidPITaskRecord(taskWithoutRejectionCount as unknown as PITaskRecord)).toBe(false);
+    });
+
+    it('record with negative rejectionCount fails validation', async () => {
+      const { isValidPITaskRecord } = await import('../internalization/peer-runner-contracts.js');
+      const task = { ...makePITask({ rejectionCount: 0 }), rejectionCount: -1 } as unknown as PITaskRecord;
+      expect(isValidPITaskRecord(task)).toBe(false);
+    });
+
+    it('record with NaN rejectionCount fails validation', async () => {
+      const { isValidPITaskRecord } = await import('../internalization/peer-runner-contracts.js');
+      const task = { ...makePITask({ rejectionCount: 0 }), rejectionCount: NaN } as unknown as PITaskRecord;
+      expect(isValidPITaskRecord(task)).toBe(false);
+    });
+  });
+
+  describe('defensive: isUnresolvable and recordRejection handle undefined rejectionCount', () => {
+    it('isUnresolvable treats undefined rejectionCount as 0 (not unresolvable)', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task = { ...makePITask(), rejectionCount: undefined } as unknown as PITaskRecord;
+      expect(isUnresolvable(task)).toBe(false);
+    });
+
+    it('recordRejection treats undefined rejectionCount as 0 and increments to 1', async () => {
+      const { recordRejection } = await import('../internalization/internalization-task-guards.js');
+      const task = { ...makePITask(), rejectionCount: undefined } as unknown as PITaskRecord;
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(1);
+    });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/task-three-strikes.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/task-three-strikes.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+import type { PITaskRecord, LineageRef, PIArtifact } from '../internalization/peer-runner-contracts.js';
+import { createMinimalPITaskRecord } from '../internalization/peer-runner-contracts.js';
+
+function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
+  return {
+    ...createMinimalPITaskRecord('test-task', 'dreamer', 'prompt'),
+    ...overrides,
+  };
+}
+
+function makeRejectedArtifact(sourceTaskId: string): PIArtifact {
+  return {
+    artifactId: 'art-1',
+    artifactKind: 'principle',
+    sourceTaskId,
+    lineageRefs: [] as LineageRef[],
+    validationStatus: 'rejected',
+  };
+}
+
+describe('PRI-141: Task Three Strikes Out Mechanism', () => {
+  describe('recordRejection', () => {
+    it('increments rejection count from 0 to 1', async () => {
+      const { recordRejection } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 0 });
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(1);
+    });
+
+    it('increments rejection count from 1 to 2', async () => {
+      const { recordRejection } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 1 });
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(2);
+    });
+
+    it('increments rejection count from 2 to 3', async () => {
+      const { recordRejection } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 2 });
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(3);
+    });
+
+    it('is monotonic — count only increases', async () => {
+      const { recordRejection } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 5 });
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(6);
+      expect(result.rejectionCount).toBeGreaterThan(task.rejectionCount);
+    });
+
+    it('preserves all other task fields', async () => {
+      const { recordRejection } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 0, taskKind: 'scribe', channel: 'code_tool_hook' });
+      const result = recordRejection(task);
+      expect(result.taskId).toBe(task.taskId);
+      expect(result.taskKind).toBe('scribe');
+      expect(result.channel).toBe('code_tool_hook');
+      expect(result.rejectionCount).toBe(1);
+    });
+  });
+
+  describe('isUnresolvable', () => {
+    it('count 0 is not unresolvable', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 0 });
+      expect(isUnresolvable(task)).toBe(false);
+    });
+
+    it('count 1 is not unresolvable', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 1 });
+      expect(isUnresolvable(task)).toBe(false);
+    });
+
+    it('count 2 is not unresolvable', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 2 });
+      expect(isUnresolvable(task)).toBe(false);
+    });
+
+    it('count 3 IS unresolvable (default threshold)', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 3 });
+      expect(isUnresolvable(task)).toBe(true);
+    });
+
+    it('count 4 IS unresolvable', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task = makePITask({ rejectionCount: 4 });
+      expect(isUnresolvable(task)).toBe(true);
+    });
+
+    it('custom threshold of 5: count 4 is not unresolvable, count 5 is', async () => {
+      const { isUnresolvable } = await import('../internalization/internalization-task-guards.js');
+      const task4 = makePITask({ rejectionCount: 4 });
+      const task5 = makePITask({ rejectionCount: 5 });
+      expect(isUnresolvable(task4, 5)).toBe(false);
+      expect(isUnresolvable(task5, 5)).toBe(true);
+    });
+  });
+
+  describe('DEFAULT_UNRESOLVABLE_THRESHOLD', () => {
+    it('is 3', async () => {
+      const { DEFAULT_UNRESOLVABLE_THRESHOLD } = await import('../internalization/internalization-task-guards.js');
+      expect(DEFAULT_UNRESOLVABLE_THRESHOLD).toBe(3);
+    });
+  });
+
+  describe('decideArtifactRejectionFeedback with three strikes', () => {
+    it('scribe with rejectionCount < 3 creates corrective task', async () => {
+      const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+      const artifact = makeRejectedArtifact('scribe-task');
+      const task = makePITask({ taskKind: 'scribe', status: 'succeeded', rejectionCount: 1 });
+      const result = decideArtifactRejectionFeedback(artifact, task);
+      expect(result.action).toBe('create_corrective_task');
+    });
+
+    it('scribe with rejectionCount >= 3 escalates instead of corrective task', async () => {
+      const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+      const artifact = makeRejectedArtifact('scribe-task');
+      const task = makePITask({ taskKind: 'scribe', status: 'succeeded', rejectionCount: 3 });
+      const result = decideArtifactRejectionFeedback(artifact, task);
+      expect(result.action).toBe('escalate');
+    });
+
+    it('artificer with rejectionCount >= 3 escalates instead of corrective task', async () => {
+      const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+      const artifact = makeRejectedArtifact('artificer-task');
+      const task = makePITask({ taskKind: 'artificer', status: 'succeeded', rejectionCount: 3 });
+      const result = decideArtifactRejectionFeedback(artifact, task);
+      expect(result.action).toBe('escalate');
+    });
+
+    it('escalation includes unresolvable reason', async () => {
+      const { decideArtifactRejectionFeedback } = await import('../internalization/internalization-state-machine.js');
+      const artifact = makeRejectedArtifact('scribe-task');
+      const task = makePITask({ taskKind: 'scribe', status: 'succeeded', rejectionCount: 3 });
+      const result = decideArtifactRejectionFeedback(artifact, task);
+      if (result.action === 'escalate') {
+        expect(result.rejectionReason).toContain('unresolvable');
+      }
+    });
+  });
+
+  describe('createNextTaskProposal with unresolvable task', () => {
+    it('unresolvable task returns null even if succeeded', async () => {
+      const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+      const task = makePITask({
+        taskId: 'dreamer-1',
+        taskKind: 'dreamer',
+        status: 'succeeded',
+        rejectionCount: 3,
+        outputArtifactRefs: [{ artifactType: 'principle', ref: 'art-1' }],
+      });
+      const result = createNextTaskProposal(task, []);
+      expect(result).toBeNull();
+    });
+
+    it('non-unresolvable succeeded task still proposes next', async () => {
+      const { createNextTaskProposal } = await import('../internalization/internalization-state-machine.js');
+      const task = makePITask({
+        taskId: 'dreamer-1',
+        taskKind: 'dreamer',
+        status: 'succeeded',
+        rejectionCount: 1,
+        outputArtifactRefs: [{ artifactType: 'principle', ref: 'art-1' }],
+      });
+      const result = createNextTaskProposal(task, []);
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('migration: old task without rejectionCount defaults to 0', () => {
+    it('parsePITaskMetadata with missing rejectionCount defaults to 0', async () => {
+      const { parsePITaskMetadata } = await import('../internalization/pitask-metadata.js');
+      const oldJson = JSON.stringify({
+        pi_metadata: {
+          dependencyTaskIds: [],
+          channel: 'prompt',
+          timeoutMs: 60000,
+          inputArtifactRefs: [],
+          outputArtifactRefs: [],
+        },
+      });
+      const result = parsePITaskMetadata(oldJson);
+      expect(result).not.toBeNull();
+      if (result) {
+        expect(result.rejectionCount).toBe(0);
+      }
+    });
+
+    it('parsePITaskMetadata with explicit rejectionCount preserves value', async () => {
+      const { parsePITaskMetadata } = await import('../internalization/pitask-metadata.js');
+      const json = JSON.stringify({
+        pi_metadata: {
+          dependencyTaskIds: [],
+          channel: 'prompt',
+          timeoutMs: 60000,
+          inputArtifactRefs: [],
+          outputArtifactRefs: [],
+          rejectionCount: 2,
+        },
+      });
+      const result = parsePITaskMetadata(json);
+      expect(result).not.toBeNull();
+      if (result) {
+        expect(result.rejectionCount).toBe(2);
+      }
+    });
+
+    it('round-trip serialize/parse preserves rejectionCount', async () => {
+      const { serializePITaskMetadata, parsePITaskMetadata } = await import('../internalization/pitask-metadata.js');
+      const metadata = {
+        dependencyTaskIds: ['dep-1'],
+        channel: 'prompt' as const,
+        timeoutMs: 30000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+        rejectionCount: 3,
+      };
+      const serialized = serializePITaskMetadata(metadata);
+      const parsed = parsePITaskMetadata(serialized);
+      expect(parsed).not.toBeNull();
+      if (parsed) {
+        expect(parsed.rejectionCount).toBe(3);
+      }
+    });
+
+    it('invalid rejectionCount (negative) returns null', async () => {
+      const { parsePITaskMetadata } = await import('../internalization/pitask-metadata.js');
+      const json = JSON.stringify({
+        pi_metadata: {
+          dependencyTaskIds: [],
+          channel: 'prompt',
+          timeoutMs: 60000,
+          inputArtifactRefs: [],
+          outputArtifactRefs: [],
+          rejectionCount: -1,
+        },
+      });
+      const result = parsePITaskMetadata(json);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('architecture: internalization-task-guards.ts has zero infrastructure imports', () => {
+    it('has no node:fs, node:path, or openclaw-plugin imports', async () => {
+      const { readFileSync } = await import('node:fs');
+      const { resolve } = await import('node:path');
+      const src = readFileSync(resolve(__dirname, '..', 'internalization', 'internalization-task-guards.ts'), 'utf-8');
+      expect(src).not.toContain('node:fs');
+      expect(src).not.toContain('node:path');
+      expect(src).not.toContain('openclaw-plugin');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -403,6 +403,9 @@ export {
   isResultRefImmutable,
   canUpdateLastError,
   isArtifactRejected,
+  isUnresolvable,
+  recordRejection,
+  DEFAULT_UNRESOLVABLE_THRESHOLD,
 } from './internalization/internalization-task-guards.js';
 
 export type {
@@ -718,6 +721,7 @@ export type {
   DependencyFailedSample,
   RetryWaitPendingSample,
   LeaseConflictSample,
+  UnresolvableSample,
 } from './internalization-queue-read-model.js';
 
 // ── GFI Core Kernel (PRI-76) ────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
@@ -21,6 +21,7 @@ import type { PeerRunnerKind, InternalizationChannel } from './internalization/p
 import { isPeerRunnerKind } from './internalization/peer-runner-contracts.js';
 import { hydratePITaskRecord } from './internalization/pitask-metadata.js';
 import { validateInternalizationTaskReady } from './internalization/internalization-state-machine.js';
+import { isUnresolvable } from './internalization/internalization-task-guards.js';
 
 // ── Output types ────────────────────────────────────────────────────────────
 
@@ -48,7 +49,8 @@ export type QueueNoReadyTasksReason =
   | 'all_blocked'
   | 'all_dependency_failed'
   | 'all_retry_wait_pending'
-  | 'all_lease_conflict';
+  | 'all_lease_conflict'
+  | 'all_unresolvable';
 
 export interface NoReadyTasksDiagnosis {
   reason: QueueNoReadyTasksReason;
@@ -68,6 +70,12 @@ export interface LeaseConflictSample {
   leaseExpiresAt: string;
 }
 
+export interface UnresolvableSample {
+  taskId: string;
+  taskKind: PeerRunnerKind;
+  rejectionCount: number;
+}
+
 export interface InternalizationQueueSnapshot {
   pendingCount: number;
   retryWaitCount: number;
@@ -79,6 +87,7 @@ export interface InternalizationQueueSnapshot {
   dependencyFailedSummary: { count: number; samples: DependencyFailedSample[] };
   leaseConflictSummary: { count: number; samples: LeaseConflictSample[]; sampleTaskIds: string[] };
   retryWaitPendingSummary: { count: number; samples: RetryWaitPendingSample[] };
+  unresolvableSummary: { count: number; samples: UnresolvableSample[] };
   readyTasks: ReadyTask[];
   noReadyTasks: NoReadyTasksDiagnosis | null;
 }
@@ -124,6 +133,7 @@ export class InternalizationQueueReadModel {
     const dependencyFailedSamples: DependencyFailedSample[] = [];
     const leaseConflictSamples: LeaseConflictSample[] = [];
     const retryWaitPendingSamples: RetryWaitPendingSample[] = [];
+    const unresolvableSamples: UnresolvableSample[] = [];
     const readyTasks: ReadyTask[] = [];
 
     let hydrationFailures = 0;
@@ -131,6 +141,7 @@ export class InternalizationQueueReadModel {
     let dependencyFailures = 0;
     let leaseConflicts = 0;
     let retryWaitPendingCount = 0;
+    let unresolvableCount = 0;
 
     const nowMs = Date.now();
 
@@ -158,6 +169,18 @@ export class InternalizationQueueReadModel {
             taskKind: piTask.taskKind,
             leaseOwner: piTask.leaseOwner ?? '',
             leaseExpiresAt: piTask.leaseExpiresAt ?? '',
+          });
+        }
+        continue;
+      }
+
+      if (isUnresolvable(piTask)) {
+        unresolvableCount++;
+        if (unresolvableSamples.length < MAX_SAMPLES) {
+          unresolvableSamples.push({
+            taskId: piTask.taskId,
+            taskKind: piTask.taskKind,
+            rejectionCount: piTask.rejectionCount,
           });
         }
         continue;
@@ -213,15 +236,17 @@ export class InternalizationQueueReadModel {
         noReadyTasks = { reason: 'no_candidates', inspectedCount };
       } else {
         const reason: QueueNoReadyTasksReason =
-          retryWaitPendingCount > 0 && retryWaitPendingCount >= hydrationFailures && retryWaitPendingCount >= dependencyFailures && retryWaitPendingCount >= blockedCount
-            ? 'all_retry_wait_pending'
-            : leaseConflicts > 0 && leaseConflicts >= hydrationFailures && leaseConflicts >= dependencyFailures && leaseConflicts >= blockedCount
-              ? 'all_lease_conflict'
-            : hydrationFailures > 0 && hydrationFailures >= dependencyFailures && hydrationFailures >= blockedCount
-              ? 'all_hydration_failed'
-              : dependencyFailures >= blockedCount
-                ? 'all_dependency_failed'
-                : 'all_blocked';
+          unresolvableCount > 0 && unresolvableCount >= hydrationFailures && unresolvableCount >= dependencyFailures && unresolvableCount >= blockedCount && unresolvableCount >= retryWaitPendingCount && unresolvableCount >= leaseConflicts
+            ? 'all_unresolvable'
+            : retryWaitPendingCount > 0 && retryWaitPendingCount >= hydrationFailures && retryWaitPendingCount >= dependencyFailures && retryWaitPendingCount >= blockedCount
+              ? 'all_retry_wait_pending'
+              : leaseConflicts > 0 && leaseConflicts >= hydrationFailures && leaseConflicts >= dependencyFailures && leaseConflicts >= blockedCount
+                ? 'all_lease_conflict'
+                : hydrationFailures > 0 && hydrationFailures >= dependencyFailures && hydrationFailures >= blockedCount
+                  ? 'all_hydration_failed'
+                  : dependencyFailures >= blockedCount
+                    ? 'all_dependency_failed'
+                    : 'all_blocked';
         noReadyTasks = { reason, inspectedCount };
       }
     }
@@ -241,6 +266,7 @@ export class InternalizationQueueReadModel {
         sampleTaskIds: leaseConflictSamples.map((sample) => sample.taskId),
       },
       retryWaitPendingSummary: { count: retryWaitPendingCount, samples: retryWaitPendingSamples },
+      unresolvableSummary: { count: unresolvableCount, samples: unresolvableSamples },
       readyTasks,
       noReadyTasks,
     };

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -30,6 +30,7 @@ import {
   canAcquireLease,
   canTransitionTo,
   canRetryNow,
+  isUnresolvable,
 } from './internalization-task-guards.js';
 
 // ── Dependency Gate Types ─────────────────────────────────────────────────────
@@ -263,7 +264,14 @@ export function decideArtifactRejectionFeedback(
     sourceTaskKind: task.taskKind,
   };
 
-  // Scribe rejections → re-run scribe to regenerate
+  if (isUnresolvable(task)) {
+    return {
+      ...base,
+      action: 'escalate',
+      rejectionReason: 'unresolvable_threshold_exceeded',
+    };
+  }
+
   if (task.taskKind === 'scribe') {
     return {
       ...base,
@@ -272,7 +280,6 @@ export function decideArtifactRejectionFeedback(
     };
   }
 
-  // Artificer rejections → re-run artificer to re-validate
   if (task.taskKind === 'artificer') {
     return {
       ...base,
@@ -281,7 +288,6 @@ export function decideArtifactRejectionFeedback(
     };
   }
 
-  // All other runners → escalate for human review
   return {
     ...base,
     action: 'escalate',
@@ -315,6 +321,10 @@ export function createNextTaskProposal(
   channel?: InternalizationChannel,
 ): NextTaskProposal | null {
   if (currentTask.status !== 'succeeded') {
+    return null;
+  }
+
+  if (isUnresolvable(currentTask)) {
     return null;
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
@@ -155,3 +155,19 @@ export function canUpdateLastError(task: PITaskRecord): boolean {
 export function isArtifactRejected(artifact: PIArtifact): boolean {
   return artifact.validationStatus === 'rejected';
 }
+
+// ── Three Strikes Out Guards (PRI-141) ──────────────────────────────────────
+
+export const DEFAULT_UNRESOLVABLE_THRESHOLD = 3;
+
+export function isUnresolvable(task: PITaskRecord, threshold: number = DEFAULT_UNRESOLVABLE_THRESHOLD): boolean {
+  return task.rejectionCount >= threshold;
+}
+
+export function recordRejection(task: PITaskRecord): PITaskRecord {
+  return {
+    ...task,
+    rejectionCount: task.rejectionCount + 1,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts
@@ -161,13 +161,15 @@ export function isArtifactRejected(artifact: PIArtifact): boolean {
 export const DEFAULT_UNRESOLVABLE_THRESHOLD = 3;
 
 export function isUnresolvable(task: PITaskRecord, threshold: number = DEFAULT_UNRESOLVABLE_THRESHOLD): boolean {
-  return task.rejectionCount >= threshold;
+  const count = task.rejectionCount ?? 0;
+  return count >= threshold;
 }
 
 export function recordRejection(task: PITaskRecord): PITaskRecord {
+  const currentCount = task.rejectionCount ?? 0;
   return {
     ...task,
-    rejectionCount: task.rejectionCount + 1,
+    rejectionCount: currentCount + 1,
     updatedAt: new Date().toISOString(),
   };
 }

--- a/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
@@ -202,6 +202,7 @@ export function isTerminalTaskStatus(status: string): boolean {
  *   - timeoutMs as number
  *   - inputArtifactRefs as array
  *   - outputArtifactRefs as array
+ *   - rejectionCount as finite non-negative number (PRI-141)
  */
 export function isValidPITaskRecord(record: TaskRecord): record is PITaskRecord {
   // Must have a valid peer runner kind
@@ -218,7 +219,8 @@ export function isValidPITaskRecord(record: TaskRecord): record is PITaskRecord 
     isInternalizationChannel(pi.channel) &&
     typeof pi.timeoutMs === 'number' &&
     Array.isArray(pi.inputArtifactRefs) &&
-    Array.isArray(pi.outputArtifactRefs)
+    Array.isArray(pi.outputArtifactRefs) &&
+    (typeof pi.rejectionCount === 'number' && Number.isFinite(pi.rejectionCount) && pi.rejectionCount >= 0)
   );
 }
 

--- a/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
@@ -113,22 +113,15 @@ export interface PIArtifact {
  * @see ADR-0003 Section 3.4
  */
 export interface PITaskRecord extends TaskRecord {
-  /** One of the 7 peer runner kinds */
   taskKind: PeerRunnerKind;
-  /** Optional parent task (for chained execution) */
   parentTaskId?: string;
-  /** Tasks that must complete before this task can be leased */
   dependencyTaskIds: string[];
-  /** The internalization channel this task uses */
   channel: InternalizationChannel;
-  /** Optional correlation ID for tracing across related tasks */
   correlationId?: string;
-  /** Timeout in milliseconds for this task's execution */
   timeoutMs: number;
-  /** Input artifacts for this task */
   inputArtifactRefs: ArtifactRef[];
-  /** Output artifacts produced by this task (set on succeeded) */
   outputArtifactRefs: ArtifactRef[];
+  rejectionCount: number;
 }
 
 // ── Type Guards ───────────────────────────────────────────────────────────────
@@ -251,5 +244,6 @@ export function createMinimalPITaskRecord(
     timeoutMs: 60000,
     inputArtifactRefs: [],
     outputArtifactRefs: [],
+    rejectionCount: 0,
   };
 }

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -48,6 +48,7 @@ export interface PITaskMetadata {
   outputArtifactRefs: ArtifactRef[];
   parentTaskId?: string;
   correlationId?: string;
+  rejectionCount?: number;
 }
 
 // ── Serialization ──────────────────────────────────────────────────────────────
@@ -66,6 +67,7 @@ export function serializePITaskMetadata(metadata: PITaskMetadata): string {
       outputArtifactRefs: metadata.outputArtifactRefs,
       parentTaskId: metadata.parentTaskId,
       correlationId: metadata.correlationId,
+      rejectionCount: metadata.rejectionCount,
     },
   });
 }
@@ -147,6 +149,12 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
     if (m.correlationId.trim() === '') return null;
   }
 
+  let rejectionCount = 0;
+  if (m.rejectionCount !== undefined) {
+    if (typeof m.rejectionCount !== 'number' || !Number.isFinite(m.rejectionCount) || m.rejectionCount < 0) return null;
+    rejectionCount = Math.floor(m.rejectionCount);
+  }
+
   return {
     dependencyTaskIds: m.dependencyTaskIds as string[],
     channel: m.channel,
@@ -155,6 +163,7 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
     outputArtifactRefs: m.outputArtifactRefs as ArtifactRef[],
     parentTaskId: m.parentTaskId,
     correlationId: m.correlationId,
+    rejectionCount,
   };
 }
 
@@ -194,5 +203,6 @@ export function hydratePITaskRecord(task: TaskRecord): PITaskRecord | null {
     outputArtifactRefs: meta.outputArtifactRefs,
     parentTaskId: meta.parentTaskId,
     correlationId: meta.correlationId,
+    rejectionCount: meta.rejectionCount ?? 0,
   } as unknown as PITaskRecord;
 }


### PR DESCRIPTION
## PRI-141: Task Three Strikes Out Mechanism

### 现象
Internalization/Activation 失败链无限重试，rejected artifacts 可以无限制地生成新的 Dreamer/Runner 尝试。

### 根因
缺少 bounded counter 来限制 rejection feedback loop 的重试次数。

### 修改文件
- \internalization/pitask-metadata.ts\ — 添加 rejectionCount 到 PI 元数据序列化/反序列化
- \internalization/peer-runner-contracts.ts\ — 添加 rejectionCount 到 PITaskRecord + createMinimalPITaskRecord
- \internalization/internalization-task-guards.ts\ — 添加 isUnresolvable / recordRejection / DEFAULT_UNRESOLVABLE_THRESHOLD
- \internalization/internalization-state-machine.ts\ — decideArtifactRejectionFeedback ≥3 时强制 escalate; createNextTaskProposal unresolvable 返回 null
- \internalization-queue-read-model.ts\ — 添加 unresolvableSummary + all_unresolvable reason
- \index.ts\ — 导出新符号 (isUnresolvable, recordRejection, DEFAULT_UNRESOLVABLE_THRESHOLD, UnresolvableSample)
- \__tests__/task-three-strikes.test.ts\ — NEW 核心测试文件 (23 tests)
- \__tests__/internalization-state-machine.test.ts\ — 更新 makePITask 含 rejectionCount
- \__tests__/internalization-queue-read-model.test.ts\ — 添加 4 个 unresolvable 测试 + 更新 makeTask
- \__tests__/pitask-metadata.test.ts\ — 更新 makeMetadata 含 rejectionCount
- \__tests__/architecture-regression.test.ts\ — PRI-141 架构回归守卫 (5 tests)

### 测试命令
\\\ash
npm run build --workspace=@principles/core
npx vitest run src/runtime-v2/__tests__/task-three-strikes.test.ts
npx vitest run src/runtime-v2/__tests__/internalization-state-machine.test.ts
npx vitest run src/runtime-v2/__tests__/internalization-queue-read-model.test.ts
npx vitest run src/runtime-v2/__tests__/pitask-metadata.test.ts
npx vitest run src/runtime-v2/__tests__/architecture-regression.test.ts -t PRI-141
\\\

### 测试结果
- task-three-strikes.test.ts: 23 passed
- internalization-state-machine.test.ts: 68 passed
- internalization-queue-read-model.test.ts: 17 passed
- pitask-metadata.test.ts: 30 passed
- architecture-regression (PRI-141): 5 passed
- Build: ✅ (core + plugin + pd-cli + typecheck)
- Lint: ✅
- Pre-push verify-merge: ✅

### 剩余风险
- rejectionCount 存储在 diagnosticJson 中，如果其他代码直接修改 diagnosticJson 可能丢失
- UNRESOLVABLE_THRESHOLD 硬编码为 3，未来可能需要可配置
- 不修改生产 DB（rejectionCount 通过 pi_metadata 信封自动迁移，缺失默认 0）

Closes #141