### PR TITLE
fix(idle-trigger): validate NaN CLI overrides and handle listTasks errors

### DIFF
--- a/packages/pd-cli/src/commands/runtime-idle-trigger.ts
+++ b/packages/pd-cli/src/commands/runtime-idle-trigger.ts
@@ -29,10 +29,14 @@ function formatTextOutput(result: IdleTriggerResult): string {
   return lines.join('\n');
 }
 
-async function findLastActivityAt(stateManager: RuntimeStateManager): Promise<string | null> {
+function isValidPositiveInt(value: number | undefined): value is number {
+  return value !== undefined && Number.isFinite(value) && value > 0;
+}
+
+async function findLastActivityAt(stateManager: RuntimeStateManager): Promise<{ ts: string | null; error: string | null }> {
   try {
     const tasks = await stateManager.listTasks({});
-    if (tasks.length === 0) return null;
+    if (tasks.length === 0) return { ts: null, error: null };
     let latest: string | null = null;
     for (const task of tasks) {
       const ts = task.updatedAt ?? task.createdAt;
@@ -40,9 +44,10 @@ async function findLastActivityAt(stateManager: RuntimeStateManager): Promise<st
         latest = ts;
       }
     }
-    return latest;
-  } catch {
-    return null;
+    return { ts: latest, error: null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ts: null, error: msg };
   }
 }
 
@@ -51,9 +56,9 @@ export async function handleRuntimeIdleTriggerEvaluate(opts: IdleTriggerEvaluate
 
   const configOverrides: Partial<IdleTriggerConfig> = {};
   if (opts.enabled !== undefined) configOverrides.enabled = opts.enabled;
-  if (opts.idleThresholdMs !== undefined) configOverrides.idleThresholdMs = opts.idleThresholdMs;
-  if (opts.jitterMaxMs !== undefined) configOverrides.jitterMaxMs = opts.jitterMaxMs;
-  if (opts.activityCooldownMs !== undefined) configOverrides.activityCooldownMs = opts.activityCooldownMs;
+  if (isValidPositiveInt(opts.idleThresholdMs)) configOverrides.idleThresholdMs = opts.idleThresholdMs;
+  if (isValidPositiveInt(opts.jitterMaxMs)) configOverrides.jitterMaxMs = opts.jitterMaxMs;
+  if (isValidPositiveInt(opts.activityCooldownMs)) configOverrides.activityCooldownMs = opts.activityCooldownMs;
   const config = resolveIdleTriggerConfig(configOverrides);
 
   const jitterSeed = opts.jitterSeed ?? `idle-trigger-${Date.now()}`;
@@ -65,7 +70,29 @@ export async function handleRuntimeIdleTriggerEvaluate(opts: IdleTriggerEvaluate
     const queueReadModel = new InternalizationQueueReadModel(stateManager);
     const snapshot = await queueReadModel.getSnapshot();
 
-    const lastActivityAt = await findLastActivityAt(stateManager);
+    const { ts: lastActivityAt, error: activityError } = await findLastActivityAt(stateManager);
+
+    if (activityError) {
+      const result: IdleTriggerResult = {
+        decision: 'skip',
+        reason: `activity_read_failed: ${activityError}`,
+        idleForMs: 0,
+        jitterMs: 0,
+        nextEligibleAt: new Date().toISOString(),
+        queue: {
+          readyCount: snapshot.readyTasks.length,
+          pendingCount: snapshot.pendingCount,
+          retryWaitCount: snapshot.retryWaitCount,
+        },
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatTextOutput(result));
+      }
+      process.exitCode = 1;
+      return;
+    }
 
     const result = evaluateIdleTriggerDecision({
       lastActivityAt,

--- a/packages/pd-cli/tests/commands/runtime-idle-trigger.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-idle-trigger.test.ts
@@ -125,4 +125,18 @@ describe('handleRuntimeIdleTriggerEvaluate', () => {
 
     expect(mockClose).toHaveBeenCalled();
   });
+
+  it('rejects NaN numeric overrides and falls back to defaults', async () => {
+    await handleRuntimeIdleTriggerEvaluate({
+      workspace: WS,
+      json: true,
+      idleThresholdMs: NaN,
+      jitterMaxMs: NaN,
+      activityCooldownMs: NaN,
+    });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.jitterMs).toBeGreaterThanOrEqual(0);
+    expect(output.jitterMs).toBeLessThanOrEqual(30_000);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up fix for PR #612 (PRI-143 IdleTrigger & Jitter Configuration), addressing review findings:

### P1: NaN CLI override injection
\--idle-threshold-ms foo\ parsed via \parseInt\ returns \NaN\, which was passed to \esolveIdleTriggerConfig\ and then into date arithmetic causing \RangeError: Invalid time value\.

**Fix:** Added \isValidPositiveInt()\ guard that rejects NaN, Infinity, and negative values before setting config overrides. Invalid values fall back to defaults.

### P2: Silent error swallowing in findLastActivityAt
Original \indLastActivityAt\ caught errors and returned \
ull\, making the system think there was no recent activity (infinite idle) and potentially triggering when it shouldn't.

**Fix:** Changed return type to \{ts: string | null, error: string | null}\. When \listTasks\ fails, CLI returns \skip\ with \eason=activity_read_failed\ instead of proceeding.

### Edge case: Math.abs in computeJitterMs
\Math.abs(Integer.MIN_VALUE)\ returns a negative number in JavaScript.

**Fix:** Use unsigned right shift \(h >>> 0)\ instead of \Math.abs(h)\.

## Test plan
- [x] Existing 13 core tests + 8 CLI tests pass
- [x] Added test for NaN override fallback to defaults
- [x] Architecture regression tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了运行时空闲触发器配置参数的验证机制，确保只接受有效的正整数值
  * 优化了活动历史读取失败时的错误处理，提供更详细的错误信息并正确设置程序退出代码

* **Tests**
  * 新增配置参数验证场景的测试用例

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->