### PR TITLE
test(core): add missing test coverage for boundary cases

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/recovery-sweep-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/recovery-sweep-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RuntimeStateHandle } from '../runtime-state-handle.js';
+import { createRecoverySweepService } from '../recovery-sweep-service.js';
+
+const mockDetectExpiredLeases = vi.fn();
+const mockRecoverTask = vi.fn();
+const mockStateManagerClose = vi.fn();
+
+vi.mock('../store/runtime-state-manager.js', () => ({
+  RuntimeStateManager: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.initialize = vi.fn().mockResolvedValue(undefined);
+    this.close = mockStateManagerClose;
+    this.detectExpiredLeases = mockDetectExpiredLeases;
+    this.recoverTask = mockRecoverTask;
+    this.isInitialized = true;
+  }),
+}));
+
+describe('createRecoverySweepService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    mockDetectExpiredLeases.mockResolvedValue([]);
+    mockRecoverTask.mockResolvedValue(null);
+    mockStateManagerClose.mockResolvedValue(undefined);
+  });
+
+  it('creates service with stateManager and close handle', async () => {
+    const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
+    expect(handle.service).toBeDefined();
+    expect(typeof handle.close).toBe('function');
+  });
+
+  it('detectExpiredLeases delegates to stateManager', async () => {
+    mockDetectExpiredLeases.mockResolvedValue(['task-1', 'task-2']);
+    const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
+    const expired = await handle.service.detectExpiredLeases();
+    expect(expired).toEqual(['task-1', 'task-2']);
+    expect(mockDetectExpiredLeases).toHaveBeenCalledTimes(1);
+  });
+
+  it('recoverTask delegates to stateManager', async () => {
+    mockRecoverTask.mockResolvedValue({ previousStatus: 'leased', newStatus: 'retry_wait' });
+    const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
+    const result = await handle.service.recoverTask('task-1');
+    expect(result).toEqual({ previousStatus: 'leased', newStatus: 'retry_wait' });
+    expect(mockRecoverTask).toHaveBeenCalledWith('task-1');
+  });
+
+  it('close is idempotent via RuntimeStateHandle', async () => {
+    const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
+    await handle.close();
+    await handle.close();
+    await handle.close();
+    expect(mockStateManagerClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('recoverTask returns null when stateManager returns null', async () => {
+    mockRecoverTask.mockResolvedValue(null);
+    const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
+    const result = await handle.service.recoverTask('nonexistent-task');
+    expect(result).toBeNull();
+  });
+
+  it('service close is no-op (managed by handle)', async () => {
+    const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
+    await handle.service.close();
+    expect(mockStateManagerClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/recovery-sweep-service.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/recovery-sweep-service.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { RuntimeStateHandle } from '../runtime-state-handle.js';
 import { createRecoverySweepService } from '../recovery-sweep-service.js';
 
 const mockDetectExpiredLeases = vi.fn();
 const mockRecoverTask = vi.fn();
 const mockStateManagerClose = vi.fn();
+const mockInitialize = vi.fn();
+const mockAssertInitialized = vi.fn();
 
 vi.mock('../store/runtime-state-manager.js', () => ({
   RuntimeStateManager: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
-    this.initialize = vi.fn().mockResolvedValue(undefined);
+    this.initialize = mockInitialize;
     this.close = mockStateManagerClose;
     this.detectExpiredLeases = mockDetectExpiredLeases;
     this.recoverTask = mockRecoverTask;
+    this.assertInitialized = mockAssertInitialized;
     this.isInitialized = true;
   }),
 }));
@@ -20,9 +22,11 @@ describe('createRecoverySweepService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
+    mockInitialize.mockResolvedValue(undefined);
     mockDetectExpiredLeases.mockResolvedValue([]);
     mockRecoverTask.mockResolvedValue(null);
     mockStateManagerClose.mockResolvedValue(undefined);
+    mockAssertInitialized.mockReturnValue(undefined);
   });
 
   it('creates service with stateManager and close handle', async () => {
@@ -39,11 +43,23 @@ describe('createRecoverySweepService', () => {
     expect(mockDetectExpiredLeases).toHaveBeenCalledTimes(1);
   });
 
-  it('recoverTask delegates to stateManager', async () => {
-    mockRecoverTask.mockResolvedValue({ previousStatus: 'leased', newStatus: 'retry_wait' });
+  it('recoverTask delegates to stateManager and returns full RecoveryResult', async () => {
+    mockRecoverTask.mockResolvedValue({
+      taskId: 'task-1',
+      recoveredAt: '2026-05-21T00:00:00.000Z',
+      previousStatus: 'leased',
+      newStatus: 'retry_wait',
+      wasLeaseExpired: true,
+    });
     const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
     const result = await handle.service.recoverTask('task-1');
-    expect(result).toEqual({ previousStatus: 'leased', newStatus: 'retry_wait' });
+    expect(result).toEqual({
+      taskId: 'task-1',
+      recoveredAt: '2026-05-21T00:00:00.000Z',
+      previousStatus: 'leased',
+      newStatus: 'retry_wait',
+      wasLeaseExpired: true,
+    });
     expect(mockRecoverTask).toHaveBeenCalledWith('task-1');
   });
 
@@ -66,5 +82,11 @@ describe('createRecoverySweepService', () => {
     const handle = await createRecoverySweepService({ workspaceDir: '/tmp/test-ws' });
     await handle.service.close();
     expect(mockStateManagerClose).not.toHaveBeenCalled();
+  });
+
+  it('propagates initialization failure from RuntimeStateManager', async () => {
+    mockInitialize.mockRejectedValueOnce(new Error('DB init failed'));
+    await expect(createRecoverySweepService({ workspaceDir: '/tmp/test-ws' }))
+      .rejects.toThrow('DB init failed');
   });
 });

--- a/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
@@ -328,18 +328,26 @@ describe('RuleHostWriter', () => {
     expect(result.riskLevel).toBe('high');
   });
 
-  it('rejects artifact with invalid validationStatus', async () => {
+  it('rejects artifact with pending validationStatus', async () => {
     const { RuleHostWriter } = await importWriter();
     const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
-    const artifact = makeRuleArtifact();
-    Object.defineProperty(artifact, 'validationStatus', {
-      value: 'unknown',
-      writable: false,
-      configurable: true,
+    const artifact = makeRuleArtifact({
+      validationStatus: 'pending',
     });
     const result = await writer.canActivate(artifact);
     expect(result.ok).toBe(false);
-    expect(result.reason).toContain('artifact_validation_status');
+    expect(result.reason).toContain('artifact_validation_status_pending');
+  });
+
+  it('rejects artifact with rejected validationStatus', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      validationStatus: 'rejected',
+    });
+    const result = await writer.canActivate(artifact);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('artifact_validation_status_rejected');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
@@ -263,6 +263,84 @@ describe('RuleHostWriter', () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toContain('no_implementation_code');
   });
+
+  it('returns high riskLevel when affectedTools is empty array', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: [],
+      }),
+    });
+    const result = await writer.canActivate(artifact);
+    expect(result.ok).toBe(true);
+    expect(result.riskLevel).toBe('high');
+  });
+
+  it('returns critical riskLevel for tools containing destructive prefixes (substring match)', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['my-edit-wrapper', 'pre-write-hook', 'post-delete-callback'],
+      }),
+    });
+    const result = await writer.canActivate(artifact);
+    expect(result.ok).toBe(true);
+    expect(result.riskLevel).toBe('critical');
+  });
+
+  it('returns high riskLevel for mixed tools where none contain destructive prefixes', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['search', 'grep', 'list_files'],
+      }),
+    });
+    const result = await writer.canActivate(artifact);
+    expect(result.ok).toBe(true);
+    expect(result.riskLevel).toBe('high');
+  });
+
+  it('treats non-string items in affectedTools as safe', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact({
+      contentJson: JSON.stringify({
+        implementationCode: 'function evaluate() {}',
+        goldenTrace: makeGoldenTrace(),
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: [123, null, undefined, {}],
+      }),
+    });
+    const result = await writer.canActivate(artifact);
+    expect(result.ok).toBe(true);
+    expect(result.riskLevel).toBe('high');
+  });
+
+  it('rejects artifact with invalid validationStatus', async () => {
+    const { RuleHostWriter } = await importWriter();
+    const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
+    const artifact = makeRuleArtifact();
+    Object.defineProperty(artifact, 'validationStatus', {
+      value: 'unknown',
+      writable: false,
+      configurable: true,
+    });
+    const result = await writer.canActivate(artifact);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('artifact_validation_status');
+  });
 });
 
 describe('RuleHostWriter.buildApprovalContext', () => {


### PR DESCRIPTION
## Summary

This PR adds targeted test coverage improvements to address gaps identified in recent code changes.

## Changes

### New Test Files
- **recovery-sweep-service.test.ts**: Direct unit tests for the RecoverySweepService wrapper
  - Tests service creation with proper delegation to RuntimeStateManager
  - Verifies close() idempotency via RuntimeStateHandle
  - Tests edge cases for detectExpiredLeases and recoverTask delegation

### Enhanced Test Coverage
- **rule-host-writer.test.ts**: Additional boundary tests for assessRiskLevel function
  - Empty affectedTools array returns high riskLevel
  - Tools containing destructive prefixes (substring match) returns critical
  - Mixed tools without destructive prefixes returns high
  - Non-string items in affectedTools treated as safe
  - Invalid validationStatus rejection

## Risk Reduction

These tests address the following coverage gaps:

| Scenario | Risk | Mitigation |
|----------|------|------------|
| RecoverySweepService delegation | Low | Unit tests ensure proper delegation |
| assessRiskLevel boundary cases | Medium | Tests verify risk classification logic |
| Invalid inputs to canActivate | Medium | Tests prevent silent failures |

## Testing

All new tests pass (35 tests in related test suites).

## Related Issues

None - this is a proactive test coverage improvement.