### PR TITLE
feat(core): add deterministic TraceRefiner read model (PRI-191)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ If a code review catches your error, record it in the handbook and tag the Linea
 5. **No `any`**: Use `unknown` for truly unknown types. Strict TypeScript mode.
 6. **No AI merge**: Never use `gh pr merge` or auto-merge PRs. User must merge manually.
 7. **Conventional commits**: `feat()`, `fix()`, `docs()`, `refactor()`, `test()`, `chore()`.
+8. **MANDATORY: Check PR comments first**: When asked to review/fix an existing PR, **FIRST** fetch and read **all PR comments/reviews** before doing ANY work. Retry at least 2 times if GitHub API fails. If no other way, ask user to copy-paste PR comments.
 
 ## Build & Test
 

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -159,11 +159,23 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-006]** | Missed Codex PR review comments due to API failure + no retry
+
+- **What happened**: When asked to use `pr-review` skill on an existing PR, GitHub API calls timed out and I skipped checking for PR comments completely. Missed critical Codex review feedback on type safety issues that were already identified on the PR.
+- **Why it's wrong**: The PR already had the review information available, but I failed to persistently retrieve it. This caused duplicate work and delayed fixing an issue that was already found.
+- **Correct approach**: When working on an existing PR, **ALWAYS** try multiple ways to get PR comments/reviews (retry API, ask user, check git log). Never skip this critical step.
+- **How to prevent**: Added Rule #8 in AGENTS.md. When asked to review/fix an existing PR, FIRST fetch all comments/reviews before doing any work. Retry API at least twice, or ask user to paste comments.
+- **Source**: PRI-191 / PR #637
+- **Date**: 2026-05-19
+- **Recurrence**: No
+
+---
+
 ## Statistics
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 5 |
+| Total lessons | 6 |
 | Last updated | 2026-05-19 |
 | Top category | Schema & Type |
 | Recurring errors | 1 |

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -63,6 +63,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-001 | `as string` cast on untrusted JSON bypasses runtime validation | PRI-189 |
 | ERR-003 | PII sanitizer uses `includes()` substring matching causing false-positive over-sanitization | PRI-171 |
 | ERR-004 | `sourceTaskId` set to diagnostician task ID instead of located source task ID | PRI-190 |
+| ERR-005 | Invalid salvaged arrays bypass type contract in validate failure path | PRI-191 |
 
 ---
 
@@ -146,11 +147,23 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-005]** | Invalid salvaged arrays bypass type contract in validate failure path
+
+- **What happened**: In `refineFullTrace()` validation failure path, `sourceRunIds`, `ambiguityNotes`, `sanitizationNotes` only checked `Array.isArray()` then used `as string[]` cast without validating element types. For invalid FullTrace JSON like `sourceRunIds: [42]`, this returned a `RefinedTracePayload` whose arrays violated the `string[]` contract, reintroducing the same untrusted-JSON problem the FullTrace contract was meant to avoid.
+- **Why it's wrong**: `as string[]` is a compile-time assertion with zero runtime validation. When parsing untrusted JSON, a cast alone doesn't make elements strings. This would have caused downstream consumers expecting `string[]` to fail silently or incorrectly.
+- **Correct approach**: When salvaging arrays from invalid JSON, filter elements with `(v): v is string => typeof v === 'string'` to keep only valid strings, otherwise return empty array.
+- **How to prevent**: Never use `as` array type casts on untrusted JSON arrays without validating element types first. Always apply element-wise type guards when preserving data from invalid payloads.
+- **Source**: PRI-191
+- **Date**: 2026-05-19
+- **Recurrence**: Yes - similar pattern to ERR-001 where `as` bypassed validation
+
+---
+
 ## Statistics
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 4 |
+| Total lessons | 5 |
 | Last updated | 2026-05-19 |
 | Top category | Schema & Type |
-| Recurring errors | 0 |
+| Recurring errors | 1 |

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -138,6 +138,8 @@ const REQUIRED_SOURCE_FILES = [
   'store/trajectory/sqlite-source-trace-locator.ts',
   // PRI-190
   'full-trace-contract.ts',
+  // PRI-191
+  'trace-refiner.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -191,6 +193,8 @@ const REQUIRED_TEST_FILES = [
   '../activation/__tests__/sqlite-approval-store.test.ts',
   // PRI-190
   'full-trace-contract.test.ts',
+  // PRI-191
+  'trace-refiner.test.ts',
 ];
 
 const REQUIRED_DOC_FILES: string[] = [];
@@ -2839,6 +2843,52 @@ describe('PRI-190 FullTrace quality contract boundary', () => {
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'context-payload.ts'), 'utf-8');
     expect(src).toContain('FullTracePayloadV2Schema');
+  });
+});
+
+describe('PRI-191 TraceRefiner read model boundary', () => {
+  it('trace-refiner.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'trace-refiner.ts'), 'utf-8');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('node:path');
+    expect(src).not.toContain('node:process');
+    expect(src).not.toContain('openclaw-plugin');
+  });
+
+  it('trace-refiner.ts has no LLM or network imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'trace-refiner.ts'), 'utf-8');
+    expect(src).not.toContain('node:http');
+    expect(src).not.toContain('node:https');
+    expect(src).not.toContain('node:net');
+    expect(src).not.toContain('fetch(');
+    expect(src).not.toContain('openai');
+    expect(src).not.toContain('anthropic');
+  });
+
+  it('core barrel exports refineFullTrace and RefinedTracePayload', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('refineFullTrace');
+    expect(src).toContain('RefinedTracePayload');
+    expect(src).toContain('RefinedTraceEvent');
+    expect(src).toContain('TraceRefinerOptions');
+    expect(src).toContain('REFINED_EVENT_KINDS');
+    expect(src).toContain('SEVERITY_LEVELS');
+  });
+
+  it('trace-refiner.ts imports only from full-trace-contract', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'trace-refiner.ts'), 'utf-8');
+    const importLines = src.split('\n').filter((line) => line.trim().startsWith('import'));
+    for (const line of importLines) {
+      expect(line).toContain('full-trace-contract');
+    }
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
@@ -451,6 +451,27 @@ describe('refineFullTrace: invalid input handling', () => {
     expect(result.ambiguityNotes).toContain('some ambiguity');
     expect(result.refinementNotes).toContain('invalid_full_trace_input');
   });
+
+  it('partially valid input with non-string array elements filters safely to maintain type contract', () => {
+    const partial = {
+      sourceTaskId: 'task_001',
+      sourcePainId: 'pain-001',
+      sourceRunIds: ['valid-run', 42, 'another-run', true], // mix of valid and invalid types
+      capturedAt: 'not-a-date',
+      sourceRefs: [],
+      timeline: [],
+      ambiguityNotes: ['valid note', null, 123],
+      sanitizationNotes: [{ invalid: 'object' }, 'sanitized'],
+    } as unknown as FullTracePayloadV2;
+
+    const result = refineFullTrace(partial);
+
+    // Only string elements should survive
+    expect(result.sourceRunIds).toEqual(['valid-run', 'another-run']);
+    expect(result.ambiguityNotes).toEqual(['valid note']);
+    expect(result.sanitizationNotes).toEqual(['sanitized']);
+    expect(result.refinementNotes).toContain('invalid_full_trace_input');
+  });
 });
 
 // ── Evidence Refs / Source Lineage ──

--- a/packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
@@ -1,0 +1,573 @@
+/**
+ * TraceRefiner read model tests (PRI-191).
+ *
+ * TDD tests for:
+ *   - refineFullTrace: deterministic FullTracePayloadV2 → RefinedTracePayload
+ *   - Failure extraction from timeline
+ *   - Tool use extraction
+ *   - User intent extraction
+ *   - Empty timeline handling
+ *   - Sanitized trace handling
+ *   - Ambiguity notes preservation
+ *   - Unrecognized JSON shape timeline entries
+ *   - Output size bounding
+ *   - Deterministic output
+ *   - Invalid input handling
+ */
+import { describe, it, expect } from 'vitest';
+import { refineFullTrace } from '../trace-refiner.js';
+import type { FullTracePayloadV2 } from '../full-trace-contract.js';
+
+function makeValidPayload(overrides?: Partial<FullTracePayloadV2>): FullTracePayloadV2 {
+  return {
+    sourceTaskId: 'task_src_001',
+    sourcePainId: 'pain-001',
+    sourceRunIds: ['run_001', 'run_002'],
+    capturedAt: '2026-05-19T00:00:00Z',
+    sourceRefs: [
+      { kind: 'task', id: 'task_src_001' },
+      { kind: 'run', id: 'run_001' },
+      { kind: 'run', id: 'run_002' },
+    ],
+    timeline: [
+      { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'User asked to fix bug' },
+      { at: '2026-05-19T00:00:01Z', kind: 'tool_call', summary: 'Read (succeeded)', metadata: { toolName: 'Read', status: 'succeeded' } },
+      { at: '2026-05-19T00:00:02Z', kind: 'tool_result', summary: 'Result from Read' },
+      { at: '2026-05-19T00:00:03Z', kind: 'assistant_message', summary: 'I fixed the bug' },
+    ],
+    ambiguityNotes: [],
+    sanitizationNotes: [],
+    ...overrides,
+  };
+}
+
+// ── Failure Extraction ──
+
+describe('refineFullTrace: failure extraction', () => {
+  it('tool error in metadata produces failure keyEvent and non-null failureSummary', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Write file', metadata: { toolName: 'Write', error: 'permission denied: /etc/hosts' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.failureSummary).not.toBeNull();
+    expect(result.keyEvents.some((e) => e.kind === 'failure')).toBe(true);
+    expect(result.keyEvents.find((e) => e.kind === 'failure')?.summary).toContain('Write file');
+  });
+
+  it('error keyword in summary produces failure keyEvent', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_result', summary: 'Error from Bash: command failed with exit code 1' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.failureSummary).not.toBeNull();
+    expect(result.keyEvents.some((e) => e.kind === 'failure')).toBe(true);
+  });
+
+  it('timeout in summary produces failure keyEvent', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_result', summary: 'Operation timed out after 30s' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.failureSummary).not.toBeNull();
+    expect(result.keyEvents.some((e) => e.kind === 'failure')).toBe(true);
+  });
+
+  it('exception in summary produces failure keyEvent', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'unknown', summary: 'Unhandled exception in worker thread' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.failureSummary).not.toBeNull();
+    expect(result.keyEvents.some((e) => e.kind === 'failure')).toBe(true);
+  });
+
+  it('failed tool status produces failure keyEvent', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Edit file', metadata: { toolName: 'Edit', status: 'failed' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.keyEvents.some((e) => e.kind === 'failure')).toBe(true);
+  });
+
+  it('failure severity is high for fatal/crash errors', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_result', summary: 'Fatal crash occurred', metadata: { error: 'fatal: process crashed' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const failureEvent = result.keyEvents.find((e) => e.kind === 'failure');
+    expect(failureEvent).toBeDefined();
+    if (failureEvent) {
+      expect(failureEvent.severity).toBe('high');
+    }
+  });
+
+  it('failure severity is medium for timeout/permission errors', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_result', summary: 'Timeout occurred', metadata: { error: 'timeout: operation exceeded 30s' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const failureEvent = result.keyEvents.find((e) => e.kind === 'failure');
+    expect(failureEvent).toBeDefined();
+    if (failureEvent) {
+      expect(failureEvent.severity).toBe('medium');
+    }
+  });
+});
+
+// ── Tool Use Extraction ──
+
+describe('refineFullTrace: tool use extraction', () => {
+  it('tool_call/tool_result timeline produces toolUseSummary with tool names', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Read (succeeded)', metadata: { toolName: 'Read', status: 'succeeded' } },
+        { at: '2026-05-19T00:00:01Z', kind: 'tool_result', summary: 'Result from Read', metadata: { toolName: 'Read' } },
+        { at: '2026-05-19T00:00:02Z', kind: 'tool_call', summary: 'Edit (succeeded)', metadata: { toolName: 'Edit', status: 'succeeded' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.toolUseSummary).toContain('Read (succeeded)');
+    expect(result.toolUseSummary).toContain('Edit (succeeded)');
+  });
+
+  it('tool_use keyEvents have low severity when succeeded', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Read (succeeded)', metadata: { toolName: 'Read', status: 'succeeded' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const toolEvent = result.keyEvents.find((e) => e.kind === 'tool_use');
+    expect(toolEvent).toBeDefined();
+    if (toolEvent) {
+      expect(toolEvent.severity).toBe('low');
+    }
+  });
+
+  it('tool_use keyEvents have evidenceRefs', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Read', metadata: { toolName: 'Read' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const toolEvent = result.keyEvents.find((e) => e.kind === 'tool_use');
+    expect(toolEvent).toBeDefined();
+    if (toolEvent) {
+      expect(toolEvent.evidenceRefs.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── User Intent Extraction ──
+
+describe('refineFullTrace: user intent extraction', () => {
+  it('user_message timeline produces non-null userIntentSummary', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'Fix the authentication bug' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.userIntentSummary).not.toBeNull();
+    expect(result.userIntentSummary).toBe('Fix the authentication bug');
+  });
+
+  it('user_intent keyEvent is produced', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'Refactor the module' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.keyEvents.some((e) => e.kind === 'user_intent')).toBe(true);
+  });
+
+  it('only first user_message becomes userIntentSummary', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'First message' },
+        { at: '2026-05-19T00:00:01Z', kind: 'user_message', summary: 'Second message' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.userIntentSummary).toBe('First message');
+    expect(result.keyEvents.filter((e) => e.kind === 'user_intent').length).toBe(2);
+  });
+});
+
+// ── Empty Timeline ──
+
+describe('refineFullTrace: empty timeline', () => {
+  it('empty timeline produces valid refined payload with empty_timeline refinementNote', () => {
+    const payload = makeValidPayload({ timeline: [] });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.sourceTaskId).toBe('task_src_001');
+    expect(result.sourcePainId).toBe('pain-001');
+    expect(result.keyEvents).toEqual([]);
+    expect(result.failureSummary).toBeNull();
+    expect(result.toolUseSummary).toEqual([]);
+    expect(result.userIntentSummary).toBeNull();
+    expect(result.refinementNotes).toContain('empty_timeline');
+  });
+});
+
+// ── Sanitized Trace ──
+
+describe('refineFullTrace: sanitized trace', () => {
+  it('sanitizationNotes are preserved in refined output', () => {
+    const payload = makeValidPayload({
+      sanitizationNotes: ['timeline[0].summary: secret pattern redacted'],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.sanitizationNotes).toContain('timeline[0].summary: secret pattern redacted');
+    expect(result.refinementNotes).toContain('sanitized_input_present');
+  });
+});
+
+// ── Ambiguity Notes ──
+
+describe('refineFullTrace: ambiguity notes', () => {
+  it('ambiguityNotes are preserved in refined output', () => {
+    const notes = [
+      'Ambiguous source trace for sourcePainId=pain-001: 2 matched candidates',
+      'diagnostic_json_unparseable for taskIds: task_003',
+    ];
+    const payload = makeValidPayload({ ambiguityNotes: notes });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.ambiguityNotes).toEqual(notes);
+    expect(result.refinementNotes).toContain('source_trace_ambiguous');
+  });
+});
+
+// ── Unrecognized JSON Shape ──
+
+describe('refineFullTrace: unrecognized JSON shape timeline', () => {
+  it('unknown timeline entries become unknown/system_context keyEvents', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'unknown', summary: '{"prompt":"fix bug"}', metadata: { parseStatus: 'unrecognized_json_shape' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const unknownEvent = result.keyEvents.find((e) => e.kind === 'unknown');
+    expect(unknownEvent).toBeDefined();
+    if (unknownEvent) {
+      expect(unknownEvent.summary).toContain('prompt');
+    }
+  });
+
+  it('system_event timeline becomes system_context keyEvent', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'system_event', summary: 'Session started' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const systemEvent = result.keyEvents.find((e) => e.kind === 'system_context');
+    expect(systemEvent).toBeDefined();
+    if (systemEvent) {
+      expect(systemEvent.summary).toBe('Session started');
+    }
+  });
+});
+
+// ── Output Size Bounding ──
+
+describe('refineFullTrace: output size bounding', () => {
+  it('keyEvents exceeding max are truncated with refinementNote', () => {
+    const timeline = Array.from({ length: 25 }, (_, i) => ({
+      at: `2026-05-19T00:00:${String(i).padStart(2, '0')}Z`,
+      kind: 'tool_call' as const,
+      summary: `Tool call ${i}`,
+      metadata: { toolName: `Tool${i}` },
+    }));
+    const payload = makeValidPayload({ timeline });
+
+    const result = refineFullTrace(payload, { maxKeyEvents: 20 });
+
+    expect(result.keyEvents.length).toBe(20);
+    expect(result.refinementNotes.some((n) => n.startsWith('truncated_key_events'))).toBe(true);
+  });
+
+  it('summary is truncated when exceeding maxSummaryLength', () => {
+    const longSummary = 'A'.repeat(500);
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: longSummary },
+      ],
+    });
+
+    const result = refineFullTrace(payload, { maxSummaryLength: 300 });
+
+    const userEvent = result.keyEvents.find((e) => e.kind === 'user_intent');
+    expect(userEvent).toBeDefined();
+    if (userEvent) {
+      expect(userEvent.summary.length).toBeLessThanOrEqual(300);
+    }
+  });
+
+  it('default maxKeyEvents is 20', () => {
+    const timeline = Array.from({ length: 25 }, (_, i) => ({
+      at: `2026-05-19T00:00:${String(i).padStart(2, '0')}Z`,
+      kind: 'tool_call' as const,
+      summary: `Tool call ${i}`,
+      metadata: { toolName: `Tool${i}` },
+    }));
+    const payload = makeValidPayload({ timeline });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.keyEvents.length).toBe(20);
+  });
+});
+
+// ── Deterministic Output ──
+
+describe('refineFullTrace: deterministic output', () => {
+  it('same input produces deep-equal output', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'Fix bug' },
+        { at: '2026-05-19T00:00:01Z', kind: 'tool_call', summary: 'Read (succeeded)', metadata: { toolName: 'Read', status: 'succeeded' } },
+        { at: '2026-05-19T00:00:02Z', kind: 'tool_result', summary: 'Error from Read', metadata: { toolName: 'Read', error: 'file not found' } },
+      ],
+    });
+
+    const result1 = refineFullTrace(payload);
+    const result2 = refineFullTrace(payload);
+
+    expect(result1).toEqual(result2);
+  });
+
+  it('deterministic across different option objects with same values', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'Fix bug' },
+      ],
+    });
+
+    const result1 = refineFullTrace(payload, { maxKeyEvents: 10 });
+    const result2 = refineFullTrace(payload, { maxKeyEvents: 10 });
+
+    expect(result1).toEqual(result2);
+  });
+});
+
+// ── Invalid Input Handling ──
+
+describe('refineFullTrace: invalid input handling', () => {
+  it('invalid fullTrace returns structured refinementNotes, not random throw', () => {
+    const invalidPayload = {
+      sourceTaskId: '',
+      sourcePainId: '',
+      sourceRunIds: [],
+      capturedAt: 'not-a-date',
+      sourceRefs: [],
+      timeline: [],
+      ambiguityNotes: [],
+      sanitizationNotes: [],
+    } as unknown as FullTracePayloadV2;
+
+    const result = refineFullTrace(invalidPayload);
+
+    expect(result.refinementNotes).toContain('invalid_full_trace_input');
+    expect(result.refinementNotes.some((n) => n.startsWith('validation_error'))).toBe(true);
+    expect(result.keyEvents).toEqual([]);
+  });
+
+  it('null input returns structured error', () => {
+    const result = refineFullTrace(null as unknown as FullTracePayloadV2);
+
+    expect(result.refinementNotes).toContain('invalid_full_trace_input');
+  });
+
+  it('partially valid input preserves extractable fields', () => {
+    const partial = {
+      sourceTaskId: 'task_001',
+      sourcePainId: 'pain-001',
+      sourceRunIds: ['run_001'],
+      capturedAt: 'not-a-date',
+      sourceRefs: [],
+      timeline: [],
+      ambiguityNotes: ['some ambiguity'],
+      sanitizationNotes: [],
+    } as unknown as FullTracePayloadV2;
+
+    const result = refineFullTrace(partial);
+
+    expect(result.sourceTaskId).toBe('task_001');
+    expect(result.sourcePainId).toBe('pain-001');
+    expect(result.ambiguityNotes).toContain('some ambiguity');
+    expect(result.refinementNotes).toContain('invalid_full_trace_input');
+  });
+});
+
+// ── Evidence Refs / Source Lineage ──
+
+describe('refineFullTrace: evidence refs and source lineage', () => {
+  it('sourceTaskId/sourcePainId/sourceRunIds are preserved', () => {
+    const payload = makeValidPayload();
+
+    const result = refineFullTrace(payload);
+
+    expect(result.sourceTaskId).toBe('task_src_001');
+    expect(result.sourcePainId).toBe('pain-001');
+    expect(result.sourceRunIds).toEqual(['run_001', 'run_002']);
+  });
+
+  it('evidenceRefs are derived from sourceRefs', () => {
+    const payload = makeValidPayload({
+      sourceRefs: [
+        { kind: 'task', id: 'task_src_001' },
+        { kind: 'run', id: 'run_001' },
+        { kind: 'run', id: 'run_002' },
+        { kind: 'artifact', id: 'artifact_log_001' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.evidenceRefs).toContain('task:task_src_001');
+    expect(result.evidenceRefs).toContain('run:run_001');
+    expect(result.evidenceRefs).toContain('artifact:artifact_log_001');
+  });
+
+  it('keyEvents carry evidenceRefs', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Read', metadata: { toolName: 'Read' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    for (const event of result.keyEvents) {
+      expect(event.evidenceRefs.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── No Failure Evidence Note ──
+
+describe('refineFullTrace: no failure evidence note', () => {
+  it('non-empty timeline without failures produces no_failure_evidence refinementNote', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'Hello' },
+        { at: '2026-05-19T00:00:01Z', kind: 'assistant_message', summary: 'Hi there' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.refinementNotes).toContain('no_failure_evidence');
+    expect(result.failureSummary).toBeNull();
+  });
+});
+
+// ── Assistant Action ──
+
+describe('refineFullTrace: assistant action', () => {
+  it('assistant_message produces assistant_action keyEvent', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'assistant_message', summary: 'I will fix the bug now' },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.keyEvents.some((e) => e.kind === 'assistant_action')).toBe(true);
+    expect(result.keyEvents.find((e) => e.kind === 'assistant_action')?.summary).toBe('I will fix the bug now');
+  });
+});
+
+// ── Combined Scenario ──
+
+describe('refineFullTrace: combined scenario', () => {
+  it('full trace with mixed events produces correct refined output', () => {
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'user_message', summary: 'Fix the login bug' },
+        { at: '2026-05-19T00:00:01Z', kind: 'tool_call', summary: 'Read (succeeded)', metadata: { toolName: 'Read', status: 'succeeded' } },
+        { at: '2026-05-19T00:00:02Z', kind: 'tool_result', summary: 'Result from Read' },
+        { at: '2026-05-19T00:00:03Z', kind: 'tool_call', summary: 'Edit (failed)', metadata: { toolName: 'Edit', status: 'failed', error: 'permission denied' } },
+        { at: '2026-05-19T00:00:04Z', kind: 'assistant_message', summary: 'The edit was not applied due to permissions' },
+        { at: '2026-05-19T00:00:05Z', kind: 'system_event', summary: 'Session initialized' },
+        { at: '2026-05-19T00:00:06Z', kind: 'unknown', summary: '{"raw":"data"}' },
+      ],
+      ambiguityNotes: ['Multiple candidates found'],
+      sanitizationNotes: ['timeline[3].metadata: secret key redacted'],
+    });
+
+    const result = refineFullTrace(payload);
+
+    expect(result.sourceTaskId).toBe('task_src_001');
+    expect(result.sourcePainId).toBe('pain-001');
+    expect(result.failureSummary).not.toBeNull();
+    expect(result.failureSummary).toContain('permission denied');
+    expect(result.toolUseSummary.length).toBeGreaterThanOrEqual(2);
+    expect(result.userIntentSummary).toBe('Fix the login bug');
+    expect(result.ambiguityNotes).toEqual(['Multiple candidates found']);
+    expect(result.sanitizationNotes).toEqual(['timeline[3].metadata: secret key redacted']);
+    expect(result.refinementNotes).toContain('sanitized_input_present');
+    expect(result.refinementNotes).toContain('source_trace_ambiguous');
+    expect(result.keyEvents.some((e) => e.kind === 'failure')).toBe(true);
+    expect(result.keyEvents.some((e) => e.kind === 'tool_use')).toBe(true);
+    expect(result.keyEvents.some((e) => e.kind === 'user_intent')).toBe(true);
+    expect(result.keyEvents.some((e) => e.kind === 'assistant_action')).toBe(true);
+    expect(result.keyEvents.some((e) => e.kind === 'system_context')).toBe(true);
+    expect(result.keyEvents.some((e) => e.kind === 'unknown')).toBe(true);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
@@ -191,6 +191,61 @@ describe('refineFullTrace: tool use extraction', () => {
       expect(toolEvent.evidenceRefs.length).toBeGreaterThan(0);
     }
   });
+
+  it('tool event evidenceRefs include all run refs, not just the first', () => {
+    const payload = makeValidPayload({
+      sourceRefs: [
+        { kind: 'task', id: 'task_src_001' },
+        { kind: 'run', id: 'run_001' },
+        { kind: 'run', id: 'run_002' },
+        { kind: 'run', id: 'run_003' },
+      ],
+      sourceRunIds: ['run_001', 'run_002', 'run_003'],
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Read', metadata: { toolName: 'Read' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload);
+
+    const toolEvent = result.keyEvents.find((e) => e.kind === 'tool_use');
+    expect(toolEvent).toBeDefined();
+    if (toolEvent) {
+      expect(toolEvent.evidenceRefs).toContain('run:run_001');
+      expect(toolEvent.evidenceRefs).toContain('run:run_002');
+      expect(toolEvent.evidenceRefs).toContain('run:run_003');
+    }
+  });
+
+  it('toolUseSummary is truncated when toolName exceeds maxSummaryLength', () => {
+    const longToolName = 'A'.repeat(500);
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Call', metadata: { toolName: longToolName, status: 'succeeded' } },
+      ],
+    });
+
+    const result = refineFullTrace(payload, { maxSummaryLength: 300 });
+
+    for (const entry of result.toolUseSummary) {
+      expect(entry.length).toBeLessThanOrEqual(300);
+    }
+  });
+
+  it('toolUseSummary is truncated when status exceeds maxSummaryLength', () => {
+    const longStatus = 'S'.repeat(500);
+    const payload = makeValidPayload({
+      timeline: [
+        { at: '2026-05-19T00:00:00Z', kind: 'tool_call', summary: 'Call', metadata: { toolName: 'Read', status: longStatus } },
+      ],
+    });
+
+    const result = refineFullTrace(payload, { maxSummaryLength: 300 });
+
+    for (const entry of result.toolUseSummary) {
+      expect(entry.length).toBeLessThanOrEqual(300);
+    }
+  });
 });
 
 // ── User Intent Extraction ──

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -27,6 +27,9 @@ export { PDTaskStatusSchema, TaskRecordSchema, DiagnosticianTaskRecordSchema } f
 export { RuntimeSelectionCriteriaSchema } from './runtime-selector.js';
 // Context payload schemas (Phase 2)
 export { HistoryQueryEntrySchema, TrajectoryLocateQuerySchema, TrajectoryCandidateSchema, TrajectoryLocateResultSchema, HistoryQueryResultSchema, DiagnosisTargetSchema, ContextPayloadSchema, DiagnosticianContextPayloadSchema, ToolCallEntrySchema, PainContextSchema, FullTracePayloadSchema, FullTracePayloadV2Schema, TraceSourceRefSchema, TraceTimelineEntrySchema, TraceEventKindSchema, SourceRefKindSchema, validateFullTracePayload, sanitizeFullTracePayload, buildFullTraceTimeline, buildSourceRefs, checkFullTracePayloadSchema, TRACE_EVENT_KINDS, SOURCE_REF_KINDS } from './context-payload.js';
+// Trace refiner (PRI-191)
+export { refineFullTrace, REFINED_EVENT_KINDS, SEVERITY_LEVELS } from './trace-refiner.js';
+export type { RefinedTraceEvent, RefinedEventKind, RefinedTracePayload, SeverityLevel, TraceRefinerOptions } from './trace-refiner.js';
 // Diagnostician output schemas (Phase 2)
 export { DiagnosticianViolatedPrincipleSchema, DiagnosticianEvidenceSchema, RecommendationKindSchema, DiagnosticianRecommendationSchema, DiagnosticianOutputV1Schema, DiagnosticianInvocationInputSchema } from './diagnostician-output.js';
 // Principle tree types schemas

--- a/packages/principles-core/src/runtime-v2/trace-refiner.ts
+++ b/packages/principles-core/src/runtime-v2/trace-refiner.ts
@@ -200,17 +200,29 @@ export function refineFullTrace(
   const validation = validateFullTracePayload(fullTrace);
   if (!validation.valid) {
     const p = fullTrace as Record<string, unknown>;
+    
+    // Validate that salvaged arrays contain only string elements to maintain type contract
+    const safeSourceRunIds = Array.isArray(p.sourceRunIds) 
+      ? p.sourceRunIds.filter((v): v is string => typeof v === 'string') 
+      : [];
+    const safeAmbiguityNotes = Array.isArray(p.ambiguityNotes) 
+      ? p.ambiguityNotes.filter((v): v is string => typeof v === 'string') 
+      : [];
+    const safeSanitizationNotes = Array.isArray(p.sanitizationNotes) 
+      ? p.sanitizationNotes.filter((v): v is string => typeof v === 'string') 
+      : [];
+    
     return {
       sourceTaskId: typeof p.sourceTaskId === 'string' ? p.sourceTaskId : '',
       sourcePainId: typeof p.sourcePainId === 'string' ? p.sourcePainId : '',
-      sourceRunIds: Array.isArray(p.sourceRunIds) ? (p.sourceRunIds as string[]) : [],
+      sourceRunIds: safeSourceRunIds,
       evidenceRefs: [],
       keyEvents: [],
       failureSummary: null,
       toolUseSummary: [],
       userIntentSummary: null,
-      ambiguityNotes: Array.isArray(p.ambiguityNotes) ? (p.ambiguityNotes as string[]) : [],
-      sanitizationNotes: Array.isArray(p.sanitizationNotes) ? (p.sanitizationNotes as string[]) : [],
+      ambiguityNotes: safeAmbiguityNotes,
+      sanitizationNotes: safeSanitizationNotes,
       refinementNotes: [
         'invalid_full_trace_input',
         ...validation.errors.map((e) => `validation_error: ${e}`),

--- a/packages/principles-core/src/runtime-v2/trace-refiner.ts
+++ b/packages/principles-core/src/runtime-v2/trace-refiner.ts
@@ -252,8 +252,8 @@ export function refineFullTrace(
 
     const toolName = extractToolName(entry);
     if (toolName) {
-      const runRef = fullTrace.sourceRefs.find((r) => r.kind === 'run');
-      if (runRef) entryEvidenceRefs.push(sourceRefToString(runRef));
+      const runRefs = fullTrace.sourceRefs.filter((r) => r.kind === 'run');
+      for (const ref of runRefs) entryEvidenceRefs.push(sourceRefToString(ref));
     }
     if (entryEvidenceRefs.length === 0 && evidenceRefs.length > 0) {
       entryEvidenceRefs.push(...evidenceRefs);
@@ -278,11 +278,10 @@ export function refineFullTrace(
 
     if (refinedKind === 'tool_use') {
       const status = extractToolStatus(entry);
-      if (toolName) {
-        toolUseSummaries.push(status ? `${toolName} (${status})` : toolName);
-      } else {
-        toolUseSummaries.push(status ? `unknown_tool (${status})` : 'unknown_tool');
-      }
+      const toolSummary = toolName
+        ? (status ? `${toolName} (${status})` : toolName)
+        : (status ? `unknown_tool (${status})` : 'unknown_tool');
+      toolUseSummaries.push(truncateSummary(toolSummary, maxSummaryLength));
     }
 
     if (refinedKind === 'user_intent' && userIntentText === null) {

--- a/packages/principles-core/src/runtime-v2/trace-refiner.ts
+++ b/packages/principles-core/src/runtime-v2/trace-refiner.ts
@@ -1,0 +1,320 @@
+/**
+ * Deterministic TraceRefiner read model (PRI-191).
+ *
+ * Converts FullTracePayloadV2 into a compact, evidence-preserving,
+ * prompt-safe RefinedTracePayload for Diagnostician / GoldenTrace consumption.
+ *
+ * Key invariants:
+ *   - Deterministic: same input always produces deep-equal output
+ *   - No LLM calls, no I/O, no filesystem/path/process/network imports
+ *   - No plugin dependency
+ *   - Preserves sourceTaskId/sourcePainId/sourceRunIds lineage
+ *   - Preserves evidenceRefs from sourceRefs
+ *   - Bounded output: keyEvents max 20, summary max 300 chars
+ *   - Invalid input returns structured refinementNotes, never throws randomly
+ *   - Does not modify FullTracePayloadV2 contract
+ */
+import type { FullTracePayloadV2, TraceTimelineEntry, TraceSourceRef } from './full-trace-contract.js';
+import { validateFullTracePayload } from './full-trace-contract.js';
+
+// ── Refined Trace Event ──
+
+export const REFINED_EVENT_KINDS = [
+  'failure',
+  'tool_use',
+  'user_intent',
+  'assistant_action',
+  'system_context',
+  'unknown',
+] as const;
+
+export type RefinedEventKind = (typeof REFINED_EVENT_KINDS)[number];
+
+export const SEVERITY_LEVELS = ['low', 'medium', 'high'] as const;
+export type SeverityLevel = (typeof SEVERITY_LEVELS)[number];
+
+export interface RefinedTraceEvent {
+  kind: RefinedEventKind;
+  summary: string;
+  evidenceRefs: string[];
+  severity: SeverityLevel;
+  at: string | null;
+}
+
+// ── Refined Trace Payload ──
+
+export interface RefinedTracePayload {
+  sourceTaskId: string;
+  sourcePainId: string;
+  sourceRunIds: string[];
+  evidenceRefs: string[];
+  keyEvents: RefinedTraceEvent[];
+  failureSummary: string | null;
+  toolUseSummary: string[];
+  userIntentSummary: string | null;
+  ambiguityNotes: string[];
+  sanitizationNotes: string[];
+  refinementNotes: string[];
+}
+
+// ── Options ──
+
+export interface TraceRefinerOptions {
+  maxKeyEvents?: number;
+  maxSummaryLength?: number;
+}
+
+const DEFAULT_MAX_KEY_EVENTS = 20;
+const DEFAULT_MAX_SUMMARY_LENGTH = 300;
+
+// ── Failure Signal Detection ──
+
+const FAILURE_SIGNALS = [
+  'error',
+  'failed',
+  'exception',
+  'timeout',
+  'timed out',
+  'permission denied',
+  'denied',
+  'crashed',
+  'fatal',
+  'abort',
+  'unreachable',
+];
+
+function containsFailureSignal(text: string): boolean {
+  const lower = text.toLowerCase();
+  return FAILURE_SIGNALS.some((signal) => lower.includes(signal));
+}
+
+function extractMetadataError(entry: TraceTimelineEntry): string | undefined {
+  if (!entry.metadata || typeof entry.metadata !== 'object') return undefined;
+  const meta = entry.metadata as Record<string, unknown>;
+  if (typeof meta.error === 'string' && meta.error.length > 0) return meta.error;
+  if (typeof meta.error === 'object' && meta.error !== null) {
+    try { return JSON.stringify(meta.error); } catch { return undefined; }
+  }
+  return undefined;
+}
+
+function extractToolName(entry: TraceTimelineEntry): string | undefined {
+  if (!entry.metadata || typeof entry.metadata !== 'object') return undefined;
+  const meta = entry.metadata as Record<string, unknown>;
+  if (typeof meta.toolName === 'string' && meta.toolName.length > 0) return meta.toolName;
+  return undefined;
+}
+
+function extractToolStatus(entry: TraceTimelineEntry): string | undefined {
+  if (!entry.metadata || typeof entry.metadata !== 'object') return undefined;
+  const meta = entry.metadata as Record<string, unknown>;
+  if (typeof meta.status === 'string' && meta.status.length > 0) return meta.status;
+  return undefined;
+}
+
+function sourceRefToString(ref: TraceSourceRef): string {
+  return `${ref.kind}:${ref.id}`;
+}
+
+function truncateSummary(summary: string, maxLength: number): string {
+  if (summary.length <= maxLength) return summary;
+  return summary.slice(0, maxLength - 3) + '...';
+}
+
+function classifySeverity(entry: TraceTimelineEntry, kind: RefinedEventKind): SeverityLevel {
+  if (kind === 'failure') {
+    const errorText = extractMetadataError(entry);
+    if (errorText) {
+      const lower = errorText.toLowerCase();
+      if (lower.includes('fatal') || lower.includes('crash')) return 'high';
+      if (lower.includes('timeout') || lower.includes('permission denied')) return 'medium';
+    }
+    return 'high';
+  }
+  if (kind === 'tool_use') {
+    const status = extractToolStatus(entry);
+    if (status) {
+      const lower = status.toLowerCase();
+      if (lower.includes('fail') || lower.includes('error')) return 'high';
+      if (lower.includes('partial') || lower.includes('timeout')) return 'medium';
+    }
+    return 'low';
+  }
+  if (kind === 'unknown') return 'low';
+  if (kind === 'system_context') return 'low';
+  return 'low';
+}
+
+function mapTimelineKindToRefinedKind(entry: TraceTimelineEntry): RefinedEventKind {
+  switch (entry.kind) {
+    case 'tool_call':
+    case 'tool_result':
+      return 'tool_use';
+    case 'user_message':
+      return 'user_intent';
+    case 'assistant_message':
+      return 'assistant_action';
+    case 'system_event':
+      return 'system_context';
+    case 'unknown':
+    default:
+      return 'unknown';
+  }
+}
+
+function isFailureEntry(entry: TraceTimelineEntry): boolean {
+  if (extractMetadataError(entry)) return true;
+  if (containsFailureSignal(entry.summary)) return true;
+  if (entry.rawPreview && containsFailureSignal(entry.rawPreview)) return true;
+  const status = extractToolStatus(entry);
+  if (status && containsFailureSignal(status)) return true;
+  return false;
+}
+
+// ── Main Refiner Function ──
+
+export function refineFullTrace(
+  fullTrace: FullTracePayloadV2,
+  options?: TraceRefinerOptions,
+): RefinedTracePayload {
+  const maxKeyEvents = options?.maxKeyEvents ?? DEFAULT_MAX_KEY_EVENTS;
+  const maxSummaryLength = options?.maxSummaryLength ?? DEFAULT_MAX_SUMMARY_LENGTH;
+  const refinementNotes: string[] = [];
+
+  if (fullTrace === null || fullTrace === undefined || typeof fullTrace !== 'object') {
+    return {
+      sourceTaskId: '',
+      sourcePainId: '',
+      sourceRunIds: [],
+      evidenceRefs: [],
+      keyEvents: [],
+      failureSummary: null,
+      toolUseSummary: [],
+      userIntentSummary: null,
+      ambiguityNotes: [],
+      sanitizationNotes: [],
+      refinementNotes: ['invalid_full_trace_input', 'validation_error: FullTracePayload must be an object'],
+    };
+  }
+
+  const validation = validateFullTracePayload(fullTrace);
+  if (!validation.valid) {
+    const p = fullTrace as Record<string, unknown>;
+    return {
+      sourceTaskId: typeof p.sourceTaskId === 'string' ? p.sourceTaskId : '',
+      sourcePainId: typeof p.sourcePainId === 'string' ? p.sourcePainId : '',
+      sourceRunIds: Array.isArray(p.sourceRunIds) ? (p.sourceRunIds as string[]) : [],
+      evidenceRefs: [],
+      keyEvents: [],
+      failureSummary: null,
+      toolUseSummary: [],
+      userIntentSummary: null,
+      ambiguityNotes: Array.isArray((fullTrace as Record<string, unknown>).ambiguityNotes)
+        ? ((fullTrace as Record<string, unknown>).ambiguityNotes as string[])
+        : [],
+      sanitizationNotes: Array.isArray((fullTrace as Record<string, unknown>).sanitizationNotes)
+        ? ((fullTrace as Record<string, unknown>).sanitizationNotes as string[])
+        : [],
+      refinementNotes: [
+        'invalid_full_trace_input',
+        ...validation.errors.map((e) => `validation_error: ${e}`),
+      ],
+    };
+  }
+
+  const { timeline } = fullTrace;
+  const evidenceRefs = fullTrace.sourceRefs.map(sourceRefToString);
+
+  if (timeline.length === 0) {
+    refinementNotes.push('empty_timeline');
+  }
+
+  const keyEvents: RefinedTraceEvent[] = [];
+  const toolUseSummaries: string[] = [];
+  const failureSummaries: string[] = [];
+  let userIntentText: string | null = null;
+
+  for (const entry of timeline) {
+    const isFailure = isFailureEntry(entry);
+    const refinedKind = isFailure ? 'failure' : mapTimelineKindToRefinedKind(entry);
+    const severity = classifySeverity(entry, refinedKind);
+
+    const summary = truncateSummary(entry.summary, maxSummaryLength);
+    const entryEvidenceRefs: string[] = [];
+
+    const toolName = extractToolName(entry);
+    if (toolName) {
+      const runRef = fullTrace.sourceRefs.find((r) => r.kind === 'run');
+      if (runRef) entryEvidenceRefs.push(sourceRefToString(runRef));
+    }
+    if (entryEvidenceRefs.length === 0 && evidenceRefs.length > 0) {
+      entryEvidenceRefs.push(...evidenceRefs);
+    }
+
+    keyEvents.push({
+      kind: refinedKind,
+      summary,
+      evidenceRefs: entryEvidenceRefs,
+      severity,
+      at: entry.at,
+    });
+
+    if (refinedKind === 'failure') {
+      const errorDetail = extractMetadataError(entry);
+      if (errorDetail) {
+        failureSummaries.push(truncateSummary(errorDetail, maxSummaryLength));
+      } else {
+        failureSummaries.push(summary);
+      }
+    }
+
+    if (refinedKind === 'tool_use') {
+      const status = extractToolStatus(entry);
+      if (toolName) {
+        toolUseSummaries.push(status ? `${toolName} (${status})` : toolName);
+      } else {
+        toolUseSummaries.push(status ? `unknown_tool (${status})` : 'unknown_tool');
+      }
+    }
+
+    if (refinedKind === 'user_intent' && userIntentText === null) {
+      userIntentText = truncateSummary(entry.summary, maxSummaryLength);
+    }
+  }
+
+  if (failureSummaries.length === 0 && timeline.length > 0) {
+    refinementNotes.push('no_failure_evidence');
+  }
+
+  if (fullTrace.sanitizationNotes.length > 0) {
+    refinementNotes.push('sanitized_input_present');
+  }
+
+  if (fullTrace.ambiguityNotes.length > 0) {
+    refinementNotes.push('source_trace_ambiguous');
+  }
+
+  let truncatedKeyEvents = keyEvents;
+  if (keyEvents.length > maxKeyEvents) {
+    truncatedKeyEvents = keyEvents.slice(0, maxKeyEvents);
+    refinementNotes.push(`truncated_key_events: ${keyEvents.length} total, kept ${maxKeyEvents}`);
+  }
+
+  const failureSummary = failureSummaries.length > 0
+    ? truncateSummary(failureSummaries.join('; '), maxSummaryLength)
+    : null;
+
+  return {
+    sourceTaskId: fullTrace.sourceTaskId,
+    sourcePainId: fullTrace.sourcePainId,
+    sourceRunIds: [...fullTrace.sourceRunIds],
+    evidenceRefs,
+    keyEvents: truncatedKeyEvents,
+    failureSummary,
+    toolUseSummary: toolUseSummaries,
+    userIntentSummary: userIntentText,
+    ambiguityNotes: [...fullTrace.ambiguityNotes],
+    sanitizationNotes: [...fullTrace.sanitizationNotes],
+    refinementNotes,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/trace-refiner.ts
+++ b/packages/principles-core/src/runtime-v2/trace-refiner.ts
@@ -209,12 +209,8 @@ export function refineFullTrace(
       failureSummary: null,
       toolUseSummary: [],
       userIntentSummary: null,
-      ambiguityNotes: Array.isArray((fullTrace as Record<string, unknown>).ambiguityNotes)
-        ? ((fullTrace as Record<string, unknown>).ambiguityNotes as string[])
-        : [],
-      sanitizationNotes: Array.isArray((fullTrace as Record<string, unknown>).sanitizationNotes)
-        ? ((fullTrace as Record<string, unknown>).sanitizationNotes as string[])
-        : [],
+      ambiguityNotes: Array.isArray(p.ambiguityNotes) ? (p.ambiguityNotes as string[]) : [],
+      sanitizationNotes: Array.isArray(p.sanitizationNotes) ? (p.sanitizationNotes as string[]) : [],
       refinementNotes: [
         'invalid_full_trace_input',
         ...validation.errors.map((e) => `validation_error: ${e}`),


### PR DESCRIPTION
## Why PRI-191 after PRI-190

PRI-190 established the FullTracePayloadV2 quality contract with sourceTaskId/sourcePainId/sourceRunIds, sourceRefs, structured timeline, ambiguityNotes, and sanitizationNotes. However, the raw FullTracePayloadV2 is too verbose and unstructured for the Diagnostician to consume directly. PRI-191 adds a deterministic read model that refines FullTracePayloadV2 into a compact, evidence-preserving, prompt-safe RefinedTracePayload.

## RefinedTracePayload Public Contract

\\\	s
interface RefinedTraceEvent {
  kind: 'failure' | 'tool_use' | 'user_intent' | 'assistant_action' | 'system_context' | 'unknown';
  summary: string;           // max 300 chars
  evidenceRefs: string[];    // sourceRefs lineage
  severity: 'low' | 'medium' | 'high';
  at: string | null;
}

interface RefinedTracePayload {
  sourceTaskId: string;
  sourcePainId: string;
  sourceRunIds: string[];
  evidenceRefs: string[];
  keyEvents: RefinedTraceEvent[];  // max 20, truncated with note
  failureSummary: string | null;
  toolUseSummary: string[];
  userIntentSummary: string | null;
  ambiguityNotes: string[];
  sanitizationNotes: string[];
  refinementNotes: string[];
}

function refineFullTrace(fullTrace: FullTracePayloadV2, options?: TraceRefinerOptions): RefinedTracePayload
\\\

## Deterministic / No LLM / No I/O Guarantees

- **Deterministic**: Same input always produces deep-equal output. No randomness, no LLM calls.
- **No I/O**: Zero imports of \
ode:fs\, \
ode:path\, \
ode:process\, \
ode:http\, \
ode:https\, \
ode:net\. No filesystem, network, or database access.
- **No plugin dependency**: Only imports from \ull-trace-contract.ts\ within core.
- **Architecture regression tests** guard all of the above.

## Evidence Refs / Source Lineage Preservation

- \sourceTaskId\, \sourcePainId\, \sourceRunIds\ are copied verbatim from FullTracePayloadV2.
- \videnceRefs\ are derived from \sourceRefs\ as \kind:id\ strings (e.g., \	ask:task_src_001\, \un:run_001\).
- Each \RefinedTraceEvent\ carries its own \videnceRefs\ array, preserving lineage per event.
- \mbiguityNotes\ and \sanitizationNotes\ are preserved as-is.

## Truncation and RefinementNotes Behavior

| Condition | refinementNote |
|---|---|
| Empty timeline | \mpty_timeline\ |
| No failure evidence found | \
o_failure_evidence\ |
| keyEvents exceed max (default 20) | \	runcated_key_events: N total, kept 20\ |
| Sanitization notes present | \sanitized_input_present\ |
| Ambiguity notes present | \source_trace_ambiguous\ |
| Invalid fullTrace input | \invalid_full_trace_input\ + \alidation_error: ...\ |

Summary strings are truncated to 300 chars with \...\ suffix.

## Test Commands and Results

\\\ash
npm run build --workspace=@principles/core
npx vitest run packages/principles-core/src/runtime-v2/__tests__/trace-refiner.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/full-trace-contract.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
\\\

All **470 tests pass** across 3 test files:
- trace-refiner.test.ts: 32 tests (failure extraction, tool use, user intent, empty timeline, sanitized trace, ambiguity notes, unrecognized JSON shape, output size bounding, deterministic output, invalid input, evidence refs, assistant action, combined scenario)
- full-trace-contract.test.ts: 54 tests (unchanged)
- architecture-regression.test.ts: 384 tests (4 new PRI-191 boundary guards added)

Pre-push verify:merge also passes (lint, build, typecheck all green).

## Not Implemented (Future PRI)

- **TraceRefinerAgent** (PRI-192): LLM-powered trace refinement built on this deterministic baseline
- **GoldenTrace** (PRI-193): Golden trace candidate generation from RefinedTracePayload
- **Diagnostician prompt integration**: Not modified in this PR
- **DiagnosticianOutputV1**: Not modified

Closes: Linear PRI-191