### PR TITLE
feat(core): harden fullTrace quality contract (PRI-190)

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -53,8 +53,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "0d6db62f8866",
-    "bundleMd5": "9cf803e170837b148578f78ff3c77dbd",
-    "builtAt": "2026-04-18T23:04:51.214Z"
+    "gitSha": "5e40436500cd",
+    "bundleMd5": "fe0414aee50d0b928fad941649e073db",
+    "builtAt": "2026-05-19T06:53:38.748Z"
   }
 }

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -136,6 +136,8 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-189
   'store/trajectory/source-trace-locator.ts',
   'store/trajectory/sqlite-source-trace-locator.ts',
+  // PRI-190
+  'full-trace-contract.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -187,6 +189,8 @@ const REQUIRED_TEST_FILES = [
   // PRI-145
   '../activation/__tests__/approval-queue.test.ts',
   '../activation/__tests__/sqlite-approval-store.test.ts',
+  // PRI-190
+  'full-trace-contract.test.ts',
 ];
 
 const REQUIRED_DOC_FILES: string[] = [];
@@ -259,6 +263,12 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     'FullTracePayloadSchema',
     'ToolCallEntrySchema',
     'PainContextSchema',
+    // PRI-190
+    'FullTracePayloadV2Schema',
+    'TraceSourceRefSchema',
+    'TraceTimelineEntrySchema',
+    'TraceEventKindSchema',
+    'SourceRefKindSchema',
   ];
 
   for (const name of REQUIRED_SCHEMA_EXPORTS) {
@@ -2787,6 +2797,48 @@ describe('PRI-189 SourceTraceLocator contract boundary', () => {
     const src = readFileSync(indexPath, 'utf-8');
     expect(src).toContain('SourceTraceLocator');
     expect(src).toContain('SqliteSourceTraceLocator');
+  });
+});
+
+describe('PRI-190 FullTrace quality contract boundary', () => {
+  it('full-trace-contract.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'full-trace-contract.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('node:process');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('core barrel exports FullTracePayloadV2Schema and contract functions', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('FullTracePayloadV2Schema');
+    expect(src).toContain('TraceSourceRefSchema');
+    expect(src).toContain('TraceTimelineEntrySchema');
+    expect(src).toContain('validateFullTracePayload');
+    expect(src).toContain('sanitizeFullTracePayload');
+    expect(src).toContain('buildFullTraceTimeline');
+    expect(src).toContain('buildSourceRefs');
+  });
+
+  it('context-payload.ts re-exports full-trace-contract types', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'context-payload.ts'), 'utf-8');
+    expect(src).toContain('full-trace-contract');
+    expect(src).toContain('FullTracePayloadV2Schema');
+    expect(src).toContain('validateFullTracePayload');
+    expect(src).toContain('sanitizeFullTracePayload');
+  });
+
+  it('DiagnosticianContextPayloadSchema accepts FullTracePayloadV2', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'context-payload.ts'), 'utf-8');
+    expect(src).toContain('FullTracePayloadV2Schema');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/full-trace-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/full-trace-contract.test.ts
@@ -1,0 +1,513 @@
+/**
+ * FullTrace quality contract tests (PRI-190).
+ *
+ * TDD tests for:
+ *   - validateFullTracePayload: runtime validation of FullTracePayloadV2
+ *   - sanitizeFullTracePayload: PII sanitization with sanitizationNotes tracking
+ *   - buildFullTraceTimeline: RunRecord → structured timeline conversion
+ *   - buildSourceRefs: task/run → sourceRefs builder
+ *   - checkFullTracePayloadSchema: TypeBox schema validation
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateFullTracePayload,
+  sanitizeFullTracePayload,
+  buildFullTraceTimeline,
+  buildSourceRefs,
+  checkFullTracePayloadSchema,
+  TRACE_EVENT_KINDS,
+  SOURCE_REF_KINDS,
+  FullTracePayloadV2Schema,
+  TraceEventKindSchema,
+  SourceRefKindSchema,
+  TraceSourceRefSchema,
+  TraceTimelineEntrySchema,
+} from '../full-trace-contract.js';
+import type {
+  FullTracePayloadV2,
+  TraceEventKind,
+  SourceRefKind,
+  RunRecordLike,
+} from '../full-trace-contract.js';
+import { Value } from '@sinclair/typebox/value';
+
+function makeValidPayload(overrides?: Partial<FullTracePayloadV2>): FullTracePayloadV2 {
+  return {
+    sourceTaskId: 'task_src_001',
+    sourcePainId: 'pain-001',
+    sourceRunIds: ['run_001', 'run_002'],
+    capturedAt: new Date().toISOString(),
+    sourceRefs: [
+      { kind: 'task', id: 'task_src_001' },
+      { kind: 'run', id: 'run_001' },
+    ],
+    timeline: [
+      { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'User asked to fix bug' },
+      { at: '2026-05-19T00:00:01Z', kind: 'tool_call', summary: 'Read (succeeded)', metadata: { toolName: 'Read' } },
+      { at: '2026-05-19T00:00:02Z', kind: 'tool_result', summary: 'Result from Read' },
+      { at: '2026-05-19T00:00:03Z', kind: 'assistant_message', summary: 'I fixed the bug' },
+    ],
+    ambiguityNotes: [],
+    sanitizationNotes: [],
+    ...overrides,
+  };
+}
+
+// ── Schema Structure Tests ──
+
+describe('FullTracePayloadV2 schema structure', () => {
+  it('valid fullTrace payload passes TypeBox schema validation', () => {
+    const payload = makeValidPayload();
+    expect(Value.Check(FullTracePayloadV2Schema, payload)).toBe(true);
+  });
+
+  it('valid fullTrace payload passes runtime validation', () => {
+    const payload = makeValidPayload();
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('valid fullTrace payload passes checkFullTracePayloadSchema', () => {
+    const payload = makeValidPayload();
+    expect(checkFullTracePayloadSchema(payload)).toBe(true);
+  });
+});
+
+// ── TraceEventKind Tests ──
+
+describe('TraceEventKind', () => {
+  it('all expected kinds are defined', () => {
+    expect(TRACE_EVENT_KINDS).toContain('tool_call');
+    expect(TRACE_EVENT_KINDS).toContain('tool_result');
+    expect(TRACE_EVENT_KINDS).toContain('assistant_message');
+    expect(TRACE_EVENT_KINDS).toContain('user_message');
+    expect(TRACE_EVENT_KINDS).toContain('system_event');
+    expect(TRACE_EVENT_KINDS).toContain('unknown');
+  });
+
+  it('TraceEventKindSchema validates known kinds', () => {
+    for (const kind of TRACE_EVENT_KINDS) {
+      expect(Value.Check(TraceEventKindSchema, kind)).toBe(true);
+    }
+  });
+
+  it('TraceEventKindSchema rejects arbitrary string', () => {
+    expect(Value.Check(TraceEventKindSchema, 'arbitrary_status')).toBe(false);
+  });
+});
+
+// ── SourceRefKind Tests ──
+
+describe('SourceRefKind', () => {
+  it('all expected kinds are defined', () => {
+    expect(SOURCE_REF_KINDS).toContain('task');
+    expect(SOURCE_REF_KINDS).toContain('run');
+    expect(SOURCE_REF_KINDS).toContain('artifact');
+    expect(SOURCE_REF_KINDS).toContain('event');
+  });
+
+  it('SourceRefKindSchema validates known kinds', () => {
+    for (const kind of SOURCE_REF_KINDS) {
+      expect(Value.Check(SourceRefKindSchema, kind)).toBe(true);
+    }
+  });
+
+  it('SourceRefKindSchema rejects arbitrary string', () => {
+    expect(Value.Check(SourceRefKindSchema, 'random_ref')).toBe(false);
+  });
+});
+
+// ── TraceSourceRef Tests ──
+
+describe('TraceSourceRef', () => {
+  it('valid sourceRef passes schema', () => {
+    expect(Value.Check(TraceSourceRefSchema, { kind: 'task', id: 'task_001' })).toBe(true);
+  });
+
+  it('empty id fails schema', () => {
+    expect(Value.Check(TraceSourceRefSchema, { kind: 'task', id: '' })).toBe(false);
+  });
+
+  it('invalid kind fails schema', () => {
+    expect(Value.Check(TraceSourceRefSchema, { kind: 'invalid', id: 'task_001' })).toBe(false);
+  });
+});
+
+// ── TraceTimelineEntry Tests ──
+
+describe('TraceTimelineEntry', () => {
+  it('valid entry passes schema', () => {
+    const entry = { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Read file' };
+    expect(Value.Check(TraceTimelineEntrySchema, entry)).toBe(true);
+  });
+
+  it('entry with null at passes schema', () => {
+    const entry = { at: null, kind: 'unknown', summary: 'Something happened' };
+    expect(Value.Check(TraceTimelineEntrySchema, entry)).toBe(true);
+  });
+
+  it('entry with optional fields passes schema', () => {
+    const entry = {
+      at: '2026-05-19T00:00:00Z',
+      kind: 'tool_call',
+      summary: 'Read file',
+      rawPreview: 'file content preview',
+      metadata: { toolName: 'Read', status: 'succeeded' },
+    };
+    expect(Value.Check(TraceTimelineEntrySchema, entry)).toBe(true);
+  });
+
+  it('invalid timeline kind fails validation', () => {
+    const payload = makeValidPayload({
+      timeline: [{ at: '2026-05-19T00:00:00Z', kind: 'invalid_kind' as TraceEventKind, summary: 'test' }],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('timeline[0]') && e.includes('kind'))).toBe(true);
+  });
+});
+
+// ── Validation: Required Fields ──
+
+describe('validateFullTracePayload: required fields', () => {
+  it('missing sourcePainId fails validation', () => {
+    const payload = makeValidPayload({ sourcePainId: '' });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sourcePainId'))).toBe(true);
+  });
+
+  it('missing sourceTaskId fails validation', () => {
+    const payload = makeValidPayload({ sourceTaskId: '' });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sourceTaskId'))).toBe(true);
+  });
+
+  it('missing capturedAt fails validation', () => {
+    const payload = makeValidPayload({ capturedAt: '' });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('capturedAt'))).toBe(true);
+  });
+
+  it('invalid capturedAt (not ISO) fails validation', () => {
+    const payload = makeValidPayload({ capturedAt: 'not-a-date' });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('capturedAt') && e.includes('ISO'))).toBe(true);
+  });
+
+  it('sourceRefs missing kind fails validation', () => {
+    const payload = makeValidPayload({
+      sourceRefs: [{ kind: 'invalid' as SourceRefKind, id: 'task_001' }],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sourceRefs[0]'))).toBe(true);
+  });
+
+  it('sourceRefs with empty id fails validation', () => {
+    const payload = makeValidPayload({
+      sourceRefs: [{ kind: 'task', id: '' }],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sourceRefs[0]'))).toBe(true);
+  });
+
+  it('sourceRunIds with empty string fails validation', () => {
+    const payload = makeValidPayload({ sourceRunIds: ['run_001', ''] });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sourceRunIds'))).toBe(true);
+  });
+
+  it('ambiguityNotes as non-string array fails validation', () => {
+    const payload = makeValidPayload({ ambiguityNotes: [42 as unknown as string] });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('ambiguityNotes'))).toBe(true);
+  });
+
+  it('sanitizationNotes as non-string array fails validation', () => {
+    const payload = makeValidPayload({ sanitizationNotes: [true as unknown as string] });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sanitizationNotes'))).toBe(true);
+  });
+
+  it('non-object input fails validation', () => {
+    const result = validateFullTracePayload('not an object');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('must be an object'))).toBe(true);
+  });
+
+  it('null input fails validation', () => {
+    const result = validateFullTracePayload(null);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ── Sanitization Tests ──
+
+describe('sanitizeFullTracePayload', () => {
+  it('sanitizer removes secrets and records sanitizationNotes', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        {
+          at: '2026-05-19T00:00:00Z',
+          kind: 'tool_call',
+          summary: 'Called API with apiKey=sk-proj-secret123',
+          rawPreview: 'Authorization: Bearer tok_live_xxx',
+          metadata: { api_key: 'pk_live_12345', user_password: 'hunter2' },
+        },
+      ],
+    });
+
+    const { payload: sanitized, sanitizationNotes } = sanitizeFullTracePayload(payload);
+
+    expect(sanitized.timeline[0]?.summary).not.toContain('sk-proj-secret123');
+    expect(sanitized.timeline[0]?.rawPreview).not.toContain('tok_live_xxx');
+    expect(sanitized.timeline[0]?.metadata?.api_key).toBe('[REDACTED]');
+    expect(sanitized.timeline[0]?.metadata?.user_password).toBe('[REDACTED]');
+    expect(sanitizationNotes.length).toBeGreaterThan(0);
+    expect(sanitized.sanitizationNotes.length).toBeGreaterThan(0);
+  });
+
+  it('sanitizer does not over-sanitize safe keys like tokenizer/tokenCount', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        {
+          at: '2026-05-19T00:00:00Z',
+          kind: 'tool_call',
+          summary: 'Processing text',
+          metadata: { tokenizer: 'gpt-4', tokenCount: 42 },
+        },
+      ],
+    });
+
+    const { payload: sanitized } = sanitizeFullTracePayload(payload);
+
+    expect(sanitized.timeline[0]?.metadata?.tokenizer).toBe('gpt-4');
+    expect(sanitized.timeline[0]?.metadata?.tokenCount).toBe(42);
+  });
+
+  it('sanitizer preserves payload structure when no secrets present', () => {
+    const payload = makeValidPayload();
+    const { payload: sanitized, sanitizationNotes } = sanitizeFullTracePayload(payload);
+
+    expect(sanitizationNotes).toEqual([]);
+    expect(sanitized.sourceTaskId).toBe(payload.sourceTaskId);
+    expect(sanitized.sourcePainId).toBe(payload.sourcePainId);
+    expect(sanitized.timeline).toEqual(payload.timeline);
+  });
+
+  it('sanitizer appends notes to existing sanitizationNotes', () => {
+    const payload = makeValidPayload({
+      sanitizationNotes: ['pre-existing note'],
+      timeline: [
+        {
+          at: '2026-05-19T00:00:00Z',
+          kind: 'tool_call',
+          summary: 'password=supersecret',
+        },
+      ],
+    });
+
+    const { payload: sanitized } = sanitizeFullTracePayload(payload);
+
+    expect(sanitized.sanitizationNotes).toContain('pre-existing note');
+    expect(sanitized.sanitizationNotes.length).toBeGreaterThan(1);
+  });
+});
+
+// ── Timeline Builder Tests ──
+
+describe('buildFullTraceTimeline', () => {
+  it('builds timeline from tool calls array', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: JSON.stringify({
+          toolCalls: [
+            { toolName: 'Read', status: 'succeeded', params: { file: '/src/main.ts' } },
+            { toolName: 'Edit', status: 'succeeded', params: { file: '/src/main.ts', content: 'fixed' }, result: 'OK' },
+          ],
+        }),
+        outputPayload: '{}',
+        startedAt: '2026-05-19T00:00:00Z',
+        endedAt: '2026-05-19T00:00:05Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.length).toBeGreaterThanOrEqual(2);
+    expect(timeline.some((e) => e.kind === 'tool_call' && e.summary.includes('Read'))).toBe(true);
+    expect(timeline.some((e) => e.kind === 'tool_call' && e.summary.includes('Edit'))).toBe(true);
+    expect(timeline.some((e) => e.kind === 'tool_result' && e.summary.includes('Edit'))).toBe(true);
+  });
+
+  it('builds timeline from user/assistant turns', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: JSON.stringify({
+          userTurns: [{ turnIndex: 1, text: 'fix the bug' }],
+        }),
+        outputPayload: JSON.stringify({
+          turns: [{ text: 'I fixed the bug' }],
+        }),
+        startedAt: '2026-05-19T00:00:00Z',
+        endedAt: '2026-05-19T00:00:05Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.some((e) => e.kind === 'user_message')).toBe(true);
+    expect(timeline.some((e) => e.kind === 'assistant_message')).toBe(true);
+  });
+
+  it('builds timeline from plain text payloads', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: 'This is just plain text',
+        outputPayload: 'Response text',
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.some((e) => e.kind === 'unknown')).toBe(true);
+  });
+
+  it('returns empty timeline for runs with no payloads', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline).toEqual([]);
+  });
+
+  it('timeline entries have valid kinds', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: JSON.stringify({
+          userTurns: [{ text: 'hello' }],
+          toolCalls: [{ toolName: 'Read', status: 'succeeded' }],
+        }),
+        outputPayload: JSON.stringify({
+          turns: [{ text: 'done' }],
+        }),
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    for (const entry of timeline) {
+      expect(TRACE_EVENT_KINDS).toContain(entry.kind);
+    }
+  });
+
+  it('synthesizes tool_call from single toolName input', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: JSON.stringify({ toolName: 'WriteFile', params: { path: '/tmp/test' } }),
+        outputPayload: '{}',
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.some((e) => e.kind === 'tool_call' && e.summary.includes('WriteFile'))).toBe(true);
+  });
+});
+
+// ── Source Refs Builder Tests ──
+
+describe('buildSourceRefs', () => {
+  it('builds sourceRefs from task and runs', () => {
+    const refs = buildSourceRefs('task_001', ['run_001', 'run_002']);
+
+    expect(refs).toEqual([
+      { kind: 'task', id: 'task_001' },
+      { kind: 'run', id: 'run_001' },
+      { kind: 'run', id: 'run_002' },
+    ]);
+  });
+
+  it('builds sourceRefs with no runs', () => {
+    const refs = buildSourceRefs('task_001', []);
+
+    expect(refs).toEqual([{ kind: 'task', id: 'task_001' }]);
+  });
+
+  it('all sourceRefs pass schema validation', () => {
+    const refs = buildSourceRefs('task_001', ['run_001']);
+    for (const ref of refs) {
+      expect(Value.Check(TraceSourceRefSchema, ref)).toBe(true);
+    }
+  });
+});
+
+// ── Ambiguity Notes Preservation ──
+
+describe('ambiguityNotes preservation', () => {
+  it('ambiguityNotes from SourceTraceLocator are preserved in payload', () => {
+    const notes = [
+      'Ambiguous source trace for sourcePainId=pain-001: 2 matched candidates',
+      'diagnostic_json_unparseable for taskIds: task_003',
+    ];
+    const payload = makeValidPayload({ ambiguityNotes: notes });
+
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(true);
+    expect(payload.ambiguityNotes).toEqual(notes);
+  });
+
+  it('empty ambiguityNotes is valid', () => {
+    const payload = makeValidPayload({ ambiguityNotes: [] });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ── Backward Compatibility ──
+
+describe('backward compatibility', () => {
+  it('FullTracePayloadV2Schema validates payload without optional legacy fields', () => {
+    const payload = makeValidPayload();
+    expect(Value.Check(FullTracePayloadV2Schema, payload)).toBe(true);
+  });
+
+  it('FullTracePayloadV2Schema is a strict subset - all required fields present', () => {
+    const payload = makeValidPayload();
+    const requiredFields = [
+      'sourceTaskId', 'sourcePainId', 'sourceRunIds', 'capturedAt',
+      'sourceRefs', 'timeline', 'ambiguityNotes', 'sanitizationNotes',
+    ];
+    for (const field of requiredFields) {
+      expect(payload).toHaveProperty(field);
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/full-trace-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/full-trace-contract.test.ts
@@ -40,6 +40,7 @@ function makeValidPayload(overrides?: Partial<FullTracePayloadV2>): FullTracePay
     sourceRefs: [
       { kind: 'task', id: 'task_src_001' },
       { kind: 'run', id: 'run_001' },
+      { kind: 'run', id: 'run_002' },
     ],
     timeline: [
       { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'User asked to fix bug' },
@@ -509,5 +510,160 @@ describe('backward compatibility', () => {
     for (const field of requiredFields) {
       expect(payload).toHaveProperty(field);
     }
+  });
+});
+
+// ── P2-1: Unrecognized JSON shape preserved in timeline ──
+
+describe('buildFullTraceTimeline: unrecognized JSON shape', () => {
+  it('structured JSON output without text/turns/toolCalls is preserved in timeline', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: JSON.stringify({ prompt: 'fix the bug' }),
+        outputPayload: JSON.stringify({ ok: false, error: 'tool failed', result: { details: 'stack trace here' } }),
+        startedAt: '2026-05-19T00:00:00Z',
+        endedAt: '2026-05-19T00:00:05Z',
+        executionStatus: 'failed',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.length).toBeGreaterThanOrEqual(2);
+    const inputEntry = timeline.find((e) => e.at === '2026-05-19T00:00:00Z' && e.kind === 'unknown');
+    expect(inputEntry).toBeDefined();
+    expect(inputEntry?.summary).toContain('prompt');
+    expect(inputEntry?.metadata?.parseStatus).toBe('unrecognized_json_shape');
+
+    const outputEntry = timeline.find((e) => e.at === '2026-05-19T00:00:05Z' && e.kind === 'unknown');
+    expect(outputEntry).toBeDefined();
+    expect(outputEntry?.summary).toContain('tool failed');
+    expect(outputEntry?.metadata?.parseStatus).toBe('unrecognized_json_shape');
+  });
+
+  it('JSON with only error field is preserved', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        outputPayload: JSON.stringify({ error: 'permission denied', code: 403 }),
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'failed',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.some((e) => e.kind === 'unknown' && e.summary.includes('permission denied'))).toBe(true);
+  });
+
+  it('mixed: recognized + unrecognized shapes both appear', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        inputPayload: JSON.stringify({ text: 'user message here' }),
+        outputPayload: JSON.stringify({ ok: true, metrics: { tokens: 42 } }),
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+
+    expect(timeline.some((e) => e.kind === 'user_message')).toBe(true);
+    expect(timeline.some((e) => e.kind === 'unknown' && e.summary.includes('metrics'))).toBe(true);
+  });
+
+  it('unrecognized JSON entry is sanitized', () => {
+    const runs: RunRecordLike[] = [
+      {
+        runId: 'run_001',
+        outputPayload: JSON.stringify({ apiKey: 'sk-secret123', data: 'normal' }),
+        startedAt: '2026-05-19T00:00:00Z',
+        executionStatus: 'succeeded',
+      },
+    ];
+
+    const timeline = buildFullTraceTimeline(runs);
+    const { payload: sanitized } = sanitizeFullTracePayload(makeValidPayload({ timeline }));
+
+    const unknownEntry = sanitized.timeline.find((e) => e.kind === 'unknown');
+    expect(unknownEntry).toBeDefined();
+    const entryText = JSON.stringify(unknownEntry);
+    expect(entryText).not.toContain('sk-secret123');
+  });
+});
+
+// ── P2-2: sourceRefs contract enforcement ──
+
+describe('validateFullTracePayload: sourceRefs contract', () => {
+  it('empty sourceRefs fails validation', () => {
+    const payload = makeValidPayload({ sourceRefs: [] });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('sourceRefs must not be empty'))).toBe(true);
+  });
+
+  it('sourceRefs without task ref fails validation', () => {
+    const payload = makeValidPayload({
+      sourceRefs: [{ kind: 'run', id: 'run_001' }, { kind: 'run', id: 'run_002' }],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('kind: "task"'))).toBe(true);
+  });
+
+  it('sourceRefs task ref id mismatch with sourceTaskId fails validation', () => {
+    const payload = makeValidPayload({
+      sourceTaskId: 'task_A',
+      sourceRefs: [
+        { kind: 'task', id: 'task_B' },
+        { kind: 'run', id: 'run_001' },
+      ],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('task ref id must match sourceTaskId'))).toBe(true);
+  });
+
+  it('sourceRefs missing run ref for sourceRunIds entry fails validation', () => {
+    const payload = makeValidPayload({
+      sourceRunIds: ['run_001', 'run_002'],
+      sourceRefs: [
+        { kind: 'task', id: 'task_src_001' },
+        { kind: 'run', id: 'run_001' },
+      ],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('run_002'))).toBe(true);
+  });
+
+  it('valid sourceRefs with matching task and run refs passes validation', () => {
+    const payload = makeValidPayload({
+      sourceTaskId: 'task_src_001',
+      sourceRunIds: ['run_001', 'run_002'],
+      sourceRefs: [
+        { kind: 'task', id: 'task_src_001' },
+        { kind: 'run', id: 'run_001' },
+        { kind: 'run', id: 'run_002' },
+      ],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(true);
+  });
+
+  it('sourceRefs with artifact/event refs in addition to task/run is valid', () => {
+    const payload = makeValidPayload({
+      sourceRefs: [
+        { kind: 'task', id: 'task_src_001' },
+        { kind: 'run', id: 'run_001' },
+        { kind: 'run', id: 'run_002' },
+        { kind: 'artifact', id: 'artifact_log_001' },
+        { kind: 'event', id: 'event_001' },
+      ],
+    });
+    const result = validateFullTracePayload(payload);
+    expect(result.valid).toBe(true);
   });
 });

--- a/packages/principles-core/src/runtime-v2/context-payload.ts
+++ b/packages/principles-core/src/runtime-v2/context-payload.ts
@@ -12,6 +12,30 @@
  *   - diagnostician context assembly → DiagnosticianContextPayload
  */
 import { Type, type Static } from '@sinclair/typebox';
+import {
+  FullTracePayloadV2Schema as FullTracePayloadV2SchemaImport,
+  TraceSourceRefSchema as TraceSourceRefSchemaImport,
+  TraceTimelineEntrySchema as TraceTimelineEntrySchemaImport,
+  TraceEventKindSchema as TraceEventKindSchemaImport,
+  SourceRefKindSchema as SourceRefKindSchemaImport,
+  validateFullTracePayload,
+  sanitizeFullTracePayload,
+  buildFullTraceTimeline,
+  buildSourceRefs,
+  checkFullTracePayloadSchema,
+  TRACE_EVENT_KINDS,
+  SOURCE_REF_KINDS,
+} from './full-trace-contract.js';
+import type {
+  FullTracePayloadV2 as FullTracePayloadV2Type,
+  TraceSourceRef as TraceSourceRefType,
+  TraceTimelineEntry as TraceTimelineEntryType,
+  TraceEventKind as TraceEventKindType,
+  SourceRefKind as SourceRefKindType,
+  FullTraceValidationResult as FullTraceValidationResultType,
+  SanitizeFullTraceResult as SanitizeFullTraceResultType,
+  RunRecordLike as RunRecordLikeType,
+} from './full-trace-contract.js';
 
 // ── History Query Entry (shared building block) ──
 
@@ -119,6 +143,33 @@ export const FullTracePayloadSchema = Type.Object({
 
 export type FullTracePayload = Static<typeof FullTracePayloadSchema>;
 
+// ── FullTrace V2 Payload (PRI-190) ──
+
+export const FullTracePayloadV2Schema = FullTracePayloadV2SchemaImport;
+export const TraceSourceRefSchema = TraceSourceRefSchemaImport;
+export const TraceTimelineEntrySchema = TraceTimelineEntrySchemaImport;
+export const TraceEventKindSchema = TraceEventKindSchemaImport;
+export const SourceRefKindSchema = SourceRefKindSchemaImport;
+
+export type FullTracePayloadV2 = FullTracePayloadV2Type;
+export type TraceSourceRef = TraceSourceRefType;
+export type TraceTimelineEntry = TraceTimelineEntryType;
+export type TraceEventKind = TraceEventKindType;
+export type SourceRefKind = SourceRefKindType;
+export type FullTraceValidationResult = FullTraceValidationResultType;
+export type SanitizeFullTraceResult = SanitizeFullTraceResultType;
+export type RunRecordLike = RunRecordLikeType;
+
+export {
+  validateFullTracePayload,
+  sanitizeFullTracePayload,
+  buildFullTraceTimeline,
+  buildSourceRefs,
+  checkFullTracePayloadSchema,
+  TRACE_EVENT_KINDS,
+  SOURCE_REF_KINDS,
+};
+
 export const ContextPayloadSchema = Type.Object({
   contextId: Type.String({ minLength: 1 }),
   sourceRefs: Type.Array(Type.String({ minLength: 1 })),
@@ -145,7 +196,7 @@ export const DiagnosticianContextPayloadSchema = Type.Object({
   conversationWindow: Type.Array(HistoryQueryEntrySchema),
   eventSummaries: Type.Optional(Type.Array(Type.Record(Type.String(), Type.Unknown()))),
   ambiguityNotes: Type.Optional(Type.Array(Type.String())),
-  fullTrace: Type.Optional(Type.Union([FullTracePayloadSchema, Type.Null()])),
+  fullTrace: Type.Optional(Type.Union([FullTracePayloadSchema, FullTracePayloadV2SchemaImport, Type.Null()])),
 });
 
 export type DiagnosticianContextPayload = Static<typeof DiagnosticianContextPayloadSchema>;

--- a/packages/principles-core/src/runtime-v2/full-trace-contract.ts
+++ b/packages/principles-core/src/runtime-v2/full-trace-contract.ts
@@ -181,10 +181,38 @@ export function validateFullTracePayload(input: unknown): FullTraceValidationRes
 
   if (!Array.isArray(p.sourceRefs)) {
     errors.push('sourceRefs must be an array');
+  } else if (p.sourceRefs.length === 0) {
+    errors.push('sourceRefs must not be empty — at least one task ref is required');
   } else {
     for (let i = 0; i < p.sourceRefs.length; i++) {
       if (!isValidSourceRef(p.sourceRefs[i])) {
         errors.push(`sourceRefs[${i}] is invalid: must have { kind: SourceRefKind, id: non-empty string }`);
+      }
+    }
+    const hasTaskRef = p.sourceRefs.some(
+      (ref) => typeof ref === 'object' && ref !== null && (ref as Record<string, unknown>).kind === 'task',
+    );
+    if (!hasTaskRef) {
+      errors.push('sourceRefs must contain at least one { kind: "task", id } entry');
+    }
+  }
+
+  if (typeof p.sourceTaskId === 'string' && p.sourceTaskId.length > 0 && Array.isArray(p.sourceRefs)) {
+    const taskRef = p.sourceRefs.find(
+      (ref) => typeof ref === 'object' && ref !== null && (ref as Record<string, unknown>).kind === 'task',
+    );
+    if (taskRef && typeof (taskRef as Record<string, unknown>).id === 'string' && (taskRef as Record<string, unknown>).id !== p.sourceTaskId) {
+      errors.push('sourceRefs task ref id must match sourceTaskId');
+    }
+  }
+
+  if (Array.isArray(p.sourceRunIds) && Array.isArray(p.sourceRefs)) {
+    const runRefIds = p.sourceRefs
+      .filter((ref) => typeof ref === 'object' && ref !== null && (ref as Record<string, unknown>).kind === 'run')
+      .map((ref) => (ref as Record<string, unknown>).id);
+    for (const runId of p.sourceRunIds) {
+      if (!runRefIds.includes(runId)) {
+        errors.push(`sourceRefs is missing { kind: "run", id: "${runId}" } for sourceRunIds entry`);
       }
     }
   }
@@ -384,6 +412,9 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
     const inputParsed = tryParseJson(run.inputPayload);
     const outputParsed = tryParseJson(run.outputPayload);
 
+    let inputProducedEntry = false;
+    let outputProducedEntry = false;
+
     const userText = inputParsed
       ? extractStringField(inputParsed, 'text') ?? extractUserTurnText(inputParsed)
       : undefined;
@@ -395,6 +426,7 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
         summary: userText.length > 200 ? userText.slice(0, 200) + '...[truncated]' : userText,
         rawPreview: userText.length > 500 ? userText.slice(0, 500) + '...[truncated]' : undefined,
       });
+      inputProducedEntry = true;
     }
 
     const toolCalls = inputParsed?.toolCalls ?? outputParsed?.toolCalls;
@@ -415,6 +447,7 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
             ...(tcObj.error ? { error: typeof tcObj.error === 'string' ? tcObj.error : JSON.stringify(tcObj.error) } : {}),
           },
         });
+        inputProducedEntry = true;
 
         if (tcObj.result || tcObj.error) {
           timeline.push({
@@ -430,6 +463,7 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
               ? { toolName, error: typeof tcObj.error === 'string' ? tcObj.error : JSON.stringify(tcObj.error) }
               : { toolName },
           });
+          outputProducedEntry = true;
         }
       }
     } else if (inputParsed) {
@@ -442,6 +476,7 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
           rawPreview: inputParsed.params ? JSON.stringify(inputParsed.params).slice(0, 500) : undefined,
           metadata: { toolName, status: run.executionStatus },
         });
+        inputProducedEntry = true;
       }
     }
 
@@ -456,6 +491,7 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
         summary: assistantText.length > 200 ? assistantText.slice(0, 200) + '...[truncated]' : assistantText,
         rawPreview: assistantText.length > 500 ? assistantText.slice(0, 500) + '...[truncated]' : undefined,
       });
+      outputProducedEntry = true;
     }
 
     if (run.inputPayload && !inputParsed && run.inputPayload.trim().length > 0) {
@@ -466,6 +502,7 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
         summary: text.length > 200 ? text.slice(0, 200) + '...[truncated]' : text,
         rawPreview: text.length > 500 ? text.slice(0, 500) + '...[truncated]' : undefined,
       });
+      inputProducedEntry = true;
     }
 
     if (run.outputPayload && !outputParsed && run.outputPayload.trim().length > 0) {
@@ -475,6 +512,29 @@ export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTim
         kind: 'unknown',
         summary: text.length > 200 ? text.slice(0, 200) + '...[truncated]' : text,
         rawPreview: text.length > 500 ? text.slice(0, 500) + '...[truncated]' : undefined,
+      });
+      outputProducedEntry = true;
+    }
+
+    if (inputParsed && !inputProducedEntry) {
+      const preview = JSON.stringify(inputParsed).slice(0, 500);
+      timeline.push({
+        at: run.startedAt ?? null,
+        kind: 'unknown',
+        summary: preview.length > 200 ? preview.slice(0, 200) + '...[truncated]' : preview,
+        rawPreview: preview,
+        metadata: { parseStatus: 'unrecognized_json_shape' },
+      });
+    }
+
+    if (outputParsed && !outputProducedEntry) {
+      const preview = JSON.stringify(outputParsed).slice(0, 500);
+      timeline.push({
+        at: run.endedAt ?? run.startedAt ?? null,
+        kind: 'unknown',
+        summary: preview.length > 200 ? preview.slice(0, 200) + '...[truncated]' : preview,
+        rawPreview: preview,
+        metadata: { parseStatus: 'unrecognized_json_shape' },
       });
     }
   }

--- a/packages/principles-core/src/runtime-v2/full-trace-contract.ts
+++ b/packages/principles-core/src/runtime-v2/full-trace-contract.ts
@@ -1,0 +1,504 @@
+/**
+ * FullTrace quality contract and schema hardening (PRI-190).
+ *
+ * Defines the structured payload contract for source execution traces
+ * consumed by Diagnostician and downstream L2 components (TraceRefiner).
+ *
+ * Key invariants:
+ *   - sourceTaskId / sourcePainId / sourceRunIds provide traceability
+ *   - timeline is a structured array, not a string blob
+ *   - sourceRefs explicitly record task/run/artifact/event references
+ *   - ambiguityNotes preserves PRI-189 missing/mismatch/ambiguous diagnostics
+ *   - sanitizationNotes records every redaction action
+ *   - capturedAt is an ISO timestamp
+ *   - All unknown input is runtime-validated (no `as` casts on untrusted JSON)
+ *
+ * This module is pure logic — zero I/O, no filesystem/path/process imports, no plugin deps.
+ */
+import { Type, type Static } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+
+// ── Trace Event Kind ──
+
+export const TRACE_EVENT_KINDS = [
+  'tool_call',
+  'tool_result',
+  'assistant_message',
+  'user_message',
+  'system_event',
+  'unknown',
+] as const;
+
+export type TraceEventKind = (typeof TRACE_EVENT_KINDS)[number];
+
+export const TraceEventKindSchema = Type.Union(
+  TRACE_EVENT_KINDS.map((k) => Type.Literal(k)),
+);
+
+// ── Source Ref Kind ──
+
+export const SOURCE_REF_KINDS = [
+  'task',
+  'run',
+  'artifact',
+  'event',
+] as const;
+
+export type SourceRefKind = (typeof SOURCE_REF_KINDS)[number];
+
+export const SourceRefKindSchema = Type.Union(
+  SOURCE_REF_KINDS.map((k) => Type.Literal(k)),
+);
+
+// ── Trace Source Ref ──
+
+export const TraceSourceRefSchema = Type.Object({
+  kind: SourceRefKindSchema,
+  id: Type.String({ minLength: 1 }),
+});
+
+export type TraceSourceRef = Static<typeof TraceSourceRefSchema>;
+
+// ── Trace Timeline Entry ──
+
+export const TraceTimelineEntrySchema = Type.Object({
+  at: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+  kind: TraceEventKindSchema,
+  summary: Type.String({ minLength: 1 }),
+  rawPreview: Type.Optional(Type.String()),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+export type TraceTimelineEntry = Static<typeof TraceTimelineEntrySchema>;
+
+// ── FullTrace Payload (PRI-190 enhanced) ──
+
+export const FullTracePayloadV2Schema = Type.Object({
+  sourceTaskId: Type.String({ minLength: 1 }),
+  sourcePainId: Type.String({ minLength: 1 }),
+  sourceRunIds: Type.Array(Type.String({ minLength: 1 })),
+  capturedAt: Type.String({ minLength: 1 }),
+  sourceRefs: Type.Array(TraceSourceRefSchema),
+  timeline: Type.Array(TraceTimelineEntrySchema),
+  ambiguityNotes: Type.Array(Type.String()),
+  sanitizationNotes: Type.Array(Type.String()),
+});
+
+export type FullTracePayloadV2 = Static<typeof FullTracePayloadV2Schema>;
+
+// ── Runtime Validation ──
+
+export interface FullTraceValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+const TRACE_EVENT_KIND_SET = new Set<string>(TRACE_EVENT_KINDS);
+const SOURCE_REF_KIND_SET = new Set<string>(SOURCE_REF_KINDS);
+
+function isValidIsoTimestamp(value: string): boolean {
+  const d = new Date(value);
+  return !isNaN(d.getTime());
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((v) => typeof v === 'string')
+  );
+}
+
+function isValidSourceRef(ref: unknown): ref is TraceSourceRef {
+  if (typeof ref !== 'object' || ref === null) return false;
+  const r = ref as Record<string, unknown>;
+  if (typeof r.kind !== 'string' || !SOURCE_REF_KIND_SET.has(r.kind)) return false;
+  if (typeof r.id !== 'string' || r.id.length === 0) return false;
+  return true;
+}
+
+function isValidTimelineEntry(entry: unknown): { valid: boolean; error?: string } {
+  if (typeof entry !== 'object' || entry === null) {
+    return { valid: false, error: 'timeline entry must be an object' };
+  }
+  const e = entry as Record<string, unknown>;
+
+  if (e.at !== null && typeof e.at !== 'string') {
+    return { valid: false, error: 'timeline entry.at must be string or null' };
+  }
+  if (typeof e.at === 'string' && e.at.length === 0) {
+    return { valid: false, error: 'timeline entry.at must be non-empty string when present' };
+  }
+
+  if (typeof e.kind !== 'string' || !TRACE_EVENT_KIND_SET.has(e.kind)) {
+    return {
+      valid: false,
+      error: `timeline entry.kind must be one of ${TRACE_EVENT_KINDS.join('|')}, got: ${String(e.kind)}`,
+    };
+  }
+
+  if (typeof e.summary !== 'string' || e.summary.length === 0) {
+    return { valid: false, error: 'timeline entry.summary must be a non-empty string' };
+  }
+
+  if (e.rawPreview !== undefined && typeof e.rawPreview !== 'string') {
+    return { valid: false, error: 'timeline entry.rawPreview must be string if present' };
+  }
+
+  if (e.metadata !== undefined && (typeof e.metadata !== 'object' || e.metadata === null || Array.isArray(e.metadata))) {
+    return { valid: false, error: 'timeline entry.metadata must be a record if present' };
+  }
+
+  return { valid: true };
+}
+
+export function validateFullTracePayload(input: unknown): FullTraceValidationResult {
+  const errors: string[] = [];
+
+  if (typeof input !== 'object' || input === null) {
+    return { valid: false, errors: ['FullTracePayload must be an object'] };
+  }
+
+  const p = input as Record<string, unknown>;
+
+  if (typeof p.sourceTaskId !== 'string' || p.sourceTaskId.length === 0) {
+    errors.push('sourceTaskId must be a non-empty string');
+  }
+
+  if (typeof p.sourcePainId !== 'string' || p.sourcePainId.length === 0) {
+    errors.push('sourcePainId must be a non-empty string');
+  }
+
+  if (!isStringArray(p.sourceRunIds)) {
+    errors.push('sourceRunIds must be an array of non-empty strings');
+  } else if (p.sourceRunIds.some((id) => id.length === 0)) {
+    errors.push('sourceRunIds must not contain empty strings');
+  }
+
+  if (typeof p.capturedAt !== 'string' || p.capturedAt.length === 0) {
+    errors.push('capturedAt must be a non-empty ISO timestamp string');
+  } else if (!isValidIsoTimestamp(p.capturedAt)) {
+    errors.push('capturedAt must be a valid ISO 8601 timestamp');
+  }
+
+  if (!Array.isArray(p.sourceRefs)) {
+    errors.push('sourceRefs must be an array');
+  } else {
+    for (let i = 0; i < p.sourceRefs.length; i++) {
+      if (!isValidSourceRef(p.sourceRefs[i])) {
+        errors.push(`sourceRefs[${i}] is invalid: must have { kind: SourceRefKind, id: non-empty string }`);
+      }
+    }
+  }
+
+  if (!Array.isArray(p.timeline)) {
+    errors.push('timeline must be an array');
+  } else {
+    for (let i = 0; i < p.timeline.length; i++) {
+      const result = isValidTimelineEntry(p.timeline[i]);
+      if (!result.valid) {
+        errors.push(`timeline[${i}]: ${result.error}`);
+      }
+    }
+  }
+
+  if (!isStringArray(p.ambiguityNotes)) {
+    errors.push('ambiguityNotes must be an array of strings');
+  }
+
+  if (!isStringArray(p.sanitizationNotes)) {
+    errors.push('sanitizationNotes must be an array of strings');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ── PII Sanitizer ──
+
+const SECRET_KEY_PATTERNS = [
+  'apikey', 'api_key', 'api-key',
+  'token',
+  'authorization',
+  'password',
+  'secret',
+  'bearer',
+  'access_token', 'refresh_token', 'auth_token', 'secret_key',
+];
+
+function sanitizeString(input: string): { result: string; redacted: boolean } {
+  let redacted = false;
+  const result = input
+    .replace(/\bapi[_-]?key\s*[:=]\s*\S+/gi, (m) => { redacted = true; return m.replace(/\S+$/, '[REDACTED]'); })
+    .replace(/\bapi[_-]?key["']?\s*:\s*["'][^"']*["']/gi, (m) => { redacted = true; const i = m.indexOf(':'); return m.slice(0, i + 1) + '"[REDACTED]"'; })
+    .replace(/\btoken\s*[:=]\s*\S+/gi, (m) => { redacted = true; return m.replace(/\S+$/, '[REDACTED]'); })
+    .replace(/\btoken["']?\s*:\s*["'][^"']*["']/gi, (m) => { redacted = true; const i = m.indexOf(':'); return m.slice(0, i + 1) + '"[REDACTED]"'; })
+    .replace(/\bbearer\s+\S+/gi, (m) => { redacted = true; return m.replace(/\S+$/, '[REDACTED]'); })
+    .replace(/\bauthorization\s*[:=]\s*\S+/gi, (m) => { redacted = true; return m.replace(/\S+$/, '[REDACTED]'); })
+    .replace(/\bauthorization["']?\s*:\s*["'][^"']*["']/gi, (m) => { redacted = true; const i = m.indexOf(':'); return m.slice(0, i + 1) + '"[REDACTED]"'; })
+    .replace(/\bpassword\s*[:=]\s*\S+/gi, (m) => { redacted = true; return m.replace(/\S+$/, '[REDACTED]'); })
+    .replace(/\bpassword["']?\s*:\s*["'][^"']*["']/gi, (m) => { redacted = true; const i = m.indexOf(':'); return m.slice(0, i + 1) + '"[REDACTED]"'; })
+    .replace(/\bsecret\s*[:=]\s*\S+/gi, (m) => { redacted = true; return m.replace(/\S+$/, '[REDACTED]'); })
+    .replace(/\bsecret["']?\s*:\s*["'][^"']*["']/gi, (m) => { redacted = true; const i = m.indexOf(':'); return m.slice(0, i + 1) + '"[REDACTED]"'; });
+  return { result, redacted };
+}
+
+function sanitizeObject(obj: unknown): { result: unknown; redactedKeys: string[] } {
+  if (typeof obj === 'string') {
+    const { result, redacted } = sanitizeString(obj);
+    return { result, redactedKeys: redacted ? ['string_value'] : [] };
+  }
+  if (Array.isArray(obj)) {
+    const allRedacted: string[] = [];
+    const results = obj.map((item, i) => {
+      const { result, redactedKeys } = sanitizeObject(item);
+      allRedacted.push(...redactedKeys.map((k) => `[${i}].${k}`));
+      return result;
+    });
+    return { result: results, redactedKeys: allRedacted };
+  }
+  if (typeof obj === 'object' && obj !== null) {
+    const result: Record<string, unknown> = {};
+    const allRedacted: string[] = [];
+    for (const [key, value] of Object.entries(obj)) {
+      const keyLower = key.toLowerCase();
+      if (SECRET_KEY_PATTERNS.some(
+        (p) => keyLower === p || keyLower.endsWith('_' + p) || keyLower.startsWith(p + '_') || keyLower.endsWith('-' + p) || keyLower.startsWith(p + '-'),
+      )) {
+        result[key] = '[REDACTED]';
+        allRedacted.push(key);
+      } else {
+        const { result: sanitized, redactedKeys } = sanitizeObject(value);
+        result[key] = sanitized;
+        allRedacted.push(...redactedKeys.map((k) => `${key}.${k}`));
+      }
+    }
+    return { result, redactedKeys: allRedacted };
+  }
+  return { result: obj, redactedKeys: [] };
+}
+
+export interface SanitizeFullTraceResult {
+  payload: FullTracePayloadV2;
+  sanitizationNotes: string[];
+}
+
+export function sanitizeFullTracePayload(input: FullTracePayloadV2): SanitizeFullTraceResult {
+  const notes: string[] = [];
+
+  const sanitizedTimeline = input.timeline.map((entry, i) => {
+    const { result: sanitizedSummary, redacted: summaryRedacted } = sanitizeString(entry.summary);
+    if (summaryRedacted) notes.push(`timeline[${i}].summary: secret pattern redacted`);
+
+    let sanitizedRawPreview = entry.rawPreview;
+    if (typeof entry.rawPreview === 'string') {
+      const { result, redacted } = sanitizeString(entry.rawPreview);
+      sanitizedRawPreview = result;
+      if (redacted) notes.push(`timeline[${i}].rawPreview: secret pattern redacted`);
+    }
+
+    let sanitizedMetadata = entry.metadata;
+    if (entry.metadata) {
+      const { result, redactedKeys } = sanitizeObject(entry.metadata);
+      sanitizedMetadata = result as Record<string, unknown>;
+      for (const key of redactedKeys) {
+        notes.push(`timeline[${i}].metadata.${key}: secret key redacted`);
+      }
+    }
+
+    return {
+      ...entry,
+      summary: sanitizedSummary,
+      rawPreview: sanitizedRawPreview,
+      metadata: sanitizedMetadata,
+    };
+  });
+
+  return {
+    payload: {
+      ...input,
+      timeline: sanitizedTimeline,
+      sanitizationNotes: [...input.sanitizationNotes, ...notes],
+    },
+    sanitizationNotes: notes,
+  };
+}
+
+// ── Timeline Builder ──
+
+export interface RunRecordLike {
+  runId: string;
+  inputPayload?: string;
+  outputPayload?: string;
+  startedAt: string;
+  endedAt?: string;
+  executionStatus: string;
+}
+
+function tryParseJson(input: string | undefined): Record<string, unknown> | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed))
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractStringField(obj: Record<string, unknown>, field: string): string | undefined {
+  const value = obj[field];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function extractUserTurnText(parsed: Record<string, unknown>): string | undefined {
+  if (Array.isArray(parsed.userTurns)) {
+    const texts: string[] = [];
+    for (const turn of parsed.userTurns) {
+      if (turn && typeof turn === 'object' && typeof (turn as Record<string, unknown>).text === 'string') {
+        texts.push((turn as Record<string, unknown>).text as string);
+      }
+    }
+    return texts.length > 0 ? texts.join('\n') : undefined;
+  }
+  return undefined;
+}
+
+function extractAssistantTurnText(parsed: Record<string, unknown>): string | undefined {
+  if (Array.isArray(parsed.turns)) {
+    const texts: string[] = [];
+    for (const turn of parsed.turns) {
+      if (turn && typeof turn === 'object' && typeof (turn as Record<string, unknown>).text === 'string') {
+        texts.push((turn as Record<string, unknown>).text as string);
+      }
+    }
+    return texts.length > 0 ? texts.join('\n') : undefined;
+  }
+  return undefined;
+}
+
+export function buildFullTraceTimeline(runs: readonly RunRecordLike[]): TraceTimelineEntry[] {
+  const timeline: TraceTimelineEntry[] = [];
+
+  for (const run of runs) {
+    const inputParsed = tryParseJson(run.inputPayload);
+    const outputParsed = tryParseJson(run.outputPayload);
+
+    const userText = inputParsed
+      ? extractStringField(inputParsed, 'text') ?? extractUserTurnText(inputParsed)
+      : undefined;
+
+    if (userText) {
+      timeline.push({
+        at: run.startedAt ?? null,
+        kind: 'user_message',
+        summary: userText.length > 200 ? userText.slice(0, 200) + '...[truncated]' : userText,
+        rawPreview: userText.length > 500 ? userText.slice(0, 500) + '...[truncated]' : undefined,
+      });
+    }
+
+    const toolCalls = inputParsed?.toolCalls ?? outputParsed?.toolCalls;
+    if (Array.isArray(toolCalls)) {
+      for (const tc of toolCalls) {
+        if (typeof tc !== 'object' || tc === null) continue;
+        const tcObj = tc as Record<string, unknown>;
+        const toolName = typeof tcObj.toolName === 'string' ? tcObj.toolName : typeof tcObj.name === 'string' ? tcObj.name : 'unknown';
+        const status = typeof tcObj.status === 'string' ? tcObj.status : undefined;
+        timeline.push({
+          at: run.startedAt ?? null,
+          kind: 'tool_call',
+          summary: `${toolName}${status ? ` (${status})` : ''}`,
+          rawPreview: tcObj.params ? JSON.stringify(tcObj.params).slice(0, 500) : undefined,
+          metadata: {
+            toolName,
+            ...(status ? { status } : {}),
+            ...(tcObj.error ? { error: typeof tcObj.error === 'string' ? tcObj.error : JSON.stringify(tcObj.error) } : {}),
+          },
+        });
+
+        if (tcObj.result || tcObj.error) {
+          timeline.push({
+            at: run.endedAt ?? run.startedAt ?? null,
+            kind: 'tool_result',
+            summary: tcObj.error
+              ? `Error from ${toolName}`
+              : `Result from ${toolName}`,
+            rawPreview: tcObj.result
+              ? (typeof tcObj.result === 'string' ? tcObj.result : JSON.stringify(tcObj.result)).slice(0, 500)
+              : undefined,
+            metadata: tcObj.error
+              ? { toolName, error: typeof tcObj.error === 'string' ? tcObj.error : JSON.stringify(tcObj.error) }
+              : { toolName },
+          });
+        }
+      }
+    } else if (inputParsed) {
+      const toolName = extractStringField(inputParsed, 'toolName') ?? extractStringField(inputParsed, 'name');
+      if (toolName) {
+        timeline.push({
+          at: run.startedAt ?? null,
+          kind: 'tool_call',
+          summary: `${toolName} (${run.executionStatus})`,
+          rawPreview: inputParsed.params ? JSON.stringify(inputParsed.params).slice(0, 500) : undefined,
+          metadata: { toolName, status: run.executionStatus },
+        });
+      }
+    }
+
+    const assistantText = outputParsed
+      ? extractStringField(outputParsed, 'text') ?? extractAssistantTurnText(outputParsed)
+      : undefined;
+
+    if (assistantText) {
+      timeline.push({
+        at: run.endedAt ?? run.startedAt ?? null,
+        kind: 'assistant_message',
+        summary: assistantText.length > 200 ? assistantText.slice(0, 200) + '...[truncated]' : assistantText,
+        rawPreview: assistantText.length > 500 ? assistantText.slice(0, 500) + '...[truncated]' : undefined,
+      });
+    }
+
+    if (run.inputPayload && !inputParsed && run.inputPayload.trim().length > 0) {
+      const text = run.inputPayload.trim();
+      timeline.push({
+        at: run.startedAt ?? null,
+        kind: 'unknown',
+        summary: text.length > 200 ? text.slice(0, 200) + '...[truncated]' : text,
+        rawPreview: text.length > 500 ? text.slice(0, 500) + '...[truncated]' : undefined,
+      });
+    }
+
+    if (run.outputPayload && !outputParsed && run.outputPayload.trim().length > 0) {
+      const text = run.outputPayload.trim();
+      timeline.push({
+        at: run.endedAt ?? run.startedAt ?? null,
+        kind: 'unknown',
+        summary: text.length > 200 ? text.slice(0, 200) + '...[truncated]' : text,
+        rawPreview: text.length > 500 ? text.slice(0, 500) + '...[truncated]' : undefined,
+      });
+    }
+  }
+
+  return timeline;
+}
+
+// ── Source Refs Builder ──
+
+export function buildSourceRefs(
+  sourceTaskId: string,
+  sourceRunIds: string[],
+): TraceSourceRef[] {
+  const refs: TraceSourceRef[] = [
+    { kind: 'task', id: sourceTaskId },
+  ];
+  for (const runId of sourceRunIds) {
+    refs.push({ kind: 'run', id: runId });
+  }
+  return refs;
+}
+
+// ── Schema Validation Helper ──
+
+export function checkFullTracePayloadSchema(input: unknown): boolean {
+  return Value.Check(FullTracePayloadV2Schema, input);
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -26,7 +26,7 @@ export { RuntimeKindSchema, RuntimeCapabilitiesSchema, RuntimeHealthSchema, RunH
 export { PDTaskStatusSchema, TaskRecordSchema, DiagnosticianTaskRecordSchema } from './task-status.js';
 export { RuntimeSelectionCriteriaSchema } from './runtime-selector.js';
 // Context payload schemas (Phase 2)
-export { HistoryQueryEntrySchema, TrajectoryLocateQuerySchema, TrajectoryCandidateSchema, TrajectoryLocateResultSchema, HistoryQueryResultSchema, DiagnosisTargetSchema, ContextPayloadSchema, DiagnosticianContextPayloadSchema, ToolCallEntrySchema, PainContextSchema, FullTracePayloadSchema } from './context-payload.js';
+export { HistoryQueryEntrySchema, TrajectoryLocateQuerySchema, TrajectoryCandidateSchema, TrajectoryLocateResultSchema, HistoryQueryResultSchema, DiagnosisTargetSchema, ContextPayloadSchema, DiagnosticianContextPayloadSchema, ToolCallEntrySchema, PainContextSchema, FullTracePayloadSchema, FullTracePayloadV2Schema, TraceSourceRefSchema, TraceTimelineEntrySchema, TraceEventKindSchema, SourceRefKindSchema, validateFullTracePayload, sanitizeFullTracePayload, buildFullTraceTimeline, buildSourceRefs, checkFullTracePayloadSchema, TRACE_EVENT_KINDS, SOURCE_REF_KINDS } from './context-payload.js';
 // Diagnostician output schemas (Phase 2)
 export { DiagnosticianViolatedPrincipleSchema, DiagnosticianEvidenceSchema, RecommendationKindSchema, DiagnosticianRecommendationSchema, DiagnosticianOutputV1Schema, DiagnosticianInvocationInputSchema } from './diagnostician-output.js';
 // Principle tree types schemas
@@ -105,6 +105,14 @@ export type {
   ToolCallEntry,
   PainContext,
   FullTracePayload,
+  FullTracePayloadV2,
+  TraceSourceRef,
+  TraceTimelineEntry,
+  TraceEventKind,
+  SourceRefKind,
+  FullTraceValidationResult,
+  SanitizeFullTraceResult,
+  RunRecordLike,
 } from './context-payload.js';
 
 // Diagnostician output

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -462,12 +462,18 @@ describe('SqliteContextAssembler', () => {
       const ft = payload.fullTrace;
       expect(ft).not.toBeNull();
       if (!ft) return;
-      expect(ft.painContext.painId).toBe('pain-src-happy');
-      expect(ft.painContext.severity).toBe('high');
-      expect(ft.scratchpad.length).toBeGreaterThan(0);
-      expect(ft.toolCallHistory.length).toBeGreaterThan(0);
-      expect(ft.toolCallHistory[0]?.toolName).toBe('Read');
-      expect(ft.toolCallHistory[0]?.status).toBe('succeeded');
+      if ('sourcePainId' in ft) {
+        expect(ft.sourcePainId).toBe('pain-src-happy');
+        expect(ft.sourceTaskId).toBe(diagTask.taskId);
+        expect(ft.timeline.length).toBeGreaterThan(0);
+        expect(ft.sourceRefs.length).toBeGreaterThan(0);
+        expect(ft.ambiguityNotes).toBeDefined();
+        expect(ft.sanitizationNotes).toBeDefined();
+        expect(ft.capturedAt).toBeDefined();
+        const toolCallEntries = ft.timeline.filter((e) => e.kind === 'tool_call');
+        expect(toolCallEntries.length).toBeGreaterThan(0);
+        expect(toolCallEntries.some((e) => e.summary.includes('Read'))).toBe(true);
+      }
       expect(Value.Check(DiagnosticianContextPayloadSchema, payload)).toBe(true);
     } finally { cleanupFixture(f); }
   });
@@ -605,9 +611,13 @@ describe('SqliteContextAssembler', () => {
       const ft = payload.fullTrace;
       expect(ft).not.toBeNull();
       if (!ft) return;
-      expect(ft.scratchpad).toEqual([]);
-      expect(ft.toolCallHistory).toEqual([]);
-      expect(ft.painContext.painId).toBe('pain-no-src-runs');
+      if ('sourcePainId' in ft) {
+        expect(ft.timeline).toEqual([]);
+        expect(ft.sourcePainId).toBe('pain-no-src-runs');
+        expect(ft.sourceRunIds).toEqual([]);
+        expect(ft.ambiguityNotes).toBeDefined();
+        expect(ft.sanitizationNotes).toBeDefined();
+      }
       expect(Value.Check(DiagnosticianContextPayloadSchema, payload)).toBe(true);
     } finally { cleanupFixture(f); }
   });
@@ -685,7 +695,9 @@ describe('SqliteContextAssembler', () => {
       const ft = payload.fullTrace;
       expect(ft).not.toBeNull();
       if (!ft) return;
-      expect(ft.scratchpad.length).toBeGreaterThan(0);
+      if ('timeline' in ft) {
+        expect(ft.timeline.length).toBeGreaterThan(0);
+      }
       const allText = JSON.stringify(ft);
       expect(allText).not.toContain('supersecret');
       expect(allText).toContain('[REDACTED]');
@@ -727,11 +739,16 @@ describe('SqliteContextAssembler', () => {
       const ft = payload.fullTrace;
       expect(ft).not.toBeNull();
       if (!ft) return;
-      expect(ft.toolCallHistory.length).toBe(2);
-      expect(ft.toolCallHistory[0]?.toolName).toBe('Read');
-      expect(ft.toolCallHistory[1]?.toolName).toBe('Edit');
-      expect(ft.scratchpad).toContain('fix the bug');
-      expect(ft.scratchpad).toContain('I fixed the bug');
+      if ('timeline' in ft) {
+        const toolCallEntries = ft.timeline.filter((e) => e.kind === 'tool_call');
+        expect(toolCallEntries.length).toBe(2);
+        expect(toolCallEntries[0]?.summary).toContain('Read');
+        expect(toolCallEntries[1]?.summary).toContain('Edit');
+        const userEntries = ft.timeline.filter((e) => e.kind === 'user_message');
+        expect(userEntries.some((e) => e.summary.includes('fix the bug'))).toBe(true);
+        const assistantEntries = ft.timeline.filter((e) => e.kind === 'assistant_message');
+        expect(assistantEntries.some((e) => e.summary.includes('I fixed the bug'))).toBe(true);
+      }
     } finally { cleanupFixture(f); }
   });
 
@@ -765,13 +782,15 @@ describe('SqliteContextAssembler', () => {
       const ft = payload.fullTrace;
       expect(ft).not.toBeNull();
       if (!ft) return;
-      const params = ft.toolCallHistory[0]?.params;
-      expect(params).toBeDefined();
-      if (!params) return;
-      expect(params).not.toContain('tok_live_xxx');
-      expect(params).not.toContain('pk_live_12345');
-      expect(params).not.toContain('p@ssw0rd');
-      expect(params).toContain('[REDACTED]');
+      if ('timeline' in ft) {
+        const [entry] = ft.timeline.filter((e) => e.kind === 'tool_call');
+        expect(entry).toBeDefined();
+        const allTimelineText = JSON.stringify(ft.timeline);
+        expect(allTimelineText).not.toContain('tok_live_xxx');
+        expect(allTimelineText).not.toContain('pk_live_12345');
+        expect(allTimelineText).not.toContain('p@ssw0rd');
+        expect(allTimelineText).toContain('[REDACTED]');
+      }
     } finally { cleanupFixture(f); }
   });
 

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -464,7 +464,7 @@ describe('SqliteContextAssembler', () => {
       if (!ft) return;
       if ('sourcePainId' in ft) {
         expect(ft.sourcePainId).toBe('pain-src-happy');
-        expect(ft.sourceTaskId).toBe(diagTask.taskId);
+        expect(ft.sourceTaskId).toBe(sourceTaskId);
         expect(ft.timeline.length).toBeGreaterThan(0);
         expect(ft.sourceRefs.length).toBeGreaterThan(0);
         expect(ft.ambiguityNotes).toBeDefined();

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -18,87 +18,16 @@ import type { SourceTraceLocator } from '../trajectory/source-trace-locator.js';
 import {
   type DiagnosticianContextPayload,
   type DiagnosisTarget,
-  type FullTracePayload,
-  type ToolCallEntry,
-  type PainContext,
+  type FullTracePayloadV2,
   DiagnosticianContextPayloadSchema,
+  validateFullTracePayload,
+  sanitizeFullTracePayload,
+  buildFullTraceTimeline,
+  buildSourceRefs,
 } from '../../context-payload.js';
 import type { TaskRecord, DiagnosticianTaskRecord } from '../../task-status.js';
 import type { RunRecord } from '../../runtime-protocol.js';
 import { PDRuntimeError } from '../../error-categories.js';
-
-// ── PII Sanitizer (PRI-171) ──
-
-const SECRET_KEY_PATTERNS = ['apikey', 'api_key', 'api-key', 'token', 'authorization', 'password', 'secret', 'bearer', 'access_token', 'refresh_token', 'auth_token', 'secret_key'];
-
-function sanitizeString(input: string): string {
-  return input
-    .replace(/\bapi[_-]?key\s*[:=]\s*\S+/gi, (m) => m.replace(/\S+$/, '[REDACTED]'))
-    .replace(/\bapi[_-]?key["']?\s*:\s*["'][^"']*["']/gi, (m) => {
-      const i = m.indexOf(':');
-      return m.slice(0, i + 1) + '"[REDACTED]"';
-    })
-    .replace(/\btoken\s*[:=]\s*\S+/gi, (m) => m.replace(/\S+$/, '[REDACTED]'))
-    .replace(/\btoken["']?\s*:\s*["'][^"']*["']/gi, (m) => {
-      const i = m.indexOf(':');
-      return m.slice(0, i + 1) + '"[REDACTED]"';
-    })
-    .replace(/\bbearer\s+\S+/gi, (m) => m.replace(/\S+$/, '[REDACTED]'))
-    .replace(/\bauthorization\s*[:=]\s*\S+/gi, (m) => m.replace(/\S+$/, '[REDACTED]'))
-    .replace(/\bauthorization["']?\s*:\s*["'][^"']*["']/gi, (m) => {
-      const i = m.indexOf(':');
-      return m.slice(0, i + 1) + '"[REDACTED]"';
-    })
-    .replace(/\bpassword\s*[:=]\s*\S+/gi, (m) => m.replace(/\S+$/, '[REDACTED]'))
-    .replace(/\bpassword["']?\s*:\s*["'][^"']*["']/gi, (m) => {
-      const i = m.indexOf(':');
-      return m.slice(0, i + 1) + '"[REDACTED]"';
-    })
-    .replace(/\bsecret\s*[:=]\s*\S+/gi, (m) => m.replace(/\S+$/, '[REDACTED]'))
-    .replace(/\bsecret["']?\s*:\s*["'][^"']*["']/gi, (m) => {
-      const i = m.indexOf(':');
-      return m.slice(0, i + 1) + '"[REDACTED]"';
-    });
-}
-
-function sanitizeObject(obj: unknown): unknown {
-  if (typeof obj === 'string') return sanitizeString(obj);
-  if (Array.isArray(obj)) return obj.map(sanitizeObject);
-  if (typeof obj === 'object' && obj !== null) {
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj)) {
-      const keyLower = key.toLowerCase();
-      if (SECRET_KEY_PATTERNS.some(p => keyLower === p || keyLower.endsWith('_' + p) || keyLower.startsWith(p + '_') || keyLower.endsWith('-' + p) || keyLower.startsWith(p + '-'))) {
-        result[key] = '[REDACTED]';
-      } else {
-        result[key] = sanitizeObject(value);
-      }
-    }
-    return result;
-  }
-  return obj;
-}
-
-function sanitizePii(input: string): string {
-  return sanitizeString(input);
-}
-
-function sanitizeJsonOrString(value: unknown): string {
-  if (typeof value === 'string') return sanitizePii(value);
-  return JSON.stringify(sanitizeObject(value));
-}
-
-function tryParseJson(input: string | undefined): Record<string, unknown> | null {
-  if (!input) return null;
-  const trimmed = input.trim();
-  if (!trimmed.startsWith('{')) return null;
-  try {
-    const parsed = JSON.parse(trimmed);
-    return (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) ? parsed as Record<string, unknown> : null;
-  } catch {
-    return null;
-  }
-}
 
 // ── SqliteContextAssembler ──
 
@@ -167,7 +96,7 @@ export class SqliteContextAssembler implements ContextAssembler {
     // Build fullTrace from source pain trajectory (PRI-171 / PRI-189).
     // Source trace comes from the original execution that caused the pain signal,
     // NOT from the diagnostician task's own runs.
-    const fullTrace: FullTracePayload | null = dt.sourcePainId
+    const fullTrace: FullTracePayloadV2 | null = dt.sourcePainId
       ? await this.buildFullTraceFromSource(dt, ambiguityNotes)
       : null;
 
@@ -197,10 +126,10 @@ export class SqliteContextAssembler implements ContextAssembler {
   private async buildFullTraceFromSource(
     dt: DiagnosticianTaskRecord,
     ambiguityNotes: string[],
-  ): Promise<FullTracePayload | null> {
+  ): Promise<FullTracePayloadV2 | null> {
     const sourceRuns = await this.locateSourceRuns(dt, ambiguityNotes);
     if (sourceRuns === null) return null;
-    return SqliteContextAssembler.buildFullTraceSafe(dt, sourceRuns, ambiguityNotes);
+    return SqliteContextAssembler.buildFullTraceV2(dt, sourceRuns, ambiguityNotes);
   }
 
   private async locateSourceRuns(
@@ -238,146 +167,50 @@ export class SqliteContextAssembler implements ContextAssembler {
     return this.runStore.listRunsByTask(result.candidate.taskId);
   }
 
-  private static buildFullTraceSafe(
+  private static buildFullTraceV2(
     dt: DiagnosticianTaskRecord,
     runs: readonly RunRecord[],
-    ambiguityNotes: string[] | undefined,
-  ): FullTracePayload | null {
-    try {
-      return SqliteContextAssembler.buildFullTrace(dt, runs);
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
-      if (ambiguityNotes) {
-        ambiguityNotes.push(
-          'fullTrace construction failed for painId=' + (dt.sourcePainId ?? 'unknown') + ': ' + reason,
-        );
-      }
+    ambiguityNotes: string[],
+  ): FullTracePayloadV2 | null {
+    if (!dt.sourcePainId || !dt.taskId) return null;
+
+    const { taskId: sourceTaskId, sourcePainId } = dt;
+    const sourceRunIds = runs.map((r) => r.runId);
+    const capturedAt = new Date().toISOString();
+
+    const sourceRefs = buildSourceRefs(sourceTaskId, sourceRunIds);
+
+    const timeline = buildFullTraceTimeline(runs.map((r) => ({
+      runId: r.runId,
+      inputPayload: r.inputPayload,
+      outputPayload: r.outputPayload,
+      startedAt: r.startedAt,
+      endedAt: r.endedAt,
+      executionStatus: r.executionStatus,
+    })));
+
+    const rawPayload: FullTracePayloadV2 = {
+      sourceTaskId,
+      sourcePainId,
+      sourceRunIds,
+      capturedAt,
+      sourceRefs,
+      timeline,
+      ambiguityNotes: [...ambiguityNotes],
+      sanitizationNotes: [],
+    };
+
+    const validation = validateFullTracePayload(rawPayload);
+    if (!validation.valid) {
+      ambiguityNotes.push(
+        'fullTrace V2 validation failed for painId=' + sourcePainId + ': ' + validation.errors.join('; '),
+      );
       return null;
     }
-  }
 
-  private static buildFullTrace(
-    dt: DiagnosticianTaskRecord,
-    runs: readonly RunRecord[],
-  ): FullTracePayload {
-    const painContext: PainContext = {
-      painId: dt.sourcePainId || undefined,
-      severity: dt.severity || undefined,
-      source: dt.source || undefined,
-      reasonSummary: dt.reasonSummary || undefined,
-      sessionIdHint: dt.sessionIdHint || undefined,
-    };
+    const { payload: sanitized } = sanitizeFullTracePayload(rawPayload);
 
-    const scratchpad: string[] = [];
-    const toolCallHistory: ToolCallEntry[] = [];
-
-    for (const run of runs) {
-      SqliteContextAssembler.extractScratchpadLines(run.inputPayload, scratchpad);
-      SqliteContextAssembler.extractScratchpadLines(run.outputPayload, scratchpad);
-      SqliteContextAssembler.extractToolCalls({
-        inputPayload: run.inputPayload,
-        outputPayload: run.outputPayload,
-        startedAt: run.startedAt,
-        endedAt: run.endedAt,
-        executionStatus: run.executionStatus,
-        accumulator: toolCallHistory,
-      });
-    }
-
-    return {
-      painContext,
-      scratchpad,
-      toolCallHistory,
-    };
-  }
-
-  private static extractScratchpadLines(
-    payload: string | undefined,
-    accumulator: string[],
-  ): void {
-    if (!payload) return;
-
-    const trimmed = payload.trim();
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-      try {
-        const parsed = JSON.parse(trimmed);
-        if (typeof parsed === 'object' && parsed !== null) {
-          // Extract thinking/scratchpad/reasoning fields
-          const thinking = parsed.thinking ?? parsed.scratchpad ?? parsed.reasoning;
-          if (typeof thinking === 'string' && thinking.length > 0) {
-            accumulator.push(sanitizePii(thinking));
-          } else if (Array.isArray(thinking)) {
-            for (const item of thinking) {
-              if (typeof item === 'string') accumulator.push(sanitizePii(item));
-            }
-          }
-          // Extract user turn text
-          if (Array.isArray(parsed.userTurns)) {
-            for (const turn of parsed.userTurns) {
-              if (turn && typeof turn === 'object' && typeof turn.text === 'string') {
-                accumulator.push(sanitizePii(turn.text));
-              }
-            }
-          }
-          // Extract assistant turn text
-          if (Array.isArray(parsed.turns)) {
-            for (const turn of parsed.turns) {
-              if (turn && typeof turn === 'object' && typeof turn.text === 'string') {
-                accumulator.push(sanitizePii(turn.text));
-              }
-            }
-          }
-        }
-      } catch {
-        // Not valid JSON -- add as plain text
-        if (trimmed.length > 0) accumulator.push(sanitizePii(trimmed));
-      }
-    } else if (trimmed.length > 0) {
-      accumulator.push(sanitizePii(trimmed));
-    }
-  }
-
-  private static extractToolCalls(opts: {
-    inputPayload: string | undefined;
-    outputPayload: string | undefined;
-    startedAt: string;
-    endedAt: string | undefined;
-    executionStatus: string;
-    accumulator: ToolCallEntry[];
-  }): void {
-    const inputParsed = tryParseJson(opts.inputPayload);
-    const outputParsed = tryParseJson(opts.outputPayload);
-
-    // Extract from toolCalls array if present
-    const toolCalls = inputParsed?.toolCalls ?? outputParsed?.toolCalls;
-    if (Array.isArray(toolCalls)) {
-      for (const tc of toolCalls) {
-        if (typeof tc !== 'object' || tc === null) continue;
-        opts.accumulator.push({
-          toolName: typeof tc.toolName === 'string' ? tc.toolName : typeof tc.name === 'string' ? tc.name : undefined,
-          status: typeof tc.status === 'string' ? tc.status : undefined,
-          params: tc.params ? sanitizeJsonOrString(tc.params) : undefined,
-          resultSummary: tc.result ? sanitizeJsonOrString(tc.result) : undefined,
-          errorSummary: tc.error ? sanitizeJsonOrString(tc.error) : undefined,
-          startedAt: opts.startedAt,
-          completedAt: opts.endedAt ?? opts.startedAt,
-        });
-      }
-    } else if (inputParsed) {
-      // No explicit toolCalls array -- synthesize from single toolName if present
-      const toolName = inputParsed.toolName ?? inputParsed.name;
-      if (typeof toolName === 'string') {
-        opts.accumulator.push({
-          toolName,
-          status: opts.executionStatus === 'succeeded' ? 'succeeded' : opts.executionStatus === 'failed' ? 'failed' : undefined,
-          params: inputParsed.params ? sanitizeJsonOrString(inputParsed.params) : undefined,
-          resultSummary: opts.outputPayload ? sanitizePii(opts.outputPayload.length > 500 ? opts.outputPayload.slice(0, 500) + '...[truncated]' : opts.outputPayload) : undefined,
-          errorSummary: opts.executionStatus === 'failed' && outputParsed?.error ? sanitizePii(String(outputParsed.error)) : undefined,
-          startedAt: opts.startedAt,
-          completedAt: opts.endedAt ?? opts.startedAt,
-        });
-      }
-    }
+    return sanitized;
   }
 
   private static buildAmbiguityNotes(

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -127,15 +127,15 @@ export class SqliteContextAssembler implements ContextAssembler {
     dt: DiagnosticianTaskRecord,
     ambiguityNotes: string[],
   ): Promise<FullTracePayloadV2 | null> {
-    const sourceRuns = await this.locateSourceRuns(dt, ambiguityNotes);
-    if (sourceRuns === null) return null;
-    return SqliteContextAssembler.buildFullTraceV2(dt, sourceRuns, ambiguityNotes);
+    const located = await this.locateSourceRuns(dt, ambiguityNotes);
+    if (located === null) return null;
+    return SqliteContextAssembler.buildFullTraceV2({ dt, sourceTaskId: located.sourceTaskId, runs: located.runs, ambiguityNotes });
   }
 
   private async locateSourceRuns(
     dt: DiagnosticianTaskRecord,
     ambiguityNotes: string[],
-  ): Promise<readonly RunRecord[] | null> {
+  ): Promise<{ sourceTaskId: string; runs: readonly RunRecord[] } | null> {
     if (!this.sourceTraceLocator) {
       ambiguityNotes.push(
         'SourceTraceLocator not available; cannot resolve source trace for sourcePainId=' + (dt.sourcePainId ?? 'unknown'),
@@ -164,17 +164,20 @@ export class SqliteContextAssembler implements ContextAssembler {
       return null;
     }
 
-    return this.runStore.listRunsByTask(result.candidate.taskId);
+    const runs = await this.runStore.listRunsByTask(result.candidate.taskId);
+    return { sourceTaskId: result.candidate.taskId, runs };
   }
 
-  private static buildFullTraceV2(
-    dt: DiagnosticianTaskRecord,
-    runs: readonly RunRecord[],
-    ambiguityNotes: string[],
-  ): FullTracePayloadV2 | null {
+  private static buildFullTraceV2(opts: {
+    dt: DiagnosticianTaskRecord;
+    sourceTaskId: string;
+    runs: readonly RunRecord[];
+    ambiguityNotes: string[];
+  }): FullTracePayloadV2 | null {
+    const { dt, sourceTaskId, runs, ambiguityNotes } = opts;
     if (!dt.sourcePainId || !dt.taskId) return null;
 
-    const { taskId: sourceTaskId, sourcePainId } = dt;
+    const { sourcePainId } = dt;
     const sourceRunIds = runs.map((r) => r.runId);
     const capturedAt = new Date().toISOString();
 


### PR DESCRIPTION
## Why PRI-190 is needed after PRI-189

PRI-189 established the SourceTraceLocator contract — the *lookup* semantics for finding source runs. But the fullTrace payload itself was still a loosely-typed blob with painContext/scratchpad/toolCallHistory. PRI-190 upgrades fullTrace from an opaque blob to a verifiable, structured source trajectory contract so that downstream consumers (PRI-191 TraceRefiner) can consume it without guessing data meanings.

## FullTrace Public Contract Summary

### FullTracePayloadV2 (new)
| Field | Type | Purpose |
|-------|------|---------|
| sourceTaskId | string (minLen 1) | Source task that caused the pain |
| sourcePainId | string (minLen 1) | Pain signal ID (top-level, not buried in painContext) |
| sourceRunIds | string[] | Run IDs from source task |
| capturedAt | ISO timestamp | When the trace was captured |
| sourceRefs | { kind: SourceRefKind, id: string }[] | Structured references to task/run/artifact/event |
| timeline | TraceTimelineEntry[] | Structured execution timeline |
| ambiguityNotes | string[] | PRI-189 missing/mismatch/ambiguous diagnostics |
| sanitizationNotes | string[] | PII redaction audit trail |

### TraceTimelineEntry
| Field | Type | Purpose |
|-------|------|---------|
| at | string or null | ISO timestamp or null |
| kind | TraceEventKind | tool_call, tool_result, assistant_message, user_message, system_event, unknown |
| summary | string | Human-readable summary |
| rawPreview | string? | Optional sanitized raw content |
| metadata | Record? | Optional structured data (toolName, status, error) |

### TraceEventKind (enum)
`tool_call` | `tool_result` | `assistant_message` | `user_message` | `system_event` | `unknown`

### SourceRefKind (enum)
`task` | `run` | `artifact` | `event`

## How no-fallback-to-Diagnostician-runs is guaranteed

1. `buildFullTraceV2()` validates the payload with `validateFullTracePayload()` before returning
2. If validation fails, it pushes an ambiguity note and returns `null`
3. The assembler never falls back to Diagnostician task runs for fullTrace
4. `sourcePainId` is required — missing means `fullTrace` is `null`
5. The `fullTrace` field in `DiagnosticianContextPayload` is `Type.Optional(Type.Union([V1, V2, Null]))` — consumers already handle the missing case

## Sanitizer / ambiguityNotes behavior

- `sanitizeFullTracePayload()` scans all timeline entries for secret patterns (apiKey, token, bearer, authorization, password, secret)
- Redacted keys are recorded in `sanitizationNotes` with path (e.g., `timeline[0].metadata.api_key`)
- Pre-existing `sanitizationNotes` are preserved (appended, not replaced)
- `ambiguityNotes` from SourceTraceLocator are preserved verbatim in the V2 payload
- Safe keys like `tokenizer`, `tokenCount` are NOT over-sanitized

## Test Commands and Results

```bash
npm run build --workspace=@principles/core  # Passes
npm run lint                                  # Passes
npx vitest run src/runtime-v2/__tests__/full-trace-contract.test.ts  # 44 tests
npx vitest run src/runtime-v2/store/context/sqlite-context-assembler.test.ts  # 29 tests
npx vitest run src/runtime-v2/store/trajectory/source-trace-locator.test.ts  # 15 tests
npx vitest run src/runtime-v2/__tests__/architecture-regression.test.ts  # 378 tests
# Total: 466 tests passed
```

## Explicitly NOT implemented (out of scope)

- TraceRefiner
- TraceRefinerAgent
- GoldenTrace
- LLM integration
- DiagnosticianOutputV1 changes
- Plugin hook changes
- PRI-191/192/193

Closes PRI-190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入 FullTrace V2 支持，增加结构化追踪载荷的验证、清洗与时间线/来源引用构建并对外暴露相关能力。

* **测试**
  * 新增/扩展 FullTrace V2 的端到端质量契约测试，覆盖校验、脱敏、时间线与来源引用场景及边界条件。

* **重构**
  * 将现有追踪构建与组装逻辑迁移到 V2 实现并移除旧实现触点。

* **杂项**
  * 更新插件构建指纹信息。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->