### PR TITLE
feat(runtime): add idle trigger decision model (PRI-143)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-idle-trigger.ts
+++ b/packages/pd-cli/src/commands/runtime-idle-trigger.ts
@@ -1,0 +1,94 @@
+import * as path from 'path';
+import {
+  RuntimeStateManager,
+  InternalizationQueueReadModel,
+  evaluateIdleTriggerDecision,
+  resolveIdleTriggerConfig,
+} from '@principles/core/runtime-v2';
+import type { IdleTriggerResult, IdleTriggerConfig } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface IdleTriggerEvaluateOptions {
+  workspace?: string;
+  json?: boolean;
+  enabled?: boolean;
+  idleThresholdMs?: number;
+  jitterMaxMs?: number;
+  activityCooldownMs?: number;
+  jitterSeed?: string;
+}
+
+function formatTextOutput(result: IdleTriggerResult): string {
+  const lines: string[] = [];
+  lines.push(`IdleTrigger: ${result.decision}`);
+  lines.push(`  reason: ${result.reason}`);
+  lines.push(`  idleForMs: ${result.idleForMs}`);
+  lines.push(`  jitterMs: ${result.jitterMs}`);
+  lines.push(`  nextEligibleAt: ${result.nextEligibleAt}`);
+  lines.push(`  queue: ready=${result.queue.readyCount} pending=${result.queue.pendingCount} retryWait=${result.queue.retryWaitCount}`);
+  return lines.join('\n');
+}
+
+async function findLastActivityAt(stateManager: RuntimeStateManager): Promise<string | null> {
+  try {
+    const tasks = await stateManager.listTasks({});
+    if (tasks.length === 0) return null;
+    let latest: string | null = null;
+    for (const task of tasks) {
+      const ts = task.updatedAt ?? task.createdAt;
+      if (ts && (!latest || ts > latest)) {
+        latest = ts;
+      }
+    }
+    return latest;
+  } catch {
+    return null;
+  }
+}
+
+export async function handleRuntimeIdleTriggerEvaluate(opts: IdleTriggerEvaluateOptions): Promise<void> {
+  const workspaceDir = opts.workspace ? path.resolve(opts.workspace) : resolveWorkspaceDir();
+
+  const configOverrides: Partial<IdleTriggerConfig> = {};
+  if (opts.enabled !== undefined) configOverrides.enabled = opts.enabled;
+  if (opts.idleThresholdMs !== undefined) configOverrides.idleThresholdMs = opts.idleThresholdMs;
+  if (opts.jitterMaxMs !== undefined) configOverrides.jitterMaxMs = opts.jitterMaxMs;
+  if (opts.activityCooldownMs !== undefined) configOverrides.activityCooldownMs = opts.activityCooldownMs;
+  const config = resolveIdleTriggerConfig(configOverrides);
+
+  const jitterSeed = opts.jitterSeed ?? `idle-trigger-${Date.now()}`;
+
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+  await stateManager.initialize();
+
+  try {
+    const queueReadModel = new InternalizationQueueReadModel(stateManager);
+    const snapshot = await queueReadModel.getSnapshot();
+
+    const lastActivityAt = await findLastActivityAt(stateManager);
+
+    const result = evaluateIdleTriggerDecision({
+      lastActivityAt,
+      queue: {
+        readyCount: snapshot.readyTasks.length,
+        pendingCount: snapshot.pendingCount,
+        retryWaitCount: snapshot.retryWaitCount,
+      },
+      config,
+      jitterSeed,
+      now: new Date().toISOString(),
+    });
+
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatTextOutput(result));
+    }
+
+    if (result.decision === 'skip') {
+      process.exitCode = 1;
+    }
+  } finally {
+    await stateManager.close();
+  }
+}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -39,6 +39,7 @@ import { handleRuntimeInternalizationIntegrity } from './commands/runtime-intern
 import { handleRuntimeInternalizationIntegrityRepair } from './commands/runtime-internalization-integrity-repair.js';
 import { handleRuntimeDiagnosticsExport } from './commands/runtime-diagnostics-export.js';
 import { handleRuntimeRecoverySweep } from './commands/runtime-recovery.js';
+import { handleRuntimeIdleTriggerEvaluate } from './commands/runtime-idle-trigger.js';
 
 const program = new Command();
 
@@ -449,6 +450,32 @@ internalizationCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleRuntimeInternalizationIntegrityRepair({ workspace: opts.workspace, confirm: opts.confirm, dryRun: opts.dryRun, json: opts.json });
+  });
+
+const idleTriggerCmd = runtimeCmd
+  .command('idle-trigger')
+  .description('Idle trigger decision model (read-only)');
+
+idleTriggerCmd
+  .command('evaluate')
+  .description('Evaluate whether idle trigger should fire (read-only, no mutations)')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .option('--enabled <boolean>', 'Override config enabled', v => v === 'true')
+  .option('--idle-threshold-ms <number>', 'Override idle threshold in ms', parseInt)
+  .option('--jitter-max-ms <number>', 'Override jitter max in ms', parseInt)
+  .option('--activity-cooldown-ms <number>', 'Override activity cooldown in ms', parseInt)
+  .option('--jitter-seed <string>', 'Jitter seed for deterministic evaluation')
+  .action(async (opts) => {
+    await handleRuntimeIdleTriggerEvaluate({
+      workspace: opts.workspace,
+      json: opts.json,
+      enabled: opts.enabled,
+      idleThresholdMs: opts.idleThresholdMs,
+      jitterMaxMs: opts.jitterMaxMs,
+      activityCooldownMs: opts.activityCooldownMs,
+      jitterSeed: opts.jitterSeed,
+    });
   });
 
 const diagnosticsCmd = runtimeCmd

--- a/packages/pd-cli/tests/commands/runtime-idle-trigger.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-idle-trigger.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetSnapshot = vi.fn();
+const mockClose = vi.fn().mockResolvedValue(undefined);
+const mockListTasks = vi.fn();
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>;
+  return {
+    ...original,
+    RuntimeStateManager: vi.fn().mockImplementation(function () {
+      return {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        close: mockClose,
+        listTasks: mockListTasks,
+      };
+    }),
+    InternalizationQueueReadModel: vi.fn().mockImplementation(function () {
+      return { getSnapshot: mockGetSnapshot };
+    }),
+  };
+});
+
+import { handleRuntimeIdleTriggerEvaluate } from '../../src/commands/runtime-idle-trigger.js';
+
+const WS = '/fake/workspace';
+
+describe('handleRuntimeIdleTriggerEvaluate', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetSnapshot.mockResolvedValue({
+      readyTasks: [{ taskId: 't1', taskKind: 'dreamer', channel: 'prompt' }],
+      pendingCount: 1,
+      retryWaitCount: 0,
+    });
+    mockListTasks.mockResolvedValue([
+      { taskId: 't1', updatedAt: new Date(Date.now() - 600_000).toISOString(), createdAt: new Date(Date.now() - 600_000).toISOString() },
+    ]);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('outputs JSON with correct structure', async () => {
+    await handleRuntimeIdleTriggerEvaluate({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output).toHaveProperty('decision');
+    expect(output).toHaveProperty('reason');
+    expect(output).toHaveProperty('idleForMs');
+    expect(output).toHaveProperty('jitterMs');
+    expect(output).toHaveProperty('nextEligibleAt');
+    expect(output).toHaveProperty('queue');
+    expect(output.queue).toHaveProperty('readyCount');
+    expect(output.queue).toHaveProperty('pendingCount');
+    expect(output.queue).toHaveProperty('retryWaitCount');
+  });
+
+  it('does not call wake/run/acquireLease', async () => {
+    await handleRuntimeIdleTriggerEvaluate({ workspace: WS, json: true });
+
+    const calls = mockGetSnapshot.mock.calls;
+    expect(calls.length).toBe(1);
+  });
+
+  it('sets exit code 1 on skip decision', async () => {
+    mockGetSnapshot.mockResolvedValue({
+      readyTasks: [],
+      pendingCount: 0,
+      retryWaitCount: 0,
+    });
+
+    await handleRuntimeIdleTriggerEvaluate({ workspace: WS, json: true });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('uses default config when no overrides provided', async () => {
+    await handleRuntimeIdleTriggerEvaluate({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.jitterMs).toBeGreaterThanOrEqual(0);
+    expect(output.jitterMs).toBeLessThanOrEqual(30_000);
+  });
+
+  it('respects config overrides from CLI flags', async () => {
+    await handleRuntimeIdleTriggerEvaluate({
+      workspace: WS,
+      json: true,
+      enabled: false,
+    });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('skip');
+    expect(output.reason).toBe('disabled');
+  });
+
+  it('text output is human-readable', async () => {
+    await handleRuntimeIdleTriggerEvaluate({ workspace: WS, json: false });
+
+    const text = consoleLogSpy.mock.calls[0][0];
+    expect(text).toContain('IdleTrigger:');
+    expect(text).toContain('reason:');
+    expect(text).toContain('idleForMs:');
+    expect(text).toContain('jitterMs:');
+    expect(text).toContain('queue:');
+  });
+
+  it('closes state manager even on error', async () => {
+    mockGetSnapshot.mockRejectedValue(new Error('DB error'));
+
+    try {
+      await handleRuntimeIdleTriggerEvaluate({ workspace: WS, json: true });
+    } catch {
+      // expected
+    }
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -119,6 +119,11 @@ const REQUIRED_SOURCE_FILES = [
   'l1-hard-cap.ts',
   // PRI-142
   'internalization/intake-to-internalization-bridge.ts',
+  // PRI-143
+  'idle-trigger/idle-trigger-types.ts',
+  'idle-trigger/idle-trigger-policy.ts',
+  'idle-trigger/idle-trigger-decision.ts',
+  'idle-trigger/index.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -163,6 +168,8 @@ const REQUIRED_TEST_FILES = [
   'l1-hard-cap.test.ts',
   // PRI-142
   'intake-to-internalization-bridge.test.ts',
+  // PRI-143
+  '../idle-trigger/__tests__/idle-trigger-decision.test.ts',
 ];
 
 const REQUIRED_DOC_FILES = [
@@ -2578,6 +2585,64 @@ describe('PRI-142 IntakeToInternalizationBridge', () => {
     expect(src).toContain('BridgeDecision');
     expect(src).toContain('BridgeTaskSeed');
     expect(src).toContain('BridgeTaskStore');
+  });
+});
+
+// ── PRI-143: IdleTrigger Decision Model ──────────────────────────────────────
+
+describe('PRI-143 IdleTrigger Decision Model', () => {
+  it('core barrel exports evaluateIdleTriggerDecision, evaluateIdleTrigger, computeJitterMs, DEFAULT_IDLE_TRIGGER_CONFIG, resolveIdleTriggerConfig', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('evaluateIdleTriggerDecision');
+    expect(src).toContain('evaluateIdleTrigger');
+    expect(src).toContain('computeJitterMs');
+    expect(src).toContain('DEFAULT_IDLE_TRIGGER_CONFIG');
+    expect(src).toContain('resolveIdleTriggerConfig');
+  });
+
+  it('core barrel exports IdleTriggerConfig, IdleTriggerQueueSnapshot, IdleTriggerInput, IdleTriggerResult types', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('IdleTriggerConfig');
+    expect(src).toContain('IdleTriggerQueueSnapshot');
+    expect(src).toContain('IdleTriggerInput');
+    expect(src).toContain('IdleTriggerResult');
+  });
+
+  it('idle-trigger core files have zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const files = [
+      resolve(__dirname, '..', 'idle-trigger', 'idle-trigger-types.ts'),
+      resolve(__dirname, '..', 'idle-trigger', 'idle-trigger-policy.ts'),
+      resolve(__dirname, '..', 'idle-trigger', 'idle-trigger-decision.ts'),
+      resolve(__dirname, '..', 'idle-trigger', 'index.ts'),
+    ];
+    for (const file of files) {
+      const src = readFileSync(file, 'utf-8');
+      expect(src).not.toContain('node:fs');
+      expect(src).not.toContain('node:path');
+      expect(src).not.toContain('node:process');
+      expect(src).not.toContain('openclaw-plugin');
+    }
+  });
+
+  it('idle-trigger/index.ts exports all public symbols', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'idle-trigger', 'index.ts'), 'utf-8');
+    expect(src).toContain('IdleTriggerConfig');
+    expect(src).toContain('IdleTriggerQueueSnapshot');
+    expect(src).toContain('IdleTriggerInput');
+    expect(src).toContain('IdleTriggerResult');
+    expect(src).toContain('DEFAULT_IDLE_TRIGGER_CONFIG');
+    expect(src).toContain('resolveIdleTriggerConfig');
+    expect(src).toContain('computeJitterMs');
+    expect(src).toContain('evaluateIdleTrigger');
+    expect(src).toContain('evaluateIdleTriggerDecision');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/idle-trigger/__tests__/idle-trigger-decision.test.ts
+++ b/packages/principles-core/src/runtime-v2/idle-trigger/__tests__/idle-trigger-decision.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateIdleTriggerDecision,
+  evaluateIdleTrigger,
+  computeJitterMs,
+  DEFAULT_IDLE_TRIGGER_CONFIG,
+  resolveIdleTriggerConfig,
+} from '../index.js';
+import type { IdleTriggerInput, IdleTriggerConfig } from '../index.js';
+
+const NOW = '2026-05-17T12:00:00.000Z';
+const NOW_MS = new Date(NOW).getTime();
+
+function makeInput(overrides?: Partial<IdleTriggerInput>): IdleTriggerInput {
+  return {
+    lastActivityAt: new Date(NOW_MS - 600_000).toISOString(),
+    queue: { readyCount: 1, pendingCount: 1, retryWaitCount: 0 },
+    config: DEFAULT_IDLE_TRIGGER_CONFIG,
+    jitterSeed: 'test-seed',
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('IdleTrigger Decision Model (PRI-143)', () => {
+  it('idle duration exceeds threshold with ready tasks → trigger', () => {
+    const input = makeInput({
+      lastActivityAt: new Date(NOW_MS - 600_000).toISOString(),
+      queue: { readyCount: 1, pendingCount: 1, retryWaitCount: 0 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('trigger');
+    expect(result.reason).toBe('idle_threshold_met');
+    expect(result.idleForMs).toBe(600_000);
+    expect(result.queue.readyCount).toBe(1);
+  });
+
+  it('idle duration below threshold → skip with reason=not_idle_enough', () => {
+    const input = makeInput({
+      lastActivityAt: new Date(NOW_MS - 100_000).toISOString(),
+      queue: { readyCount: 1, pendingCount: 1, retryWaitCount: 0 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('skip');
+    expect(result.reason).toBe('not_idle_enough');
+    expect(result.idleForMs).toBe(100_000);
+  });
+
+  it('no ready tasks → skip with reason=no_ready_tasks', () => {
+    const input = makeInput({
+      lastActivityAt: new Date(NOW_MS - 600_000).toISOString(),
+      queue: { readyCount: 0, pendingCount: 0, retryWaitCount: 0 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('skip');
+    expect(result.reason).toBe('no_ready_tasks');
+  });
+
+  it('jitter is deterministic with same seed', () => {
+    const seed = 'deterministic-seed-123';
+    const j1 = computeJitterMs(seed, 30_000);
+    const j2 = computeJitterMs(seed, 30_000);
+    const j3 = computeJitterMs(seed, 30_000);
+    expect(j1).toBe(j2);
+    expect(j2).toBe(j3);
+    expect(j1).toBeGreaterThanOrEqual(0);
+    expect(j1).toBeLessThanOrEqual(30_000);
+  });
+
+  it('jitter produces different values for different seeds', () => {
+    const j1 = computeJitterMs('seed-a', 30_000);
+    const j2 = computeJitterMs('seed-b', 30_000);
+    expect(typeof j1).toBe('number');
+    expect(typeof j2).toBe('number');
+  });
+
+  it('config missing fields → safe defaults via resolveIdleTriggerConfig', () => {
+    const resolved = resolveIdleTriggerConfig({ enabled: true });
+    expect(resolved.idleThresholdMs).toBe(DEFAULT_IDLE_TRIGGER_CONFIG.idleThresholdMs);
+    expect(resolved.jitterMaxMs).toBe(DEFAULT_IDLE_TRIGGER_CONFIG.jitterMaxMs);
+    expect(resolved.activityCooldownMs).toBe(DEFAULT_IDLE_TRIGGER_CONFIG.activityCooldownMs);
+    expect(resolved.enabled).toBe(true);
+
+    const emptyResolved = resolveIdleTriggerConfig();
+    expect(emptyResolved).toEqual(DEFAULT_IDLE_TRIGGER_CONFIG);
+  });
+
+  it('disabled config → skip with reason=disabled', () => {
+    const config: IdleTriggerConfig = { ...DEFAULT_IDLE_TRIGGER_CONFIG, enabled: false };
+    const input = makeInput({
+      config,
+      lastActivityAt: new Date(NOW_MS - 600_000).toISOString(),
+      queue: { readyCount: 1, pendingCount: 1, retryWaitCount: 0 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('skip');
+    expect(result.reason).toBe('disabled');
+  });
+
+  it('retry_wait pending with no ready tasks → skip with reason=retry_wait_pending', () => {
+    const input = makeInput({
+      lastActivityAt: new Date(NOW_MS - 600_000).toISOString(),
+      queue: { readyCount: 0, pendingCount: 2, retryWaitCount: 3 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('skip');
+    expect(result.reason).toBe('retry_wait_pending');
+  });
+
+  it('lastActivityAt within activityCooldownMs → skip with reason=not_idle_enough', () => {
+    const config: IdleTriggerConfig = {
+      ...DEFAULT_IDLE_TRIGGER_CONFIG,
+      idleThresholdMs: 10_000,
+      activityCooldownMs: 120_000,
+    };
+    const input = makeInput({
+      config,
+      lastActivityAt: new Date(NOW_MS - 60_000).toISOString(),
+      queue: { readyCount: 1, pendingCount: 1, retryWaitCount: 0 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('skip');
+    expect(result.reason).toBe('not_idle_enough');
+  });
+
+  it('null lastActivityAt treats idle as infinite → trigger when ready tasks exist', () => {
+    const input = makeInput({
+      lastActivityAt: null,
+      queue: { readyCount: 1, pendingCount: 1, retryWaitCount: 0 },
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    expect(result.decision).toBe('trigger');
+    expect(result.idleForMs).toBe(NOW_MS);
+  });
+
+  it('evaluateIdleTrigger and evaluateIdleTriggerDecision produce identical results', () => {
+    const input = makeInput();
+    const r1 = evaluateIdleTrigger(input);
+    const r2 = evaluateIdleTriggerDecision(input);
+    expect(r1).toEqual(r2);
+  });
+
+  it('computeJitterMs with maxMs=0 returns 0', () => {
+    expect(computeJitterMs('any-seed', 0)).toBe(0);
+  });
+
+  it('result includes jitterMs from seeded jitter', () => {
+    const input = makeInput({
+      lastActivityAt: new Date(NOW_MS - 600_000).toISOString(),
+      jitterSeed: 'jitter-test',
+    });
+    const result = evaluateIdleTriggerDecision(input);
+    const expectedJitter = computeJitterMs('jitter-test', DEFAULT_IDLE_TRIGGER_CONFIG.jitterMaxMs);
+    expect(result.jitterMs).toBe(expectedJitter);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-decision.ts
+++ b/packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-decision.ts
@@ -1,0 +1,6 @@
+import type { IdleTriggerInput, IdleTriggerResult } from './idle-trigger-types.js';
+import { evaluateIdleTrigger } from './idle-trigger-policy.js';
+
+export function evaluateIdleTriggerDecision(input: IdleTriggerInput): IdleTriggerResult {
+  return evaluateIdleTrigger(input);
+}

--- a/packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-policy.ts
+++ b/packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-policy.ts
@@ -1,0 +1,89 @@
+import type { IdleTriggerInput, IdleTriggerResult } from './idle-trigger-types.js';
+
+export function computeJitterMs(seed: string, maxMs: number): number {
+  if (maxMs <= 0) return 0;
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(31, h) + seed.charCodeAt(i) | 0;
+  }
+  h = h ^ (h >>> 16);
+  h = Math.imul(h, 0x45d9f3b);
+  h = h ^ (h >>> 16);
+  const abs = Math.abs(h);
+  return abs % (maxMs + 1);
+}
+
+export function evaluateIdleTrigger(input: IdleTriggerInput): IdleTriggerResult {
+  const { config, queue, jitterSeed, now } = input;
+  const jitterMs = computeJitterMs(jitterSeed, config.jitterMaxMs);
+
+  const nowMs = new Date(now).getTime();
+  const lastActivityMs = input.lastActivityAt
+    ? new Date(input.lastActivityAt).getTime()
+    : 0;
+  const idleForMs = nowMs - lastActivityMs;
+
+  if (!config.enabled) {
+    return {
+      decision: 'skip',
+      reason: 'disabled',
+      idleForMs,
+      jitterMs,
+      nextEligibleAt: now,
+      queue,
+    };
+  }
+
+  if (queue.readyCount === 0 && queue.retryWaitCount > 0) {
+    return {
+      decision: 'skip',
+      reason: 'retry_wait_pending',
+      idleForMs,
+      jitterMs,
+      nextEligibleAt: new Date(nowMs + config.idleThresholdMs).toISOString(),
+      queue,
+    };
+  }
+
+  if (queue.readyCount === 0) {
+    return {
+      decision: 'skip',
+      reason: 'no_ready_tasks',
+      idleForMs,
+      jitterMs,
+      nextEligibleAt: now,
+      queue,
+    };
+  }
+
+  if (input.lastActivityAt && idleForMs < config.activityCooldownMs) {
+    return {
+      decision: 'skip',
+      reason: 'not_idle_enough',
+      idleForMs,
+      jitterMs,
+      nextEligibleAt: new Date(lastActivityMs + config.activityCooldownMs).toISOString(),
+      queue,
+    };
+  }
+
+  if (idleForMs < config.idleThresholdMs) {
+    return {
+      decision: 'skip',
+      reason: 'not_idle_enough',
+      idleForMs,
+      jitterMs,
+      nextEligibleAt: new Date(lastActivityMs + config.idleThresholdMs + jitterMs).toISOString(),
+      queue,
+    };
+  }
+
+  return {
+    decision: 'trigger',
+    reason: 'idle_threshold_met',
+    idleForMs,
+    jitterMs,
+    nextEligibleAt: new Date(nowMs + config.idleThresholdMs + jitterMs).toISOString(),
+    queue,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-types.ts
+++ b/packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-types.ts
@@ -1,0 +1,45 @@
+export interface IdleTriggerConfig {
+  enabled: boolean;
+  idleThresholdMs: number;
+  jitterMaxMs: number;
+  activityCooldownMs: number;
+}
+
+export interface IdleTriggerQueueSnapshot {
+  readyCount: number;
+  pendingCount: number;
+  retryWaitCount: number;
+}
+
+export interface IdleTriggerInput {
+  lastActivityAt: string | null;
+  queue: IdleTriggerQueueSnapshot;
+  config: IdleTriggerConfig;
+  jitterSeed: string;
+  now: string;
+}
+
+export interface IdleTriggerResult {
+  decision: 'trigger' | 'skip';
+  reason: string;
+  idleForMs: number;
+  jitterMs: number;
+  nextEligibleAt: string;
+  queue: IdleTriggerQueueSnapshot;
+}
+
+export const DEFAULT_IDLE_TRIGGER_CONFIG: IdleTriggerConfig = {
+  enabled: true,
+  idleThresholdMs: 300_000,
+  jitterMaxMs: 30_000,
+  activityCooldownMs: 60_000,
+};
+
+export function resolveIdleTriggerConfig(partial?: Partial<IdleTriggerConfig>): IdleTriggerConfig {
+  return {
+    enabled: partial?.enabled ?? DEFAULT_IDLE_TRIGGER_CONFIG.enabled,
+    idleThresholdMs: partial?.idleThresholdMs ?? DEFAULT_IDLE_TRIGGER_CONFIG.idleThresholdMs,
+    jitterMaxMs: partial?.jitterMaxMs ?? DEFAULT_IDLE_TRIGGER_CONFIG.jitterMaxMs,
+    activityCooldownMs: partial?.activityCooldownMs ?? DEFAULT_IDLE_TRIGGER_CONFIG.activityCooldownMs,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/idle-trigger/index.ts
+++ b/packages/principles-core/src/runtime-v2/idle-trigger/index.ts
@@ -1,0 +1,20 @@
+export type {
+  IdleTriggerConfig,
+  IdleTriggerQueueSnapshot,
+  IdleTriggerInput,
+  IdleTriggerResult,
+} from './idle-trigger-types.js';
+
+export {
+  DEFAULT_IDLE_TRIGGER_CONFIG,
+  resolveIdleTriggerConfig,
+} from './idle-trigger-types.js';
+
+export {
+  computeJitterMs,
+  evaluateIdleTrigger,
+} from './idle-trigger-policy.js';
+
+export {
+  evaluateIdleTriggerDecision,
+} from './idle-trigger-decision.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -744,6 +744,23 @@ export type {
   UnresolvableSample,
 } from './internalization-queue-read-model.js';
 
+// ── Idle Trigger Decision Model (PRI-143) ──────────────────────────────────
+
+export type {
+  IdleTriggerConfig,
+  IdleTriggerQueueSnapshot,
+  IdleTriggerInput,
+  IdleTriggerResult,
+} from './idle-trigger/index.js';
+
+export {
+  DEFAULT_IDLE_TRIGGER_CONFIG,
+  resolveIdleTriggerConfig,
+  computeJitterMs,
+  evaluateIdleTrigger,
+  evaluateIdleTriggerDecision,
+} from './idle-trigger/index.js';
+
 // ── GFI Core Kernel (PRI-76) ────────────────────────────────────────────────
 
 export {


### PR DESCRIPTION
## Phenomenon

No way to evaluate whether idle trigger should fire without actually running the internalization pipeline. No deterministic jitter for multi-process coordination. No safe-default configuration for idle trigger behavior.

## Goal

Implement core-owned IdleTrigger read-only decision model that tells operators whether internalization should be triggered based on idle state, queue health, and configuration.

## Changes

### Core (packages/principles-core)
- **NEW** `idle-trigger/idle-trigger-types.ts` — `IdleTriggerConfig`, `IdleTriggerInput`, `IdleTriggerResult`, `IdleTriggerQueueSnapshot`, `DEFAULT_IDLE_TRIGGER_CONFIG`, `resolveIdleTriggerConfig`
- **NEW** `idle-trigger/idle-trigger-policy.ts` — Pure decision functions: `evaluateIdleTrigger` (skip/trigger logic), `computeJitterMs` (deterministic seeded jitter)
- **NEW** `idle-trigger/idle-trigger-decision.ts` — `evaluateIdleTriggerDecision` entry point (future extension point)
- **NEW** `idle-trigger/index.ts` — Barrel exports
- **NEW** `idle-trigger/__tests__/idle-trigger-decision.test.ts` — 13 tests covering all decision branches
- **MOD** `runtime-v2/index.ts` — Added barrel exports for all idle-trigger symbols
- **MOD** `architecture-regression.test.ts` — Added PRI-143 source/test file existence checks + 4 architecture guard tests

### CLI (packages/pd-cli)
- **NEW** `commands/runtime-idle-trigger.ts` — `pd runtime idle-trigger evaluate` command handler
- **NEW** `tests/commands/runtime-idle-trigger.test.ts` — 7 CLI tests
- **MOD** `src/index.ts` — Registered `runtime idle-trigger evaluate` subcommand

## Decision Logic (priority order)

1. `config.enabled === false` → skip, reason=`disabled`
2. `queue.readyCount === 0 && queue.retryWaitCount > 0` → skip, reason=`retry_wait_pending`
3. `queue.readyCount === 0` → skip, reason=`no_ready_tasks`
4. `lastActivityAt` within `activityCooldownMs` → skip, reason=`not_idle_enough`
5. `idleForMs < idleThresholdMs` → skip, reason=`not_idle_enough`
6. All conditions met → trigger, reason=`idle_threshold_met`

## Test Commands and Results

```bash
npm run build --workspace=@principles/core          # pass
npm run build --workspace=@principles/pd-cli         # pass
npm run typecheck:openclaw-plugin                    # pass
npx vitest run packages/principles-core/src/runtime-v2/idle-trigger/__tests__/idle-trigger-decision.test.ts  # 13/13 pass
npx vitest run packages/pd-cli/tests/commands/runtime-idle-trigger.test.ts  # 7/7 pass
```

## Remaining Risks

- **ConfigLoader (PRI-162) not yet implemented**: Using `IdleTriggerConfig` interface + `DEFAULT_IDLE_TRIGGER_CONFIG` constant. CLI constructs config manually. Future PRI-162 integration needed.
- **lastActivityAt source**: Derived from task `updatedAt` timestamps in state.db. May not precisely reflect user activity.
- **retry_wait_pending**: Uses count-level info only; detailed backoff timing check delegated to `InternalizationOrchestrator.wakeOnce()`.

## Key Constraints Verified

- Core idle-trigger files have zero infrastructure imports (no fs/path/process/plugin)
- CLI evaluate is read-only — does not call wake/run/acquireLease
- Jitter is deterministic when seed provided
- Config defaults are safe (300s idle threshold, 30s jitter max, 60s cooldown)
- Does not modify Nocturnal/sleep-cycle code
