### PR TITLE
feat(core): build GoldenTrace candidates from refined traces (PRI-193)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -142,6 +142,8 @@ const REQUIRED_SOURCE_FILES = [
   'trace-refiner.ts',
   // PRI-192
   'trace-refiner-agent.ts',
+  // PRI-193
+  'golden-trace-candidate-builder.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -199,6 +201,8 @@ const REQUIRED_TEST_FILES = [
   'trace-refiner.test.ts',
   // PRI-192
   'trace-refiner-agent.test.ts',
+  // PRI-193
+  'golden-trace-candidate-builder.test.ts',
 ];
 
 const REQUIRED_DOC_FILES: string[] = [];

--- a/packages/principles-core/src/runtime-v2/__tests__/golden-trace-candidate-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/golden-trace-candidate-builder.test.ts
@@ -1,0 +1,753 @@
+import { describe, it, expect } from 'vitest';
+import { buildGoldenTraceCandidate } from '../golden-trace-candidate-builder.js';
+import type { FullTracePayloadV2 } from '../full-trace-contract.js';
+import type { RefinedTracePayload } from '../trace-refiner.js';
+import { validateGoldenTrace } from '../golden-trace.js';
+import { refineFullTrace } from '../trace-refiner.js';
+import { replayGoldenTrace } from '../golden-trace-replay-validator.js';
+
+function makeFullTrace(overrides: Partial<FullTracePayloadV2> = {}): FullTracePayloadV2 {
+  return {
+    sourceTaskId: 'task-001',
+    sourcePainId: 'pain-001',
+    sourceRunIds: ['run-001'],
+    capturedAt: '2026-05-19T12:00:00.000Z',
+    sourceRefs: [
+      { kind: 'task', id: 'task-001' },
+      { kind: 'run', id: 'run-001' },
+    ],
+    timeline: [],
+    ambiguityNotes: [],
+    sanitizationNotes: [],
+    ...overrides,
+  };
+}
+
+function makeRefinedTrace(overrides: Partial<RefinedTracePayload> = {}): RefinedTracePayload {
+  return {
+    sourceTaskId: 'task-001',
+    sourcePainId: 'pain-001',
+    sourceRunIds: ['run-001'],
+    evidenceRefs: ['task:task-001', 'run:run-001'],
+    keyEvents: [],
+    failureSummary: null,
+    toolUseSummary: [],
+    userIntentSummary: null,
+    ambiguityNotes: [],
+    sanitizationNotes: [],
+    refinementNotes: [],
+    ...overrides,
+  };
+}
+
+describe('buildGoldenTraceCandidate', () => {
+  it('returns insufficient_evidence when no failure evidence exists', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+      ],
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('insufficient_evidence');
+    if (result.decision === 'insufficient_evidence') {
+      expect(result.reasons.length).toBeGreaterThan(0);
+      expect(result.reasons.some((r) => r.includes('failure') || r.includes('negative'))).toBe(true);
+    }
+  });
+
+  it('returns insufficient_evidence when no positive comparator exists', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Write (failed)',
+          rawPreview: '{"file_path":"/etc/passwd","content":"root::0:0"}',
+          metadata: { toolName: 'Write', status: 'failed' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Write',
+          rawPreview: 'Permission denied',
+          metadata: { toolName: 'Write', error: 'Permission denied' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Write (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+      ],
+      failureSummary: 'Write: Permission denied',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('insufficient_evidence');
+    if (result.decision === 'insufficient_evidence') {
+      expect(result.reasons.some((r) => r.includes('positive') || r.includes('comparator'))).toBe(true);
+    }
+  });
+
+  it('returns insufficient_evidence when tool params are missing', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'timeout' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:02.000Z',
+        },
+      ],
+      failureSummary: 'Bash: timeout',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('insufficient_evidence');
+    if (result.decision === 'insufficient_evidence') {
+      expect(result.reasons.some((r) => r.includes('params') || r.includes('param'))).toBe(true);
+    }
+  });
+
+  it('creates candidate from failing tool call with positive comparator', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'Permission denied' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          rawPreview: 'Permission denied',
+          metadata: { toolName: 'Bash', error: 'Permission denied' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001', 'run:run-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001', 'run:run-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: Permission denied',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      expect(result.goldenTrace).toBeDefined();
+      expect(result.evidenceRefs.length).toBeGreaterThan(0);
+      expect(result.builderNotes.length).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('generated GoldenTrace passes validateGoldenTrace', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous command' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous command' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous command',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      const validation = validateGoldenTrace(result.goldenTrace);
+      expect(validation.valid).toBe(true);
+      expect(validation.errors).toHaveLength(0);
+    }
+  });
+
+  it('preserves source refs in every generated case', () => {
+    const fullTrace = makeFullTrace({
+      sourceTaskId: 'task-042',
+      sourcePainId: 'pain-042',
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Write (failed)',
+          rawPreview: '{"file_path":"/etc/shadow","content":"root:x:0:0"}',
+          metadata: { toolName: 'Write', status: 'failed', error: 'permission denied' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Write',
+          metadata: { toolName: 'Write', error: 'permission denied' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/app.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      sourceTaskId: 'task-042',
+      sourcePainId: 'pain-042',
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Write (failed)',
+          evidenceRefs: ['task:task-042'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-042'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Write: permission denied',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      for (const c of result.goldenTrace.cases) {
+        expect(c.sourceRefs).toBeDefined();
+        expect(c.sourceRefs?.painId).toBe('pain-042');
+      }
+      expect(result.goldenTrace.sourcePainId).toBe('pain-042');
+    }
+  });
+
+  it('replay validator can consume generated candidate in deterministic mode', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      const blockBashEvaluate = () => ({
+        decision: 'block' as const,
+        matched: true,
+        reason: 'dangerous command',
+        confidence: 0.95,
+      });
+      const replayResult = replayGoldenTrace(blockBashEvaluate, result.goldenTrace.cases);
+      expect(replayResult.totalCases).toBe(result.goldenTrace.cases.length);
+      expect(typeof replayResult.passed).toBe('boolean');
+    }
+  });
+
+  it('generated IDs are deterministic for same input', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+    });
+
+    const result1 = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+    const result2 = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result1.decision).toBe('candidate_created');
+    expect(result2.decision).toBe('candidate_created');
+    if (result1.decision === 'candidate_created' && result2.decision === 'candidate_created') {
+      expect(result1.goldenTrace.traceId).toBe(result2.goldenTrace.traceId);
+      expect(result1.goldenTrace.cases.map((c) => c.caseId)).toEqual(
+        result2.goldenTrace.cases.map((c) => c.caseId),
+      );
+    }
+  });
+
+  it('ambiguous/refinement notes are preserved in builder notes', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+      ambiguityNotes: ['source_trace_ambiguous: multiple runs found'],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+      ambiguityNotes: ['source_trace_ambiguous: multiple runs found'],
+      refinementNotes: ['sanitized_input_present'],
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      expect(result.builderNotes.some((n) => n.includes('ambiguous') || n.includes('refinement'))).toBe(true);
+    }
+  });
+
+  it('negative case has block expectedDecision for failing tool call', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      const negativeCases = result.goldenTrace.cases.filter((c) => c.kind === 'negative');
+      expect(negativeCases.length).toBeGreaterThan(0);
+      for (const nc of negativeCases) {
+        expect(nc.expectedDecision).toBe('block');
+        expect(nc.toolName).toBe('Bash');
+        expect(nc.params).toBeDefined();
+        expect(typeof nc.params).toBe('object');
+      }
+    }
+  });
+
+  it('positive case has allow expectedDecision for non-failing tool call', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      const positiveCases = result.goldenTrace.cases.filter((c) => c.kind === 'positive');
+      expect(positiveCases.length).toBeGreaterThan(0);
+      for (const pc of positiveCases) {
+        expect(pc.expectedDecision).toBe('allow');
+        expect(pc.toolName).toBeDefined();
+        expect(pc.params).toBeDefined();
+      }
+    }
+  });
+
+  it('works with real refineFullTrace output', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous command blocked' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          rawPreview: 'dangerous command blocked',
+          metadata: { toolName: 'Bash', error: 'dangerous command blocked' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = refineFullTrace(fullTrace);
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      const validation = validateGoldenTrace(result.goldenTrace);
+      expect(validation.valid).toBe(true);
+    }
+  });
+
+  it('returns insufficient_evidence when timeline is empty', () => {
+    const fullTrace = makeFullTrace({ timeline: [] });
+    const refinedTrace = makeRefinedTrace({ keyEvents: [], refinementNotes: ['empty_timeline'] });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('insufficient_evidence');
+    if (result.decision === 'insufficient_evidence') {
+      expect(result.reasons.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('uses provided createdAt when given', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:03.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+    });
+
+    const result = buildGoldenTraceCandidate({
+      fullTrace,
+      refinedTrace,
+      createdAt: '2026-06-01T00:00:00.000Z',
+    });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      expect(result.goldenTrace.createdAt).toBe('2026-06-01T00:00:00.000Z');
+    }
+  });
+});
+
+describe('buildGoldenTraceCandidate architecture guard', () => {
+  it('builder module has no plugin import', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../golden-trace-candidate-builder.ts'),
+      'utf-8',
+    );
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain("from 'fs'");
+    expect(src).not.toContain("from 'path'");
+    expect(src).not.toContain("from 'node:fs'");
+    expect(src).not.toContain("from 'node:path'");
+    expect(src).not.toContain("from 'node:process'");
+    expect(src).not.toContain("from 'net'");
+    expect(src).not.toContain("from 'http'");
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/golden-trace-candidate-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/golden-trace-candidate-builder.test.ts
@@ -675,6 +675,66 @@ describe('buildGoldenTraceCandidate', () => {
     }
   });
 
+  it('candidate_created includes missing_params in builderNotes when some tool calls lack params', () => {
+    const fullTrace = makeFullTrace({
+      timeline: [
+        {
+          at: '2026-05-19T12:00:01.000Z',
+          kind: 'tool_call',
+          summary: 'Bash (failed)',
+          rawPreview: '{"command":"rm -rf /"}',
+          metadata: { toolName: 'Bash', status: 'failed', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:02.000Z',
+          kind: 'tool_result',
+          summary: 'Error from Bash',
+          metadata: { toolName: 'Bash', error: 'dangerous' },
+        },
+        {
+          at: '2026-05-19T12:00:03.000Z',
+          kind: 'tool_call',
+          summary: 'Grep (failed)',
+          metadata: { toolName: 'Grep', status: 'failed', error: 'not found' },
+        },
+        {
+          at: '2026-05-19T12:00:04.000Z',
+          kind: 'tool_call',
+          summary: 'Read (completed)',
+          rawPreview: '{"file_path":"/src/main.ts"}',
+          metadata: { toolName: 'Read', status: 'completed' },
+        },
+      ],
+    });
+    const refinedTrace = makeRefinedTrace({
+      keyEvents: [
+        {
+          kind: 'failure',
+          summary: 'Bash (failed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'high',
+          at: '2026-05-19T12:00:01.000Z',
+        },
+        {
+          kind: 'tool_use',
+          summary: 'Read (completed)',
+          evidenceRefs: ['task:task-001'],
+          severity: 'low',
+          at: '2026-05-19T12:00:04.000Z',
+        },
+      ],
+      failureSummary: 'Bash: dangerous',
+    });
+
+    const result = buildGoldenTraceCandidate({ fullTrace, refinedTrace });
+
+    expect(result.decision).toBe('candidate_created');
+    if (result.decision === 'candidate_created') {
+      expect(result.builderNotes.some((n) => n.includes('missing_params'))).toBe(true);
+      expect(result.builderNotes.some((n) => n.includes('Grep'))).toBe(true);
+    }
+  });
+
   it('uses provided createdAt when given', () => {
     const fullTrace = makeFullTrace({
       timeline: [

--- a/packages/principles-core/src/runtime-v2/golden-trace-candidate-builder.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-candidate-builder.ts
@@ -169,7 +169,9 @@ export function buildGoldenTraceCandidate(
     const toolNames = noParamsEvidence
       .map((e) => extractMetadataString(e, 'toolName'))
       .filter((n): n is string => n !== undefined);
-    reasons.push(`missing_params: tool calls without extractable params: ${toolNames.join(', ')}`);
+    const missingParamsNote = `missing_params: tool calls without extractable params: ${toolNames.join(', ')}`;
+    reasons.push(missingParamsNote);
+    builderNotes.push(missingParamsNote);
   }
 
   if (failureEvidence.length === 0 || positiveEvidence.length === 0) {

--- a/packages/principles-core/src/runtime-v2/golden-trace-candidate-builder.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-candidate-builder.ts
@@ -1,0 +1,253 @@
+import type { FullTracePayloadV2, TraceTimelineEntry } from './full-trace-contract.js';
+import type { RefinedTracePayload } from './trace-refiner.js';
+import type { GoldenTrace, GoldenTraceCase } from './golden-trace.js';
+
+export type GoldenTraceCandidateDecision =
+  | 'candidate_created'
+  | 'insufficient_evidence';
+
+export interface GoldenTraceCandidateBuilderInput {
+  fullTrace: FullTracePayloadV2;
+  refinedTrace: RefinedTracePayload;
+  createdAt?: string;
+}
+
+export interface GoldenTraceCandidateRefusal {
+  decision: 'insufficient_evidence';
+  reasons: string[];
+  evidenceRefs: string[];
+}
+
+export interface GoldenTraceCandidateCreated {
+  decision: 'candidate_created';
+  goldenTrace: GoldenTrace;
+  evidenceRefs: string[];
+  builderNotes: string[];
+}
+
+export type GoldenTraceCandidateBuilderResult =
+  | GoldenTraceCandidateCreated
+  | GoldenTraceCandidateRefusal;
+
+const FAILURE_SIGNALS = [
+  'error',
+  'failed',
+  'exception',
+  'timeout',
+  'timed out',
+  'permission denied',
+  'denied',
+  'crashed',
+  'fatal',
+  'abort',
+  'unreachable',
+];
+
+function containsFailureSignal(text: string): boolean {
+  const lower = text.toLowerCase();
+  return FAILURE_SIGNALS.some((signal) => lower.includes(signal));
+}
+
+function extractMetadataString(entry: TraceTimelineEntry, field: string): string | undefined {
+  if (!entry.metadata || typeof entry.metadata !== 'object') return undefined;
+  const meta = entry.metadata as Record<string, unknown>;
+  const value = meta[field];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isFailureEntry(entry: TraceTimelineEntry): boolean {
+  const errorText = extractMetadataString(entry, 'error');
+  if (errorText) return true;
+  if (containsFailureSignal(entry.summary)) return true;
+  if (entry.rawPreview && containsFailureSignal(entry.rawPreview)) return true;
+  const status = extractMetadataString(entry, 'status');
+  if (status && containsFailureSignal(status)) return true;
+  return false;
+}
+
+function tryParseJsonParams(raw: string | undefined): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface ToolCallEvidence {
+  toolName: string;
+  params: Record<string, unknown>;
+  isFailure: boolean;
+  timelineIndex: number;
+}
+
+function hasFailureResult(
+  timeline: TraceTimelineEntry[],
+  toolCallIndex: number,
+  toolName: string,
+): boolean {
+  for (let i = toolCallIndex + 1; i < timeline.length; i++) {
+    const entry = timeline[i];
+    if (!entry) continue;
+    if (entry.kind === 'tool_result') {
+      const resultToolName = extractMetadataString(entry, 'toolName');
+      if (resultToolName === toolName) {
+        return isFailureEntry(entry);
+      }
+    }
+    if (entry.kind === 'tool_call') break;
+  }
+  return false;
+}
+
+function extractToolCallEvidence(timeline: TraceTimelineEntry[]): ToolCallEvidence[] {
+  const results: ToolCallEvidence[] = [];
+
+  for (let i = 0; i < timeline.length; i++) {
+    const entry = timeline[i];
+    if (!entry || entry.kind !== 'tool_call') continue;
+
+    const toolName = extractMetadataString(entry, 'toolName');
+    if (!toolName) continue;
+
+    const params = tryParseJsonParams(entry.rawPreview);
+    if (!params) continue;
+
+    const isFailure = isFailureEntry(entry) || hasFailureResult(timeline, i, toolName);
+
+    results.push({
+      toolName,
+      params,
+      isFailure,
+      timelineIndex: i,
+    });
+  }
+
+  return results;
+}
+
+function deterministicHash(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+export function buildGoldenTraceCandidate(
+  input: GoldenTraceCandidateBuilderInput,
+): GoldenTraceCandidateBuilderResult {
+  const { fullTrace, refinedTrace } = input;
+  const reasons: string[] = [];
+  const builderNotes: string[] = [];
+
+  const toolCallEvidence = extractToolCallEvidence(fullTrace.timeline);
+
+  const failureEvidence = toolCallEvidence.filter((e) => e.isFailure);
+  const positiveEvidence = toolCallEvidence.filter((e) => !e.isFailure);
+
+  if (failureEvidence.length === 0) {
+    reasons.push('no_failure_evidence: trace contains no failing tool calls with extractable params');
+  }
+
+  if (positiveEvidence.length === 0) {
+    reasons.push('no_positive_comparator: trace contains no non-failing tool calls with extractable params');
+  }
+
+  const noParamsEvidence = fullTrace.timeline.filter(
+    (e) => e.kind === 'tool_call' && extractMetadataString(e, 'toolName') && !tryParseJsonParams(e.rawPreview),
+  );
+  if (noParamsEvidence.length > 0) {
+    const toolNames = noParamsEvidence
+      .map((e) => extractMetadataString(e, 'toolName'))
+      .filter((n): n is string => n !== undefined);
+    reasons.push(`missing_params: tool calls without extractable params: ${toolNames.join(', ')}`);
+  }
+
+  if (failureEvidence.length === 0 || positiveEvidence.length === 0) {
+    return {
+      decision: 'insufficient_evidence',
+      reasons,
+      evidenceRefs: [...refinedTrace.evidenceRefs],
+    };
+  }
+
+  if (refinedTrace.ambiguityNotes.length > 0) {
+    builderNotes.push(...refinedTrace.ambiguityNotes.map((n) => `ambiguous: ${n}`));
+  }
+
+  if (refinedTrace.refinementNotes.length > 0) {
+    builderNotes.push(...refinedTrace.refinementNotes.map((n) => `refinement: ${n}`));
+  }
+
+  if (refinedTrace.sanitizationNotes.length > 0) {
+    builderNotes.push(...refinedTrace.sanitizationNotes.map((n) => `sanitized: ${n}`));
+  }
+
+  const { sourcePainId } = fullTrace;
+  const { sourceTaskId } = fullTrace;
+  const evidenceRefs = [...refinedTrace.evidenceRefs];
+
+  const cases: GoldenTraceCase[] = [];
+
+  let negativeIndex = 0;
+  for (const evidence of failureEvidence) {
+    negativeIndex++;
+    const caseId = `neg-${deterministicHash(`${sourceTaskId}:${evidence.toolName}:${negativeIndex}`)}`;
+    cases.push({
+      caseId,
+      kind: 'negative',
+      toolName: evidence.toolName,
+      params: { ...evidence.params },
+      expectedDecision: 'block',
+      sourceRefs: {
+        painId: sourcePainId,
+        candidateId: sourceTaskId,
+      },
+    });
+  }
+
+  let positiveIndex = 0;
+  for (const evidence of positiveEvidence) {
+    positiveIndex++;
+    const caseId = `pos-${deterministicHash(`${sourceTaskId}:${evidence.toolName}:${positiveIndex}`)}`;
+    cases.push({
+      caseId,
+      kind: 'positive',
+      toolName: evidence.toolName,
+      params: { ...evidence.params },
+      expectedDecision: 'allow',
+      sourceRefs: {
+        painId: sourcePainId,
+        candidateId: sourceTaskId,
+      },
+    });
+  }
+
+  const traceId = `gtc-${deterministicHash(`${sourceTaskId}:${sourcePainId}:${failureEvidence.map((e) => e.toolName).join(',')}`)}`;
+  const createdAt = input.createdAt ?? new Date().toISOString().replace(/\.\d{3}Z$/, '.000Z');
+
+  const goldenTrace: GoldenTrace = {
+    traceId,
+    sourcePainId,
+    sourceCandidateId: sourceTaskId,
+    cases,
+    createdAt,
+    version: 1,
+  };
+
+  return {
+    decision: 'candidate_created',
+    goldenTrace,
+    evidenceRefs,
+    builderNotes,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -33,6 +33,9 @@ export type { RefinedTraceEvent, RefinedEventKind, RefinedTracePayload, Severity
 // Trace refiner agent shadow contract (PRI-192)
 export { createTraceRefinerAgentInput, validateTraceRefinerAgentOutput, applyTraceRefinerAgentShadowResult } from './trace-refiner-agent.js';
 export type { TraceRefinerAgentObjective, TraceRefinerAgentMode, TraceRefinerAgentInput, TraceRefinerEvidenceClaim, TraceRefinerRejectedEvidence, TraceRefinerAgentStatus, TraceRefinerAgentOutput } from './trace-refiner-agent.js';
+// GoldenTrace candidate builder (PRI-193)
+export { buildGoldenTraceCandidate } from './golden-trace-candidate-builder.js';
+export type { GoldenTraceCandidateDecision, GoldenTraceCandidateBuilderInput, GoldenTraceCandidateRefusal, GoldenTraceCandidateCreated, GoldenTraceCandidateBuilderResult } from './golden-trace-candidate-builder.js';
 // Diagnostician output schemas (Phase 2)
 export { DiagnosticianViolatedPrincipleSchema, DiagnosticianEvidenceSchema, RecommendationKindSchema, DiagnosticianRecommendationSchema, DiagnosticianOutputV1Schema, DiagnosticianInvocationInputSchema } from './diagnostician-output.js';
 // Principle tree types schemas


### PR DESCRIPTION
## Why

GoldenTrace is the safety gate for generated L2 rule code. It needs high-quality positive/negative cases grounded in real source evidence. This PR adds a pure core read-model builder that converts FullTracePayloadV2 + RefinedTracePayload into GoldenTrace candidates.

## Public Contract Summary

\\\	s
export type GoldenTraceCandidateDecision = 'candidate_created' | 'insufficient_evidence';

export interface GoldenTraceCandidateBuilderInput {
  fullTrace: FullTracePayloadV2;
  refinedTrace: RefinedTracePayload;
  createdAt?: string;
}

export interface GoldenTraceCandidateRefusal {
  decision: 'insufficient_evidence';
  reasons: string[];
  evidenceRefs: string[];
}

export interface GoldenTraceCandidateCreated {
  decision: 'candidate_created';
  goldenTrace: GoldenTrace;
  evidenceRefs: string[];
  builderNotes: string[];
}

export type GoldenTraceCandidateBuilderResult =
  | GoldenTraceCandidateCreated
  | GoldenTraceCandidateRefusal;

export function buildGoldenTraceCandidate(
  input: GoldenTraceCandidateBuilderInput,
): GoldenTraceCandidateBuilderResult
\\\

## Insufficient Evidence Strategy

The builder is conservative — it only produces a candidate when **both** failure evidence (negative case) and non-failure comparator evidence (positive case) exist with extractable toolName + params. Otherwise it returns \insufficient_evidence\ with structured reasons:

- \
o_failure_evidence\: no failing tool calls with extractable params
- \
o_positive_comparator\: no non-failing tool calls with extractable params
- \missing_params\: tool calls found but params could not be extracted from rawPreview

## How Evidence Is Not Invented

1. **toolName** extracted only from \metadata.toolName\ — never guessed
2. **params** parsed only from \awPreview\ JSON — never fabricated
3. **expectedDecision** derived from failure signal detection (same logic as trace-refiner.ts) — negative cases get \lock\, positive cases get \llow\
4. **sourceRefs** mapped from \sourcePainId\ → \sourceRefs.painId\ and \sourceTaskId\ → \sourceRefs.candidateId\
5. If any tool call lacks extractable params, it is skipped and noted in reasons

## Files Changed

- \packages/principles-core/src/runtime-v2/golden-trace-candidate-builder.ts\ — new builder
- \packages/principles-core/src/runtime-v2/__tests__/golden-trace-candidate-builder.test.ts\ — 15 tests
- \packages/principles-core/src/runtime-v2/index.ts\ — exports
- \packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts\ — source/test file entries

## Test Commands & Results

\\\ash
npm run build --workspace=@principles/core  # ✅ passes
npx vitest run packages/principles-core/src/runtime-v2/__tests__/golden-trace-candidate-builder.test.ts  # ✅ 15/15
npx vitest run packages/principles-core/src/runtime-v2/__tests__/golden-trace.test.ts  # ✅ 28/28
npx vitest run packages/principles-core/src/runtime-v2/__tests__/golden-trace-replay-validator.test.ts  # ✅ 9/9
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  # ✅ 392/392
npm run lint  # ✅ passes
\\\

## Not Implemented (out of scope)

- LLM TraceRefinerAgent runtime
- Rule compilation
- RuleHost activation
- Ledger mutation
- DiagnosticianOutputV1 dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 新增黄金轨迹候选构建器，基于完整轨迹和精炼信息生成黄金轨迹用例，自动判定证据充分性并为每个用例标注预期的安全决策。

* **Tests**
  * 新增黄金轨迹候选构建器的全面测试套件，涵盖多种场景、决策分支和用例生成验证，确保功能的正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->