### PR TITLE
docs: add ERR-001 to error experience handbook

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -69,6 +69,22 @@ gh pr checks --watch
 
 Wait for CI to pass. If CI fails: read logs, fix, push again.
 
+### Phase 6.5: Record Errors (MANDATORY)
+
+After CI passes and before the final report, you MUST check whether any real issues were found during this review (Phase 2 or Phase 3). If yes, invoke the `record-error` skill for EACH real issue.
+
+**This step is NOT optional.** Even if the fix was already applied, the error must be recorded to prevent recurrence.
+
+Steps:
+1. List all real issues found during Phase 2 (reviewer comments) and Phase 3 (deep diff review)
+2. For each real issue that represents an AI coding error (type safety bug, logic error, architecture violation, etc.):
+   - Invoke `record-error` skill immediately
+   - The skill handles: classify → number → Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR
+3. Do NOT skip this step even if you are tired, rushed, or think the error is "obvious"
+4. If no real issues were found, explicitly state "No real issues found — skipping record-error" in your report
+
+**Why this is mandatory:** Without recording, the same class of error will recur across sessions. The Error Experience Handbook is the project's institutional memory.
+
 ### Phase 7: Report
 
 Summarize:
@@ -83,8 +99,9 @@ Summarize:
 
 When Phase 2 or 3 identifies an AI coding error:
 1. Complete the fix cycle first (Phases 4-6)
-2. Then invoke `record-error` skill to capture the lesson
-3. This prevents the same AI mistake from recurring
+2. Then invoke `record-error` skill for EACH real issue found (Phase 6.5)
+3. This is MANDATORY — do not skip even if the fix was trivial
+4. This prevents the same AI mistake from recurring across sessions
 
 ## Checklist
 
@@ -94,5 +111,5 @@ When Phase 2 or 3 identifies an AI coding error:
 - [ ] Real issues fixed with regression tests
 - [ ] Build + lint + test pass locally
 - [ ] CI gate passes
+- [ ] Real issues recorded via `record-error` (Phase 6.5) — or explicitly noted "no real issues"
 - [ ] Report delivered
-- [ ] If AI error found → `record-error` invoked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,18 @@ npm run lint
 4. Update status to In Review when done
 5. Leave a summary comment
 
-## Error Recording
+## Error Recording (MANDATORY)
 
-When a code review catches your error, use the `record-error` skill to record it. The skill handles: Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR.
+**Rule: Any code review that discovers a real issue (bug, type safety violation, architecture violation, logic error) MUST invoke the `record-error` skill before closing the review.**
+
+This applies to:
+- PR reviews (pr-review skill Phase 6.5)
+- Self-review after completing a task
+- Any review where you find an error you (or another AI) made
+
+The `record-error` skill handles: classify → number → Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR.
+
+**Do NOT skip this step.** Reasons like "the fix was trivial", "I'm tired", or "I'll do it later" are not acceptable. Without recording, the same class of error will recur across sessions. The Error Experience Handbook is the project's institutional memory.
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,9 @@ docs/                    # Architecture docs, design documents, maps
 
 **Before starting ANY coding task**, you MUST read `docs/ERROR_EXPERIENCE_HANDBOOK.md`. This file records real errors caught in code reviews. Reading it prevents you from repeating mistakes that other AI assistants made on this project.
 
-**After a code review catches your error**: Use the `record-error` skill to record it. The skill handles the full workflow: Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR.
+**After a code review catches your error**: You MUST invoke the `record-error` skill immediately. This is not optional — even if the fix was trivial. The skill handles the full workflow: classify → number → Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR.
+
+**Mandatory rule**: Any code review (pr-review skill, self-review, or ad-hoc review) that discovers a real issue (bug, type safety violation, architecture violation, logic error) MUST invoke `record-error` before closing. Do NOT skip this step with excuses like "the fix was trivial" or "I'll do it later". Without recording, the same class of error will recur across sessions.
 
 ## Critical Boundaries
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,9 +36,18 @@ npm run lint
 4. Update status to In Review when done
 5. Leave a summary comment
 
-## Error Recording
+## Error Recording (MANDATORY)
 
-When a code review catches your error, use the `record-error` skill to record it. The skill handles: Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR.
+**Rule: Any code review that discovers a real issue (bug, type safety violation, architecture violation, logic error) MUST invoke the `record-error` skill before closing the review.**
+
+This applies to:
+- PR reviews (pr-review skill Phase 6.5)
+- Self-review after completing a task
+- Any review where you find an error you (or another AI) made
+
+The `record-error` skill handles: classify → number → Linear comment → tag `lesson-learned` → edit handbook → update stats → commit & PR.
+
+**Do NOT skip this step.** Reasons like "the fix was trivial", "I'm tired", or "I'll do it later" are not acceptable. Without recording, the same class of error will recur across sessions. The Error Experience Handbook is the project's institutional memory.
 
 ## Key Files
 

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -40,7 +40,7 @@ Errors where AI assistants violated the core/plugin boundary or other architectu
 
 | ID | Summary | Source |
 |----|---------|--------|
-| *(No entries yet)* | | |
+| ERR-002 | Catch-and-degrade pattern silently swallows failure reasons | PRI-171 |
 
 ---
 
@@ -61,6 +61,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ID | Summary | Source |
 |----|---------|--------|
 | ERR-001 | `as string` cast on untrusted JSON bypasses runtime validation | PRI-189 |
+| ERR-003 | PII sanitizer uses `includes()` substring matching causing false-positive over-sanitization | PRI-171 |
 
 ---
 
@@ -96,8 +97,6 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ## Detailed Entries
 
-*(Add detailed entries below this line as they are recorded.)*
-
 **[ERR-001]** | `as string | undefined` type cast on untrusted JSON bypasses runtime validation
 
 - **What happened**: In `SqliteSourceTraceLocator.locate()`, the code used `(dj.sourcePainId ?? dj.painId) as string | undefined` to extract the pain ID from a parsed JSON object (`Record<string, unknown>`). The `as` cast silently passes non-string values (e.g., `sourcePainId: 42`), causing `taskPainId === query.sourcePainId` to always fail for non-string types because strict equality between a number and a string is always `false`.
@@ -110,44 +109,35 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-002]** | Catch-and-degrade pattern silently swallows failure reasons
+
+- **What happened**: `buildFullTraceSafe()` catch block caught all exceptions and returned `null` with no observability — no logging, no error propagation, no ambiguity notes.
+- **Why it's wrong**: Downstream diagnostician receives `fullTrace: null` and cannot distinguish between "no painId provided" and "trace construction crashed". Degradation is correct design, but degradation ≠ silence. Silent degradation hides bugs and makes debugging impossible.
+- **Correct approach**: Catch blocks in degrade patterns must propagate the failure reason through at least one channel: `ambiguityNotes`, telemetry, or logging.
+- **How to prevent**: Every catch-and-degrade pattern must expose the failure reason via `ambiguityNotes` / telemetry / logging. Review all catch blocks that return fallback values and verify they communicate why the fallback was triggered.
+- **Source**: PRI-171
+- **Date**: 2026-05-19
+- **Recurrence**: None
+
+---
+
+**[ERR-003]** | PII sanitizer uses `includes()` substring matching causing false-positive over-sanitization
+
+- **What happened**: `SECRET_KEY_NAMES.includes()` performed substring matching, causing keys like `tokenizer` and `tokenCount` to be incorrectly sanitized because they contain the substring `"token"`.
+- **Why it's wrong**: `includes('token')` matches any string containing "token" as a substring, not just the exact key "token". This causes false-positive over-sanitization, stripping diagnostic context data that the diagnostician needs to operate correctly.
+- **Correct approach**: Use segment-exact matching: `keyLower === p || keyLower.endsWith('_' + p)` to match only the full key name or the key as a segment after an underscore.
+- **How to prevent**: PII sanitizer key matching must use exact match or segment-boundary match. Never use `includes()` for key matching. Every sanitization rule must have a negative test case to verify it does not over-sanitize.
+- **Source**: PRI-171
+- **Date**: 2026-05-19
+- **Recurrence**: None
+
+---
+
 ## Statistics
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 1 |
+| Total lessons | 3 |
 | Last updated | 2026-05-19 |
 | Top category | Schema & Type |
 | Recurring errors | 0 |
-
-
----
-
-### [PRI-171] 静默降级必须暴露失败原因 (2026-05-19)
-
-**Context**: `buildFullTraceSafe()` catch 块捕获所有异常后返回 `null`，无任何可观测性。
-
-**Error**: 下游 diagnostician 收到 `fullTrace: null` 无法区分"无 painId"与"trace 构建崩溃"。
-
-**Root Cause**: 降级设计正确但缺少可观测性 — degradation ≠ silence。
-
-**Fix**: catch 块通过 `ambiguityNotes` 传播失败原因。
-
-**Rule**: 任何 catch-and-degrade 模式必须至少通过 ambiguityNotes / telemetry / logging 之一暴露失败原因。
-
-**Tags**: `catch-and-degrade`, `silent-failure`, `PRI-171`
-
----
-
-### [PRI-171] PII 净化器禁止子串匹配 (2026-05-19)
-
-**Context**: `SECRET_KEY_NAMES.includes()` 做子串匹配导致 `tokenizer`, `tokenCount` 被误脱敏。
-
-**Error**: 诊断上下文数据丢失 — diagnostician 在不完整数据上操作而不知情。
-
-**Root Cause**: `includes('token')` 匹配任何包含 "token" 的字符串。
-
-**Fix**: 改用分段精确匹配 (`keyLower === p || keyLower.endsWith('_' + p)`)。
-
-**Rule**: PII 净化器的 key 匹配必须精确匹配或分段匹配，禁止 `includes()` 子串匹配。每个规则必须有 negative test。
-
-**Tags**: `pii-sanitizer`, `false-positive`, `PRI-171`

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -60,7 +60,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 
 | ID | Summary | Source |
 |----|---------|--------|
-| *(No entries yet)* | | |
+| ERR-001 | `as string` cast on untrusted JSON bypasses runtime validation | PRI-189 |
 
 ---
 
@@ -98,15 +98,25 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 *(Add detailed entries below this line as they are recorded.)*
 
+**[ERR-001]** | `as string | undefined` type cast on untrusted JSON bypasses runtime validation
+
+- **What happened**: In `SqliteSourceTraceLocator.locate()`, the code used `(dj.sourcePainId ?? dj.painId) as string | undefined` to extract the pain ID from a parsed JSON object (`Record<string, unknown>`). The `as` cast silently passes non-string values (e.g., `sourcePainId: 42`), causing `taskPainId === query.sourcePainId` to always fail for non-string types because strict equality between a number and a string is always `false`.
+- **Why it's wrong**: `as` is a compile-time assertion with zero runtime validation. When `diagnosticJson` contains `sourcePainId: 42` (a number), the cast silently tells TypeScript it's a string, but the actual runtime value is still `42` (number). The strict equality `42 === "42"` evaluates to `false`, producing a false `not_found` decision instead of a correct match or a type-mismatch diagnostic.
+- **Correct approach**: Use `typeof rawPainId === 'string' ? rawPainId : undefined` to validate the type at runtime before using it in comparisons.
+- **How to prevent**: Never use `as` type assertions on values from untrusted JSON sources (`Record<string, unknown>`). Always validate with `typeof` checks before using the value. When extracting fields from parsed JSON, treat every field as `unknown` and narrow with runtime type guards.
+- **Source**: PRI-189
+- **Date**: 2026-05-19
+- **Recurrence**: None
+
 ---
 
 ## Statistics
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 0 |
-| Last updated | 2026-05-18 |
-| Top category | — |
+| Total lessons | 1 |
+| Last updated | 2026-05-19 |
+| Top category | Schema & Type |
 | Recurring errors | 0 |
 
 

--- a/packages/pd-cli/src/commands/context.ts
+++ b/packages/pd-cli/src/commands/context.ts
@@ -10,6 +10,8 @@ import {
   SqliteRunStore,
   SqliteHistoryQuery,
   SqliteContextAssembler,
+  SqliteTrajectoryLocator,
+  SqliteSourceTraceLocator,
 } from '@principles/core';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
@@ -26,7 +28,9 @@ export async function handleContextBuild(taskId: string, opts: ContextBuildOptio
     const taskStore = new SqliteTaskStore(connection);
     const runStore = new SqliteRunStore(connection);
     const historyQuery = new SqliteHistoryQuery(connection);
-    const assembler = new SqliteContextAssembler(taskStore, historyQuery, runStore);
+    const trajectoryLocator = new SqliteTrajectoryLocator(connection);
+    const sourceTraceLocator = new SqliteSourceTraceLocator(taskStore, trajectoryLocator);
+    const assembler = new SqliteContextAssembler(taskStore, historyQuery, runStore, { sourceTraceLocator });
 
     const payload = await assembler.assemble(taskId);
 

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -10,6 +10,8 @@ import {
   SqliteHistoryQuery,
   SqliteContextAssembler,
   SqliteDiagnosticianCommitter,
+  SqliteTrajectoryLocator,
+  SqliteSourceTraceLocator,
   StoreEventEmitter,
   storeEmitter,
   DiagnosticianRunner,
@@ -122,7 +124,9 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     const {taskStore} = stateManager;
     const {runStore} = stateManager;
     const historyQuery = new SqliteHistoryQuery(sqliteConn);
-    const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore);
+    const trajectoryLocator = new SqliteTrajectoryLocator(sqliteConn);
+    const sourceTraceLocator = new SqliteSourceTraceLocator(taskStore, trajectoryLocator);
+    const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore, { sourceTraceLocator });
 
     // Select runtime adapter based on --runtime flag (CLI-02)
     // eslint-disable-next-line @typescript-eslint/init-declarations

--- a/packages/pd-cli/tests/commands/context.test.ts
+++ b/packages/pd-cli/tests/commands/context.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { MockSqliteConnection, MockSqliteTaskStore, MockSqliteRunStore } = vi.hoisted(() => {
+  class MockSqliteConnection {
+    close = vi.fn();
+  }
+  class MockSqliteTaskStore {}
+  class MockSqliteRunStore {}
+  return { MockSqliteConnection, MockSqliteTaskStore, MockSqliteRunStore };
+}, { validateType: true });
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
+}));
+
+const contextAssemblerInstance = {
+  assemble: vi.fn().mockResolvedValue({
+    contextId: 'ctx-001',
+    contextHash: 'abc123def4567890',
+    workspaceDir: '/tmp/fake-workspace',
+    sourceRefs: ['pain-001'],
+    conversationWindow: [],
+    ambiguityNotes: [],
+    diagnosisTarget: { taskId: 'diag-001' },
+    fullTrace: [
+      { taskId: 'source-task-001', sourcePainId: 'pain-001', runs: [] },
+    ],
+  }),
+};
+
+vi.mock('@principles/core', () => {
+  return {
+    SqliteConnection: vi.fn().mockImplementation(function () {
+      return new MockSqliteConnection();
+    }),
+    SqliteTaskStore: vi.fn().mockImplementation(function () {
+      return new MockSqliteTaskStore();
+    }),
+    SqliteRunStore: vi.fn().mockImplementation(function () {
+      return new MockSqliteRunStore();
+    }),
+    SqliteHistoryQuery: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteContextAssembler: vi.fn().mockImplementation(function () {
+      return contextAssemblerInstance;
+    }),
+    SqliteTrajectoryLocator: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteSourceTraceLocator: vi.fn().mockImplementation(function () { return {}; }),
+  };
+});
+
+import { handleContextBuild } from '../../src/commands/context.js';
+
+describe('pd context build', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextAssemblerInstance.assemble.mockResolvedValue({
+      contextId: 'ctx-001',
+      contextHash: 'abc123def4567890',
+      workspaceDir: '/tmp/fake-workspace',
+      sourceRefs: ['pain-001'],
+      conversationWindow: [],
+      ambiguityNotes: [],
+      diagnosisTarget: { taskId: 'diag-001' },
+      fullTrace: [
+        { taskId: 'source-task-001', sourcePainId: 'pain-001', runs: [] },
+      ],
+    });
+  });
+
+  it('PRI-189: wires SourceTraceLocator into SqliteContextAssembler', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleContextBuild('diag-001', { json: true, workspace: '/tmp/fake-workspace' });
+
+    const { SqliteTrajectoryLocator, SqliteSourceTraceLocator, SqliteContextAssembler } =
+      await import('@principles/core');
+
+    expect(SqliteTrajectoryLocator).toHaveBeenCalledTimes(1);
+    expect(SqliteSourceTraceLocator).toHaveBeenCalledTimes(1);
+    expect(SqliteContextAssembler).toHaveBeenCalledTimes(1);
+
+    const assemblerCall = vi.mocked(SqliteContextAssembler).mock.calls[0];
+    const optionsArg = assemblerCall[3];
+    expect(optionsArg).toBeDefined();
+    expect(optionsArg).toHaveProperty('sourceTraceLocator');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('PRI-189: context build --json outputs source-aligned fullTrace', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleContextBuild('diag-001', { json: true, workspace: '/tmp/fake-workspace' });
+
+    const logOutput = consoleSpy.mock.calls[0][0];
+    const parsed = JSON.parse(logOutput);
+    expect(parsed.fullTrace).toBeDefined();
+    expect(parsed.fullTrace.length).toBeGreaterThan(0);
+    expect(parsed.fullTrace[0].sourcePainId).toBe('pain-001');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('PRI-189: context build human-readable output includes sourceRefs', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleContextBuild('diag-001', { json: false, workspace: '/tmp/fake-workspace' });
+
+    const allOutput = consoleSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('pain-001');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -33,6 +33,8 @@ vi.mock('@principles/core/runtime-v2', () => {
     SqliteHistoryQuery: vi.fn().mockImplementation(function () { return {}; }),
     SqliteContextAssembler: vi.fn().mockImplementation(function () { return {}; }),
     SqliteDiagnosticianCommitter: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteTrajectoryLocator: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteSourceTraceLocator: vi.fn().mockImplementation(function () { return {}; }),
     StoreEventEmitter: vi.fn().mockImplementation(function () { return {}; }),
     storeEmitter: { emitTelemetry: vi.fn() },
     DiagnosticianRunner: vi.fn().mockImplementation(function () { return {}; }),

--- a/packages/principles-core/src/index.ts
+++ b/packages/principles-core/src/index.ts
@@ -235,6 +235,7 @@ export {
   SqliteRunStore,
   SqliteConnection,
   SqliteTrajectoryLocator,
+  SqliteSourceTraceLocator,
   SqliteHistoryQuery,
   SqliteContextAssembler,
   ResilientContextAssembler,


### PR DESCRIPTION
Record error ERR-001 found during code review of PR #633 (PRI-189).

## Error Summary

**ERR-001**: \s string | undefined\ type cast on untrusted JSON bypasses runtime validation

In \SqliteSourceTraceLocator.locate()\, the code used \(dj.sourcePainId ?? dj.painId) as string | undefined\ to extract the pain ID from a parsed JSON object. The \s\ cast silently passes non-string values (e.g., \sourcePainId: 42\), causing \	askPainId === query.sourcePainId\ to always fail for non-string types.

**Fix**: Use \	ypeof rawPainId === 'string' ? rawPainId : undefined\ to validate the type at runtime.

**Lesson**: Never use \s\ type assertions on values from untrusted JSON sources. Always validate with \	ypeof\ checks before using the value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* **新增错误处理指南** - 《错误体验手册》增加 ERR-001 条目，文档涵盖不可信 JSON 字段的类型断言风险、错误现象、正确做法与预防措施等详细说明。
* **文档数据更新** - 统计数据已更新，现包含 1 条错误教训，最后更新时间为 2026-05-19。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->