### PR TITLE
feat(runtime): add intake-to-internalization bridge (PRI-142)

### DIFF
--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -21,7 +21,8 @@ import {
   loadLedger,
   getLedgerFilePathPublic,
   decideInternalizationRoute,
-  createPITaskDiagnosticJson,
+  computeBridgeDecision,
+  buildDreamerTaskSeed,
   type LedgerPrincipleEntry,
 } from '@principles/core/runtime-v2';
 import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
@@ -213,13 +214,6 @@ interface CandidateInternalizeResult {
   reason?: string;
 }
 
-const ROUTE_CHANNEL_MAP: Record<string, string> = {
-  'principle-ledger': 'prompt',
-  'rule-candidate': 'code_tool_hook',
-  'implementation-candidate': 'skill',
-  'prompt-injection-candidate': 'prompt',
-};
-
 export async function handleCandidateInternalize(opts: CandidateInternalizeOptions): Promise<void> {
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
   const stateManager = new RuntimeStateManager({ workspaceDir });
@@ -248,12 +242,23 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
 
     const decision = decideInternalizationRoute(recommendation as Parameters<typeof decideInternalizationRoute>[0]);
 
-    if (!decision.ready || decision.route === 'deferred') {
+    const bridgeInput = {
+      candidateId: opts.candidateId,
+      recommendationKind: recommendation.kind,
+      route: decision.route,
+    };
+
+    const bridgeDecision = computeBridgeDecision(bridgeInput);
+
+    if (bridgeDecision.decision !== 'seeded') {
+      const reason = bridgeDecision.decision === 'already_exists'
+        ? `Task ${bridgeDecision.taskId} already exists`
+        : bridgeDecision.reason;
       const result: CandidateInternalizeResult = {
         candidateId: opts.candidateId,
         route: decision.route,
         status: 'no_task_created',
-        reason: decision.reason,
+        reason,
       };
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
@@ -267,7 +272,8 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
       return;
     }
 
-    const channel = ROUTE_CHANNEL_MAP[decision.route] ?? 'prompt';
+    const {channel} = bridgeDecision;
+    const {taskId} = bridgeDecision;
 
     if (opts.dryRun) {
       const result: CandidateInternalizeResult = {
@@ -288,8 +294,6 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
       }
       return;
     }
-
-    const taskId = `dreamer-${opts.candidateId}-${channel}`;
 
     const existingTask = await stateManager.getTask(taskId);
     if (existingTask) {
@@ -313,32 +317,29 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
       return;
     }
 
-    const diagnosticJson = createPITaskDiagnosticJson({
-      dependencyTaskIds: [],
-      channel: channel as 'prompt' | 'skill' | 'code_tool_hook' | 'model_training',
-      timeoutMs: 300_000,
-      inputArtifactRefs: [{ artifactType: 'candidate', ref: `candidate://${opts.candidateId}` }],
-      outputArtifactRefs: [],
-      parentTaskId: undefined,
-      correlationId: opts.candidateId,
-    });
-
-    let finalDiagnosticJson = diagnosticJson;
-    try {
-      const diagObj = JSON.parse(diagnosticJson);
-      diagObj.candidateId = opts.candidateId;
-      finalDiagnosticJson = JSON.stringify(diagObj);
-    } catch {
-      finalDiagnosticJson = diagnosticJson;
+    const seed = buildDreamerTaskSeed(bridgeInput);
+    if ('decision' in seed) {
+      const result: CandidateInternalizeResult = {
+        candidateId: opts.candidateId,
+        route: decision.route,
+        status: 'no_task_created',
+        reason: (seed as { reason: string }).reason,
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.error(`Bridge seed failed: ${(seed as { reason: string }).reason}`);
+      }
+      return;
     }
 
     const task = await stateManager.createTask({
-      taskId,
-      taskKind: 'dreamer',
-      status: 'pending',
-      attemptCount: 0,
-      maxAttempts: 3,
-      diagnosticJson: finalDiagnosticJson,
+      taskId: seed.taskId,
+      taskKind: seed.taskKind,
+      status: seed.status,
+      attemptCount: seed.attemptCount,
+      maxAttempts: seed.maxAttempts,
+      diagnosticJson: seed.diagnosticJson,
     });
 
     const result: CandidateInternalizeResult = {
@@ -780,14 +781,25 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
       const recommendation = resolveCandidateRecommendation(candidate, stateManager, candidateId);
       const decision = decideInternalizationRoute(recommendation as Parameters<typeof decideInternalizationRoute>[0]);
 
-      if (!decision.ready || decision.route === 'deferred') {
+      const bridgeInput = {
+        candidateId,
+        recommendationKind: recommendation.kind,
+        route: decision.route,
+      };
+
+      const bridgeDecision = computeBridgeDecision(bridgeInput);
+
+      if (bridgeDecision.decision !== 'seeded') {
         output.deferred++;
-        output.results.push({ candidateId, route: decision.route, status: 'deferred', reason: decision.reason });
+        const reason = bridgeDecision.decision === 'already_exists'
+          ? `Task ${bridgeDecision.taskId} already exists`
+          : bridgeDecision.reason;
+        output.results.push({ candidateId, route: decision.route, status: 'deferred', reason });
         continue;
       }
 
-      const channel = ROUTE_CHANNEL_MAP[decision.route] ?? 'prompt';
-      const taskId = `dreamer-${candidateId}-${channel}`;
+      const {channel} = bridgeDecision;
+      const {taskId} = bridgeDecision;
 
       const existingTask = await stateManager.getTask(taskId);
       if (existingTask) {
@@ -813,27 +825,20 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
       }
 
       try {
-        const diagnosticJson = createPITaskDiagnosticJson({
-          dependencyTaskIds: [],
-          channel: channel as 'prompt' | 'skill' | 'code_tool_hook' | 'model_training',
-          timeoutMs: 300_000,
-          inputArtifactRefs: [{ artifactType: 'candidate', ref: `candidate://${candidateId}` }],
-          outputArtifactRefs: [],
-          parentTaskId: undefined,
-          correlationId: candidateId,
-        });
-
-        const diagObj = JSON.parse(diagnosticJson);
-        diagObj.candidateId = candidateId;
-        const finalDiagnosticJson = JSON.stringify(diagObj);
+        const seed = buildDreamerTaskSeed(bridgeInput);
+        if ('decision' in seed) {
+          output.errors++;
+          output.results.push({ candidateId, route: decision.route, status: 'error', reason: (seed as { reason: string }).reason });
+          continue;
+        }
 
         const task = await stateManager.createTask({
-          taskId,
-          taskKind: 'dreamer',
-          status: 'pending',
-          attemptCount: 0,
-          maxAttempts: 3,
-          diagnosticJson: finalDiagnosticJson,
+          taskId: seed.taskId,
+          taskKind: seed.taskKind,
+          status: seed.status,
+          attemptCount: seed.attemptCount,
+          maxAttempts: seed.maxAttempts,
+          diagnosticJson: seed.diagnosticJson,
         });
 
         output.created++;

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -246,6 +246,7 @@ export async function handleCandidateInternalize(opts: CandidateInternalizeOptio
       candidateId: opts.candidateId,
       recommendationKind: recommendation.kind,
       route: decision.route,
+      ready: decision.ready,
     };
 
     const bridgeDecision = computeBridgeDecision(bridgeInput);
@@ -785,6 +786,7 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
         candidateId,
         recommendationKind: recommendation.kind,
         route: decision.route,
+        ready: decision.ready,
       };
 
       const bridgeDecision = computeBridgeDecision(bridgeInput);

--- a/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
@@ -16,50 +16,46 @@ vi.mock('../../src/principle-tree-ledger-adapter.js', () => ({
   PrincipleTreeLedgerAdapter: vi.fn(),
 }));
 
-vi.mock('@principles/core/runtime-v2', () => ({
-  RuntimeStateManager: vi.fn().mockImplementation(function () {
-    return {
-      initialize: mockInitialize,
-      close: mockClose,
-      getCandidate: mockGetCandidate,
-      getTask: mockGetTask,
-      createTask: mockCreateTask,
-      updateTaskDiagnosticJson: mockUpdateTaskDiagnosticJson,
-      connection: {
-        getDb: () => ({
-          prepare: () => ({ all: mockAll, get: vi.fn(), run: vi.fn() }),
-        }),
-      },
-    };
-  }),
-  SqliteConnection: vi.fn(),
-  candidateList: vi.fn(),
-  candidateShow: vi.fn(),
-  CandidateIntakeService: vi.fn(),
-  CandidateIntakeError: class CandidateIntakeError extends Error {},
-  loadLedger: vi.fn(),
-  getLedgerFilePathPublic: vi.fn(),
-  decideInternalizationRoute: vi.fn(() => ({
-    ready: true,
-    route: 'principle-ledger',
-    reason: 'ready',
-    missingFields: [],
-    nextAction: 'internalize',
-  })),
-  createPITaskDiagnosticJson: vi.fn(() => JSON.stringify({ pi_metadata: { channel: 'prompt' } })),
-  createRemediationResult: vi.fn((input) => ({
-    mode: input.mode,
-    status: input.status ?? (input.mode === 'dry_run'
-      ? (input.actions?.length > 0 ? 'would_change' : 'no_op')
-      : (input.repairedCount > 0 ? 'changed' : 'no_op')),
-    safeToConfirm: input.safeToConfirm ?? false,
-    repairedCount: input.repairedCount ?? 0,
-    skippedCount: input.skippedCount ?? 0,
-    actions: input.actions ?? [],
-    warnings: input.warnings ?? [],
-  })),
-  remediationAction: vi.fn((input) => input),
-}));
+vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>;
+  return {
+    ...original,
+    RuntimeStateManager: vi.fn().mockImplementation(function () {
+      return {
+        initialize: mockInitialize,
+        close: mockClose,
+        getCandidate: mockGetCandidate,
+        getTask: mockGetTask,
+        createTask: mockCreateTask,
+        updateTaskDiagnosticJson: mockUpdateTaskDiagnosticJson,
+        connection: {
+          getDb: () => ({
+            prepare: () => ({ all: mockAll, get: vi.fn(), run: vi.fn() }),
+          }),
+        },
+      };
+    }),
+    decideInternalizationRoute: vi.fn(() => ({
+      ready: true,
+      route: 'principle-ledger',
+      reason: 'ready',
+      missingFields: [],
+      nextAction: 'internalize',
+    })),
+    createRemediationResult: vi.fn((input: { mode: string; status?: string; safeToConfirm?: boolean; repairedCount?: number; skippedCount?: number; actions?: unknown[]; warnings?: unknown[] }) => ({
+      mode: input.mode,
+      status: input.status ?? (input.mode === 'dry_run'
+        ? ((input.actions?.length ?? 0) > 0 ? 'would_change' : 'no_op')
+        : ((input.repairedCount ?? 0) > 0 ? 'changed' : 'no_op')),
+      safeToConfirm: input.safeToConfirm ?? false,
+      repairedCount: input.repairedCount ?? 0,
+      skippedCount: input.skippedCount ?? 0,
+      actions: input.actions ?? [],
+      warnings: input.warnings ?? [],
+    })),
+    remediationAction: vi.fn((input: unknown) => input),
+  };
+});
 
 import { handleCandidateInternalizationBackfill } from '../../src/commands/candidate.js';
 
@@ -121,4 +117,3 @@ describe('pd candidate internalization backfill remediation contract', () => {
     exitSpy.mockRestore();
   });
 });
-

--- a/packages/pd-cli/tests/commands/candidate-internalize.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-internalize.test.ts
@@ -21,11 +21,14 @@ const { mockStateManager, MockRuntimeStateManager } = vi.hoisted(() => {
   return { mockStateManager, MockRuntimeStateManager };
 });
 
-vi.mock('@principles/core/runtime-v2', () => ({
-  RuntimeStateManager: MockRuntimeStateManager,
-  decideInternalizationRoute: vi.fn(),
-  createPITaskDiagnosticJson: vi.fn().mockReturnValue('{"pi_metadata":{}}'),
-}));
+vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>;
+  return {
+    ...original,
+    RuntimeStateManager: MockRuntimeStateManager,
+    decideInternalizationRoute: vi.fn(),
+  };
+});
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/test-workspace'),

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -117,6 +117,8 @@ const REQUIRED_SOURCE_FILES = [
   'store/sqlite-connection.ts',
   // PRI-139
   'l1-hard-cap.ts',
+  // PRI-142
+  'internalization/intake-to-internalization-bridge.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -159,6 +161,8 @@ const REQUIRED_TEST_FILES = [
   'task-three-strikes.test.ts',
   // PRI-139
   'l1-hard-cap.test.ts',
+  // PRI-142
+  'intake-to-internalization-bridge.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [
@@ -2526,6 +2530,54 @@ describe('PRI-139 L1 Hard Cap & LRU Eviction', () => {
     const src = readFileSync(resolve(__dirname, '..', 'pruning-read-model.ts'), 'utf-8');
     expect(src).toContain('activeL1Count');
     expect(src).toContain('l1Cap');
+  });
+});
+
+// ── PRI-142: IntakeToInternalizationBridge ──────────────────────────────────────
+
+describe('PRI-142 IntakeToInternalizationBridge', () => {
+  it('core barrel exports computeBridgeDecision, buildDreamerTaskSeed, seedIntakeTask, ROUTE_CHANNEL_MAP', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('computeBridgeDecision');
+    expect(src).toContain('buildDreamerTaskSeed');
+    expect(src).toContain('seedIntakeTask');
+    expect(src).toContain('ROUTE_CHANNEL_MAP');
+  });
+
+  it('core barrel exports IntakeToInternalizationBridgeInput, BridgeDecision, BridgeTaskSeed, BridgeTaskStore types', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('IntakeToInternalizationBridgeInput');
+    expect(src).toContain('BridgeDecision');
+    expect(src).toContain('BridgeTaskSeed');
+    expect(src).toContain('BridgeTaskStore');
+  });
+
+  it('intake-to-internalization-bridge.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'intake-to-internalization-bridge.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('node:process');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('internalization/index.ts exports bridge symbols', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).toContain('computeBridgeDecision');
+    expect(src).toContain('buildDreamerTaskSeed');
+    expect(src).toContain('seedIntakeTask');
+    expect(src).toContain('ROUTE_CHANNEL_MAP');
+    expect(src).toContain('IntakeToInternalizationBridgeInput');
+    expect(src).toContain('BridgeDecision');
+    expect(src).toContain('BridgeTaskSeed');
+    expect(src).toContain('BridgeTaskStore');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  computeBridgeDecision,
+  buildDreamerTaskSeed,
+  seedIntakeTask,
+  ROUTE_CHANNEL_MAP,
+} from '../internalization/intake-to-internalization-bridge.js';
+import type {
+  IntakeToInternalizationBridgeInput,
+  BridgeTaskStore,
+} from '../internalization/intake-to-internalization-bridge.js';
+import { parsePITaskMetadata } from '../internalization/pitask-metadata.js';
+import type { InternalizationRouteKind } from '../internalization/internalization-route.js';
+
+const validInput: IntakeToInternalizationBridgeInput = {
+  candidateId: 'cand-001',
+  recommendationKind: 'principle',
+  route: 'principle-ledger',
+};
+
+describe('IntakeToInternalizationBridge (PRI-142)', () => {
+  describe('computeBridgeDecision', () => {
+    it('internalizable candidate returns seeded decision', () => {
+      const result = computeBridgeDecision(validInput);
+      expect(result.decision).toBe('seeded');
+      if (result.decision === 'seeded') {
+        expect(result.taskId).toBe('dreamer-cand-001-prompt');
+        expect(result.taskKind).toBe('dreamer');
+        expect(result.channel).toBe('prompt');
+      }
+    });
+
+    it('defer route returns not_internalizable', () => {
+      const result = computeBridgeDecision({
+        ...validInput,
+        route: 'deferred',
+        recommendationKind: 'defer',
+      });
+      expect(result.decision).toBe('not_internalizable');
+      if (result.decision === 'not_internalizable') {
+        expect(result.reason).toContain('deferred');
+      }
+    });
+
+    it('empty candidateId returns invalid_candidate', () => {
+      const result = computeBridgeDecision({
+        ...validInput,
+        candidateId: '',
+      });
+      expect(result.decision).toBe('invalid_candidate');
+    });
+
+    it('whitespace-only candidateId returns invalid_candidate', () => {
+      const result = computeBridgeDecision({
+        ...validInput,
+        candidateId: '   ',
+      });
+      expect(result.decision).toBe('invalid_candidate');
+    });
+
+    it('unknown route returns not_internalizable', () => {
+      const result = computeBridgeDecision({
+        ...validInput,
+        route: 'unknown-route' as InternalizationRouteKind,
+      });
+      expect(result.decision).toBe('not_internalizable');
+    });
+
+    it('rule-candidate route maps to code_tool_hook channel', () => {
+      const result = computeBridgeDecision({
+        candidateId: 'cand-rule',
+        recommendationKind: 'rule',
+        route: 'rule-candidate',
+      });
+      expect(result.decision).toBe('seeded');
+      if (result.decision === 'seeded') {
+        expect(result.channel).toBe('code_tool_hook');
+        expect(result.taskId).toBe('dreamer-cand-rule-code_tool_hook');
+      }
+    });
+
+    it('implementation-candidate route maps to skill channel', () => {
+      const result = computeBridgeDecision({
+        candidateId: 'cand-impl',
+        recommendationKind: 'implementation',
+        route: 'implementation-candidate',
+      });
+      expect(result.decision).toBe('seeded');
+      if (result.decision === 'seeded') {
+        expect(result.channel).toBe('skill');
+      }
+    });
+
+    it('prompt-injection-candidate route maps to prompt channel', () => {
+      const result = computeBridgeDecision({
+        candidateId: 'cand-prompt',
+        recommendationKind: 'prompt',
+        route: 'prompt-injection-candidate',
+      });
+      expect(result.decision).toBe('seeded');
+      if (result.decision === 'seeded') {
+        expect(result.channel).toBe('prompt');
+      }
+    });
+  });
+
+  describe('buildDreamerTaskSeed', () => {
+    it('returns BridgeTaskSeed for valid input', () => {
+      const result = buildDreamerTaskSeed(validInput);
+      if (!('decision' in result)) {
+        expect(result.taskId).toBe('dreamer-cand-001-prompt');
+        expect(result.taskKind).toBe('dreamer');
+        expect(result.channel).toBe('prompt');
+        expect(result.status).toBe('pending');
+        expect(result.attemptCount).toBe(0);
+        expect(result.maxAttempts).toBe(3);
+      }
+    });
+
+    it('returns BridgeDecision for invalid input', () => {
+      const result = buildDreamerTaskSeed({
+        ...validInput,
+        candidateId: '',
+      });
+      if ('decision' in result) {
+        expect(result.decision).toBe('invalid_candidate');
+      }
+    });
+
+    it('created task metadata can be parsed by parsePITaskMetadata', () => {
+      const result = buildDreamerTaskSeed(validInput);
+      if ('diagnosticJson' in result) {
+        const meta = parsePITaskMetadata(result.diagnosticJson);
+        expect(meta).not.toBeNull();
+        if (meta) {
+          expect(meta.dependencyTaskIds).toEqual([]);
+          expect(meta.channel).toBe('prompt');
+          expect(meta.timeoutMs).toBe(300_000);
+          expect(meta.inputArtifactRefs).toEqual([
+            { artifactType: 'candidate', ref: 'candidate://cand-001' },
+          ]);
+          expect(meta.outputArtifactRefs).toEqual([]);
+          expect(meta.correlationId).toBe('cand-001');
+        }
+      }
+    });
+
+    it('dependencyTaskIds is empty, channel is correct, taskKind is dreamer', () => {
+      const result = buildDreamerTaskSeed(validInput);
+      if ('diagnosticJson' in result) {
+        const meta = parsePITaskMetadata(result.diagnosticJson);
+        if (meta) {
+          expect(meta.dependencyTaskIds).toEqual([]);
+          expect(meta.channel).toBe('prompt');
+        }
+        expect(result.taskKind).toBe('dreamer');
+      }
+    });
+  });
+
+  describe('seedIntakeTask', () => {
+    const mockStore: BridgeTaskStore = {
+      getTask: vi.fn().mockResolvedValue(null),
+      createTask: vi.fn().mockResolvedValue({ taskId: 'dreamer-cand-001-prompt' }),
+    };
+
+    it('creates dreamer task for internalizable candidate', async () => {
+      vi.clearAllMocks();
+      (mockStore.getTask as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (mockStore.createTask as ReturnType<typeof vi.fn>).mockResolvedValue({ taskId: 'dreamer-cand-001-prompt' });
+
+      const result = await seedIntakeTask(validInput, mockStore);
+      expect(result.decision).toBe('seeded');
+      if (result.decision === 'seeded') {
+        expect(result.taskId).toBe('dreamer-cand-001-prompt');
+        expect(result.taskKind).toBe('dreamer');
+        expect(result.channel).toBe('prompt');
+      }
+      expect(mockStore.createTask).toHaveBeenCalledOnce();
+    });
+
+    it('returns already_exists when task already exists', async () => {
+      vi.clearAllMocks();
+      (mockStore.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({ taskId: 'dreamer-cand-001-prompt' });
+
+      const result = await seedIntakeTask(validInput, mockStore);
+      expect(result.decision).toBe('already_exists');
+      if (result.decision === 'already_exists') {
+        expect(result.taskId).toBe('dreamer-cand-001-prompt');
+      }
+      expect(mockStore.createTask).not.toHaveBeenCalled();
+    });
+
+    it('returns not_internalizable for deferred route', async () => {
+      vi.clearAllMocks();
+      const result = await seedIntakeTask(
+        { ...validInput, route: 'deferred', recommendationKind: 'defer' },
+        mockStore,
+      );
+      expect(result.decision).toBe('not_internalizable');
+      expect(mockStore.getTask).not.toHaveBeenCalled();
+      expect(mockStore.createTask).not.toHaveBeenCalled();
+    });
+
+    it('returns invalid_candidate for empty candidateId', async () => {
+      vi.clearAllMocks();
+      const result = await seedIntakeTask(
+        { ...validInput, candidateId: '' },
+        mockStore,
+      );
+      expect(result.decision).toBe('invalid_candidate');
+      expect(mockStore.getTask).not.toHaveBeenCalled();
+      expect(mockStore.createTask).not.toHaveBeenCalled();
+    });
+
+    it('fails loud on store createTask error', async () => {
+      vi.clearAllMocks();
+      (mockStore.getTask as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (mockStore.createTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB write failed'));
+
+      await expect(
+        seedIntakeTask(validInput, mockStore),
+      ).rejects.toThrow('DB write failed');
+    });
+
+    it('fails loud on store getTask error', async () => {
+      vi.clearAllMocks();
+      (mockStore.getTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB read failed'));
+
+      await expect(
+        seedIntakeTask(validInput, mockStore),
+      ).rejects.toThrow('DB read failed');
+    });
+  });
+
+  describe('ROUTE_CHANNEL_MAP', () => {
+    it('maps all four internalizable routes', () => {
+      expect(ROUTE_CHANNEL_MAP['principle-ledger']).toBe('prompt');
+      expect(ROUTE_CHANNEL_MAP['rule-candidate']).toBe('code_tool_hook');
+      expect(ROUTE_CHANNEL_MAP['implementation-candidate']).toBe('skill');
+      expect(ROUTE_CHANNEL_MAP['prompt-injection-candidate']).toBe('prompt');
+    });
+
+    it('does not map deferred route', () => {
+      expect(ROUTE_CHANNEL_MAP.deferred).toBeUndefined();
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
@@ -122,14 +122,16 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
   describe('buildDreamerTaskSeed', () => {
     it('returns BridgeTaskSeed for valid input', () => {
       const result = buildDreamerTaskSeed(validInput);
-      if (!('decision' in result)) {
-        expect(result.taskId).toBe('dreamer-cand-001-prompt');
-        expect(result.taskKind).toBe('dreamer');
-        expect(result.channel).toBe('prompt');
-        expect(result.status).toBe('pending');
-        expect(result.attemptCount).toBe(0);
-        expect(result.maxAttempts).toBe(3);
+      expect('decision' in result).toBe(false);
+      if ('decision' in result) {
+        throw new Error(`unexpected decision: ${(result as { decision: string }).decision}`);
       }
+      expect(result.taskId).toBe('dreamer-cand-001-prompt');
+      expect(result.taskKind).toBe('dreamer');
+      expect(result.channel).toBe('prompt');
+      expect(result.status).toBe('pending');
+      expect(result.attemptCount).toBe(0);
+      expect(result.maxAttempts).toBe(3);
     });
 
     it('returns BridgeDecision for invalid input', () => {
@@ -137,9 +139,11 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
         ...validInput,
         candidateId: '',
       });
-      if ('decision' in result) {
-        expect(result.decision).toBe('invalid_candidate');
+      expect('decision' in result).toBe(true);
+      if (!('decision' in result)) {
+        throw new Error('expected decision result');
       }
+      expect(result.decision).toBe('invalid_candidate');
     });
 
     it('returns BridgeDecision for not-ready input', () => {
@@ -147,47 +151,55 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
         ...validInput,
         ready: false,
       });
-      if ('decision' in result) {
-        expect(result.decision).toBe('not_internalizable');
+      expect('decision' in result).toBe(true);
+      if (!('decision' in result)) {
+        throw new Error('expected decision result');
       }
+      expect(result.decision).toBe('not_internalizable');
     });
 
     it('created task metadata can be parsed by parsePITaskMetadata', () => {
       const result = buildDreamerTaskSeed(validInput);
-      if ('diagnosticJson' in result) {
-        const meta = parsePITaskMetadata(result.diagnosticJson);
-        expect(meta).not.toBeNull();
-        if (meta) {
-          expect(meta.dependencyTaskIds).toEqual([]);
-          expect(meta.channel).toBe('prompt');
-          expect(meta.timeoutMs).toBe(300_000);
-          expect(meta.inputArtifactRefs).toEqual([
-            { artifactType: 'candidate', ref: 'candidate://cand-001' },
-          ]);
-          expect(meta.outputArtifactRefs).toEqual([]);
-          expect(meta.correlationId).toBe('cand-001');
-        }
+      expect('decision' in result).toBe(false);
+      if ('decision' in result) {
+        throw new Error(`unexpected decision: ${(result as { decision: string }).decision}`);
+      }
+      const meta = parsePITaskMetadata(result.diagnosticJson);
+      expect(meta).not.toBeNull();
+      if (meta) {
+        expect(meta.dependencyTaskIds).toEqual([]);
+        expect(meta.channel).toBe('prompt');
+        expect(meta.timeoutMs).toBe(300_000);
+        expect(meta.inputArtifactRefs).toEqual([
+          { artifactType: 'candidate', ref: 'candidate://cand-001' },
+        ]);
+        expect(meta.outputArtifactRefs).toEqual([]);
+        expect(meta.correlationId).toBe('cand-001');
       }
     });
 
     it('diagnosticJson contains top-level candidateId for chain integrity', () => {
       const result = buildDreamerTaskSeed(validInput);
-      if ('diagnosticJson' in result) {
-        const diagObj = JSON.parse(result.diagnosticJson);
-        expect(diagObj.candidateId).toBe('cand-001');
+      expect('decision' in result).toBe(false);
+      if ('decision' in result) {
+        throw new Error(`unexpected decision: ${(result as { decision: string }).decision}`);
       }
+      const diagObj = JSON.parse(result.diagnosticJson);
+      expect(diagObj.candidateId).toBe('cand-001');
     });
 
     it('dependencyTaskIds is empty, channel is correct, taskKind is dreamer', () => {
       const result = buildDreamerTaskSeed(validInput);
-      if ('diagnosticJson' in result) {
-        const meta = parsePITaskMetadata(result.diagnosticJson);
-        if (meta) {
-          expect(meta.dependencyTaskIds).toEqual([]);
-          expect(meta.channel).toBe('prompt');
-        }
-        expect(result.taskKind).toBe('dreamer');
+      expect('decision' in result).toBe(false);
+      if ('decision' in result) {
+        throw new Error(`unexpected decision: ${(result as { decision: string }).decision}`);
       }
+      const meta = parsePITaskMetadata(result.diagnosticJson);
+      if (meta) {
+        expect(meta.dependencyTaskIds).toEqual([]);
+        expect(meta.channel).toBe('prompt');
+      }
+      expect(result.taskKind).toBe('dreamer');
     });
   });
 
@@ -274,6 +286,32 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
       await expect(
         seedIntakeTask(validInput, mockStore),
       ).rejects.toThrow('DB read failed');
+    });
+
+    it('returns already_exists on concurrent createTask conflict', async () => {
+      vi.clearAllMocks();
+      (mockStore.getTask as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ taskId: 'dreamer-cand-001-prompt' });
+      (mockStore.createTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('UNIQUE constraint failed'));
+
+      const result = await seedIntakeTask(validInput, mockStore);
+      expect(result.decision).toBe('already_exists');
+      if (result.decision === 'already_exists') {
+        expect(result.taskId).toBe('dreamer-cand-001-prompt');
+      }
+    });
+
+    it('re-throws non-concurrent createTask errors', async () => {
+      vi.clearAllMocks();
+      (mockStore.getTask as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      (mockStore.createTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('disk full'));
+
+      await expect(
+        seedIntakeTask(validInput, mockStore),
+      ).rejects.toThrow('disk full');
     });
   });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
@@ -16,6 +16,7 @@ const validInput: IntakeToInternalizationBridgeInput = {
   candidateId: 'cand-001',
   recommendationKind: 'principle',
   route: 'principle-ledger',
+  ready: true,
 };
 
 describe('IntakeToInternalizationBridge (PRI-142)', () => {
@@ -27,6 +28,17 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
         expect(result.taskId).toBe('dreamer-cand-001-prompt');
         expect(result.taskKind).toBe('dreamer');
         expect(result.channel).toBe('prompt');
+      }
+    });
+
+    it('ready=false returns not_internalizable even with mapped route', () => {
+      const result = computeBridgeDecision({
+        ...validInput,
+        ready: false,
+      });
+      expect(result.decision).toBe('not_internalizable');
+      if (result.decision === 'not_internalizable') {
+        expect(result.reason).toContain('not ready');
       }
     });
 
@@ -71,6 +83,7 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
         candidateId: 'cand-rule',
         recommendationKind: 'rule',
         route: 'rule-candidate',
+        ready: true,
       });
       expect(result.decision).toBe('seeded');
       if (result.decision === 'seeded') {
@@ -84,6 +97,7 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
         candidateId: 'cand-impl',
         recommendationKind: 'implementation',
         route: 'implementation-candidate',
+        ready: true,
       });
       expect(result.decision).toBe('seeded');
       if (result.decision === 'seeded') {
@@ -96,6 +110,7 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
         candidateId: 'cand-prompt',
         recommendationKind: 'prompt',
         route: 'prompt-injection-candidate',
+        ready: true,
       });
       expect(result.decision).toBe('seeded');
       if (result.decision === 'seeded') {
@@ -127,6 +142,16 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
       }
     });
 
+    it('returns BridgeDecision for not-ready input', () => {
+      const result = buildDreamerTaskSeed({
+        ...validInput,
+        ready: false,
+      });
+      if ('decision' in result) {
+        expect(result.decision).toBe('not_internalizable');
+      }
+    });
+
     it('created task metadata can be parsed by parsePITaskMetadata', () => {
       const result = buildDreamerTaskSeed(validInput);
       if ('diagnosticJson' in result) {
@@ -142,6 +167,14 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
           expect(meta.outputArtifactRefs).toEqual([]);
           expect(meta.correlationId).toBe('cand-001');
         }
+      }
+    });
+
+    it('diagnosticJson contains top-level candidateId for chain integrity', () => {
+      const result = buildDreamerTaskSeed(validInput);
+      if ('diagnosticJson' in result) {
+        const diagObj = JSON.parse(result.diagnosticJson);
+        expect(diagObj.candidateId).toBe('cand-001');
       }
     });
 
@@ -195,6 +228,17 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
       vi.clearAllMocks();
       const result = await seedIntakeTask(
         { ...validInput, route: 'deferred', recommendationKind: 'defer' },
+        mockStore,
+      );
+      expect(result.decision).toBe('not_internalizable');
+      expect(mockStore.getTask).not.toHaveBeenCalled();
+      expect(mockStore.createTask).not.toHaveBeenCalled();
+    });
+
+    it('returns not_internalizable for ready=false', async () => {
+      vi.clearAllMocks();
+      const result = await seedIntakeTask(
+        { ...validInput, ready: false },
         mockStore,
       );
       expect(result.decision).toBe('not_internalizable');

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -713,6 +713,22 @@ export type {
 export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';
 export { MemoryPIArtifactStore } from './internalization/pi-artifact-store.js';
 
+// ── Intake To Internalization Bridge (PRI-142) ────────────────────────────────
+
+export type {
+  IntakeToInternalizationBridgeInput,
+  BridgeDecision,
+  BridgeTaskSeed,
+  BridgeTaskStore,
+} from './internalization/intake-to-internalization-bridge.js';
+
+export {
+  ROUTE_CHANNEL_MAP,
+  computeBridgeDecision,
+  buildDreamerTaskSeed,
+  seedIntakeTask,
+} from './internalization/intake-to-internalization-bridge.js';
+
 // ── Internalization Queue Read Model (PRI-73) ──────────────────────────────
 
 export { InternalizationQueueReadModel } from './internalization-queue-read-model.js';

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -422,3 +422,19 @@ export { InternalizationOrchestrator, WAKE_ONCE_DECISIONS } from './internalizat
 export type { PIArtifactRecord, PIArtifactStore } from './pi-artifact.js';
 export { MemoryPIArtifactStore } from './pi-artifact-store.js';
 export { SqlitePIArtifactStore } from '../store/artifact/sqlite-pi-artifact-store.js';
+
+// ── Intake To Internalization Bridge (PRI-142) ────────────────────────────────
+
+export type {
+  IntakeToInternalizationBridgeInput,
+  BridgeDecision,
+  BridgeTaskSeed,
+  BridgeTaskStore,
+} from './intake-to-internalization-bridge.js';
+
+export {
+  ROUTE_CHANNEL_MAP,
+  computeBridgeDecision,
+  buildDreamerTaskSeed,
+  seedIntakeTask,
+} from './intake-to-internalization-bridge.js';

--- a/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
@@ -123,14 +123,22 @@ export async function seedIntakeTask(
     return seed;
   }
 
-  await store.createTask({
-    taskId: seed.taskId,
-    taskKind: seed.taskKind,
-    status: seed.status,
-    attemptCount: seed.attemptCount,
-    maxAttempts: seed.maxAttempts,
-    diagnosticJson: seed.diagnosticJson,
-  });
+  try {
+    await store.createTask({
+      taskId: seed.taskId,
+      taskKind: seed.taskKind,
+      status: seed.status,
+      attemptCount: seed.attemptCount,
+      maxAttempts: seed.maxAttempts,
+      diagnosticJson: seed.diagnosticJson,
+    });
+  } catch (error) {
+    const concurrent = await store.getTask(seed.taskId);
+    if (concurrent) {
+      return { decision: 'already_exists', taskId: concurrent.taskId };
+    }
+    throw error;
+  }
 
   return decision;
 }

--- a/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
@@ -1,0 +1,127 @@
+import type { InternalizationChannel } from './peer-runner-contracts.js';
+import type { InternalizationRouteKind } from './internalization-route.js';
+import { createPITaskDiagnosticJson } from './pitask-metadata.js';
+
+export interface IntakeToInternalizationBridgeInput {
+  candidateId: string;
+  recommendationKind: string;
+  route: InternalizationRouteKind;
+  sourcePainId?: string;
+  workspaceDir?: string;
+  now?: string;
+}
+
+export type BridgeDecision =
+  | { decision: 'seeded'; taskId: string; taskKind: 'dreamer'; channel: InternalizationChannel }
+  | { decision: 'already_exists'; taskId: string }
+  | { decision: 'not_internalizable'; reason: string }
+  | { decision: 'invalid_candidate'; reason: string };
+
+export const ROUTE_CHANNEL_MAP: Record<string, InternalizationChannel> = {
+  'principle-ledger': 'prompt',
+  'rule-candidate': 'code_tool_hook',
+  'implementation-candidate': 'skill',
+  'prompt-injection-candidate': 'prompt',
+};
+
+export function computeBridgeDecision(
+  input: IntakeToInternalizationBridgeInput,
+): BridgeDecision {
+  if (!input.candidateId || input.candidateId.trim() === '') {
+    return { decision: 'invalid_candidate', reason: 'candidateId must be a non-empty string' };
+  }
+
+  if (input.route === 'deferred') {
+    return { decision: 'not_internalizable', reason: `Route "${input.route}" is deferred — no internalization action required` };
+  }
+
+  const channel = ROUTE_CHANNEL_MAP[input.route];
+  if (!channel) {
+    return { decision: 'not_internalizable', reason: `Route "${input.route}" has no channel mapping — not internalizable` };
+  }
+
+  const taskId = `dreamer-${input.candidateId}-${channel}`;
+  return { decision: 'seeded', taskId, taskKind: 'dreamer', channel };
+}
+
+export interface BridgeTaskSeed {
+  taskId: string;
+  taskKind: 'dreamer';
+  channel: InternalizationChannel;
+  diagnosticJson: string;
+  status: 'pending';
+  attemptCount: number;
+  maxAttempts: number;
+}
+
+export function buildDreamerTaskSeed(
+  input: IntakeToInternalizationBridgeInput,
+): BridgeTaskSeed | BridgeDecision {
+  const decision = computeBridgeDecision(input);
+  if (decision.decision !== 'seeded') {
+    return decision;
+  }
+
+  const diagnosticJson = createPITaskDiagnosticJson({
+    dependencyTaskIds: [],
+    channel: decision.channel,
+    timeoutMs: 300_000,
+    inputArtifactRefs: [{ artifactType: 'candidate', ref: `candidate://${input.candidateId}` }],
+    outputArtifactRefs: [],
+    parentTaskId: undefined,
+    correlationId: input.candidateId,
+  });
+
+  return {
+    taskId: decision.taskId,
+    taskKind: 'dreamer',
+    channel: decision.channel,
+    diagnosticJson,
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+  };
+}
+
+export interface BridgeTaskStore {
+  getTask(taskId: string): Promise<{ taskId: string } | null>;
+  createTask(input: {
+    taskId: string;
+    taskKind: string;
+    status: string;
+    attemptCount: number;
+    maxAttempts: number;
+    diagnosticJson: string;
+  }): Promise<{ taskId: string }>;
+}
+
+export async function seedIntakeTask(
+  input: IntakeToInternalizationBridgeInput,
+  store: BridgeTaskStore,
+): Promise<BridgeDecision> {
+  const decision = computeBridgeDecision(input);
+  if (decision.decision !== 'seeded') {
+    return decision;
+  }
+
+  const existing = await store.getTask(decision.taskId);
+  if (existing) {
+    return { decision: 'already_exists', taskId: existing.taskId };
+  }
+
+  const seed = buildDreamerTaskSeed(input);
+  if ('decision' in seed) {
+    return seed;
+  }
+
+  await store.createTask({
+    taskId: seed.taskId,
+    taskKind: seed.taskKind,
+    status: seed.status,
+    attemptCount: seed.attemptCount,
+    maxAttempts: seed.maxAttempts,
+    diagnosticJson: seed.diagnosticJson,
+  });
+
+  return decision;
+}

--- a/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
@@ -6,6 +6,7 @@ export interface IntakeToInternalizationBridgeInput {
   candidateId: string;
   recommendationKind: string;
   route: InternalizationRouteKind;
+  ready: boolean;
   sourcePainId?: string;
   workspaceDir?: string;
   now?: string;
@@ -29,6 +30,10 @@ export function computeBridgeDecision(
 ): BridgeDecision {
   if (!input.candidateId || input.candidateId.trim() === '') {
     return { decision: 'invalid_candidate', reason: 'candidateId must be a non-empty string' };
+  }
+
+  if (!input.ready) {
+    return { decision: 'not_internalizable', reason: `Route "${input.route}" is not ready — missing required fields` };
   }
 
   if (input.route === 'deferred') {
@@ -72,11 +77,15 @@ export function buildDreamerTaskSeed(
     correlationId: input.candidateId,
   });
 
+  const diagObj = JSON.parse(diagnosticJson);
+  diagObj.candidateId = input.candidateId;
+  const finalDiagnosticJson = JSON.stringify(diagObj);
+
   return {
     taskId: decision.taskId,
     taskKind: 'dreamer',
     channel: decision.channel,
-    diagnosticJson,
+    diagnosticJson: finalDiagnosticJson,
     status: 'pending',
     attemptCount: 0,
     maxAttempts: 3,


### PR DESCRIPTION
## 现象/目标

Candidate accepted/probation/consumed 不会自动产生 root dreamer PI task，需要手工 CLI backfill。Pipeline break ①: Pain → Candidate → Ledger 可以工作，但 probation → dreamer 入队不是自动的。

## 修改文件

| 文件 | 操作 | 说明 |
|------|------|------|
| \packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts\ | 新增 | Bridge 核心逻辑：computeBridgeDecision, buildDreamerTaskSeed, seedIntakeTask |
| \packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts\ | 新增 | 20 个 TDD 测试 |
| \packages/principles-core/src/runtime-v2/internalization/index.ts\ | 修改 | 导出 bridge 符号 |
| \packages/principles-core/src/runtime-v2/index.ts\ | 修改 | Re-export bridge 符号 |
| \packages/pd-cli/src/commands/candidate.ts\ | 修改 | 重构为调用 bridge，删除内联 ROUTE_CHANNEL_MAP |
| \packages/pd-cli/tests/commands/candidate-internalize.test.ts\ | 修改 | 适配 bridge 调用 |
| \packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts\ | 修改 | 添加 PRI-142 guard |

## 测试命令与结果

\\\ash
npm run build --workspace=@principles/core     # ✅
npm run build --workspace=@principles/pd-cli   # ✅
npm run typecheck:openclaw-plugin              # ✅
npx vitest run packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts  # 20/20 ✅
npx vitest run packages/pd-cli/tests/commands/candidate-internalize.test.ts  # 7/7 ✅
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts -t PRI-142  # 4/4 ✅
\\\

## 剩余风险

- CLI backfill handler 使用 bridge 进行 route→channel 映射，但仍内联处理 existing-task candidateId patching（best-effort 向后兼容）。未来可提取到 bridge。
- Architecture-regression 有 6 个 pre-existing 失败（nocturnal/evolution infrastructure import），与 PRI-142 无关。

Closes: PRI-142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 优化了候选对象内化流程的决策逻辑，改进了任务路由和创建机制。
  * 增强了任务诊断信息的生成方式，提升了系统可追溯性。

* **Tests**
  * 新增架构守卫和单元测试，确保内化流程的稳定性和可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->