### PR TITLE
fix(core): add missing rulehostAutoCorrectApplied stats

### DIFF
--- a/packages/openclaw-plugin/src/core/event-log.ts
+++ b/packages/openclaw-plugin/src/core/event-log.ts
@@ -461,6 +461,8 @@ export class EventLog {
       stats.evolution.rulehostRequireApproval++;
     } else if (entry.type === 'rulehost_auto_correct_proposed') {
       stats.evolution.rulehostAutoCorrectProposed++;
+    } else if (entry.type === 'rulehost_auto_correct_applied') {
+      stats.evolution.rulehostAutoCorrectApplied++;
     }
   }
 

--- a/packages/openclaw-plugin/tests/core/event-log.test.ts
+++ b/packages/openclaw-plugin/tests/core/event-log.test.ts
@@ -279,5 +279,40 @@ describe('EventLog', () => {
       // Other sub-counters should not be set
       expect(stats.evolution.reportsMissingJson).toBe(0);
     });
+
+    it('should count rulehost_auto_correct_applied events', () => {
+      const today = new Date().toISOString().slice(0, 10);
+
+      eventLog.recordRuleHostAutoCorrectProposed({
+        toolName: 'write',
+        filePath: '/test/file.ts',
+        ruleId: 'r1',
+        confidence: 0.9,
+        reason: 'fix typo',
+        applicationMode: 'live',
+        correctedFields: ['content'],
+        validationValid: true,
+      });
+      eventLog.recordRuleHostAutoCorrectApplied({
+        toolName: 'write',
+        filePath: '/test/file.ts',
+        ruleId: 'r1',
+        confidence: 0.9,
+        reason: 'fix typo',
+        correctedFields: [{ field: 'content', original: 'broken', applied: 'fixed' }],
+      });
+
+      const stats = eventLog.getDailyStats(today);
+      expect(stats.evolution.rulehostAutoCorrectProposed).toBe(1);
+      expect(stats.evolution.rulehostAutoCorrectApplied).toBe(1);
+    });
+
+    it('should have rulehostAutoCorrectApplied field in evolution stats', () => {
+      const today = new Date().toISOString().slice(0, 10);
+      const stats = eventLog.getDailyStats(today);
+
+      expect(stats.evolution).toBeDefined();
+      expect(stats.evolution.rulehostAutoCorrectApplied).toBe(0);
+    });
   });
 });

--- a/packages/principles-core/src/runtime-v2/types/event-types.ts
+++ b/packages/principles-core/src/runtime-v2/types/event-types.ts
@@ -818,6 +818,7 @@ export interface EventEvolutionStats {
   rulehostBlocked: number;
   rulehostRequireApproval: number;
   rulehostAutoCorrectProposed: number;
+  rulehostAutoCorrectApplied: number;
 }
 
 // Backward compatibility alias
@@ -843,6 +844,7 @@ export const EventEvolutionStatsSchema = Type.Object({
   rulehostBlocked: Type.Number(),
   rulehostRequireApproval: Type.Number(),
   rulehostAutoCorrectProposed: Type.Number(),
+  rulehostAutoCorrectApplied: Type.Number(),
 });
 export type EventEvolutionStatsStatic = Static<typeof EventEvolutionStatsSchema>;
 
@@ -1016,6 +1018,7 @@ export function createEmptyDailyStats(date: string): DailyStats {
       rulehostBlocked: 0,
       rulehostRequireApproval: 0,
       rulehostAutoCorrectProposed: 0,
+      rulehostAutoCorrectApplied: 0,
     },
     hooks: {
       total: 0,


### PR DESCRIPTION
## Summary

Bug: The rulehost_auto_correct_applied event was recorded when live auto-corrections were applied (PRI-174), but this event type was **missing** from DailyStats.

## Impact

Data Integrity Issue: Users could not see how many auto-corrections were successfully applied in their daily statistics.

## Fix

- Add rulehostAutoCorrectApplied field to EventEvolutionStats
- Add rulehostAutoCorrectApplied to EventEvolutionStatsSchema  
- Add rulehostAutoCorrectApplied: 0 to createEmptyDailyStats()
- Add rulehost_auto_correct_applied case in updateStats()
- Add test coverage

Refs: PRI-174