### PR TITLE
fix(deps): upgrade lint-staged to v17.0.5 with lockfile sync and CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/architecture/ACTIVATION_CHANNELS.md
+++ b/docs/architecture/ACTIVATION_CHANNELS.md
@@ -1,0 +1,1043 @@
+# Activation Channels 设计（5 通道激活规范）
+
+> **状态**: Active
+> **最后更新**: 2026-05-15
+> **关联 ADR**: ADR-0006（混合激活机制）, ADR-0004（L2 自动校正）, ADR-0005（Nocturnal 合并）
+> **关联文档**: `PD_ARCHITECTURE_OVERVIEW.md`, `INTERNALIZATION_PIPELINE.md`
+
+本文档是 ADR-0006 的工程化展开，详细定义 PD 系统的 5 个内化通道如何**实际作用于代理行为**。
+
+---
+
+## 1. 通道总览
+
+PD 的内化通过 5 个通道生效：
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                          │
+│  PIArtifact (validationStatus=validated)                                │
+│         │                                                                │
+│         ▼                                                                │
+│  ┌──────────────────────┐                                               │
+│  │ ActivationDispatcher │ ← 唯一入口                                    │
+│  └──────────┬───────────┘                                               │
+│             │                                                            │
+│             │ 按 channel 路由                                            │
+│             │                                                            │
+│  ┌──────────┼─────────────┬─────────────┬──────────────┬──────────────┐│
+│  │          │             │             │              │              ││
+│  ▼          ▼             ▼             ▼              ▼              ││
+│ prompt  defer_archive   skill      code_tool_hook  model_training     ││
+│  L1     N/A             L1.5       L2              L3                  ││
+│ 自动    自动            自动*       人审            人审+二次          ││
+│  │          │             │             │              │              ││
+│  ▼          ▼             ▼             ▼              ▼              ││
+│ Ledger    Ledger       Skill File   Implementation  Training Export   ││
+│ active    archive      .principles/ Code File       .pd/training/     ││
+│                        skills/      .principles/                       ││
+│                                     implementations/                    ││
+└─────────────────────────────────────────────────────────────────────────┘
+
+*skill 默认自动，可配置为审批
+```
+
+---
+
+## 2. 核心组件
+
+### 2.1 ActivationDispatcher
+
+位置：`packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts`（已落地基础版）
+
+**唯一职责**：接收 validated PIArtifact，根据 channel 路由到对应的激活路径（自动激活 / 入队审批 / 拒绝）。
+
+```typescript
+interface ActivationDispatcher {
+  dispatch(input: DispatchInput): Promise<DispatchResult>;
+}
+
+interface DispatchInput {
+  artifactId: string;
+  channel: InternalizationChannel;
+  /** 来自 RolloutReviewer 的发布建议 */
+  rolloutDecision: 'auto_activate' | 'require_approval' | 'reject';
+  /** 触发方信息 */
+  actor: ActivationActor;
+  /** 幂等键（默认由 artifactId + channel 组合） */
+  idempotencyKey?: string;
+}
+
+type ActivationActor =
+  | { kind: 'system'; source: 'rollout_reviewer' | 'recovery_sweep' }
+  | { kind: 'agent'; agentId: string }
+  | { kind: 'human'; userId: string };
+
+type DispatchResult =
+  | {
+      decision: 'activated';
+      activatedAt: string;
+      channelTarget: string;  // 例：'ledger://P_001' | 'file:///.principles/skills/abc/SKILL.md'
+      activationId: string;
+    }
+  | {
+      decision: 'queued_for_approval';
+      approvalId: string;
+      queuedAt: string;
+      requiresSecondConfirmation: boolean;
+    }
+  | {
+      decision: 'rejected';
+      reason: string;
+      rejectionFeedbackId: string;
+    }
+  | {
+      decision: 'skipped';
+      reason: 'already_active' | 'channel_disabled' | 'already_in_approval_queue';
+    };
+```
+
+**路由决策表**：
+
+| RolloutDecision | 通道 | Dispatch 决策 |
+|----------------|------|---------------|
+| `reject` | 任意 | `rejected` + 写 RejectionFeedback |
+| `auto_activate` | `prompt` / `defer_archive` | `activated`（直接调用 ChannelWriter）|
+| `auto_activate` | `skill` | 取决于 config：默认 `activated`，配置 require_approval 后 `queued_for_approval` |
+| `auto_activate` | `code_tool_hook` | **强制** `queued_for_approval`（覆盖 auto_activate）|
+| `auto_activate` | `model_training` | **强制** `queued_for_approval` + `requiresSecondConfirmation=true` |
+| `require_approval` | 任意 | `queued_for_approval`（含通道默认风险等级）|
+
+### 2.2 ChannelWriter 接口
+
+每个通道有一个 ChannelWriter 实现，负责"激活"和"撤销激活"。
+
+```typescript
+interface ChannelWriter<T = unknown> {
+  /** 通道标识 */
+  readonly channel: InternalizationChannel;
+
+  /** 检查 artifact 是否可以激活到此通道（前置校验） */
+  canActivate(artifact: PIArtifact): Promise<CanActivateResult>;
+
+  /** 实际写入激活状态 */
+  activate(artifact: PIArtifact, context: ActivationContext): Promise<ActivationOutcome<T>>;
+
+  /** 撤销激活（rollback） */
+  deactivate(activationId: string, context: DeactivationContext): Promise<void>;
+
+  /** 查询激活状态 */
+  getActivationStatus(activationId: string): Promise<ActivationStatus | null>;
+}
+
+interface CanActivateResult {
+  ok: boolean;
+  reason?: string;
+  /** 风险评估（影响是否需要 shadow mode 等） */
+  riskAssessment?: {
+    estimatedImpact: 'low' | 'medium' | 'high' | 'critical';
+    affectedScope: string[];  // 例：['edit_tool', 'read_tool']
+  };
+}
+
+interface ActivationContext {
+  approvalId?: string;          // 经审批激活时的审批 ID
+  approvedBy?: string;
+  approvedAt?: string;
+  approvalNote?: string;
+  idempotencyKey: string;
+  /** 是否启用 shadow mode（仅 code_tool_hook 默认 true） */
+  shadowMode?: boolean;
+  shadowModeCycles?: number;
+}
+
+interface ActivationOutcome<T> {
+  activationId: string;
+  channelTarget: string;       // URI 形式：ledger://... | file://... | sql://...
+  activatedAt: string;
+  /** 通道特定的元数据 */
+  channelMetadata?: T;
+}
+```
+
+**实现清单**：
+
+| ChannelWriter | 通道 | 写入位置 |
+|--------------|------|---------|
+| `PromptWriter`（设计稿称 `LedgerPromptWriter`）| prompt | `Ledger.principles[id].status = 'active'` |
+| `DeferArchiveWriter`（设计稿称 `LedgerArchiveWriter`）| defer_archive | `Ledger.principles[id].status = 'archived'` |
+| `SkillFileWriter` | skill | `{workspace}/.principles/skills/{skillId}/` |
+| `RuleHostWriter` | code_tool_hook | `Ledger.implementations[id].lifecycleState = 'active'` + `.principles/implementations/code/{implId}/` |
+| `TrainingExporter` | model_training | `{workspace}/.pd/training-exports/{batchId}/` |
+
+### 2.3 ApprovalQueue
+
+位置：`packages/principles-core/src/runtime-v2/activation/approval-queue.ts`（已落地基础版）
+
+> 当前代码实现的 Approval 状态为 `pending / approved / rejected / cancelled`。本文中提到的
+> `expired` 与 `awaiting_second_confirmation` 是 ADR-0006 的 future extension，不能按当前生产能力使用。当前代码 `ApprovalStatus` 仅包含 4 种状态：`pending | approved | rejected | cancelled`。
+
+下面是 ADR-0006 的目标接口。当前基础实现已覆盖 `enqueue / listPending / approve / reject / get`，
+尚未实现 `secondConfirm / cancel / expired` 等扩展能力。
+
+```typescript
+interface ApprovalQueue {
+  enqueue(input: ApprovalEnqueueInput): Promise<ApprovalRecord>;
+  listPending(filter?: ApprovalFilter): Promise<ApprovalRecord[]>;
+  approve(approvalId: string, approver: string, note?: string): Promise<ApprovalDecisionResult>;
+  reject(approvalId: string, approver: string, reason: string): Promise<ApprovalDecisionResult>;
+  /** 二次确认（仅 critical 风险） */
+  secondConfirm(approvalId: string, secondApprover: string): Promise<ApprovalDecisionResult>;
+
+  /** 查询单条 */
+  get(approvalId: string): Promise<ApprovalRecord | null>;
+
+  /** 取消待审批（仅本人提交可取消） */
+  cancel(approvalId: string, requester: string): Promise<void>;
+}
+
+interface ApprovalRecord {
+  approvalId: string;
+  artifactId: string;
+  channel: InternalizationChannel;
+  riskLevel: 'medium' | 'high' | 'critical';
+  status: 'pending' | 'approved' | 'rejected' | 'expired' | 'cancelled' | 'awaiting_second_confirmation';
+  requestedAt: string;
+  requestedBy: ActivationActor;
+  decidedAt?: string;
+  decidedBy?: string;
+  reason?: string;
+  /** 仅 critical 风险有此字段 */
+  requiresSecondConfirmation?: boolean;
+  secondConfirmedAt?: string;
+  secondConfirmedBy?: string;
+  /** 冷却期信息 */
+  cooldownExpiresAt?: string;
+  metadata: Record<string, unknown>;
+}
+```
+
+**存储**：`state.db: approvals` 表（新建）
+
+```sql
+CREATE TABLE approvals (
+  approval_id TEXT PRIMARY KEY,
+  artifact_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  risk_level TEXT NOT NULL,
+  status TEXT NOT NULL,
+  requested_at TEXT NOT NULL,
+  requested_by_kind TEXT NOT NULL,
+  requested_by_id TEXT,
+  decided_at TEXT,
+  decided_by TEXT,
+  reason TEXT,
+  requires_second_confirmation INTEGER DEFAULT 0,
+  second_confirmed_at TEXT,
+  second_confirmed_by TEXT,
+  cooldown_expires_at TEXT,
+  metadata_json TEXT NOT NULL,
+  FOREIGN KEY (artifact_id) REFERENCES pi_artifacts(artifact_id)
+);
+
+CREATE INDEX idx_approvals_status ON approvals(status, channel);
+CREATE INDEX idx_approvals_artifact ON approvals(artifact_id);
+```
+
+### 2.4 RejectionFeedback
+
+```typescript
+interface RejectionFeedback {
+  feedbackId: string;
+  approvalId: string;
+  artifactId: string;
+  channel: InternalizationChannel;
+  rejectionReason: string;
+  rejectedBy: string;
+  rejectedAt: string;
+  feedbackAction: 'retry_with_correction' | 'discard' | 'escalate';
+  correctionHints?: string[];
+}
+```
+
+**存储**：`state.db: rejection_feedbacks` 表（新建）
+
+```sql
+CREATE TABLE rejection_feedbacks (
+  feedback_id TEXT PRIMARY KEY,
+  approval_id TEXT NOT NULL,
+  artifact_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  rejection_reason TEXT NOT NULL,
+  rejected_by TEXT NOT NULL,
+  rejected_at TEXT NOT NULL,
+  feedback_action TEXT NOT NULL,
+  correction_hints_json TEXT,
+  FOREIGN KEY (approval_id) REFERENCES approvals(approval_id)
+);
+```
+
+---
+
+## 3. 各通道详细规范
+
+### 3.1 prompt 通道（自动）
+
+#### 用途
+最低成本的内化路径。让原则文本进入 LLM 的 system prompt。
+
+#### 触发
+- RolloutReviewer 输出 `decision=auto_activate`
+- ActivationDispatcher 直接调用 `LedgerPromptWriter.activate()`
+
+#### 操作
+
+```typescript
+class LedgerPromptWriter implements ChannelWriter {
+  channel = 'prompt' as const;
+
+  async canActivate(artifact: PIArtifact): Promise<CanActivateResult> {
+    // 检查：
+    // 1. PIArtifact.kind === 'principle'
+    // 2. 关联的 LedgerEntry 存在且不是 active
+    // 3. 原则文本长度合理（< 500 字符建议值）
+    return { ok: true, riskAssessment: { estimatedImpact: 'low', affectedScope: ['system_prompt'] } };
+  }
+
+  async activate(artifact, context): Promise<ActivationOutcome> {
+    const ledgerEntryId = extractLedgerEntryId(artifact);
+    await mutateLedger(stateDir, (store) => {
+      const principle = store.tree.principles[ledgerEntryId];
+      principle.status = 'active';
+      principle.activatedAt = context.approvedAt ?? new Date().toISOString();
+      principle.activatedBy = context.approvedBy ?? 'system';
+    });
+
+    return {
+      activationId: `act_prompt_${ledgerEntryId}`,
+      channelTarget: `ledger://${ledgerEntryId}`,
+      activatedAt: new Date().toISOString(),
+    };
+  }
+
+  async deactivate(activationId): Promise<void> {
+    // 回退：principle.status = 'probation'（保留历史）
+  }
+}
+```
+
+#### 生效时机
+下次 `before_prompt_build` hook 触发时，PromptBuilder 自动读取 `Ledger.principles[*].status = 'active'` 注入。
+
+#### 回滚
+- pd-cli: `pd principle rollback <id>`
+- 自动回滚：如果 90 天内 `painPreventedCount === 0`（无效原则）
+
+#### 性能预算
+- canActivate: < 10ms
+- activate: < 100ms（含 atomic 文件写入）
+- 影响：下次 prompt build 时间 + < 5ms（每个 active 原则）
+
+---
+
+### 3.2 defer_archive 通道（自动）
+
+#### 用途
+将原则归档，不再出现在活动注入列表。常用于：
+- 已被 L2 实现完全替代的 L1 原则
+- 已过时或冲突的原则
+- RoutingPolicy 推荐 archive 的原则
+
+#### 触发
+- RolloutReviewer / RoutingPolicy 推荐 `defer_archive`
+- 全自动，无审批
+
+#### 操作
+
+```typescript
+class LedgerArchiveWriter implements ChannelWriter {
+  channel = 'defer_archive' as const;
+
+  async activate(artifact, context): Promise<ActivationOutcome> {
+    const ledgerEntryId = extractLedgerEntryId(artifact);
+    await mutateLedger(stateDir, (store) => {
+      const principle = store.tree.principles[ledgerEntryId];
+      principle.status = 'archived';
+      principle.archivedReason = artifact.contentJson?.archiveReason
+        ?? 'auto_archived_by_routing_policy';
+      principle.archivedAt = new Date().toISOString();
+    });
+
+    return {
+      activationId: `act_archive_${ledgerEntryId}`,
+      channelTarget: `ledger://${ledgerEntryId}#archived`,
+      activatedAt: new Date().toISOString(),
+    };
+  }
+
+  async deactivate(activationId): Promise<void> {
+    // 回退到 active 或 probation
+  }
+}
+```
+
+#### 回滚
+对归档操作的回滚需要人工干预（pd-console 或 pd-cli `pd principle unarchive <id>`）。
+
+---
+
+### 3.3 skill 通道（默认自动，可配置）
+
+#### 用途
+将原则转化为 OpenClaw / Claude Code 的 skill 文档。代理可在需要时调用此 skill。
+
+#### 触发
+- RolloutReviewer 输出 `auto_activate`
+- 检查 config：`skill.auto_activate`，默认为 `true`
+- 如果配置为 `false`，则 `queued_for_approval`
+
+#### 操作
+
+```typescript
+class SkillFileWriter implements ChannelWriter {
+  channel = 'skill' as const;
+
+  async canActivate(artifact: PIArtifact): Promise<CanActivateResult> {
+    // 检查：
+    // 1. ScribeOutput 已生成 skill 内容
+    // 2. 文件路径冲突检查
+    // 3. SKILL.md 内容大小 < 10 KB
+  }
+
+  async activate(artifact, context): Promise<ActivationOutcome> {
+    const skillId = artifact.contentJson.skillId;
+    const skillDir = path.join(workspaceDir, '.principles/skills', skillId);
+
+    fs.mkdirSync(skillDir, { recursive: true });
+    atomicWriteFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      artifact.contentJson.skillContent
+    );
+    atomicWriteFileSync(
+      path.join(skillDir, 'manifest.json'),
+      JSON.stringify({ skillId, principleId, version: '1.0.0', activatedAt: now }, null, 2)
+    );
+
+    return {
+      activationId: `act_skill_${skillId}`,
+      channelTarget: `file://${skillDir}`,
+      activatedAt: new Date().toISOString(),
+      channelMetadata: { skillId, skillDir },
+    };
+  }
+
+  async deactivate(activationId): Promise<void> {
+    // 删除 skill 目录
+  }
+}
+```
+
+#### 配置
+
+```yaml
+activation:
+  channels:
+    skill:
+      mode: auto             # 'auto' | 'require_approval'
+      auto_activate: true
+      max_skills_per_workspace: 50
+      skill_size_limit_bytes: 10240
+```
+
+#### 风险考量
+Skill 是文档型内化，风险中等：
+- 不直接拦截工具调用
+- 代理可选择性使用（不强制）
+- 易于回滚（删除文件）
+
+#### 回滚
+`pd-cli pd skill disable <skill-id>` 或人工删除 skill 目录。
+
+---
+
+### 3.4 code_tool_hook 通道（必须人工审批）
+
+#### 用途
+**最强的内化形式**之一。在 `before_tool_call` 阶段拦截或修正工具调用参数。属于 L2 硬内化。
+
+#### 触发
+- 无论 RolloutReviewer 输出什么，**都强制走审批队列**
+- ActivationDispatcher 自动设 `riskLevel = 'high'`
+
+#### 前置校验（canActivate）
+
+```typescript
+class RuleHostWriter implements ChannelWriter {
+  channel = 'code_tool_hook' as const;
+
+  async canActivate(artifact: PIArtifact): Promise<CanActivateResult> {
+    const result = { ok: true, riskAssessment: { estimatedImpact: 'high' as const, affectedScope: [] } };
+
+    // 1. GoldenTrace replay 测试（详见 ADR-0004）
+    const replayResult = await replayGoldenTrace(artifact);
+    if (!replayResult.allPassed) {
+      return { ok: false, reason: `GoldenTrace replay failed: ${replayResult.failures}` };
+    }
+
+    // 2. Forbidden pattern 检查
+    const code = extractImplementationCode(artifact);
+    const forbiddenCheck = checkForbiddenPatterns(code);
+    if (!forbiddenCheck.passed) {
+      return { ok: false, reason: `Forbidden patterns: ${forbiddenCheck.violations}` };
+    }
+
+    // 3. Lineage 完整性
+    if (!verifyLineageComplete(artifact)) {
+      return { ok: false, reason: 'Source lineage incomplete' };
+    }
+
+    // 4. 评估影响范围
+    result.riskAssessment.affectedScope = extractAffectedTools(code);
+    if (result.riskAssessment.affectedScope.includes('edit') ||
+        result.riskAssessment.affectedScope.includes('write')) {
+      result.riskAssessment.estimatedImpact = 'critical';
+    }
+
+    return result;
+  }
+
+  // ... activate
+}
+```
+
+#### 入队审批
+
+```typescript
+// ActivationDispatcher.dispatch() 路径
+const canActivate = await ruleHostWriter.canActivate(artifact);
+if (!canActivate.ok) {
+  return { decision: 'rejected', reason: canActivate.reason };
+}
+
+const approval = await approvalQueue.enqueue({
+  artifactId: artifact.artifactId,
+  channel: 'code_tool_hook',
+  riskLevel: canActivate.riskAssessment.estimatedImpact === 'critical' ? 'critical' : 'high',
+  requiresSecondConfirmation: false,  // code_tool_hook 不要求二次确认（除 critical 外）
+  metadata: {
+    proposedRuleId: artifact.sourceRuleId,
+    goldenTraceReport: replayResult,
+    forbiddenPatternCheckResult: forbiddenCheck,
+    riskAssessment: canActivate.riskAssessment,
+  },
+});
+
+return { decision: 'queued_for_approval', approvalId: approval.approvalId, ... };
+```
+
+#### 审批通过后激活（Shadow Mode）
+
+```typescript
+async activate(artifact, context): Promise<ActivationOutcome> {
+  const implId = artifact.sourceRuleId;
+  const implDir = path.join(workspaceDir, '.principles/implementations/code', implId);
+
+  // 1. 写入实现代码
+  fs.mkdirSync(implDir, { recursive: true });
+  atomicWriteFileSync(
+    path.join(implDir, 'entry.ts'),
+    artifact.contentJson.implementationCode
+  );
+  atomicWriteFileSync(
+    path.join(implDir, 'manifest.json'),
+    JSON.stringify({
+      implId,
+      ruleId: artifact.sourceRuleId,
+      principleId: artifact.sourcePrincipleId,
+      activatedAt: context.approvedAt,
+      activatedBy: context.approvedBy,
+      shadowMode: context.shadowMode ?? true,
+      shadowModeCycles: context.shadowModeCycles ?? 30,
+      shadowModeStartedAt: new Date().toISOString(),
+    })
+  );
+
+  // 2. 标记 ledger.implementations[implId] 为 active
+  await mutateLedger(stateDir, (store) => {
+    const impl = store.tree.implementations[implId];
+    impl.lifecycleState = 'active';
+    impl.shadowMode = true;  // ★ 默认启用 shadow mode
+    impl.shadowModeRemaining = 30;
+  });
+
+  return {
+    activationId: `act_code_${implId}`,
+    channelTarget: `ledger://${implId}`,
+    activatedAt: new Date().toISOString(),
+  };
+}
+```
+
+#### Shadow Mode 行为
+
+详见 ADR-0004。要点：
+
+1. **Shadow 期间**（默认 30 个调用周期）：
+   - RuleHost 加载实现并执行
+   - **不**应用 `decision`（不 block / 不 propose_correction）
+   - 每次执行写 `CorrectionAuditEvent`，记录"如果应用，会发生什么"
+
+2. **Shadow 期满**：
+   - 自动生成 shadow report
+   - 写入 ledger：`shadowMode = false`
+   - 进入 live 模式
+
+3. **Shadow 期间发现异常**（如误杀率高）：
+   - 自动 deactivate
+   - 写 RejectionFeedback
+   - 触发新的 Dreamer task（修正建议）
+
+#### 配置
+
+```yaml
+activation:
+  channels:
+    code_tool_hook:
+      mode: require_approval         # 不可改
+      shadow_mode_default: true       # 不可改
+      shadow_mode_cycles: 30          # 可调
+      shadow_max_false_positive_rate: 0.05  # 超过即自动 deactivate
+      max_active_implementations: 100  # 总量限制
+```
+
+#### 回滚
+
+```bash
+# pd-cli
+pd impl rollback <implId> --reason "false positive too high"
+
+# 自动回滚条件：
+# - shadow mode 期间误杀率 > 阈值
+# - active 期间触发 RuleHost 异常超过 N 次
+```
+
+---
+
+### 3.5 model_training 通道（必须人工审批 + 二次确认）
+
+#### 用途
+将训练数据导出，供外部模型训练系统使用。属于 L3 内化（最高强度，最低成本，最大风险）。
+
+#### 触发
+- 仅 Trainer Runner 输出（`PIArtifact.kind = 'training_data'`）
+- 强制 `requiresSecondConfirmation = true`
+
+#### 前置校验
+
+```typescript
+class TrainingExporter implements ChannelWriter {
+  channel = 'model_training' as const;
+
+  async canActivate(artifact: PIArtifact): Promise<CanActivateResult> {
+    // 1. 训练数据质量门禁
+    const dataset = parseTrainingDataset(artifact);
+    if (dataset.size < 100) {
+      return { ok: false, reason: 'Dataset too small (< 100 samples)' };
+    }
+    if (dataset.domainCoverage < 0.6) {
+      return { ok: false, reason: 'Domain coverage insufficient' };
+    }
+    if (dataset.duplicateRate > 0.1) {
+      return { ok: false, reason: 'Duplicate rate too high' };
+    }
+
+    // 2. PII 敏感性扫描
+    const piiCheck = await scanForPII(dataset);
+    if (piiCheck.hasViolations) {
+      return { ok: false, reason: `PII detected: ${piiCheck.violations}` };
+    }
+
+    return {
+      ok: true,
+      riskAssessment: {
+        estimatedImpact: 'critical',
+        affectedScope: ['model_weights', 'agent_baseline'],
+      },
+    };
+  }
+
+  // ... 入队审批 + 二次确认 + activate
+}
+```
+
+#### 入队审批
+
+```typescript
+const approval = await approvalQueue.enqueue({
+  artifactId: artifact.artifactId,
+  channel: 'model_training',
+  riskLevel: 'critical',
+  requiresSecondConfirmation: true,
+  metadata: {
+    datasetSize: dataset.size,
+    qualityMetrics: dataset.metrics,
+    estimatedTrainingCost: estimateCost(dataset),
+    targetCheckpoint: artifact.contentJson.targetCheckpoint,
+    piiCheckPassed: true,
+  },
+});
+```
+
+#### 双人审批流程
+
+```
+1. 第一审批人 approve
+   → status: awaiting_second_confirmation
+   → cooldownExpiresAt: now + 24h
+   → 通知第二审批人
+
+2. 等待 24 小时冷却（不可绕过）
+
+3. 第二审批人 secondConfirm（必须不同于第一审批人）
+   → status: approved
+   → 调用 TrainingExporter.activate()
+
+4. 任一时刻可 reject 终止
+```
+
+#### 激活操作
+
+```typescript
+async activate(artifact, context): Promise<ActivationOutcome> {
+  const batchId = `train_${Date.now()}`;
+  const exportDir = path.join(workspaceDir, '.pd/training-exports', batchId);
+
+  // 1. 导出训练数据
+  fs.mkdirSync(exportDir, { recursive: true });
+  atomicWriteFileSync(
+    path.join(exportDir, 'dataset.jsonl'),
+    artifact.contentJson.trainingData
+  );
+  atomicWriteFileSync(
+    path.join(exportDir, 'metadata.json'),
+    JSON.stringify({
+      batchId,
+      sourceArtifactId: artifact.artifactId,
+      approvedBy: context.approvedBy,
+      secondConfirmedBy: artifact.metadata.secondConfirmedBy,
+      exportedAt: new Date().toISOString(),
+      targetCheckpoint: artifact.contentJson.targetCheckpoint,
+    })
+  );
+
+  // 2. 通知外部训练系统（webhook / file watcher）
+  // PD 不直接训练，由外部系统消费 export
+
+  return {
+    activationId: `act_training_${batchId}`,
+    channelTarget: `file://${exportDir}`,
+    activatedAt: new Date().toISOString(),
+  };
+}
+```
+
+#### 配置
+
+```yaml
+activation:
+  channels:
+    model_training:
+      mode: require_approval                 # 不可改
+      requires_second_confirmation: true     # 不可改
+      cooldown_hours: 24                     # 不可改（可通过 ADR 修改）
+      second_approver_must_differ: true      # 不可改
+      min_dataset_size: 100
+      min_domain_coverage: 0.6
+      max_duplicate_rate: 0.1
+      pii_scan_required: true
+```
+
+#### 回滚
+- 训练已开始 → 不可回滚（导出已发生）
+- 训练未开始 → `pd-cli pd training-export cancel <batchId>`
+- 已部署的 checkpoint 回滚 → 由独立的 `model_deployment_registry` 管理（不属于本通道）
+
+---
+
+## 4. 通道间互斥与冲突
+
+### 4.1 同一原则可同时激活的通道组合
+
+| 组合 | 是否允许 | 备注 |
+|------|---------|------|
+| prompt + skill | ✅ | 互补 |
+| prompt + code_tool_hook | ✅ | prompt 提醒 + code 强制（typical 升级路径）|
+| prompt + model_training | ✅ | 渐进式内化 |
+| skill + code_tool_hook | ⚠️ | 允许但需注意逻辑一致性 |
+| code_tool_hook + model_training | ✅ | L2 + L3 协同 |
+| 任意 + defer_archive | ❌ | 互斥（archive 后不再激活其他通道）|
+
+### 4.2 通道升级路径（渐进式内化）
+
+PD 鼓励渐进式内化路径：
+
+```
+新原则
+  │
+  ▼
+prompt 通道（自动）        ← 起点
+  │
+  │ 经过 N 个 painPreventedCount 验证
+  ▼
+skill 通道（自动）         ← 加深一步
+  │
+  │ 经过更多验证 + 人工评估
+  ▼
+code_tool_hook（人审）     ← L2 硬内化
+  │
+  │ 经过大量样本 + 多人评估
+  ▼
+model_training（双人审）   ← L3 终极内化
+  │
+  │ 训练完成 + 验证有效
+  ▼
+原 prompt 原则可 archive   ← Pruning
+```
+
+每步升级都要重新经过完整的 Internalization Pipeline（Dreamer → ... → RolloutReviewer）。
+
+---
+
+## 5. pd-console 审批 UI 规范
+
+### 5.1 路由结构
+
+```
+/approvals                    审批队列首页
+/approvals/pending            待审批列表
+/approvals/{id}               审批详情
+/approvals/{id}/approve       批准操作
+/approvals/{id}/reject        拒绝操作
+/approvals/history            历史记录
+/approvals/config             配置管理
+```
+
+### 5.2 审批列表页内容
+
+每条 Pending 显示：
+- ApprovalId / 提交时间 / 等待时间
+- ArtifactId + 关联的 Principle / Rule
+- 通道类型 + 风险等级（颜色编码：高=红、中=黄、低=绿）
+- 触发方（system / agent）
+- "查看详情" 按钮
+
+### 5.3 审批详情页（`code_tool_hook` 示例）
+
+必须展示：
+1. **原则与规则文本**：来自 sourcePrincipleId 与 sourceRuleId
+2. **代码 diff**：被批准后将激活的 implementation 代码
+3. **GoldenTrace 报告**：哪些 case 通过 / 失败
+4. **Forbidden pattern 检查结果**
+5. **影响范围**：affectedScope 列表
+6. **历史血缘**：从 PainSignal 到 PIArtifact 的完整链
+7. **相关历史决策**：同类 PIArtifact 过去的批准/拒绝率
+
+操作区：
+- ✓ 批准：必须勾选"我已审查代码并理解风险"
+- ✗ 拒绝：必须填写理由，可选择反馈动作（retry_with_correction / discard / escalate）
+- ↩ 取消：仅原提交人可取消
+
+### 5.4 二次确认页（`model_training` 专用）
+
+第一审批通过后进入冷却：
+- 倒计时显示剩余冷却时间
+- "通知第二审批人"按钮
+- 第二审批人登录后看到 `awaiting_second_confirmation` 状态
+- 第二审批人不能与第一审批人相同（前后端双重校验）
+
+---
+
+## 6. 不变量与约束总表
+
+| ID | 约束 | 强制方式 |
+|----|------|---------|
+| AC-1 | 所有激活必须经过 ActivationDispatcher | architecture-regression test：禁止其他模块直接调用 ChannelWriter |
+| AC-2 | code_tool_hook 强制 require_approval | 代码硬编码，config 不可覆盖 |
+| AC-3 | model_training 强制 second confirmation | 代码硬编码，config 不可覆盖 |
+| AC-4 | 二次审批人必须不同于第一审批人 | ApprovalQueue.secondConfirm 校验 |
+| AC-5 | 24h 冷却不可绕过 | ApprovalQueue 时间校验 |
+| AC-6 | 拒绝必须产生 RejectionFeedback | reject() 内部强制写入 |
+| AC-7 | 激活必须幂等 | idempotencyKey 必填 |
+| AC-8 | code_tool_hook 默认启用 shadow mode | RuleHostWriter.activate 默认 shadowMode=true |
+| AC-9 | 配置篡改有审计 | 修改 activation.yaml 必须通过 pd-cli + 写日志 |
+| AC-10 | Activation 操作必须发出 telemetry | ActivationDispatcher 强制 emit |
+| AC-11 | 审批人不能审批自己提交的工件（如果 actor=human） | enqueue/approve 校验 |
+| AC-12 | 已激活的工件不能重复激活 | canActivate 检查现有状态 |
+
+---
+
+## 7. 配置完整 schema
+
+`{workspace}/.pd/config/activation.yaml`：
+
+```yaml
+activation:
+  # 全局开关
+  enabled: true
+
+  # 调度行为
+  dispatcher:
+    max_concurrent_dispatches: 5
+    dispatch_timeout_ms: 30000
+
+  # 审批队列
+  approval_queue:
+    pending_ttl_hours: 168     # 7 天未处理过期
+    expired_action: 'auto_reject'
+    notification:
+      pd_console_email: false
+      webhook_url: null
+
+  # 各通道配置
+  channels:
+    prompt:
+      mode: auto                 # 不可改
+      max_active_per_workspace: 200
+      auto_archive_after_days: 90  # 90 天无 painPreventedCount 自动归档
+
+    defer_archive:
+      mode: auto                 # 不可改
+
+    skill:
+      mode: auto                 # 'auto' | 'require_approval'
+      auto_activate: true
+      max_skills_per_workspace: 50
+      skill_size_limit_bytes: 10240
+      validate_skill_format: true
+
+    code_tool_hook:
+      mode: require_approval     # 不可改
+      shadow_mode_default: true  # 不可改
+      shadow_mode_cycles: 30
+      shadow_max_false_positive_rate: 0.05
+      max_active_implementations: 100
+      golden_trace_required: true
+      forbidden_pattern_check_required: true
+
+    model_training:
+      mode: require_approval               # 不可改
+      requires_second_confirmation: true   # 不可改
+      cooldown_hours: 24                   # 不可改
+      second_approver_must_differ: true    # 不可改
+      min_dataset_size: 100
+      min_domain_coverage: 0.6
+      max_duplicate_rate: 0.1
+      pii_scan_required: true              # 不可改
+      max_export_size_mb: 100
+```
+
+---
+
+## 8. 可观测性
+
+### 8.1 必发的 Telemetry Events
+
+```typescript
+// ActivationDispatcher
+'activation_dispatched'        // 每次 dispatch 调用
+'activation_completed'         // 成功激活
+'activation_skipped'           // 已存在或已禁用
+
+// ApprovalQueue
+'approval_queued'             // 入队
+'approval_decided'            // approve / reject
+'approval_expired'            // TTL 过期
+'approval_second_confirmed'   // 二次确认通过
+
+// ChannelWriter
+'channel_writer_activated'    // 写入成功
+'channel_writer_failed'       // 写入失败
+'channel_writer_deactivated'  // 撤销
+'shadow_mode_completed'       // shadow 期满
+'shadow_mode_aborted'         // shadow 期间触发 abort
+```
+
+### 8.2 关键指标
+
+| Metric | 类型 | 意义 |
+|--------|-----|------|
+| `pd.activation.dispatched_total` | counter | 总分发数 |
+| `pd.activation.activated_total` | counter | 总激活数 |
+| `pd.activation.rejected_total` | counter | 总拒绝数 |
+| `pd.activation.queued_total` | counter | 入队数 |
+| `pd.approval.pending_count` | gauge | 当前待审批数 |
+| `pd.approval.avg_decision_latency_ms` | histogram | 平均决策延迟 |
+| `pd.approval.approval_rate` | gauge | 批准率 |
+| `pd.shadow_mode.false_positive_rate` | histogram | shadow mode 误杀率 |
+| `pd.shadow_mode.aborted_total` | counter | shadow 期间被 abort 的数量 |
+
+### 8.3 审计日志
+
+所有 approval / activation / deactivation 必须写入 `.state/audit-log.jsonl`：
+
+```json
+{"timestamp":"2026-05-15T...","event":"approval_decided","approvalId":"...","artifactId":"...","channel":"code_tool_hook","decision":"approved","actor":"user@example.com","reason":"...","metadata":{}}
+```
+
+---
+
+## 9. 测试要求
+
+### 9.1 单元测试
+
+每个 ChannelWriter / ActivationDispatcher / ApprovalQueue 必须有：
+- happy path 测试
+- 幂等性测试
+- 错误分支测试
+- 配置覆盖测试
+
+### 9.2 集成测试场景
+
+1. **prompt 通道全自动**：RolloutReviewer auto_activate → ActivationDispatcher → Ledger.active
+2. **code_tool_hook 完整审批链**：auto_activate → 强制入队 → pd-console 批准 → shadow mode → live
+3. **model_training 双人审批**：入队 → 第一审批 → 24h 冷却 → 第二审批 → export
+4. **拒绝反馈环**：Reject → RejectionFeedback → 新 Dreamer task 触发
+5. **shadow mode abort**：shadow 期间误杀率超阈值 → 自动 deactivate
+
+### 9.3 安全测试
+
+- 不能绕过审批：直接调用 ChannelWriter.activate() 必须失败
+- 同一个人不能完成双重审批
+- 配置篡改必须有审计
+- 24h 冷却不可绕过
+
+---
+
+## 10. 实施进度
+
+详见 ADR-0006 §8 实施计划。本节维护组件级状态：
+
+| 组件 | 状态 |
+|------|------|
+| ActivationDispatcher | ✅ 基础版已落地 |
+| LedgerPromptWriter / PromptWriter | ✅ 基础版已落地 |
+| LedgerArchiveWriter / DeferArchiveWriter | ✅ 基础版已落地 |
+| SkillFileWriter | ❌ 待建 |
+| RuleHostWriter | ❌ 待建 |
+| TrainingExporter | ❌ 待建 |
+| ApprovalQueue + SQLite schema | ✅ 基础版已落地（4 状态；二次确认/过期待扩展） |
+| RejectionFeedback | ❌ 待建 |
+| pd-console /approvals 路由 | ✅ 基础版已落地 |
+| 配置 schema 校验 | ❌ 待建 |
+| 审计日志 | ❌ 待建 |
+
+---
+
+## 11. 关联文档
+
+- [ADR-0006](../adr/0006-hybrid-activation-mechanism.md) — 决策依据
+- [ADR-0004](../adr/0004-l2-auto-correction-and-replay.md) — code_tool_hook 通道的安全机制
+- [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) — 上层视图
+- [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) — 上游数据流
+- [`COMPONENTS.md`](./COMPONENTS.md) — 组件目录
+- [`SECURITY_ARCHITECTURE.md`](./SECURITY_ARCHITECTURE.md) — 双人审批的安全考量（待建）

--- a/docs/architecture/ACTIVATION_CHANNELS.md
+++ b/docs/architecture/ACTIVATION_CHANNELS.md
@@ -288,12 +288,12 @@ CREATE TABLE rejection_feedbacks (
 
 #### 触发
 - RolloutReviewer 输出 `decision=auto_activate`
-- ActivationDispatcher 直接调用 `LedgerPromptWriter.activate()`
+- ActivationDispatcher 直接调用 `PromptWriter.activate()`（设计稿原名 LedgerPromptWriter）
 
 #### 操作
 
 ```typescript
-class LedgerPromptWriter implements ChannelWriter {
+class PromptWriter implements ChannelWriter {
   channel = 'prompt' as const;
 
   async canActivate(artifact: PIArtifact): Promise<CanActivateResult> {
@@ -355,7 +355,7 @@ class LedgerPromptWriter implements ChannelWriter {
 #### 操作
 
 ```typescript
-class LedgerArchiveWriter implements ChannelWriter {
+class DeferArchiveWriter implements ChannelWriter {
   channel = 'defer_archive' as const;
 
   async activate(artifact, context): Promise<ActivationOutcome> {
@@ -1020,8 +1020,8 @@ activation:
 | 组件 | 状态 |
 |------|------|
 | ActivationDispatcher | ✅ 基础版已落地 |
-| LedgerPromptWriter / PromptWriter | ✅ 基础版已落地 |
-| LedgerArchiveWriter / DeferArchiveWriter | ✅ 基础版已落地 |
+| `PromptWriter`（设计稿名 `LedgerPromptWriter`）| ✅ 基础版已落地 |
+| `DeferArchiveWriter`（设计稿名 `LedgerArchiveWriter`）| ✅ 基础版已落地 |
 | SkillFileWriter | ❌ 待建 |
 | RuleHostWriter | ❌ 待建 |
 | TrainingExporter | ❌ 待建 |

--- a/docs/architecture/COMPONENTS.md
+++ b/docs/architecture/COMPONENTS.md
@@ -1,0 +1,605 @@
+# PD 组件目录（Components Catalog）
+
+> **状态**: Active
+> **最后更新**: 2026-05-15
+> **定位**: PD 系统**所有架构组件**的扁平索引。每个组件有清晰的 owner、契约、不变量。
+> **关联**: `PD_ARCHITECTURE_OVERVIEW.md`（层级视图）, `GLOSSARY.md`（术语）
+
+本文档以**表格形式**列出 PD 的所有组件。每个组件至少要回答：
+- 它在哪一层、哪个包
+- 输入和输出是什么
+- 谁是 owner、状态如何
+- 不变量与禁止行为
+- 当前实现状态
+
+新增/修改组件必须**先更新本目录**，再写代码。
+
+---
+
+## 1. 组件分类
+
+PD 系统有 5 类组件：
+
+| 类型 | 标识 | 定义 |
+|-----|------|------|
+| Service | 🔵 Service | 长期存在的业务逻辑封装，有内部状态 |
+| Runner | 🟢 Runner | Internalization Pipeline 中的 Peer Runner |
+| Store | 🟡 Store | 持久化存储抽象（CRUD） |
+| ReadModel | 🟣 ReadModel | 只读视图聚合 |
+| Adapter | 🔴 Adapter | 外部系统/平台桥接 |
+| Bridge | 🟠 Bridge | 跨阶段衔接（事件 → 任务 / 工件 → 激活） |
+| Hook | ⚫ Hook | 平台事件回调 |
+| Writer | 🟤 Writer | 通道激活写入器 |
+| Schema | 📋 Schema | 数据契约（TypeBox） |
+| Util | 🔧 Util | 纯工具函数（无状态） |
+
+---
+
+## 2. Layer 1: Foundation（基础层）
+
+### 2.1 Schema 与契约
+
+| 组件 | 类型 | 包 | 定义位置 | 输入 | 输出 | Owner | 状态 |
+|------|-----|----|----|----|----|-------|------|
+| `PainSignalSchema` | 📋 Schema | core | `pain-signal.ts` | n/a（schema） | TypeBox schema | core | ✅ |
+| `TelemetryEventSchema` | 📋 Schema | core | `telemetry-event.ts` | n/a | TypeBox schema | core | ✅ |
+| `AgentSpecSchema` | 📋 Schema | core | `runtime-v2/agent-spec.ts` | n/a | TypeBox schema | core | ✅ |
+| `RuntimeProtocolSchemas` | 📋 Schema | core | `runtime-v2/runtime-protocol.ts` | n/a | RunHandle/Status/Input | core | ✅ |
+| `TaskRecord` schema | 📋 Schema | core | `runtime-v2/task-status.ts` | n/a | TaskRecord type | core | ✅ |
+| `PITaskRecord` schema | 📋 Schema | core | `runtime-v2/internalization/peer-runner-contracts.ts` | n/a | PITaskRecord type | core | ✅ |
+| `PIArtifact` schema | 📋 Schema | core | `runtime-v2/internalization/pi-artifact.ts` | n/a | PIArtifact type | core | ✅ |
+| `DiagnosticianOutputV1Schema` | 📋 Schema | core | `runtime-v2/diagnostician-output.ts` | n/a | TypeBox schema | core | ✅ |
+| `*RunnerOutputV1Schema`（7 个） | 📋 Schema | core | `runtime-v2/internalization/*-output.ts` | n/a | TypeBox schemas | core | ✅ |
+| `PDErrorCategory` | 📋 Schema | core | `runtime-v2/error-categories.ts` | n/a | enum + map | core | ✅ |
+| `LedgerPrincipleEntry` schema | 📋 Schema | core | `runtime-v2/candidate-intake.ts` | n/a | type | core | ✅ |
+| `CorrectionProposal` schema | 📋 Schema | core | `runtime-v2/internalization/correction-proposal.ts` | n/a | TypeBox schema | core | ✅ |
+| `GoldenTrace` schema | 📋 Schema | core | `runtime-v2/internalization/golden-trace.ts` | n/a | TypeBox schema | core | ✅ |
+| `ApprovalRecord` type | 📋 Schema | core | `runtime-v2/activation/activation-types.ts` | n/a | TS contract（TypeBox schema 待补） | core | ⚠️ 部分 |
+
+### 2.2 Stores
+
+| 组件 | 类型 | 包 | 文件 | 持久化 | 操作 | 不变量 | 状态 |
+|------|-----|----|----|----|----|------|------|
+| `TaskStore` (Sqlite/Memory) | 🟡 Store | core | `runtime-v2/store/task/` | state.db | CRUD + listByStatus | 状态机转移须经 IdempotentTransitions | ✅ |
+| `RunStore` (Sqlite/Memory) | 🟡 Store | core | `runtime-v2/store/run/` | state.db | CRUD + listByTask | 1 Task : N Runs | ✅ |
+| `CommitStore` (Sqlite/Memory) | 🟡 Store | core | `runtime-v2/store/commit/` | state.db | CRUD | append-only | ✅ |
+| `CandidateStore` (Sqlite/Memory) | 🟡 Store | core | `runtime-v2/store/candidate/` | state.db | CRUD + listByTask | candidate.status 状态机 | ✅ |
+| `ArtifactStore` (Sqlite/Memory) | 🟡 Store | core | `runtime-v2/store/artifact/` | state.db | CRUD | artifact 不可变 | ✅ |
+| `PIArtifactStore` | 🟡 Store | core | `runtime-v2/internalization/pi-artifact-store.ts` | state.db | upsert + listBySourceTaskId | (sourceTaskId, artifactKind) 幂等 | ✅ |
+| `TrajectoryLocator` | 🟡 Store | core | `runtime-v2/store/trajectory/` | state.db | locate by 多种维度 | read-only 后 hydrate | ✅ |
+| `HistoryQuery` | 🟡 Store | core | `runtime-v2/store/history/` | state.db | bounded query + 分页 | 不允许无 bound 的 scan | ✅ |
+| `ContextAssembler` | 🟡 Store | core | `runtime-v2/store/context/` | state.db | assemble(taskId) | output 可序列化 | ✅ |
+| `LedgerStore`（基于 JSON） | 🟡 Store | core | `principle-tree-ledger.ts` | `principle_training_state.json` | mutateLedger 包装 | atomic write only | ✅ |
+| `PainFlagWriter` | 🟡 Store | core | `pain-recorder.ts` | state.db + ledger | recordPainSignal | 幂等键 painId | ✅ |
+| `EvolutionScorecard` | 🟡 Store | plugin | `core/evolution-engine.ts` | `.state/evolution-scorecard.json` | atomic write | 仅增不减 | ✅ |
+| `ApprovalStore` | 🟡 Store | core | `runtime-v2/activation/sqlite-approval-store.ts` / `memory-approval-store.ts` | state.db / memory | CRUD | (artifactId, channel) 确定性 approvalId | ✅ |
+| `RejectionFeedbackStore` | 🟡 Store | core | `runtime-v2/activation/rejection-feedback-store.ts` | state.db | append-only | 不可修改 | ❌ 待建 |
+| `RuntimeStateManager` | 🟡 Store（聚合） | core | `runtime-v2/store/runtime-state-manager.ts` | state.db | task / run / candidate / artifact 统一入口 | LeaseManager 包装 | ✅ |
+| `LeaseManager` | 🟡 Store（辅助） | core | `runtime-v2/store/lifecycle/lease-manager.ts` | state.db | acquireLease / releaseLease | TTL 强制 | ✅ |
+| `RecoverySweep` | 🟡 Store（辅助） | core | `runtime-v2/store/lifecycle/recovery-sweep.ts` | state.db | sweep expired leases | 幂等 | ✅ |
+| `RetryPolicy` | 🟡 Store（辅助） | core | `runtime-v2/store/lifecycle/retry-policy.ts` | n/a | shouldRetry(task) | 永久错误集合固定 | ✅ |
+| `StoreEventEmitter` | 🟡 Store（辅助） | core | `runtime-v2/store/event-emitter.ts` | state.db: events | emitTelemetry | 异步可丢失允许 | ✅ |
+
+### 2.3 Read Models
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 副作用 | 状态 |
+|------|-----|----|----|----|----|------|------|
+| `PainChainReadModel` | 🟣 ReadModel | core | `runtime-v2/pain-chain-read-model.ts` | painId | 完整链 trace | 无 | ✅ |
+| `InternalizationQueueReadModel` | 🟣 ReadModel | core | `runtime-v2/internalization-queue-read-model.ts` | n/a | 队列健康快照 | 无 | ✅ |
+| `PruningReadModel` | 🟣 ReadModel | core | `runtime-v2/pruning-read-model.ts` | n/a | PruningSignal[] | 无 | ✅ |
+| `OperatorHealthReadModel` | 🟣 ReadModel | core | `runtime-v2/operator-health-read-model.ts` | n/a | 整体健康 | 无 | ✅ |
+| `LifecycleReadModel` | 🟣 ReadModel | core | `runtime-v2/internalization/lifecycle-read-model.ts` | principleId | 生命周期 evidence | 无 | ✅ |
+| `SchemaConformanceReadModel` | 🟣 ReadModel | core | `runtime-v2/schema-conformance-read-model.ts` | n/a | schema 一致性报告 | 无 | ✅ |
+| `InternalizationChainIntegrityReadModel` | 🟣 ReadModel | core | `runtime-v2/internalization-chain-integrity-read-model.ts` | n/a | 断链检测 | 无 | ✅ |
+| `EventLogReadModel` | 🟣 ReadModel | console | `pd-console/server/models/EventLogReadModel.ts` | filter | events[] | 无 | ✅ |
+| `ApprovalQueueReadModel` | 🟣 ReadModel | core | `runtime-v2/activation/approval-queue.ts` + store list APIs | filter | ApprovalRecord[] | 无 | ⚠️ 基础版 |
+| `ActivationStatusReadModel` | 🟣 ReadModel | core | `runtime-v2/activation/*activation-state-store.ts` | idempotencyKey | 激活状态 | 无 | ✅ |
+| `GfiWorkspaceReadModel` | 🟣 ReadModel | core | `runtime-v2/gfi/gfi-read-model.ts` | n/a | GFI 快照 | 无 | ✅ |
+
+### 2.4 Util / Pure Functions
+
+| 组件 | 类型 | 包 | 文件 | 用途 | 状态 |
+|------|-----|----|----|----|------|
+| `atomicWriteFileSync` | 🔧 Util | core | `io.ts` | 原子文件写入 | ✅ |
+| `resolvePainFlagPath` | 🔧 Util | core | `pain-flag-resolver.ts` | 路径解析 | ✅ |
+| `validateRuleImplementationCandidate` | 🔧 Util | core | `runtime-v2/internalization/rule-code-validator.ts` | 代码安全校验 | ✅ |
+| `checkForbiddenPatterns` | 🔧 Util | core | `runtime-v2/internalization/rule-code-validator.ts` | 禁用模式检测 | ✅ |
+| `mergeDecisions` | 🔧 Util | core | `runtime-v2/internalization/rule-host-evaluator.ts` | RuleHost 决策合并 | ✅ |
+| `createRuleHostHelpers` | 🔧 Util | core | `runtime-v2/internalization/rule-host-helpers.ts` | RuleHost 沙箱辅助 | ✅ |
+| `recommendLifecycleRoute` | 🔧 Util | core | `runtime-v2/internalization/routing-policy.ts` | 路由决策 | ✅ |
+| `decideInternalizationRoute` | 🔧 Util | core | `runtime-v2/internalization/internalization-route.ts` | recommendation kind → route | ✅ |
+| `assessDeprecatedReadiness` | 🔧 Util | core | `runtime-v2/internalization/deprecated-readiness.ts` | 评估归档准备度 | ✅ |
+| `computeRuleMetrics` | 🔧 Util | core | `runtime-v2/internalization/lifecycle-metrics.ts` | 规则覆盖率计算 | ✅ |
+| `replayGoldenTrace` | 🔧 Util | core | `runtime-v2/golden-trace-replay-validator.ts` | GoldenTrace 回放 | ✅ |
+| `validateProposedParams` | 🔧 Util | core | `runtime-v2/internalization/correction-proposal.ts` | 校正参数校验 | ✅ |
+
+---
+
+## 3. Layer 2: Domain Services & Runners（领域服务层）
+
+### 3.1 Pain Pipeline 组件
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | Owner | 状态 |
+|------|-----|----|----|----|----|------|------|
+| `PainSignalAdapter` | 🔵 Service | core | `pain-signal-adapter.ts` | 平台事件 | PainSignal | core | ✅ |
+| `PainSignalBridge` | 🟠 Bridge | core | `runtime-v2/pain-signal-bridge.ts` | PainDetectedData | PainSignalBridgeResult | core | ✅ |
+| `PainToPrincipleService` | 🔵 Service | core | `runtime-v2/pain-to-principle-service.ts` | PainToPrincipleInput | Output | core | ✅ |
+| `DiagnosticianRunner` | 🟢 Runner | core | `runtime-v2/runner/diagnostician-runner.ts` | taskId | RunnerResult | core | ✅ |
+| `DiagnosticianValidator` | 🔵 Service | core | `runtime-v2/runner/default-validator.ts` | RawOutput | ValidationResult | core | ✅ |
+| `DiagnosticianCommitter` | 🔵 Service | core | `runtime-v2/store/commit/diagnostician-committer.ts` | output | CommitResult | core | ✅ |
+| `CandidateIntakeService` | 🔵 Service | core | `runtime-v2/candidate-intake-service.ts` | candidateId | LedgerPrincipleEntry | core | ✅ |
+| `DiagnosticianPromptBuilder` | 🔵 Service | core | `runtime-v2/diagnostician-prompt-builder.ts` | ContextPayload | prompt | core | ✅ |
+| `RecordPainSignalObservability` | 🔵 Service | core | `runtime-v2/pain-signal-observability.ts` | PainSignalData | warnings | core | ✅ |
+
+### 3.2 Internalization Pipeline 组件
+
+#### 3.2.1 编排与桥接
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `InternalizationOrchestrator` | 🔵 Service | core | `runtime-v2/internalization/internalization-orchestrator.ts` | taskKind? | WakeOnceResult | ✅ |
+| `IntakeToInternalizationBridge` | 🟠 Bridge | core | `runtime-v2/internalization/intake-to-internalization-bridge.ts` | ProbationCreatedInput | BridgeResult | ✅ 已落地 |
+| `IdleTrigger` | 🔵 Service | core | `runtime-v2/idle-trigger/`（纯策略） | idle config | wakeOnce 决策 | ✅ Done（core 纯策略；plugin 宿主适配待建）|
+| `InternalizationStateMachine` | 🔧 Util | core | `runtime-v2/internalization/internalization-state-machine.ts` | task / dependencies | gate decision | ✅ |
+| `InternalizationJobGraph` | 🔧 Util | core | `runtime-v2/internalization/internalization-job-graph.ts` | n/a | ALLOWED_EDGES | ✅ |
+| `InternalizationIntegrityRemediation` | 🔵 Service | core | `runtime-v2/internalization-integrity-remediation.ts` | broken link | remediation | ✅ |
+
+#### 3.2.2 7 个 Peer Runner
+
+| Runner | 类型 | 包 | 文件 | 输入工件 | 输出工件 | 状态 |
+|--------|-----|----|----|---------|---------|------|
+| `DreamerRunner` | 🟢 Runner | core | `runtime-v2/internalization/dreamer-runner.ts` | LedgerPrincipleEntry | PIArtifact(principle) | ✅ |
+| `PhilosopherRunner` | 🟢 Runner | core | `runtime-v2/internalization/philosopher-runner.ts` | DreamerOutput | PIArtifact(principle) | ✅ |
+| `ScribeRunner` | 🟢 Runner | core | `runtime-v2/internalization/scribe-runner.ts` | PhilosopherOutput | PIArtifact(principle) | ✅ |
+| `ArtificerRunner` | 🟢 Runner | core | `runtime-v2/internalization/artificer-runner.ts` | ScribeOutput | PIArtifact(rule) | ✅ |
+| `EvaluatorRunner` | 🟢 Runner | core | `runtime-v2/internalization/evaluator-runner.ts` | ArtificerOutput | PIArtifact(rule) | ✅ |
+| `RolloutReviewerRunner` | 🟢 Runner | core | `runtime-v2/internalization/rollout-reviewer-runner.ts` | EvaluatorOutput | PIArtifact(rule) + 触发 ActivationDispatcher | ⚠️ 需扩展 |
+| `TrainerRunner` | 🟢 Runner | core | `runtime-v2/internalization/trainer-runner.ts` | RolloutReviewerOutput | PIArtifact(training_data) | ✅ |
+
+#### 3.2.3 Runner 输出 Validator（每 Runner 一个）
+
+| Validator | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|-----------|-----|----|----|----|----|------|
+| `DefaultDiagnosticianValidator` | 🔵 Service | core | `runtime-v2/runner/default-validator.ts` | DiagnosticianOutputV1 | ValidationResult | ✅ |
+| `DefaultDreamerValidator` | 🔵 Service | core | `runtime-v2/internalization/dreamer-output.ts` | DreamerOutput | ValidationResult | ✅ |
+| `DefaultPhilosopherValidator` | 🔵 Service | core | `runtime-v2/internalization/philosopher-output.ts` | PhilosopherOutput | ValidationResult | ✅ |
+| `DefaultScribeValidator` | 🔵 Service | core | `runtime-v2/internalization/scribe-output.ts` | ScribeOutput | ValidationResult | ✅ |
+| `DefaultArtificerValidator` | 🔵 Service | core | `runtime-v2/internalization/artificer-output.ts` | ArtificerOutput | ValidationResult | ✅ |
+| `DefaultEvaluatorValidator` | 🔵 Service | core | `runtime-v2/internalization/evaluator-output.ts` | EvaluatorOutput | ValidationResult | ✅ |
+| `DefaultRolloutReviewerValidator` | 🔵 Service | core | `runtime-v2/internalization/rollout-reviewer-output.ts` | RolloutReviewerOutput | ValidationResult | ✅ |
+| `DefaultTrainerValidator` | 🔵 Service | core | `runtime-v2/internalization/trainer-output.ts` | TrainerOutput | ValidationResult | ✅ |
+
+#### 3.2.4 Prompt Builders
+
+| 组件 | 包 | 文件 | 状态 |
+|------|----|----|------|
+| `DiagnosticianPromptBuilder` | core | `runtime-v2/diagnostician-prompt-builder.ts` | ✅ |
+| `DreamerPromptBuilder` | core | `runtime-v2/internalization/dreamer-prompt-builder.ts` | ✅ |
+| `PhilosopherPromptBuilder` | core | `runtime-v2/internalization/philosopher-prompt-builder.ts` | ✅ |
+| `ScribePromptBuilder` | core | `runtime-v2/internalization/scribe-prompt-builder.ts` | ✅ |
+| `ArtificerPromptBuilder` | core | `runtime-v2/internalization/artificer-prompt-builder.ts` | ✅ |
+| `EvaluatorPromptBuilder` | core | `runtime-v2/internalization/evaluator-prompt-builder.ts` | ✅ |
+| `RolloutReviewerPromptBuilder` | core | `runtime-v2/internalization/rollout-reviewer-prompt-builder.ts` | ✅ |
+| `TrainerPromptBuilder` | core | `runtime-v2/internalization/trainer-prompt-builder.ts` | ✅ |
+
+### 3.3 Activation Pipeline 组件
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `ActivationDispatcher` | 🔵 Service | core | `runtime-v2/activation/activation-dispatcher.ts` | DispatchInput | DispatchResult | ✅ 基础版 |
+| `ApprovalQueue` | 🔵 Service | core | `runtime-v2/activation/approval-queue.ts` | enqueue/approve/reject | ApprovalRecord | ✅ 基础版（4 状态） |
+| `PromptWriter` | 🟤 Writer | core | `runtime-v2/activation/low-risk-writers.ts` | PIArtifact | ActivationOutcome | ✅ 基础版 |
+| `DeferArchiveWriter` | 🟤 Writer | core | `runtime-v2/activation/low-risk-writers.ts` | PIArtifact | ActivationOutcome | ✅ 基础版 |
+| `SkillFileWriter` | 🟤 Writer | core | `runtime-v2/activation/writers/skill-file-writer.ts` | PIArtifact | ActivationOutcome | ❌ 待建 |
+| `RuleHostWriter` | 🟤 Writer | core | `runtime-v2/activation/writers/rule-host-writer.ts` | PIArtifact | ActivationOutcome | ❌ 待建 |
+| `TrainingExporter` | 🟤 Writer | core | `runtime-v2/activation/writers/training-exporter.ts` | PIArtifact | ActivationOutcome | ❌ 待建 |
+| `RejectionFeedbackService` | 🔵 Service | core | `runtime-v2/activation/rejection-feedback-service.ts` | reject input | feedbackId | ❌ 待建 |
+
+### 3.4 Pruning Pipeline 组件
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `PruningReadModel` | 🟣 ReadModel | core | `runtime-v2/pruning-read-model.ts` | n/a | PruningSignal[] | ✅ |
+| `PruningReviewLog` | 🟡 Store | core | `runtime-v2/pruning-review-log.ts` | review record | append-only | ✅ |
+| `PruningMask` | 🔧 Util | core | `runtime-v2/pruning-mask.ts` | ledger + reviews | maskedSet | ✅ |
+| `PruningAction`（未来） | 🔵 Service | core | TBD | review approved | ledger mutation | ❌ 未规划 |
+
+### 3.5 Runtime Adapters
+
+| 组件 | 类型 | 包 | 文件 | 状态 |
+|------|-----|----|----|------|
+| `PDRuntimeAdapter` interface | 📋 Schema | core | `runtime-v2/runtime-protocol.ts` | ✅ |
+| `OpenClawCliRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/openclaw-cli-runtime-adapter.ts` | ✅ |
+| `PiAiRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/pi-ai-runtime-adapter.ts` | ✅ |
+| `TestDoubleRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/test-double-runtime-adapter.ts` | ✅ |
+| `PrincipleTreeLedgerAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/principle-tree-ledger-adapter.ts` | ✅ |
+| `RuntimeSelector` | 🔵 Service | core | `runtime-v2/runtime-selector.ts` | ✅ |
+| `ClaudeCodeRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/claude-code-runtime-adapter.ts` | ❌ 待建（ADR-0008）|
+| `CodexCliRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/codex-cli-runtime-adapter.ts` | ❌ 待建（ADR-0008）|
+| `GeminiCliRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/gemini-cli-runtime-adapter.ts` | ❌ 待建（ADR-0008）|
+| `OpenCodeRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/opencode-runtime-adapter.ts` | ❌ 待建（ADR-0008）|
+| `HermesRuntimeAdapter` | 🔴 Adapter | core | `runtime-v2/adapter/hermes-runtime-adapter.ts` | ❌ 待建（ADR-0008）|
+
+### 3.8 BALM — Built-in Agent Lifecycle Manager（ADR-0008）
+
+> 统一管理 PD 内置代理的身份、提示词、工具、工作流、后端路由和版本。
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `BuiltInAgentRegistry` | 🔵 Service | core | `runtime-v2/agents/agent-registry.ts` | agentId | AgentManifest | ❌ 待建 |
+| `AgentManifest` schema | 📋 Schema | core | `runtime-v2/agents/agent-manifest.ts` | n/a | TypeBox schema | ❌ 待建 |
+| `AgentRuntimeResolver` | 🔵 Service | core | `runtime-v2/agents/agent-runtime-resolver.ts` | agentId + caps | PDRuntimeAdapter | ❌ 待建 |
+| `AgentLoader` | 🔵 Service | core | `runtime-v2/agents/agent-loader.ts` | agentId + runtimeKind | AgentBundle | ❌ 待建 |
+| `AgentVersioning` | 🔵 Service | core | `runtime-v2/agents/agent-versioning.ts` | agentId + samples | EvalResult | ❌ 待建 |
+| `diagnostician.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/diagnostician.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `dreamer.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/dreamer.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `philosopher.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/philosopher.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `scribe.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/scribe.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `artificer.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/artificer.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `evaluator.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/evaluator.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `rollout-reviewer.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/rollout-reviewer.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+| `trainer.agent.yaml` | 📋 Schema | core | `runtime-v2/agents/definitions/trainer.agent.yaml` | n/a | AgentManifest | ❌ 待建 |
+
+**不变量**：
+- `BALM-1`：所有内置代理必须有 manifest，禁止匿名 Peer Runner
+- `BALM-2`：Peer Runner 不得直接 import Adapter 实现，必须通过 BALM 解析
+- `BALM-3`：Agent prompt 必须从 manifest 加载，不得硬编码
+
+### 3.9 LRAS — Long-Running Agent Session（ADR-0009）
+
+> 代理持续工作直到完成的会话模型。10 分钟起步，有检查点、自校验工具、错误日志回灌。
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `AgentSession` | 🔵 Service | core | `runtime-v2/session/agent-session.ts` | taskId + agentBundle | SessionResult | ❌ 待建 |
+| `SessionCheckpoint` | 🟡 Store | core | `runtime-v2/session/session-checkpoint.ts` | sessionId + scratchpad | checkpointId | ❌ 待建 |
+| `SessionStateMachine` | 🔧 Util | core | `runtime-v2/session/session-state-machine.ts` | state + event | nextState | ❌ 待建 |
+| `SelfValidationTools` | 🔵 Service | core | `runtime-v2/session/self-validation-tools.ts` | output + schema | ValidationResult | ❌ 待建 |
+| `LogBackflow` | 🔵 Service | core | `runtime-v2/session/log-backflow.ts` | workspaceDir + lookback | logLines[] | ❌ 待建 |
+
+**PD 元工具（pd-cli 暴露给代理）**：
+
+| 工具 | pd-cli 命令 | 作用 | 状态 |
+|-----|-----------|------|------|
+| `pd_validate_output` | `pd validate-output` | 在线校验输出是否符合 schema | ❌ 待建 |
+| `pd_fetch_recent_logs` | `pd logs recent` | 拉取最近 N 条 error/warn 日志 | ❌ 待建 |
+| `pd_fetch_pain_history` | `pd pain history` | 拉取 painId 的历史诊断 | ❌ 待建 |
+| `pd_fetch_principle_ledger` | `pd ledger read` | 只读访问账本 | ❌ 待建 |
+| `pd_check_schema_drift` | `pd schema check` | 验证当前 schema 版本 | ❌ 待建 |
+
+**不变量**：
+- `LRAS-1`：每个 LRAS session 至少有 1 个 checkpoint
+- `LRAS-2`：self-validation tools 不得有副作用（只读）
+- `LRAS-3`：Log backflow 必须脱敏（应用 log-sanitizer）
+
+### 3.10 GAP — Goal-Aligned Pain + Goals（ADR-0010）
+
+> 目标驱动的痛苦信号源。Mission/Objective 数据模型 + GAP 信号生成器 + 决策卫生门控。
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `ObjectiveStore` | 🟡 Store | core | `runtime-v2/goals/objective-store.ts` | Objective | CRUD | ❌ 待建 |
+| `KeyResultStore` | 🟡 Store | core | `runtime-v2/goals/key-result-store.ts` | KeyResult | CRUD | ❌ 待建 |
+| `MissionStore` | 🟡 Store | core | `runtime-v2/goals/mission-store.ts` | Mission | CRUD | ❌ 待建 |
+| `GAPSignalGenerator` | 🔵 Service | core | `runtime-v2/goals/gap-signal-generator.ts` | workspaceDir | GAPSignal[] | ❌ 待建 |
+| `AlignmentEvaluator` | 🔧 Util | core | `runtime-v2/goals/alignment-evaluator.ts` | mission + objective | alignmentScore | ❌ 待建 |
+| `DecisionHygieneGate` | 🔵 Service | core | `runtime-v2/decision-hygiene/decision-hygiene-gate.ts` | DecisionContext | HygieneRequirement | ❌ 待建 |
+| `ThinkingModels` | 🔧 Util | core | `runtime-v2/decision-hygiene/thinking-models.ts` | n/a | framework list | ❌ 待建 |
+
+**GAP 信号三层架构**：
+
+| 层 | 信号类型 | 触发 Diagnostician | 说明 |
+|----|---------|------------------|------|
+| Layer 1（主信号）| `mission_failed` / `mission_stalled` / `okr_drift` / `decision_skipped` / `rework_loop` | ✅ 独立触发 | 目标层事件 |
+| Layer 2（强信号）| `explicit_user_complaint` / `user_correction` | ✅ 独立触发 | 用户反馈 |
+| Layer 3（辅助）| `tool_failure` / `empathy_inferred` | ❌ 仅作为证据 | 不独立触发 |
+
+**DecisionHygieneGate 触发规则**：
+
+| 条件 | 触发类型 |
+|------|---------|
+| 估计影响 = high / critical | 强制（hard gate）|
+| 涉及不可逆变更（删数据、改 schema、生产部署）| 强制 |
+| 同一 mission 已 rework 过 3 次 | 强制 |
+| 偏离当前 OKR > 20% | 强制 |
+| 其他情况 | 提醒（soft reminder）|
+
+**不变量**：
+- `GAP-1`：Layer 3 信号不得独立触发 Diagnostician（GAP Generator 强制）
+- `HYGIENE-1`：high/critical 影响的决策必须经过 DecisionHygieneGate
+
+### 3.11 MissionScheduler — 三层任务调度（ADR-0011）
+
+> 替代 polling 模型，按 Objective → Mission → Run 三层优先级调度代理工作。
+
+| 组件 | 类型 | 包 | 文件 | 输入 | 输出 | 状态 |
+|------|-----|----|----|----|----|------|
+| `MissionScheduler` | 🔵 Service | core | `runtime-v2/scheduler/mission-scheduler.ts` | n/a | ScheduleDecision[] | ❌ 待建 |
+| `PriorityCalculator` | 🔧 Util | core | `runtime-v2/scheduler/priority-calculator.ts` | mission + objective | priority score | ❌ 待建 |
+| `DependencyResolver` | 🔧 Util | core | `runtime-v2/scheduler/dependency-resolver.ts` | taskId | resolved deps | ❌ 待建 |
+
+**三层任务模型**：
+
+| 层 | 实体 | 生命周期 | 关联 |
+|----|------|---------|------|
+| L1 | `Objective` | 数月（季度目标）| 由人类设置 |
+| L2 | `Mission` | 数小时到数天 | 可选关联 Objective |
+| L3 | `Run`（现有 TaskRecord）| 数分钟到数十分钟 | 关联 Mission |
+
+**不变量**：
+- `SCHED-1`：MissionScheduler 调度决策必须可解释（reason 字段非空）
+- `SCHED-2`：IdleTrigger 唤起后调用 MissionScheduler，不直接调用 Orchestrator
+
+### 3.6 GFI（Global Friction Index）
+
+| 组件 | 类型 | 包 | 文件 | 状态 |
+|------|-----|----|----|------|
+| `GfiKernel`（pure functions） | 🔧 Util | core | `runtime-v2/gfi/gfi-kernel.ts` | ✅ |
+| `GfiPolicy` | 📋 Schema | core | `runtime-v2/gfi/gfi-types.ts` | ✅ |
+| `GfiReadModel` | 🟣 ReadModel | core | `runtime-v2/gfi/gfi-read-model.ts` | ✅ |
+| `GfiSessionAdapter` | 🔴 Adapter | plugin | `core/session-tracker.ts` | ✅ |
+
+### 3.7 Prompt Builder Primitives
+
+| 组件 | 类型 | 包 | 文件 | 状态 |
+|------|-----|----|----|------|
+| `buildAttitudeDirective` | 🔧 Util | core | `prompt-builder/attitude-directive.ts` | ✅ |
+| `detectCorrectionCue` | 🔧 Util | core | `prompt-builder/correction-cue.ts` | ✅ |
+| `truncateInjectionToBudget` | 🔧 Util | core | `prompt-builder/size-guard.ts` | ✅ |
+| `matchEmpathyKeywords` | 🔧 Util | core | `prompt-builder/empathy-keyword-matching.ts` | ✅ |
+| `compressFocusContent` | 🔧 Util | core | `prompt-builder/focus-compression.ts` | ✅ |
+| `extractMessageContent` | 🔧 Util | core | `prompt-builder/message-extraction.ts` | ✅ |
+
+---
+
+## 4. Layer 3: Host Integration（宿主集成层）
+
+### 4.1 OpenClaw Hooks
+
+| Hook | 包 | 文件 | 触发时机 | 主要工作 | 状态 |
+|------|----|----|---------|---------|------|
+| `before_prompt_build` | plugin | `hooks/prompt.ts` | 每次构建 prompt | 注入 active 原则 + thinking OS | ✅ |
+| `before_tool_call` | plugin | `hooks/gate.ts` | 工具执行前 | RuleHost 评估 + Progressive gate | ✅ |
+| `after_tool_call` | plugin | `hooks/pain.ts` | 工具执行后 | 痛苦信号检测 + 触发 PainBridge | ✅ |
+| `llm_output` | plugin | `hooks/llm.ts` | LLM 响应后 | 检测 user empathy 信号 | ✅ |
+| `subagent_ended` | plugin | `hooks/subagent.ts` | 子代理结束 | 完成 shadow observation | ✅ |
+| `subagent_spawning` | plugin | `hooks/subagent.ts` | 子代理生成前 | 路由分类 + 拦截 | ✅ |
+| `before_reset` / `before_compaction` / `after_compaction` | plugin | `hooks/lifecycle.ts` | 上下文压缩 | 工作记忆保存与恢复 | ✅ |
+| `trajectory_collector` | plugin | `hooks/trajectory-collector.ts` | 各种点 | 轨迹采集 | ✅ |
+| `lifecycle_routing` | plugin | `hooks/lifecycle-routing.ts` | 各种点 | 生命周期路由 | ✅ |
+| `message_sanitize` | plugin | `hooks/message-sanitize.ts` | 消息接收 | PII 脱敏 | ⚠️ 设计文档建议删除 |
+
+### 4.2 Plugin Services（合并后保留）
+
+| 组件 | 类型 | 包 | 文件 | 职责 | 状态 |
+|------|-----|----|----|----|------|
+| `EvolutionWorkerService` | 🔵 Service | plugin | `service/evolution-worker.ts` | 进化队列调度 | ⚠️ 需重构（合并后）|
+| `IdleTrigger` | 🔵 Service | core | `runtime-v2/idle-trigger/`（纯策略） | 空闲检测策略 + wakeOnce 决策 | ✅ Done（core 纯策略模块；plugin 宿主适配层待后续 issue）|
+| `TrajectoryService` | 🔵 Service | plugin | `service/trajectory-service.ts` | 轨迹存储 | ✅ |
+| `PDTaskService` | 🔵 Service | plugin | `core/pd-task-service.ts` | 后台任务调度 | ⚠️ 部分实现 |
+| `CentralSyncService` | 🔵 Service | plugin | `service/central-sync-service.ts` | 跨工作区同步 | ✅ |
+| `KeywordOptimizationService` | 🔵 Service | plugin | `service/keyword-optimization-service.ts` | empathy 关键词优化 | ✅ |
+| `MonitoringQueryService` | 🔵 Service | plugin | `service/monitoring-query-service.ts` | 监控查询 | ✅ |
+| `RuntimeSummaryService` | 🔵 Service | plugin | `service/runtime-summary-service.ts` | 运行时摘要 | ✅ |
+| `WorkflowWatchdog` | 🔵 Service | plugin | `service/workflow-watchdog.ts` | 工作流看门狗 | ✅ |
+| `EventLogAuditor` | 🔵 Service | plugin | `service/event-log-auditor.ts` | 事件日志审计 | ✅ |
+| `StartupReconciler` | 🔵 Service | plugin | `service/startup-reconciler.ts` | 启动一致性校验 | ✅ |
+
+### 4.3 Plugin Services（计划删除/迁移，参见 ADR-0005）
+
+| 组件 | 包 | 文件 | 处理方式 |
+|------|----|----|---------|
+| `NocturnalService` | plugin | `service/nocturnal-service.ts` | 拆解：触发部分迁入 IdleTrigger，业务部分删除 |
+| `NocturnalRuntime` | plugin | `service/nocturnal-runtime.ts` | 删除 |
+| `NocturnalConfig` | plugin | `service/nocturnal-config.ts` | 部分迁入 internalization config |
+| `NocturnalTargetSelector` | plugin | `service/nocturnal-target-selector.ts` | 删除（被 InternalizationQueueReadModel 替代） |
+| `SleepCycle` | plugin | `service/sleep-cycle.ts` | 简化：只保留唤起判断 |
+| `TrinityRuntimeAdapter` | plugin | `core/nocturnal-trinity.ts` | 删除（被 PDRuntimeAdapter 替代） |
+| `nocturnal-trinity` | plugin | `core/nocturnal-trinity.ts` | 删除 |
+| `nocturnal-arbiter` | plugin | `core/nocturnal-arbiter.ts` | 删除 |
+| `nocturnal-artificer` | plugin | `core/nocturnal-artificer.ts` | 删除 |
+| `nocturnal-executability` | plugin | `core/nocturnal-executability.ts` | 部分迁入 core |
+| `nocturnal-trajectory-extractor` | plugin | `core/nocturnal-trajectory-extractor.ts` | 部分迁入 core 的 ContextAssembler |
+
+### 4.4 Plugin Commands（命令实现）
+
+| 命令 | 文件 | 状态 |
+|------|----|------|
+| `/pd-init` | `commands/strategy.ts` | ✅ |
+| `/pd-bootstrap` | `commands/capabilities.ts` | ✅ |
+| `/pd-research` | `commands/capabilities.ts` | ✅ |
+| `/pd-status` / `/pd-evolution-status` | `commands/evolution-status.ts` | ✅ |
+| `/pd-reflect` | `commands/pd-reflect.ts` | ✅ |
+| `/pd-promote-impl` / `/pd-disable-impl` / `/pd-archive-impl` / `/pd-rollback-impl` | `commands/promote-impl.ts` 等 | ✅ |
+| `/pd-principle-rollback` | `commands/principle-rollback.ts` | ✅ |
+| `/pd-rollback` | `commands/rollback.ts` | ✅ |
+| `/pd-pain` | `commands/pain.ts` | ✅ |
+| `/pd-context` | `commands/context.ts` | ✅ |
+| `/pd-focus` | `commands/focus.ts` | ✅ |
+| `/pd-export` | `commands/export.ts` | ✅ |
+| `/pd-samples` | `commands/samples.ts` | ✅ |
+| `/pd-thinking-os` | `commands/thinking-os.ts` | ✅ |
+| `/pd-manage-okr` | `commands/strategy.ts` | ✅ |
+| `/pd-workflow-debug` | `commands/workflow-debug.ts` | ✅ |
+| `/pd-nocturnal-*` | `commands/nocturnal-*.ts` | ⚠️ 待重命名为 `/pd-internalization-*` |
+
+---
+
+## 5. Layer 4: Surface（表面层）
+
+### 5.1 pd-cli 命令（for AI Agent）
+
+| 命令 | 文件 | 输入 | 输出 | 状态 |
+|------|----|----|----|------|
+| `pd diagnose` | `pd-cli/commands/diagnose.ts` | painId | DiagnoseRunResult | ✅ |
+| `pd run` | `pd-cli/commands/run.ts` | taskId | RunResult | ✅ |
+| `pd status` | `pd-cli/commands/health.ts` | n/a | health snapshot | ✅ |
+| `pd context build` | `pd-cli/commands/context.ts` | filter | ContextPayload | ✅ |
+| `pd history query` | `pd-cli/commands/history.ts` | filter | history[] | ✅ |
+| `pd trajectory locate` | `pd-cli/commands/trajectory.ts` | hint | candidates | ✅ |
+| `pd pain record` | `pd-cli/commands/pain-record.ts` | PainSignalInput | painId | ✅ |
+| `pd task list / show` | `pd-cli/commands/task.ts` | filter | TaskRecord[] | ✅ |
+| `pd flow status` | `pd-cli/commands/flow.ts` | n/a | pipeline status | ✅ |
+| `pd trace show` | `pd-cli/commands/trace.ts` | painId | PainChainTrace | ✅ |
+| `pd runtime *` | `pd-cli/commands/runtime*.ts` | 多种 | 多种 | ✅ |
+| `pd runtime internalization-queue` | `pd-cli/commands/runtime-internalization-queue.ts` | n/a | queue snapshot | ✅ |
+| `pd runtime internalization-wake-once` | `pd-cli/commands/runtime-internalization-wake-once.ts` | taskKind? | WakeOnceResult | ✅ |
+| `pd runtime internalization-run-once` | `pd-cli/commands/runtime-internalization-run-once.ts` | taskId | RunnerResult | ✅ |
+| `pd activation list` | `pd-cli/commands/activation.ts` | filter | ApprovalRecord[]（read only）| ❌ 待建 |
+| `pd activation status` | `pd-cli/commands/activation.ts` | artifactId | activation status | ❌ 待建 |
+| `pd legacy-import` | `pd-cli/commands/legacy-import.ts` | nocturnal artifacts | imported count | ✅ |
+| `pd legacy-cleanup` | `pd-cli/commands/legacy-cleanup.ts` | n/a | cleaned count | ✅ |
+| `pd central-sync` | `pd-cli/commands/central-sync.ts` | n/a | sync result | ✅ |
+| `pd samples list / review` | `pd-cli/commands/samples-*.ts` | filter | samples | ✅ |
+| `pd remediation output` | `pd-cli/commands/remediation-output.ts` | n/a | remediation list | ✅ |
+| `pd evolution-tasks list / show` | `pd-cli/commands/evolution-tasks-*.ts` | n/a | evolution tasks | ✅ |
+| `pd runtime-canary` | `pd-cli/commands/runtime-canary.ts` | n/a | canary report | ✅ |
+| `pd runtime-uat` | `pd-cli/commands/runtime-uat.ts` | n/a | UAT result | ✅ |
+
+### 5.2 pd-console 路由（for Human）
+
+| 路由 | 文件 | 用途 | 状态 |
+|------|----|----|------|
+| `/dashboard` | `pd-console/ui/pages/Dashboard.tsx` | 总览 | ✅ |
+| `/health` | `pd-console/ui/pages/Health.tsx` | 健康监控 | ✅ |
+| `/pipeline` | `pd-console/ui/pages/Pipeline.tsx` | 流水线状态 | ✅ |
+| `/events` | `pd-console/ui/pages/EventLog.tsx` | 事件日志 | ✅ |
+| `/principles` | `pd-console/ui/pages/Principles.tsx` | 原则列表 | ⚠️ 部分 |
+| `/approvals` | `pd-console/src/ui/pages/TasksPage.tsx` | 审批队列（基础版） | ✅ 基础版 |
+| `/approvals/{id}` | TBD | 审批详情 | ❌ 待建 |
+| `/approvals/history` | `pd-console/ui/pages/ApprovalHistory.tsx` | 审批历史 | ❌ 待建 |
+| `/pruning` | `pd-console/ui/pages/Pruning.tsx` | 修剪信号 | ⚠️ 部分 |
+
+### 5.3 pd-console 模型（read-only）
+
+| 模型 | 文件 | 用途 | 状态 |
+|------|----|----|------|
+| `EventLogReadModel` | `pd-console/server/models/EventLogReadModel.ts` | 事件聚合 | ✅ |
+| `GateConsoleModel` | `pd-console/server/models/GateConsoleModel.ts` | gate 状态 | ✅ |
+| `FeedbackConsoleModel` | `pd-console/server/models/FeedbackConsoleModel.ts` | 反馈 | ✅ |
+| `ApprovalConsoleModel` | TBD | 审批数据 | ❌ 待建 |
+
+---
+
+## 6. 跨层组件的依赖矩阵
+
+```
+                    Schema  Util   Store  ReadModel  Service  Runner  Adapter  Bridge  Hook  Writer  Surface
+Schema                ●
+Util                         ●
+Store                  ●     ●      ●
+ReadModel              ●     ●      ●        ●
+Service                ●     ●      ●        ●         ●
+Runner                 ●     ●      ●        ●         ●        ●
+Adapter                ●     ●      ●                  ●                ●
+Bridge                 ●     ●      ●                  ●                         ●
+Hook                   ●     ●      ●        ●         ●                                  ●
+Writer                 ●     ●      ●                  ●                                          ●
+Surface                ●     ●      ●        ●         ●                ●                                ●
+
+● = 可依赖
+```
+
+**强约束（架构守护测试）**：
+
+1. Schema/Util 不允许依赖任何上层组件
+2. Store 不允许依赖 Service / Runner / Bridge / Hook
+3. Runner 必须通过 Store 入队，不允许直接调用其他 Runner
+4. Hook 不允许包含业务逻辑，只允许调用 Service/Bridge
+5. Writer 必须通过 ActivationDispatcher 调用，不允许直接被 Runner 调用
+6. Adapter 不允许依赖 Hook / Surface / Bridge
+
+---
+
+## 7. 不变量与责任清单
+
+### 7.1 全局不变量（适用于所有组件）
+
+| ID | 不变量 | 强制方式 |
+|----|------|---------|
+| INV-1 | 不允许 core 依赖 plugin / cli / console | architecture-regression test |
+| INV-2 | 不允许 plugin 依赖 cli / console | architecture-regression test |
+| INV-3 | 不允许 cli / console 之间相互依赖 | architecture-regression test |
+| INV-4 | 不允许在 core 中使用 setInterval / cron | architecture-regression test |
+| INV-5 | 不允许直接调用 LLM API（除 Adapter 外） | architecture-regression test |
+| INV-6 | Schema 改动必须 backward compatible | manual review + 集成测试 |
+| INV-7 | Store 写入必须原子或事务 | implementation requirement |
+| INV-8 | Runner 必须通过 PDRuntimeAdapter | architecture-regression test |
+| INV-9 | Activation 必须通过 ActivationDispatcher | architecture-regression test |
+
+### 7.2 组件级 Owner 责任
+
+每个组件的 Owner 负责：
+
+1. **维护契约**：组件接口稳定，破坏性变更走 ADR
+2. **维护文档**：本目录中本组件相关行的准确性
+3. **维护测试**：单元测试 + 集成测试
+4. **响应 issue**：与该组件相关的 bug
+
+Owner 标记规则：
+- **core**：默认 Owner 是 core 维护组（具体到模块的 Owner 在 `OWNERSHIP.md` 列出）
+- **plugin / cli / console**：相应包的维护者
+
+---
+
+## 8. 索引
+
+### 按字母顺序
+
+`ActivationDispatcher` §3.3 ✅
+`ApprovalQueue` §3.3 ✅
+`ArtificerRunner` §3.2.2 ✅
+`atomicWriteFileSync` §2.4 ✅
+`CandidateIntakeService` §3.1 ✅
+`ChannelWriter` §3.3
+`ContextAssembler` §2.2 ✅
+`DiagnosticianRunner` §3.1 ✅
+`DiagnosticianValidator` §3.1 ✅
+`DreamerRunner` §3.2.2 ✅
+`EvaluatorRunner` §3.2.2 ✅
+`EvolutionWorkerService` §4.2 ⚠️
+`IdleTrigger` §4.2 ✅
+`InternalizationOrchestrator` §3.2.1 ✅
+`IntakeToInternalizationBridge` §3.2.1 ✅
+`LeaseManager` §2.2 ✅
+`LedgerArchiveWriter` §3.3 ✅（`DeferArchiveWriter`）
+`LedgerPromptWriter` §3.3 ✅（`PromptWriter`）
+`LedgerStore` §2.2 ✅
+`OpenClawCliRuntimeAdapter` §3.5 ✅
+`PainSignalAdapter` §3.1 ✅
+`PainSignalBridge` §3.1 ✅
+`PainToPrincipleService` §3.1 ✅
+`PDRuntimeAdapter` §3.5 ✅
+`PhilosopherRunner` §3.2.2 ✅
+`PIArtifactStore` §2.2 ✅
+`PiAiRuntimeAdapter` §3.5 ✅
+`PrincipleTreeLedgerAdapter` §3.5 ✅
+`PromptBuilder` 各个 §3.2.4
+`PruningReadModel` §3.4 ✅
+`RecoverySweep` §2.2 ✅
+`RolloutReviewerRunner` §3.2.2 ✅
+`RuleHostWriter` §3.3 ❌
+`RuntimeStateManager` §2.2 ✅
+`ScribeRunner` §3.2.2 ✅
+`SkillFileWriter` §3.3 ❌
+`TrainerRunner` §3.2.2 ✅
+`TrainingExporter` §3.3 ❌
+
+### 按状态
+
+| 状态 | 数量 |
+|------|----|
+| ✅ 完整实现 | ~90 |
+| ⚠️ 部分实现/需重构 | ~10 |
+| ❌ 待建 | ~10 |
+
+---
+
+## 9. 关联文档
+
+- [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) — 层级视图
+- [`GLOSSARY.md`](./GLOSSARY.md) — 术语
+- [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) — 数据流
+- [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) — 通道详细
+- [`DATA_ARCHITECTURE.md`](./DATA_ARCHITECTURE.md) — 数据存储
+- [`ERROR_ARCHITECTURE.md`](./ERROR_ARCHITECTURE.md) — 错误处理

--- a/docs/architecture/DATA_ARCHITECTURE.md
+++ b/docs/architecture/DATA_ARCHITECTURE.md
@@ -1,0 +1,846 @@
+# PD 数据架构（Data Architecture）
+
+> **状态**: Active（2026-05-15 修订版）
+> **最后更新**: 2026-05-15（与 ADR-0005 / ADR-0006 / ADR-0007 对齐）
+> **取代**: 2026-05-09 版（已归档）
+> **关联**: `PD_ARCHITECTURE_OVERVIEW.md`, `DOMAIN_MODEL.md`, `VERSIONING_AND_COMPATIBILITY.md`
+
+本文档定义 PD 系统的**数据存储架构、读写分离策略、并发协调、迁移路径**。
+
+---
+
+## 1. 存储原则
+
+### 1.1 核心信条
+
+1. **本地优先** —— 所有数据默认存本地，不依赖远程数据库
+2. **单一数据库** —— 一个 workspace 一个 SQLite + 一个 Ledger 文件
+3. **读写分离** —— Write Side 经过门控 Service，Read Side 通过不可变 ReadModel
+4. **原子性** —— 所有跨字段写入必须事务化或 atomic file write
+5. **幂等性** —— 跨进程并发场景下所有关键写入可重试
+
+### 1.2 数据生命周期
+
+```
+┌──────────────────────────────────────────────────────┐
+│  数据类型按生命周期划分：                              │
+│                                                       │
+│  长期数据   —— state.db: principles / implementations │
+│  中期数据   —— state.db: tasks / runs / artifacts     │
+│  短期数据   —— state.db: events / audit              │
+│  瞬时数据   —— 缓存 / module-level state             │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. 存储组件总览
+
+### 2.1 Runtime V2 Canonical Storage（权威存储）
+
+PD Runtime V2 的权威数据存储分为**两个物理事实源**：
+
+| 物理路径 | 技术 | 存储内容 |
+|---------|------|---------|
+| `{workspace}/.pd/state.db` | SQLite（WAL 模式） | Task / Run / Commit / Candidate / Artifact / PIArtifact / History / Trajectory / Events / **Approvals**（新）/ **RejectionFeedbacks**（新）|
+| `{workspace}/.state/principle_training_state.json` | JSON 文件（atomic write） | Principle Tree 账本（Principle / Rule / Implementation）|
+
+### 2.2 Activation Pipeline 工件存储（新增 — ADR-0006）
+
+激活后的工件存储在文件系统的不同位置：
+
+| 工件类型 | 物理路径 | 用途 |
+|---------|---------|------|
+| Skill 文件 | `{workspace}/.principles/skills/{skillId}/SKILL.md` + `manifest.json` | `skill` 通道激活产物 |
+| Code Implementation | `{workspace}/.principles/implementations/code/{implId}/entry.ts` + `manifest.json` + `tests.jsonl` + `last-eval.json` | `code_tool_hook` 通道激活产物 |
+| Training Export | `{workspace}/.pd/training-exports/{batchId}/dataset.jsonl` + `metadata.json` | `model_training` 通道激活产物 |
+
+### 2.3 审计与合规存储（新增 — `OBSERVABILITY_ARCHITECTURE.md`）
+
+| 物理路径 | 格式 | 写入特性 |
+|---------|------|---------|
+| `{workspace}/.pd/audit-log.jsonl` | JSONL | append-only，**永久保留**，同步 fsync |
+| `{workspace}/.state/pruning_reviews.jsonl` | JSONL | append-only |
+
+### 2.4 Plugin / Host 辅助状态
+
+以下辅助状态由 plugin / host 管理，**不属于** Runtime V2 authoritative store，但存在于工作区中：
+
+| 路径 | 说明 | 管理方 |
+|------|-----|-------|
+| `{workspace}/.state/trajectory.db` | OpenClaw 原始轨迹数据 | openclaw-plugin |
+| `{workspace}/.state/sessions/` | OpenClaw 会话记录 | openclaw-plugin |
+| `{workspace}/.state/event-log.jsonl` | OpenClaw 事件日志 | openclaw-plugin |
+| `{workspace}/.state/daily-stats/` | 每日统计 | openclaw-plugin |
+| `{workspace}/.state/CURRENT_FOCUS` | 当前焦点 | openclaw-plugin |
+| `{workspace}/.state/evolution.jsonl` | 进化事件流 | openclaw-plugin |
+| `{workspace}/.state/evolution-scorecard.json` | 进化积分卡 | openclaw-plugin |
+
+> **注**：这些辅助状态可能在未来版本被 Runtime V2 的 events 表 / Telemetry 替代。当前由 plugin 独立管理。
+
+### 2.5 配置存储（参见 `CONFIGURATION_ARCHITECTURE.md`）
+
+| 路径 | 格式 | 用途 |
+|------|------|-----|
+| `{workspace}/.pd/config/*.yaml` | YAML | 工作区级配置（详见 §9）|
+| `~/.openclaw/extensions/principles-disciple/default-config.yaml` | YAML | 全局默认 |
+
+### 2.6 Cache 与瞬时数据
+
+| 路径 | 用途 | 清理策略 |
+|------|-----|---------|
+| `{workspace}/.pd/cache/` | 派生数据缓存 | 任意时刻可清空 |
+| Module-level memory cache | 静态文件 TTL 缓存（如 PRINCIPLES.md）| TTL 60s + mtime 检查 |
+
+---
+
+## 3. SQLite Schema 详细
+
+### 3.1 主要表清单
+
+```
+state.db
+├── 任务调度
+│   ├── tasks                          PITaskRecord 主表（含 mission_id / priority / depends_on）
+│   ├── runs                           RunRecord 主表
+│   └── leases (隐式：在 tasks 中通过 leaseOwner / leaseExpiresAt 字段)
+├── Diagnostician 子系统
+│   ├── candidates                     PrincipleCandidate
+│   ├── artifacts                      Diagnostician artifact
+│   └── commits                        DiagnosticianCommit
+├── Internalization 子系统
+│   └── pi_artifacts                   PIArtifact（含 shadow_eval_results）
+├── Activation 子系统（新增 — ADR-0006）
+│   ├── approvals                      ApprovalRecord
+│   └── rejection_feedbacks            RejectionFeedback
+├── Goals 子系统（新增 — ADR-0010）
+│   ├── objectives                     Objective（OKR 季度目标）
+│   ├── key_results                    KeyResult（可量化关键结果）
+│   ├── missions                       Mission（长程任务）
+│   └── agent_session_checkpoints      LRAS 检查点（ADR-0009）
+├── 历史与查询
+│   ├── history (各子表)
+│   └── trajectory (各子表)
+├── 可观测性
+│   ├── events                         TelemetryEvent
+│   ├── correction_audit_events        CorrectionProposal 审计 (ADR-0004)
+│   └── (可选) metrics_*               指标聚合
+└── 元数据
+    └── schema_migrations               迁移版本
+```
+
+### 3.2 关键表 Schema（新增表）
+
+#### 3.2.1 approvals（ADR-0006）
+
+```sql
+CREATE TABLE approvals (
+  approval_id TEXT PRIMARY KEY,
+  artifact_id TEXT NOT NULL,
+  channel TEXT NOT NULL,                      -- prompt / skill / code_tool_hook / model_training / defer_archive
+  risk_level TEXT NOT NULL,                   -- medium / high / critical
+  status TEXT NOT NULL,                       -- pending / approved / rejected / cancelled（当前生产状态）；awaiting_second_confirmation / expired 为 ADR-0006 目标状态，尚未落地
+  requested_at TEXT NOT NULL,
+  requested_by_kind TEXT NOT NULL,            -- system / agent / human
+  requested_by_id TEXT,                       -- agentId / userId
+  decided_at TEXT,
+  decided_by TEXT,
+  reason TEXT,
+  requires_second_confirmation INTEGER DEFAULT 0,
+  second_confirmed_at TEXT,
+  second_confirmed_by TEXT,
+  cooldown_expires_at TEXT,                   -- ISO 8601, model_training 用
+  metadata_json TEXT NOT NULL,
+  FOREIGN KEY (artifact_id) REFERENCES pi_artifacts(artifact_id)
+);
+
+CREATE INDEX idx_approvals_status ON approvals(status, channel);
+CREATE INDEX idx_approvals_artifact ON approvals(artifact_id);
+CREATE INDEX idx_approvals_requested_at ON approvals(requested_at);
+```
+
+**约束**：
+- 同一个 `artifact_id` 在 `pending` 状态下只能有一条记录（应用层强制）
+- `decided_at` 必须晚于 `requested_at`
+- `second_confirmed_by != decided_by`（应用层强制 APR-1）
+- `model_training` 通道时 `requires_second_confirmation = 1` 强制为 1（应用层）
+
+#### 3.2.2 rejection_feedbacks（ADR-0006）
+
+```sql
+CREATE TABLE rejection_feedbacks (
+  feedback_id TEXT PRIMARY KEY,
+  approval_id TEXT NOT NULL,
+  artifact_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  rejection_reason TEXT NOT NULL,
+  rejected_by TEXT NOT NULL,
+  rejected_at TEXT NOT NULL,
+  feedback_action TEXT NOT NULL,              -- retry_with_correction / discard / escalate
+  correction_hints_json TEXT,                 -- 用于注入到下游 Dreamer prompt
+  FOREIGN KEY (approval_id) REFERENCES approvals(approval_id)
+);
+
+CREATE INDEX idx_rejection_feedbacks_artifact ON rejection_feedbacks(artifact_id);
+CREATE INDEX idx_rejection_feedbacks_action ON rejection_feedbacks(feedback_action);
+```
+
+**特性**：
+- **Append-only**：不允许 UPDATE / DELETE
+- 用于触发 retry 任务（feedback_action = retry_with_correction）
+
+#### 3.2.3 correction_audit_events（ADR-0004）
+
+```sql
+CREATE TABLE correction_audit_events (
+  event_id TEXT PRIMARY KEY,
+  timestamp TEXT NOT NULL,
+  proposal_json TEXT NOT NULL,                -- 序列化的 CorrectionProposal
+  original_params_json TEXT NOT NULL,
+  outcome TEXT NOT NULL,                      -- applied / shadow_logged / rejected_by_hook / rejected_by_confidence
+  session_id TEXT,
+  tool_name TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  principle_id TEXT,
+  application_mode TEXT NOT NULL,             -- shadow / live
+  confidence REAL
+);
+
+CREATE INDEX idx_correction_audit_rule ON correction_audit_events(rule_id);
+CREATE INDEX idx_correction_audit_outcome ON correction_audit_events(outcome, timestamp);
+CREATE INDEX idx_correction_audit_timestamp ON correction_audit_events(timestamp);
+```
+
+**特性**：
+- 用于支撑 shadow mode 报告
+- 用于排查误杀
+- 永久保留（合规需要）
+
+#### 3.2.4 Goals 子系统表（ADR-0010）
+
+```sql
+-- Objective（OKR 季度目标）
+CREATE TABLE objectives (
+  objective_id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  start_date TEXT NOT NULL,
+  end_date TEXT NOT NULL,
+  status TEXT NOT NULL,                       -- active / achieved / abandoned
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- KeyResult（可量化关键结果）
+CREATE TABLE key_results (
+  kr_id TEXT PRIMARY KEY,
+  objective_id TEXT NOT NULL REFERENCES objectives(objective_id),
+  metric TEXT NOT NULL,                       -- "完成 5 个 PR"、"通过 80% 测试"
+  target REAL NOT NULL,
+  current REAL NOT NULL DEFAULT 0,
+  unit TEXT NOT NULL,                         -- "PRs", "%", "lines"
+  measurement_source TEXT NOT NULL,           -- manual / auto_query
+  query TEXT,                                 -- auto_query 时的查询表达式
+  updated_at TEXT NOT NULL
+);
+
+-- Mission（长程任务）
+CREATE TABLE missions (
+  mission_id TEXT PRIMARY KEY,
+  objective_id TEXT REFERENCES objectives(objective_id),  -- 可选关联
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL,                       -- planning / executing / review / succeeded / failed / stalled
+  expected_duration_days INTEGER,
+  started_at TEXT,
+  completed_at TEXT,
+  alignment_json TEXT NOT NULL,               -- { objectiveContribution, riskLevel, requiresDecisionHygiene }
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_missions_status ON missions(status);
+CREATE INDEX idx_missions_objective ON missions(objective_id);
+
+-- tasks 表扩展（ADR-0011）
+-- ALTER TABLE tasks ADD COLUMN mission_id TEXT REFERENCES missions(mission_id);
+-- ALTER TABLE tasks ADD COLUMN priority INTEGER DEFAULT 50;
+-- ALTER TABLE tasks ADD COLUMN depends_on TEXT;  -- JSON array of taskId
+```
+
+#### 3.2.5 agent_session_checkpoints（ADR-0009）
+
+```sql
+CREATE TABLE agent_session_checkpoints (
+  checkpoint_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  task_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  state TEXT NOT NULL,                        -- LRAS 状态机状态
+  step_number INTEGER NOT NULL,
+  scratchpad TEXT NOT NULL,                   -- 代理工作记忆（JSON）
+  partial_output TEXT,                        -- 部分输出
+  tool_call_history TEXT NOT NULL,            -- 累计工具调用记录（JSON）
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_checkpoints_session ON agent_session_checkpoints(session_id, step_number);
+CREATE INDEX idx_checkpoints_task ON agent_session_checkpoints(task_id);
+```
+
+**特性**：
+- 崩溃恢复：`RecoverySweep` 启动时扫描未完成 session，读取最近 checkpoint 续跑
+- 每 2 分钟（可配）自动保存
+
+### 3.3 已有表（无变更）
+
+详见 `@principles/core/runtime-v2/store/` 下的各 `sqlite-*.ts`。本文档不重复 schema 定义，仅总览。
+
+---
+
+## 4. Ledger（JSON）Schema 详细
+
+### 4.1 文件结构
+
+```json
+{
+  "schemaVersion": "ledger-v1",
+  "trainingStore": {
+    "<principleId>": { /* legacy training state */ }
+  },
+  "_tree": {
+    "principles": {
+      "<principleId>": {
+        "id": "P_001",
+        "version": 1,
+        "text": "...",
+        "triggerPattern": "...",
+        "action": "...",
+        "status": "active",
+        "priority": "P1",
+        "scope": "general",
+        "evaluability": "weak_heuristic",
+        "valueScore": 0.85,
+        "adherenceRate": 0.92,
+        "painPreventedCount": 12,
+        "derivedFromPainIds": ["pain_..."],
+        "ruleIds": ["R_001_a"],
+        "conflictsWithPrincipleIds": [],
+        "createdAt": "...",
+        "updatedAt": "...",
+        "activatedAt": "...",          // ADR-0006 新增
+        "activatedBy": {                // ADR-0006 新增
+          "kind": "system",
+          "id": "rollout_reviewer"
+        },
+        "archivedReason": null,         // ADR-0006 新增
+        "archivedAt": null              // ADR-0006 新增
+      }
+    },
+    "rules": {
+      "<ruleId>": {
+        "id": "R_001_a",
+        "principleId": "P_001",
+        "implementationIds": ["IMPL_001_a_hook"],
+        "type": "hook",
+        "status": "implemented",
+        "lifecycleState": "active",
+        "createdAt": "...",
+        "updatedAt": "..."
+      }
+    },
+    "implementations": {
+      "<implId>": {
+        "id": "IMPL_001_a_hook",
+        "ruleId": "R_001_a",
+        "type": "code",
+        "lifecycleState": "active",
+        "shadowMode": false,            // ADR-0006 新增（仅 code_tool_hook）
+        "shadowModeRemaining": 0,       // ADR-0006 新增
+        "version": "1.0.0",
+        "path": ".principles/implementations/code/IMPL_001_a_hook",
+        "coversCondition": "...",
+        "...": "..."
+      }
+    },
+    "metrics": {
+      "<principleId>": {
+        "principleId": "P_001",
+        "painPreventedCount": 12,
+        "complianceRate": 0.92,
+        "..." : "..."
+      }
+    },
+    "lastUpdated": "..."
+  }
+}
+```
+
+### 4.2 写入规范
+
+详见 `@principles/core/principle-tree-ledger.ts`。要点：
+
+- 所有写入通过 `mutateLedger(stateDir, mutate)` 包装
+- 实现使用 `atomicWriteFileSync`（写临时文件 + rename）
+- 单进程序列化（不依赖 SQLite 的并发）
+- 跨进程通过 `LeaseManager` 协调
+
+### 4.3 适配器
+
+`@principles/core/runtime-v2/adapter/principle-tree-ledger-adapter.ts` 提供 `LedgerAdapter` 接口给 `CandidateIntakeService` 等使用。新版本必须支持：
+
+```typescript
+interface LedgerAdapter {
+  existsForCandidate(candidateId: string): LedgerPrincipleEntry | null;
+  writeProbationEntry(entry: LedgerPrincipleEntry): LedgerPrincipleEntry;
+  // 新增（ADR-0006）：
+  activatePrinciple(principleId: string, ctx: ActivationContext): void;
+  archivePrinciple(principleId: string, reason: string, ctx: ActivationContext): void;
+  rollbackPrinciple(principleId: string, ctx: ActivationContext): void;
+}
+```
+
+---
+
+## 5. 五条数据流的存储路径
+
+### 5.1 Pain Pipeline（Stage 1）
+
+```
+[PainSignal]
+   │
+   ├─► state.db: pain_signals（写）
+   ├─► ledger.json: pain_flag（写，可选）
+   └─► state.db: tasks (taskKind=diagnostician, status=pending)（写）
+
+[DiagnosticianRunner.run]
+   │
+   ├─► state.db: tasks (status=leased → succeeded)（更新）
+   ├─► state.db: runs (1 task: N runs)（写）
+   ├─► state.db: artifacts (kind=diagnosis_report)（写）
+   ├─► state.db: candidates (status=pending)（写）
+   ├─► state.db: events（写 telemetry）
+   └─► state.db: commits（写 commit record）
+
+[CandidateIntakeService.intake]
+   │
+   ├─► ledger.json: principles[P_xxx].status=probation（写）
+   └─► state.db: candidates (status=consumed)（更新）
+```
+
+### 5.2 Internalization Pipeline（Stage 2）
+
+```
+[IntakeToInternalizationBridge]（新增 — 解决断点 ①）
+   │
+   └─► state.db: tasks (taskKind=dreamer, channel=X, status=pending)（写）
+
+[DreamerRunner / PhilosopherRunner / ...]
+   │
+   ├─► state.db: tasks (status 转换)（更新）
+   ├─► state.db: runs（写）
+   ├─► state.db: pi_artifacts（每个 Runner 输出）（写）
+   └─► state.db: events（写 telemetry）
+
+[RolloutReviewerRunner.succeed]
+   │
+   └─► ActivationDispatcher.dispatch（触发 Stage 3）
+```
+
+### 5.3 Activation Pipeline（Stage 3）（新增 — ADR-0006）
+
+```
+[ActivationDispatcher.dispatch]
+   │
+   ├─► 自动通道路径：
+   │   └─► ChannelWriter.activate
+   │       ├─► [prompt] ledger.json: principles[id].status=active
+   │       ├─► [defer_archive] ledger.json: principles[id].status=archived
+   │       └─► [skill 自动] file: .principles/skills/{id}/...
+   │
+   ├─► 审批通道路径：
+   │   ├─► state.db: approvals (status=pending)（写）
+   │   ├─► [pd-console 审批]
+   │   ├─► state.db: approvals (status=approved/rejected)（更新）
+   │   ├─► 审计：audit-log.jsonl（写）
+   │   ├─► [approved] ChannelWriter.activate
+   │   │   ├─► [code_tool_hook] file: .principles/implementations/code/{id}/...
+   │   │   │                  + ledger.json: implementations[id].lifecycleState=active
+   │   │   │                  + ledger.json: implementations[id].shadowMode=true
+   │   │   └─► [model_training] file: .pd/training-exports/{batchId}/...
+   │   └─► [rejected] state.db: rejection_feedbacks（写）
+   │
+   └─► 任何分支均：state.db: events（写 telemetry）
+```
+
+### 5.4 Operations Pipeline
+
+```
+[ReadModel 查询]
+   │
+   ├─► state.db: 各表（读）
+   ├─► ledger.json（读）
+   └─► 不修改任何状态
+
+[人工审批]（pd-console）
+   │
+   ├─► state.db: approvals（更新）
+   └─► audit-log.jsonl（写）
+
+[低风险写]（pd-cli）
+   │
+   └─► state.db: 通过 RuntimeStateManager
+```
+
+### 5.5 Pruning Pipeline
+
+```
+[PruningReadModel.scan]
+   │
+   ├─► ledger.json（读）
+   ├─► state.db: 各表（读）
+   └─► 输出 PruningSignal[]（不持久化）
+
+[人工 review]
+   │
+   └─► .state/pruning_reviews.jsonl（append）
+
+[PruningAction]（未来 — 暂未实现）
+   │
+   └─► ledger.json: principles[id].status=deprecated（写）
+```
+
+---
+
+## 6. 读写分离策略
+
+### 6.1 写侧（Write Side）
+
+**写侧统一入口**：
+
+| 数据类型 | 唯一写入路径 |
+|---------|------------|
+| PainSignal | `PainSignalAdapter.recordPain()` |
+| Diagnostician 任务 | `PainSignalBridge.onPainDetected()` |
+| Diagnostician artifact | `DiagnosticianCommitter.commit()` |
+| LedgerPrincipleEntry | `CandidateIntakeService.intake()` |
+| Internalization 任务 | `IntakeToInternalizationBridge.onProbationCreated()` 或 `Orchestrator.commitNextTaskProposal()` |
+| PIArtifact | 各 Peer Runner（通过 `PIArtifactStore.upsertArtifact`）|
+| ApprovalRecord | `ApprovalQueue.enqueue / approve / reject / secondConfirm` |
+| RejectionFeedback | `RejectionFeedbackService.emit` |
+| Ledger principle.status 变更 | `ChannelWriter.activate / deactivate`（仅通过 ActivationDispatcher）|
+| Audit log | `AuditLogger.write`（同步 fsync）|
+
+**写入保证**：
+
+- **Lease**：所有 task 状态变更必须先 `acquireLease`
+- **幂等性**：所有跨进程写入必须有幂等键
+- **原子性**：跨字段写入用事务（SQLite）或 atomic write（JSON）
+- **审计**：高风险写入必须同步写 audit log
+
+### 6.2 读侧（Read Side）
+
+**读模型清单**：
+
+| ReadModel | 用途 | 副作用 |
+|-----------|-----|-------|
+| `PainChainReadModel` | painId 完整链 trace | 无 |
+| `InternalizationQueueReadModel` | PI 任务队列健康 | 无 |
+| `PruningReadModel` | 修剪信号 | 无 |
+| `OperatorHealthReadModel` | 整体健康 | 无 |
+| `LifecycleReadModel` | 原则生命周期 | 无 |
+| `SchemaConformanceReadModel` | schema 一致性 | 无 |
+| `InternalizationChainIntegrityReadModel` | 链路完整性 | 无 |
+| `ApprovalQueueReadModel` (新增) | 审批队列 | 无 |
+| `ActivationStatusReadModel` (新增) | 激活状态 | 无 |
+| `EventLogReadModel` | 事件流（pd-console）| 无 |
+| `GfiWorkspaceReadModel` | GFI 状态 | 无 |
+
+**读取原则**：
+
+- 所有读操作非破坏性
+- 读模型不修改底层状态
+- 资源临时不可用时使用 `Resilient*` 包装器自动重试
+
+### 6.3 严格不变量
+
+| ID | 不变量 |
+|----|------|
+| RW-1 | Read 路径不允许触发 Write |
+| RW-2 | 同一概念只能有**一个**写入路径 |
+| RW-3 | Write 必须经过 Service 层（不允许 SQL 直写）|
+| RW-4 | 高风险 Write 必须经过 ActivationDispatcher / ApprovalQueue |
+| RW-5 | Audit log 写入失败必须中止业务 |
+
+---
+
+## 7. 并发与事务
+
+### 7.1 SQLite WAL 模式
+
+PD 默认启用 SQLite WAL（Write-Ahead Logging）模式：
+
+- 读不阻塞写
+- 写不阻塞读
+- 单写者（同一时刻只有一个 write transaction）
+
+**强制要求**（架构守护测试覆盖）：
+
+```typescript
+// 每个 SQLite 连接建立时必须执行以下 PRAGMA
+db.pragma('journal_mode = WAL');
+db.pragma('busy_timeout = 5000');   // 等待 5s 而非立即失败（防止多 workspace 并发锁竞争）
+db.pragma('synchronous = NORMAL'); // WAL 模式下 NORMAL 足够安全且性能更好
+```
+
+> **背景**：多个 workspace 或多个 Agent 同时进入 Idle 状态时，会同时争抢 SQLite 的 `pending` 任务锁。没有 WAL + busy_timeout，会出现 `Database is locked` 错误导致任务丢失。
+
+### 7.2 跨进程协调
+
+```
+进程 A（plugin）              进程 B（pd-cli）              进程 C（pd-console）
+       │                            │                              │
+       │── acquireLease(taskId) ───▶│                              │
+       │   ✓ 成功                    │                              │
+       │                            │── acquireLease(taskId) ──────│
+       │                            │   ✗ lease_conflict           │
+       │                            │                              │
+       │── markTaskSucceeded ──────▶│                              │
+       │                            │── 重试 acquireLease ─────────│
+       │                            │   ✗ already succeeded        │
+```
+
+机制：
+
+1. **LeaseManager**：`acquireLease(taskId, owner, runtimeKind)` 通过 SQLite 事务实现互斥
+2. **TTL**：lease 自动过期，`RecoverySweep` 定期清理
+3. **原子文件写入**：JSON 文件写临时文件后 `rename`（POSIX 原子）
+
+### 7.3 事务边界
+
+| 操作 | 事务范围 |
+|------|---------|
+| acquireLease | 单 SQL UPDATE |
+| markTaskSucceeded + updateRunOutput | 跨表事务 |
+| DiagnosticianCommitter.commit | 跨多个 INSERT 事务 |
+| ApprovalQueue.approve + ChannelWriter.activate | **不**单事务（跨 SQLite + JSON）|
+| Schema migration | 单事务 |
+
+**说明**：跨 SQLite + JSON 的复合操作不能用单事务，需要应用层补偿（详见 §7.4）。
+
+### 7.4 跨存储的最终一致性
+
+ApprovalQueue.approve 会同时影响：
+- `state.db: approvals` (status=approved)
+- `ledger.json: principles[id].status` (active)
+- `audit-log.jsonl` (写记录)
+
+由于跨存储无法事务，采用**记录中间状态 + 重试**：
+
+```typescript
+async approveAndActivate(approvalId): Promise<void> {
+  // 1. 标记 approval=approved（state.db 单事务）
+  await db.transaction(() => {
+    updateApproval(approvalId, { status: 'approved' });
+    writeAuditLog({ event: 'approval_decided', ... });
+  });
+
+  // 2. 调用 ChannelWriter
+  try {
+    await channelWriter.activate(...);
+    // 成功：更新状态
+    await db.transaction(() => {
+      updateApproval(approvalId, { activatedAt: now });
+    });
+  } catch (err) {
+    // 失败：approval 仍是 approved，下次重试
+    await writeAuditLog({ event: 'activation_failed', approvalId, error: err });
+    throw err;
+  }
+}
+```
+
+`ApprovalRecoverySweep`（待建）定期扫描 `status=approved && activatedAt=null` 的记录，重试激活。
+
+---
+
+## 8. 数据迁移
+
+详见 [`VERSIONING_AND_COMPATIBILITY.md`](./VERSIONING_AND_COMPATIBILITY.md) §4-5。
+
+### 8.1 SQLite Migration（forward-only）
+
+```
+@principles/core/runtime-v2/store/migrations/
+├── 001-initial.sql
+├── 002-add-pi-artifacts.sql
+├── 003-add-approvals.sql              ★ 待建（ADR-0006）
+├── 004-add-rejection-feedbacks.sql    ★ 待建（ADR-0006）
+└── 005-add-correction-audit-events.sql ★ 待建（ADR-0004）
+```
+
+启动时由 `migration-runner.ts` 自动应用。
+
+### 8.2 Ledger Migration
+
+通过 `parseLedger` 中的版本检测 + upgrade 函数实现，详见 §4.2。
+
+### 8.3 数据迁移命令
+
+| 命令 | 用途 |
+|------|-----|
+| `pd legacy-import nocturnal-artifacts` | NocturnalArtifact → PIArtifact（ADR-0005）|
+| `pd legacy-cleanup --older-than 30d` | 清理过期数据 |
+| `pd runtime-recovery vacuum` | SQLite VACUUM |
+
+---
+
+## 9. 数据流综合视图
+
+```mermaid
+flowchart TD
+    subgraph Stage1["Pain Pipeline"]
+        Pain[PainSignal] --> Bridge[PainSignalBridge]
+        Bridge --> DiagTask[Task: diagnostician]
+        DiagTask --> Diag[DiagnosticianRunner]
+        Diag --> Cand[Candidate]
+        Cand --> Intake[CandidateIntakeService]
+        Intake --> Probation[Ledger: probation]
+    end
+
+    subgraph Stage2["Internalization Pipeline"]
+        Probation --> IntakeBridge[IntakeToInternalizationBridge]
+        IntakeBridge --> DreamerTask[Task: dreamer]
+        DreamerTask --> Runners[7 Peer Runners]
+        Runners --> PIArt[PIArtifact validated]
+    end
+
+    subgraph Stage3["Activation Pipeline"]
+        PIArt --> Dispatcher[ActivationDispatcher]
+        Dispatcher --> Auto[自动通道]
+        Dispatcher --> Approval[ApprovalQueue]
+        Approval --> Console[pd-console 审批]
+        Console -->|approve| Auto
+        Console -->|reject| Feedback[RejectionFeedback]
+        Feedback -.->|retry| DreamerTask
+        Auto --> Activate[ChannelWriter activate]
+    end
+
+    subgraph Storage["权威存储"]
+        SQLite[(state.db)]
+        Ledger[(ledger.json)]
+        Files[/artifacts files/]
+        Audit[(audit-log.jsonl)]
+    end
+
+    Pain --> SQLite
+    DiagTask --> SQLite
+    Cand --> SQLite
+    Probation --> Ledger
+    DreamerTask --> SQLite
+    PIArt --> SQLite
+    Approval --> SQLite
+    Feedback --> SQLite
+    Activate --> Ledger
+    Activate --> Files
+    Console --> Audit
+```
+
+---
+
+## 10. 容量规划
+
+### 10.1 单工作区数据量预估
+
+| 时间 | state.db | ledger.json | 文件总计 |
+|------|---------|------------|--------|
+| 启动时 | 0.5 MB | < 10 KB | < 1 MB |
+| 1 个月 | 10-30 MB | 1-3 MB | 5-15 MB |
+| 6 个月 | 50-150 MB | 5-10 MB | 30-100 MB |
+| 1 年（无清理）| 100-300 MB | 10-20 MB | 100-300 MB |
+| 1 年（带归档清理）| 30-80 MB | 10-20 MB | 50-150 MB |
+
+详见 [`PERFORMANCE_BUDGETS.md`](./PERFORMANCE_BUDGETS.md) §5。
+
+### 10.2 自动归档触发
+
+| 阈值 | 行为 |
+|------|-----|
+| state.db 软上限 100MB | 警告 |
+| state.db 硬上限 500MB | 自动归档 events / runs（保留 30 天）|
+| ledger.json 软上限 5MB | 警告（ledger 不归档，由 pruning 处理）|
+| Audit log | 不归档（永久）|
+
+---
+
+## 11. 已迁移与待迁移
+
+### 11.1 已完成迁移（ADR-0001 / ADR-0002）
+
+| 组件 | 原位置 | 新位置 | 状态 |
+|------|--------|--------|-----|
+| PainToPrincipleService | plugin | `@principles/core` | ✅ |
+| PainChainReadModel | pd-cli | `@principles/core` | ✅ |
+| PruningReadModel | plugin | `@principles/core` | ✅ |
+| PrincipleTreeLedger | plugin | `@principles/core` | ✅ |
+| TemplateGenerator | plugin | `@principles/core` | ✅ |
+| RuleHost contracts | plugin | `@principles/core` | ✅（PRI-42）|
+| RoutingPolicy | plugin | `@principles/core` | ✅（PRI-43）|
+| LifecycleMetrics | plugin | `@principles/core` | ✅（PRI-42）|
+| Principle Schema / Rule / Implementation | plugin | `@principles/core/runtime-v2/types` | ✅ |
+| Evolution Types | plugin | `@principles/core/runtime-v2/evolution` | ✅ |
+| Correction Types | plugin | `@principles/core/runtime-v2/correction` | ✅ |
+| Nocturnal Trinity Types | plugin | `@principles/core/runtime-v2/nocturnal` | ✅ |
+| Nocturnal Candidate Scoring | plugin | `@principles/core/runtime-v2/nocturnal` | ✅ |
+| Event Types | plugin | `@principles/core/runtime-v2/types` | ✅ |
+| Principle Tree Data Structures | plugin | `@principles/core/runtime-v2/types` | ✅ |
+| Queue / Hygiene / Runtime Summary Types | plugin | `@principles/core/runtime-v2/types` | ✅ |
+
+### 11.2 进行中（ADR-0005 / ADR-0006）
+
+| 组件 | 当前 | 目标 |
+|------|-----|------|
+| NocturnalArtifact | plugin: `nocturnal-arbiter.ts` | 替换为 PIArtifact，旧文件保留只读 |
+| TrinityRuntimeAdapter | plugin: `nocturnal-trinity.ts` | 替换为 PDRuntimeAdapter |
+| Approval / RejectionFeedback tables | n/a | 新建（ADR-0006）|
+| ActivationDispatcher / ChannelWriter 写入路径 | n/a | 新建 |
+
+### 11.3 未来计划
+
+| 组件 | 计划 |
+|------|-----|
+| Store modularization | `@principles/core/store/` 重组（PRI-47）|
+| Pruning Action 写入路径 | 独立 issue 推进 |
+| Cross-workspace 同步 | `central-sync-service` 已有基础 |
+
+---
+
+## 12. 不变量与守护
+
+| ID | 不变量 | 强制方式 |
+|----|------|---------|
+| DAT-1 | 一个 workspace 一个 state.db | path-resolver |
+| DAT-2 | 一个 workspace 一个 ledger.json | path-resolver |
+| DAT-3 | Ledger 写入必须 atomic | mutateLedger 包装 |
+| DAT-4 | 跨进程写入必须 lease 协调 | LeaseManager |
+| DAT-5 | Audit log 必须 append-only | 文件权限 + 测试 |
+| DAT-6 | 工作区路径不允许逃逸 | validateWorkspacePath |
+| DAT-7 | Schema migration 不允许修改已发布版本 | hash 校验 |
+| DAT-8 | 只读 ReadModel 不允许触发写 | architecture-regression test |
+| **DAT-9** | **每个 SQLite 连接必须设置 `journal_mode=WAL` + `busy_timeout=5000`** | **架构守护测试** |
+| **DAT-10** | **active principles count 不得超过 `l1_capacity.hard_limit`（默认 12）** | **LedgerPromptWriter 强制检查** |
+
+---
+
+## 13. 关联文档
+
+- [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) §6（横切约束）
+- [`DOMAIN_MODEL.md`](./DOMAIN_MODEL.md) §6（代码映射）
+- [`COMPONENTS.md`](./COMPONENTS.md) §2（Store / ReadModel 列表）
+- [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) §5（数据流）
+- [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) §2（Activation 表设计）
+- [`OBSERVABILITY_ARCHITECTURE.md`](./OBSERVABILITY_ARCHITECTURE.md) §5（审计日志）
+- [`SECURITY_ARCHITECTURE.md`](./SECURITY_ARCHITECTURE.md) §2（工作区隔离）
+- [`VERSIONING_AND_COMPATIBILITY.md`](./VERSIONING_AND_COMPATIBILITY.md) §4-5（迁移）
+- [`PERFORMANCE_BUDGETS.md`](./PERFORMANCE_BUDGETS.md) §5（存储预算）
+- ADR-0001 / 0003 / 0004 / 0005 / 0006 / 0007

--- a/docs/architecture/INTERNALIZATION_PIPELINE.md
+++ b/docs/architecture/INTERNALIZATION_PIPELINE.md
@@ -194,9 +194,9 @@ nocturnal-service.runReflection()    InternalizationOrchestrator.wakeOnce()
 
 **问题**：Probation 候选写入 Ledger 后，谁负责把它转换为 `dreamer` 任务入队？
 
-**当前现状**：无自动桥接，需手动 `pd-cli wake-once`。
+**当前现状**：`IntakeToInternalizationBridge` 已在 core 落地，负责 probation/candidate → root dreamer task 自动入队。生产链路持续验证中；host 调度适配仍需后续 issue。
 
-**新设计**：引入 `IntakeToInternalizationBridge`（核心新组件）
+**设计**（已落地）：`IntakeToInternalizationBridge`（core 已落地组件）
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐

--- a/docs/architecture/INTERNALIZATION_PIPELINE.md
+++ b/docs/architecture/INTERNALIZATION_PIPELINE.md
@@ -187,7 +187,7 @@ nocturnal-service.runReflection()    InternalizationOrchestrator.wakeOnce()
 ```
 
 **新链路**：触发与执行分离。
-- **触发**：`openclaw-plugin/service/idle-trigger.ts` 决定何时唤起
+- **触发**：`@principles/core/runtime-v2/idle-trigger/`（核心策略）决定何时唤起；宿主层调用 wakeOnce
 - **执行**：`@principles/core` 的 InternalizationOrchestrator + 7 个 Runner
 
 ### 3.3 流水线启动条件（断点 ① 解决方案）
@@ -222,7 +222,7 @@ nocturnal-service.runReflection()    InternalizationOrchestrator.wakeOnce()
 
 #### 3.3.1 IntakeToInternalizationBridge 契约
 
-位置：`@principles/core/runtime-v2/internalization/intake-to-internalization-bridge.ts`（新建）
+位置：`@principles/core/runtime-v2/internalization/intake-to-internalization-bridge.ts`（已落地）
 
 ```typescript
 interface IntakeToInternalizationBridge {

--- a/docs/architecture/INTERNALIZATION_PIPELINE.md
+++ b/docs/architecture/INTERNALIZATION_PIPELINE.md
@@ -1,0 +1,1025 @@
+# Internalization Pipeline 设计（内化流水线）
+
+> **状态**: Active
+> **最后更新**: 2026-05-15
+> **关联 ADR**: ADR-0001（服务边界）, ADR-0003（Peer Agent 状态机）, ADR-0005（Nocturnal 合并）, ADR-0006（混合激活）
+> **关联文档**: `PD_ARCHITECTURE_OVERVIEW.md`, `ACTIVATION_CHANNELS.md`, `GLOSSARY.md`
+
+本文档定义 PD 系统从**痛苦信号**到**已激活实现**的**完整端到端流水线**。它是 ADR-0003 / ADR-0005 / ADR-0006 决议在工程层的具象化。
+
+---
+
+## 1. 流水线总览
+
+PD 的内化流水线是一条**单向**、**事件驱动**、**状态可追溯**的处理链。从输入到输出共有 4 个主要阶段：
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                       │
+│  ┌─────────┐   ┌──────────────┐   ┌──────────────┐   ┌─────────┐    │
+│  │ Pain    │   │ Pain         │   │ Internaliz-  │   │ Acti-   │    │
+│  │ Capture │ → │ Pipeline     │ → │ ation        │ → │ vation  │    │
+│  │         │   │ (Diagnos)    │   │ Pipeline     │   │ Pipeline│    │
+│  └─────────┘   └──────────────┘   └──────────────┘   └─────────┘    │
+│                                                                       │
+│  PainSignal     LedgerPrincipleEntry  PIArtifact         实际生效    │
+│                 (status=probation)    (validated)                     │
+│                                                                       │
+└─────────────────────────────────────────────────────────────────────┘
+        Stage 0           Stage 1            Stage 2          Stage 3
+```
+
+**关键特征**：
+
+- **单向**：数据流从左到右单向传递，每阶段产出**不可变工件**
+- **事件驱动**：每阶段完成后通过 SQLite TaskStore 入队下一阶段，不直接调用
+- **状态可追溯**：每个 painId 都可通过 `PainChainReadModel` 查询完整证据链
+- **可中断恢复**：任意阶段崩溃后，下次唤起 IdleTrigger 自动从断点继续
+
+本文档**重点**讨论 Stage 1（痛苦诊断）和 Stage 2（内化蒸馏）。Stage 3（激活）详见 [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md)。
+
+---
+
+## 2. Stage 1: Pain Pipeline（痛苦诊断）
+
+### 2.1 目的
+
+把代理的**结构化失败事件**（PainSignal）转化为**可摄入的原则候选**（LedgerPrincipleEntry, status=probation）。
+
+### 2.1.1 信号源三层架构（GAP — Goal-Aligned Pain）
+
+PD 的痛苦信号按重要性分为三层。**只有 Layer 1 和 Layer 2 独立触发 Diagnostician**；Layer 3 仅作为证据补充，不再独立触发（详见 ADR-0010）。
+
+| 层 | 信号类型 | 触发 Diagnostician | 来源 |
+|----|---------|------------------|------|
+| **Layer 1（主信号）** | `mission_failed` / `mission_stalled` / `okr_drift` / `decision_skipped` / `rework_loop` | ✅ 独立触发 | `GAPSignalGenerator` 每日扫描 |
+| **Layer 2（强信号）** | `explicit_user_complaint` / `user_correction` | ✅ 独立触发 | 用户显式反馈 / 共情系统 |
+| **Layer 3（辅助）** | `tool_failure` / `empathy_inferred` | ❌ 仅作为证据 | Plugin Hook（after_tool_call / llm_output）|
+
+**关键变化**：
+- Layer 3 不再独立触发 Diagnostician，只作为"证据"附加到 Layer 1/2 的 painId 中
+- GFI Kernel 简化：不再做多源加权聚合，只做"上层信号 + 下层证据"的组装
+- 这解决了"工具失败太琐碎"的问题：一次 `git push` 失败不触发反思，**连续 3 天目标推进为 0** 才触发
+
+### 2.2 数据流
+
+```
+[Tool Failure / User Frustration / Subagent Error]
+         │
+         │  Plugin Hook（after_tool_call / llm_output / subagent_ended）
+         ▼
+   PainSignalAdapter.recordPain()
+         │
+         ▼
+   ┌─────────────────────────┐
+   │  state.db: pain_signals │
+   │  ledger.json: pain_flag │
+   └──────────┬──────────────┘
+              │
+              ▼
+   PainBridge.onPainDetected(painId)
+              │
+              │  幂等检查：createDiagnosticianTaskId(painId)
+              ▼
+   ┌──────────────────────────┐
+   │  state.db: tasks         │
+   │  taskKind=diagnostician  │
+   │  status=pending          │
+   └──────────┬───────────────┘
+              │
+              │  IdleTrigger 唤起 / 立即调度
+              ▼
+   DiagnosticianRunner.run(taskId)
+   ├─ acquireLease
+   ├─ buildContext (ContextAssembler)
+   ├─ invokeRuntime (PDRuntimeAdapter)
+   ├─ pollUntilTerminal
+   ├─ fetchOutput → DiagnosticianOutputV1
+   ├─ validate (DiagnosticianValidator)
+   └─ commit (DiagnosticianCommitter)
+              │
+              ▼
+   ┌─────────────────────────────────┐
+   │  state.db: artifacts            │
+   │  artifactKind=diagnosis_report  │
+   │                                 │
+   │  state.db: candidates           │
+   │  status=pending                 │
+   └──────────┬──────────────────────┘
+              │
+              ▼
+   CandidateIntakeService.intake(candidateId)
+   ├─ existsForCandidate?  → noop（幂等）
+   ├─ load candidate + artifact
+   ├─ build LedgerPrincipleEntry
+   └─ writeProbationEntry
+              │
+              ▼
+   ┌─────────────────────────────────┐
+   │  ledger.json:                   │
+   │  principle.status = probation   │
+   └─────────────────────────────────┘
+```
+
+### 2.3 各组件契约
+
+| 组件 | 包 | 输入 | 输出 | 失败语义 |
+|------|----|----|----|---------|
+| `PainSignalAdapter` | core | 平台事件 | PainSignal | 失败 → 静默丢弃（next opportunity） |
+| `PainBridge` | core | PainSignal | 异步 ack | 幂等：同 painId 第二次进入返回缓存结果 |
+| `DiagnosticianRunner` | core | taskId | RunnerResult | 重试机制详见 retry-policy |
+| `DiagnosticianValidator` | core | RawOutput | 校验通过/失败 | 失败 → output_invalid，可重试 |
+| `DiagnosticianCommitter` | core | output | commitId | 失败 → artifact_commit_failed，重试 |
+| `CandidateIntakeService` | core | candidateId | LedgerPrincipleEntry | 失败 → 抛 CandidateIntakeError，候选保持 pending |
+
+### 2.4 关键不变量
+
+1. **幂等性**：同一个 `painId` 的处理是幂等的
+   - `createDiagnosticianTaskId(painId)` 是确定性映射
+   - `PainBridge.onPainDetected` 检查 task 状态：`succeeded` 直接返回缓存，`leased` 返回 skipped
+2. **不丢失**：PainSignal 一旦写入 SQLite，必须可被 Diagnostician 处理
+   - 如果 Plugin 崩溃，下次启动时 RecoverySweep 扫描 `pending` task 重启
+3. **可追溯**：每条 PainSignal 都能通过 PainChainReadModel 反查到 candidate / ledger entry
+4. **不静默吞没错误**：任何失败必须留下 `PDRuntimeError` 记录
+
+### 2.5 性能预算
+
+| 步骤 | 预算 |
+|------|------|
+| Pain 捕获到 SQLite 写入 | < 50 ms（Hook 同步路径） |
+| Pain → Task 入队 | < 100 ms |
+| Diagnostician 完整运行 | 默认 5 分钟，可配置 |
+| Candidate Intake | < 1 秒 |
+
+### 2.6 当前实现状态
+
+| 组件 | 实现状态 |
+|------|---------|
+| PainSignalAdapter | ✅ 完整 |
+| PainBridge | ✅ 完整 |
+| DiagnosticianRunner | ✅ 完整 |
+| DiagnosticianValidator (DefaultValidator) | ✅ 完整 |
+| DiagnosticianCommitter (Sqlite) | ✅ 完整 |
+| CandidateIntakeService | ✅ 完整 |
+
+---
+
+## 3. Stage 2: Internalization Pipeline（内化流水线）
+
+### 3.1 目的
+
+把 **probation 候选原则**通过 7 个 Peer Runner 串联**蒸馏**为 5 类可激活的实现工件（PIArtifact）。
+
+### 3.2 关键架构变更（基于 ADR-0005）
+
+合并后的 Internalization Pipeline 取代了原有的 nocturnal-trinity 链：
+
+```
+旧（已废弃）：                       新（canonical）：
+nocturnal-service.runReflection()    InternalizationOrchestrator.wakeOnce()
+  ├ TargetSelector                     ├ findCandidates(pending tasks)
+  ├ TrajectoryExtractor                ├ resolveDependencies
+  ├ Trinity (D/P/S)                    ├ acquireLease
+  ├ Arbiter                            └ → DreamerRunner / ... / TrainerRunner
+  ├ Executability
+  ├ Artificer
+  └ Persist
+```
+
+**新链路**：触发与执行分离。
+- **触发**：`openclaw-plugin/service/idle-trigger.ts` 决定何时唤起
+- **执行**：`@principles/core` 的 InternalizationOrchestrator + 7 个 Runner
+
+### 3.3 流水线启动条件（断点 ① 解决方案）
+
+**问题**：Probation 候选写入 Ledger 后，谁负责把它转换为 `dreamer` 任务入队？
+
+**当前现状**：无自动桥接，需手动 `pd-cli wake-once`。
+
+**新设计**：引入 `IntakeToInternalizationBridge`（核心新组件）
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  CandidateIntakeService.intake() succeeds                          │
+│  → 触发 ledger 写入 + emit telemetry event                          │
+└──────────────────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+            IntakeToInternalizationBridge.onProbationCreated()
+                       │
+                       │  1. 检查路由策略 (RoutingPolicy)
+                       │  2. 决定首选 channel (prompt/skill/code/training/archive)
+                       │  3. 创建 dreamer 任务（task graph 起点）
+                       ▼
+            ┌─────────────────────────────────────┐
+            │  state.db: tasks                    │
+            │  taskKind=dreamer                   │
+            │  channel=<route>                    │
+            │  status=pending                     │
+            │  metadata.parentLedgerEntryId=...   │
+            └─────────────────────────────────────┘
+```
+
+#### 3.3.1 IntakeToInternalizationBridge 契约
+
+位置：`@principles/core/runtime-v2/internalization/intake-to-internalization-bridge.ts`（新建）
+
+```typescript
+interface IntakeToInternalizationBridge {
+  /**
+   * 当 CandidateIntakeService 写入新的 probation 条目时触发。
+   * 决定路由策略并入队首个内化任务（dreamer）。
+   *
+   * 幂等：同一个 ledgerEntryId 重复触发返回缓存的 dreamerTaskId
+   */
+  onProbationCreated(input: ProbationCreatedInput): Promise<BridgeResult>;
+}
+
+interface ProbationCreatedInput {
+  ledgerEntryId: string;
+  principleId: string;
+  sourceCandidateId: string;
+  sourceArtifactId: string;
+  /** 来源路径，用于路由策略判断 */
+  sourcePainId?: string;
+  /** 来自 Diagnostician 的 recommendation kind */
+  recommendationKind: 'principle' | 'rule' | 'implementation' | 'prompt' | 'defer';
+}
+
+type BridgeResult =
+  | { decision: 'task_created'; dreamerTaskId: string; channel: InternalizationChannel }
+  | { decision: 'skipped'; reason: 'route_says_defer' | 'principle_already_in_pipeline' }
+  | { decision: 'task_exists'; existingTaskId: string };
+```
+
+#### 3.3.2 路由决策（RoutingPolicy）
+
+`RoutingPolicy` 已存在于 `core/runtime-v2/internalization/routing-policy.ts`。本桥接器直接调用：
+
+```typescript
+const route = recommendLifecycleRoute({
+  principle,
+  evidence: lifecycleEvidence,
+});
+
+// route.recommended → 'L1_PROMPT' | 'L2_CODE_HOOK' | 'L3_MODEL_TRAINING'
+//                   | 'KEEP' | 'ARCHIVE' | 'DEPRECATE'
+
+const channel = mapRouteToChannel(route.recommended);
+```
+
+#### 3.3.3 路由 → 通道映射
+
+| RoutingPolicy 输出 | 内化通道 | 备注 |
+|-------------------|---------|------|
+| `L1_PROMPT` | `prompt` | 默认起点 |
+| `L1_SKILL`（新增） | `skill` | 适合流程性原则 |
+| `L2_CODE_HOOK` | `code_tool_hook` | 高风险，必须人工审批 |
+| `L3_MODEL_TRAINING` | `model_training` | 极高风险 |
+| `ARCHIVE` / `DEPRECATE` | `defer_archive` | 跳过流水线，直接归档 |
+| `KEEP` | （无入队） | 保持现状，不产生新任务 |
+
+**默认行为**：当 RoutingPolicy 未给出推荐时，默认使用 `prompt` 通道（最低风险）。
+
+### 3.4 7 个 Peer Runner 的 Job Graph
+
+详见 ADR-0003 的 ALLOWED_EDGES。本节给出**实际数据流视图**：
+
+```
+                  ┌───────────────────┐
+                  │ Dreamer           │
+                  │ (生成候选纠正方案) │
+                  │ → DreamerOutput   │
+                  └─────────┬─────────┘
+                            │
+                            ▼
+                  ┌───────────────────┐
+                  │ Philosopher       │
+                  │ (评估并精炼候选)   │
+                  │ → PhilosopherOutput│
+                  └─────────┬─────────┘
+                            │
+                            ▼
+                  ┌───────────────────┐
+                  │ Scribe            │
+                  │ (产出原则草稿)     │
+                  │ → ScribeOutput    │
+                  └─────────┬─────────┘
+                            │
+                            ▼
+                  ┌───────────────────┐
+                  │ Artificer         │
+                  │ (生成实现计划)     │
+                  │ → ArtificerOutput │
+                  └─────────┬─────────┘
+                            │
+                            ▼
+                  ┌───────────────────┐
+                  │ Evaluator         │
+                  │ (打分与决策)       │
+                  │ → EvaluatorOutput │
+                  └─────────┬─────────┘
+                            │
+                            ▼
+                  ┌───────────────────┐
+                  │ RolloutReviewer   │
+                  │ (发布决策)         │
+                  │ → RolloutReviewerOutput
+                  └─────────┬─────────┘
+                            │
+                            ▼
+              ┌─────────────┴─────────────┐
+              │                           │
+        ┌─────▼──────┐           ┌────────▼─────────┐
+        │ ActivationDispatcher   │ Trainer (仅 L3)  │
+        │ (Stage 3)  │           │ (生成训练数据)    │
+        └────────────┘           └──────────────────┘
+```
+
+### 3.5 Runner 的统一行为契约
+
+每个 Peer Runner 必须实现以下生命周期，无例外（已在 DiagnosticianRunner / DreamerRunner / 其他 Runner 中固定）：
+
+```typescript
+interface PeerRunner<TOutput> {
+  run(taskId: string): Promise<RunnerResult<TOutput>>;
+}
+
+// 统一执行序列：
+// 1. acquireLease(taskId)      → TaskRecord (leased)
+// 2. resolveStoreRunId         → runId
+// 3. buildContext              → ContextPayload + contextHash
+// 4. invokeRuntime             → RunHandle (via PDRuntimeAdapter)
+// 5. pollUntilTerminal         → RunStatus
+// 6. fetchAndParseOutput       → TOutput
+// 7. validate                  → ValidationResult
+// 8. (write PIArtifact)        → artifactId
+// 9. markTaskSucceeded         → resultRef
+// 10. (optional) propose next  → 下游 task 入队
+```
+
+**严格禁止**：
+- Runner 直接调用其他 Runner（必须通过 TaskStore 入队）
+- Runner 直接读 ledger / 写 ledger（除非通过 ChannelWriter）
+- Runner 直接调用 LLM SDK（必须通过 PDRuntimeAdapter）
+- Runner 内部使用 setInterval / cron（属于 IdleTrigger 职责）
+
+### 3.6 数据契约：Runner 之间通过 PIArtifact 传递
+
+每个 Runner 的输出**必须**写入 `PIArtifactStore`，作为下游 Runner 的输入。
+
+```typescript
+interface PIArtifact {
+  artifactId: string;
+  artifactKind: 'principle' | 'rule' | 'training_data' | 'skill' | 'patch';
+  sourceTaskId: string;
+  sourcePrincipleId?: string;
+  sourceRuleId?: string;
+  lineageRefs: LineageRef[];
+  validationStatus: 'pending' | 'validated' | 'rejected';
+  contentJson: string;  // 序列化的 Runner 输出
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+**幂等键**：`(sourceTaskId, artifactKind)` —— 同一任务重跑覆盖同一 artifact。
+
+**血缘**：每个 Runner 在写入 artifact 时记录 `lineageRefs`，指向上游所有 dependency artifacts。
+
+### 3.7 Runner 输出 Schema 概览
+
+| Runner | OutputSchemaRef | 关键字段 | PIArtifact kind |
+|--------|----------------|---------|-----------------|
+| Dreamer | `dreamer-output-v1` | `candidates[]` (badDecision, betterDecision, confidence) | `principle` |
+| Philosopher | `philosopher-output-v1` | `principleCandidates[]` (refinedText, evidence) | `principle` |
+| Scribe | `scribe-output-v1` | `principleDrafts[]` (title, text, scope) | `principle` |
+| Artificer | `artificer-output-v1` | `implementationPlans[]` (channel, code/template, expectedDecision) | `rule` |
+| Evaluator | `evaluator-output-v1` | `evaluations[]` (score, decision, evidence) | `rule` |
+| RolloutReviewer | `rollout-reviewer-output-v1` | `reviews[]` (decision: auto_activate/require_approval/reject) | `rule` |
+| Trainer | `trainer-output-v1` | `ruleCandidate` (proposedDecision, confidence, trainingData) | `training_data` |
+
+### 3.8 状态机视图
+
+```
+[Probation Ledger Entry]
+        │
+        ▼ IntakeToInternalizationBridge
+[dreamer task: pending]
+        │
+        ▼ IdleTrigger.wakeOnce → acquireLease
+[dreamer task: leased]
+        │
+        ▼ DreamerRunner 执行
+[dreamer task: succeeded] + [PIArtifact: kind=principle, status=pending]
+        │
+        ▼ proposeNextTask → philosopher 入队
+[philosopher task: pending] (depends on dreamer task)
+        │
+        ▼ ... (重复 5 次直到 RolloutReviewer)
+[rollout_reviewer task: succeeded] + [PIArtifact: validated]
+        │
+        ▼ ActivationDispatcher.dispatch()  ← Stage 3 入口
+```
+
+每个 Runner 失败的状态转移（详见 ADR-0003）：
+- 临时失败 → `retry_wait` → 下次唤起重试
+- 永久失败 → `failed` → 不再重试，需人工干预
+- 超过最大重试次数 → `failed` (with `max_attempts_exceeded`)
+
+---
+
+## 4. 触发器与编排（IdleTrigger + Orchestrator）
+
+### 4.1 IdleTrigger（core 层策略 + plugin 层宿主适配）
+
+位置：核心策略模块 `@principles/core/runtime-v2/idle-trigger/`；宿主调度适配仍由 plugin 负责（未来）
+
+职责：
+- 监听 OpenClaw 的 heartbeat / 工作区空闲信号
+- 决定何时调用 `InternalizationOrchestrator.wakeOnce()`
+- 暴露状态查询给 pd-console
+
+**严格不允许**：
+- 实现 LLM 调用
+- 直接读写 PIArtifact / Ledger
+- 实现任何 Runner 逻辑
+
+```typescript
+interface IdleTrigger {
+  start(orchestrator: InternalizationOrchestrator): void;
+  stop(): Promise<void>;
+  status(): IdleTriggerStatus;
+}
+
+interface IdleTriggerStatus {
+  enabled: boolean;
+  lastWakeAt: string | null;
+  lastResult: 'leased' | 'no_ready_tasks' | 'error' | null;
+  nextScheduledAt: string | null;
+  /** 累计唤起次数 */
+  totalWakeCount: number;
+  /** 累计成功 lease 次数 */
+  totalLeasedCount: number;
+}
+```
+
+### 4.2 触发策略
+
+可配置的触发条件（在 `{workspace}/.pd/config/idle-trigger.yaml`）：
+
+```yaml
+idle_trigger:
+  enabled: true
+  policies:
+    - kind: heartbeat_idle      # 默认：心跳空闲超过 N 秒
+      idle_threshold_seconds: 300
+    - kind: scheduled            # 定时唤起
+      cron: "0 */15 * * * *"     # 每 15 分钟
+    - kind: queue_pressure       # 队列积压触发
+      pending_threshold: 10
+  max_concurrent_runs: 3
+```
+
+### 4.3 InternalizationOrchestrator（core 层，已存在）
+
+位置：`@principles/core/runtime-v2/internalization/internalization-orchestrator.ts`
+
+职责：
+- `wakeOnce(taskKind?)` —— 找到一个可执行任务并 acquireLease
+- `proposeNextTask(taskId)` —— 为已成功的任务建议下一阶段
+- `commitNextTaskProposal(taskId)` —— 实际入队下一阶段任务
+
+详见 ADR-0003 §3。
+
+---
+
+## 5. 数据存储
+
+### 5.1 主要表/文件
+
+| 数据类型 | 物理位置 | 说明 |
+|---------|---------|------|
+| TaskRecord / PITaskRecord | `state.db: tasks` | 任务队列 |
+| RunRecord | `state.db: runs` | 执行记录 |
+| PIArtifact | `state.db: pi_artifacts` | Runner 产物 |
+| CandidateRecord | `state.db: candidates` | Diagnostician 候选 |
+| ArtifactRecord | `state.db: artifacts` | Diagnostician 工件 |
+| Ledger | `.state/principle_training_state.json` | 原则树主账本 |
+| TelemetryEvent | `state.db: events` | 跨流水线事件流 |
+
+### 5.2 Ledger 字段（probation 入口后的字段流转）
+
+```
+intake 写入 →  status=probation, sourceRef=candidate://..., artifactRef=artifact://...
+
+Dreamer 执行 → 不修改 Ledger，写入 PIArtifact
+
+...
+
+ActivationDispatcher (channel=prompt) →
+  status=active, activatedAt=<now>, activatedBy=<actor>
+
+ActivationDispatcher (channel=defer_archive) →
+  status=archived, archivedReason=<route_recommendation>
+
+ActivationDispatcher (channel=code_tool_hook) →
+  status=active + 写入 implementation 文件
+
+ActivationDispatcher (channel=skill) →
+  status=active + 写入 skill 文件
+
+ActivationDispatcher (channel=model_training) →
+  status=active + 写入 training-exports
+```
+
+### 5.3 跨阶段血缘视图
+
+```
+PainSignal(painId)
+    │ 1:1
+    ▼
+TaskRecord(taskKind=diagnostician)
+    │ 1:N
+    ▼
+RunRecord
+    │ 1:1
+    ▼
+ArtifactRecord(diagnosis_report)
+    │ 1:N
+    ▼
+CandidateRecord
+    │ 1:1
+    ▼
+LedgerPrincipleEntry(probation)
+    │ 1:1
+    ▼
+TaskRecord(taskKind=dreamer)  ← IntakeToInternalizationBridge 创建
+    │ 1:N (Job Graph)
+    ▼
+TaskRecord(taskKind=philosopher) → ... → TaskRecord(rollout_reviewer)
+    │ 每个 task 1:1
+    ▼
+PIArtifact(各 kind)
+    │
+    ▼ ActivationDispatcher
+ApprovalRecord（可选） → 实际激活
+```
+
+---
+
+## 6. 关键不变量与约束
+
+### 6.1 一致性
+
+1. **PIArtifact 写入与 Task 状态变更必须原子**：Runner 在 succeed 前必须先成功写 PIArtifact
+2. **Ledger 写入必须原子**：通过 `atomicWriteFileSync`
+3. **审批结果与激活必须原子**：approve 后必须保证 ChannelWriter 被调用，失败需重试
+
+### 6.2 幂等性
+
+| 操作 | 幂等键 |
+|------|-------|
+| Pain → Diagnostician task | `painId → taskId(deterministic)` |
+| Candidate → Ledger entry | `existsForCandidate(candidateId)` |
+| Probation → Dreamer task | `(ledgerEntryId, channel)` |
+| 任何 Runner 输出 → PIArtifact | `(sourceTaskId, artifactKind)` |
+| Validated → Activation | `(artifactId, channel)` |
+
+### 6.3 可恢复性
+
+- 任意阶段崩溃，下次启动时 `RecoverySweep` 扫描 `pending` / `leased` task 自动恢复
+- `lease_expired` 视为可恢复，重置为 `pending`
+- 每个 Runner 必须支持从中断点重启（不依赖内存状态）
+
+### 6.4 可观测性
+
+每个阶段必须发出至少 3 个 telemetry event：
+
+| 阶段 | 事件 |
+|------|------|
+| Diagnostician | `diagnostician_task_leased` / `diagnostician_run_started` / `diagnostician_task_succeeded` 或 `_failed` |
+| Bridge | `probation_to_internalization_bridged` / `bridge_skipped` |
+| 每个 Peer Runner | `<runner>_task_leased` / `<runner>_run_started` / `<runner>_task_succeeded` 或 `_failed` |
+| Activation | 详见 ADR-0006 |
+
+### 6.5 性能预算
+
+| 阶段 | 预算 | 触发降级 |
+|------|------|---------|
+| 单个 Pain → Probation | < 6 分钟 (P95) | > 10 分钟报警 |
+| Probation → Validated PIArtifact (整链) | < 30 分钟 (P95) | > 1 小时报警 |
+| 任意单个 Runner 调用 | < 5 分钟（默认 timeout） | timeout → retry_wait |
+| Hook 同步路径（pain capture） | < 50ms | 超出阻塞工具调用 |
+
+---
+
+## 7. 错误处理与降级
+
+### 7.1 错误分类（详见 `ERROR_ARCHITECTURE.md`）
+
+| 错误类别 | 重试策略 | 降级策略 |
+|---------|---------|---------|
+| `runtime_unavailable` | 指数退避 | 等待下次 IdleTrigger |
+| `output_invalid` | 最多 3 次重试，注入修复提示 | 失败后 mark failed，等人审 |
+| `lease_conflict` | 不重试（其他 Runner 在执行） | 跳过此次 |
+| `timeout` | 重试 1 次（超时翻倍） | 失败后 mark failed |
+| `storage_unavailable` | 永久错误 | 立即停止流水线，告警 |
+| `workspace_invalid` | 永久错误 | 立即停止 |
+
+### 7.2 部分失败的处理
+
+**场景 A**：Diagnostician 成功但 CandidateIntake 失败
+- 候选保持 `pending`
+- 下次 IdleTrigger 重新尝试 intake
+
+**场景 B**：Dreamer 成功但 Philosopher 失败
+- Philosopher task 进入 `retry_wait`
+- 已生成的 PIArtifact 保留，下次重试可复用
+
+**场景 C**：RolloutReviewer 成功但 ActivationDispatcher 失败
+- 进入 ApprovalQueue（如果是高风险通道）
+- 写入审批 pending 记录，等待人工
+
+### 7.3 反馈环（Rejection Feedback Loop）
+
+详见 ADR-0006 §2.6。当人工 reject 一个 PIArtifact 时：
+
+```
+RejectionFeedback 写入
+        │
+        ▼
+（可选）创建新的 Dreamer task
+        │
+        │ 注入 correctionHints 到 prompt context
+        ▼
+Dreamer 在新一轮中知道"上次为何被拒"
+```
+
+### 7.4 三振出局（Three Strikes Out）— 防止无底洞重试
+
+**问题**：大模型在被拒绝后极易陷入"死脑筋"——生成逻辑相同但变量名不同的代码，导致无限重试消耗 Token 并撑爆任务队列。
+
+**机制**：在 `TaskStore` 的 task 记录中增加 `rejection_count` 字段。
+
+```typescript
+interface TaskRecord {
+  // ... 现有字段 ...
+  rejection_count: number;          // 被人工拒绝的次数（默认 0）
+  unresolvable_at?: string;         // 打上 UNRESOLVABLE 标签的时间
+  unresolvable_reason?: string;     // 原因（rejection_limit_exceeded / ...）
+}
+```
+
+**规则**：
+
+| 条件 | 行为 |
+|------|-----|
+| `rejection_count < 3` | 正常创建新 Dreamer task，注入 correctionHints |
+| `rejection_count >= 3` | 打上 `UNRESOLVABLE` 标签，**不再创建新 AI 任务** |
+| UNRESOLVABLE 后 | 在 pd-console 显示为"需要人工开发者介入"，作为传统 Issue 处理 |
+
+**不变量**：
+- `rejection_count` 只增不减（append-only 语义）
+- UNRESOLVABLE 状态不可由 AI 自动解除，只能由人工 `pd task reopen <taskId>` 重置
+- 每次 reject 必须写入 `RejectionFeedback`，`rejection_count` 在 reject 时原子递增
+
+**可观测性**：
+- `pd health` 输出 `unresolvable_task_count`
+- pd-console 在 Tasks 页面单独展示 UNRESOLVABLE 任务列表
+
+---
+
+## 8. 与 Activation Pipeline 的衔接（断点 ② 解决方案）
+
+详见 [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md)。本节只给出衔接点：
+
+```
+RolloutReviewerRunner.succeed() {
+  ...
+  await activationDispatcher.dispatch({
+    artifactId,
+    channel: piTask.channel,
+    rolloutDecision: output.review.decision,
+    actor: { kind: 'system', source: 'rollout_reviewer' },
+  });
+  ...
+}
+```
+
+`ActivationDispatcher` 是流水线的**唯一出口**。所有"激活"操作必须经过它。
+
+---
+
+## 9. 配置与可调参数
+
+### 9.1 流水线配置
+
+位置：`{workspace}/.pd/config/internalization.yaml`（新建）
+
+```yaml
+internalization:
+  default_runner_timeout_ms: 300000
+  default_max_attempts: 3
+
+  # IdleTrigger（参见 §4.2）
+  idle_trigger:
+    enabled: true
+
+  # Job graph 灰度
+  enabled_channels:
+    - prompt
+    - skill
+    - code_tool_hook
+    - model_training
+    - defer_archive
+
+  # 每通道并发上限
+  max_concurrent_per_channel:
+    prompt: 5
+    skill: 3
+    code_tool_hook: 2
+    model_training: 1
+
+  # Bridge 行为
+  bridge:
+    auto_create_dreamer_task: true
+    skip_if_already_in_pipeline: true
+```
+
+### 9.2 路由策略可覆盖
+
+`RoutingPolicy` 默认基于 lifecycle evidence 推荐路由，可通过 config 强制覆盖：
+
+```yaml
+routing_policy:
+  overrides:
+    - principle_id_pattern: "^P_security_.*"
+      force_channel: code_tool_hook  # 安全相关原则强制走代码内化
+    - principle_id_pattern: "^P_style_.*"
+      force_channel: prompt          # 风格相关只走 prompt
+```
+
+---
+
+## 10. 测试要求
+
+### 10.1 单元测试覆盖
+
+每个 Runner / Bridge / Service 必须有单元测试：
+- happy path
+- 各种 PDErrorCategory 的处理
+- 幂等性（重复输入返回相同输出）
+- 输入校验失败
+
+### 10.2 集成测试
+
+至少 3 条端到端集成测试场景：
+
+1. **Pain → Probation → Activated（prompt 通道）**：完整自动链
+2. **Pain → Probation → Approval Required（code_tool_hook）**：高风险审批分支
+3. **Pain → Rejected by Validator → Retry**：错误恢复路径
+
+### 10.3 架构守护测试
+
+- Runner 之间不得相互直接 import
+- Core 模块不得 import openclaw-plugin
+- 任何 LLM 调用必须经过 PDRuntimeAdapter
+
+### 10.4 性能基线
+
+定期跑性能基线测试：
+- 100 个并发 Pain Signal 的吞吐量
+- 单个 Pain → Activated 的端到端延迟分布
+
+---
+
+## 11. 当前实现状态对照表
+
+| 组件 | 状态 | 待办 |
+|------|------|------|
+| **Stage 1 (Pain)** | | |
+| PainSignalAdapter | ✅ | |
+| PainBridge | ✅ | |
+| DiagnosticianRunner | ✅ | |
+| CandidateIntakeService | ✅ | |
+| **Stage 2 (Internalization)** | | |
+| IntakeToInternalizationBridge | ✅ | 已解决断点 ①：probation/candidate → root dreamer task |
+| RoutingPolicy | ✅ | 可能需要扩展 channel mapping |
+| InternalizationOrchestrator | ✅ | |
+| DreamerRunner | ✅ | |
+| PhilosopherRunner | ✅ | |
+| ScribeRunner | ✅ | |
+| ArtificerRunner | ✅ | |
+| EvaluatorRunner | ✅ | |
+| RolloutReviewerRunner | ✅ | 增加 ActivationDispatcher 调用 |
+| TrainerRunner | ✅ | 仅 model_training 通道 |
+| **触发** | | |
+| IdleTrigger | ✅ | core 纯策略模块已落地（idle-trigger-policy/decision/types）；plugin 宿主适配层待后续 issue |
+| **Stage 3 (Activation)** | | |
+| ActivationDispatcher + low-risk ChannelWriters | ✅ | prompt / defer_archive 已落地 |
+| ApprovalQueue + SQLite store | ✅ | 基础 pending / approve / reject / cancel 状态已落地；二次确认 / 过期策略待扩展 |
+| RuleHostWriter / SkillFileWriter / TrainingExporter | ❌ | 高风险 / 中风险 / L3 writer 待建 |
+| **数据迁移** | | |
+| Nocturnal → PIArtifact 迁移 | ❌ | 见 ADR-0005 |
+
+---
+
+## 12. 实施优先级
+
+按 ADR-0005 / ADR-0006 给出的阶段：
+
+### 优先级 P0（解锁端到端流水线）
+- [x] `IntakeToInternalizationBridge` 实现 → 解决断点 ①
+- [x] `IdleTrigger` 实现 → 替代 nocturnal-service 触发部分
+- [x] `ActivationDispatcher` 框架 + prompt/archive 两个 ChannelWriter → 解决断点 ②（最低风险通道）
+- [ ] **L1 容量硬上限（Hard Cap）** → 防止 System Prompt 膨胀导致 LLM 失效（见 §9.1）
+- [ ] **三振出局机制** → `rejection_count` 字段 + UNRESOLVABLE 状态（见 §7.4）
+- [ ] **BALM 骨架** → AgentRegistry + AgentManifest schema + 改 Diagnostician 用 BALM（ADR-0008）
+- [ ] **LRAS 基础** → Session checkpoint + self-validation tools + log backflow（ADR-0009）
+- [ ] **GAP 信号源** → Mission/Objective 数据模型 + GAPSignalGenerator + GFI 简化（ADR-0010）
+
+### 优先级 P1（高风险通道）
+- [ ] `SkillFileWriter`
+- [ ] `RuleHostWriter` + shadow mode（Offline Replay 模式，见 §9.2）
+- [x] `ApprovalQueue` 基础队列 + SQLite store
+- [x] pd-console 审批 UI/API 基础版
+- [x] **基于置信度的自动晋升**（Auto-Promotion by Confidence，见 §9.3）基础策略
+- [ ] `RejectionFeedback` 结构化反馈闭环
+- [ ] **新 RuntimeAdapter**（Claude Code / Codex CLI 至少各 1 个，ADR-0008）
+- [ ] **DecisionHygieneGate**（high/critical 影响强制触发，ADR-0010）
+- [ ] **MissionScheduler**（三层任务调度，替代 polling，ADR-0011）
+
+### 优先级 P2（清理与合并）
+- [ ] 删除 `nocturnal-service.ts`、`nocturnal-trinity.ts` 等冗余代码
+- [ ] 删除 RuleImplementationArtifact 旧概念引用
+- [ ] 数据迁移脚本
+
+### 优先级 P3（最高风险通道）
+- [ ] `TrainingExporter` + 二次确认
+- [ ] 与外部模型训练系统集成
+
+---
+
+## 9. 运行时防御机制（Runtime Safeguards）
+
+> 本节补充评审 3 识别的 5 个致命缺陷对应的设计约束。这些机制是 P0/P1 实施的**强制要求**，不是可选优化。
+
+### 9.1 L1 容量硬上限（防止 System Prompt 膨胀）
+
+**问题根源**：根据 `PD_System_Dynamics_Model.md`，L1（软内化）膨胀是导致 LLM 变笨的主要原因。如果 Pruning Action 排到 P3（6+ 个月），系统全力运转后 System Prompt 会在数周内超过 LLM 有效注意力窗口。
+
+**强制约束**：
+
+```yaml
+# {workspace}/.pd/config/internalization.yaml
+internalization:
+  l1_capacity:
+    soft_limit: 8          # 超过时 pd health 报 warning
+    hard_limit: 12         # 超过时强制 LRU 淘汰
+    lru_eviction: true     # 硬上限触发时自动淘汰最久未触发的 principle
+    eviction_audit: true   # 每次淘汰写入 audit log
+```
+
+**LRU 淘汰规则**：
+- 当 `active principles count > hard_limit` 时，淘汰 `last_triggered_at` 最早的 principle
+- 淘汰 = 将 `Ledger.principles[id].status` 从 `active` 改为 `archived`，原因 `lru_eviction`
+- 淘汰操作写入 `correction_audit_events` 表，可通过 `pd audit list --type lru_eviction` 查询
+- 淘汰不等于删除：principle 数据保留，可通过 `pd principle restore <id>` 重新激活
+
+**不变量**：
+- `active principles count` 在任何时刻不得超过 `hard_limit`（代码强制，不依赖 config）
+- 代码默认 `hard_limit = 12`，config 只能调低不能调高（防止误配置）
+
+> **注意**：这是"低端但保底"的修剪机制，不替代完整的 Pruning Action（P3）。完整 Pruning Action 需要人工审批和回滚机制，但 LRU 硬上限是系统存活的最低保障。
+
+### 9.2 Shadow Mode 重新定义（Offline Replay，非旁路运行）
+
+**问题根源**：对于 `code_tool_hook` 通道的拦截器（RuleHost Gate），传统"影子模式"（只记录不拦截）存在逻辑悖论——如果不拦截，危险操作会真实发生；如果拦截，就不是影子模式。
+
+**正确定义**：Shadow Mode = **Offline Replay 测试**，不是旁路运行。
+
+```
+新生成的 RuleHost 代码
+        │
+        │ 不上线，不拦截任何真实调用
+        ▼
+每日夜间 Offline Replay
+        │
+        │ 把过去 N 天的全量 Trajectory 日志过一遍新规则
+        ▼
+评估结果
+  ├── 误杀率 > 阈值（误杀了历史正常操作）→ 打回，不激活
+  ├── 命中率 < 阈值（没有命中历史 Pain 记录）→ 打回，不激活
+  └── 连续 30 天通过 → 进入人工审批队列
+```
+
+**实现要求**：
+- `GoldenTrace` 已实现（PR #568），作为 Replay 的数据源
+- 新增 `ShadowModeEvaluator` 组件，每日调度一次 Replay
+- Replay 结果写入 `pi_artifacts` 的 `shadow_eval_results` 字段
+- 30 天通过后自动触发 `ApprovalQueue.enqueue()`
+
+**配置**：
+```yaml
+code_tool_hook:
+  shadow_mode_cycles: 30        # 连续通过天数（默认 30）
+  false_positive_threshold: 0.05  # 误杀率上限（5%）
+  hit_rate_threshold: 0.8       # 命中率下限（80%）
+```
+
+### 9.3 基于置信度的自动晋升（Auto-Promotion by Confidence）
+
+**问题根源**：如果所有 L2 变更都需要人工审批，操作员会产生"报警疲劳"，要么闭眼 Approve（护栏失效），要么让队列堆满（系统便秘）。
+
+**机制**：在 `ActivationDispatcher` 中增加置信度评估，满足以下**全部条件**时允许跳过人工审批：
+
+| 条件 | 说明 |
+|------|-----|
+| `rollout_confidence >= 0.95` | RolloutReviewer 给出 95% 以上置信度 |
+| `shadow_eval_false_positive_rate < 0.01` | Offline Replay 误杀率 < 1% |
+| `scope = non_destructive_only` | 规则作用域仅限非破坏性工具（如 `git status`、`read_file`）|
+| `rejection_count = 0` | 此 artifact 从未被拒绝过 |
+
+**不允许自动晋升的情况**（无论置信度多高）：
+- 涉及 `write_file`、`exec`、`delete` 等破坏性工具的拦截规则
+- `model_training` 通道（永远需要双人审批）
+- `rejection_count > 0` 的 artifact
+
+**配置**：
+```yaml
+code_tool_hook:
+  auto_promotion:
+    enabled: true                    # 默认开启
+    confidence_threshold: 0.95
+    max_false_positive_rate: 0.01
+    allowed_scopes:                  # 白名单：只有这些工具可以自动晋升
+      - read_file
+      - git_status
+      - list_directory
+```
+
+### 9.4 SQLite 并发安全（WAL + Jitter）
+
+**问题根源**：多个 workspace 或多个 Agent 同时进入 Idle 状态时，会同时争抢 SQLite 的 `pending` 任务锁，导致 `Database is locked` 错误。
+
+**强制要求**：
+
+**1. WAL 模式（必须）**：
+
+```typescript
+// packages/principles-core/src/runtime-v2/sqlite-connection.ts
+// 每个连接建立时必须执行：
+db.pragma('journal_mode = WAL');
+db.pragma('busy_timeout = 5000');   // 等待 5s 而非立即失败
+db.pragma('synchronous = NORMAL');  // WAL 模式下 NORMAL 足够安全
+```
+
+**2. IdleTrigger Jitter（必须）**：
+
+```typescript
+// 核心策略：packages/principles-core/src/runtime-v2/idle-trigger/idle-trigger-types.ts
+// Jitter 由 core idle-trigger-decision.ts 决定，宿主层在调用 wakeOnce 前应用
+const jitterMs = Math.random() * (maxJitterMs - minJitterMs) + minJitterMs;
+await sleep(jitterMs);
+await orchestrator.wakeOnce();
+```
+
+配置：
+```yaml
+idle_trigger:
+  jitter_min_ms: 5000    # 最少等待 5 秒
+  jitter_max_ms: 30000   # 最多等待 30 秒
+```
+
+**3. LeaseManager 超时（已有，确认配置）**：
+- Lease 超时默认 5 分钟，防止死锁
+- `RecoverySweep` 每次启动时清理过期 lease
+
+**不变量**：
+- 任何 SQLite 连接建立时必须设置 `journal_mode = WAL`（架构守护测试覆盖）
+- `IdleTrigger` 必须有 jitter，不允许固定间隔触发（架构守护测试覆盖）
+
+---
+
+## 13. 与其他文档的关系
+
+| 文档 | 关系 |
+|------|------|
+| [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) | 上层视图；本文档展开 §4.1-4.2 的细节 |
+| [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) | 下游：本文档结束于 ActivationDispatcher.dispatch() |
+| [`COMPONENTS.md`](./COMPONENTS.md) | 各组件契约的扁平索引 |
+| [`DATA_ARCHITECTURE.md`](./DATA_ARCHITECTURE.md) | 表/文件存储细节 |
+| [`ERROR_ARCHITECTURE.md`](./ERROR_ARCHITECTURE.md) | 错误处理详细规范 |
+| ADR-0001 / 0003 / 0005 / 0006 | 决策依据 |
+
+---
+
+## 14. 变更追踪
+
+本文档代表流水线的**目标状态**。任何对流水线的设计变更必须：
+
+1. 提交 ADR 修改本文档列表的某条决策
+2. 同步修订本文档相应章节
+3. 更新 `当前实现状态对照表`（§11）
+4. 更新 `GLOSSARY.md` 如有新词

--- a/docs/architecture/PD_ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/PD_ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,541 @@
+# PD 架构总览（PD Architecture Overview）
+
+> **状态**: Active / SSoT-ENTRY-POINT
+> **最后更新**: 2026-05-15
+> **定位**: 整个 PD 项目的**唯一架构入口文档**。任何架构相关的疑问，先来这里。
+> **一致性约束**: 本文档是 SSoT（Single Source of Truth）。其他架构文档必须与本文一致；冲突时以本文为准，并通过 PR 同步修订。
+
+本文档回答四个问题：
+1. PD 是什么？
+2. PD 由哪些子系统构成？
+3. 数据如何在子系统之间流转？
+4. 想了解某个细节，应该读哪份文档？
+
+---
+
+## 1. PD 是什么
+
+**Principles Disciple（PD）** 是一个面向 AI 编程代理的**原则演化框架**。它捕获代理执行过程中的失败信号（痛苦），把失败提炼为可复用的原则（Principle），再把原则**内化**为更稳定、更低成本的行为约束（Prompt / Skill / Hook 代码 / 模型参数），最终改变代理的实际行为。
+
+PD 的核心循环：
+
+```
+痛苦信号  ──→  诊断  ──→  原则候选  ──→  内化流水线  ──→  激活生效
+   ▲                                                          │
+   └──────────────────  代理行为改变  ←──────────────────────┘
+```
+
+PD 的设计哲学：
+
+- **行动品格优先于单次成功率** —— PD 不追求局部任务最优，追求长期稳定行为
+- **最便宜的内化方式优先** —— `prompt < code < model_training < fine-tune`
+- **代理是日常用户，人是审核员和风险责任人** —— 全自动是目标，人工保留在高风险路径
+- **人在回路最低化但不可缺位** —— L2/L3 高风险通道必须有人工审核
+- **目标对齐优先于局部优化** —— 代理的每个行动应能追溯到 Objective，偏离目标才是真正的痛苦
+- **长程自主优先于短任务轮询** —— 内置代理应持续工作直到完成，而非被超时切碎
+
+---
+
+## 2. 系统边界与四大交付物
+
+PD 是一个 monorepo，由四个独立可交付的包构成。每个包有清晰的职责边界，包之间只允许**单向依赖**。
+
+### 2.1 包依赖关系（强约束）
+
+```
+                    ┌──────────────────────┐
+                    │   @principles/core   │
+                    │  （Domain & Runtime） │
+                    └──────────┬───────────┘
+                               │ 单向依赖
+            ┌──────────────────┼──────────────────┐
+            │                  │                  │
+   ┌────────▼─────────┐ ┌──────▼──────┐ ┌────────▼──────────┐
+   │  openclaw-plugin │ │ @principles │ │  @principles/     │
+   │   （Host Adapter）│ │   /pd-cli   │ │    pd-console     │
+   │                  │ │  （for AI）  │ │     （for Human）  │
+   └──────────────────┘ └─────────────┘ └───────────────────┘
+```
+
+**强约束（CI 守护，违反即拒）**：
+- `@principles/core` 不得反向依赖任何包
+- `openclaw-plugin` / `pd-cli` / `pd-console` 之间不得相互依赖
+- 任何 host-specific 代码（OpenClaw API、Codex CLI 等）只能存在于 `openclaw-plugin` 或将来其他 adapter 包
+
+### 2.2 四大交付物职责矩阵
+
+| 包 | 角色 | 主要受众 | 进程模型 | 拥有 | 不拥有 |
+|----|------|---------|---------|------|--------|
+| `@principles/core` | Domain & Runtime SDK | 其他包 | Library | 业务领域、状态机、Runner、Store、Read Model、Schema、**BALM（代理生命周期管理）**、**LRAS（长程会话）**、**GAP（目标驱动信号）**、**MissionScheduler** | 任何宿主 API、UI、CLI |
+| `openclaw-plugin` | Host Adapter | OpenClaw Gateway | Plugin in-proc | Hook 桥接、PainSignal 捕获、Runtime Adapter 注册、IdleTrigger 宿主调度适配、**新 CLI Adapter（Claude Code/Codex/Gemini 等）** | 业务规则、原则生命周期、Runner 实现 |
+| `@principles/pd-cli` | Agent Operator | AI 代理 (OpenClaw / Codex / Gemini) | Stdout-driven CLI | 结构化 JSON 接口、读侧查询、低风险写操作、**PD 元工具（pd_validate_output / pd_fetch_recent_logs 等）** | 高风险审批、长连接 UI |
+| `@principles/pd-console` | Human Operator | 开发者 / 运维 / 研究员 | Local Web Server | 可视化 UI、人工审批工作流、长任务流式输出、**Mission/Objective 视图**、**Agent 健康面板** | 业务规则 |
+
+### 2.3 三个独立 deliverable 共用同一个 core
+
+- **同一份 SQLite 数据库**（`{workspace}/.pd/state.db`）
+- **同一份 Ledger 文件**（`{workspace}/.state/principle_training_state.json`）
+- **同一份 PIArtifact Store**
+
+但读写规则不同：
+
+```
+                  ┌──────────────┐
+                  │  state.db    │
+                  │  ledger.json │
+                  │  artifacts/  │
+                  └──┬─────┬──┬──┘
+                     │     │  │
+        ┌────────────┘     │  └────────────┐
+        │ 读+写            │ 读+部分写       │ 读+部分写（含审批）
+   ┌────▼────┐       ┌────▼─────┐     ┌────▼──────┐
+   │ Plugin  │       │  pd-cli  │     │ pd-console│
+   └─────────┘       └──────────┘     └───────────┘
+```
+
+写操作的并发安全由 `@principles/core` 内部的 `LeaseManager` + 原子写入保证（详见 `DATA_ARCHITECTURE.md`）。
+
+---
+
+## 3. 四层架构
+
+PD 采用**四层架构**。从上到下：
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Layer 4: Surface（表面层）                                         │
+│  ┌────────────────────┐  ┌────────────────────┐                    │
+│  │ pd-cli（for Agent）│  │ pd-console（for 人） │  ← 用户/代理交互   │
+│  └────────────────────┘  └────────────────────┘                    │
+└────────────────────────────────────────────────────────────────────┘
+                              ▲
+┌────────────────────────────────────────────────────────────────────┐
+│  Layer 3: Host Integration（宿主集成层）                            │
+│  ┌────────────────────────────────────────────────┐                │
+│  │ openclaw-plugin                                 │                │
+│  │  - Hooks (pain/gate/prompt/llm/lifecycle)      │ ← 平台桥接     │
+│  │  - IdleTrigger 宿主调度适配（核心策略在 core/idle-trigger/）│
+│  │  - RuntimeAdapter (OpenClaw / Claude Code /    │                │
+│  │    Codex / Gemini / opencode / Hermes 等)      │                │
+│  └────────────────────────────────────────────────┘                │
+└────────────────────────────────────────────────────────────────────┘
+                              ▲
+┌────────────────────────────────────────────────────────────────────┐
+│  Layer 2: Domain Services & Runners（领域服务层）                   │
+│  ┌──────────────────┬──────────────────┬───────────────────┐       │
+│  │ Pain Pipeline    │ Internalization  │ Activation        │       │
+│  │ (PainBridge,     │ Pipeline         │ Pipeline          │       │
+│  │  Diagnostician,  │ (Dreamer→Trainer │ (5 Channel        │       │
+│  │  Intake)         │  + Orchestrator) │  Dispatcher)      │       │
+│  ├──────────────────┼──────────────────┼───────────────────┤       │
+│  │ BALM             │ LRAS             │ GAP + Goals       │       │
+│  │ (代理生命周期)    │ (长程会话)        │ (目标驱动信号)     │       │
+│  └──────────────────┴──────────────────┴───────────────────┘       │
+└────────────────────────────────────────────────────────────────────┘
+                              ▲
+┌────────────────────────────────────────────────────────────────────┐
+│  Layer 1: Foundation（基础层）                                      │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │ Schema & Contracts │ Stores │ Read Models │ Error Categories │   │
+│  │ (TypeBox)          │ (SQLite│ (immutable  │ (PDErrorCategory)│   │
+│  │                    │  + JSON)│  views)    │                  │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**层级约束（强约束，CI 守护）**：
+- 高层依赖低层，禁止反向
+- 同层之间依赖必须显式声明在 `COMPONENTS.md`
+- Layer 1 和 2 全部位于 `@principles/core`，Layer 3 位于 `openclaw-plugin`，Layer 4 位于 `pd-cli` / `pd-console`
+
+---
+
+## 4. 五条核心数据流
+
+PD 的所有运行时行为可以归为五条数据流。每条流有：明确的触发器、端到端步骤、产物、Owner、不变量。
+
+### 4.1 Pain Pipeline（痛苦流水线）
+
+**目的**：把代理的失败转化为结构化原则候选。
+
+**信号源三层架构（GAP — Goal-Aligned Pain）**：
+
+```
+Layer 1: GAP 主信号（目标驱动）          ← 独立触发 Diagnostician
+  mission_failed / mission_stalled
+  okr_drift / decision_skipped / rework_loop
+
+Layer 2: 用户反馈信号（强信号）           ← 独立触发 Diagnostician
+  explicit_user_complaint / user_correction
+
+Layer 3: 工具/系统失败（辅助信号）        ← 仅作为 Layer 1/2 的证据补充
+  tool_failure / empathy_inferred          不独立触发 Diagnostician
+```
+
+**数据流**：
+
+```
+[GAP Signal / User Feedback / Tool Failure]
+      │ Plugin Hook / GAP Generator / 用户显式反馈
+      ▼
+[PainSignal] ─────► PainSignalAdapter ─────► state.db: pain_signals
+      │
+      ▼
+PainBridge.onPainDetected()
+      │
+      ▼
+DiagnosticianRunner.run()  ◄──── PDRuntimeAdapter（LLM 调用，LRAS 长程会话）
+      │
+      ▼
+DiagnosticianOutputV1
+      │
+      ▼
+CandidateIntakeService.intake()
+      │
+      ▼
+[LedgerPrinciple status=probation] ◄──── ledger.json
+```
+
+| 阶段 | 组件 | 包 | 详见 |
+|------|------|-----|------|
+| 信号捕获 | Hook + `pain-recorder` | plugin + core | `INTERNALIZATION_PIPELINE.md` §2 |
+| 诊断 | `DiagnosticianRunner` | core | ADR-0001 |
+| 摄入 | `CandidateIntakeService` | core | `DATA_ARCHITECTURE.md` |
+
+**关键不变量**：
+- `painId` 是唯一来源标识，可追溯
+- 同一个 `painId` 重复进入是幂等的（`createDiagnosticianTaskId(painId)` 确定性映射）
+- Diagnostician 失败必须留下 `PDRuntimeError`，不得静默吞没
+- Ledger 写入是原子的（`atomicWriteFileSync`）
+
+### 4.2 Internalization Pipeline（内化流水线）
+
+**目的**：把 probation 候选**蒸馏**为可激活的实现工件（PIArtifact）。
+
+```
+[Ledger: probation principle]
+      │
+      ▼
+IntakeToInternalizationBridge   ★ 关键桥接器（自动入队）
+      │
+      ▼
+InternalizationOrchestrator.wakeOnce()
+      │
+      ▼
+PIArtifactStore + TaskStore（同一个 state.db）
+      │
+      ▼  按 Job Graph 顺序执行
+┌───────────────────────────────────────────────────────────┐
+│ Dreamer ──► Philosopher ──► Scribe ──► Artificer          │
+│            ──► Evaluator ──► RolloutReviewer ──► Trainer  │
+└───────────────────────────────────────────────────────────┘
+      │ 每个 Runner 都产出一个 PIArtifact
+      ▼
+[PIArtifact: validation_status=validated]
+      │ RolloutReviewer 通过 → 可激活
+      ▼
+RolloutDecision: { autoActivate | requireApproval }
+```
+
+| 阶段 | 组件 | 包 | 详见 |
+|------|------|-----|------|
+| 入队 | `IntakeToInternalizationBridge`（待建） | core | `INTERNALIZATION_PIPELINE.md` §3 |
+| 编排 | `InternalizationOrchestrator` | core | ADR-0003 |
+| Runner 执行 | 7 个 PeerRunner | core | ADR-0003 |
+| 评估 | `Evaluator` + `RolloutReviewer` | core | `INTERNALIZATION_PIPELINE.md` §4 |
+
+**关键不变量**：
+- 每个 Runner 必须遵循 `lease → invoke → poll → validate → succeed/fail`
+- 所有 Runner 必须通过 `PDRuntimeAdapter` 调用 LLM，禁止直连 SDK
+- Runner 之间禁止直接调用，必须通过 TaskStore 入队
+- PIArtifact 的 `validationStatus` 在 `pending → validated` 之前不得激活
+- 触发流水线的策略（cron / idle / 立即）由宿主层（plugin）拥有，core 只提供 `wakeOnce` 接口
+
+### 4.3 Activation Pipeline（激活流水线）★ 新增
+
+**目的**：把 validated 的 PIArtifact 通过 5 个通道**实际作用于代理行为**。
+
+```
+[PIArtifact: validated, channel=X]
+      │
+      ▼
+ActivationDispatcher（按 channel 路由）
+      │
+      ├──── channel=prompt          ──► [自动] LedgerWriter.activate()
+      ├──── channel=defer_archive   ──► [自动] LedgerWriter.archive()
+      ├──── channel=skill           ──► [可配置] SkillWriter.write()
+      ├──── channel=code_tool_hook  ──► [必须人工审批] ApprovalQueue
+      └──── channel=model_training  ──► [必须人工审批 + 二次确认]
+                                        ApprovalQueue
+                                              │
+                                              ▼
+                              [pd-console 人工审批]
+                                              │
+                                  approve     ▼     reject
+                                     ┌────────┼────────┐
+                                     ▼                 ▼
+                            LedgerWriter.activate  RejectionFeedback
+                                                       │
+                                                       ▼
+                                                  [回到内化流水线优化]
+```
+
+| 阶段 | 组件 | 包 | 详见 |
+|------|------|-----|------|
+| 调度 | `ActivationDispatcher`（基础版已落地） | core | `ACTIVATION_CHANNELS.md` |
+| 通道实现 | `PromptWriter` / `DeferArchiveWriter` 已落地；`SkillFileWriter` / `RuleHostWriter` / `TrainingExporter` 待建 | core | `ACTIVATION_CHANNELS.md` |
+| 审批队列 | `ApprovalQueue` + `pd-console` Approvals 基础 UI/API | core + console | ADR-0006 |
+| 拒绝反馈 | `RejectionFeedbackLoop` | core | ADR-0006 |
+
+**关键不变量**：
+- 默认安全策略：未明确为 `auto` 的通道必须经过人工审批
+- 拒绝必须产生 `RejectionFeedback` 记录，不得静默丢弃
+- 激活操作是原子的（`Ledger.principle.status = active` 与对应资源写入必须一致）
+- 撤销激活（rollback）必须可追溯到批准人和批准时间
+
+### 4.4 Operations Pipeline（运维流水线）
+
+**目的**：人和代理对 PD 状态的查询、审批、修剪、回滚。
+
+```
+                  ┌────────────────────────────┐
+                  │   Read Models（不可变视图） │
+                  ├────────────────────────────┤
+                  │ PainChainReadModel         │
+                  │ InternalizationQueueRM     │
+                  │ PruningReadModel           │
+                  │ OperatorHealthReadModel    │
+                  │ LifecycleReadModel         │
+                  └─────────┬──────────────────┘
+                            │
+              ┌─────────────┼─────────────┐
+              ▼                           ▼
+         ┌────────┐                  ┌──────────┐
+         │ pd-cli │                  │pd-console│
+         │ (json) │                  │ (visual) │
+         └────────┘                  └──────────┘
+              │                           │
+              │ 低风险写                  │ 高风险审批
+              ▼                           ▼
+         ┌──────────────────────────────────────┐
+         │   Write APIs（少量授权写入）          │
+         ├──────────────────────────────────────┤
+         │ PromoteImpl / DisableImpl            │
+         │ PrincipleRollback                    │
+         │ PruningReview (append-only audit)    │
+         │ ApprovalDecision (pd-console only)   │
+         └──────────────────────────────────────┘
+```
+
+| 阶段 | 组件 | 包 | 详见 |
+|------|------|-----|------|
+| 读模型 | 各 ReadModel 类 | core | `COMPONENTS.md` |
+| pd-cli | 全部命令 | pd-cli | `COMPONENTS.md` |
+| pd-console | 审批 UI | pd-console | `COMPONENTS.md` |
+
+**关键不变量**：
+- 读模型是**只读**的，禁止从读模型路径触发写
+- 写 API 必须记录 `actor`（agent / human / system）
+- 审批操作只能从 `pd-console` 入口进入，`pd-cli` 不得绕过
+
+### 4.5 Pruning Pipeline（修剪流水线）
+
+**目的**：清理已被更低层吸收或已无价值的原则，控制 Prompt 上下文压力。
+
+```
+[Ledger.active principles]
+      │
+      ▼
+PruningReadModel.scan()  （只读，定期）
+      │
+      ▼
+PruningSignal: 候选修剪集
+      │
+      ▼  （pd-cli / pd-console 展示）
+[人工审查]
+      │
+      ▼
+PruningReviewLog (append-only)  ◄── 仅审计意图，不改 Ledger
+      │
+      ▼  （独立 issue 触发）
+PruningAction（高风险，必须人工 approve + dry-run）
+      │
+      ▼
+LedgerWriter.deprecate() / archive()
+```
+
+**关键不变量**（现状已落地）：
+- `PruningReadModel` 不得修改 Ledger
+- `PruningReviewLog` 是 append-only 审计日志
+- `PruningAction` 至今**未实现**，等待独立 issue 推进
+- 任何对 active 原则的状态变更必须可回滚
+
+详见 `PRUNING_PIPELINE.md`（待建）和 `DOMAIN_MODEL.md` §4。
+
+---
+
+## 5. 文档导航：想了解 X，应该读哪份
+
+### 5.1 决策路径速查表
+
+| 你的问题 | 入口文档 |
+|---------|---------|
+| 一个新概念该叫什么名字 | `GLOSSARY.md` → 标准术语词典 |
+| 一段代码该放哪个包 | 本文 §2.2 + `COMPONENTS.md` |
+| 一个新组件应该归到哪一层 | 本文 §3 + `COMPONENTS.md` |
+| 怎么处理一个新错误 | `ERROR_ARCHITECTURE.md` |
+| 数据存哪里 | `DATA_ARCHITECTURE.md` |
+| 怎么观测某个流水线 | `OBSERVABILITY_ARCHITECTURE.md` |
+| 一个新通道怎么接入激活 | `ACTIVATION_CHANNELS.md` |
+| 性能怎么做约束 | `PERFORMANCE_BUDGETS.md` |
+| 安全和工作区隔离 | `SECURITY_ARCHITECTURE.md` |
+| Schema 升级怎么做 | `VERSIONING_AND_COMPATIBILITY.md` |
+| 配置文件层级 | `CONFIGURATION_ARCHITECTURE.md` |
+
+### 5.2 五条数据流的详细文档
+
+| 数据流 | 主文档 | 相关 ADR |
+|-------|-------|---------|
+| Pain Pipeline | `INTERNALIZATION_PIPELINE.md` §2 | ADR-0001 |
+| Internalization Pipeline | `INTERNALIZATION_PIPELINE.md` §3-4 | ADR-0003, ADR-0005 |
+| Activation Pipeline | `ACTIVATION_CHANNELS.md` | ADR-0006 |
+| Operations Pipeline | `COMPONENTS.md` + 各 ReadModel | ADR-0007 |
+| Pruning Pipeline | `DOMAIN_MODEL.md` §4 | （待建） |
+
+### 5.3 战略层 vs 执行层
+
+| 文档类型 | 关注点 | 代表文档 |
+|---------|-------|---------|
+| 战略蓝图（不易变） | "为什么" + "应该是什么" | `PD_System_Dynamics_Model.md`, ADR |
+| 架构蓝图（中等稳定） | "由哪些部分构成" + "如何分层" | 本文 + `PD_SYSTEM_ARCHITECTURE.md` + `COMPONENTS.md` |
+| 实现指南（频繁更新） | "代码怎么写" | `docs/maps/` + 各模块 README |
+
+---
+
+## 6. 横切约束（Cross-Cutting Constraints）
+
+以下约束适用于所有四层、所有交付物、所有数据流。每一项都有专门文档详述（部分待建）。
+
+### 6.1 安全（Security）
+
+- **工作区隔离**：每个 PD 实例只操作 `workspaceDir` 范围内的文件，不得跨工作区
+- **沙箱执行**：所有用户/LLM 提供的可执行代码（RuleHost implementations）必须在 `node:vm` 受限上下文中执行
+- **PII 保护**：trajectory 数据中的用户消息必须经过 `pain-context-extractor` 脱敏处理
+- **密钥管理**：API Key 通过环境变量传入，禁止落盘
+- 详见：`SECURITY_ARCHITECTURE.md`
+
+### 6.2 性能（Performance Budgets）
+
+- **Hook 延迟预算**：`before_prompt_build` < 50ms, `before_tool_call` < 20ms
+- **Runner 超时**：默认 5 分钟，可配置
+- **SQLite 大小**：单工作区 state.db 上限 500MB（超限触发归档）
+- **Ledger 文件**：单 ledger.json 上限 10MB
+- 详见：`PERFORMANCE_BUDGETS.md`
+
+### 6.3 幂等性（Idempotency）
+
+- 所有跨进程触发的操作必须可幂等重试
+- 幂等键（`idempotencyKey`）由调用方提供（`taskId:runId:painId` 等组合）
+- Pain → Diagnostician 任务幂等：同一 `painId` 第二次触发返回缓存结果
+- Candidate → Ledger 幂等：`existsForCandidate` 优先查询
+- PIArtifact 写入幂等：`sourceTaskId + artifactKind` 为唯一键
+
+### 6.4 可观测性（Observability）
+
+- **三位一体**：Logs（结构化）+ Metrics（计数器）+ Traces（traceId 贯穿）
+- **TelemetryEvent**：所有跨流水线事件统一格式（`@principles/core/telemetry-event`）
+- **强制事件**：每个 Runner 必须发出 `*_task_leased` / `*_task_succeeded` / `*_task_failed`
+- 详见：`OBSERVABILITY_ARCHITECTURE.md`
+
+### 6.5 版本与兼容（Versioning）
+
+- **Schema 版本号**：`RUNTIME_V2_SCHEMA_VERSION`（语义化版本）
+- **Schema 演化**：仅允许添加可选字段；删除/重命名字段需经 ADR 决议
+- **数据迁移**：所有 schema 变更必须提供 forward migration（旧数据可读）
+- **Deprecation 流程**：`@deprecated` JSDoc → 一个 minor 版本警告 → 下个 major 删除
+- 详见：`VERSIONING_AND_COMPATIBILITY.md`
+
+### 6.6 可测试性（Testability）
+
+- **架构守护测试**：`architecture-regression.test.ts` 检查层级依赖、命名禁区、duplicate writers
+- **测试比例约定**：unit (70%) + integration (20%) + e2e (10%)
+- **Property-based**：状态机转换必须有 property-based 测试
+- **测试隔离**：每个测试必须使用独立的 tmp workspaceDir
+
+---
+
+## 7. 设计原则汇总
+
+PD 在做架构决策时，按以下优先级判断：
+
+1. **正确性 > 性能** —— 慢但正确，强于快但偶尔出错
+2. **可观测性 > 自动化** —— 静默成功不如显式失败
+3. **简单 > 通用** —— 不为不存在的需求做抽象
+4. **本地 > 远程** —— 默认 SQLite + 文件，不引入网络依赖
+5. **声明式 > 命令式** —— 状态用 schema 表达，不用 ad-hoc 字段
+6. **代理优先 > 人优先** —— pd-cli 是日常路径，pd-console 是审计路径
+7. **可组合 > 绑定** —— core 不绑定任何宿主框架
+8. **守恒 > 增量** —— 删除冗余优于添加新代码
+
+---
+
+## 8. 关于变更
+
+### 8.1 修改本文档的流程
+
+- 本文是 SSoT，修改必须通过 PR
+- PR 标题必须包含 `[OVERVIEW]` 标签
+- PR 描述必须列出所有受影响的下游文档
+- 至少需要一个架构维护者批准
+
+### 8.2 与现有文档不一致时怎么办
+
+| 场景 | 处理方式 |
+|------|---------|
+| 本文 vs ADR | ADR 是单点决策，本文是综合视图。冲突时通常本文滞后；要么修订本文，要么修订 ADR |
+| 本文 vs 代码 | 代码是事实，本文是意图。冲突时检查：是代码偏离了意图？还是意图过时了？通过 PR 修订一方 |
+| 本文 vs 其他架构文档 | 本文优先。其他文档需在 PR 同步修订 |
+
+### 8.3 索引与归档
+
+- 本目录的所有文档在 `README.md` 索引中维护
+- 标记为 `Deprecated` 的文档保留 2 个 minor 版本后归档到 `archive/`
+- 归档不删除，永久可追溯
+
+---
+
+## 9. 当前状态快照（实施进度）
+
+> **注**：本节按月更新一次，反映架构落地进度。最后更新：2026-05-18
+
+| 子系统 | 状态 | 主要 gap |
+|-------|------|---------|
+| Pain Pipeline | ✅ 完整 | 无 |
+| Internalization Pipeline | ⚠️ 90% | `IntakeToInternalizationBridge` 已落地；仍需生产链路持续验证与 legacy nocturnal 清理 |
+| Activation Pipeline | ⚠️ 75% | `ActivationDispatcher`、低风险 writers、`ApprovalQueue` 已落地；`RuleHostWriter` / `SkillFileWriter` / `TrainingExporter` 待建 |
+| Operations Pipeline | ⚠️ 80% | pd-console approvals 基础 UI/API 已落地；仍需 RejectionFeedback、二次确认、审批历史与更强审计 |
+| Pruning Pipeline | ⚠️ 50% | PruningAction 未实现 |
+| 横切约束 | ⚠️ 70% | 核心横切文档已建立；仍需文档-代码漂移守护与 invariant 编号覆盖 |
+| 守护测试 | ⚠️ 70% | architecture-regression.test 已覆盖多条 Runtime V2/Activation 边界；仍需 AC-* / BALM-* / GAP-* / SCHED-* 编号化覆盖 |
+| **BALM（代理生命周期）** | ❌ 0% | 全部待建（ADR-0008）|
+| **LRAS（长程代理会话）** | ❌ 0% | 全部待建（ADR-0009）|
+| **GAP（目标驱动信号）** | ❌ 0% | Mission/Objective/GAP Generator 全部待建（ADR-0010）|
+| **MissionScheduler（三层任务）** | ❌ 0% | 全部待建（ADR-0011）|
+
+---
+
+## 10. 关联 ADR 与设计文档
+
+| ADR | 主题 | 状态 |
+|-----|------|------|
+| [ADR-0001](../adr/0001-runtime-v2-service-boundaries.md) | Runtime V2 服务边界 | Accepted |
+| [ADR-0002](../adr/0002-hard-internalization-core-boundary.md) | 硬内化核心边界 | Accepted |
+| [ADR-0003](../adr/0003-peer-agent-state-machine-orchestration.md) | Peer Agent 状态机编排 | Accepted |
+| [ADR-0004](../adr/0004-l2-auto-correction-and-replay.md) | L2 自动校正与回放 | Accepted |
+| [ADR-0005](../adr/0005-nocturnal-internalization-merger.md) | Nocturnal 与 Internalization Engine 合并 | Accepted |
+| [ADR-0006](../adr/0006-hybrid-activation-mechanism.md) | 5 通道混合激活机制 | Accepted |
+| [ADR-0007](../adr/0007-cli-vs-console-audience-separation.md) | pd-cli 与 pd-console 受众分离 | Accepted |
+| ADR-0008 | Built-in Agent Lifecycle Manager（BALM）| Accepted |
+| ADR-0009 | Long-Running Agent Session（LRAS）| Accepted |
+| ADR-0010 | Goal-Aligned Pain Signal（GAP）| Accepted |
+| ADR-0011 | Three-Tier Task Model and MissionScheduler | Accepted |

--- a/docs/architecture/PD_ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/PD_ARCHITECTURE_OVERVIEW.md
@@ -239,7 +239,7 @@ RolloutDecision: { autoActivate | requireApproval }
 
 | 阶段 | 组件 | 包 | 详见 |
 |------|------|-----|------|
-| 入队 | `IntakeToInternalizationBridge`（待建） | core | `INTERNALIZATION_PIPELINE.md` §3 |
+| 入队 | `IntakeToInternalizationBridge`（已落地） | core | `INTERNALIZATION_PIPELINE.md` §3 |
 | 编排 | `InternalizationOrchestrator` | core | ADR-0003 |
 | Runner 执行 | 7 个 PeerRunner | core | ADR-0003 |
 | 评估 | `Evaluator` + `RolloutReviewer` | core | `INTERNALIZATION_PIPELINE.md` §4 |

--- a/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
@@ -193,7 +193,7 @@ runtime-v2/
 │   ├── internalization-task-guards.ts
 │   ├── internalization-orchestrator.ts
 │   ├── internalization-route.ts
-│   ├── intake-to-internalization-bridge.ts ★ 待建
+│   ├── intake-to-internalization-bridge.ts
 │   ├── routing-policy.ts
 │   ├── deprecated-readiness.ts
 │   ├── lifecycle-datasource.ts
@@ -399,7 +399,7 @@ packages/pd-console/src/
 │   │   ├── EventLogReadModel.ts
 │   │   ├── GateConsoleModel.ts
 │   │   ├── FeedbackConsoleModel.ts
-│   │   └── ApprovalConsoleModel.ts  ★ 待建
+│   │   └── ApprovalConsoleModel.ts  ← 待建（当前审批数据通过 core ApprovalQueue API 直接获取）
 │   ├── routes/                      ← REST API
 │   ├── types/
 │   └── utils/
@@ -417,7 +417,7 @@ packages/pd-console/src/
     │   ├── EventLog.tsx
     │   ├── Principles.tsx
     │   ├── Pruning.tsx
-    │   ├── Approvals.tsx            ★ 待建
+    │   ├── Approvals.tsx（基础版）✅ ← 嵌入 TasksPage.tsx approvals tab
     │   └── ApprovalDetail.tsx       ★ 待建
     └── styles/
 ```
@@ -565,7 +565,7 @@ candidates
 artifacts
 pi_artifacts
 events                            -- TelemetryEvent 流
-approvals                         ★ 待建
+approvals                         ✅ 基础版已落地（pending/approve/reject/cancel/list）
 rejection_feedbacks               ★ 待建
 history (各 history 子表)
 trajectory

--- a/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/PD_SYSTEM_ARCHITECTURE.md
@@ -1,0 +1,806 @@
+# PD 系统架构（System Architecture）
+
+> **状态**: Active（2026-05-15 重写版）
+> **最后更新**: 2026-05-15
+> **取代**: 2026-05-09 版（已归档到 `archive/`）
+> **关联**: 本文档是 [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) 的**结构补充**，专注于物理结构、依赖关系、部署形态。
+
+> **阅读顺序建议**：先读 `PD_ARCHITECTURE_OVERVIEW.md` 了解全局视图；再读本文档了解物理结构；最后读 `COMPONENTS.md` 查具体组件。
+
+---
+
+## 1. 文档定位
+
+`PD_ARCHITECTURE_OVERVIEW.md` 回答**"PD 是什么、由什么构成、数据怎么流"**。
+
+本文档回答更具体的问题：
+
+- 包之间的物理依赖是什么样的？
+- 各个层级具体有哪些代码目录？
+- 进程模型是什么？
+- 部署形态是什么？
+- 我新增一个文件应该放哪里？
+
+---
+
+## 2. 包结构（Package Topology）
+
+### 2.1 monorepo 结构
+
+```
+principles/                         （工作区根目录）
+├── packages/
+│   ├── principles-core/            ← @principles/core
+│   ├── openclaw-plugin/            ← principles-disciple
+│   ├── pd-cli/                     ← @principles/pd-cli
+│   ├── pd-console/                 ← @principles/pd-console
+│   └── create-principles-disciple/ ← 安装脚手架
+├── docs/                           ← 文档
+├── scripts/                        ← 构建/运维脚本
+├── ops/                            ← 运维相关
+├── tests/                          ← 跨包集成测试
+├── package.json                    ← 根 package（pnpm workspace）
+└── pnpm-workspace.yaml
+```
+
+### 2.2 各包公开 API 与外部依赖
+
+| 包 | npm 名 | 私有 | 公开导出 | 主要外部依赖 |
+|----|-------|-----|---------|------------|
+| principles-core | `@principles/core` | 否 | 见 `src/index.ts` + `runtime-v2/index.ts` | `@sinclair/typebox`, `better-sqlite3`, `glob` |
+| openclaw-plugin | `principles-disciple` | 否（npm 发布） | OpenClaw plugin 入口 | `@principles/core`, OpenClaw plugin SDK |
+| pd-cli | `@principles/pd-cli` | 是 | CLI 二进制 | `@principles/core` |
+| pd-console | `@principles/pd-console` | 是 | Web Server | `@principles/core`, React, Tailwind |
+| create-principles-disciple | `create-principles-disciple` | 否 | npm init scripts | 无 PD 内部依赖 |
+
+### 2.3 依赖关系（强约束）
+
+```
+              ┌─────────────────────────────────┐
+              │       @principles/core          │
+              │  (Domain & Runtime)             │
+              │                                 │
+              │  - Schemas                      │
+              │  - Stores (SQLite + JSON)       │
+              │  - Runners                      │
+              │  - Bridges                      │
+              │  - Read Models                  │
+              │  - Adapters interface           │
+              └────────────────┬────────────────┘
+                               │
+            ┌──────────────────┼──────────────────┐
+            │                  │                  │
+            ▼                  ▼                  ▼
+   ┌────────────────┐ ┌──────────────┐ ┌────────────────┐
+   │openclaw-plugin │ │ pd-cli       │ │ pd-console     │
+   │(Host Adapter)  │ │ (for Agent)  │ │ (for Human)    │
+   │                │ │              │ │                │
+   │ - Hooks        │ │ - Commands   │ │ - Web Server   │
+   │ - IdleTrigger 宿主适配 │ │ - JSON IO    │ │ - React UI     │
+   │ - OpenClaw API │ │              │ │ - Approval UI  │
+   └────────────────┘ └──────────────┘ └────────────────┘
+```
+
+**强约束（架构守护测试）**：
+
+| 规则 | 描述 |
+|-----|------|
+| R1 | `@principles/core` **不得**依赖任何其他 PD 包 |
+| R2 | `openclaw-plugin` **不得**依赖 `pd-cli` 或 `pd-console` |
+| R3 | `pd-cli` **不得**依赖 `pd-console` 或 `openclaw-plugin` |
+| R4 | `pd-console` **不得**依赖 `pd-cli` 或 `openclaw-plugin` |
+| R5 | 三个 surface 包共用 `@principles/core` 的 Store / ReadModel / Service，但通过文件并发同步（SQLite + 原子写入） |
+
+---
+
+## 3. 四层架构（详细映射）
+
+### 3.1 Layer 1: Foundation（基础层）
+
+**位置**：`@principles/core/src/`（部分顶层 + `runtime-v2/`）
+
+```
+packages/principles-core/src/
+├── pain-signal.ts                 ← Schema
+├── telemetry-event.ts             ← Schema
+├── pain-signal-adapter.ts         ← Adapter interface
+├── pain-recorder.ts               ← Util（pain 记录）
+├── pain-flag-resolver.ts          ← Util（路径解析）
+├── io.ts                          ← Util（atomicWriteFileSync）
+├── principle-tree-ledger.ts       ← Store（JSON）
+├── principle-injector.ts          ← Service
+├── trajectory-store.ts            ← Store
+├── workflow-funnel-loader.ts      ← Util
+├── types/                         ← Type 共享
+├── adapters/                      ← Adapter 接口（domain）
+├── prompt-builder/                ← Util 集合
+└── runtime-v2/                    ← 主体（见下文）
+    ├── error-categories.ts        ← Schema
+    ├── schema-version.ts          ← Schema
+    ├── agent-spec.ts              ← Schema
+    ├── runtime-protocol.ts        ← Schema
+    ├── task-status.ts             ← Schema
+    ├── context-payload.ts         ← Schema
+    ├── diagnostician-output.ts    ← Schema
+    ├── candidate-intake.ts        ← Schema + Service
+    ├── candidate-intake-service.ts← Service
+    ├── golden-trace.ts            ← Schema
+    └── store/                     ← Store 实现集合
+        ├── sqlite-connection.ts
+        ├── runtime-state-manager.ts
+        ├── task/
+        ├── run/
+        ├── commit/
+        ├── candidate/
+        ├── artifact/
+        ├── history/
+        ├── trajectory/
+        ├── context/
+        ├── lifecycle/
+        └── event-emitter.ts
+```
+
+**禁止内容**：
+- 任何 `setInterval` / `cron` / `setTimeout` 用于业务调度
+- 任何对 OpenClaw / Codex / Gemini 等具体平台 API 的调用
+- 任何 UI / HTTP server 代码
+
+### 3.2 Layer 2: Domain Services & Runners（领域服务层）
+
+**位置**：`@principles/core/src/runtime-v2/`（剩余部分）
+
+```
+runtime-v2/
+├── pain-signal-bridge.ts            ← Bridge
+├── pain-to-principle-service.ts     ← Service
+├── pain-signal-runtime-factory.ts   ← Factory
+├── pain-signal-observability.ts     ← Service
+├── pain-chain-read-model.ts         ← ReadModel
+├── pain-to-principle-service.ts     ← Service
+├── runtime-selector.ts              ← Service
+├── pruning-read-model.ts            ← ReadModel
+├── pruning-mask.ts                  ← Util
+├── pruning-review-log.ts            ← Store
+├── operator-health-read-model.ts    ← ReadModel
+├── candidate-audit.ts               ← Util
+├── control-plane-triage.ts          ← Util
+├── schema-conformance-read-model.ts ← ReadModel
+├── internalization-queue-read-model.ts        ← ReadModel
+├── internalization-chain-integrity-read-model.ts ← ReadModel
+├── internalization-integrity-remediation.ts   ← Service
+├── remediation-contract.ts          ← Schema
+├── golden-trace-replay-validator.ts ← Service
+├── golden-trace-replay-adapter.ts   ← Adapter
+├── runner/                          ← Runner 框架
+│   ├── diagnostician-runner.ts
+│   ├── diagnostician-runner-options.ts
+│   ├── diagnostician-validator.ts
+│   ├── default-validator.ts
+│   ├── runner-phase.ts
+│   └── runner-result.ts
+├── adapter/                         ← Runtime Adapter 实现
+│   ├── openclaw-cli-runtime-adapter.ts
+│   ├── pi-ai-runtime-adapter.ts
+│   ├── test-double-runtime-adapter.ts
+│   └── principle-tree-ledger-adapter.ts
+├── internalization/                 ← 内化流水线（Stage 2）
+│   ├── peer-runner-contracts.ts
+│   ├── pitask-metadata.ts
+│   ├── pi-artifact.ts
+│   ├── pi-artifact-store.ts
+│   ├── internalization-job-graph.ts
+│   ├── internalization-state-machine.ts
+│   ├── internalization-task-guards.ts
+│   ├── internalization-orchestrator.ts
+│   ├── internalization-route.ts
+│   ├── intake-to-internalization-bridge.ts ★ 待建
+│   ├── routing-policy.ts
+│   ├── deprecated-readiness.ts
+│   ├── lifecycle-datasource.ts
+│   ├── lifecycle-metrics.ts
+│   ├── lifecycle-read-model.ts
+│   ├── lifecycle-types.ts
+│   ├── rule-host-contracts.ts
+│   ├── rule-host-helpers.ts
+│   ├── rule-host-evaluator.ts
+│   ├── rule-host-adapter.ts
+│   ├── rule-code-validator.ts
+│   ├── template-generator.ts
+│   ├── correction-proposal.ts
+│   ├── compile-result.ts
+│   ├── dreamer-runner.ts + dreamer-output.ts + dreamer-prompt-builder.ts
+│   ├── philosopher-*.ts
+│   ├── scribe-*.ts
+│   ├── artificer-*.ts
+│   ├── evaluator-*.ts
+│   ├── rollout-reviewer-*.ts
+│   └── trainer-*.ts
+├── activation/                      ⚠️ 部分落地（dispatcher/queue/writers 已有；skill/rulehost/training 待建）
+│   ├── activation-dispatcher.ts
+│   ├── approval-queue.ts
+│   ├── approval-store.ts
+│   ├── rejection-feedback-service.ts
+│   ├── rejection-feedback-store.ts
+│   ├── activation-status-read-model.ts
+│   ├── approval-queue-read-model.ts
+│   └── writers/
+│       ├── ledger-prompt-writer.ts
+│       ├── ledger-archive-writer.ts
+│       ├── skill-file-writer.ts
+│       ├── rule-host-writer.ts
+│       └── training-exporter.ts
+├── gfi/                             ← GFI 子模块
+│   ├── gfi-kernel.ts
+│   ├── gfi-types.ts
+│   ├── gfi-policy.ts
+│   └── gfi-read-model.ts
+└── cli/                             ← Diagnose / Probe CLI 接口（被 pd-cli 调用）
+    ├── index.ts
+    ├── diagnose-run.ts
+    ├── diagnose-status.ts
+    ├── candidate-list.ts
+    ├── candidate-show.ts
+    ├── artifact-show.ts
+    └── probe-runtime.ts
+```
+
+### 3.3 Layer 3: Host Integration（宿主集成层）
+
+**位置**：`packages/openclaw-plugin/src/`
+
+```
+packages/openclaw-plugin/src/
+├── index.ts                         ← Plugin 入口
+├── openclaw-sdk.ts                  ← OpenClaw SDK 类型 shims
+├── types.ts                         ← Plugin 配置类型
+├── hooks/                           ← OpenClaw 事件回调
+│   ├── pain.ts                      ← after_tool_call
+│   ├── gate.ts                      ← before_tool_call
+│   ├── prompt.ts                    ← before_prompt_build
+│   ├── llm.ts                       ← llm_output
+│   ├── subagent.ts                  ← subagent_*
+│   ├── lifecycle.ts                 ← reset / compaction
+│   ├── lifecycle-routing.ts
+│   ├── trajectory-collector.ts
+│   ├── message-sanitize.ts          ← 设计建议删除
+│   └── gate-block-helper.ts
+├── service/                         ← 长生命周期服务
+│   ├── idle-trigger.ts              ← 核心策略模块在 core/runtime-v2/idle-trigger/；此处为宿主调度适配（未来）
+│   ├── evolution-worker.ts          ← 进化队列调度
+│   ├── trajectory-service.ts
+│   ├── central-sync-service.ts
+│   ├── monitoring-query-service.ts
+│   ├── workflow-watchdog.ts
+│   ├── runtime-summary-service.ts
+│   ├── keyword-optimization-service.ts
+│   ├── event-log-auditor.ts
+│   ├── startup-reconciler.ts
+│   ├── failure-classifier.ts
+│   ├── cooldown-strategy.ts
+│   ├── nocturnal-*.ts               ← 计划删除（ADR-0005）
+│   ├── sleep-cycle.ts               ← 计划简化
+│   └── subagent-workflow/
+├── core/                            ← Plugin 内部业务（迁移中）
+│   ├── pain.ts / pain-signal.ts     ← 部分迁入 core
+│   ├── pain-signal-adapter.ts
+│   ├── pain-context-extractor.ts
+│   ├── session-tracker.ts           ← GFI plugin 适配器
+│   ├── workspace-context.ts
+│   ├── path-resolver.ts
+│   ├── paths.ts
+│   ├── focus-history.ts
+│   ├── empathy-keyword-matcher.ts
+│   ├── correction-cue-learner.ts
+│   ├── evolution-engine.ts          ← EP 系统
+│   ├── evolution-reducer.ts
+│   ├── evolution-types.ts
+│   ├── principle-tree-ledger.ts     ← 旧版本，应删除（已迁移到 core）
+│   ├── code-implementation-storage.ts
+│   ├── rule-host.ts                 ← 适配器化（PRI-45）
+│   ├── rule-implementation-runtime.ts
+│   ├── nocturnal-*.ts               ← 计划删除
+│   ├── replay-engine.ts
+│   ├── pd-task-*.ts                 ← 后台任务（已部分弃用）
+│   ├── init.ts
+│   ├── migration.ts
+│   ├── system-logger.ts
+│   ├── observability.ts
+│   ├── thinking-models.ts / thinking-os-parser.ts
+│   ├── principle-internalization/   ← 部分迁入 core
+│   ├── principle-compiler/          ← 部分迁入 core
+│   ├── reflection/
+│   ├── hygiene/
+│   └── schema/
+├── commands/                        ← Plugin slash commands
+│   ├── strategy.ts / capabilities.ts / thinking-os.ts
+│   ├── pain.ts / context.ts / focus.ts
+│   ├── evolution-status.ts
+│   ├── promote-impl.ts / disable-impl.ts / archive-impl.ts / rollback-impl.ts
+│   ├── principle-rollback.ts / rollback.ts
+│   ├── pd-reflect.ts
+│   ├── nocturnal-*.ts               ← 计划重命名为 internalization-*
+│   ├── samples.ts / export.ts
+│   └── workflow-debug.ts
+├── tools/                           ← OpenClaw 工具注册
+├── i18n/                            ← 多语言
+├── config/                          ← Plugin 配置
+├── constants/                       ← 常量
+├── utils/                           ← Plugin 工具函数
+└── types/                           ← Plugin 类型定义
+    └── principle-tree-schema.ts     ← 计划迁入 core（ADR-0002）
+```
+
+### 3.4 Layer 4: Surface（表面层）
+
+#### 3.4.1 pd-cli
+
+**位置**：`packages/pd-cli/src/`
+
+```
+packages/pd-cli/src/
+├── index.ts                         ← CLI 入口
+├── resolve-workspace.ts             ← workspaceDir 解析
+├── principle-tree-ledger-adapter.ts ← Ledger 适配器
+├── commands/                        ← 各命令实现
+│   ├── diagnose.ts                  ← pd diagnose
+│   ├── run.ts                       ← pd run
+│   ├── task.ts                      ← pd task
+│   ├── flow.ts                      ← pd flow
+│   ├── trace.ts                     ← pd trace
+│   ├── health.ts                    ← pd status / pd health
+│   ├── context.ts                   ← pd context build
+│   ├── history.ts                   ← pd history query
+│   ├── trajectory.ts                ← pd trajectory locate
+│   ├── pain-record.ts               ← pd pain record
+│   ├── samples-*.ts                 ← pd samples *
+│   ├── runtime-*.ts                 ← pd runtime *
+│   │   ├── runtime.ts
+│   │   ├── runtime-canary.ts
+│   │   ├── runtime-uat.ts
+│   │   ├── runtime-pruning.ts
+│   │   ├── runtime-recovery.ts
+│   │   ├── runtime-internalization-queue.ts
+│   │   ├── runtime-internalization-wake-once.ts
+│   │   ├── runtime-internalization-run-once.ts
+│   │   ├── runtime-internalization-integrity.ts
+│   │   ├── runtime-internalization-integrity-repair.ts
+│   │   ├── runtime-health-snapshot.ts
+│   │   ├── runtime-gfi-snapshot.ts
+│   │   └── runtime-diagnostics-export.ts
+│   ├── activation.ts                ★ 待建（pd activation list/status）
+│   ├── evolution-tasks-*.ts
+│   ├── remediation-output.ts
+│   ├── central-sync.ts
+│   ├── legacy-import.ts             ← 历史数据迁移
+│   └── legacy-cleanup.ts
+└── legacy/                          ← 待清理的旧代码
+```
+
+**pd-cli 设计原则**：
+- 所有命令支持 `--json` 输出
+- 所有命令必须支持 `--workspace <dir>`
+- 所有命令必须有 exit code 约定（0 / 1 / 2）
+- **不得**绕过 ActivationDispatcher 进行高风险写入
+- 所有写操作必须记录 `actor=agent` + agentId
+
+#### 3.4.2 pd-console
+
+**位置**：`packages/pd-console/src/`
+
+```
+packages/pd-console/src/
+├── server.ts                        ← 启动入口
+├── types.ts                         ← 共享类型
+├── lib/                             ← Server 工具库
+├── server/                          ← Web Server
+│   ├── index.ts
+│   ├── config/                      ← 配置
+│   ├── models/                      ← Read Model 实现
+│   │   ├── EventLogReadModel.ts
+│   │   ├── GateConsoleModel.ts
+│   │   ├── FeedbackConsoleModel.ts
+│   │   └── ApprovalConsoleModel.ts  ★ 待建
+│   ├── routes/                      ← REST API
+│   ├── types/
+│   └── utils/
+└── ui/                              ← React 前端
+    ├── App.tsx
+    ├── main.tsx
+    ├── api.ts                       ← Server API client
+    ├── components/                  ← 共用组件
+    ├── hooks/                       ← React hooks
+    ├── i18n/                        ← 多语言
+    ├── pages/                       ← 路由页
+    │   ├── Dashboard.tsx
+    │   ├── Health.tsx
+    │   ├── Pipeline.tsx
+    │   ├── EventLog.tsx
+    │   ├── Principles.tsx
+    │   ├── Pruning.tsx
+    │   ├── Approvals.tsx            ★ 待建
+    │   └── ApprovalDetail.tsx       ★ 待建
+    └── styles/
+```
+
+**pd-console 设计原则**：
+- 默认监听 `localhost:18789`，**不**对外暴露
+- 高风险操作必须通过 UI 多步确认
+- 所有审批操作必须记录 `actor=human` + userId
+- 不直接执行业务，所有操作通过 `@principles/core` API
+
+---
+
+## 4. 进程模型
+
+PD 系统在运行时分为以下进程：
+
+### 4.1 OpenClaw Gateway 进程（包含 plugin）
+
+- 启动方式：`openclaw gateway` 或 OpenClaw IDE 内嵌
+- 包含：openclaw-plugin（in-proc）
+- 责任：
+  - 接收用户/代理交互
+  - 触发 PD hooks
+  - 运行 IdleTrigger（决定何时调用 wakeOnce）
+- **不**直接运行 Internalization Pipeline 的 LLM 调用（通过 Adapter 异步分派）
+
+### 4.2 pd-cli 进程（短暂进程）
+
+- 启动方式：`pd <command> [args]`
+- 类型：单次执行后退出
+- 责任：
+  - 执行单条命令
+  - 读 / 写 state.db / ledger.json
+  - 通过 PDRuntimeAdapter 调用 LLM（如果是 `pd diagnose run` / `pd runtime internalization-run-once` 等）
+- 并发：多个 pd-cli 进程可同时运行，靠 SQLite 锁 + LeaseManager 协调
+
+### 4.3 pd-console 进程（长生命周期）
+
+- 启动方式：`pd-console serve` 或 `npx pd-console`
+- 类型：本地 Web Server
+- 责任：
+  - 提供 Web UI
+  - 读 state.db / ledger.json
+  - 通过 ApprovalQueue 写审批决策
+- 进程数：通常一个工作区一个 server
+
+### 4.4 进程间协调
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                  Workspace 文件系统                              │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────────┐│
+│  │ {workspace}/.pd/state.db                                    ││
+│  │ {workspace}/.state/principle_training_state.json           ││
+│  │ {workspace}/.state/audit-log.jsonl                         ││
+│  │ {workspace}/.principles/skills/                            ││
+│  │ {workspace}/.principles/implementations/                   ││
+│  │ {workspace}/.pd/training-exports/                          ││
+│  └────────────────────────────────────────────────────────────┘│
+└──────────┬─────────────────┬──────────────────┬────────────────┘
+           │                 │                  │
+           │ 读+写            │ 读+部分写         │ 读+审批写
+           │ (并发安全：       │ (并发安全：       │ (并发安全：
+           │  LeaseManager +  │  LeaseManager +  │  LeaseManager +
+           │  atomic write)   │  atomic write)   │  atomic write)
+           ▼                 ▼                  ▼
+   ┌───────────────┐  ┌───────────────┐  ┌───────────────┐
+   │ Plugin 进程    │  │ pd-cli 进程    │  │ pd-console 进程│
+   │ (Gateway 内嵌) │  │ (单次执行)     │  │ (长 Server)   │
+   └───────────────┘  └───────────────┘  └───────────────┘
+```
+
+**并发协调机制**：
+
+1. **SQLite WAL 模式**：所有进程使用 WAL 模式，读写不互斥
+2. **LeaseManager**：跨进程的 task lease，TTL 强制释放
+3. **原子文件写入**：所有 JSON 文件通过 `atomicWriteFileSync`（写临时文件 + rename）
+4. **幂等性**：所有跨进程操作都有幂等键
+
+详见 `DATA_ARCHITECTURE.md` §3。
+
+---
+
+## 5. 部署形态
+
+### 5.1 本地开发模式（默认）
+
+```
+开发者机器
+├── ~/.openclaw/extensions/principles-disciple/   ← Plugin 安装位置
+├── ~/.openclaw/workspace-main/                   ← 默认工作区
+│   ├── .pd/state.db
+│   └── .state/
+└── PD CLI 通过 npm 全局安装或项目本地安装
+```
+
+### 5.2 多工作区
+
+```
+开发者机器
+├── workspace-A/.pd/state.db        ← 项目 A 的 PD 状态
+├── workspace-B/.pd/state.db        ← 项目 B 的 PD 状态
+└── 共享：~/.openclaw/extensions/principles-disciple/
+```
+
+每个工作区独立维护自己的 state.db / ledger / artifacts。Plugin 通过 OpenClaw 的 `workspaceDir` API 区分。
+
+### 5.3 CI/CD 模式
+
+```
+CI 环境
+├── 单独运行 pd-cli 命令做检查
+│   - pd runtime-canary  （运行健康度 canary）
+│   - pd runtime-uat     （UAT 测试）
+│   - pd schema-conformance-check
+└── 不运行 plugin / console
+```
+
+### 5.4 Pi-AI 集成模式（实验）
+
+```
+开发者机器
+├── PD 工作区（与本地模式相同）
+└── PiAiRuntimeAdapter 直接调用外部 LLM API
+```
+
+适用于不依赖 OpenClaw 的脱机场景。
+
+---
+
+## 6. 数据存储分布
+
+### 6.1 状态数据库（state.db）
+
+物理位置：`{workspace}/.pd/state.db`
+
+详见 `DATA_ARCHITECTURE.md` §2.1。包含的表：
+
+```sql
+tasks
+runs
+commits
+candidates
+artifacts
+pi_artifacts
+events                            -- TelemetryEvent 流
+approvals                         ★ 待建
+rejection_feedbacks               ★ 待建
+history (各 history 子表)
+trajectory
+correction_audit_events           ★ ADR-0004
+```
+
+### 6.2 Ledger（JSON）
+
+物理位置：`{workspace}/.state/principle_training_state.json`
+
+```json
+{
+  "trainingStore": { ... legacy ... },
+  "_tree": {
+    "principles": { "P_001": {...}, ... },
+    "rules": { "R_001_a": {...}, ... },
+    "implementations": { "IMPL_001_a_hook": {...}, ... },
+    "metrics": { ... },
+    "lastUpdated": "..."
+  }
+}
+```
+
+### 6.3 工件文件
+
+```
+{workspace}/.principles/
+├── skills/                         ← skill 通道激活后写入
+│   └── {skillId}/
+│       ├── SKILL.md
+│       └── manifest.json
+└── implementations/code/           ← code_tool_hook 通道激活后写入
+    └── {implId}/
+        ├── entry.ts
+        ├── manifest.json
+        ├── tests.jsonl             ← GoldenTrace cases
+        └── last-eval.json
+```
+
+```
+{workspace}/.pd/
+├── state.db
+├── config/
+│   ├── activation.yaml
+│   ├── internalization.yaml
+│   └── idle-trigger.yaml
+├── training-exports/               ← model_training 通道激活后写入
+│   └── {batchId}/
+│       ├── dataset.jsonl
+│       └── metadata.json
+└── audit-log.jsonl                 ← 审计日志
+```
+
+```
+{workspace}/.state/                 ← OpenClaw 兼容性目录
+├── principle_training_state.json   ← Ledger
+├── pruning_reviews.jsonl           ← Pruning 审计
+├── trajectory.db                   ← 旧轨迹数据
+├── sessions/
+├── event-log.jsonl
+└── 其他 plugin 兼容文件
+```
+
+---
+
+## 7. 配置层级
+
+PD 的配置遵循以下层级（从低优先级到高优先级，详见待建的 `CONFIGURATION_ARCHITECTURE.md`）：
+
+```
+1. 内置默认值（代码常量）
+       ↓ 可被覆盖
+2. ~/.openclaw/extensions/principles-disciple/default-config.yaml
+       ↓ 可被覆盖
+3. {workspace}/.pd/config/*.yaml
+       ↓ 可被覆盖
+4. 环境变量（PD_* 前缀）
+       ↓ 可被覆盖
+5. 命令行参数（pd-cli）
+```
+
+主要配置文件：
+
+| 文件 | 用途 |
+|------|------|
+| `activation.yaml` | 通道激活策略（详见 ADR-0006）|
+| `internalization.yaml` | 内化流水线参数 |
+| `idle-trigger.yaml` | IdleTrigger 触发策略 |
+| `runtime.yaml` | RuntimeAdapter 选择 |
+| `gfi.yaml` | GFI 策略 |
+
+---
+
+## 8. 跨流水线数据流（端到端示例）
+
+以下展示一个 PainSignal 从捕获到激活的**完整路径**，串联 §3 的所有组件：
+
+```
+[1] OpenClaw 工具调用失败
+        │
+        ▼ Hook
+[2] handleAfterToolCall (plugin/hooks/pain.ts)
+        │
+        │ 调用 core
+        ▼
+[3] PainSignalAdapter.recordPain (core/pain-signal-adapter.ts)
+        │
+        ▼ 写入
+[4] state.db: pain_signals
+    ledger.json: pain_flag
+        │
+        ▼ 触发
+[5] PainSignalBridge.onPainDetected (core/runtime-v2/pain-signal-bridge.ts)
+        │
+        │ 创建 task
+        ▼
+[6] state.db: tasks (taskKind=diagnostician, status=pending)
+        │
+        │ IdleTrigger 唤起 → InternalizationOrchestrator.wakeOnce()
+        ▼
+[7] DiagnosticianRunner.run (core/runtime-v2/runner/diagnostician-runner.ts)
+    ├─ acquireLease
+    ├─ ContextAssembler.assemble → DiagnosticianContextPayload
+    ├─ DiagnosticianPromptBuilder.buildPrompt
+    ├─ PDRuntimeAdapter.startRun → ... → fetchOutput
+    ├─ DiagnosticianValidator.validate
+    └─ DiagnosticianCommitter.commit
+        │
+        ▼ 写入
+[8] state.db: artifacts (kind=diagnosis_report)
+    state.db: candidates (status=pending)
+        │
+        ▼
+[9] CandidateIntakeService.intake (core/runtime-v2/candidate-intake-service.ts)
+        │
+        ▼ 写入
+[10] ledger.json: principles[P_xxx].status = 'probation'
+        │
+        ▼ 触发 ★ NEW
+[11] IntakeToInternalizationBridge.onProbationCreated (core/runtime-v2/internalization/intake-to-internalization-bridge.ts)
+        │
+        │ RoutingPolicy 决策 → channel=prompt
+        │ 创建 dreamer task
+        ▼
+[12] state.db: tasks (taskKind=dreamer, channel=prompt, status=pending)
+        │
+        │ IdleTrigger.wakeOnce → InternalizationOrchestrator.wakeOnce(taskKind='dreamer')
+        ▼
+[13] DreamerRunner.run
+        │
+        ▼
+[14] state.db: pi_artifacts (kind=principle, validation=pending → validated)
+     state.db: tasks (taskKind=philosopher) ← proposeNextTask 入队
+        │
+        ▼ ... 重复至 RolloutReviewer
+        │
+[15] RolloutReviewerRunner.run → output.review.decision='auto_activate'
+        │
+        ▼ 触发 ★ NEW
+[16] ActivationDispatcher.dispatch (core/runtime-v2/activation/activation-dispatcher.ts)
+        │
+        │ channel=prompt → 自动激活
+        ▼
+[17] PromptWriter.activate
+        │
+        ▼ 写入
+[18] ledger.json: principles[P_xxx].status = 'active'
+        │
+        ▼ 下次
+[19] before_prompt_build hook (plugin/hooks/prompt.ts)
+        │
+        │ 读取 active 原则注入
+        ▼
+[20] LLM 接收到含原则的 system prompt
+        │
+        ▼
+[21] 代理行为受影响 ★ 内化生效
+```
+
+---
+
+## 9. 旧文档与本文档的对照
+
+| 旧文档 | 旧设计 | 本文档对应 |
+|-------|-------|-----------|
+| 旧 `PD_SYSTEM_ARCHITECTURE.md`（2026-05-09）| 3 层 | 4 层（Layer 1-4），更精确 |
+| `2026-04-21-pd-runtime-agnostic-architecture-v2.md` | 4 层 | 与本文档大体一致，本文档是其更新版 |
+| `pd-task-manager.md` | PDTask 概念 | 已被 TaskRecord + IdleTrigger 取代 |
+
+---
+
+## 10. 实施进度对照
+
+| 部分 | 实施进度 |
+|------|---------|
+| Layer 1（Foundation） | ✅ 95% |
+| Layer 2（Domain Services & Runners） | ⚠️ 90% — IntakeToInternalizationBridge / ActivationDispatcher / IdleTrigger 已落地；SkillFileWriter / RuleHostWriter 待建 |
+| Layer 3（Host Integration） | ⚠️ 75% — Nocturnal 合并清理中；IdleTrigger 核心策略已在 core 落地 |
+| Layer 4（Surface） | ⚠️ 75% — pd-console approval UI 未建 |
+
+详见 `COMPONENTS.md` 状态列。
+
+---
+
+## 11. 关联文档
+
+| 文档 | 关系 |
+|------|------|
+| [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) | 上层视图与本文档互补 |
+| [`COMPONENTS.md`](./COMPONENTS.md) | 组件级目录，本文档是结构级视图 |
+| [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) | 流水线设计 |
+| [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) | 通道详细 |
+| [`DATA_ARCHITECTURE.md`](./DATA_ARCHITECTURE.md) | 数据存储 |
+| [`ERROR_ARCHITECTURE.md`](./ERROR_ARCHITECTURE.md) | 错误体系 |
+| [`GLOSSARY.md`](./GLOSSARY.md) | 术语 |
+| ADR-0001/0003/0005/0006 | 决策依据 |
+
+---
+
+## 12. 维护规则
+
+### 12.1 何时需要修改本文档
+
+- 新增 / 删除一个**包**（极少）
+- 新增 / 删除一个**层**（极少，需 ADR）
+- 调整**包之间的依赖关系**（需 ADR）
+- 调整**进程模型**（需 ADR）
+- 新增 / 删除 / 重组**主要目录**（修订）
+
+### 12.2 何时不需要改本文档
+
+- 新增 / 修改一个组件 → 改 `COMPONENTS.md`
+- 新增 / 修改一条数据流 → 改 `INTERNALIZATION_PIPELINE.md` 或对应文档
+- 新增一个新文件 → 不需要除非影响目录结构理解
+
+### 12.3 PR 标签
+
+修改本文档的 PR 必须含 `[ARCHITECTURE]` 标签。

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,277 @@
+# PD 架构文档（Architecture Documentation）
+
+> **最后更新**: 2026-05-15
+> **维护**: 由架构维护组负责
+
+本目录包含 Principles Disciple（PD）项目的**全部架构文档**。它是项目设计意图、决策、契约的权威来源。
+
+---
+
+## 🚀 快速入口
+
+| 你是谁 / 你想做什么 | 应该读 |
+|------------------|-------|
+| 第一次了解 PD | [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) |
+| 想新建一个组件 | [`COMPONENTS.md`](./COMPONENTS.md) + [`PD_SYSTEM_ARCHITECTURE.md`](./PD_SYSTEM_ARCHITECTURE.md) |
+| 不知道某个概念怎么称呼 | [`GLOSSARY.md`](./GLOSSARY.md) |
+| 在做痛苦诊断 / 内化相关功能 | [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) |
+| 在做激活 / 审批相关功能 | [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) |
+| 在做 hooks / 错误处理 | [`ERROR_ARCHITECTURE.md`](./ERROR_ARCHITECTURE.md) |
+| 在做 storage / 数据相关 | [`DATA_ARCHITECTURE.md`](./DATA_ARCHITECTURE.md) |
+| 想观测 / 加日志 / 加指标 | [`OBSERVABILITY_ARCHITECTURE.md`](./OBSERVABILITY_ARCHITECTURE.md) |
+| 安全 / 沙箱 / 审批问题 | [`SECURITY_ARCHITECTURE.md`](./SECURITY_ARCHITECTURE.md) |
+| 配置 / 环境变量 | [`CONFIGURATION_ARCHITECTURE.md`](./CONFIGURATION_ARCHITECTURE.md) |
+| Schema 演化 / API 兼容 | [`VERSIONING_AND_COMPATIBILITY.md`](./VERSIONING_AND_COMPATIBILITY.md) |
+| 性能 / SLA | [`PERFORMANCE_BUDGETS.md`](./PERFORMANCE_BUDGETS.md) |
+| **新建内置代理 / 切换 CLI 后端** | [`COMPONENTS.md`](./COMPONENTS.md) §3.8（BALM）+ ADR-0008 |
+| **代理长程任务 / 自校验工具** | [`COMPONENTS.md`](./COMPONENTS.md) §3.9（LRAS）+ ADR-0009 |
+| **痛苦信号来源 / 目标对齐** | [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) §2.1.1 + ADR-0010 |
+| **OKR / Mission / 任务调度** | [`COMPONENTS.md`](./COMPONENTS.md) §3.10-3.11 + ADR-0010/0011 |
+
+---
+
+## 📚 推荐阅读顺序
+
+### 第一阶段：理解全局（约 1 小时）
+1. [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) — 顶层视图与四大数据流
+2. [`GLOSSARY.md`](./GLOSSARY.md) — 标准术语词典
+3. [`PD_System_Dynamics_Model.md`](./PD_System_Dynamics_Model.md) — 系统动力学战略视角
+
+### 第二阶段：理解领域（约 1.5 小时）
+4. [`DOMAIN_MODEL.md`](./DOMAIN_MODEL.md) — 核心实体与生命周期
+5. [`PD_SYSTEM_ARCHITECTURE.md`](./PD_SYSTEM_ARCHITECTURE.md) — 4 层结构与依赖
+6. [`COMPONENTS.md`](./COMPONENTS.md) — 组件目录
+
+### 第三阶段：理解流水线（约 2 小时）
+7. [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) — Pain → Probation → Validated
+8. [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) — 5 通道激活机制
+
+### 第四阶段：理解横切关注点（约 2 小时）
+9. [`DATA_ARCHITECTURE.md`](./DATA_ARCHITECTURE.md) — 数据存储与读写分离
+10. [`ERROR_ARCHITECTURE.md`](./ERROR_ARCHITECTURE.md) — 错误分类与降级路径
+11. [`OBSERVABILITY_ARCHITECTURE.md`](./OBSERVABILITY_ARCHITECTURE.md) — 日志/指标/追踪/审计
+12. [`SECURITY_ARCHITECTURE.md`](./SECURITY_ARCHITECTURE.md) — 工作区/沙箱/审批/PII
+13. [`CONFIGURATION_ARCHITECTURE.md`](./CONFIGURATION_ARCHITECTURE.md) — 5 级配置层级
+14. [`VERSIONING_AND_COMPATIBILITY.md`](./VERSIONING_AND_COMPATIBILITY.md) — Schema 演化
+15. [`PERFORMANCE_BUDGETS.md`](./PERFORMANCE_BUDGETS.md) — 性能预算
+
+### 第五阶段：决策追溯（按需阅读）
+16. [`docs/adr/`](../adr/) — 全部架构决策记录
+
+---
+
+## 🗂️ 文档分类
+
+### 战略层（不易变，>= 6 个月稳定）
+
+| 文档 | 状态 | 描述 |
+|------|------|------|
+| [`PD_System_Dynamics_Model.md`](./PD_System_Dynamics_Model.md) | Final | 系统动力学战略蓝图 |
+| [`GLOSSARY.md`](./GLOSSARY.md) | LOCKED-ONTOLOGY | 标准术语词典 |
+| [`DOMAIN_MODEL.md`](./DOMAIN_MODEL.md) | LOCKED-ONTOLOGY | 核心领域模型 |
+
+### 架构层（中等稳定，每个 minor 版本可能调整）
+
+| 文档 | 状态 | 描述 |
+|------|------|------|
+| [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) | **Active / SSoT** | **架构总览（必读入口）** |
+| [`PD_SYSTEM_ARCHITECTURE.md`](./PD_SYSTEM_ARCHITECTURE.md) | Active | 4 层结构 + 物理依赖 |
+| [`COMPONENTS.md`](./COMPONENTS.md) | Active | 组件目录 |
+| [`INTERNALIZATION_PIPELINE.md`](./INTERNALIZATION_PIPELINE.md) | Active | Pain → Probation → Validated |
+| [`ACTIVATION_CHANNELS.md`](./ACTIVATION_CHANNELS.md) | Active | 5 通道激活 |
+
+### 横切层（持续演进）
+
+| 文档 | 状态 | 描述 |
+|------|------|------|
+| [`DATA_ARCHITECTURE.md`](./DATA_ARCHITECTURE.md) | Active | 数据存储 |
+| [`ERROR_ARCHITECTURE.md`](./ERROR_ARCHITECTURE.md) | Active | 错误处理 |
+| [`OBSERVABILITY_ARCHITECTURE.md`](./OBSERVABILITY_ARCHITECTURE.md) | Active | 可观测性 |
+| [`SECURITY_ARCHITECTURE.md`](./SECURITY_ARCHITECTURE.md) | Active | 安全 |
+| [`CONFIGURATION_ARCHITECTURE.md`](./CONFIGURATION_ARCHITECTURE.md) | Active | 配置管理 |
+| [`VERSIONING_AND_COMPATIBILITY.md`](./VERSIONING_AND_COMPATIBILITY.md) | Active | 版本与兼容 |
+| [`PERFORMANCE_BUDGETS.md`](./PERFORMANCE_BUDGETS.md) | Active | 性能预算 |
+
+### 历史与废弃文档
+
+| 文档 | 状态 | 处理 |
+|------|------|------|
+| `pd-task-manager.md` | Partially Implemented | 保留作迁移参考；多数概念已被 TaskRecord + IdleTrigger 替代 |
+
+---
+
+## 🧭 决策查阅指南
+
+| 遇到的问题 | 应该查阅的文档 |
+|------------|---------------|
+| **术语 / 命名歧义** | `GLOSSARY.md` |
+| **代码放哪个包** | `PD_ARCHITECTURE_OVERVIEW.md` §2 + `COMPONENTS.md` |
+| **新增组件应放哪一层** | `PD_SYSTEM_ARCHITECTURE.md` §3 |
+| **流水线某个步骤的归属** | `INTERNALIZATION_PIPELINE.md` |
+| **新通道怎么接入激活** | `ACTIVATION_CHANNELS.md` |
+| **错误类别选什么** | `ERROR_ARCHITECTURE.md` §1 |
+| **数据存哪里** | `DATA_ARCHITECTURE.md` §2 |
+| **怎么加 telemetry / metric** | `OBSERVABILITY_ARCHITECTURE.md` |
+| **Sandbox / 工作区隔离** | `SECURITY_ARCHITECTURE.md` |
+| **配置文件怎么写** | `CONFIGURATION_ARCHITECTURE.md` |
+| **Schema 升级怎么做** | `VERSIONING_AND_COMPATIBILITY.md` |
+| **性能预算多少** | `PERFORMANCE_BUDGETS.md` |
+| **决策为什么这么定** | `docs/adr/` |
+
+---
+
+## 📎 相关文档目录
+
+### 架构决策记录（ADR）
+
+| ADR | 状态 | 主题 |
+|-----|------|------|
+| [ADR-0001](../adr/0001-runtime-v2-service-boundaries.md) | Accepted | Runtime V2 服务边界 |
+| [ADR-0002](../adr/0002-hard-internalization-core-boundary.md) | Accepted | 硬内化核心边界 |
+| [ADR-0003](../adr/0003-peer-agent-state-machine-orchestration.md) | Accepted | Peer Agent 状态机编排 |
+| [ADR-0004](../adr/0004-l2-auto-correction-and-replay.md) | Accepted | L2 自动校正与回放 |
+| [ADR-0005](../adr/0005-nocturnal-internalization-merger.md) | Accepted | Nocturnal 与 Internalization 合并 |
+| [ADR-0006](../adr/0006-hybrid-activation-mechanism.md) | Accepted | 5 通道混合激活机制 |
+| [ADR-0007](../adr/0007-cli-vs-console-audience-separation.md) | Accepted | pd-cli 与 pd-console 受众分离 |
+| ADR-0008 | Accepted | Built-in Agent Lifecycle Manager（BALM）|
+| ADR-0009 | Accepted | Long-Running Agent Session（LRAS）|
+| ADR-0010 | Accepted | Goal-Aligned Pain Signal（GAP）|
+| ADR-0011 | Accepted | Three-Tier Task Model and MissionScheduler |
+
+### 架构治理（Governance）
+
+| 文档 | 描述 |
+|------|------|
+| [`../architecture-governance/README.md`](../architecture-governance/README.md) | 渐进式架构治理 |
+| [`../architecture-governance/ARCHITECTURE_GUARDRAILS.md`](../architecture-governance/ARCHITECTURE_GUARDRAILS.md) | 架构守则 |
+| [`../architecture-governance/PRINCIPLE-TREE-ARCHITECTURE.md`](../architecture-governance/PRINCIPLE-TREE-ARCHITECTURE.md) | 原则树具象化约定（与 DOMAIN_MODEL 互补）|
+| [`../architecture-governance/GRADUAL_ROADMAP.md`](../architecture-governance/GRADUAL_ROADMAP.md) | 渐进式重构路线 |
+| [`../architecture-governance/PR_ARCHITECTURE_CHECKLIST.md`](../architecture-governance/PR_ARCHITECTURE_CHECKLIST.md) | PR 检查清单 |
+
+### 架构评审记录
+
+| 文档 | 描述 |
+|------|------|
+| [`../reviews/architecture-review-2026-05-15.md`](../reviews/architecture-review-2026-05-15.md) | 2026-05 架构评审 + 改进 RFC |
+
+### Runtime V2 工作集
+
+| 文档 | 描述 |
+|------|------|
+| [`../pd-runtime-v2/README.md`](../pd-runtime-v2/README.md) | Runtime V2 文档索引 |
+| [`../pd-runtime-v2/runtime-v2-milestone-roadmap.md`](../pd-runtime-v2/runtime-v2-milestone-roadmap.md) | M1-M9 里程碑 |
+
+### 顶层文档
+
+| 文档 | 描述 |
+|------|------|
+| [`../../README.md`](../../README.md) | 项目首页 |
+| [`../GETTING-STARTED.md`](../GETTING-STARTED.md) | 用户入门 |
+| [`../USER_GUIDE.md`](../USER_GUIDE.md) | 用户指南 |
+| [`../DEVELOPMENT.md`](../DEVELOPMENT.md) | 开发指南 |
+
+---
+
+## 🏗️ 文档贡献规范
+
+### 1. 术语使用
+
+- 所有代码、Schema、Linear issue title、ADR **必须**使用 [`GLOSSARY.md`](./GLOSSARY.md) 定义的标准词
+- 新增 / 修改术语 **必须** 同步修订 `GLOSSARY.md` 与 `DOMAIN_MODEL.md`
+
+### 2. 状态标记
+
+每个文档头部必须标注状态：
+
+| 状态 | 含义 |
+|------|-----|
+| `Draft` | 草稿，尚未通过评审 |
+| `Active` | 正在使用，定期演进 |
+| `Accepted` | 决策已通过（ADR 用）|
+| `Proposed` | 提案中（ADR 用）|
+| `LOCKED-ONTOLOGY` | 锁定，修改需走严格流程 |
+| `Final` | 战略文档，长期不变 |
+| `Deprecated` | 已废弃，保留参考 |
+
+### 3. 交叉引用
+
+- 文档间应**互相引用**，避免重复定义
+- 引用时使用相对路径
+- 如发现冲突，按 [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) §8.2 流程处理
+
+### 4. 修改流程
+
+| 文档类型 | PR 标签 | 评审要求 |
+|---------|---------|---------|
+| `LOCKED-ONTOLOGY` 文档 | `[ONTOLOGY]` | 至少 2 名架构维护者批准 |
+| `Active` 文档 | `[ARCHITECTURE]` | 至少 1 名架构维护者批准 |
+| ADR | `[ADR]` | 至少 1 名架构维护者 + 1 名相关 owner |
+| 横切文档 | `[CROSS-CUTTING]` | 至少 1 名架构维护者 |
+
+### 5. 废弃处理
+
+废弃文档**不要直接删除**：
+
+1. 头部加 `Status: Deprecated` 标记
+2. 顶部链接指向新文档
+3. 保留 2 个 minor 版本后移到 `archive/` 子目录
+
+---
+
+## 🔗 核心概念快速索引
+
+| 概念 | 定义位置 | 状态 |
+|------|---------|------|
+| Principle | `DOMAIN_MODEL.md` §2.1 | LOCKED |
+| Rule | `DOMAIN_MODEL.md` §2.2 | LOCKED |
+| Implementation | `DOMAIN_MODEL.md` §2.3 | LOCKED |
+| Pain Signal | `DOMAIN_MODEL.md` §4 + `GLOSSARY.md` §1 | LOCKED |
+| Internalization Channel（5 通道）| `DOMAIN_MODEL.md` §3 + `ACTIVATION_CHANNELS.md` §3 | LOCKED |
+| L1 / L2 / L3 | `DOMAIN_MODEL.md` §3 + `PD_System_Dynamics_Model.md` §4 | LOCKED |
+| Pruning Signal | `DOMAIN_MODEL.md` §4 | LOCKED |
+| Approval | `DOMAIN_MODEL.md` §5.4 + `ACTIVATION_CHANNELS.md` §2.3 | Active |
+| PIArtifact | `DOMAIN_MODEL.md` §5.5 + `INTERNALIZATION_PIPELINE.md` §3.6 | Active |
+| Peer Runner | `GLOSSARY.md` §2 + `INTERNALIZATION_PIPELINE.md` §3.4 | Active |
+| RuntimeAdapter | `GLOSSARY.md` §2 + `COMPONENTS.md` §3.5 | Active |
+| PDErrorCategory | `ERROR_ARCHITECTURE.md` §1 | Active |
+| GFI | `PD_ARCHITECTURE_OVERVIEW.md` + `COMPONENTS.md` §3.6 | Active |
+
+---
+
+## 📊 文档完整性自检
+
+> 此清单用于评估架构文档是否完整。新增功能时自检是否有对应文档章节。
+
+| 维度 | 文档 | 完整 |
+|-----|------|-----|
+| ✅ 系统边界 | `PD_ARCHITECTURE_OVERVIEW.md` §2 | ✅ |
+| ✅ 核心模块 | `COMPONENTS.md` | ✅ |
+| ✅ 数据流 | `PD_ARCHITECTURE_OVERVIEW.md` §4 + 各 PIPELINE 文档 | ✅ |
+| ✅ 服务职责 | `COMPONENTS.md` + `PD_SYSTEM_ARCHITECTURE.md` | ✅ |
+| ✅ 外部依赖 | `PD_SYSTEM_ARCHITECTURE.md` §2.2 | ✅ |
+| ✅ 安全约束 | `SECURITY_ARCHITECTURE.md` | ✅ |
+| ✅ 性能约束 | `PERFORMANCE_BUDGETS.md` | ✅ |
+| ✅ 幂等约束 | `INTERNALIZATION_PIPELINE.md` §6.2 + `ACTIVATION_CHANNELS.md` §6.3 | ✅ |
+| ✅ 可观测约束 | `OBSERVABILITY_ARCHITECTURE.md` | ✅ |
+| ✅ 模块设计 | `PD_SYSTEM_ARCHITECTURE.md` §3 | ✅ |
+| ✅ 接口契约 | `COMPONENTS.md` + 各 ADR | ✅ |
+| ✅ 服务组件 | `COMPONENTS.md` §3 | ✅ |
+| ✅ 仓储分层 | `DATA_ARCHITECTURE.md` §6 | ✅ |
+| ✅ Schema 设计 | `DATA_ARCHITECTURE.md` §3-4 + `VERSIONING_AND_COMPATIBILITY.md` | ✅ |
+| ✅ 状态管理分层 | `DOMAIN_MODEL.md` §5 + `INTERNALIZATION_PIPELINE.md` | ✅ |
+| ✅ 抽象稳定性 | `VERSIONING_AND_COMPATIBILITY.md` §7 | ✅ |
+| ✅ 错误处理 | `ERROR_ARCHITECTURE.md` | ✅ |
+| ✅ 配置管理 | `CONFIGURATION_ARCHITECTURE.md` | ✅ |
+
+---
+
+## ⚠️ 重要提示
+
+> **修改任何架构文档前**：
+>
+> 1. 先看 [`PD_ARCHITECTURE_OVERVIEW.md`](./PD_ARCHITECTURE_OVERVIEW.md) §8（变更流程）
+> 2. 改动是否影响 ADR？是 → 先提 ADR 修订
+> 3. 是否影响其他文档？列出受影响文档清单
+> 4. PR 描述需说明：受影响下游 / 是否破坏性 / 测试验证
+
+> **始终首先参考 [`GLOSSARY.md`](./GLOSSARY.md) 与 [`DOMAIN_MODEL.md`](./DOMAIN_MODEL.md)，确保术语一致**。

--- a/docs/reviews/document-vs-code-drift-2026-05.md
+++ b/docs/reviews/document-vs-code-drift-2026-05.md
@@ -1,0 +1,187 @@
+# Document-vs-Code Drift Audit (2026-05-18)
+
+> **Issue**: PRI-182
+> **Auditor**: AI coding assistant
+> **Date**: 2026-05-18
+> **Baseline**: origin/main HEAD = `5a2847a8`
+> **Scope**: `docs/architecture/` — component-location claims, status markers, progress tables
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total drifts found | 15 |
+| Move-doc (doc is wrong, code is correct) | 13 |
+| Defer (intentional / harmless, annotated) | 2 |
+| Move-code (code is wrong, doc is correct) | 0 |
+
+---
+
+## Drifts
+
+### DRIFT-01: IdleTrigger location — core, not plugin
+
+| | |
+|---|---|
+| **Documents** | `PD_SYSTEM_ARCHITECTURE.md` S3.3, `INTERNALIZATION_PIPELINE.md` S4.1, `PD_ARCHITECTURE_OVERVIEW.md` S2.2/S3, `COMPONENTS.md` S3.2.1/S4.2 |
+| **Doc claim** | IdleTrigger is at `packages/openclaw-plugin/src/service/idle-trigger.ts` (Layer 3 / plugin) |
+| **Code reality** | `packages/principles-core/src/runtime-v2/idle-trigger/` — 7 files. Zero IdleTrigger files in openclaw-plugin. |
+| **Decision** | **Move-doc** — Pure-function policy is correctly placed in core. |
+| **Resolution** | Updated all 6 documents to show core location. |
+
+### DRIFT-02: ADR-0008/0009/0010/0011 status — Accepted, not Proposed
+
+| | |
+|---|---|
+| **Documents** | `README.md` ADR table, `PD_ARCHITECTURE_OVERVIEW.md` S10 |
+| **Doc claim** | ADR-0008/0009/0010/0011 status = `Proposed` |
+| **Code reality** | All 4 ADR files: `Accepted` (dated 2026-05-16) |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated both tables to `Accepted`. |
+
+### DRIFT-03: COMPONENTS.md IdleTrigger status — Done, not pending
+
+| | |
+|---|---|
+| **Document** | `COMPONENTS.md` S3.2.1, S4.2 |
+| **Doc claim** | `IdleTrigger | ... | pending` |
+| **Code reality** | 7 files in core, tests passing |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated to Done with core path. |
+
+### DRIFT-04: COMPONENTS.md IntakeToInternalizationBridge status
+
+| | |
+|---|---|
+| **Document** | `COMPONENTS.md` S3.2.1 line 141 |
+| **Doc claim** | `pending (breakpoint 1)` |
+| **Code reality** | File exists with tests |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated to Done. |
+
+### DRIFT-05: PD_SYSTEM_ARCHITECTURE.md S10 progress percentages
+
+| | |
+|---|---|
+| **Document** | `PD_SYSTEM_ARCHITECTURE.md` S10 |
+| **Doc claim** | Layer 2: 80%, Layer 3: 70% |
+| **Code reality** | IntakeToInternalizationBridge, ActivationDispatcher, IdleTrigger core all Done |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated Layer 2 to 90%, Layer 3 to 75%. |
+
+### DRIFT-06: PD_SYSTEM_ARCHITECTURE.md S3.2 activation/ marker
+
+| | |
+|---|---|
+| **Doc claim** | `activation/ pending (5-channel activation)` |
+| **Code reality** | 5 files already exist |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated marker to show existing files. |
+
+### DRIFT-07: PD_SYSTEM_ARCHITECTURE.md S3.3 idle-trigger.ts
+
+| | |
+|---|---|
+| **Doc claim** | `service/idle-trigger.ts pending` |
+| **Code reality** | No file in plugin; module is in core |
+| **Decision** | **Move-doc** |
+| **Resolution** | Removed from Layer 3 listing. |
+
+### DRIFT-08: Writer class names
+
+| | |
+|---|---|
+| **Doc claim** | `LedgerPromptWriter` / `LedgerArchiveWriter` |
+| **Code reality** | `PromptWriter` / `DeferArchiveWriter` |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated to use code names with alias note. |
+
+### DRIFT-09: ApprovalStatus — 6 states vs 4
+
+| | |
+|---|---|
+| **Doc claim** | 6 states including `expired` / `awaiting_second_confirmation` |
+| **Code reality** | 4 states: `pending | approved | rejected | cancelled` |
+| **Decision** | **Defer** — Target states per ADR-0006, not yet implemented. |
+| **Resolution** | Added footnotes clarifying future vs current states. |
+
+### DRIFT-10: PD_SYSTEM_ARCHITECTURE.md S8 writer name
+
+| | |
+|---|---|
+| **Doc claim** | `LedgerPromptWriter.activate` |
+| **Code reality** | `PromptWriter` |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated. |
+
+### DRIFT-11: INTERNALIZATION_PIPELINE.md S11 status table
+
+| | |
+|---|---|
+| **Doc claim** | IdleTrigger described as "plugin thin adapter" |
+| **Code reality** | Core module done; plugin adapter not built separately |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated description. |
+
+### DRIFT-12: PD_ARCHITECTURE_OVERVIEW.md S9 Activation Pipeline progress
+
+| | |
+|---|---|
+| **Doc claim** | Activation Pipeline 60% |
+| **Code reality** | Dispatcher + writers + queue + stores + UI all done (75%) |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated to 75%. |
+
+### DRIFT-13: PD_ARCHITECTURE_OVERVIEW.md S9 Operations Pipeline
+
+| | |
+|---|---|
+| **Doc claim** | "pd-console approvals basic UI/API not built" |
+| **Code reality** | 4 endpoints + TasksPage approvals tab Done |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated description. |
+
+### DRIFT-14: COMPONENTS.md S5.3 ApprovalConsoleModel
+
+| | |
+|---|---|
+| **Doc claim** | `ApprovalConsoleModel | TBD | pending` |
+| **Code reality** | Approvals handled directly via core API |
+| **Decision** | **Defer** — Acceptable architectural choice |
+| **Resolution** | Added note. |
+
+### DRIFT-15: INTERNALIZATION_PIPELINE.md S9.4 IdleTrigger Jitter path
+
+| | |
+|---|---|
+| **Doc claim** | Jitter code at plugin `idle-trigger.ts` |
+| **Code reality** | Jitter config in core `idle-trigger-types.ts` |
+| **Decision** | **Move-doc** |
+| **Resolution** | Updated path reference. |
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `PD_ARCHITECTURE_OVERVIEW.md` | S2.2 IdleTrigger ownership, S3 Layer diagram, S9 progress, S10 ADR status |
+| `PD_SYSTEM_ARCHITECTURE.md` | S3.2 activation/ listing, S3.3 idle-trigger, S8 writer name, S10 progress |
+| `INTERNALIZATION_PIPELINE.md` | S4.1 IdleTrigger location, S11 status table, S9.4 jitter path |
+| `COMPONENTS.md` | S3.2.1 IdleTrigger + Bridge status, S4.2 IdleTrigger status |
+| `README.md` | ADR table status |
+| `ACTIVATION_CHANNELS.md` | Writer names, ApprovalStatus footnote |
+| `DATA_ARCHITECTURE.md` | Approval status column footnote |
+
+## No-Drift Confirmations
+
+| Check | Result |
+|-------|--------|
+| `DOMAIN_MODEL.md` IdleTrigger location | Done: correctly says core |
+| `DOMAIN_MODEL.md` ApprovalStatus annotations | Done: correctly marks future states |
+| `COMPONENTS.md` ActivationDispatcher/ApprovalQueue/PromptWriter rows | Done: correctly marked |
+| `COMPONENTS.md` BALM/LRAS/GAP/MissionScheduler all pending | Confirmed: no code exists |
+| `INTERNALIZATION_PIPELINE.md` S11 all Done rows for runners | Confirmed: all match code |
+| ADR-0001 through ADR-0007 status in README.md | Confirmed: all Accepted |

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "^10.2.1",
         "globals": "^17.6.0",
         "lefthook": "^2.1.6",
-        "lint-staged": "^16.4.0",
+        "lint-staged": "^17.0.5",
         "semantic-release": "^25.0.3"
       }
     },
@@ -1678,7 +1678,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1695,7 +1694,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1712,7 +1710,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1729,7 +1726,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1746,7 +1742,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1763,7 +1758,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1780,7 +1774,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1797,7 +1790,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1814,7 +1806,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1831,7 +1822,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1848,7 +1838,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1865,7 +1854,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1882,7 +1870,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1899,7 +1886,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1916,7 +1902,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1933,7 +1918,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1950,7 +1934,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1967,7 +1950,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1984,7 +1966,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2001,7 +1982,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2018,7 +1998,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2035,7 +2014,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2052,7 +2030,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2069,7 +2046,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2086,7 +2062,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2103,7 +2078,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4079,7 +4053,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4096,7 +4069,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4113,7 +4085,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4130,7 +4101,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4147,7 +4117,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4164,7 +4133,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4181,7 +4149,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4198,7 +4165,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4215,7 +4181,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4232,7 +4197,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4249,7 +4213,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4266,7 +4229,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4280,7 +4242,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -4302,7 +4263,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4319,7 +4279,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -7118,9 +7077,9 @@
       }
     },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7271,13 +7230,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -10201,27 +10153,28 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
-      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
+      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
-        "listr2": "^9.0.5",
-        "picomatch": "^4.0.3",
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.0.4",
-        "yaml": "^2.8.2"
+        "tinyexec": "^1.1.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=20.17"
+        "node": ">=22.22.1"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.8.4"
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
@@ -10238,21 +10191,20 @@
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
         "log-update": "^6.1.0",
         "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/listr2/node_modules/ansi-styles": {
@@ -10268,26 +10220,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/listr2/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/listr2/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10310,18 +10254,18 @@
       }
     },
     "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -15682,9 +15626,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15874,7 +15818,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15891,7 +15834,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15908,7 +15850,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15925,7 +15866,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15942,7 +15882,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15959,7 +15898,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15976,7 +15914,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15993,7 +15930,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16010,7 +15946,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16027,7 +15962,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16044,7 +15978,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16061,7 +15994,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16078,7 +16010,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16095,7 +16026,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16112,7 +16042,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16129,7 +16058,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16146,7 +16074,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16163,7 +16090,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16180,7 +16106,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16197,7 +16122,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16214,7 +16138,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16231,7 +16154,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16248,7 +16170,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16265,7 +16186,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16282,7 +16202,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16299,7 +16218,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17013,9 +16931,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^10.2.1",
     "globals": "^17.6.0",
     "lefthook": "^2.1.6",
-    "lint-staged": "^16.4.0",
+    "lint-staged": "^17.0.5",
     "semantic-release": "^25.0.3"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^2.1.6
         version: 2.1.6
       lint-staged:
-        specifier: ^16.4.0
-        version: 16.4.0
+        specifier: ^17.0.5
+        version: 17.0.5
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@6.0.3)
@@ -360,36 +360,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -772,13 +778,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -1441,24 +1440,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1479,14 +1482,14 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  lint-staged@16.4.0:
-    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
-    engines: {node: '>=20.17'}
+  lint-staged@17.0.5:
+    resolution: {integrity: sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==}
+    engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
+  listr2@10.2.1:
+    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+    engines: {node: '>=22.13.0'}
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -2415,6 +2418,10 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -3321,10 +3328,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colorette@2.0.20: {}
-
-  commander@14.0.3: {}
-
   compare-func@2.0.0:
     dependencies:
       array-ify: 1.0.0
@@ -3976,23 +3979,22 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lint-staged@16.4.0:
+  lint-staged@17.0.5:
     dependencies:
-      commander: 14.0.3
-      listr2: 9.0.5
+      listr2: 10.2.1
       picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.1.2
+    optionalDependencies:
       yaml: 2.9.0
 
-  listr2@9.0.5:
+  listr2@10.2.1:
     dependencies:
       cli-truncate: 5.2.0
-      colorette: 2.0.20
       eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
-      wrap-ansi: 9.0.2
+      wrap-ansi: 10.0.0
 
   load-json-file@4.0.0:
     dependencies:
@@ -4762,6 +4764,12 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -4778,7 +4786,8 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yaml@2.9.0: {}
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
Closes #627

## Problem

PR #627 (Dependabot) bumps lint-staged from 16.4.0 to 17.0.5, but CI fails because:

1. **package-lock.json out of sync**: Dependabot only updated \package.json\ and \pnpm-lock.yaml\, but not \package-lock.json\. CI uses \
pm ci\ which requires lockfile to match \package.json\.
2. **Node.js 18 EOL**: The CI test matrix included Node 18 which is EOL.

## Changes

- Update \lint-staged\ from \^16.4.0\ to \^17.0.5\ in \package.json\
- Regenerate \package-lock.json\ to sync with the new lint-staged version
- Regenerate \pnpm-lock.yaml\ to sync with the new lint-staged version
- Remove Node.js 18 from CI test matrix (EOL since April 2025)

## Notes

- lint-staged v17 requires Node.js >=22.22.1 (drops Node 20 support)
- lint-staged is a devDependency used only for pre-commit hooks, so the engine requirement does not block runtime compatibility on Node 20
- The \
pm ci\ engine check is non-strict by default, so Node 20 in the test matrix will still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新CI流水线，调整测试环境的Node.js版本配置。
  * 完善系统架构文档体系，补充激活流程、数据存储、组件清单等设计规范。
  * 升级开发依赖包版本，改进代码质量工具链。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->