### PR TITLE
docs: add ERR-010 to error experience handbook

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -67,6 +67,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-007 | Non-string evidenceRefs silently skipped instead of rejected in validator | PRI-192 |
 | ERR-008 | Missing lineage field validation allows agent to return trace with wrong attribution | PRI-192 |
 | ERR-009 | Validator silently skips missing/malformed required array fields instead of failing loud | PRI-192 |
+| ERR-010 | Falsy evaluator return silently passes validation instead of recording failure | PRI-172 |
 
 ---
 
@@ -208,9 +209,19 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **Date**: 2026-05-19
 - **Recurrence**: Yes - same pattern as ERR-001, ERR-005, ERR-007
 
+**[ERR-010]** | Falsy evaluator return silently passes validation instead of recording failure
+
+- **What happened**: In `evaluateInRefinerSandbox`, the code used `if (result)` to guard validation, meaning a null/undefined return from `evaluateCode` was treated as a pass (no failure recorded).
+- **Why it's wrong**: A null/undefined evaluator result is a validation failure — the evaluator failed to produce a decision. Silently passing it violates the invariant that every case must have an explicit pass/fail outcome. Same class as ERR-001/ERR-005/ERR-007/ERR-009 where falsy/invalid values bypass validation.
+- **Correct approach**: Use `if (!result)` to record a `validation_failed` failure for null/undefined results, then `continue`. Only proceed to `validateCaseDecision` when `result` is truthy.
+- **How to prevent**: When writing validation logic, always handle the falsy/null/undefined case explicitly as a failure. Never use `if (value)` to skip validation — use `if (!value)` to record failure.
+- **Source**: PRI-172
+- **Date**: 2026-05-20
+- **Recurrence**: Yes - same pattern as ERR-001, ERR-005, ERR-007, ERR-009
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 9 |
-| Last updated | 2026-05-19 |
+| Total lessons | 10 |
+| Last updated | 2026-05-20 |
 | Top category | Schema & Type |
-| Recurring errors | 3 |
+| Recurring errors | 4 |


### PR DESCRIPTION
Record error ERR-010 found during PR #641 code review: falsy evaluator return silently passes validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 新增错误记录 [ERR-010]，补充了关于空值/假值评估处理的文档说明及纠正指南。
  * 更新错误体验手册的统计指标，包括总错误数、最后更新日期及重复错误数量。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->