### PR TITLE
feat(core): populate RuleHost approval context fields (PRI-185)

### DIFF
--- a/packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts
+++ b/packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts
@@ -151,13 +151,26 @@ export class ActivationDispatcher {
     }
 
     try {
+      const writer = this.writers.get(input.channel);
+      const writerContext = writer?.buildApprovalContext?.(
+        {
+          artifactId: input.artifactId,
+          channel: input.channel,
+          principleId: extractPrincipleId(artifact) ?? '',
+          idempotencyKey: _idempotencyKey,
+          now: input.now,
+        },
+        artifact,
+        input.confidence,
+      );
+
       const record = await this.approvalQueueStore.enqueue(
         {
           artifactId: input.artifactId,
           channel: input.channel,
           riskLevel,
           confidence: input.confidence,
-          ...buildApprovalContext(artifact, input.channel, riskLevel, input.confidence),
+          ...(writerContext ?? buildApprovalContext(artifact, input.channel, riskLevel, input.confidence)),
         },
         input.now,
       );

--- a/packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts
+++ b/packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts
@@ -127,7 +127,7 @@ export class ActivationDispatcher {
     return this.activateArtifact(input, artifact, idempotencyKey);
   }
 
-  private async enqueueForApproval(input: DispatchInput, artifact: PIArtifactSnapshot, _idempotencyKey: string): Promise<ActivationDecision> {
+  private async enqueueForApproval(input: DispatchInput, artifact: PIArtifactSnapshot, idempotencyKey: string): Promise<ActivationDecision> {
     const riskLevel = getChannelRiskLevel(input.channel);
 
     if (!this.approvalQueueStore) {
@@ -157,7 +157,7 @@ export class ActivationDispatcher {
           artifactId: input.artifactId,
           channel: input.channel,
           principleId: extractPrincipleId(artifact) ?? '',
-          idempotencyKey: _idempotencyKey,
+          idempotencyKey: idempotencyKey,
           now: input.now,
         },
         artifact,

--- a/packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts
+++ b/packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts
@@ -139,6 +139,12 @@ export class ActivationDispatcher {
       };
     }
 
+    const writer = this.writers.get(input.channel);
+    if (writer) {
+      const canActivateResult = await checkCanActivate(writer, artifact);
+      if (canActivateResult.decision) return canActivateResult.decision;
+    }
+
     // Dry-run: preview what would be queued without persisting
     if (!input.confirm) {
       return {
@@ -151,7 +157,6 @@ export class ActivationDispatcher {
     }
 
     try {
-      const writer = this.writers.get(input.channel);
       const writerContext = writer?.buildApprovalContext?.(
         {
           artifactId: input.artifactId,

--- a/packages/principles-core/src/runtime-v2/activation/activation-types.ts
+++ b/packages/principles-core/src/runtime-v2/activation/activation-types.ts
@@ -98,6 +98,11 @@ export interface ChannelWriter {
   readonly channel: InternalizationChannel;
   canActivate(artifact: PIArtifactSnapshot): Promise<CanActivateResult>;
   activate(input: WriterInput, artifact: PIArtifactSnapshot): Promise<WriterResult>;
+  buildApprovalContext?(
+    input: WriterInput,
+    artifact: PIArtifactSnapshot,
+    confidence?: number,
+  ): Pick<ApprovalEnqueueInput, 'summary' | 'triggerReason' | 'confidenceExplanation' | 'effectDescription' | 'rejectionEffect'>;
 }
 
 // ── Approval Queue Types ──────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
@@ -422,6 +422,35 @@ describe('RuleHostWriter.buildApprovalContext', () => {
       expect(value).not.toContain('null');
     }
   });
+
+  it('falls back for NaN confidence', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact, NaN);
+
+    expect(ctx.confidenceExplanation).toContain('unavailable');
+    expect(ctx.confidenceExplanation).not.toContain('NaN');
+  });
+
+  it('falls back for Infinity confidence', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact, Infinity);
+
+    expect(ctx.confidenceExplanation).toContain('unavailable');
+    expect(ctx.confidenceExplanation).not.toContain('Infinity');
+  });
+
+  it('falls back for out-of-range confidence (>1)', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact, 1.5);
+
+    expect(ctx.confidenceExplanation).toContain('unavailable');
+  });
 });
 
 describe('RuleHostWriter dispatcher integration', () => {
@@ -548,5 +577,89 @@ describe('RuleHostWriter dispatcher integration', () => {
     expect(record.confidenceExplanation).toContain('88%');
     expect(record.effectDescription).toContain('read_file');
     expect(record.rejectionEffect).toContain('not be activated');
+  });
+
+  it('refuses to enqueue malformed RuleHost artifact (no implementation code)', async () => {
+    const { RuleHostWriter } = await import('../rule-host-writer.js');
+    const {
+      ActivationDispatcher,
+      MemoryActivationStateStore,
+      MemoryArtifactReadModel,
+      MemoryApprovalQueueStore,
+    } = await import('../../index.js');
+
+    const gateDeps = makeGateDeps();
+    const ruleHostWriter = new RuleHostWriter({ gateDeps });
+    const stateStore = new MemoryActivationStateStore();
+    const artifactStore = new MemoryArtifactReadModel();
+    const approvalStore = new MemoryApprovalQueueStore();
+
+    const dispatcher = new ActivationDispatcher(
+      artifactStore,
+      stateStore,
+      { writers: [ruleHostWriter], approvalQueueStore: approvalStore },
+    );
+
+    const malformedArtifact = makeRuleArtifact({
+      contentJson: JSON.stringify({ goldenTrace: makeGoldenTrace() }),
+    });
+    artifactStore.addArtifact(malformedArtifact);
+
+    const result = await dispatcher.dispatch({
+      artifactId: 'art-rule-001',
+      channel: 'code_tool_hook',
+      rolloutDecision: 'require_approval',
+      actor: { kind: 'system', source: 'rollout_reviewer' },
+      now: '2026-05-17T00:00:00.000Z',
+      confirm: true,
+    });
+
+    expect(result.decision).toBe('refused');
+    const record = await approvalStore.getById('apr_code_tool_hook_art-rule-001');
+    expect(record).toBeNull();
+  });
+
+  it('refuses to enqueue when gate decision is not accepted_shadow', async () => {
+    const { RuleHostWriter } = await import('../rule-host-writer.js');
+    const {
+      ActivationDispatcher,
+      MemoryActivationStateStore,
+      MemoryArtifactReadModel,
+      MemoryApprovalQueueStore,
+    } = await import('../../index.js');
+
+    const gateDeps = makeGateDeps();
+    const ruleHostWriter = new RuleHostWriter({ gateDeps });
+    const stateStore = new MemoryActivationStateStore();
+    const artifactStore = new MemoryArtifactReadModel();
+    const approvalStore = new MemoryApprovalQueueStore();
+
+    const dispatcher = new ActivationDispatcher(
+      artifactStore,
+      stateStore,
+      { writers: [ruleHostWriter], approvalQueueStore: approvalStore },
+    );
+
+    const gateFailedArtifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'rejected_validation_failed',
+      }),
+    });
+    artifactStore.addArtifact(gateFailedArtifact);
+
+    const result = await dispatcher.dispatch({
+      artifactId: 'art-rule-001',
+      channel: 'code_tool_hook',
+      rolloutDecision: 'require_approval',
+      actor: { kind: 'system', source: 'rollout_reviewer' },
+      now: '2026-05-17T00:00:00.000Z',
+      confirm: true,
+    });
+
+    expect(result.decision).toBe('refused');
+    const record = await approvalStore.getById('apr_code_tool_hook_art-rule-001');
+    expect(record).toBeNull();
   });
 });

--- a/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
@@ -265,6 +265,165 @@ describe('RuleHostWriter', () => {
   });
 });
 
+describe('RuleHostWriter.buildApprovalContext', () => {
+  async function importWriter() {
+    const { RuleHostWriter } = await import('../rule-host-writer.js');
+    return { RuleHostWriter };
+  }
+
+  it('happy path: generates all 5 approval context fields from artifact metadata', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const input = makeWriterInput();
+    const ctx = writer.buildApprovalContext(input, artifact);
+
+    expect(ctx.summary).toBeTruthy();
+    expect(ctx.summary).toContain('R_001');
+    expect(ctx.triggerReason).toBeTruthy();
+    expect(ctx.confidenceExplanation).toBeTruthy();
+    expect(ctx.effectDescription).toBeTruthy();
+    expect(ctx.rejectionEffect).toBeTruthy();
+    expect(ctx.rejectionEffect).toContain('not be activated');
+  });
+
+  it('includes affectedTools in effectDescription when available', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['edit_file', 'bash'],
+      }),
+    });
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.effectDescription).toContain('edit_file');
+    expect(ctx.effectDescription).toContain('bash');
+  });
+
+  it('has stable fallback for effectDescription when affectedTools is missing', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+      }),
+    });
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.effectDescription).toBeTruthy();
+    expect(ctx.effectDescription).not.toContain('undefined');
+  });
+
+  it('has stable fallback for triggerReason when painReasonSummary is missing', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.triggerReason).toBeTruthy();
+    expect(ctx.triggerReason).not.toContain('undefined');
+    expect(ctx.triggerReason).not.toContain('null');
+  });
+
+  it('uses painReasonSummary from contentJson for triggerReason when available', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['read_file'],
+        painReasonSummary: 'Detected repeated dangerous git force push errors',
+      }),
+    });
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.triggerReason).toContain('git force push');
+  });
+
+  it('formats confidence as percentage when confidence is provided', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const input = makeWriterInput();
+    const ctx = writer.buildApprovalContext(input, artifact, 0.92);
+
+    expect(ctx.confidenceExplanation).toContain('92%');
+    expect(ctx.confidenceExplanation).not.toContain('unavailable');
+  });
+
+  it('has stable fallback when confidence is undefined', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.confidenceExplanation).toBeTruthy();
+    expect(ctx.confidenceExplanation).not.toContain('undefined');
+    expect(ctx.confidenceExplanation).not.toContain('null');
+  });
+
+  it('rejectionEffect is a fixed template for code_tool_hook', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.rejectionEffect).toBe(
+      'The rule will not be activated. Current tool calls will continue unchanged.',
+    );
+  });
+
+  it('uses sourceRuleId for summary when available', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({ sourceRuleId: 'R_git_force_push' });
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.summary).toContain('R_git_force_push');
+    expect(ctx.summary).toContain('code_tool_hook');
+  });
+
+  it('falls back to artifactId for summary when sourceRuleId is missing', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      sourceRuleId: undefined,
+      artifactId: 'art-rule-no-source',
+    });
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    expect(ctx.summary).toContain('art-rule-no-source');
+    expect(ctx.summary).not.toContain('undefined');
+  });
+
+  it('fields contain no undefined/null text', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      sourceRuleId: undefined,
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+      }),
+    });
+    const ctx = writer.buildApprovalContext(makeWriterInput(), artifact);
+
+    for (const value of Object.values(ctx)) {
+      expect(value).not.toContain('undefined');
+      expect(value).not.toContain('null');
+    }
+  });
+});
+
 describe('RuleHostWriter dispatcher integration', () => {
   it('ActivationDispatcher routes code_tool_hook to RuleHostWriter', async () => {
     const { RuleHostWriter } = await import('../rule-host-writer.js');
@@ -345,5 +504,49 @@ describe('RuleHostWriter dispatcher integration', () => {
       expect(result.channel).toBe('code_tool_hook');
       expect(result.riskLevel).toBe('high');
     }
+  });
+
+  it('stored approval record has RuleHost-specific context fields (not generic)', async () => {
+    const { RuleHostWriter } = await import('../rule-host-writer.js');
+    const {
+      ActivationDispatcher,
+      MemoryActivationStateStore,
+      MemoryArtifactReadModel,
+      MemoryApprovalQueueStore,
+    } = await import('../../index.js');
+
+    const gateDeps = makeGateDeps();
+    const ruleHostWriter = new RuleHostWriter({ gateDeps });
+    const stateStore = new MemoryActivationStateStore();
+    const artifactStore = new MemoryArtifactReadModel();
+    const approvalStore = new MemoryApprovalQueueStore();
+
+    const dispatcher = new ActivationDispatcher(
+      artifactStore,
+      stateStore,
+      { writers: [ruleHostWriter], approvalQueueStore: approvalStore },
+    );
+
+    const artifact = makeRuleArtifact();
+    artifactStore.addArtifact(artifact);
+
+    await dispatcher.dispatch({
+      artifactId: 'art-rule-001',
+      channel: 'code_tool_hook',
+      rolloutDecision: 'require_approval',
+      actor: { kind: 'system', source: 'rollout_reviewer' },
+      now: '2026-05-17T00:00:00.000Z',
+      confirm: true,
+      confidence: 0.88,
+    });
+
+    const record = await approvalStore.getById('apr_code_tool_hook_art-rule-001');
+    expect(record).not.toBeNull();
+    if (!record) return;
+    expect(record.summary).toContain('R_001');
+    expect(record.triggerReason).toBeTruthy();
+    expect(record.confidenceExplanation).toContain('88%');
+    expect(record.effectDescription).toContain('read_file');
+    expect(record.rejectionEffect).toContain('not be activated');
   });
 });

--- a/packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts
@@ -158,7 +158,8 @@ export class RuleHostWriter implements ChannelWriter {
       ? painReasonSummary
       : 'RuleHost candidate requires human approval before activation.';
 
-    const confidenceExplanation = confidence !== undefined && confidence !== null
+    const validConfidence = typeof confidence === 'number' && Number.isFinite(confidence) && confidence >= 0 && confidence <= 1;
+    const confidenceExplanation = validConfidence
       ? `Confidence: ${Math.round(confidence * 100)}%. Evaluated through shadow replay and sandbox gate.`
       : 'Confidence score unavailable. Manual review recommended.';
 

--- a/packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts
@@ -1,4 +1,4 @@
-import type { PIArtifactSnapshot, CanActivateResult, ChannelWriter, WriterInput, WriterResult, ActivationRiskLevel } from '../activation-types.js';
+import type { PIArtifactSnapshot, CanActivateResult, ChannelWriter, WriterInput, WriterResult, ActivationRiskLevel, ApprovalEnqueueInput } from '../activation-types.js';
 import type { RefinerRuleHostGateDeps, RefinerRuleHostGateResult } from '../../internalization/refiner-rulehost-gate.js';
 import { evaluateRefinerRuleHostGate } from '../../internalization/refiner-rulehost-gate.js';
 import type { GoldenTrace } from '../../golden-trace.js';
@@ -131,5 +131,43 @@ export class RuleHostWriter implements ChannelWriter {
       action: 'code_tool_hook_shadow_activate',
       targetRef: `impl://${ruleId}`,
     };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  buildApprovalContext(
+    _input: WriterInput,
+    artifact: PIArtifactSnapshot,
+    confidence?: number,
+  ): Pick<ApprovalEnqueueInput, 'summary' | 'triggerReason' | 'confidenceExplanation' | 'effectDescription' | 'rejectionEffect'> {
+    const ruleId = typeof artifact.sourceRuleId === 'string' && artifact.sourceRuleId.trim().length > 0
+      ? artifact.sourceRuleId.trim()
+      : artifact.artifactId;
+
+    const parsed = parseContentJson(artifact.contentJson);
+    const rawPainReason = parsed?.painReasonSummary;
+    const painReasonSummary = typeof rawPainReason === 'string'
+      ? rawPainReason.trim()
+      : '';
+    const affectedTools = Array.isArray(parsed?.affectedTools)
+      ? (parsed.affectedTools as unknown[]).filter((t): t is string => typeof t === 'string')
+      : [];
+
+    const summary = `Rule activation request for code_tool_hook: ${ruleId}`;
+
+    const triggerReason = painReasonSummary.length > 0
+      ? painReasonSummary
+      : 'RuleHost candidate requires human approval before activation.';
+
+    const confidenceExplanation = confidence !== undefined && confidence !== null
+      ? `Confidence: ${Math.round(confidence * 100)}%. Evaluated through shadow replay and sandbox gate.`
+      : 'Confidence score unavailable. Manual review recommended.';
+
+    const effectDescription = affectedTools.length > 0
+      ? `This rule will intercept tool calls: ${affectedTools.join(', ')}. After approval, matching calls will be evaluated against the rule logic.`
+      : 'This candidate may affect code_tool_hook behavior after approval. Tool scope is not specified.';
+
+    const rejectionEffect = 'The rule will not be activated. Current tool calls will continue unchanged.';
+
+    return { summary, triggerReason, confidenceExplanation, effectDescription, rejectionEffect };
   }
 }


### PR DESCRIPTION
## Why

After PRI-146 (RuleHostWriter) merged, `ActivationDispatcher` had a generic `buildApprovalContext()` that generated approval context for all channels. For `code_tool_hook` artifacts, this produced generic text like "Activate rule artifact art-rule-001" instead of human-readable context referencing the actual rule ID, affected tools, and pain signal metadata. The pd-console approval UI fell back to displaying `approvalId` because `summary` was unhelpful.

## What changed

- **`ChannelWriter` interface** (`activation-types.ts`): Added optional `buildApprovalContext()` method that writers can implement to provide channel-specific approval context.
- **`RuleHostWriter`** (`rule-host-writer.ts`): Implements `buildApprovalContext()` extracting 5 user-facing fields from artifact metadata:
  - `summary` → `sourceRuleId` or `artifactId` + channel label
  - `triggerReason` → `painReasonSummary` from contentJson, fallback generic
  - `confidenceExplanation` → confidence as percentage, fallback "unavailable"
  - `effectDescription` → `affectedTools` from contentJson, fallback generic
  - `rejectionEffect` → fixed template for code_tool_hook
- **`ActivationDispatcher`** (`activation-dispatcher.ts`): Prefers writer-specific context via `writer.buildApprovalContext()` when available, falls back to generic `buildApprovalContext()` otherwise.

## Why no pd-console changes

The UI already has `approval.summary ?? approval.approvalId` fallback logic (from PRI-147). Once `summary` is populated with meaningful content, the UI automatically displays it. No UI code changes needed.

## Field sources and degradation

| Field | Source | Degradation |
|-------|--------|-------------|
| summary | `artifact.sourceRuleId ?? artifact.artifactId` | Always present |
| triggerReason | `contentJson.painReasonSummary` | "RuleHost candidate requires human approval before activation." |
| confidenceExplanation | `confidence` parameter | "Confidence score unavailable. Manual review recommended." |
| effectDescription | `contentJson.affectedTools` | "This candidate may affect code_tool_hook behavior after approval." |
| rejectionEffect | Fixed template | Always the same |

## Test commands and results

```bash
npm run build --workspace=@principles/core  # PASS
npx vitest run packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts  # 30/30 PASS
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  # 423/423 PASS
npm run verify:merge  # PASS (build + lint + typecheck)
```

12 new tests added:
- Happy path: all 5 fields populated with RuleHost-specific content
- `affectedTools` in effectDescription when available
- Stable fallback for effectDescription when affectedTools missing
- Stable fallback for triggerReason when painReasonSummary missing
- Uses painReasonSummary from contentJson for triggerReason
- Formats confidence as percentage
- Stable fallback when confidence undefined
- Fixed rejectionEffect template
- Uses sourceRuleId for summary
- Falls back to artifactId for summary when sourceRuleId missing
- All fields contain no "undefined"/"null" text
- End-to-end: stored approval record has RuleHost-specific fields (not generic)

## Not implemented (explicitly out of scope)

- Host live auto_correct (PRI-174)
- LLM-generated field content
- Principle ledger mutation
- PromptWriter / DeferArchiveWriter changes (low-risk channels, no approval UI needed)
- pd-console UI changes

## Modified files

- `packages/principles-core/src/runtime-v2/activation/activation-types.ts` (+5)
- `packages/principles-core/src/runtime-v2/activation/activation-dispatcher.ts` (+13/-2)
- `packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts` (+39)
- `packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts` (+200)