### PR TITLE
fix: add SQLite persistence for activation state

### DIFF
--- a/packages/pd-cli/src/commands/runtime-activation.ts
+++ b/packages/pd-cli/src/commands/runtime-activation.ts
@@ -4,7 +4,7 @@ import {
   ActivationDispatcher,
   PromptWriter,
   DeferArchiveWriter,
-  MemoryActivationStateStore,
+  SqliteActivationStateStore,
 } from '@principles/core/runtime-v2';
 import type { ActivationDecision, PIArtifactSnapshot, RolloutActivationDecision } from '@principles/core/runtime-v2';
 import type { PIArtifactRecord } from '@principles/core/runtime-v2';
@@ -143,7 +143,7 @@ export async function handleRuntimeActivationDispatch(opts: ActivationDispatchOp
       },
     };
 
-    const activationStateStore = new MemoryActivationStateStore();
+    const activationStateStore = new SqliteActivationStateStore(stateManager.connection);
     const dispatcher = new ActivationDispatcher(
       artifactReadModel,
       activationStateStore,

--- a/packages/principles-core/src/runtime-v2/activation/__tests__/sqlite-activation-state-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/__tests__/sqlite-activation-state-store.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SqliteActivationStateStore } from '../sqlite-activation-state-store.js';
+import type { SqliteConnection } from '../../store/sqlite-connection.js';
+import type { ActivationStatusRecord } from '../activation-types.js';
+
+const mockDb = {
+  prepare: vi.fn(),
+};
+
+const mockConnection = {
+  getDb: vi.fn(() => mockDb),
+} as unknown as SqliteConnection;
+
+describe('SqliteActivationStateStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getActivationStatus', () => {
+    it('returns null when no activation exists for idempotency key', async () => {
+      const mockGet = vi.fn().mockReturnValue(undefined);
+      mockDb.prepare.mockReturnValue({ get: mockGet });
+
+      const store = new SqliteActivationStateStore(mockConnection);
+      const result = await store.getActivationStatus('art-001::prompt');
+
+      expect(result).toBeNull();
+      expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('SELECT'));
+      expect(mockGet).toHaveBeenCalledWith('art-001::prompt');
+    });
+
+    it('returns activation record when exists', async () => {
+      const mockGet = vi.fn().mockReturnValue({
+        activation_id: 'act_001',
+        idempotency_key: 'art-001::prompt',
+        artifact_id: 'art-001',
+        channel: 'prompt',
+        action: 'prompt_activate',
+        target_ref: 'ledger://P_001',
+        activated_at: '2026-05-17T00:00:00.000Z',
+      });
+      mockDb.prepare.mockReturnValue({ get: mockGet });
+
+      const store = new SqliteActivationStateStore(mockConnection);
+      const result = await store.getActivationStatus('art-001::prompt');
+
+      expect(result).toEqual({
+        activationId: 'act_001',
+        idempotencyKey: 'art-001::prompt',
+        artifactId: 'art-001',
+        channel: 'prompt',
+        action: 'prompt_activate',
+        targetRef: 'ledger://P_001',
+        activatedAt: '2026-05-17T00:00:00.000Z',
+      });
+    });
+
+    it('returns activation record for defer_archive channel', async () => {
+      const mockGet = vi.fn().mockReturnValue({
+        activation_id: 'act_002',
+        idempotency_key: 'art-002::defer_archive',
+        artifact_id: 'art-002',
+        channel: 'defer_archive',
+        action: 'defer_archive',
+        target_ref: 'ledger://P_002#archived',
+        activated_at: '2026-05-17T01:00:00.000Z',
+      });
+      mockDb.prepare.mockReturnValue({ get: mockGet });
+
+      const store = new SqliteActivationStateStore(mockConnection);
+      const result = await store.getActivationStatus('art-002::defer_archive');
+
+      expect(result).toEqual({
+        activationId: 'act_002',
+        idempotencyKey: 'art-002::defer_archive',
+        artifactId: 'art-002',
+        channel: 'defer_archive',
+        action: 'defer_archive',
+        targetRef: 'ledger://P_002#archived',
+        activatedAt: '2026-05-17T01:00:00.000Z',
+      });
+    });
+  });
+
+  describe('recordActivation', () => {
+    it('inserts activation record with INSERT OR REPLACE', async () => {
+      const mockRun = vi.fn();
+      mockDb.prepare.mockReturnValue({ run: mockRun });
+
+      const record: ActivationStatusRecord = {
+        activationId: 'act_001',
+        idempotencyKey: 'art-001::prompt',
+        artifactId: 'art-001',
+        channel: 'prompt',
+        action: 'prompt_activate',
+        targetRef: 'ledger://P_001',
+        activatedAt: '2026-05-17T00:00:00.000Z',
+      };
+
+      const store = new SqliteActivationStateStore(mockConnection);
+      await store.recordActivation(record);
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT OR REPLACE'));
+      expect(mockRun).toHaveBeenCalledWith(
+        'act_001',
+        'art-001::prompt',
+        'art-001',
+        'prompt',
+        'prompt_activate',
+        'ledger://P_001',
+        '2026-05-17T00:00:00.000Z',
+      );
+    });
+
+    it('handles different channel types correctly', async () => {
+      const mockRun = vi.fn();
+      mockDb.prepare.mockReturnValue({ run: mockRun });
+
+      const record: ActivationStatusRecord = {
+        activationId: 'act_003',
+        idempotencyKey: 'art-003::defer_archive',
+        artifactId: 'art-003',
+        channel: 'defer_archive',
+        action: 'defer_archive',
+        targetRef: 'ledger://P_003#archived',
+        activatedAt: '2026-05-17T02:00:00.000Z',
+      };
+
+      const store = new SqliteActivationStateStore(mockConnection);
+      await store.recordActivation(record);
+
+      expect(mockRun).toHaveBeenCalledWith(
+        'act_003',
+        'art-003::defer_archive',
+        'art-003',
+        'defer_archive',
+        'defer_archive',
+        'ledger://P_003#archived',
+        '2026-05-17T02:00:00.000Z',
+      );
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/activation/index.ts
+++ b/packages/principles-core/src/runtime-v2/activation/index.ts
@@ -37,3 +37,5 @@ export {
   MemoryActivationStateStore,
   MemoryArtifactReadModel,
 } from './memory-activation-state-store.js';
+
+export { SqliteActivationStateStore } from './sqlite-activation-state-store.js';

--- a/packages/principles-core/src/runtime-v2/activation/sqlite-activation-state-store.ts
+++ b/packages/principles-core/src/runtime-v2/activation/sqlite-activation-state-store.ts
@@ -1,5 +1,5 @@
 import type { ActivationStateReadModel, ActivationStatusRecord } from './activation-types.js';
-import type { SqliteConnection } from '../../store/sqlite-connection.js';
+import type { SqliteConnection } from '../store/sqlite-connection.js';
 
 export class SqliteActivationStateStore implements ActivationStateReadModel {
   constructor(private readonly connection: SqliteConnection) {}

--- a/packages/principles-core/src/runtime-v2/activation/sqlite-activation-state-store.ts
+++ b/packages/principles-core/src/runtime-v2/activation/sqlite-activation-state-store.ts
@@ -1,0 +1,53 @@
+import type { ActivationStateReadModel, ActivationStatusRecord } from './activation-types.js';
+import type { SqliteConnection } from '../../store/sqlite-connection.js';
+
+export class SqliteActivationStateStore implements ActivationStateReadModel {
+  constructor(private readonly connection: SqliteConnection) {}
+
+  async getActivationStatus(idempotencyKey: string): Promise<ActivationStatusRecord | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare(`
+      SELECT activation_id, idempotency_key, artifact_id, channel, action, target_ref, activated_at
+      FROM activations
+      WHERE idempotency_key = ?
+    `).get(idempotencyKey) as {
+      activation_id: string;
+      idempotency_key: string;
+      artifact_id: string;
+      channel: string;
+      action: string;
+      target_ref: string;
+      activated_at: string;
+    } | undefined;
+
+    if (!row) return null;
+
+    return {
+      activationId: row.activation_id,
+      idempotencyKey: row.idempotency_key,
+      artifactId: row.artifact_id,
+      channel: row.channel as ActivationStatusRecord['channel'],
+      action: row.action,
+      targetRef: row.target_ref,
+      activatedAt: row.activated_at,
+    };
+  }
+
+  async recordActivation(record: ActivationStatusRecord): Promise<void> {
+    const db = this.connection.getDb();
+    db.prepare(`
+      INSERT OR REPLACE INTO activations
+        (activation_id, idempotency_key, artifact_id, channel, action, target_ref, activated_at)
+      VALUES
+        (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      record.activationId,
+      record.idempotencyKey,
+      record.artifactId,
+      record.channel,
+      record.action,
+      record.targetRef,
+      record.activatedAt,
+    );
+  }
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -791,6 +791,7 @@ export {
   extractPrincipleId,
   MemoryActivationStateStore,
   MemoryArtifactReadModel,
+  SqliteActivationStateStore,
 } from './activation/index.js';
 
 // ── GFI Core Kernel (PRI-76) ────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
@@ -296,6 +296,19 @@ export class SqliteConnection {
       CREATE INDEX IF NOT EXISTS idx_pi_artifacts_artifact_kind ON pi_artifacts(artifact_kind);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_pi_artifacts_idempotency ON pi_artifacts(source_task_id, artifact_kind);
     `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS activations (
+        activation_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_ref TEXT NOT NULL,
+        activated_at TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_activations_idempotency ON activations(idempotency_key);
+    `);
   }
 
   private migrateSchema(): void {


### PR DESCRIPTION
## Summary

Fixes a critical bug discovered during post-commit correctness check: **Activation state was stored in-memory only**, causing idempotency to be lost across CLI invocations.

### Bug Description

When `pd runtime activation dispatch --confirm` was called:
1. The `ActivationDispatcher` checks if an activation already exists via `checkIdempotency()`
2. If not, it calls `recordActivation()` to store the activation
3. However, `MemoryActivationStateStore` was used, which only stores data in a Map in memory
4. When the CLI process exits, this Map is destroyed
5. The next CLI invocation creates a new `MemoryActivationStateStore` with no prior state
6. The idempotency check passes incorrectly, allowing duplicate activations

### Fix

- Added `SqliteActivationStateStore` implementing `ActivationStateReadModel`
- Created `activations` table in SQLite with idempotency key unique index
- Updated CLI to use `SqliteActivationStateStore` instead of `MemoryActivationStateStore`
- Added comprehensive unit tests

### Impact

**Before**: Principles could be activated multiple times if the activation CLI is run multiple times.

**After**: Activation state persists across CLI invocations, correctly preventing duplicate activations.

### Files Changed

| File | Change |
|------|--------|
| `activation/sqlite-activation-state-store.ts` | New - SQLite implementation |
| `store/sqlite-connection.ts` | Modified - activations table |
| `activation/index.ts` | Modified - exports |
| `runtime-v2/index.ts` | Modified - exports |
| `pd-cli/runtime-activation.ts` | Modified - use SqliteActivationStateStore |
| `activation/__tests__/sqlite-activation-state-store.test.ts` | New - tests |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 激活状态存储现已改用持久化数据库后端，确保激活记录在应用重启后仍可保留。

* **测试**
  * 新增激活状态存储的完整测试覆盖。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->