### PR TITLE
refactor(cli): migrate Tier 1 commands to read models (PRI-131)

### DIFF
--- a/packages/pd-cli/src/commands/health.ts
+++ b/packages/pd-cli/src/commands/health.ts
@@ -5,14 +5,15 @@
  *
  * Reads workspace/.pd/state.db and workspace/.state/principle_training_state.json
  * to provide Runtime V2 health diagnostics.
- * Does NOT depend on openclaw-plugin source paths.
+ * Uses read models from @principles/core/runtime-v2 (no direct ledger access).
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
-import { loadLedger, getLedgerFilePathPublic } from '@principles/core/runtime-v2';
+import { PruningReadModel, PainChainReadModel, auditCandidateLedgerConsistency, getLedgerFilePathPublic } from '@principles/core/runtime-v2';
+import type { PainChainTrace } from '@principles/core/runtime-v2';
 
 interface LastSuccessfulChain {
   painId?: string;
@@ -43,6 +44,24 @@ interface HealthOptions {
   json?: boolean;
 }
 
+function painChainTraceToLastSuccessfulChain(trace: PainChainTrace): LastSuccessfulChain {
+  const totalMs = (trace.latencyMs.painToTask ?? 0)
+    + (trace.latencyMs.taskToRun ?? 0)
+    + (trace.latencyMs.runToArtifact ?? 0);
+
+  return {
+    painId: trace.painId,
+    taskId: trace.taskId,
+    runId: trace.runId ?? '',
+    artifactId: trace.artifactId ?? '',
+    candidateIds: trace.candidateIds,
+    ledgerEntryIds: trace.ledgerEntryIds,
+    latencyMs: { totalMs: totalMs > 0 ? totalMs : undefined },
+    failureCategory: trace.failureCategory,
+    checkedAt: trace.checkedAt,
+  };
+}
+
 export async function handleHealth(opts: HealthOptions = {}): Promise<void> {
   const workspaceDir = opts.workspace
     ? path.resolve(opts.workspace)
@@ -53,32 +72,16 @@ export async function handleHealth(opts: HealthOptions = {}): Promise<void> {
   const ledgerStateDir = path.join(workspaceDir, '.state');
   const ledgerPath = getLedgerFilePathPublic(ledgerStateDir);
 
-  // Load ledger
-  const ledger = loadLedger(ledgerStateDir);
-  const principleEntries = Object.values(ledger.tree.principles);
+  const pruningModel = new PruningReadModel({ workspaceDir });
+  const healthSummary = pruningModel.getHealthSummary();
+  const ledgerByStatus = healthSummary.byStatus;
 
-  // Count by status in ledger
-  const ledgerByStatus: Record<string, number> = {};
-  for (const p of principleEntries) {
-    const status = (p as { status?: string }).status || 'unknown';
-    ledgerByStatus[status] = (ledgerByStatus[status] || 0) + 1;
-  }
+  const { missingLedgerCount } = await auditCandidateLedgerConsistency(workspaceDir);
 
-  // Build candidateId → ledgerEntryId reverse map once
-  const candidateToLedgerEntry = new Map<string, string>();
-  for (const entry of principleEntries) {
-    const e = entry as { id: string; derivedFromPainIds?: string[] };
-    for (const cid of e.derivedFromPainIds ?? []) {
-      candidateToLedgerEntry.set(cid, e.id);
-    }
-  }
-
-  // Load PD state.db metrics
   let candidatesTotal = 0, candidatesConsumed = 0, candidatesPending = 0;
   let tasksTotal = 0;
   const tasksByStatus: Record<string, number> = {};
   let pdDbExists = false;
-  let missingLedgerCount = 0;
   let lastSuccessfulChain: LastSuccessfulChain | undefined = undefined;
   let partialHealth = false;
 
@@ -91,7 +94,7 @@ export async function handleHealth(opts: HealthOptions = {}): Promise<void> {
       ledger: {
         path: ledgerPath,
         exists: fs.existsSync(ledgerPath),
-        totalPrinciples: principleEntries.length,
+        totalPrinciples: healthSummary.totalPrinciples,
         byStatus: ledgerByStatus,
       },
       candidates: { total: candidatesTotal, consumed: candidatesConsumed, pending: candidatesPending },
@@ -162,56 +165,18 @@ export async function handleHealth(opts: HealthOptions = {}): Promise<void> {
         tasksByStatus[r.status] = r.total;
       }
 
-      // Candidate/ledger consistency check
-      const consumedRows = db.prepare("SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'").all() as { candidate_id: string }[];
-      for (const r of consumedRows) {
-        if (!candidateToLedgerEntry.has(r.candidate_id)) missingLedgerCount++;
+      const painChainModel = new PainChainReadModel({ workspaceDir });
+      try {
+        const chain = await painChainModel.getLastSuccessfulChain();
+        if (chain) {
+          lastSuccessfulChain = painChainTraceToLastSuccessfulChain(chain);
+        }
+      } catch {
+        partialHealth = true;
+      } finally {
+        await painChainModel.close();
       }
-
-      // Last successful chain query — graceful degradation if schema incomplete
-      const lastSucceeded = db.prepare(
-        "SELECT task_id, input_ref, created_at FROM tasks WHERE status = 'succeeded' ORDER BY updated_at DESC LIMIT 1"
-      ).get() as { task_id: string; input_ref: string | null; created_at: string } | undefined;
-      if (!lastSucceeded) { db.close(); writeHealth(); return; }
-
-      const run = db.prepare(
-        "SELECT run_id FROM runs WHERE task_id = ? AND execution_status = 'succeeded' ORDER BY started_at DESC LIMIT 1"
-      ).get(lastSucceeded.task_id) as { run_id: string } | undefined;
-      if (!run) { db.close(); writeHealth(); return; }
-
-      const artifacts = db.prepare(
-        "SELECT artifact_id, created_at FROM artifacts WHERE run_id = ? ORDER BY created_at DESC LIMIT 1"
-      ).get(run.run_id) as { artifact_id: string; created_at: string } | undefined;
-      if (!artifacts) { db.close(); writeHealth(); return; }
-
-      const candidates = db.prepare(
-        "SELECT candidate_id FROM principle_candidates WHERE artifact_id = ?"
-      ).all(artifacts.artifact_id) as { candidate_id: string }[];
-      if (candidates.length === 0) { db.close(); writeHealth(); return; }
-
-      const ledgerEntryIds: string[] = [];
-      for (const c of candidates) {
-        const entryId = candidateToLedgerEntry.get(c.candidate_id);
-        if (entryId) ledgerEntryIds.push(entryId);
-      }
-
-      lastSuccessfulChain = {
-        painId: lastSucceeded.input_ref ?? undefined,
-        taskId: lastSucceeded.task_id,
-        runId: run.run_id,
-        artifactId: artifacts.artifact_id,
-        candidateIds: candidates.map(c => c.candidate_id),
-        ledgerEntryIds,
-        latencyMs: {
-          totalMs: lastSucceeded.created_at
-            ? Math.max(0, new Date(artifacts.created_at).getTime() - new Date(lastSucceeded.created_at).getTime())
-            : undefined,
-        },
-        failureCategory: null,
-        checkedAt: generatedAt,
-      };
     } catch (err) {
-      // Schema mismatch or transient SQLite error — emit partial health report
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`Warning: could not read full state.db metrics — partial health data: ${msg}`);
       partialHealth = true;

--- a/packages/pd-cli/src/commands/runtime-internalization-queue.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-queue.ts
@@ -8,7 +8,7 @@
  * Never acquires leases or mutates any task/run/artifact/ledger state.
  */
 import * as path from 'path';
-import { RuntimeStateManager, InternalizationQueueReadModel } from '@principles/core/runtime-v2';
+import { createInternalizationQueueReadModel } from '@principles/core/runtime-v2';
 import type { InternalizationQueueSnapshot } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
@@ -76,11 +76,9 @@ function formatTextOutput(snap: InternalizationQueueSnapshot): string {
 export async function handleRuntimeInternalizationQueue(opts: QueueOptions): Promise<void> {
   const workspaceDir = opts.workspace ? path.resolve(opts.workspace) : resolveWorkspaceDir();
 
-  const stateManager = new RuntimeStateManager({ workspaceDir });
-  await stateManager.initialize();
+  const { readModel, close } = await createInternalizationQueueReadModel({ workspaceDir });
 
   try {
-    const readModel = new InternalizationQueueReadModel(stateManager);
     const snapshot = await readModel.getSnapshot();
 
     if (opts.json) {
@@ -89,6 +87,6 @@ export async function handleRuntimeInternalizationQueue(opts: QueueOptions): Pro
       console.log(formatTextOutput(snapshot));
     }
   } finally {
-    await stateManager.close();
+    await close();
   }
 }

--- a/packages/pd-cli/src/commands/runtime-pruning.ts
+++ b/packages/pd-cli/src/commands/runtime-pruning.ts
@@ -8,7 +8,7 @@
 
 import * as path from 'path';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
-import { PruningReadModel, appendPruningReview, listPruningReviews, buildMaskedPrincipleSet, loadLedger, saveLedger } from '@principles/core/runtime-v2';
+import { PruningReadModel, appendPruningReview, listPruningReviews, buildMaskedPrincipleSet, removeOrphanReferencesFromLedger } from '@principles/core/runtime-v2';
 import type { PruningReviewDecision, OrphanDerivedCandidate, OrphanDetectionResult } from '@principles/core/runtime-v2';
 import { createRemediationResult, remediationAction } from './remediation-output.js';
 import type { RemediationResult } from './remediation-output.js';
@@ -395,38 +395,15 @@ export function handlePruningOrphans(opts: PruningOrphansOptions): void {
   }
 
   const stateDir = path.join(workspaceDir, '.state');
-  const ledger = loadLedger(stateDir);
-  const removedFromPrinciples: { principleId: string; removedIds: string[] }[] = [];
-
-  // Deep clone ledger to avoid mutating the loaded object (immutability requirement)
-  const nextLedger = JSON.parse(JSON.stringify(ledger)) as typeof ledger;
-
-  for (const [principleId, orphanIds] of orphanIdsByPrinciple) {
-    const entry = nextLedger.tree.principles[principleId];
-    if (!entry) continue;
-
-    const originalIds = entry.derivedFromPainIds ?? [];
-    const orphanIdSet = orphanIds;
-    const filteredIds = originalIds.filter((id: string) => !orphanIdSet.has(id));
-
-    if (filteredIds.length !== originalIds.length) {
-      entry.derivedFromPainIds = filteredIds;
-      removedFromPrinciples.push({
-        principleId,
-        removedIds: originalIds.filter((id: string) => orphanIdSet.has(id)),
-      });
-    }
-  }
-
-  if (removedFromPrinciples.length > 0) {
+  const removedFromPrinciples = (() => {
     try {
-      saveLedger(stateDir, nextLedger);
+      return removeOrphanReferencesFromLedger(stateDir, orphanIdsByPrinciple);
     } catch (err) {
       console.error(`❌ Failed to save ledger: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
-      return;
+      return [] as { principleId: string; removedIds: string[] }[];
     }
-  }
+  })();
 
   const removedCount = removedFromPrinciples.reduce((sum, item) => sum + item.removedIds.length, 0);
   const result: RemediationResult = createRemediationResult({

--- a/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
@@ -7,19 +7,19 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const mockGetSnapshot = vi.fn();
-const mockClose = vi.fn().mockResolvedValue(undefined);
+const { mockGetSnapshot, mockClose } = vi.hoisted(() => ({
+  mockGetSnapshot: vi.fn(),
+  mockClose: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
 }));
 
 vi.mock('@principles/core/runtime-v2', () => ({
-  RuntimeStateManager: vi.fn().mockImplementation(function () {
-    return { initialize: vi.fn().mockResolvedValue(undefined), close: mockClose };
-  }),
-  InternalizationQueueReadModel: vi.fn().mockImplementation(function () {
-    return { getSnapshot: mockGetSnapshot, close: mockClose };
+  createInternalizationQueueReadModel: vi.fn().mockResolvedValue({
+    readModel: { getSnapshot: mockGetSnapshot, close: mockClose },
+    close: mockClose,
   }),
 }));
 
@@ -38,6 +38,8 @@ function emptySnapshot() {
     blockedSummary: { count: 0, samples: [] },
     dependencyFailedSummary: { count: 0, samples: [] },
     retryWaitPendingSummary: { count: 0, samples: [] },
+    leaseConflictSummary: { count: 0, samples: [] },
+    unresolvableSummary: { count: 0, samples: [] },
     readyTasks: [],
     noReadyTasks: { reason: 'no_candidates', inspectedCount: 0 },
   };

--- a/packages/pd-cli/tests/commands/runtime-pruning.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-pruning.test.ts
@@ -60,8 +60,7 @@ const { MockPruningReadModel } = vi.hoisted(() => {
 const mockAppendPruningReview = vi.hoisted(() => vi.fn());
 const mockListPruningReviews = vi.hoisted(() => vi.fn());
 const mockBuildMaskedPrincipleSet = vi.hoisted(() => vi.fn());
-const mockLoadLedger = vi.hoisted(() => vi.fn());
-const mockSaveLedger = vi.hoisted(() => vi.fn());
+const mockRemoveOrphanReferencesFromLedger = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/test-workspace'),
@@ -87,8 +86,7 @@ vi.mock('@principles/core/runtime-v2', () => ({
   appendPruningReview: mockAppendPruningReview,
   listPruningReviews: mockListPruningReviews,
   buildMaskedPrincipleSet: mockBuildMaskedPrincipleSet,
-  loadLedger: mockLoadLedger,
-  saveLedger: mockSaveLedger,
+  removeOrphanReferencesFromLedger: mockRemoveOrphanReferencesFromLedger,
 }));
 
 import { handlePruningReport, handlePruningExplain, handlePruningReview, handlePruningRollback, handlePruningOrphans } from '../../src/commands/runtime-pruning.js';
@@ -503,8 +501,7 @@ describe('pd runtime pruning rollback', () => {
 describe('pd runtime pruning orphans', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoadLedger.mockReset();
-    mockSaveLedger.mockReset();
+    mockRemoveOrphanReferencesFromLedger.mockReset();
   });
 
   it('dry-run outputs orphan list with count (JSON)', () => {
@@ -544,23 +541,14 @@ describe('pd runtime pruning orphans', () => {
     expect(output.mode).toBe('dry_run');
     expect(output.status).toBe('no_op');
     expect(output.dryRun).toBe(true);
-    expect(mockSaveLedger).not.toHaveBeenCalled();
+    expect(mockRemoveOrphanReferencesFromLedger).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 
   it('--confirm removes orphan IDs from ledger derivedFromPainIds', () => {
-    const mockLedger = {
-      tree: {
-        principles: {
-          p1: {
-            id: 'p1',
-            derivedFromPainIds: ['c_orphan1', 'c_valid1'],
-          },
-        },
-      },
-    };
-    mockLoadLedger.mockReturnValue(mockLedger);
-    mockSaveLedger.mockImplementation(() => {});
+    mockRemoveOrphanReferencesFromLedger.mockReturnValue([
+      { principleId: 'p1', removedIds: ['c_orphan1'] },
+    ]);
 
     class MockOrphanReadModel {
       getOrphanDerivedCandidates() {
@@ -578,10 +566,7 @@ describe('pd runtime pruning orphans', () => {
 
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     handlePruningOrphans({ json: true, confirm: true });
-    expect(mockSaveLedger).toHaveBeenCalledTimes(1);
-    // Verify the saved ledger contains the correct filtered data (immutability: original mock unchanged)
-    const savedLedgerArg = mockSaveLedger.mock.calls[0]![1];
-    expect(savedLedgerArg.tree.principles.p1.derivedFromPainIds).toEqual(['c_valid1']);
+    expect(mockRemoveOrphanReferencesFromLedger).toHaveBeenCalledTimes(1);
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
     expect(output.mode).toBe('confirm');
     expect(output.status).toBe('changed');
@@ -595,18 +580,7 @@ describe('pd runtime pruning orphans', () => {
   });
 
   it('--confirm does not touch non-orphan candidates', () => {
-    const mockLedger = {
-      tree: {
-        principles: {
-          p1: {
-            id: 'p1',
-            derivedFromPainIds: ['c_valid1', 'c_valid2'],
-          },
-        },
-      },
-    };
-    mockLoadLedger.mockReturnValue(mockLedger);
-    mockSaveLedger.mockImplementation(() => {});
+    mockRemoveOrphanReferencesFromLedger.mockReturnValue([]);
 
     class MockOrphanReadModel {
       getOrphanDerivedCandidates() {
@@ -624,7 +598,8 @@ describe('pd runtime pruning orphans', () => {
 
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     handlePruningOrphans({ json: true, confirm: true });
-    expect(mockLedger.tree.principles.p1.derivedFromPainIds).toEqual(['c_valid1', 'c_valid2']);
+    const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
+    expect(output.removedFromPrinciples).toHaveLength(0);
     consoleSpy.mockRestore();
   });
 
@@ -656,7 +631,7 @@ describe('pd runtime pruning orphans', () => {
     const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
     handlePruningOrphans({ json: false, confirm: true });
     expect(processSpy).toHaveBeenCalledWith(1);
-    expect(mockSaveLedger).not.toHaveBeenCalled();
+    expect(mockRemoveOrphanReferencesFromLedger).not.toHaveBeenCalled();
     const errOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(errOutput).toContain('REFUSED');
     consoleSpy.mockRestore();
@@ -682,7 +657,7 @@ describe('pd runtime pruning orphans', () => {
     const processSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code: number) => never);
     handlePruningOrphans({ json: true, confirm: true });
     expect(processSpy).toHaveBeenCalledWith(1);
-    expect(mockSaveLedger).not.toHaveBeenCalled();
+    expect(mockRemoveOrphanReferencesFromLedger).not.toHaveBeenCalled();
     const output = JSON.parse(consoleSpy.mock.calls[0]![0] as string);
     expect(output.status).toBe('refused');
     expect(output.safeToConfirm).toBe(false);

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -623,6 +623,49 @@ describe('pd-cli command boundaries', () => {
     expect(src).not.toContain('loadLedger');
     expect(src).toContain('PainChainReadModel');
   });
+
+  it('health.ts does not import loadLedger', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const cmdPath = resolve(
+      __dirname,
+      '../../../../pd-cli/src/commands/health.ts',
+    );
+    expect(existsSync(cmdPath)).toBe(true);
+    const src = readFileSync(cmdPath, 'utf-8');
+    expect(src).not.toContain('loadLedger');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('PruningReadModel');
+  });
+
+  it('runtime-pruning.ts does not import loadLedger or saveLedger', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const cmdPath = resolve(
+      __dirname,
+      '../../../../pd-cli/src/commands/runtime-pruning.ts',
+    );
+    expect(existsSync(cmdPath)).toBe(true);
+    const src = readFileSync(cmdPath, 'utf-8');
+    expect(src).not.toContain('loadLedger');
+    expect(src).not.toContain('saveLedger');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('removeOrphanReferencesFromLedger');
+  });
+
+  it('runtime-internalization-queue.ts does not import RuntimeStateManager', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const cmdPath = resolve(
+      __dirname,
+      '../../../../pd-cli/src/commands/runtime-internalization-queue.ts',
+    );
+    expect(existsSync(cmdPath)).toBe(true);
+    const src = readFileSync(cmdPath, 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).not.toContain('loadLedger');
+    expect(src).toContain('createInternalizationQueueReadModel');
+  });
 });
 
 // ── PRI-45: RuleHost adapter boundary ────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -273,8 +273,8 @@ export { EvolutionQueueItemMigrator } from './store/task-migration.js';
 export { loadLedger, saveLedger, getLedgerFilePathPublic, updatePrinciple } from '../principle-tree-ledger.js';
 
 // Pruning read model (PRI-15)
-export { PruningReadModel } from './pruning-read-model.js';
-export type { PrinciplePruningSignal, PruningHealthSummary, PruningReadModelOptions, PruningRiskLevel, OrphanDerivedCandidate, OrphanDetectionResult } from './pruning-read-model.js';
+export { PruningReadModel, removeOrphanReferencesFromLedger } from './pruning-read-model.js';
+export type { PrinciplePruningSignal, PruningHealthSummary, PruningReadModelOptions, PruningRiskLevel, OrphanDerivedCandidate, OrphanDetectionResult, RemovedOrphanReference } from './pruning-read-model.js';
 
 // Pruning review audit log (PRI-24)
 export { appendPruningReview, listPruningReviews } from './pruning-review-log.js';
@@ -753,7 +753,7 @@ export {
 
 // ── Internalization Queue Read Model (PRI-73) ──────────────────────────────
 
-export { InternalizationQueueReadModel } from './internalization-queue-read-model.js';
+export { InternalizationQueueReadModel, createInternalizationQueueReadModel } from './internalization-queue-read-model.js';
 export type {
   InternalizationQueueSnapshot,
   NoReadyTasksDiagnosis,
@@ -764,6 +764,7 @@ export type {
   RetryWaitPendingSample,
   LeaseConflictSample,
   UnresolvableSample,
+  InternalizationQueueReadModelHandle,
 } from './internalization-queue-read-model.js';
 
 // ── Idle Trigger Decision Model (PRI-143) ──────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
@@ -16,7 +16,7 @@
  * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
  */
 import type { TaskRecord } from './task-status.js';
-import type { RuntimeStateManager } from './store/runtime-state-manager.js';
+import { RuntimeStateManager } from './store/runtime-state-manager.js';
 import type { PeerRunnerKind, InternalizationChannel } from './internalization/peer-runner-contracts.js';
 import { isPeerRunnerKind } from './internalization/peer-runner-contracts.js';
 import { hydratePITaskRecord } from './internalization/pitask-metadata.js';
@@ -285,4 +285,23 @@ export class InternalizationQueueReadModel {
   async close(): Promise<void> {
     // No-op: RuntimeStateManager lifecycle managed by caller
   }
+}
+
+export interface InternalizationQueueReadModelHandle {
+  readModel: InternalizationQueueReadModel;
+  close: () => Promise<void>;
+}
+
+export async function createInternalizationQueueReadModel(
+  opts: { workspaceDir: string },
+): Promise<InternalizationQueueReadModelHandle> {
+  const stateManager = new RuntimeStateManager({ workspaceDir: opts.workspaceDir });
+  await stateManager.initialize();
+  const readModel = new InternalizationQueueReadModel(stateManager);
+  return {
+    readModel,
+    close: async () => {
+      await stateManager.close();
+    },
+  };
 }

--- a/packages/principles-core/src/runtime-v2/pruning-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/pruning-read-model.ts
@@ -16,7 +16,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import Database from 'better-sqlite3';
-import { loadLedger } from '../principle-tree-ledger.js';
+import { loadLedger, saveLedger } from '../principle-tree-ledger.js';
 import { DEFAULT_L1_HARD_CAP, validateL1CapConfig } from './l1-hard-cap.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────────
@@ -342,4 +342,40 @@ export class PruningReadModel {
 
     return { candidates: orphans, dbReadable };
   }
+}
+
+export interface RemovedOrphanReference {
+  principleId: string;
+  removedIds: string[];
+}
+
+export function removeOrphanReferencesFromLedger(
+  stateDir: string,
+  orphanIdsByPrinciple: Map<string, Set<string>>,
+): RemovedOrphanReference[] {
+  const ledger = loadLedger(stateDir);
+  const nextLedger = JSON.parse(JSON.stringify(ledger)) as typeof ledger;
+  const removedFromPrinciples: RemovedOrphanReference[] = [];
+
+  for (const [principleId, orphanIds] of orphanIdsByPrinciple) {
+    const entry = nextLedger.tree.principles[principleId];
+    if (!entry) continue;
+
+    const originalIds = entry.derivedFromPainIds ?? [];
+    const filteredIds = originalIds.filter((id: string) => !orphanIds.has(id));
+
+    if (filteredIds.length !== originalIds.length) {
+      entry.derivedFromPainIds = filteredIds;
+      removedFromPrinciples.push({
+        principleId,
+        removedIds: originalIds.filter((id: string) => orphanIds.has(id)),
+      });
+    }
+  }
+
+  if (removedFromPrinciples.length > 0) {
+    saveLedger(stateDir, nextLedger);
+  }
+
+  return removedFromPrinciples;
 }


### PR DESCRIPTION
## Summary

This PR implements **Tier 1 only** of PRI-131: migrating CLI commands from direct `RuntimeStateManager`/`loadLedger` imports to read models.

## Migrated Commands

| Command | Before | After |
|---------|--------|-------|
| `health.ts` | `loadLedger` | `PruningReadModel` + `PainChainReadModel` + `auditCandidateLedgerConsistency` |
| `runtime-pruning.ts` | `loadLedger` + `saveLedger` | `removeOrphanReferencesFromLedger` (new core function) |
| `runtime-internalization-queue.ts` | `RuntimeStateManager` | `createInternalizationQueueReadModel` (new factory) |

## Core Additions

1. **`createInternalizationQueueReadModel(opts)`** — Factory function that encapsulates `RuntimeStateManager` lifecycle. Returns `{ readModel, close }` handle.
2. **`removeOrphanReferencesFromLedger(stateDir, orphanMap)`** — Encapsulates `loadLedger`/`saveLedger` for the pruning orphan confirm write path. Returns list of removed references.

## Architecture Guard

Added 3 new architecture regression tests in the `pd-cli command boundaries` describe block:
- `health.ts` must NOT import `loadLedger` or `RuntimeStateManager`
- `runtime-pruning.ts` must NOT import `loadLedger`, `saveLedger`, or `RuntimeStateManager`
- `runtime-internalization-queue.ts` must NOT import `RuntimeStateManager` or `loadLedger`

**No exceptions needed** — write paths are encapsulated in core service functions.

## Tier 2/3 (Out of Scope)

These commands still use `RuntimeStateManager`/`loadLedger` directly and remain for future PRs:
- `candidate.ts` (Tier 2: needs GfiReadModel + candidate-specific Read Model)
- `task.ts`, `run.ts`, `diagnose.ts`, `artifact.ts` (Tier 3: needs TaskReadModel)
- `runtime-recovery.ts`, `runtime-canary.ts`, `runtime-diagnostics-export.ts` (Tier 3: needs new Read Models)
- `runtime-internalization-run-once.ts`, `runtime-internalization-wake-once.ts` (Tier 2/3)

## Test Results

```
npm run build --workspace=@principles/core  ✅
npm run build --workspace=@principles/pd-cli  ✅
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  ✅ 395/395
npx vitest run packages/pd-cli/tests/commands/runtime-pruning.test.ts  ✅ 29/29
npx vitest run packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts  ✅ 11/11
npm run lint  ✅
```

## Modified Files

- `packages/pd-cli/src/commands/health.ts`
- `packages/pd-cli/src/commands/runtime-pruning.ts`
- `packages/pd-cli/src/commands/runtime-internalization-queue.ts`
- `packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts`
- `packages/principles-core/src/runtime-v2/pruning-read-model.ts`
- `packages/principles-core/src/runtime-v2/index.ts`
- `packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts`
- `packages/pd-cli/tests/commands/runtime-pruning.test.ts`
- `packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts`
