### PR TITLE
test(activation): add boundary tests for decideAutoPromotion confidence validation

### DIFF
--- a/packages/principles-core/src/runtime-v2/activation/__tests__/approval-queue.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/__tests__/approval-queue.test.ts
@@ -36,6 +36,18 @@ describe('decideAutoPromotion', () => {
   it('returns false for null confidence', () => {
     expect(decideAutoPromotion('skill', null as unknown as number)).toBe(false);
   });
+
+  it('returns false for negative confidence (out of range)', () => {
+    expect(decideAutoPromotion('skill', -0.1)).toBe(false);
+    expect(decideAutoPromotion('skill', -1)).toBe(false);
+    expect(decideAutoPromotion('skill', -100)).toBe(false);
+  });
+
+  it('returns false for confidence > 1 (out of range)', () => {
+    expect(decideAutoPromotion('skill', 1.1)).toBe(false);
+    expect(decideAutoPromotion('skill', 2)).toBe(false);
+    expect(decideAutoPromotion('skill', 100)).toBe(false);
+  });
 });
 
 describe('ApprovalQueue', () => {


### PR DESCRIPTION
## Summary

Add test coverage for edge cases in `decideAutoPromotion` function:

### Tests Added
- **Negative confidence values**: Verifies that confidence values like `-0.1`, `-1`, `-100` are correctly rejected
- **Confidence values > 1**: Verifies that values like `1.1`, `2`, `100` are correctly rejected

### Why These Tests Matter
The `decideAutoPromotion` function contains validation logic that rejects out-of-range confidence values:

```typescript
if (confidence < 0 || confidence > 1) return false;
```

These boundary tests ensure the fail-closed validation behavior is properly tested, preventing potential security issues where invalid confidence scores could bypass approval requirements.

### Test Results
- All 20 tests in `approval-queue.test.ts` pass
- All 126 tests in the activation test suite pass

### Files Modified
- `packages/principles-core/src/runtime-v2/activation/__tests__/approval-queue.test.ts`: Added 2 new test cases with 6 assertions