### PR TITLE
fix(pain): detect exec exit code from nested details structure

### DIFF
--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -227,7 +227,8 @@ export function handleAfterToolCall(
   // Support nested details structure where OpenClaw exec tool stores exitCode in result.details.exitCode
   const resultObj = (event.result && typeof event.result === 'object') ? event.result as Record<string, unknown> : null;
   const details = resultObj?.details && typeof resultObj.details === 'object' ? resultObj.details as Record<string, unknown> : null;
-  const exitCode = (resultObj?.exitCode as number | undefined) ?? (details?.exitCode as number | undefined) ?? 0;
+  const rawExitCode = (resultObj?.exitCode as number | undefined) ?? (details?.exitCode as number | undefined);
+  const exitCode = typeof rawExitCode === 'number' ? rawExitCode : 0;
   const isFailure = !!event.error || exitCode !== 0;
 
   if (isFailure) {

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -224,7 +224,10 @@ export function handleAfterToolCall(
   }
 
   // 1. Determine if this was a failure
-  const exitCode = (event.result && typeof event.result === 'object') ? (event.result as Record<string, unknown>).exitCode : 0;
+  // Support nested details structure where OpenClaw exec tool stores exitCode in result.details.exitCode
+  const resultObj = (event.result && typeof event.result === 'object') ? event.result as Record<string, unknown> : null;
+  const details = resultObj?.details && typeof resultObj.details === 'object' ? resultObj.details as Record<string, unknown> : null;
+  const exitCode = (resultObj?.exitCode as number | undefined) ?? (details?.exitCode as number | undefined) ?? 0;
   const isFailure = !!event.error || (exitCode !== 0 && exitCode !== undefined);
 
   if (isFailure) {

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -225,10 +225,14 @@ export function handleAfterToolCall(
 
   // 1. Determine if this was a failure
   // Support nested details structure where OpenClaw exec tool stores exitCode in result.details.exitCode
+  // Prefer the first *numeric* exit code: if result.exitCode is non-numeric, fall back to details.exitCode
   const resultObj = (event.result && typeof event.result === 'object') ? event.result as Record<string, unknown> : null;
   const details = resultObj?.details && typeof resultObj.details === 'object' ? resultObj.details as Record<string, unknown> : null;
-  const rawExitCode = (resultObj?.exitCode as number | undefined) ?? (details?.exitCode as number | undefined);
-  const exitCode = typeof rawExitCode === 'number' ? rawExitCode : 0;
+  const topExitCode = resultObj?.exitCode;
+  const detailExitCode = details?.exitCode;
+  const exitCode = typeof topExitCode === 'number' ? topExitCode
+    : typeof detailExitCode === 'number' ? detailExitCode
+    : 0;
   const isFailure = !!event.error || exitCode !== 0;
 
   if (isFailure) {

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -228,7 +228,7 @@ export function handleAfterToolCall(
   const resultObj = (event.result && typeof event.result === 'object') ? event.result as Record<string, unknown> : null;
   const details = resultObj?.details && typeof resultObj.details === 'object' ? resultObj.details as Record<string, unknown> : null;
   const exitCode = (resultObj?.exitCode as number | undefined) ?? (details?.exitCode as number | undefined) ?? 0;
-  const isFailure = !!event.error || (exitCode !== 0 && exitCode !== undefined);
+  const isFailure = !!event.error || exitCode !== 0;
 
   if (isFailure) {
     const failureSource = classifyToolFailureSource(event.toolName, event.error);

--- a/packages/openclaw-plugin/tests/hooks/pain.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain.test.ts
@@ -321,4 +321,95 @@ describe('Post-Write Checks & Pain Hook', () => {
     expect(trainingStateWrites).toEqual([]);
   });
 
+  it('should detect failure from nested details.exitCode (exec tool pattern)', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-exec-failure', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'npm test' },
+      result: { details: { exitCode: 1 } },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-exec-failure',
+      toolName: 'bash',
+      outcome: 'failure',
+    }));
+  });
+
+  it('should prefer result.exitCode over nested details.exitCode when both exist', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-exec-success', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'npm test' },
+      result: { exitCode: 0, details: { exitCode: 1 } },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockEmitSync).not.toHaveBeenCalled();
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-exec-success',
+      toolName: 'bash',
+      outcome: 'success',
+    }));
+  });
+
+  it('should treat undefined exitCode as success', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-no-exitcode', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'echo hello' },
+      result: { output: 'hello' },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockEmitSync).not.toHaveBeenCalled();
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-no-exitcode',
+      toolName: 'bash',
+      outcome: 'success',
+    }));
+  });
+
+  it('should treat exitCode 0 as success even when details.exitCode is non-zero', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-partial-success', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'npm test' },
+      result: { exitCode: 0, details: { stderr: 'some warnings', exitCode: 2 } },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockEmitSync).not.toHaveBeenCalled();
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-partial-success',
+      toolName: 'bash',
+      outcome: 'success',
+    }));
+  });
+
 });

--- a/packages/openclaw-plugin/tests/hooks/pain.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain.test.ts
@@ -412,4 +412,50 @@ describe('Post-Write Checks & Pain Hook', () => {
     }));
   });
 
+  it('should treat string exitCode as 0 (not a failure)', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-string-exitcode', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'npm test' },
+      result: { exitCode: '0' },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockEmitSync).not.toHaveBeenCalled();
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-string-exitcode',
+      toolName: 'bash',
+      outcome: 'success',
+    }));
+  });
+
+  it('should treat non-numeric details.exitCode as 0 (not a failure)', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-non-numeric-details', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'npm test' },
+      result: { details: { exitCode: '1' } },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockEmitSync).not.toHaveBeenCalled();
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-non-numeric-details',
+      toolName: 'bash',
+      outcome: 'success',
+    }));
+  });
+
 });

--- a/packages/openclaw-plugin/tests/hooks/pain.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain.test.ts
@@ -458,4 +458,26 @@ describe('Post-Write Checks & Pain Hook', () => {
     }));
   });
 
+  it('should fall back to numeric details.exitCode when top-level exitCode is non-numeric', () => {
+    const mockCtx = { workspaceDir, sessionId: 's-fallback-numeric', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'bash',
+      params: { arguments: 'npm test' },
+      result: { exitCode: '0', details: { exitCode: 1 } },
+      error: undefined,
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('package.json');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-fallback-numeric',
+      toolName: 'bash',
+      outcome: 'failure',
+    }));
+  });
+
 });


### PR DESCRIPTION
## Summary

This PR fixes the **exec tool exit code detection bug** that was originally addressed in PR #425 but was not properly preserved in the main branch.

### Problem

The OpenClaw exec tool stores `exitCode` in `result.details.exitCode`, not at the `result.exitCode` root level. This caused `isFailure` to always be false for exec non-zero exits since OpenClaw doesn't flag them as `isToolError` (status=completed, not error/timeout).

### Solution

Modified `handleAfterToolCall` in `packages/openclaw-plugin/src/hooks/pain.ts` to:
1. First check for `exitCode` at the top-level `result.exitCode`
2. Fall back to `result.details.exitCode` if top-level is undefined
3. Default to `0` if neither exists

### Test Coverage Added

Added 4 new test cases in `packages/openclaw-plugin/tests/hooks/pain.test.ts`:

1. **`should detect failure from nested details.exitCode (exec tool pattern)`**
   - Verifies that failures with `exitCode` in `result.details` are properly detected

2. **`should prefer result.exitCode over nested details.exitCode when both exist`**
   - Ensures top-level `exitCode` takes precedence over nested details

3. **`should treat undefined exitCode as success`**
   - Handles edge case where `exitCode` is completely absent

4. **`should treat exitCode 0 as success even when details.exitCode is non-zero`**
   - Verifies that partial success (root exitCode=0 with warnings) is not treated as failure

### Risk Reduction

| Risk | Before | After |
|------|--------|-------|
| Exec tool failures undetected | High | Covered |
| Incorrect GFI calculation | High | Fixed |
| Missing pain signals | Medium | Fixed |

### Verification

- All 65 pain-related tests pass
- TypeScript compilation succeeds
- ESLint passes with no errors
- No regressions in existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

**错误修复**
* 改进工具执行失败判定逻辑，优先并安全地解析多层级退出码，避免非数字值引起误判，提升执行状态判定的准确性和稳定性。

**测试**
* 新增多种退出码解析与优先级的单元测试，覆盖边界情况以确保判定与记录行为一致。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->