### PR TITLE
refactor(cli): migrate Tier 2 commands to runtime read models (PRI-149)

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -53,8 +53,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "5e40436500cd",
-    "bundleMd5": "fe0414aee50d0b928fad941649e073db",
-    "builtAt": "2026-05-19T06:53:38.748Z"
+    "gitSha": "43c83e52531d",
+    "bundleMd5": "6347e7bc74a30f830ce8b70bdf4d6bf5",
+    "builtAt": "2026-05-20T06:09:06.696Z"
   }
 }

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -53,8 +53,8 @@
     }
   },
   "buildFingerprint": {
-    "gitSha": "43c83e52531d",
-    "bundleMd5": "6347e7bc74a30f830ce8b70bdf4d6bf5",
-    "builtAt": "2026-05-20T06:09:06.696Z"
+    "gitSha": "5e40436500cd",
+    "bundleMd5": "fe0414aee50d0b928fad941649e073db",
+    "builtAt": "2026-05-19T06:53:38.748Z"
   }
 }

--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
-import { OperatorHealthReadModel, SchemaConformanceReadModel, PruningReadModel, InternalizationQueueReadModel, auditCandidateLedgerConsistency, buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from '@principles/core/runtime-v2';
+import { OperatorHealthReadModel, SchemaConformanceReadModel, PruningReadModel, createInternalizationQueueReadModel, auditCandidateLedgerConsistency, buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from '@principles/core/runtime-v2';
 import type { OperatorHealthSnapshot, SchemaConformanceResult, OrphanDetectionResult, InternalizationQueueSnapshot, GfiWorkspaceSnapshot, CandidateAuditResult } from '@principles/core/runtime-v2';
-import { RuntimeStateManager } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 export interface CanaryCheck {
@@ -171,11 +170,9 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
     })(),
     (async (): Promise<CanaryCheck> => {
       try {
-        const stateManager = new RuntimeStateManager({ workspaceDir, readonly: true });
-        await stateManager.initialize();
+        const { readModel, close } = await createInternalizationQueueReadModel({ workspaceDir, readonly: true });
         try {
-          const model = new InternalizationQueueReadModel(stateManager);
-          const snapshot: InternalizationQueueSnapshot = await model.getSnapshot();
+          const snapshot: InternalizationQueueSnapshot = await readModel.getSnapshot();
           const hasBlocked = snapshot.blockedSummary.count > 0;
           const hasDepFailed = snapshot.dependencyFailedSummary.count > 0;
           const hasInvalid = snapshot.invalidMetadataCount > 0;
@@ -190,7 +187,7 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
             details: snapshot,
           };
         } finally {
-          await stateManager.close();
+          await close();
         }
       } catch (err) {
         return { name: 'internalization_queue', status: 'error', summary: 'Internalization queue check failed.', error: String(err) };

--- a/packages/pd-cli/src/commands/runtime-diagnostics-export.ts
+++ b/packages/pd-cli/src/commands/runtime-diagnostics-export.ts
@@ -4,9 +4,8 @@ import {
   OperatorHealthReadModel,
   SchemaConformanceReadModel,
   PruningReadModel,
-  InternalizationQueueReadModel,
+  createInternalizationQueueReadModel,
   InternalizationChainIntegrityReadModel,
-  RuntimeStateManager,
   auditCandidateLedgerConsistency,
   buildGfiWorkspaceSnapshot,
 } from '@principles/core/runtime-v2';
@@ -147,13 +146,11 @@ export async function exportDiagnosticsBundle(workspaceDir: string, outDir: stri
   } });
 
   await collectArtifact({ ...baseCtx, name: 'internalization-queue', fileName: 'internalization-queue.json', collector: async () => {
-    const stateManager = new RuntimeStateManager({ workspaceDir, readonly: true });
-    await stateManager.initialize();
+    const { readModel, close } = await createInternalizationQueueReadModel({ workspaceDir, readonly: true });
     try {
-      const model = new InternalizationQueueReadModel(stateManager);
-      return await model.getSnapshot();
+      return await readModel.getSnapshot();
     } finally {
-      await stateManager.close();
+      await close();
     }
   } });
 

--- a/packages/pd-cli/src/commands/runtime-recovery.ts
+++ b/packages/pd-cli/src/commands/runtime-recovery.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { RuntimeStateManager } from '@principles/core/runtime-v2';
+import { createRecoverySweepService } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import { createRemediationResult, remediationAction } from './remediation-output.js';
 import type { RemediationResult } from './remediation-output.js';
@@ -48,11 +48,10 @@ export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Pr
   const isConfirm = opts.confirm ?? false;
   const isDryRun = !isConfirm;
 
-  const stateManager = new RuntimeStateManager({ workspaceDir });
-  await stateManager.initialize();
+  const { service, close } = await createRecoverySweepService({ workspaceDir });
 
   try {
-    const expiredLeaseTaskIds = await stateManager.detectExpiredLeases();
+    const expiredLeaseTaskIds = await service.detectExpiredLeases();
 
     const actions = expiredLeaseTaskIds.map((taskId) => remediationAction({
       action: 'recover_expired_lease',
@@ -68,7 +67,7 @@ export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Pr
     if (isConfirm && expiredLeaseTaskIds.length > 0) {
       for (const taskId of expiredLeaseTaskIds) {
         try {
-          const result = await stateManager.recoverTask(taskId);
+          const result = await service.recoverTask(taskId);
           if (result) {
             repairedCount++;
             const action = actions.find((a) => a.targetId === taskId);
@@ -103,6 +102,6 @@ export async function handleRuntimeRecoverySweep(opts: RecoverySweepOptions): Pr
       process.exitCode = 1;
     }
   } finally {
-    await stateManager.close();
+    await close();
   }
 }

--- a/packages/pd-cli/tests/commands/runtime-canary.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-canary.test.ts
@@ -6,8 +6,7 @@ const {
   mockHealthClose,
   mockOrphanCandidates,
   mockQueueSnapshot,
-  mockStateManagerInit,
-  mockStateManagerClose,
+  mockQueueClose,
   mockAuditConsistency,
   mockBuildGfiSnapshot,
   mockClassifyGfiHealth,
@@ -17,8 +16,7 @@ const {
   mockHealthClose: vi.fn().mockResolvedValue(undefined),
   mockOrphanCandidates: vi.fn(),
   mockQueueSnapshot: vi.fn(),
-  mockStateManagerInit: vi.fn().mockResolvedValue(undefined),
-  mockStateManagerClose: vi.fn().mockResolvedValue(undefined),
+  mockQueueClose: vi.fn().mockResolvedValue(undefined),
   mockAuditConsistency: vi.fn(),
   mockBuildGfiSnapshot: vi.fn(),
   mockClassifyGfiHealth: vi.fn(),
@@ -38,11 +36,9 @@ vi.mock('@principles/core/runtime-v2', () => ({
   PruningReadModel: vi.fn().mockImplementation(function () {
     return { getOrphanDerivedCandidates: mockOrphanCandidates };
   }),
-  InternalizationQueueReadModel: vi.fn().mockImplementation(function () {
-    return { getSnapshot: mockQueueSnapshot, close: vi.fn().mockResolvedValue(undefined) };
-  }),
-  RuntimeStateManager: vi.fn().mockImplementation(function () {
-    return { initialize: mockStateManagerInit, close: mockStateManagerClose };
+  createInternalizationQueueReadModel: vi.fn().mockResolvedValue({
+    readModel: { getSnapshot: mockQueueSnapshot },
+    close: mockQueueClose,
   }),
   auditCandidateLedgerConsistency: mockAuditConsistency,
   buildGfiWorkspaceSnapshot: mockBuildGfiSnapshot,
@@ -89,6 +85,9 @@ function healthyQueueSnapshot() {
     pendingCount: 0, retryWaitCount: 0, countsByTaskKind: {}, countsByChannel: {},
     invalidMetadataCount: 0, sampleInvalidTaskIds: [],
     blockedSummary: { count: 0, samples: [] }, dependencyFailedSummary: { count: 0, samples: [] },
+    leaseConflictSummary: { count: 0, samples: [], sampleTaskIds: [] },
+    retryWaitPendingSummary: { count: 0, samples: [] },
+    unresolvableSummary: { count: 0, samples: [] },
     readyTasks: [], noReadyTasks: null,
   };
 }
@@ -107,8 +106,7 @@ describe('runCanaryChecks', () => {
     mockHealthClose.mockResolvedValue(undefined);
     mockOrphanCandidates.mockReturnValue({ candidates: [], dbReadable: true });
     mockQueueSnapshot.mockResolvedValue(healthyQueueSnapshot());
-    mockStateManagerInit.mockResolvedValue(undefined);
-    mockStateManagerClose.mockResolvedValue(undefined);
+    mockQueueClose.mockResolvedValue(undefined);
     mockAuditConsistency.mockResolvedValue({ status: 'ok', consumedCount: 0, orphanCandidateCount: 0, missingLedgerCount: 0 });
     mockBuildGfiSnapshot.mockReturnValue(healthyGfiSnapshot());
     mockClassifyGfiHealth.mockReturnValue({ status: 'healthy', reason: '0 active, 0 stale sessions', staleGfiDegradedThreshold: 40 });
@@ -186,16 +184,17 @@ describe('runCanaryChecks', () => {
     expect(result.recommendedNextActions.some(a => a.includes('pruning orphans') || a.includes('dry-run'))).toBe(true);
   });
 
-  it('opens RuntimeStateManager in readonly mode for queue check', async () => {
-    await runCanaryChecks(WS);
+  it('uses createInternalizationQueueReadModel with readonly: true (no RuntimeStateManager)', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync(require.resolve('../../src/commands/runtime-canary.ts'), 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('createInternalizationQueueReadModel');
+    expect(src).toMatch(/createInternalizationQueueReadModel\(\{[^}]*readonly:\s*true/);
+  });
 
-    const RSM = vi.mocked(await import('@principles/core/runtime-v2')).RuntimeStateManager;
-    const calls = RSM.mock.calls;
-    const queueCall = calls.find(c => (c as Record<string, unknown>[])[0] && typeof (c[0] as Record<string, unknown>)?.readonly === 'boolean');
-    expect(queueCall).toBeTruthy();
-    if (queueCall) {
-      expect((queueCall[0] as Record<string, unknown>).readonly).toBe(true);
-    }
+  it('calls queue close once on healthy path', async () => {
+    await runCanaryChecks(WS);
+    expect(mockQueueClose).toHaveBeenCalledTimes(1);
   });
 
   it('includes nextReadyTaskKind and nextReadyTaskId in top-level internalizationQueueSummary when queue has ready tasks', async () => {
@@ -210,6 +209,7 @@ describe('runCanaryChecks', () => {
       dependencyFailedSummary: { count: 0, samples: [] },
       leaseConflictSummary: { count: 0, samples: [], sampleTaskIds: [] },
       retryWaitPendingSummary: { count: 0, samples: [] },
+      unresolvableSummary: { count: 0, samples: [] },
       readyTasks: [
         { taskId: 'task-abc-123', taskKind: 'dreamer', channel: 'pi' },
         { taskId: 'task-def-456', taskKind: 'philosopher', channel: 'pi' },
@@ -239,6 +239,7 @@ describe('runCanaryChecks', () => {
       dependencyFailedSummary: { count: 0, samples: [] },
       leaseConflictSummary: { count: 0, samples: [], sampleTaskIds: [] },
       retryWaitPendingSummary: { count: 0, samples: [] },
+      unresolvableSummary: { count: 0, samples: [] },
       readyTasks: [],
       noReadyTasks: { reason: 'all_hydration_failed', inspectedCount: 5 },
     });

--- a/packages/pd-cli/tests/commands/runtime-diagnostics-export.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-diagnostics-export.test.ts
@@ -8,8 +8,7 @@ const mockHealthSnapshot = vi.hoisted(() => vi.fn());
 const mockHealthClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockOrphanCandidates = vi.hoisted(() => vi.fn());
 const mockQueueSnapshot = vi.hoisted(() => vi.fn());
-const mockStateManagerInit = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const mockStateManagerClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockQueueClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockAuditConsistency = vi.hoisted(() => vi.fn());
 const mockBuildGfiSnapshot = vi.hoisted(() => vi.fn());
 const mockIntegrityCheck = vi.hoisted(() => vi.fn());
@@ -28,14 +27,12 @@ vi.mock('@principles/core/runtime-v2', () => ({
   PruningReadModel: vi.fn().mockImplementation(function () {
     return { getOrphanDerivedCandidates: mockOrphanCandidates };
   }),
-  InternalizationQueueReadModel: vi.fn().mockImplementation(function () {
-    return { getSnapshot: mockQueueSnapshot, close: vi.fn().mockResolvedValue(undefined) };
+  createInternalizationQueueReadModel: vi.fn().mockResolvedValue({
+    readModel: { getSnapshot: mockQueueSnapshot },
+    close: mockQueueClose,
   }),
   InternalizationChainIntegrityReadModel: vi.fn().mockImplementation(function () {
     return { check: mockIntegrityCheck };
-  }),
-  RuntimeStateManager: vi.fn().mockImplementation(function () {
-    return { initialize: mockStateManagerInit, close: mockStateManagerClose };
   }),
   auditCandidateLedgerConsistency: mockAuditConsistency,
   buildGfiWorkspaceSnapshot: mockBuildGfiSnapshot,
@@ -84,8 +81,7 @@ describe('exportDiagnosticsBundle', () => {
     mockHealthClose.mockResolvedValue(undefined);
     mockOrphanCandidates.mockReturnValue({ candidates: [], dbReadable: true });
     mockQueueSnapshot.mockResolvedValue({ pendingCount: 0, readyTasks: [] });
-    mockStateManagerInit.mockResolvedValue(undefined);
-    mockStateManagerClose.mockResolvedValue(undefined);
+    mockQueueClose.mockResolvedValue(undefined);
     mockAuditConsistency.mockResolvedValue({ status: 'ok', consumedCount: 0, orphanCandidateCount: 0, missingLedgerCount: 0 });
     mockBuildGfiSnapshot.mockReturnValue({ active: null, staleSessionCount: 0, totalSessionCount: 0, activeSessionCount: 0, generatedAt: new Date().toISOString() });
     mockIntegrityCheck.mockReturnValue(healthyIntegrityResult());
@@ -156,5 +152,19 @@ describe('exportDiagnosticsBundle', () => {
     expect(parsed.apiKey).toBe('[REDACTED]');
     expect(parsed.config.token).toBe('[REDACTED]');
     expect(parsed.config.safeValue).toBe('hello');
+  });
+
+  it('uses createInternalizationQueueReadModel with readonly: true (no RuntimeStateManager)', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync(require.resolve('../../src/commands/runtime-diagnostics-export.ts'), 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('createInternalizationQueueReadModel');
+    expect(src).toMatch(/createInternalizationQueueReadModel\(\{[^}]*readonly:\s*true/);
+  });
+
+  it('calls queue close once on main path', async () => {
+    const outDir = path.join(tempDir, 'snapshots');
+    await exportDiagnosticsBundle(tempDir, outDir);
+    expect(mockQueueClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-recovery.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-recovery.test.ts
@@ -2,21 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockDetectExpiredLeases = vi.hoisted(() => vi.fn());
 const mockRecoverTask = vi.hoisted(() => vi.fn());
-const mockClose = vi.hoisted(() => vi.fn());
-const mockInitialize = vi.hoisted(() => vi.fn());
+const mockServiceClose = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
 }));
 
 vi.mock('@principles/core/runtime-v2', () => ({
-  RuntimeStateManager: vi.fn().mockImplementation(function () {
-    return {
-      initialize: mockInitialize,
-      close: mockClose,
+  createRecoverySweepService: vi.fn().mockResolvedValue({
+    service: {
       detectExpiredLeases: mockDetectExpiredLeases,
       recoverTask: mockRecoverTask,
-    };
+    },
+    close: mockServiceClose,
   }),
   createRemediationResult: vi.fn((input) => ({
     mode: input.mode,
@@ -40,10 +38,9 @@ describe('pd runtime recovery sweep remediation contract', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockInitialize.mockResolvedValue(undefined);
-    mockClose.mockResolvedValue(undefined);
     mockDetectExpiredLeases.mockResolvedValue([]);
     mockRecoverTask.mockResolvedValue(null);
+    mockServiceClose.mockResolvedValue(undefined);
     process.exitCode = 0;
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -64,6 +61,7 @@ describe('pd runtime recovery sweep remediation contract', () => {
     });
     expect(output.actions[0]).toMatchObject({ action: 'recover_expired_lease', targetId: 'task-1' });
     expect(mockRecoverTask).not.toHaveBeenCalled();
+    expect(mockServiceClose).toHaveBeenCalledTimes(1);
   });
 
   it('confirm JSON reports changed after recovering expired leases', async () => {
@@ -77,13 +75,22 @@ describe('pd runtime recovery sweep remediation contract', () => {
     expect(output.status).toBe('changed');
     expect(output.repairedCount).toBe(1);
     expect(mockRecoverTask).toHaveBeenCalledWith('task-1');
+    expect(mockServiceClose).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects --dry-run and --confirm together before writing', async () => {
+  it('rejects --dry-run and --confirm together before writing (no service created)', async () => {
     await handleRuntimeRecoverySweep({ workspace: '/fake/workspace', dryRun: true, confirm: true, json: true });
 
     expect(mockRecoverTask).not.toHaveBeenCalled();
+    expect(mockServiceClose).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+  });
+
+  it('uses createRecoverySweepService (no RuntimeStateManager)', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync(require.resolve('../../src/commands/runtime-recovery.ts'), 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('createRecoverySweepService');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -146,6 +146,8 @@ const REQUIRED_SOURCE_FILES = [
   'trace-refiner-agent.ts',
   // PRI-193
   'golden-trace-candidate-builder.ts',
+  // PRI-149 Tier 2
+  'recovery-sweep-service.ts',
 ] as const;
 
 const REQUIRED_TEST_FILES = [
@@ -262,6 +264,8 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     'checkForbiddenPatterns',
     // PRI-45
     'mergeDecisions',
+    // PRI-149 Tier 2
+    'createRecoverySweepService',
   ];
 
   for (const name of REQUIRED_EXPORTS) {
@@ -667,6 +671,45 @@ describe('pd-cli command boundaries', () => {
     expect(src).not.toContain('RuntimeStateManager');
     expect(src).not.toContain('loadLedger');
     expect(src).toContain('createInternalizationQueueReadModel');
+  });
+
+  it('runtime-canary.ts does not import RuntimeStateManager', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const cmdPath = resolve(
+      __dirname,
+      '../../../../pd-cli/src/commands/runtime-canary.ts',
+    );
+    expect(existsSync(cmdPath)).toBe(true);
+    const src = readFileSync(cmdPath, 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('createInternalizationQueueReadModel');
+  });
+
+  it('runtime-diagnostics-export.ts does not import RuntimeStateManager', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const cmdPath = resolve(
+      __dirname,
+      '../../../../pd-cli/src/commands/runtime-diagnostics-export.ts',
+    );
+    expect(existsSync(cmdPath)).toBe(true);
+    const src = readFileSync(cmdPath, 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('createInternalizationQueueReadModel');
+  });
+
+  it('runtime-recovery.ts does not import RuntimeStateManager', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const cmdPath = resolve(
+      __dirname,
+      '../../../../pd-cli/src/commands/runtime-recovery.ts',
+    );
+    expect(existsSync(cmdPath)).toBe(true);
+    const src = readFileSync(cmdPath, 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).toContain('createRecoverySweepService');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -767,6 +767,11 @@ export type {
   InternalizationQueueReadModelHandle,
 } from './internalization-queue-read-model.js';
 
+// ── Recovery Sweep Service (PRI-149 Tier 2) ────────────────────────────────
+
+export { createRecoverySweepService } from './recovery-sweep-service.js';
+export type { RecoverySweepService, RecoverySweepServiceHandle } from './recovery-sweep-service.js';
+
 // ── Idle Trigger Decision Model (PRI-143) ──────────────────────────────────
 
 export type {

--- a/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
@@ -293,9 +293,9 @@ export interface InternalizationQueueReadModelHandle {
 }
 
 export async function createInternalizationQueueReadModel(
-  opts: { workspaceDir: string },
+  opts: { workspaceDir: string; readonly?: boolean },
 ): Promise<InternalizationQueueReadModelHandle> {
-  const stateManager = new RuntimeStateManager({ workspaceDir: opts.workspaceDir });
+  const stateManager = new RuntimeStateManager({ workspaceDir: opts.workspaceDir, readonly: opts.readonly ?? false });
   await stateManager.initialize();
   const readModel = new InternalizationQueueReadModel(stateManager);
   return {

--- a/packages/principles-core/src/runtime-v2/recovery-sweep-service.ts
+++ b/packages/principles-core/src/runtime-v2/recovery-sweep-service.ts
@@ -1,0 +1,43 @@
+import { RuntimeStateManager } from './store/runtime-state-manager.js';
+import type { RecoveryResult } from './store/lifecycle/recovery-sweep.js';
+
+export interface RecoverySweepService {
+  detectExpiredLeases(): Promise<string[]>;
+  recoverTask(taskId: string): Promise<RecoveryResult | null>;
+  close(): Promise<void>;
+}
+
+export interface RecoverySweepServiceHandle {
+  service: RecoverySweepService;
+  close: () => Promise<void>;
+}
+
+class RecoverySweepServiceImpl implements RecoverySweepService {
+  constructor(private readonly stateManager: RuntimeStateManager) {}
+
+  async detectExpiredLeases(): Promise<string[]> {
+    return this.stateManager.detectExpiredLeases();
+  }
+
+  async recoverTask(taskId: string): Promise<RecoveryResult | null> {
+    return this.stateManager.recoverTask(taskId);
+  }
+
+  async close(): Promise<void> {
+    await this.stateManager.close();
+  }
+}
+
+export async function createRecoverySweepService(
+  opts: { workspaceDir: string },
+): Promise<RecoverySweepServiceHandle> {
+  const stateManager = new RuntimeStateManager({ workspaceDir: opts.workspaceDir });
+  await stateManager.initialize();
+  const service = new RecoverySweepServiceImpl(stateManager);
+  return {
+    service,
+    close: async () => {
+      await stateManager.close();
+    },
+  };
+}


### PR DESCRIPTION
## Migrated Commands

| Command | Previous Import | New Facade |
|---------|----------------|------------|
| untime-canary.ts | RuntimeStateManager (readonly) | createInternalizationQueueReadModel |
| untime-diagnostics-export.ts | RuntimeStateManager (readonly) | createInternalizationQueueReadModel |
| untime-recovery.ts | RuntimeStateManager (writable) | createRecoverySweepService |

## Direct Imports Removed

All 3 commands no longer import RuntimeStateManager directly:
- \untime-canary.ts\: removed \import { RuntimeStateManager }\ and \InternalizationQueueReadModel\ constructor usage
- \untime-diagnostics-export.ts\: removed \import { RuntimeStateManager, InternalizationQueueReadModel }\ constructor usage
- \untime-recovery.ts\: removed \import { RuntimeStateManager }\ and direct \stateManager.detectExpiredLeases()\/\stateManager.recoverTask()\ calls

## New Core Facade/Read Model Contracts

### \RecoverySweepService\ (new)
- **File**: \packages/principles-core/src/runtime-v2/recovery-sweep-service.ts\
- **Factory**: \createRecoverySweepService({ workspaceDir })\ returns \{ service, close }\
- **Methods**: \detectExpiredLeases()\, \ecoverTask(taskId)\, \close()\
- **Pattern**: Matches \createInternalizationQueueReadModel()\ style from PRI-131

### \createInternalizationQueueReadModel\ (existing, reused)
- Already exported from PRI-131; now used by canary and diagnostics-export instead of manual \RuntimeStateManager\ + \InternalizationQueueReadModel\ construction

## Tests and Results

- **20/20** migrated command tests pass
- **405/405** architecture regression tests pass
- **Lint**: clean
- **Build**: \@principles/core\ + \@principles/pd-cli\ both build clean
- **verify:merge**: all gates pass (lint, build, typecheck, generated artifact check)

### New architecture regression guards
- \untime-canary.ts\ does not import \RuntimeStateManager\
- \untime-diagnostics-export.ts\ does not import \RuntimeStateManager\
- \untime-recovery.ts\ does not import \RuntimeStateManager\

### New source-file guards in CLI tests
Each migrated command test includes a regression assertion that reads the source file and verifies \RuntimeStateManager\ is absent and the new facade is present.

## Remaining Tier 3 Commands

These commands still import \RuntimeStateManager\ directly and should be addressed in future PRs:
- \untime-internalization-wake-once.ts\
- \untime-internalization-run-once.ts\
- \untime-idle-trigger.ts\
- \untime-activation.ts\
- \diagnose.ts\
- \	ask.ts\
- \un.ts\
- \rtifact.ts\
- \candidate.ts\ (also imports \loadLedger\)

## No Behavior Change

- JSON output shapes preserved
- Dry-run / confirm behavior preserved
- Command names and flags unchanged
- No nocturnal legacy files touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增恢复清扫服务，增强运行时恢复和管理能力

* **重构**
  * 改进了运行时金丝雀检查、诊断导出及恢复功能的内部实现架构
  * 优化了资源初始化和清理的管理流程

* **测试**
  * 更新测试用例以验证新的架构实现
  * 新增架构守卫测试，确保依赖边界合规

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->