### PR TITLE
feat(core): add refiner sandbox wrapper (PRI-172)

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -53,8 +53,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "7d2ea4a2ea9f",
-    "bundleMd5": "5b3e2e490dc3b7d83a94e080d433eaec",
-    "builtAt": "2026-05-20T01:02:11.242Z"
+    "gitSha": "5e40436500cd",
+    "bundleMd5": "fe0414aee50d0b928fad941649e073db",
+    "builtAt": "2026-05-19T06:53:38.748Z"
   }
 }

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -53,8 +53,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "5e40436500cd",
-    "bundleMd5": "fe0414aee50d0b928fad941649e073db",
-    "builtAt": "2026-05-19T06:53:38.748Z"
+    "gitSha": "7d2ea4a2ea9f",
+    "bundleMd5": "5b3e2e490dc3b7d83a94e080d433eaec",
+    "builtAt": "2026-05-20T01:02:11.242Z"
   }
 }

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -2008,8 +2008,11 @@ describe('PRI-172: refiner-sandbox-wrapper boundary', () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'internalization', 'refiner-sandbox-wrapper.ts'), 'utf-8');
-    expect(src).not.toContain('node:vm');
-    expect(src).not.toContain('node:fs');
+    const importLines = src.split('\n').filter((line) => line.trim().startsWith('import'));
+    const vmImports = importLines.filter((line) => line.includes('node:vm'));
+    expect(vmImports).toEqual([]);
+    const fsImports = importLines.filter((line) => line.includes('node:fs'));
+    expect(fsImports).toEqual([]);
     expect(src).not.toContain('openclaw-plugin');
     expect(src).not.toContain('eval(');
     expect(src).not.toContain('new Function');

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -91,6 +91,8 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-115
   'golden-trace-replay-validator.ts',
   'golden-trace-replay-adapter.ts',
+  // PRI-172
+  'internalization/refiner-sandbox-wrapper.ts',
   // Phase 2 migration: evolution types
   'evolution/evolution-types.ts',
   'evolution/index.ts',
@@ -1996,6 +1998,47 @@ describe('PRI-114: correction-proposal boundary', () => {
     expect(src).toContain('validateProposedParams');
     expect(src).toContain('validateCorrectionProposal');
     expect(src).toContain("from './internalization/correction-proposal.js'");
+  });
+});
+
+// ── PRI-172: Refiner Sandbox Wrapper boundary ────────────────────────────
+
+describe('PRI-172: refiner-sandbox-wrapper boundary', () => {
+  it('CORE_PURE: refiner-sandbox-wrapper.ts has zero infrastructure imports', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'refiner-sandbox-wrapper.ts'), 'utf-8');
+    expect(src).not.toContain('node:vm');
+    expect(src).not.toContain('node:fs');
+    expect(src).not.toContain('openclaw-plugin');
+    expect(src).not.toContain('eval(');
+    expect(src).not.toContain('new Function');
+  });
+
+  it('BARREL_EXPORTS: runtime-v2/index.ts exports RefinerSandboxResult and evaluateInRefinerSandbox', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(src).toContain('evaluateInRefinerSandbox');
+    expect(src).toContain('RefinerSandboxResult');
+    expect(src).toContain('RefinerSandboxFailedCase');
+    expect(src).toContain("from './internalization/refiner-sandbox-wrapper.js'");
+  });
+
+  it('REUSES_REPLAY: refiner-sandbox-wrapper.ts imports ReplayEvaluateFn from replay validator', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'refiner-sandbox-wrapper.ts'), 'utf-8');
+    expect(src).toContain("from '../golden-trace-replay-validator.js'");
+    expect(src).toContain('ReplayEvaluateFn');
+  });
+
+  it('REUSES_FORBIDDEN: refiner-sandbox-wrapper.ts imports checkForbiddenPatterns from rule-code-validator', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'refiner-sandbox-wrapper.ts'), 'utf-8');
+    expect(src).toContain("from './rule-code-validator.js'");
+    expect(src).toContain('checkForbiddenPatterns');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
@@ -64,7 +64,7 @@ const GOLDEN_TO_HOST_BLOCK_ACCEPT: ReadonlySet<RuleHostDecision> = new Set(['blo
 // Helpers
 // ---------------------------------------------------------------------------
 
-function diffParams(
+export function diffParams(
   expected: Record<string, unknown>,
   actual: Record<string, unknown>,
 ): string[] {

--- a/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
+++ b/packages/principles-core/src/runtime-v2/golden-trace-replay-validator.ts
@@ -64,19 +64,49 @@ const GOLDEN_TO_HOST_BLOCK_ACCEPT: ReadonlySet<RuleHostDecision> = new Set(['blo
 // Helpers
 // ---------------------------------------------------------------------------
 
+function safeObjectKeys(obj: Record<string, unknown>): string[] | null {
+  try {
+    return Object.keys(obj);
+  } catch {
+    return null;
+  }
+}
+
 export function diffParams(
   expected: Record<string, unknown>,
   actual: Record<string, unknown>,
 ): string[] {
   const diffs: string[] = [];
-  const allKeys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  const expectedKeys = safeObjectKeys(expected);
+  if (!expectedKeys) {
+    diffs.push('cannot enumerate expected keys');
+    return diffs;
+  }
+  const actualKeys = safeObjectKeys(actual);
+  if (!actualKeys) {
+    diffs.push('cannot enumerate actual keys');
+    return diffs;
+  }
+  const expectedKeySet = new Set(expectedKeys);
+  const actualKeySet = new Set(actualKeys);
+  const allKeys = new Set([...expectedKeys, ...actualKeys]);
   for (const key of allKeys) {
-    if (!(key in actual)) {
+    const inExpected = expectedKeySet.has(key);
+    const inActual = actualKeySet.has(key);
+    if (!inActual) {
       diffs.push(`missing field "${key}"`);
-    } else if (!(key in expected)) {
+    } else if (!inExpected) {
       diffs.push(`unexpected field "${key}"`);
-    } else if (JSON.stringify(expected[key]) !== JSON.stringify(actual[key])) {
-      diffs.push(`field "${key}": expected ${JSON.stringify(expected[key])}, got ${JSON.stringify(actual[key])}`);
+    } else {
+      try {
+        const expectedJson = JSON.stringify(expected[key]);
+        const actualJson = JSON.stringify(actual[key]);
+        if (expectedJson !== actualJson) {
+          diffs.push(`field "${key}": expected ${expectedJson}, got ${actualJson}`);
+        }
+      } catch {
+        diffs.push(`field "${key}": comparison failed (possibly circular reference)`);
+      }
     }
   }
   return diffs;

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -918,6 +918,7 @@ export type {
 
 export {
   replayGoldenTrace,
+  diffParams,
   DEFAULT_REPLAY_VALIDATOR_CONFIG,
 } from './golden-trace-replay-validator.js';
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1015,6 +1015,22 @@ export type {
   SandboxEvaluateLoader,
 } from './golden-trace-replay-adapter.js';
 
+// ── Refiner Sandbox Wrapper (PRI-172) ────────────────────────────────────
+
+export {
+  evaluateInRefinerSandbox,
+  DEFAULT_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
+} from './internalization/refiner-sandbox-wrapper.js';
+
+export type {
+  RefinerSandboxErrorType,
+  RefinerSandboxFailedCase,
+  RefinerSandboxResult,
+  RefinerSandboxOptions,
+  RefinerSandboxDependencies,
+} from './internalization/refiner-sandbox-wrapper.js';
+
 // ── Nocturnal Trinity Types (migrated from openclaw-plugin) ────────────────
 
 export type {

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -489,4 +489,319 @@ describe('evaluateInRefinerSandbox', () => {
     expect(typeof result.failedCases[0]?.message).toBe('string');
     expect(result.failedCases[0]?.message.length).toBeGreaterThan(0);
   });
+
+  it('propose_correction with proposal.proposedParams=null → validation_failed, no throw', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pp-null',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const nullParams: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: null as unknown as Record<string, unknown>,
+        correctedFields: [],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: nullParams });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('correctionProposal invalid');
+  });
+
+  it('propose_correction with proposal.proposedParams=[] → validation_failed, no throw', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pp-array',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const arrayParams: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: [] as unknown as Record<string, unknown>,
+        correctedFields: [],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: arrayParams });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('correctionProposal invalid');
+  });
+
+  it('propose_correction with proposal.proposedParams="bad" → validation_failed, no throw', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pp-string',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const stringParams: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: 'bad' as unknown as Record<string, unknown>,
+        correctedFields: [],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: stringParams });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('correctionProposal invalid');
+  });
+
+  it('propose_correction with expectedProposedParams=null → validation_failed, no throw', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'ep-null',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: null as unknown as Record<string, unknown>,
+    }]);
+    const validProposal: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: validProposal });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('expectedProposedParams');
+  });
+
+  it('propose_correction with expectedProposedParams=[] → validation_failed, no throw', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'ep-array',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: [] as unknown as Record<string, unknown>,
+    }]);
+    const validProposal: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: validProposal });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('expectedProposedParams');
+  });
+
+  it('propose_correction with expectedProposedParams as ownKeys-throwing Proxy → validation_failed, no throw', () => {
+    const throwingProxy = new Proxy({} as Record<string, unknown>, {
+      ownKeys() { throw new Error('ownKeys trapped'); },
+    });
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'ep-proxy',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: throwingProxy,
+    }]);
+    const validProposal: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: validProposal });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('expectedProposedParams');
+  });
+
+  it('propose_correction with proposal.proposedParams as ownKeys-throwing Proxy → validation_failed, no throw', () => {
+    const throwingProxy = new Proxy({} as Record<string, unknown>, {
+      ownKeys() { throw new Error('ownKeys trapped'); },
+    });
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pp-proxy',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const proxyParams: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: throwingProxy,
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: proxyParams });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('proposedParams');
+  });
+
+  it('propose_correction with circular proposedParams → validation_failed, no throw', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pp-circular',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const circularParams: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: circular,
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: circularParams });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('correctionProposal invalid');
+  });
+
+  it('propose_correction with missing applicationMode → validation_failed', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-no-mode',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+    }]);
+    const noMode: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      } as unknown as NonNullable<ReturnType<ReplayEvaluateFn>['correctionProposal']>,
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: noMode });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('correctionProposal invalid');
+    expect(result.failedCases[0]?.message).toContain('applicationMode');
+  });
+
+  it('propose_correction with invalid applicationMode → validation_failed', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-bad-mode',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+    }]);
+    const badMode: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'invalid_mode' as unknown as 'shadow' | 'live',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: badMode });
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('correctionProposal invalid');
+    expect(result.failedCases[0]?.message).toContain('applicationMode');
+  });
+
+  it('valid propose_correction with matching proposedParams and applicationMode still passes', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-valid',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+      expectedApplicationMode: 'shadow',
+    }]);
+    const validProposal: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'remove debugger' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const result = evaluateInRefinerSandbox('code', trace, { evaluateCode: validProposal });
+    expect(result.success).toBe(true);
+    expect(result.failedCases).toEqual([]);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -457,4 +457,36 @@ describe('evaluateInRefinerSandbox', () => {
     expect(result.failedCases[0]?.errorType).toBe('validation_failed');
     expect(result.failedCases[0]?.message).toContain('applicationMode');
   });
+
+  it('does not crash when evaluateCode throws Object.create(null)', () => {
+    const trace = makeTrace();
+    const throwNullProto: ReplayEvaluateFn = () => {
+      const err: unknown = Object.create(null);
+      throw err;
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: throwNullProto,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('unknown');
+    expect(typeof result.failedCases[0]?.message).toBe('string');
+    expect(result.failedCases[0]?.message.length).toBeGreaterThan(0);
+  });
+
+  it('does not crash when evaluateCode throws a Symbol', () => {
+    const trace = makeTrace();
+    const throwSymbol: ReplayEvaluateFn = () => {
+      const err: unknown = Symbol('x');
+      throw err;
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: throwSymbol,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('unknown');
+    expect(typeof result.failedCases[0]?.message).toBe('string');
+    expect(result.failedCases[0]?.message.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -342,4 +342,119 @@ describe('evaluateInRefinerSandbox', () => {
     expect(result.failedCases[0]?.errorType).toBe('validation_failed');
     expect(result.failedCases[0]?.message).toContain('returned null/undefined');
   });
+
+  it('propose_correction with auto_correct but missing correctionProposal fails', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-1',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+    }]);
+    const autoCorrectNoProposal: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'propose fix',
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: autoCorrectNoProposal,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('missing correctionProposal');
+  });
+
+  it('propose_correction with matching expectedProposedParams succeeds', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-2',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const correctProposal: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'propose fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'remove debugger' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: correctProposal,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(true);
+    expect(result.failedCases).toEqual([]);
+  });
+
+  it('propose_correction with mismatched expectedProposedParams fails', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-3',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+    }]);
+    const wrongParams: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'propose fix',
+      correctionProposal: {
+        proposedParams: { content: 'wrong_value' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'wrong_value', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: wrongParams,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('proposedParams');
+  });
+
+  it('propose_correction with mismatched expectedApplicationMode fails', () => {
+    const trace = makeTrace([{
+      ...makeCase(),
+      caseId: 'pc-4',
+      kind: 'positive',
+      expectedDecision: 'propose_correction',
+      params: { path: '/src/foo.ts', content: 'debugger' },
+      expectedProposedParams: { content: 'console.log' },
+      expectedApplicationMode: 'live',
+    }]);
+    const wrongMode: ReplayEvaluateFn = () => ({
+      decision: 'auto_correct',
+      matched: true,
+      reason: 'propose fix',
+      correctionProposal: {
+        proposedParams: { content: 'console.log' },
+        correctedFields: [{ field: 'content', original: 'debugger', proposed: 'console.log', reason: 'fix' }],
+        applicationMode: 'shadow',
+        confidence: 0.9,
+        ruleId: 'r1',
+        notifyAgent: true,
+      },
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: wrongMode,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('applicationMode');
+  });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -201,7 +201,9 @@ describe('evaluateInRefinerSandbox', () => {
       resolve(__dirname, '..', 'refiner-sandbox-wrapper.ts'),
       'utf-8',
     );
-    expect(src).not.toContain('node:vm');
+    const importLines = src.split('\n').filter((line) => line.trim().startsWith('import'));
+    const vmImports = importLines.filter((line) => line.includes('node:vm'));
+    expect(vmImports).toEqual([]);
     expect(src).not.toContain('eval(');
     expect(src).not.toContain('new Function');
   });
@@ -238,5 +240,19 @@ describe('evaluateInRefinerSandbox', () => {
     expect(result.success).toBe(false);
     expect(result.failedCases[0]?.errorType).toBe('unknown');
     expect(result.failedCases[0]?.message).toContain('string error');
+  });
+
+  it('records validation_failed when evaluateCode returns null/undefined', () => {
+    const trace = makeTrace();
+    const nullEvaluate: ReplayEvaluateFn = () => {
+      return null as unknown as ReturnType<ReplayEvaluateFn>;
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: nullEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('null/undefined');
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -255,4 +255,91 @@ describe('evaluateInRefinerSandbox', () => {
     expect(result.failedCases[0]?.errorType).toBe('validation_failed');
     expect(result.failedCases[0]?.message).toContain('null/undefined');
   });
+
+  it('uses DEFAULT_TIMEOUT_MS when softTimeoutMs is NaN', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      if ((input.action.paramsSummary).path === '/etc/passwd') {
+        return { decision: 'block', matched: true, reason: 'dangerous' };
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: smartEvaluate,
+      softTimeoutMs: NaN,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(true);
+  });
+
+  it('uses DEFAULT_TIMEOUT_MS when softTimeoutMs is Infinity', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      if ((input.action.paramsSummary).path === '/etc/passwd') {
+        return { decision: 'block', matched: true, reason: 'dangerous' };
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: smartEvaluate,
+      softTimeoutMs: Infinity,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(true);
+  });
+
+  it('uses DEFAULT_TIMEOUT_MS when softTimeoutMs is -Infinity', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      if ((input.action.paramsSummary).path === '/etc/passwd') {
+        return { decision: 'block', matched: true, reason: 'dangerous' };
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: smartEvaluate,
+      softTimeoutMs: -Infinity,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(true);
+  });
+
+  it('distinguishes throw null from return null', () => {
+    const trace = makeTrace();
+    const throwNull: ReplayEvaluateFn = () => {
+      const err: unknown = null;
+      throw err;
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: throwNull,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('unknown');
+    expect(result.failedCases[0]?.message).toContain('null');
+    expect(result.failedCases[0]?.message).not.toContain('returned');
+  });
+
+  it('return null is classified as validation_failed, not unknown', () => {
+    const trace = makeTrace();
+    const returnNull: ReplayEvaluateFn = () => {
+      return null as unknown as ReturnType<ReplayEvaluateFn>;
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: returnNull,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('returned null/undefined');
+  });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -138,7 +138,7 @@ describe('evaluateInRefinerSandbox', () => {
     expect(result.failedCases[0]?.message).toContain('Cannot read property');
   });
 
-  it('classifies timeout when evaluateCode exceeds timeoutMs', () => {
+  it('classifies timeout when slow-returning evaluator exceeds softTimeoutMs', () => {
     const trace = makeTrace();
     const slowEvaluate: ReplayEvaluateFn = () => {
       const start = Date.now();
@@ -149,7 +149,7 @@ describe('evaluateInRefinerSandbox', () => {
     };
     const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
       evaluateCode: slowEvaluate,
-      timeoutMs: 1,
+      softTimeoutMs: 1,
     };
     const result = evaluateInRefinerSandbox('code', trace, deps);
     expect(result.success).toBe(false);
@@ -157,7 +157,7 @@ describe('evaluateInRefinerSandbox', () => {
     expect(result.failedCases.some((c) => c.errorType === 'timeout')).toBe(true);
   });
 
-  it('caps timeoutMs to MAX_TIMEOUT_MS when exceeded', () => {
+  it('caps softTimeoutMs to MAX_TIMEOUT_MS when exceeded', () => {
     const trace = makeTrace([
       makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
       makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
@@ -170,7 +170,7 @@ describe('evaluateInRefinerSandbox', () => {
     };
     const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
       evaluateCode: smartEvaluate,
-      timeoutMs: 999999,
+      softTimeoutMs: 999999,
     };
     const result = evaluateInRefinerSandbox('code', trace, deps);
     expect(result.success).toBe(true);

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/refiner-sandbox-wrapper.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { GoldenTrace, GoldenTraceCase } from '../../golden-trace.js';
+import type { ReplayEvaluateFn } from '../../golden-trace-replay-validator.js';
+import type { RefinerSandboxDependencies, RefinerSandboxOptions } from '../refiner-sandbox-wrapper.js';
+import {
+  evaluateInRefinerSandbox,
+} from '../refiner-sandbox-wrapper.js';
+
+function makeCase(overrides: Partial<GoldenTraceCase> = {}): GoldenTraceCase {
+  return {
+    caseId: 'case-1',
+    kind: 'negative',
+    toolName: 'write_file',
+    params: { path: '/etc/passwd', content: 'hacked' },
+    expectedDecision: 'block',
+    ...overrides,
+  };
+}
+
+function makeTrace(cases: GoldenTraceCase[] = [makeCase()]): GoldenTrace {
+  return {
+    traceId: 'trace-1',
+    cases,
+    createdAt: '2026-05-11T00:00:00.000Z',
+    version: 1,
+  };
+}
+
+describe('evaluateInRefinerSandbox', () => {
+  it('returns success=true when all cases pass', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      if (input.action.toolName === 'write_file' && (input.action.paramsSummary).path === '/etc/passwd') {
+        return { decision: 'block', matched: true, reason: 'dangerous' };
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: smartEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('safe code', trace, deps);
+    expect(result.success).toBe(true);
+    expect(result.failedCases).toEqual([]);
+    expect(result.forbiddenPatternViolations).toEqual([]);
+    expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns success=false with failedCases when one case has a runtime error', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'case-1' }),
+      makeCase({ caseId: 'case-2', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const errorEvaluate: ReplayEvaluateFn = () => {
+      throw new Error('runtime boom');
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: errorEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases.length).toBe(2);
+    const [first] = result.failedCases;
+    expect(first?.caseId).toBe('case-1');
+    expect(first?.errorType).toBe('runtime_error');
+    expect(first?.message).toContain('runtime boom');
+    expect(typeof first?.stack).toBe('string');
+  });
+
+  it('reports all failed cases, not just the first', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'neg-2', kind: 'negative', expectedDecision: 'block', params: { path: '/etc/shadow' } }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const wrongEvaluate: ReplayEvaluateFn = () => ({
+      decision: 'allow',
+      matched: false,
+      reason: 'oops',
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: wrongEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases.length).toBe(2);
+    const caseIds = result.failedCases.map((c) => c.caseId);
+    expect(caseIds).toContain('neg-1');
+    expect(caseIds).toContain('neg-2');
+  });
+
+  it('triggers forbidden_pattern before evaluation and does not evaluate', () => {
+    const trace = makeTrace();
+    const evaluateSpy = vi.fn<ReplayEvaluateFn>().mockReturnValue({
+      decision: 'allow',
+      matched: false,
+      reason: 'ok',
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: evaluateSpy,
+    };
+    const maliciousCode = "const fs = require('fs'); fs.readFileSync('/etc/passwd');";
+    const result = evaluateInRefinerSandbox(maliciousCode, trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.forbiddenPatternViolations.length).toBeGreaterThan(0);
+    expect(result.forbiddenPatternViolations).toContain('require');
+    expect(evaluateSpy).not.toHaveBeenCalled();
+    expect(result.failedCases).toEqual([]);
+  });
+
+  it('classifies SyntaxError from evaluateCode as syntax_error', () => {
+    const trace = makeTrace();
+    const syntaxErrorEvaluate: ReplayEvaluateFn = () => {
+      throw new SyntaxError('Unexpected token');
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: syntaxErrorEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('code with syntax issue', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('syntax_error');
+    expect(result.failedCases[0]?.message).toContain('Unexpected token');
+  });
+
+  it('classifies non-SyntaxError throws as runtime_error', () => {
+    const trace = makeTrace();
+    const runtimeErrorEvaluate: ReplayEvaluateFn = () => {
+      throw new TypeError('Cannot read property of undefined');
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: runtimeErrorEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('runtime_error');
+    expect(result.failedCases[0]?.message).toContain('Cannot read property');
+  });
+
+  it('classifies timeout when evaluateCode exceeds timeoutMs', () => {
+    const trace = makeTrace();
+    const slowEvaluate: ReplayEvaluateFn = () => {
+      const start = Date.now();
+      while (Date.now() - start < 200) {
+        // busy wait
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: slowEvaluate,
+      timeoutMs: 1,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases.length).toBeGreaterThan(0);
+    expect(result.failedCases.some((c) => c.errorType === 'timeout')).toBe(true);
+  });
+
+  it('caps timeoutMs to MAX_TIMEOUT_MS when exceeded', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      if ((input.action.paramsSummary).path === '/etc/passwd') {
+        return { decision: 'block', matched: true, reason: 'dangerous' };
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: smartEvaluate,
+      timeoutMs: 999999,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(true);
+  });
+
+  it('classifies validation_failed when decision mismatches expected', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+    ]);
+    const wrongDecisionEvaluate: ReplayEvaluateFn = () => ({
+      decision: 'allow',
+      matched: false,
+      reason: 'should have blocked',
+    });
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: wrongDecisionEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('validation_failed');
+    expect(result.failedCases[0]?.message).toContain('Expected block');
+  });
+
+  it('does not import node:vm', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(
+      resolve(__dirname, '..', 'refiner-sandbox-wrapper.ts'),
+      'utf-8',
+    );
+    expect(src).not.toContain('node:vm');
+    expect(src).not.toContain('eval(');
+    expect(src).not.toContain('new Function');
+  });
+
+  it('does not break existing replayGoldenTrace contract', () => {
+    const trace = makeTrace([
+      makeCase({ caseId: 'neg-1', kind: 'negative', expectedDecision: 'block' }),
+      makeCase({ caseId: 'pos-1', kind: 'positive', expectedDecision: 'allow', params: { path: '/safe.txt' } }),
+    ]);
+    const smartEvaluate: ReplayEvaluateFn = (input) => {
+      if ((input.action.paramsSummary).path === '/etc/passwd') {
+        return { decision: 'block', matched: true, reason: 'dangerous' };
+      }
+      return { decision: 'allow', matched: false, reason: 'ok' };
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: smartEvaluate,
+    };
+    const result = evaluateInRefinerSandbox('safe code', trace, deps);
+    expect(result.success).toBe(true);
+    expect(result.failedCases).toEqual([]);
+  });
+
+  it('returns unknown errorType for non-Error throws', () => {
+    const trace = makeTrace();
+    const throwNonError: ReplayEvaluateFn = () => {
+      const err: unknown = 'string error';
+      throw err;
+    };
+    const deps: RefinerSandboxDependencies & RefinerSandboxOptions = {
+      evaluateCode: throwNonError,
+    };
+    const result = evaluateInRefinerSandbox('code', trace, deps);
+    expect(result.success).toBe(false);
+    expect(result.failedCases[0]?.errorType).toBe('unknown');
+    expect(result.failedCases[0]?.message).toContain('string error');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -40,6 +40,22 @@ export interface RefinerSandboxDependencies {
 export const DEFAULT_TIMEOUT_MS = 5000;
 export const MAX_TIMEOUT_MS = 30000;
 
+function safeErrorMessage(err: unknown): string {
+  try {
+    if (typeof err === 'string') return err;
+    if (typeof err === 'number' || typeof err === 'boolean' || typeof err === 'bigint') return String(err);
+    if (err === null) return 'null';
+    if (err === undefined) return 'undefined';
+    return String(err);
+  } catch {
+    try {
+      return Object.prototype.toString.call(err);
+    } catch {
+      return 'Unstringifiable thrown value';
+    }
+  }
+}
+
 function classifyError(err: unknown): { errorType: RefinerSandboxErrorType; message: string; stack?: string } {
   if (err instanceof SyntaxError) {
     return { errorType: 'syntax_error', message: err.message, stack: err.stack };
@@ -47,7 +63,7 @@ function classifyError(err: unknown): { errorType: RefinerSandboxErrorType; mess
   if (err instanceof Error) {
     return { errorType: 'runtime_error', message: err.message, stack: err.stack };
   }
-  return { errorType: 'unknown', message: String(err) };
+  return { errorType: 'unknown', message: safeErrorMessage(err) };
 }
 
 function resolveTimeoutMs(timeoutMs: number): number {

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -119,6 +119,13 @@ function validateCaseDecision(
   }
 }
 
+/**
+ * Evaluate rule code against GoldenTrace cases with structured error reporting.
+ *
+ * Timeout is detected post-evaluation (elapsed-time check). A synchronous
+ * infinite loop in generated code will block the call indefinitely; true
+ * async cancellation requires node:vm or AbortController at the plugin layer.
+ */
 export function evaluateInRefinerSandbox(
   code: string,
   goldenTrace: GoldenTrace,
@@ -176,15 +183,22 @@ export function evaluateInRefinerSandbox(
       continue;
     }
 
-    if (result) {
-      const validation = validateCaseDecision(traceCase, result);
-      if (!validation.passed) {
-        failedCases.push({
-          caseId: traceCase.caseId,
-          errorType: 'validation_failed',
-          message: validation.failureReason ?? 'Validation failed',
-        });
-      }
+    if (!result) {
+      failedCases.push({
+        caseId: traceCase.caseId,
+        errorType: 'validation_failed',
+        message: 'Evaluator returned null/undefined result',
+      });
+      continue;
+    }
+
+    const validation = validateCaseDecision(traceCase, result);
+    if (!validation.passed) {
+      failedCases.push({
+        caseId: traceCase.caseId,
+        errorType: 'validation_failed',
+        message: validation.failureReason ?? 'Validation failed',
+      });
     }
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -1,0 +1,197 @@
+import type { GoldenTrace, GoldenTraceCase } from '../golden-trace.js';
+import type { ReplayEvaluateFn } from '../golden-trace-replay-validator.js';
+import { checkForbiddenPatterns } from './rule-code-validator.js';
+import { createSyntheticRuleHostInput } from '../golden-trace.js';
+import type { RuleHostHelpers } from './rule-host-helpers.js';
+import type { RuleHostResult } from './rule-host-contracts.js';
+
+export type RefinerSandboxErrorType =
+  | 'forbidden_pattern'
+  | 'syntax_error'
+  | 'runtime_error'
+  | 'timeout'
+  | 'validation_failed'
+  | 'unknown';
+
+export interface RefinerSandboxFailedCase {
+  caseId: string;
+  errorType: RefinerSandboxErrorType;
+  message: string;
+  stack?: string;
+}
+
+export interface RefinerSandboxResult {
+  success: boolean;
+  failedCases: RefinerSandboxFailedCase[];
+  executionTimeMs: number;
+  forbiddenPatternViolations: string[];
+}
+
+export interface RefinerSandboxOptions {
+  timeoutMs?: number;
+}
+
+export interface RefinerSandboxDependencies {
+  evaluateCode?: ReplayEvaluateFn;
+}
+
+export const DEFAULT_TIMEOUT_MS = 5000;
+export const MAX_TIMEOUT_MS = 30000;
+
+function classifyError(err: unknown): { errorType: RefinerSandboxErrorType; message: string; stack?: string } {
+  if (err instanceof SyntaxError) {
+    return { errorType: 'syntax_error', message: err.message, stack: err.stack };
+  }
+  if (err instanceof Error) {
+    return { errorType: 'runtime_error', message: err.message, stack: err.stack };
+  }
+  return { errorType: 'unknown', message: String(err) };
+}
+
+function resolveTimeoutMs(timeoutMs: number): number {
+  if (timeoutMs > MAX_TIMEOUT_MS) {
+    return MAX_TIMEOUT_MS;
+  }
+  if (timeoutMs <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return timeoutMs;
+}
+
+function evaluateCaseWithTimeout(
+  evaluateFn: ReplayEvaluateFn,
+  traceCase: GoldenTraceCase,
+  timeoutMs: number,
+): { result: RuleHostResult | null; error: unknown; timedOut: boolean } {
+  const input = createSyntheticRuleHostInput(
+    { toolName: traceCase.toolName, params: traceCase.params },
+  );
+
+  const helpers: RuleHostHelpers = {
+    isRiskPath: () => input.workspace.isRiskPath,
+    getToolName: () => input.action.toolName,
+    getEstimatedLineChanges: () => input.derived.estimatedLineChanges,
+    getBashRisk: () => input.derived.bashRisk,
+    hasPlanFile: () => input.workspace.hasPlanFile,
+    getPlanStatus: () => input.workspace.planStatus,
+    getEpTier: () => input.evolution.epTier,
+  };
+
+  const start = Date.now();
+  try {
+    const result = evaluateFn(input, helpers);
+    const elapsed = Date.now() - start;
+    if (elapsed >= timeoutMs) {
+      return { result: null, error: null, timedOut: true };
+    }
+    return { result, error: null, timedOut: false };
+  } catch (err) {
+    const elapsed = Date.now() - start;
+    if (elapsed >= timeoutMs) {
+      return { result: null, error: null, timedOut: true };
+    }
+    return { result: null, error: err, timedOut: false };
+  }
+}
+
+function validateCaseDecision(
+  traceCase: GoldenTraceCase,
+  result: RuleHostResult,
+): { passed: boolean; failureReason?: string } {
+  switch (traceCase.expectedDecision) {
+    case 'allow':
+      if (result.decision !== 'allow' && result.matched !== false) {
+        return { passed: false, failureReason: `Expected allow but got ${result.decision}` };
+      }
+      return { passed: true };
+    case 'block':
+      if (result.decision !== 'block' && result.decision !== 'requireApproval') {
+        return { passed: false, failureReason: `Expected block but got ${result.decision}` };
+      }
+      return { passed: true };
+    case 'propose_correction':
+      if (result.decision !== 'auto_correct') {
+        return { passed: false, failureReason: `Expected auto_correct (propose_correction) but got ${result.decision}` };
+      }
+      return { passed: true };
+    default:
+      return { passed: false, failureReason: `Unknown expectedDecision: ${String(traceCase.expectedDecision)}` };
+  }
+}
+
+export function evaluateInRefinerSandbox(
+  code: string,
+  goldenTrace: GoldenTrace,
+  deps: RefinerSandboxDependencies & RefinerSandboxOptions,
+): RefinerSandboxResult {
+  const startTime = Date.now();
+  const timeoutMs = resolveTimeoutMs(deps.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  const forbiddenViolations = checkForbiddenPatterns(code);
+  if (forbiddenViolations.length > 0) {
+    return {
+      success: false,
+      failedCases: [],
+      executionTimeMs: Date.now() - startTime,
+      forbiddenPatternViolations: forbiddenViolations,
+    };
+  }
+
+  const evaluateFn = deps.evaluateCode;
+  if (!evaluateFn) {
+    return {
+      success: false,
+      failedCases: [{
+        caseId: '__no_evaluator__',
+        errorType: 'unknown',
+        message: 'No evaluateCode provided in dependencies',
+      }],
+      executionTimeMs: Date.now() - startTime,
+      forbiddenPatternViolations: [],
+    };
+  }
+
+  const failedCases: RefinerSandboxFailedCase[] = [];
+
+  for (const traceCase of goldenTrace.cases) {
+    const { result, error, timedOut } = evaluateCaseWithTimeout(evaluateFn, traceCase, timeoutMs);
+
+    if (timedOut) {
+      failedCases.push({
+        caseId: traceCase.caseId,
+        errorType: 'timeout',
+        message: `Evaluation timed out after ${timeoutMs}ms`,
+      });
+      continue;
+    }
+
+    if (error !== null) {
+      const classified = classifyError(error);
+      failedCases.push({
+        caseId: traceCase.caseId,
+        errorType: classified.errorType,
+        message: classified.message,
+        stack: classified.stack,
+      });
+      continue;
+    }
+
+    if (result) {
+      const validation = validateCaseDecision(traceCase, result);
+      if (!validation.passed) {
+        failedCases.push({
+          caseId: traceCase.caseId,
+          errorType: 'validation_failed',
+          message: validation.failureReason ?? 'Validation failed',
+        });
+      }
+    }
+  }
+
+  return {
+    success: failedCases.length === 0,
+    failedCases,
+    executionTimeMs: Date.now() - startTime,
+    forbiddenPatternViolations: [],
+  };
+}

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -28,7 +28,8 @@ export interface RefinerSandboxResult {
 }
 
 export interface RefinerSandboxOptions {
-  timeoutMs?: number;
+  /** Elapsed-time classification threshold (NOT hard cancellation). See evaluateInRefinerSandbox JSDoc. */
+  softTimeoutMs?: number;
 }
 
 export interface RefinerSandboxDependencies {
@@ -122,9 +123,12 @@ function validateCaseDecision(
 /**
  * Evaluate rule code against GoldenTrace cases with structured error reporting.
  *
- * Timeout is detected post-evaluation (elapsed-time check). A synchronous
- * infinite loop in generated code will block the call indefinitely; true
- * async cancellation requires node:vm or AbortController at the plugin layer.
+ * **Timeout semantics**: `softTimeoutMs` is an elapsed-time classification
+ * threshold, NOT a hard cancellation mechanism. If `evaluateCode` blocks
+ * synchronously (infinite loop, long computation), this wrapper cannot
+ * interrupt it — the timeout is only detected after `evaluateCode` returns.
+ * Hard cancellation requires `node:vm` or `AbortController` at the
+ * plugin/sandbox-adapter layer, which is out of scope for core.
  */
 export function evaluateInRefinerSandbox(
   code: string,
@@ -132,7 +136,7 @@ export function evaluateInRefinerSandbox(
   deps: RefinerSandboxDependencies & RefinerSandboxOptions,
 ): RefinerSandboxResult {
   const startTime = Date.now();
-  const timeoutMs = resolveTimeoutMs(deps.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const timeoutMs = resolveTimeoutMs(deps.softTimeoutMs ?? DEFAULT_TIMEOUT_MS);
 
   const forbiddenViolations = checkForbiddenPatterns(code);
   if (forbiddenViolations.length > 0) {

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -5,6 +5,7 @@ import { checkForbiddenPatterns } from './rule-code-validator.js';
 import { createSyntheticRuleHostInput } from '../golden-trace.js';
 import type { RuleHostHelpers } from './rule-host-helpers.js';
 import type { RuleHostResult } from './rule-host-contracts.js';
+import { validateCorrectionProposal } from './correction-proposal.js';
 
 export type RefinerSandboxErrorType =
   | 'forbidden_pattern'
@@ -53,6 +54,16 @@ function safeErrorMessage(err: unknown): string {
     } catch {
       return 'Unstringifiable thrown value';
     }
+  }
+}
+
+function isSafeRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  try {
+    Object.keys(value);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -138,15 +149,29 @@ function validateCaseDecision(
         return { passed: false, failureReason: 'auto_correct decision missing correctionProposal' };
       }
       {
+        const proposalValidation = validateCorrectionProposal(result.correctionProposal);
+        if (!proposalValidation.valid) {
+          return { passed: false, failureReason: `correctionProposal invalid: ${proposalValidation.errors.join('; ')}` };
+        }
         const proposal = result.correctionProposal;
         const reasons: string[] = [];
-        if (traceCase.expectedProposedParams) {
-          const diffs = diffParams(traceCase.expectedProposedParams, proposal.proposedParams);
-          if (diffs.length > 0) {
-            reasons.push(`proposedParams mismatch: ${diffs.join('; ')}`);
+        if (traceCase.expectedProposedParams !== undefined) {
+          if (!isSafeRecord(traceCase.expectedProposedParams)) {
+            reasons.push('expectedProposedParams is not a safe record');
+          } else if (!isSafeRecord(proposal.proposedParams)) {
+            reasons.push('proposedParams is not a safe record');
+          } else {
+            try {
+              const diffs = diffParams(traceCase.expectedProposedParams, proposal.proposedParams);
+              if (diffs.length > 0) {
+                reasons.push(`proposedParams mismatch: ${diffs.join('; ')}`);
+              }
+            } catch (err) {
+              reasons.push(`proposedParams comparison failed: ${safeErrorMessage(err)}`);
+            }
           }
         }
-        if (traceCase.expectedApplicationMode) {
+        if (traceCase.expectedApplicationMode !== undefined) {
           if (proposal.applicationMode !== traceCase.expectedApplicationMode) {
             reasons.push(`applicationMode mismatch: expected ${traceCase.expectedApplicationMode}, got ${proposal.applicationMode}`);
           }

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -50,6 +50,9 @@ function classifyError(err: unknown): { errorType: RefinerSandboxErrorType; mess
 }
 
 function resolveTimeoutMs(timeoutMs: number): number {
+  if (!Number.isFinite(timeoutMs)) {
+    return DEFAULT_TIMEOUT_MS;
+  }
   if (timeoutMs > MAX_TIMEOUT_MS) {
     return MAX_TIMEOUT_MS;
   }
@@ -63,7 +66,7 @@ function evaluateCaseWithTimeout(
   evaluateFn: ReplayEvaluateFn,
   traceCase: GoldenTraceCase,
   timeoutMs: number,
-): { result: RuleHostResult | null; error: unknown; timedOut: boolean } {
+): { result: RuleHostResult | null; error: unknown; timedOut: boolean; threw: boolean } {
   const input = createSyntheticRuleHostInput(
     { toolName: traceCase.toolName, params: traceCase.params },
   );
@@ -83,15 +86,15 @@ function evaluateCaseWithTimeout(
     const result = evaluateFn(input, helpers);
     const elapsed = Date.now() - start;
     if (elapsed >= timeoutMs) {
-      return { result: null, error: null, timedOut: true };
+      return { result: null, error: null, timedOut: true, threw: false };
     }
-    return { result, error: null, timedOut: false };
+    return { result, error: null, timedOut: false, threw: false };
   } catch (err) {
     const elapsed = Date.now() - start;
     if (elapsed >= timeoutMs) {
-      return { result: null, error: null, timedOut: true };
+      return { result: null, error: null, timedOut: true, threw: false };
     }
-    return { result: null, error: err, timedOut: false };
+    return { result: null, error: err, timedOut: false, threw: true };
   }
 }
 
@@ -165,7 +168,7 @@ export function evaluateInRefinerSandbox(
   const failedCases: RefinerSandboxFailedCase[] = [];
 
   for (const traceCase of goldenTrace.cases) {
-    const { result, error, timedOut } = evaluateCaseWithTimeout(evaluateFn, traceCase, timeoutMs);
+    const { result, error, timedOut, threw } = evaluateCaseWithTimeout(evaluateFn, traceCase, timeoutMs);
 
     if (timedOut) {
       failedCases.push({
@@ -176,7 +179,7 @@ export function evaluateInRefinerSandbox(
       continue;
     }
 
-    if (error !== null) {
+    if (threw) {
       const classified = classifyError(error);
       failedCases.push({
         caseId: traceCase.caseId,

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -1,5 +1,6 @@
 import type { GoldenTrace, GoldenTraceCase } from '../golden-trace.js';
 import type { ReplayEvaluateFn } from '../golden-trace-replay-validator.js';
+import { diffParams } from '../golden-trace-replay-validator.js';
 import { checkForbiddenPatterns } from './rule-code-validator.js';
 import { createSyntheticRuleHostInput } from '../golden-trace.js';
 import type { RuleHostHelpers } from './rule-host-helpers.js';
@@ -116,6 +117,27 @@ function validateCaseDecision(
     case 'propose_correction':
       if (result.decision !== 'auto_correct') {
         return { passed: false, failureReason: `Expected auto_correct (propose_correction) but got ${result.decision}` };
+      }
+      if (!result.correctionProposal) {
+        return { passed: false, failureReason: 'auto_correct decision missing correctionProposal' };
+      }
+      {
+        const proposal = result.correctionProposal;
+        const reasons: string[] = [];
+        if (traceCase.expectedProposedParams) {
+          const diffs = diffParams(traceCase.expectedProposedParams, proposal.proposedParams);
+          if (diffs.length > 0) {
+            reasons.push(`proposedParams mismatch: ${diffs.join('; ')}`);
+          }
+        }
+        if (traceCase.expectedApplicationMode) {
+          if (proposal.applicationMode !== traceCase.expectedApplicationMode) {
+            reasons.push(`applicationMode mismatch: expected ${traceCase.expectedApplicationMode}, got ${proposal.applicationMode}`);
+          }
+        }
+        if (reasons.length > 0) {
+          return { passed: false, failureReason: reasons.join('; ') };
+        }
       }
       return { passed: true };
     default:


### PR DESCRIPTION
## PRI-172: Refiner-aware Sandbox Wrapper for PrincipleCompiler

### RFC Decision: Option A

Reuse and wrap the existing GoldenTrace replay adapter. Do **not** create a new SandboxEvaluator and do **not** import \
ode:vm\ in core.

### Public Contract Summary

\\\	ypescript
type RefinerSandboxErrorType =
  | 'forbidden_pattern' | 'syntax_error' | 'runtime_error'
  | 'timeout' | 'validation_failed' | 'unknown';

interface RefinerSandboxFailedCase {
  caseId: string;
  errorType: RefinerSandboxErrorType;
  message: string;
  stack?: string;
}

interface RefinerSandboxResult {
  success: boolean;
  failedCases: RefinerSandboxFailedCase[];
  executionTimeMs: number;
  forbiddenPatternViolations: string[];
}

interface RefinerSandboxOptions {
  /** Elapsed-time classification threshold (NOT hard cancellation). */
  softTimeoutMs?: number;
}
interface RefinerSandboxDependencies { evaluateCode?: ReplayEvaluateFn; }

function evaluateInRefinerSandbox(
  code: string,
  goldenTrace: GoldenTrace,
  deps: RefinerSandboxDependencies & RefinerSandboxOptions,
): RefinerSandboxResult
\\\

### How it Reuses GoldenTrace Replay Adapter

- Uses \ReplayEvaluateFn\ type from \golden-trace-replay-validator.ts\ — same evaluator signature
- Uses \createSyntheticRuleHostInput\ from \golden-trace.ts\ — same input construction
- Uses \checkForbiddenPatterns\ from \ule-code-validator.ts\ — same forbidden pattern check
- Evaluates each case individually (not via \eplayGoldenTrace\) to capture per-case errors and timeouts

### How Core Stays Pure (no node:vm)

- \valuateCode\ is injected via \RefinerSandboxDependencies\ — core never imports \
ode:vm\
- Architecture regression test guards: no \
ode:vm\ import, no \val()\, no \
ew Function\ in wrapper
- Real VM isolation is the caller's responsibility (openclaw-plugin injects the sandbox evaluator)

### Timeout Semantics (IMPORTANT)

\softTimeoutMs\ is an **elapsed-time classification threshold**, NOT a hard cancellation mechanism.
If \valuateCode\ blocks synchronously (infinite loop, long computation), this wrapper **cannot**
interrupt it — the timeout is only detected after \valuateCode\ returns. Hard cancellation requires
\
ode:vm\ or \AbortController\ at the plugin/sandbox-adapter layer, which is out of scope for core.

### Known Limitations

1. **propose_correction validation**: Only checks \decision === 'auto_correct'\. The current
   \GoldenTraceCase\ schema does not include \xpectedProposedParams\ or \pplicationMode\
   constraints. Full validation of proposed corrections will be added when PRI-173 extends the schema.
2. **Soft timeout only**: See Timeout Semantics above. Hard timeout is the host adapter's responsibility.

### Test Commands and Results

\\\ash
npm run build --workspace=@principles/core          # passes
npm run lint                                         # passes
npx vitest run .../refiner-sandbox-wrapper.test.ts   # 13/13 pass
npx vitest run .../golden-trace-replay-validator.test.ts  # 9/9 pass
npx vitest run .../architecture-regression.test.ts   # 397/397 pass
\\\

### Not Implemented (Out of Scope)

- Refiner Loop (PRI-173)
- LLM prompt design (PRI-173)
- RuleHostWriter (PRI-146)
- Live activation / shadow mode evaluation
- Hard timeout / execution cancellation (requires host adapter layer)

### Files Changed

- **NEW**: \internalization/refiner-sandbox-wrapper.ts\
- **NEW**: \internalization/__tests__/refiner-sandbox-wrapper.test.ts\ (13 tests)
- **MOD**: \untime-v2/index.ts\ (barrel exports)
- **MOD**: \rchitecture-regression.test.ts\ (PRI-172 boundary guards)