### PR TITLE
feat(core): formalize source trace locator contract (PRI-189)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -133,6 +133,9 @@ const REQUIRED_SOURCE_FILES = [
   'activation/approval-queue.ts',
   'activation/memory-approval-store.ts',
   'activation/sqlite-approval-store.ts',
+  // PRI-189
+  'store/trajectory/source-trace-locator.ts',
+  'store/trajectory/sqlite-source-trace-locator.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -2740,6 +2743,50 @@ describe('PRI-144 ActivationDispatcher & Low-risk Writers', () => {
     expect(src).toContain('ApprovalQueueStore');
     expect(src).toContain('AUTO_PROMOTION_CONFIDENCE_THRESHOLD');
     expect(src).toContain('AUTO_PROMOTABLE_CHANNELS');
+  });
+});
+
+// ── PRI-189: SourceTraceLocator contract boundary ──────────────────────────────
+
+describe('PRI-189 SourceTraceLocator contract boundary', () => {
+  it('source-trace-locator.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'store', 'trajectory', 'source-trace-locator.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('node:process');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('sqlite-source-trace-locator.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'store', 'trajectory', 'sqlite-source-trace-locator.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('node:process');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('core barrel exports SourceTraceLocator and SqliteSourceTraceLocator', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('SourceTraceLocator');
+    expect(src).toContain('SqliteSourceTraceLocator');
+    expect(src).toContain('SourceTraceLocateDecision');
+    expect(src).toContain('SourceTraceCandidate');
+  });
+
+  it('store/trajectory/index.ts re-exports SourceTraceLocator + SqliteSourceTraceLocator', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const indexPath = resolve(__dirname, '..', 'store', 'trajectory', 'index.ts');
+    expect(existsSync(indexPath)).toBe(true);
+    const src = readFileSync(indexPath, 'utf-8');
+    expect(src).toContain('SourceTraceLocator');
+    expect(src).toContain('SqliteSourceTraceLocator');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -137,6 +137,8 @@ export { MemoryArtifactStore } from './store/artifact/memory-artifact-store.js';
 export { SqliteConnection } from './store/sqlite-connection.js';
 export type { SqlitePragmaReport } from './store/sqlite-connection.js';
 export { SqliteTrajectoryLocator } from './store/trajectory/sqlite-trajectory-locator.js';
+export { SqliteSourceTraceLocator } from './store/trajectory/sqlite-source-trace-locator.js';
+export type { SourceTraceLocator, SourceTraceLocateDecision, SourceTraceLocateQuery, SourceTraceLocateResult, SourceTraceCandidate } from './store/trajectory/source-trace-locator.js';
 export { SqliteHistoryQuery } from './store/history/sqlite-history-query.js';
 export { SqliteContextAssembler } from './store/context/sqlite-context-assembler.js';
 export { SqliteDiagnosticianCommitter } from './store/commit/diagnostician-committer.js';

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -19,6 +19,8 @@ import { SqliteDiagnosticianCommitter } from './store/commit/diagnostician-commi
 import { SqliteContextAssembler } from './store/context/sqlite-context-assembler.js';
 import { SqliteHistoryQuery } from './store/history/sqlite-history-query.js';
 import { SqliteConnection } from './store/sqlite-connection.js';
+import { SqliteTrajectoryLocator } from './store/trajectory/sqlite-trajectory-locator.js';
+import { SqliteSourceTraceLocator } from './store/trajectory/sqlite-source-trace-locator.js';
 import { OpenClawCliRuntimeAdapter } from './adapter/openclaw-cli-runtime-adapter.js';
 import { PiAiRuntimeAdapter } from './adapter/pi-ai-runtime-adapter.js';
 import { getProviders } from '@mariozechner/pi-ai';
@@ -159,11 +161,14 @@ export async function createPainSignalBridge(
   const historyQuery = new SqliteHistoryQuery(connection);
   const committer = new SqliteDiagnosticianCommitter(connection);
   const validator = new DefaultDiagnosticianValidator();
+  const trajectoryLocator = new SqliteTrajectoryLocator(connection);
+  const sourceTraceLocator = new SqliteSourceTraceLocator(stateManager.taskStore, trajectoryLocator);
 
   const contextAssembler = new SqliteContextAssembler(
     stateManager.taskStore,
     historyQuery,
     stateManager.runStore,
+    { sourceTraceLocator },
   );
 
   const runtimeAdapter: PDRuntimeAdapter = runtimeConfig.runtimeKind === 'pi-ai'

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -19,6 +19,7 @@ import { SqliteTaskStore } from '../task/sqlite-task-store.js';
 import { SqliteRunStore } from '../run/sqlite-run-store.js';
 import { SqliteHistoryQuery } from '../history/sqlite-history-query.js';
 import { SqliteTrajectoryLocator } from '../trajectory/sqlite-trajectory-locator.js';
+import { SqliteSourceTraceLocator } from '../trajectory/sqlite-source-trace-locator.js';
 import { SqliteContextAssembler } from './sqlite-context-assembler.js';
 import { DiagnosticianContextPayloadSchema } from '../../context-payload.js';
 import type { DiagnosticianTaskRecord } from '../../task-status.js';
@@ -66,7 +67,7 @@ interface TestFixture {
   sqliteTaskStore: SqliteTaskStore;
   runStore: SqliteRunStore;
   historyQuery: SqliteHistoryQuery;
-  trajectoryLocator: SqliteTrajectoryLocator | undefined;
+  sourceTraceLocator: SqliteSourceTraceLocator | undefined;
   taskStore: TaskStore;
   taskMap: Map<string, TaskRecord>;
   assembler: SqliteContextAssembler;
@@ -80,9 +81,11 @@ function createFixture(tasks?: Map<string, DiagnosticianTaskRecord>, options?: {
   const historyQuery = new SqliteHistoryQuery(connection);
   const taskMap = tasks ?? new Map();
   const taskStore = createMockTaskStore(taskMap);
-  const trajectoryLocator = options?.withLocator ? new SqliteTrajectoryLocator(connection) : undefined;
-  const assembler = new SqliteContextAssembler(taskStore, historyQuery, runStore, { trajectoryLocator });
-  return { tmpDir, connection, sqliteTaskStore, runStore, historyQuery, trajectoryLocator, taskStore, taskMap, assembler };
+  const sourceTraceLocator = options?.withLocator
+    ? new SqliteSourceTraceLocator(taskStore, new SqliteTrajectoryLocator(connection))
+    : undefined;
+  const assembler = new SqliteContextAssembler(taskStore, historyQuery, runStore, { sourceTraceLocator });
+  return { tmpDir, connection, sqliteTaskStore, runStore, historyQuery, sourceTraceLocator, taskStore, taskMap, assembler };
 }
 
 function cleanupFixture(fixture: TestFixture): void {
@@ -564,7 +567,7 @@ describe('SqliteContextAssembler', () => {
       const payload = await f.assembler.assemble(task.taskId);
 
       expect(payload.fullTrace).toBeNull();
-      expect(notesInclude(payload.ambiguityNotes, 'TrajectoryLocator not available')).toBe(true);
+      expect(notesInclude(payload.ambiguityNotes, 'SourceTraceLocator not available')).toBe(true);
     } finally { cleanupFixture(f); }
   });
 
@@ -580,7 +583,7 @@ describe('SqliteContextAssembler', () => {
       const payload = await f.assembler.assemble(task.taskId);
 
       expect(payload.fullTrace).toBeNull();
-      expect(notesInclude(payload.ambiguityNotes, 'No sessionIdHint')).toBe(true);
+      expect(notesInclude(payload.ambiguityNotes, 'sessionIdHint')).toBe(true);
     } finally { cleanupFixture(f); }
   });
 

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -14,13 +14,12 @@ import type { TaskStore } from '../task/task-store.js';
 import type { RunStore } from '../run/run-store.js';
 import type { HistoryQuery } from '../history/history-query.js';
 import type { ContextAssembler } from './context-assembler.js';
-import type { TrajectoryLocator } from '../trajectory/trajectory-locator.js';
+import type { SourceTraceLocator } from '../trajectory/source-trace-locator.js';
 import {
   type DiagnosticianContextPayload,
   type DiagnosisTarget,
   type FullTracePayload,
   type ToolCallEntry,
-  type TrajectoryCandidate,
   type PainContext,
   DiagnosticianContextPayloadSchema,
 } from '../../context-payload.js';
@@ -109,12 +108,12 @@ export class SqliteContextAssembler implements ContextAssembler {
     private readonly taskStore: TaskStore,
     private readonly historyQuery: HistoryQuery,
     private readonly runStore: RunStore,
-    options?: { trajectoryLocator?: TrajectoryLocator },
+    options?: { sourceTraceLocator?: SourceTraceLocator },
   ) {
-    this.trajectoryLocator = options?.trajectoryLocator;
+    this.sourceTraceLocator = options?.sourceTraceLocator;
   }
 
-  private readonly trajectoryLocator?: TrajectoryLocator;
+  private readonly sourceTraceLocator?: SourceTraceLocator;
 
   async assemble(taskId: string): Promise<DiagnosticianContextPayload> {
     const task = await this.taskStore.getTask(taskId);
@@ -165,7 +164,7 @@ export class SqliteContextAssembler implements ContextAssembler {
       historyResult.truncated,
     ) ?? [];
 
-    // Build fullTrace from source pain trajectory (PRI-171).
+    // Build fullTrace from source pain trajectory (PRI-171 / PRI-189).
     // Source trace comes from the original execution that caused the pain signal,
     // NOT from the diagnostician task's own runs.
     const fullTrace: FullTracePayload | null = dt.sourcePainId
@@ -208,91 +207,35 @@ export class SqliteContextAssembler implements ContextAssembler {
     dt: DiagnosticianTaskRecord,
     ambiguityNotes: string[],
   ): Promise<readonly RunRecord[] | null> {
-    if (!this.trajectoryLocator) {
+    if (!this.sourceTraceLocator) {
       ambiguityNotes.push(
-        'TrajectoryLocator not available; cannot resolve source trace for sourcePainId=' + (dt.sourcePainId ?? 'unknown'),
+        'SourceTraceLocator not available; cannot resolve source trace for sourcePainId=' + (dt.sourcePainId ?? 'unknown'),
       );
       return null;
     }
 
-    if (!dt.sessionIdHint) {
-      ambiguityNotes.push(
-        'No sessionIdHint; cannot locate source trace for sourcePainId=' + (dt.sourcePainId ?? 'unknown'),
-      );
-      return null;
-    }
-
-    if (!dt.sourcePainId) {
-      ambiguityNotes.push(
-        'No sourcePainId; cannot locate source trace for sessionId=' + dt.sessionIdHint,
-      );
-      return null;
-    }
-
-    const result = await this.trajectoryLocator.locate({
-      sessionId: dt.sessionIdHint,
-      workspace: dt.workspaceDir,
+    const result = await this.sourceTraceLocator.locate({
+      sourcePainId: dt.sourcePainId,
+      sessionIdHint: dt.sessionIdHint,
+      workspaceDir: dt.workspaceDir,
+      excludeTaskIds: [dt.taskId],
     });
 
-    const candidates = result.candidates.filter(
-      (c) => c.trajectoryRef !== dt.taskId,
-    );
-
-    if (candidates.length === 0) {
-      ambiguityNotes.push(
-        'Source trace not found for sourcePainId=' + (dt.sourcePainId ?? 'unknown') +
-        ': no source task located via sessionId=' + dt.sessionIdHint,
-      );
-      return null;
+    if (result.ambiguityNotes.length > 0) {
+      ambiguityNotes.push(...result.ambiguityNotes);
     }
 
-    const matched = await this.findPainIdMatchedCandidate(
-      dt.sourcePainId,
-      candidates,
-      ambiguityNotes,
-    );
-
-    if (!matched) return null;
-    return this.runStore.listRunsByTask(matched.trajectoryRef);
-  }
-
-  private async findPainIdMatchedCandidate(
-    sourcePainId: string,
-    candidates: readonly TrajectoryCandidate[],
-    ambiguityNotes: string[],
-  ): Promise<TrajectoryCandidate | null> {
-    const matched: TrajectoryCandidate[] = [];
-
-    for (const candidate of candidates) {
-      const task = await this.taskStore.getTask(candidate.trajectoryRef);
-      if (!task) continue;
-
-      const dj = tryParseJson(task.diagnosticJson);
-      const taskPainId = (dj?.sourcePainId ?? dj?.painId) as string | undefined;
-
-      if (taskPainId === sourcePainId) {
-        matched.push(candidate);
+    if (result.decision !== 'found' || !result.candidate) {
+      if (result.ambiguityNotes.length === 0) {
+        ambiguityNotes.push(
+          'Source trace not found for sourcePainId=' + (dt.sourcePainId ?? 'unknown') +
+          ': decision=' + result.decision,
+        );
       }
-    }
-
-    if (matched.length === 0) {
-      ambiguityNotes.push(
-        'sourcePainId mismatch: no candidate task has painId=' + sourcePainId +
-        '. Candidates checked: ' + candidates.map((c) => c.trajectoryRef).join(', '),
-      );
       return null;
     }
 
-    if (matched.length > 1) {
-      ambiguityNotes.push(
-        'Ambiguous source trace for sourcePainId=' + sourcePainId +
-        ': ' + matched.length + ' matched candidates. TaskIds: ' +
-        matched.map((c) => c.trajectoryRef).join(', '),
-      );
-      return null;
-    }
-
-    return matched[0] ?? null;
+    return this.runStore.listRunsByTask(result.candidate.taskId);
   }
 
   private static buildFullTraceSafe(

--- a/packages/principles-core/src/runtime-v2/store/trajectory/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/trajectory/index.ts
@@ -1,2 +1,4 @@
 export type { TrajectoryLocator } from './trajectory-locator.js';
 export { SqliteTrajectoryLocator } from './sqlite-trajectory-locator.js';
+export type { SourceTraceLocator, SourceTraceLocateDecision, SourceTraceLocateQuery, SourceTraceLocateResult, SourceTraceCandidate } from './source-trace-locator.js';
+export { SqliteSourceTraceLocator } from './sqlite-source-trace-locator.js';

--- a/packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.test.ts
@@ -307,4 +307,30 @@ describe('SqliteSourceTraceLocator', () => {
       }
     } finally { cleanupFixture(f); }
   });
+
+  it('ignores non-string sourcePainId values in diagnosticJson', async () => {
+    const f = createFixture();
+    try {
+      const dj = { sessionIdHint: 'sess-nonstr', sourcePainId: 42 };
+      const existing = await f.taskStore.getTask('task_nonstr_painid');
+      if (!existing) {
+        await f.taskStore.createTask({
+          taskId: 'task_nonstr_painid',
+          taskKind: 'user_session',
+          status: 'succeeded',
+          attemptCount: 1,
+          maxAttempts: 1,
+          diagnosticJson: JSON.stringify(dj),
+        } satisfies Omit<TaskRecord, 'createdAt' | 'updatedAt'>);
+      }
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: '42',
+        sessionIdHint: 'sess-nonstr',
+      }));
+
+      expect(result.decision).not.toBe('found');
+      expect(result.candidate).toBeNull();
+    } finally { cleanupFixture(f); }
+  });
 });

--- a/packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.test.ts
@@ -1,0 +1,310 @@
+/**
+ * SourceTraceLocator contract tests — PRI-189.
+ *
+ * Tests the formalized source trace lookup semantics extracted from
+ * SqliteContextAssembler. Covers all SourceTraceLocateDecision values
+ * and the core invariant: fullTrace only comes from sourcePainId-aligned
+ * source task/runs.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { SqliteConnection } from '../sqlite-connection.js';
+import { SqliteTaskStore } from '../task/sqlite-task-store.js';
+import { SqliteTrajectoryLocator } from './sqlite-trajectory-locator.js';
+import { SqliteSourceTraceLocator } from './sqlite-source-trace-locator.js';
+import type { TaskRecord } from '../../task-status.js';
+import type { SourceTraceLocateQuery } from './source-trace-locator.js';
+
+interface TestFixture {
+  tmpDir: string;
+  connection: SqliteConnection;
+  taskStore: SqliteTaskStore;
+  trajectoryLocator: SqliteTrajectoryLocator;
+  sourceTraceLocator: SqliteSourceTraceLocator;
+}
+
+const WORKSPACE = '/tmp/test-workspace';
+
+function createFixture(): TestFixture {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-source-trace-locator-test-'));
+  const connection = new SqliteConnection(tmpDir);
+  const taskStore = new SqliteTaskStore(connection);
+  const trajectoryLocator = new SqliteTrajectoryLocator(connection);
+  const sourceTraceLocator = new SqliteSourceTraceLocator(taskStore, trajectoryLocator);
+  return { tmpDir, connection, taskStore, trajectoryLocator, sourceTraceLocator };
+}
+
+function cleanupFixture(fixture: TestFixture): void {
+  fixture.connection.close();
+  fs.rmSync(fixture.tmpDir, { recursive: true, force: true });
+}
+
+async function createSourceTask(
+  fixture: TestFixture,
+  taskId: string,
+  opts: { sessionId: string; sourcePainId?: string; painId?: string },
+): Promise<void> {
+  const dj: Record<string, unknown> = { sessionIdHint: opts.sessionId };
+  if (opts.sourcePainId) dj.sourcePainId = opts.sourcePainId;
+  if (opts.painId) dj.painId = opts.painId;
+  const existing = await fixture.taskStore.getTask(taskId);
+  if (!existing) {
+    await fixture.taskStore.createTask({
+      taskId,
+      taskKind: 'user_session',
+      status: 'succeeded',
+      attemptCount: 1,
+      maxAttempts: 1,
+      diagnosticJson: JSON.stringify(dj),
+    } satisfies Omit<TaskRecord, 'createdAt' | 'updatedAt'>);
+  }
+}
+
+function q(overrides: Partial<SourceTraceLocateQuery> = {}): SourceTraceLocateQuery {
+  return {
+    sourcePainId: overrides.sourcePainId,
+    sessionIdHint: overrides.sessionIdHint,
+    workspaceDir: overrides.workspaceDir ?? WORKSPACE,
+    excludeTaskIds: overrides.excludeTaskIds,
+  };
+}
+
+describe('SqliteSourceTraceLocator', () => {
+
+  it('returns found when source task diagnosticJson has matching sourcePainId', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_src_1', { sessionId: 'sess-1', sourcePainId: 'pain-A' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-A',
+        sessionIdHint: 'sess-1',
+      }));
+
+      expect(result.decision).toBe('found');
+      expect(result.candidate).not.toBeNull();
+      if (result.candidate) {
+        expect(result.candidate.taskId).toBe('task_src_1');
+        expect(result.candidate.sourcePainId).toBe('pain-A');
+      }
+      expect(result.candidates.length).toBe(1);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns found when source task diagnosticJson has matching painId (not sourcePainId)', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_src_painid', { sessionId: 'sess-painid', painId: 'pain-B' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-B',
+        sessionIdHint: 'sess-painid',
+      }));
+
+      expect(result.decision).toBe('found');
+      expect(result.candidate).not.toBeNull();
+      if (result.candidate) {
+        expect(result.candidate.taskId).toBe('task_src_painid');
+      }
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns missing_source_pain_id when query has no sourcePainId', async () => {
+    const f = createFixture();
+    try {
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: undefined,
+        sessionIdHint: 'sess-any',
+      }));
+
+      expect(result.decision).toBe('missing_source_pain_id');
+      expect(result.candidate).toBeNull();
+      expect(result.ambiguityNotes.length).toBeGreaterThan(0);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns missing_session_hint when query has no sessionIdHint', async () => {
+    const f = createFixture();
+    try {
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-X',
+        sessionIdHint: undefined,
+      }));
+
+      expect(result.decision).toBe('missing_session_hint');
+      expect(result.candidate).toBeNull();
+      expect(result.ambiguityNotes.length).toBeGreaterThan(0);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('does not return found when session has task but diagnosticJson has no sourcePainId/painId', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_no_pain', { sessionId: 'sess-nopain' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-missing',
+        sessionIdHint: 'sess-nopain',
+      }));
+
+      expect(result.decision).not.toBe('found');
+      expect(result.candidate).toBeNull();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns source_pain_mismatch when candidate has different sourcePainId', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_mismatch', { sessionId: 'sess-mismatch', sourcePainId: 'pain-B' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-A',
+        sessionIdHint: 'sess-mismatch',
+      }));
+
+      expect(result.decision).toBe('source_pain_mismatch');
+      expect(result.candidate).toBeNull();
+      expect(result.ambiguityNotes.some(n => n.includes('mismatch'))).toBe(true);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns not_found when session has no tasks at all', async () => {
+    const f = createFixture();
+    try {
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-orphan',
+        sessionIdHint: 'sess-empty',
+      }));
+
+      expect(result.decision).toBe('not_found');
+      expect(result.candidate).toBeNull();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns ambiguous when multiple candidates match same sourcePainId', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_amb_1', { sessionId: 'sess-amb', sourcePainId: 'pain-amb' });
+      await createSourceTask(f, 'task_amb_2', { sessionId: 'sess-amb', sourcePainId: 'pain-amb' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-amb',
+        sessionIdHint: 'sess-amb',
+      }));
+
+      expect(result.decision).toBe('ambiguous');
+      expect(result.candidate).toBeNull();
+      expect(result.candidates.length).toBe(2);
+      expect(result.ambiguityNotes.some(n => n.includes('task_amb_1') || n.includes('task_amb_2'))).toBe(true);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('excludes tasks listed in excludeTaskIds', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_diag_self', { sessionId: 'sess-excl', sourcePainId: 'pain-excl' });
+      await createSourceTask(f, 'task_real_source', { sessionId: 'sess-excl', sourcePainId: 'pain-excl' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-excl',
+        sessionIdHint: 'sess-excl',
+        excludeTaskIds: ['task_diag_self'],
+      }));
+
+      expect(result.decision).toBe('found');
+      expect(result.candidate).not.toBeNull();
+      if (result.candidate) {
+        expect(result.candidate.taskId).toBe('task_real_source');
+      }
+      expect(result.candidates.every(c => c.taskId !== 'task_diag_self')).toBe(true);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns not_found when all matching candidates are excluded', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_only_one', { sessionId: 'sess-excl-all', sourcePainId: 'pain-excl-all' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-excl-all',
+        sessionIdHint: 'sess-excl-all',
+        excludeTaskIds: ['task_only_one'],
+      }));
+
+      expect(result.decision).toBe('not_found');
+      expect(result.candidate).toBeNull();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('handles candidate with null diagnosticJson without crashing', async () => {
+    const f = createFixture();
+    try {
+      const db = f.connection.getDb();
+      const now = new Date().toISOString();
+      db.prepare(
+        'INSERT INTO tasks (task_id, task_kind, status, created_at, updated_at, attempt_count, max_attempts, diagnostic_json) ' +
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      ).run('task_null_dj', 'user_session', 'succeeded', now, now, 1, 1, null);
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-nulldj',
+        sessionIdHint: 'sess-nulldj',
+      }));
+
+      expect(result.decision).not.toBe('found');
+      expect(result.candidate).toBeNull();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns storage_unavailable when TrajectoryLocator is not provided', async () => {
+    const f = createFixture();
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const locator = new SqliteSourceTraceLocator(f.taskStore, undefined as any);
+
+      const result = await locator.locate(q({
+        sourcePainId: 'pain-no-traj',
+        sessionIdHint: 'sess-no-traj',
+      }));
+
+      expect(result.decision).toBe('storage_unavailable');
+      expect(result.candidate).toBeNull();
+      expect(result.ambiguityNotes.length).toBeGreaterThan(0);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('does not return found based on sessionIdHint alone without sourcePainId match', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_session_only', { sessionId: 'sess-session-only', sourcePainId: 'pain-other' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-different',
+        sessionIdHint: 'sess-session-only',
+      }));
+
+      expect(result.decision).not.toBe('found');
+      expect(result.candidate).toBeNull();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('returns found with correct sourceTypes from TrajectoryLocator candidates', async () => {
+    const f = createFixture();
+    try {
+      await createSourceTask(f, 'task_sourcetypes', { sessionId: 'sess-st', sourcePainId: 'pain-st' });
+
+      const result = await f.sourceTraceLocator.locate(q({
+        sourcePainId: 'pain-st',
+        sessionIdHint: 'sess-st',
+      }));
+
+      expect(result.decision).toBe('found');
+      expect(result.candidate).not.toBeNull();
+      if (result.candidate) {
+        expect(result.candidate.sourceTypes.length).toBeGreaterThan(0);
+      }
+    } finally { cleanupFixture(f); }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.ts
+++ b/packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.ts
@@ -1,0 +1,51 @@
+/**
+ * SourceTraceLocator -- contract for resolving source pain trajectories.
+ *
+ * A "source trace" is the original execution trajectory that caused a pain
+ * signal, NOT the Diagnostician task's own runs. This contract formalizes
+ * the lookup semantics that were previously inline in SqliteContextAssembler.
+ *
+ * Key semantics:
+ *   - sourcePainId is mandatory for a `found` result
+ *   - sessionIdHint narrows search scope but cannot produce a candidate alone
+ *   - excludeTaskIds prevents self-trace (Diagnostician task seeing its own runs)
+ *   - Ambiguous = multiple matching candidates → candidate = null
+ *   - Mismatch = candidate found but painId doesn't match → source_pain_mismatch
+ *   - Malformed diagnosticJson → recorded as reason, doesn't crash lookup
+ *   - Storage errors → fail loud via PDRuntimeError, never silently swallowed
+ */
+
+export type SourceTraceLocateDecision =
+  | 'found'
+  | 'missing_source_pain_id'
+  | 'missing_session_hint'
+  | 'not_found'
+  | 'ambiguous'
+  | 'source_pain_mismatch'
+  | 'storage_unavailable';
+
+export interface SourceTraceLocateQuery {
+  sourcePainId?: string;
+  sessionIdHint?: string;
+  workspaceDir?: string;
+  excludeTaskIds?: string[];
+}
+
+export interface SourceTraceCandidate {
+  taskId: string;
+  sourcePainId: string;
+  confidence: number;
+  reasons: string[];
+  sourceTypes: string[];
+}
+
+export interface SourceTraceLocateResult {
+  decision: SourceTraceLocateDecision;
+  candidate: SourceTraceCandidate | null;
+  candidates: SourceTraceCandidate[];
+  ambiguityNotes: string[];
+}
+
+export interface SourceTraceLocator {
+  locate(query: SourceTraceLocateQuery): Promise<SourceTraceLocateResult>;
+}

--- a/packages/principles-core/src/runtime-v2/store/trajectory/sqlite-source-trace-locator.ts
+++ b/packages/principles-core/src/runtime-v2/store/trajectory/sqlite-source-trace-locator.ts
@@ -1,0 +1,178 @@
+/**
+ * SQLite implementation of SourceTraceLocator.
+ *
+ * Resolves source pain trajectories by:
+ * 1. Using TrajectoryLocator to find session-scoped task candidates
+ * 2. Filtering by excludeTaskIds to prevent self-trace
+ * 3. Matching each candidate's diagnosticJson.sourcePainId or diagnosticJson.painId
+ *    against the query's sourcePainId
+ * 4. Returning structured decisions for missing/mismatch/ambiguous cases
+ *
+ * Key invariant: sourcePainId is mandatory for a `found` result.
+ * sessionIdHint narrows scope but cannot produce a candidate alone.
+ */
+import type { TaskStore } from '../task/task-store.js';
+import type { TrajectoryLocator } from './trajectory-locator.js';
+import {
+  type SourceTraceLocateQuery,
+  type SourceTraceLocateResult,
+  type SourceTraceCandidate,
+  type SourceTraceLocator,
+} from './source-trace-locator.js';
+
+function tryParseJson(input: string | undefined): Record<string, unknown> | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed))
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export class SqliteSourceTraceLocator implements SourceTraceLocator {
+  constructor(
+    private readonly taskStore: TaskStore,
+    private readonly trajectoryLocator: TrajectoryLocator | undefined,
+  ) {}
+
+  async locate(query: SourceTraceLocateQuery): Promise<SourceTraceLocateResult> {
+    if (!query.sourcePainId) {
+      return {
+        decision: 'missing_source_pain_id',
+        candidate: null,
+        candidates: [],
+        ambiguityNotes: ['sourcePainId is required for source trace lookup; query has no sourcePainId'],
+      };
+    }
+
+    if (!query.sessionIdHint) {
+      return {
+        decision: 'missing_session_hint',
+        candidate: null,
+        candidates: [],
+        ambiguityNotes: [`sessionIdHint is required to scope source trace lookup for sourcePainId=${query.sourcePainId}`],
+      };
+    }
+
+    if (!this.trajectoryLocator) {
+      return {
+        decision: 'storage_unavailable',
+        candidate: null,
+        candidates: [],
+        ambiguityNotes: ['TrajectoryLocator not available; cannot resolve source trace'],
+      };
+    }
+
+    const trajResult = await this.trajectoryLocator.locate({
+      sessionId: query.sessionIdHint,
+      workspace: query.workspaceDir,
+    });
+
+    let {candidates} = trajResult;
+
+    if (query.excludeTaskIds && query.excludeTaskIds.length > 0) {
+      const excludeSet = new Set(query.excludeTaskIds);
+      candidates = candidates.filter(c => !excludeSet.has(c.trajectoryRef));
+    }
+
+    if (candidates.length === 0) {
+      return {
+        decision: 'not_found',
+        candidate: null,
+        candidates: [],
+        ambiguityNotes: [
+          `Source trace not found for sourcePainId=${query.sourcePainId}: ` +
+          `no source task located via sessionId=${query.sessionIdHint}`,
+        ],
+      };
+    }
+
+    const matched: SourceTraceCandidate[] = [];
+    const mismatchedTaskIds: string[] = [];
+    const unparseableTaskIds: string[] = [];
+
+    for (const trajCandidate of candidates) {
+      const task = await this.taskStore.getTask(trajCandidate.trajectoryRef);
+      if (!task) continue;
+
+      const dj = tryParseJson(task.diagnosticJson);
+      if (!dj) {
+        unparseableTaskIds.push(trajCandidate.trajectoryRef);
+        continue;
+      }
+
+      const taskPainId = (dj.sourcePainId ?? dj.painId) as string | undefined;
+
+      if (taskPainId === query.sourcePainId) {
+        matched.push({
+          taskId: trajCandidate.trajectoryRef,
+          sourcePainId: query.sourcePainId,
+          confidence: trajCandidate.confidence,
+          reasons: [...trajCandidate.reasons, 'source_pain_id_match'],
+          sourceTypes: trajCandidate.sourceTypes ?? ['tasks_table'],
+        });
+      } else if (taskPainId !== undefined) {
+        mismatchedTaskIds.push(trajCandidate.trajectoryRef);
+      }
+    }
+
+    const ambiguityNotes: string[] = [];
+
+    if (unparseableTaskIds.length > 0) {
+      ambiguityNotes.push(
+        `diagnostic_json_unparseable for taskIds: ${unparseableTaskIds.join(', ')}`,
+      );
+    }
+
+    if (matched.length === 0) {
+      if (mismatchedTaskIds.length > 0) {
+        ambiguityNotes.push(
+          `sourcePainId mismatch: no candidate task has painId=${query.sourcePainId}. ` +
+          `Mismatched taskIds: ${mismatchedTaskIds.join(', ')}`,
+        );
+        return {
+          decision: 'source_pain_mismatch',
+          candidate: null,
+          candidates: [],
+          ambiguityNotes,
+        };
+      }
+
+      return {
+        decision: 'not_found',
+        candidate: null,
+        candidates: [],
+        ambiguityNotes: [
+          ...ambiguityNotes,
+          `Source trace not found for sourcePainId=${query.sourcePainId}: ` +
+          `no candidate task has matching painId in diagnosticJson`,
+        ],
+      };
+    }
+
+    if (matched.length > 1) {
+      ambiguityNotes.push(
+        `Ambiguous source trace for sourcePainId=${query.sourcePainId}: ` +
+        `${matched.length} matched candidates. TaskIds: ${matched.map(c => c.taskId).join(', ')}`,
+      );
+      return {
+        decision: 'ambiguous',
+        candidate: null,
+        candidates: matched,
+        ambiguityNotes,
+      };
+    }
+
+    return {
+      decision: 'found',
+      candidate: matched[0] as SourceTraceCandidate,
+      candidates: matched,
+      ambiguityNotes,
+    };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/trajectory/sqlite-source-trace-locator.ts
+++ b/packages/principles-core/src/runtime-v2/store/trajectory/sqlite-source-trace-locator.ts
@@ -106,7 +106,8 @@ export class SqliteSourceTraceLocator implements SourceTraceLocator {
         continue;
       }
 
-      const taskPainId = (dj.sourcePainId ?? dj.painId) as string | undefined;
+      const rawPainId = dj.sourcePainId ?? dj.painId;
+      const taskPainId = typeof rawPainId === 'string' ? rawPainId : undefined;
 
       if (taskPainId === query.sourcePainId) {
         matched.push({


### PR DESCRIPTION
## Why PR #629's local lookup needs formalization

PR #629 introduced inline source trace lookup inside \SqliteContextAssembler\ — a private method chain (\locateSourceRuns\ → \indPainIdMatchedCandidate\) that mixed TrajectoryLocator queries, diagnosticJson parsing, and painId matching in one place. This had several problems:

1. **Untestable contract**: The lookup semantics were buried inside the assembler and couldn't be tested independently
2. **Implicit fallback risk**: Without a formal contract, it was easy to accidentally fall back to Diagnostician task runs when sourcePainId couldn't be resolved
3. **No structured decisions**: Missing/mismatch/ambiguous cases were just strings in ambiguityNotes, not typed decisions that downstream code could act on
4. **No reuse**: Any other component needing source trace lookup would have to duplicate the logic

## SourceTraceLocator public contract

\\\	ypescript
interface SourceTraceLocator {
  locate(query: SourceTraceLocateQuery): Promise<SourceTraceLocateResult>;
}

type SourceTraceLocateDecision =
  | 'found'                    // Exactly one matching source task found
  | 'missing_source_pain_id'   // Query has no sourcePainId
  | 'missing_session_hint'     // Query has no sessionIdHint
  | 'not_found'                // No matching source task in session
  | 'ambiguous'                // Multiple matching candidates
  | 'source_pain_mismatch'     // Candidates exist but painId doesn't match
  | 'storage_unavailable';     // TrajectoryLocator not provided
\\\

### Key query fields
- **sourcePainId** (mandatory for \ound\): The pain ID to match against candidate tasks
- **sessionIdHint** (mandatory): Narrows search to a specific session
- **workspaceDir**: Workspace for TrajectoryLocator scoping
- **excludeTaskIds**: Prevents self-trace (e.g., exclude Diagnostician task ID)

### Key result fields
- **decision**: Typed decision value
- **candidate**: The single matched candidate (null for all non-found decisions)
- **candidates**: All matching candidates (useful for ambiguous debugging)
- **ambiguityNotes**: Human-readable explanations

## Missing / Mismatch / Ambiguous behavior

| Decision | When | candidate | ambiguityNotes |
|---|---|---|---|
| \ound\ | Exactly 1 candidate with matching sourcePainId/painId | Set | May contain unparseable warnings |
| \missing_source_pain_id\ | Query has no sourcePainId | null | Explains sourcePainId is required |
| \missing_session_hint\ | Query has no sessionIdHint | null | Explains sessionIdHint is required |
| \
ot_found\ | No candidates in session, or all excluded | null | Explains what was searched |
| \source_pain_mismatch\ | Candidates exist but none match sourcePainId | null | Lists mismatched taskIds |
| \mbiguous\ | 2+ candidates match sourcePainId | null | Lists all matching taskIds |
| \storage_unavailable\ | TrajectoryLocator not provided | null | Explains dependency |

## How we guarantee no fallback to Diagnostician task runs

1. **excludeTaskIds**: The assembler always passes \xcludeTaskIds: [dt.taskId]\ to exclude the current Diagnostician task
2. **sourcePainId gating**: A candidate is only matched if its \diagnosticJson.sourcePainId\ or \diagnosticJson.painId\ equals the query's \sourcePainId\
3. **No session-only fallback**: Even if a session has exactly one task, if its painId doesn't match, the result is \source_pain_mismatch\ or \
ot_found\ — never \ound\
4. **Structured decision**: The assembler only populates \ullTrace\ when \esult.decision === 'found'\

## Test commands and results

\\\ash
# Build
npm run build --workspace=@principles/core  # ✅ PASS

# SourceTraceLocator contract tests (14 tests)
npx vitest run packages/principles-core/src/runtime-v2/store/trajectory/source-trace-locator.test.ts  # ✅ 14/14 PASS

# Assembler integration tests (29 tests)
npx vitest run packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts  # ✅ 29/29 PASS

# Architecture regression tests (367 tests)
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  # ✅ 367/367 PASS

# Full trajectory test suite (34 tests)
npx vitest run packages/principles-core/src/runtime-v2/store/trajectory  # ✅ 34/34 PASS
\\\

## Files changed

### New files
- \store/trajectory/source-trace-locator.ts\ — Interface + types
- \store/trajectory/sqlite-source-trace-locator.ts\ — SQLite implementation
- \store/trajectory/source-trace-locator.test.ts\ — 14 contract tests

### Modified files
- \store/context/sqlite-context-assembler.ts\ — Delegates to SourceTraceLocator
- \store/context/sqlite-context-assembler.test.ts\ — Updated to use SourceTraceLocator
- \store/trajectory/index.ts\ — Added re-exports
- \untime-v2/index.ts\ — Added barrel exports
- \untime-v2/pain-signal-runtime-factory.ts\ — Wires SourceTraceLocator
- \__tests__/architecture-regression.test.ts\ — Added PRI-189 boundary guards

Closes: PRI-189