### PR TITLE
feat(core): PRI-139 L1 Hard Cap & LRU Eviction

### DIFF
--- a/packages/principles-core/src/principle-tree-ledger.ts
+++ b/packages/principles-core/src/principle-tree-ledger.ts
@@ -81,6 +81,7 @@ export interface PrincipleValueMetrics {
 
 export interface LedgerPrinciple extends Principle {
   suggestedRules?: string[];
+  lastTriggeredAt?: string;
 }
 
 export interface LedgerRule extends Rule {

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -115,6 +115,8 @@ const REQUIRED_SOURCE_FILES = [
   'types/principle-tree-store.ts',
   // PRI-140
   'store/sqlite-connection.ts',
+  // PRI-139
+  'l1-hard-cap.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -155,6 +157,8 @@ const REQUIRED_TEST_FILES = [
   '../store/sqlite-connection-pragma.test.ts',
   // PRI-141
   'task-three-strikes.test.ts',
+  // PRI-139
+  'l1-hard-cap.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [
@@ -2475,6 +2479,53 @@ describe('PRI-141 Task Three Strikes Out Mechanism', () => {
       __dirname, '..', 'internalization', 'pitask-metadata.ts'
     ), 'utf-8');
     expect(src).toContain('rejectionCount');
+  });
+});
+
+// ── PRI-139: L1 Hard Cap & LRU Eviction ──────────────────────────────────────
+
+describe('PRI-139 L1 Hard Cap & LRU Eviction', () => {
+  it('core barrel exports enforceL1HardCap, validateL1CapConfig, DEFAULT_L1_HARD_CAP, MAX_L1_HARD_CAP', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('enforceL1HardCap');
+    expect(src).toContain('validateL1CapConfig');
+    expect(src).toContain('DEFAULT_L1_HARD_CAP');
+    expect(src).toContain('MAX_L1_HARD_CAP');
+  });
+
+  it('core barrel exports L1CapConfig, L1EvictionCandidate, L1EvictionResult types', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('L1CapConfig');
+    expect(src).toContain('L1EvictionCandidate');
+    expect(src).toContain('L1EvictionResult');
+  });
+
+  it('l1-hard-cap.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'l1-hard-cap.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('LedgerPrinciple includes lastTriggeredAt field', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', '..', 'principle-tree-ledger.ts'), 'utf-8');
+    expect(src).toContain('lastTriggeredAt');
+  });
+
+  it('PruningHealthSummary includes activeL1Count and l1Cap fields', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'pruning-read-model.ts'), 'utf-8');
+    expect(src).toContain('activeL1Count');
+    expect(src).toContain('l1Cap');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/l1-hard-cap.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/l1-hard-cap.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import {
+  enforceL1HardCap,
+  validateL1CapConfig,
+  DEFAULT_L1_HARD_CAP,
+  MAX_L1_HARD_CAP,
+} from '../l1-hard-cap.js';
+import type { L1EvictionCandidate } from '../l1-hard-cap.js';
+
+function makeCandidate(
+  id: string,
+  opts: {
+    lastTriggeredAt?: string;
+    status?: L1EvictionCandidate['status'];
+  } = {},
+): L1EvictionCandidate {
+  return {
+    id,
+    lastTriggeredAt: opts.lastTriggeredAt ?? '2026-01-01T00:00:00.000Z',
+    status: opts.status ?? 'active',
+  };
+}
+
+describe('validateL1CapConfig', () => {
+  it('accepts valid config with cap <= 12', () => {
+    expect(() => validateL1CapConfig({ hardCap: 12 })).not.toThrow();
+    expect(() => validateL1CapConfig({ hardCap: 5 })).not.toThrow();
+    expect(() => validateL1CapConfig({ hardCap: 1 })).not.toThrow();
+  });
+
+  it('rejects config with cap > 12', () => {
+    expect(() => validateL1CapConfig({ hardCap: 13 })).toThrow(/cap.*12/i);
+    expect(() => validateL1CapConfig({ hardCap: 100 })).toThrow(/cap.*12/i);
+  });
+
+  it('rejects config with cap <= 0', () => {
+    expect(() => validateL1CapConfig({ hardCap: 0 })).toThrow(/cap/i);
+    expect(() => validateL1CapConfig({ hardCap: -1 })).toThrow(/cap/i);
+  });
+});
+
+describe('enforceL1HardCap', () => {
+  it('active count <= cap does nothing', () => {
+    const candidates = [
+      makeCandidate('p1', { lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+      makeCandidate('p2', { lastTriggeredAt: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const result = enforceL1HardCap(candidates, { hardCap: 12 });
+    expect(result.beforeCount).toBe(2);
+    expect(result.afterCount).toBe(2);
+    expect(result.evictedIds).toEqual([]);
+    expect(result.reason).toBe('');
+  });
+
+  it('active count > cap evicts oldest lastTriggeredAt', () => {
+    const candidates = [
+      makeCandidate('p_old', { lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+      makeCandidate('p_mid', { lastTriggeredAt: '2026-03-01T00:00:00.000Z' }),
+      makeCandidate('p_new', { lastTriggeredAt: '2026-06-01T00:00:00.000Z' }),
+    ];
+    const result = enforceL1HardCap(candidates, { hardCap: 2 });
+    expect(result.beforeCount).toBe(3);
+    expect(result.afterCount).toBe(2);
+    expect(result.evictedIds).toEqual(['p_old']);
+    expect(result.reason).toContain('l1-hard-cap');
+  });
+
+  it('evicts multiple when active count far exceeds cap', () => {
+    const candidates = Array.from({ length: 15 }, (_, i) =>
+      makeCandidate(`p_${String(i).padStart(2, '0')}`, {
+        lastTriggeredAt: `2026-${String(i + 1).padStart(2, '0')}-01T00:00:00.000Z`,
+      }),
+    );
+    const result = enforceL1HardCap(candidates, { hardCap: 12 });
+    expect(result.beforeCount).toBe(15);
+    expect(result.afterCount).toBe(12);
+    expect(result.evictedIds).toHaveLength(3);
+    expect(result.evictedIds[0]).toBe('p_00');
+    expect(result.evictedIds[1]).toBe('p_01');
+    expect(result.evictedIds[2]).toBe('p_02');
+  });
+
+  it('tie-break: same lastTriggeredAt → sort by id (deterministic)', () => {
+    const sameTime = '2026-01-01T00:00:00.000Z';
+    const candidates = [
+      makeCandidate('p_charlie', { lastTriggeredAt: sameTime }),
+      makeCandidate('p_alpha', { lastTriggeredAt: sameTime }),
+      makeCandidate('p_bravo', { lastTriggeredAt: sameTime }),
+    ];
+    const result = enforceL1HardCap(candidates, { hardCap: 2 });
+    expect(result.evictedIds).toHaveLength(1);
+    expect(result.evictedIds[0]).toBe('p_alpha');
+  });
+
+  it('only active principles considered; archived/candidate/deprecated/probation ignored', () => {
+    const candidates = [
+      makeCandidate('p_active_1', { status: 'active', lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+      makeCandidate('p_active_2', { status: 'active', lastTriggeredAt: '2026-02-01T00:00:00.000Z' }),
+      makeCandidate('p_archived', { status: 'archived', lastTriggeredAt: '2025-01-01T00:00:00.000Z' }),
+      makeCandidate('p_candidate', { status: 'candidate', lastTriggeredAt: '2025-06-01T00:00:00.000Z' }),
+      makeCandidate('p_deprecated', { status: 'deprecated', lastTriggeredAt: '2025-03-01T00:00:00.000Z' }),
+      makeCandidate('p_probation', { status: 'probation', lastTriggeredAt: '2025-09-01T00:00:00.000Z' }),
+    ];
+    const result = enforceL1HardCap(candidates, { hardCap: 12 });
+    expect(result.beforeCount).toBe(2);
+    expect(result.afterCount).toBe(2);
+    expect(result.evictedIds).toEqual([]);
+  });
+
+  it('non-active principles are not evicted even when cap is exceeded', () => {
+    const candidates = [
+      makeCandidate('p_active_old', { status: 'active', lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+      makeCandidate('p_active_new', { status: 'active', lastTriggeredAt: '2026-06-01T00:00:00.000Z' }),
+      makeCandidate('p_archived', { status: 'archived', lastTriggeredAt: '2025-01-01T00:00:00.000Z' }),
+    ];
+    const result = enforceL1HardCap(candidates, { hardCap: 1 });
+    expect(result.beforeCount).toBe(2);
+    expect(result.afterCount).toBe(1);
+    expect(result.evictedIds).toEqual(['p_active_old']);
+  });
+
+  it('idempotent: calling twice with same input produces same result', () => {
+    const candidates = Array.from({ length: 15 }, (_, i) =>
+      makeCandidate(`p_${i}`, {
+        lastTriggeredAt: `2026-${String(i + 1).padStart(2, '0')}-01T00:00:00.000Z`,
+      }),
+    );
+    const result1 = enforceL1HardCap(candidates, { hardCap: 12 });
+    const result2 = enforceL1HardCap(candidates, { hardCap: 12 });
+    expect(result1).toEqual(result2);
+  });
+
+  it('observable result includes beforeCount, afterCount, evictedIds, reason, cap', () => {
+    const candidates = [
+      makeCandidate('p1', { lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+      makeCandidate('p2', { lastTriggeredAt: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const result = enforceL1HardCap(candidates, { hardCap: 1 });
+    expect(result).toHaveProperty('beforeCount');
+    expect(result).toHaveProperty('afterCount');
+    expect(result).toHaveProperty('evictedIds');
+    expect(result).toHaveProperty('reason');
+    expect(result).toHaveProperty('cap');
+    expect(result.cap).toBe(1);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it('empty candidates returns zero result', () => {
+    const result = enforceL1HardCap([], { hardCap: 12 });
+    expect(result.beforeCount).toBe(0);
+    expect(result.afterCount).toBe(0);
+    expect(result.evictedIds).toEqual([]);
+  });
+});
+
+describe('DEFAULT_L1_HARD_CAP and MAX_L1_HARD_CAP', () => {
+  it('DEFAULT_L1_HARD_CAP is 12', () => {
+    expect(DEFAULT_L1_HARD_CAP).toBe(12);
+  });
+
+  it('MAX_L1_HARD_CAP is 12', () => {
+    expect(MAX_L1_HARD_CAP).toBe(12);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/l1-hard-cap.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/l1-hard-cap.test.ts
@@ -37,6 +37,18 @@ describe('validateL1CapConfig', () => {
     expect(() => validateL1CapConfig({ hardCap: 0 })).toThrow(/cap/i);
     expect(() => validateL1CapConfig({ hardCap: -1 })).toThrow(/cap/i);
   });
+
+  it('rejects config with NaN', () => {
+    expect(() => validateL1CapConfig({ hardCap: NaN })).toThrow(/finite integer/i);
+  });
+
+  it('rejects config with non-integer', () => {
+    expect(() => validateL1CapConfig({ hardCap: 1.5 })).toThrow(/finite integer/i);
+  });
+
+  it('rejects config with Infinity', () => {
+    expect(() => validateL1CapConfig({ hardCap: Infinity })).toThrow(/finite integer/i);
+  });
 });
 
 describe('enforceL1HardCap', () => {
@@ -68,7 +80,7 @@ describe('enforceL1HardCap', () => {
   it('evicts multiple when active count far exceeds cap', () => {
     const candidates = Array.from({ length: 15 }, (_, i) =>
       makeCandidate(`p_${String(i).padStart(2, '0')}`, {
-        lastTriggeredAt: `2026-${String(i + 1).padStart(2, '0')}-01T00:00:00.000Z`,
+        lastTriggeredAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`,
       }),
     );
     const result = enforceL1HardCap(candidates, { hardCap: 12 });
@@ -122,7 +134,7 @@ describe('enforceL1HardCap', () => {
   it('idempotent: calling twice with same input produces same result', () => {
     const candidates = Array.from({ length: 15 }, (_, i) =>
       makeCandidate(`p_${i}`, {
-        lastTriggeredAt: `2026-${String(i + 1).padStart(2, '0')}-01T00:00:00.000Z`,
+        lastTriggeredAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`,
       }),
     );
     const result1 = enforceL1HardCap(candidates, { hardCap: 12 });
@@ -150,6 +162,22 @@ describe('enforceL1HardCap', () => {
     expect(result.beforeCount).toBe(0);
     expect(result.afterCount).toBe(0);
     expect(result.evictedIds).toEqual([]);
+  });
+
+  it('throws on invalid lastTriggeredAt timestamp', () => {
+    const candidates = [
+      makeCandidate('p1', { lastTriggeredAt: 'not-a-date' }),
+      makeCandidate('p2', { lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    expect(() => enforceL1HardCap(candidates, { hardCap: 1 })).toThrow(/Invalid lastTriggeredAt/);
+  });
+
+  it('throws on empty string lastTriggeredAt', () => {
+    const candidates = [
+      makeCandidate('p1', { lastTriggeredAt: '' }),
+      makeCandidate('p2', { lastTriggeredAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    expect(() => enforceL1HardCap(candidates, { hardCap: 1 })).toThrow(/Invalid lastTriggeredAt/);
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
@@ -437,6 +437,8 @@ describe('PruningReadModel', () => {
     expect(summary.watchCount).toBe(0);
     expect(summary.reviewCount).toBe(0);
     expect(summary.averageAgeDays).toBe(0);
+    expect(summary.activeL1Count).toBe(0);
+    expect(summary.l1Cap).toBe(12);
     expect(summary.generatedAt).toBeTruthy();
   });
 
@@ -589,6 +591,18 @@ describe('PruningReadModel', () => {
 
     expect(summary.totalPrinciples).toBe(4);
     expect(summary.orphanDerivedCandidateCount).toBe(1);
+    expect(summary.activeL1Count).toBe(3);
+  });
+
+  it('health summary uses custom l1Cap when provided', () => {
+    mockLedgerData = LEDGER_MIXED;
+    mockDbExists = false;
+
+    const model = new PruningReadModel({ workspaceDir: WORKSPACE, l1Cap: 8 });
+    const summary = model.getHealthSummary();
+
+    expect(summary.l1Cap).toBe(8);
+    expect(summary.activeL1Count).toBe(3);
   });
 
   it('orphan count matches getOrphanDerivedCandidates for same data', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
@@ -605,6 +605,12 @@ describe('PruningReadModel', () => {
     expect(summary.activeL1Count).toBe(3);
   });
 
+  it('constructor rejects invalid l1Cap via validateL1CapConfig', () => {
+    expect(() => new PruningReadModel({ workspaceDir: WORKSPACE, l1Cap: 0 })).toThrow();
+    expect(() => new PruningReadModel({ workspaceDir: WORKSPACE, l1Cap: 13 })).toThrow();
+    expect(() => new PruningReadModel({ workspaceDir: WORKSPACE, l1Cap: 1.5 })).toThrow();
+  });
+
   it('orphan count matches getOrphanDerivedCandidates for same data', () => {
     mockLedgerData = {
       tree: {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -294,6 +294,10 @@ export type { CompileResult } from './internalization/compile-result.js';
 // Pruning mask — builds masked principle set from review log (PRI-48)
 export { buildMaskedPrincipleSet, getCachedMaskedPrincipleSet, clearPruningMaskCache } from './pruning-mask.js';
 
+// L1 Hard Cap & LRU Eviction (PRI-139)
+export { enforceL1HardCap, validateL1CapConfig, DEFAULT_L1_HARD_CAP, MAX_L1_HARD_CAP } from './l1-hard-cap.js';
+export type { L1CapConfig, L1EvictionCandidate, L1EvictionResult } from './l1-hard-cap.js';
+
 // Decision merge and adapter interface (PRI-45)
 export type { DecisionMergeLogger, RuleHostLogger } from './internalization/rule-host-evaluator.js';
 export { mergeDecisions } from './internalization/rule-host-evaluator.js';

--- a/packages/principles-core/src/runtime-v2/l1-hard-cap.ts
+++ b/packages/principles-core/src/runtime-v2/l1-hard-cap.ts
@@ -22,12 +22,23 @@ export interface L1EvictionResult {
 }
 
 export function validateL1CapConfig(config: L1CapConfig): void {
+  if (!Number.isFinite(config.hardCap) || !Number.isInteger(config.hardCap)) {
+    throw new Error(`L1 hard cap must be a finite integer, got ${config.hardCap}.`);
+  }
   if (config.hardCap > MAX_L1_HARD_CAP) {
     throw new Error(`L1 hard cap ${config.hardCap} exceeds maximum allowed cap of ${MAX_L1_HARD_CAP}. Config may lower but not raise the cap above ${MAX_L1_HARD_CAP}.`);
   }
   if (config.hardCap <= 0) {
     throw new Error(`L1 hard cap must be a positive integer, got ${config.hardCap}.`);
   }
+}
+
+function parseTriggeredAtOrThrow(id: string, value: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid lastTriggeredAt for principle "${id}": ${value}`);
+  }
+  return parsed;
 }
 
 export function enforceL1HardCap(
@@ -50,8 +61,8 @@ export function enforceL1HardCap(
   }
 
   const sorted = [...active].sort((a, b) => {
-    const timeA = Date.parse(a.lastTriggeredAt);
-    const timeB = Date.parse(b.lastTriggeredAt);
+    const timeA = parseTriggeredAtOrThrow(a.id, a.lastTriggeredAt);
+    const timeB = parseTriggeredAtOrThrow(b.id, b.lastTriggeredAt);
     if (timeA !== timeB) return timeA - timeB;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });

--- a/packages/principles-core/src/runtime-v2/l1-hard-cap.ts
+++ b/packages/principles-core/src/runtime-v2/l1-hard-cap.ts
@@ -1,0 +1,69 @@
+import type { PrincipleStatus } from './pruning-read-model.js';
+
+export const DEFAULT_L1_HARD_CAP = 12;
+export const MAX_L1_HARD_CAP = 12;
+
+export interface L1CapConfig {
+  hardCap: number;
+}
+
+export interface L1EvictionCandidate {
+  id: string;
+  lastTriggeredAt: string;
+  status: PrincipleStatus;
+}
+
+export interface L1EvictionResult {
+  beforeCount: number;
+  afterCount: number;
+  evictedIds: string[];
+  reason: string;
+  cap: number;
+}
+
+export function validateL1CapConfig(config: L1CapConfig): void {
+  if (config.hardCap > MAX_L1_HARD_CAP) {
+    throw new Error(`L1 hard cap ${config.hardCap} exceeds maximum allowed cap of ${MAX_L1_HARD_CAP}. Config may lower but not raise the cap above ${MAX_L1_HARD_CAP}.`);
+  }
+  if (config.hardCap <= 0) {
+    throw new Error(`L1 hard cap must be a positive integer, got ${config.hardCap}.`);
+  }
+}
+
+export function enforceL1HardCap(
+  candidates: L1EvictionCandidate[],
+  config: L1CapConfig,
+): L1EvictionResult {
+  validateL1CapConfig(config);
+
+  const active = candidates.filter((c) => c.status === 'active');
+  const beforeCount = active.length;
+
+  if (beforeCount <= config.hardCap) {
+    return {
+      beforeCount,
+      afterCount: beforeCount,
+      evictedIds: [],
+      reason: '',
+      cap: config.hardCap,
+    };
+  }
+
+  const sorted = [...active].sort((a, b) => {
+    const timeA = Date.parse(a.lastTriggeredAt);
+    const timeB = Date.parse(b.lastTriggeredAt);
+    if (timeA !== timeB) return timeA - timeB;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  const evictCount = beforeCount - config.hardCap;
+  const evictedIds = sorted.slice(0, evictCount).map((c) => c.id);
+
+  return {
+    beforeCount,
+    afterCount: config.hardCap,
+    evictedIds,
+    reason: `l1-hard-cap: ${beforeCount} active L1 principles exceeded cap of ${config.hardCap}, evicted ${evictCount} least-recently-triggered`,
+    cap: config.hardCap,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/pruning-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-read-model.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import Database from 'better-sqlite3';
 import { loadLedger } from '../principle-tree-ledger.js';
+import { DEFAULT_L1_HARD_CAP } from './l1-hard-cap.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────────
 
@@ -45,6 +46,8 @@ export interface PruningHealthSummary {
   reviewCount: number;
   orphanDerivedCandidateCount: number;
   averageAgeDays: number;
+  activeL1Count: number;
+  l1Cap: number;
   generatedAt: string;
 }
 
@@ -67,6 +70,8 @@ export interface PruningReadModelOptions {
   watchThresholdDays?: number;
   /** Override days threshold for 'review' risk level (default: 90) */
   reviewThresholdDays?: number;
+  /** Override L1 hard cap for health summary (default: 12) */
+  l1Cap?: number;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -143,11 +148,13 @@ export class PruningReadModel {
   private readonly workspaceDir: string;
   private readonly watchThresholdDays: number;
   private readonly reviewThresholdDays: number;
+  private readonly l1Cap: number;
 
   constructor(opts: PruningReadModelOptions) {
     this.workspaceDir = opts.workspaceDir;
     this.watchThresholdDays = opts.watchThresholdDays ?? 30;
     this.reviewThresholdDays = opts.reviewThresholdDays ?? 90;
+    this.l1Cap = opts.l1Cap ?? DEFAULT_L1_HARD_CAP;
   }
 
   /**
@@ -276,6 +283,8 @@ export class PruningReadModel {
       averageAgeDays: signals.length > 0
         ? Math.round(totalAgeDays / signals.length)
         : 0,
+      activeL1Count: byStatus.active ?? 0,
+      l1Cap: this.l1Cap,
       generatedAt: now.toISOString(),
     };
   }

--- a/packages/principles-core/src/runtime-v2/pruning-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-read-model.ts
@@ -17,7 +17,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import Database from 'better-sqlite3';
 import { loadLedger } from '../principle-tree-ledger.js';
-import { DEFAULT_L1_HARD_CAP } from './l1-hard-cap.js';
+import { DEFAULT_L1_HARD_CAP, validateL1CapConfig } from './l1-hard-cap.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────────
 
@@ -155,6 +155,7 @@ export class PruningReadModel {
     this.watchThresholdDays = opts.watchThresholdDays ?? 30;
     this.reviewThresholdDays = opts.reviewThresholdDays ?? 90;
     this.l1Cap = opts.l1Cap ?? DEFAULT_L1_HARD_CAP;
+    validateL1CapConfig({ hardCap: this.l1Cap });
   }
 
   /**


### PR DESCRIPTION
## 现象

PD 可以产生超过 LLM 可靠使用的 active prompt principles，导致 system prompt 膨胀。

## 根因

无 hard cap 限制 active L1 principle 数量，Activation 自动化会无限增加。

## 修改文件

- \untime-v2/l1-hard-cap.ts\ (新建) — L1 hard cap 纯函数 + 类型
- \untime-v2/__tests__/l1-hard-cap.test.ts\ (新建) — 14 个 TDD 测试
- \principle-tree-ledger.ts\ (修改) — 添加 \lastTriggeredAt?: string\
- \untime-v2/pruning-read-model.ts\ (修改) — 扩展 health summary 增加 \ctiveL1Count\ 和 \l1Cap\
- \untime-v2/index.ts\ (修改) — 导出新符号
- \untime-v2/__tests__/architecture-regression.test.ts\ (修改) — 添加 PRI-139 断言
- \untime-v2/__tests__/pruning-read-model.test.ts\ (修改) — 扩展 health summary 测试

## 测试命令

\\\ash
npm run build --workspace=@principles/core
npx vitest run packages/principles-core/src/runtime-v2/__tests__/l1-hard-cap.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts -t PRI-139
npx vitest run packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
\\\

## 测试结果

- 14 l1-hard-cap tests: ✅ PASS
- 5 PRI-139 architecture-regression tests: ✅ PASS
- 24 pruning-read-model tests: ✅ PASS
- 71 total tests across affected files: ✅ PASS
- Build: ✅ PASS
- Lint: ✅ PASS
- TypeCheck (core + plugin + cli): ✅ PASS

## 剩余风险

- \lastTriggeredAt\ 需要调用方在 principle 被触发时更新，当前仅添加字段定义
- 实际的 ledger 写入淘汰操作由 plugin 侧调用，本 PR 只提供纯函数
- 淘汰语义为 status active → archived，调用方需通过现有 ledger API 执行状态变更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新增功能**
  * 新增 L1 硬上限（Hard Cap）功能，支持配置和强制执行原则 L1 层级的容量限制。
  * 当活跃原则数量超出上限时，系统将自动按最近触发时间优先驱逐超限部分。
  * 健康摘要现支持显示活跃 L1 原则数量及当前容量上限。

* **测试**
  * 新增 L1 硬上限验证和驱逐机制的单元测试。
  * 新增架构回归测试，确保相关模块完整性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->