### PR TITLE
fix(core): cross-check correction proposal fields (PRI-201)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -69,6 +69,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-008 | Missing lineage field validation allows agent to return trace with wrong attribution | PRI-192 |
 | ERR-009 | Validator silently skips missing/malformed required array fields instead of failing loud | PRI-192 |
 | ERR-010 | Falsy evaluator return silently passes validation instead of recording failure | PRI-172 |
+| ERR-013 | `in` operator on untrusted object matches inherited Object.prototype properties | PRI-201 |
 
 ---
 
@@ -244,9 +245,21 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-013]** | `in` operator on untrusted object matches inherited Object.prototype properties
+
+- **What happened**: In `validateCorrectionProposal()`, the cross-check for `correctedFields[].field` against `proposedParams` used `cf.field in proposal.proposedParams`. The `in` operator traverses the prototype chain, so inherited properties like `toString`, `constructor`, `valueOf` would match even though they are not actual keys in `proposedParams`. A `correctedFields` entry with `field: 'toString'` would incorrectly pass validation, allowing the semantic-contradiction bug the cross-check was designed to prevent.
+- **Why it's wrong**: When checking whether a key exists in an untrusted object (one that came from LLM output), the `in` operator is the wrong tool because it matches inherited properties from `Object.prototype`. This is the same class of error as ERR-001/ERR-005/ERR-007 where runtime semantics differ from the developer's intent due to type-system/primitive mismatches.
+- **Correct approach**: Use `Object.hasOwn(obj, key)` which only checks own properties and does not traverse the prototype chain. This is the correct semantics for "is this key present in the data the agent provided".
+- **How to prevent**: When checking key existence in untrusted objects (LLM output, parsed JSON, `Record<string, unknown>`), always use `Object.hasOwn()` or `Object.prototype.hasOwnProperty.call()`, never the `in` operator. Add a test case with an inherited property name (e.g., `toString`) to every validator that checks key existence.
+- **Source**: PRI-201 / PR #663 (Codex review)
+- **Date**: 2026-05-21
+- **Recurrence**: Yes - same class as ERR-001/ERR-005/ERR-007 where runtime semantics bypass validation intent
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 12 |
+| Total lessons | 13 |
 | Last updated | 2026-05-21 |
 | Top category | Schema & Type |
-| Recurring errors | 5 |
+| Recurring errors | 6 |

--- a/packages/openclaw-plugin/tests/hooks/gate-auto-correct.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-auto-correct.test.ts
@@ -307,13 +307,13 @@ describe('PRI-174: Gate auto_correct live mode', () => {
     // Verify 'applied' telemetry was NOT emitted
     expect(mockEventLogInstance.recordRuleHostAutoCorrectApplied).not.toHaveBeenCalled();
 
+    // Verify proposed telemetry was emitted with validationValid: false
+    expect(mockEventLogInstance.recordRuleHostAutoCorrectProposed).toHaveBeenCalledTimes(1);
+    const proposedCall = mockEventLogInstance.recordRuleHostAutoCorrectProposed.mock.calls[0][0];
+    expect(proposedCall.validationValid).toBe(false);
+
     // Verify no warning returned
     expect(result).toBeUndefined();
-
-    // Verify warning logged
-    expect(ctx.logger?.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to apply auto-correction')
-    );
   });
 
   it('Field missing from proposedParams: fail-open, no mutation, no applied telemetry', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
@@ -305,9 +305,6 @@ describe('Attack E2E: LLM output unreliability across pipeline handoffs', () => 
   });
 
   it('ATTACK-5: correctionProposal semantic contradiction — correctedFields vs proposedParams mismatch', () => {
-    // NOTE: This documents a known validateCorrectionProposal gap for ruleId
-    // R_attack_5. The validator currently permits correctedFields entries that
-    // are not present in proposedParams; gate.ts still fail-opens before mutation.
     const proposal = {
       proposedParams: { content: 'fixed' },
       correctedFields: [
@@ -322,7 +319,8 @@ describe('Attack E2E: LLM output unreliability across pipeline handoffs', () => 
 
     const validation = validateCorrectionProposal(proposal);
 
-    expect(validation.valid).toBe(true);
+    expect(validation.valid).toBe(false);
+    expect(validation.errors.some((e: string) => e.includes('file_path'))).toBe(true);
   });
 
   it('ATTACK-6: LLM returns empty recommendations — bridge must report failure, not silent success', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
@@ -479,4 +479,67 @@ describe('validateCorrectionProposal', () => {
     expect(result.errors.some((e: string) => e.includes('toString'))).toBe(true);
   });
 
+  it('rejects correctedFields field "toString" when proposedParams is empty object', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: {},
+      correctedFields: [
+        { field: 'toString', original: 'old', proposed: 'new', reason: 'bypass' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_inherit_toString',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('toString'))).toBe(true);
+  });
+
+  it('rejects correctedFields field "constructor" when proposedParams is empty object', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: {},
+      correctedFields: [
+        { field: 'constructor', original: 'old', proposed: 'new', reason: 'bypass' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_inherit_constructor',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('constructor'))).toBe(true);
+  });
+
+  it('rejects correctedFields field "hasOwnProperty" when proposedParams is empty object', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: {},
+      correctedFields: [
+        { field: 'hasOwnProperty', original: 'old', proposed: 'new', reason: 'bypass' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_inherit_hasOwnProperty',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('hasOwnProperty'))).toBe(true);
+  });
+
+  it('accepts correctedFields field "toString" when proposedParams explicitly contains { toString: null }', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { toString: null },
+      correctedFields: [
+        { field: 'toString', original: 'old', proposed: null, reason: 'explicit own key' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_explicit_toString',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(true);
+  });
+
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
@@ -349,4 +349,117 @@ describe('validateCorrectionProposal', () => {
     expect(result.errors.some((e: string) => e.includes('sessionId'))).toBe(true);
   });
 
+  // PRI-201: correctedFields vs proposedParams cross-check
+  it('rejects correctedFields field not present in proposedParams', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { content: 'fixed' },
+      correctedFields: [
+        { field: 'content', original: 'broken', proposed: 'fixed', reason: 'fix' },
+        { field: 'file_path', original: '/old/path', proposed: '/new/path', reason: 'fix path' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_crosscheck_1',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('file_path'))).toBe(true);
+  });
+
+  it('accepts correctedFields field with null value in proposedParams (key exists)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { file_path: null },
+      correctedFields: [
+        { field: 'file_path', original: '/old/path', proposed: null, reason: 'fix' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_crosscheck_2',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts correctedFields field with false value in proposedParams (key exists)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { enabled: false },
+      correctedFields: [
+        { field: 'enabled', original: true, proposed: false, reason: 'disable' },
+      ],
+      applicationMode: 'shadow',
+      confidence: 0.8,
+      ruleId: 'R_crosscheck_3',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts correctedFields field with 0 value in proposedParams (key exists)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { count: 0 },
+      correctedFields: [
+        { field: 'count', original: 5, proposed: 0, reason: 'reset' },
+      ],
+      applicationMode: 'shadow',
+      confidence: 0.7,
+      ruleId: 'R_crosscheck_4',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts correctedFields field with empty string value in proposedParams (key exists)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { name: '' },
+      correctedFields: [
+        { field: 'name', original: 'old', proposed: '', reason: 'clear' },
+      ],
+      applicationMode: 'shadow',
+      confidence: 0.6,
+      ruleId: 'R_crosscheck_5',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects multiple correctedFields fields not present in proposedParams', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { content: 'fixed' },
+      correctedFields: [
+        { field: 'content', original: 'broken', proposed: 'fixed', reason: 'fix' },
+        { field: 'missing_a', original: 'a', proposed: 'b', reason: 'fix a' },
+        { field: 'missing_b', original: 'c', proposed: 'd', reason: 'fix b' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_crosscheck_6',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('missing_a'))).toBe(true);
+    expect(result.errors.some((e: string) => e.includes('missing_b'))).toBe(true);
+  });
+
+  it('accepts valid correctedFields where all fields exist in proposedParams', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { content: 'fixed', encoding: 'utf-8' },
+      correctedFields: [
+        { field: 'content', original: 'broken', proposed: 'fixed', reason: 'fix' },
+        { field: 'encoding', original: 'ascii', proposed: 'utf-8', reason: 'upgrade' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_crosscheck_7',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(true);
+  });
+
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts
@@ -462,4 +462,21 @@ describe('validateCorrectionProposal', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('rejects correctedFields field matching inherited Object.prototype property (e.g. toString)', async () => {
+    const { validateCorrectionProposal } = await getModule();
+    const result = validateCorrectionProposal({
+      proposedParams: { content: 'fixed' },
+      correctedFields: [
+        { field: 'content', original: 'broken', proposed: 'fixed', reason: 'fix' },
+        { field: 'toString', original: 'old', proposed: 'new', reason: 'bypass' },
+      ],
+      applicationMode: 'live',
+      confidence: 0.9,
+      ruleId: 'R_crosscheck_8',
+      notifyAgent: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('toString'))).toBe(true);
+  });
+
 });

--- a/packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts
@@ -168,6 +168,12 @@ export function validateCorrectionProposal(
     typeof f.reason === 'string' && f.reason.trim().length > 0
   )) {
     errors.push('correctedFields must contain objects with non-empty field and reason');
+  } else if (isPlainObject(proposal.proposedParams)) {
+    for (const cf of proposal.correctedFields) {
+      if (!(cf.field in proposal.proposedParams)) {
+        errors.push(`correctedFields entry "${cf.field}" is not present in proposedParams`);
+      }
+    }
   }
 
   // applicationMode — required, must be 'shadow' or 'live'

--- a/packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts
@@ -170,7 +170,7 @@ export function validateCorrectionProposal(
     errors.push('correctedFields must contain objects with non-empty field and reason');
   } else if (isPlainObject(proposal.proposedParams)) {
     for (const cf of proposal.correctedFields) {
-      if (!(cf.field in proposal.proposedParams)) {
+      if (!Object.hasOwn(proposal.proposedParams, cf.field)) {
         errors.push(`correctedFields entry "${cf.field}" is not present in proposedParams`);
       }
     }


### PR DESCRIPTION
## Problem Root Cause

PR #659 attack E2E exposed a pure validator gap: \alidateCorrectionProposal()\ validates \correctedFields\ and \proposedParams\ independently but does not require that \correctedFields[].field\ exists as a key in \proposedParams\. An agent could output a correction claiming to fix a field that doesn't appear in the proposed parameters — a semantic contradiction that the core validator should reject.

The plugin gate currently fail-opens at runtime (no mutation), but this is defense-in-depth only. The contradiction should be caught at the core validator layer, earlier in the pipeline.

## Validator New Contract

\alidateCorrectionProposal()\ now cross-checks every \correctedFields[].field\ against \proposedParams\:

- If any \correctedFields[].field\ does not exist as a key in \proposedParams\, the proposal is **invalid**.
- The cross-check only runs when both \correctedFields\ and \proposedParams\ pass their individual structural validation (plain object + array of valid entries).

## null/false/0 Key-Existence Behavior

Uses JavaScript \in\ operator for key-existence checks — **not** truthiness:

| proposedParams value | \ield in proposedParams\ | Valid? |
|---------------------|---------------------------|--------|
| \ile_path: null\ | \	rue\ | ✅ valid |
| \nabled: false\ | \	rue\ | ✅ valid |
| \count: 0\ | \	rue\ | ✅ valid |
| \
ame: ''\ | \	rue\ | ✅ valid |
| key absent | \alse\ | ❌ invalid |

This follows the same pattern as \alidateProposedParams()\ which uses \key in originalParams\.

## Attack E2E Update

ATTACK-5 changed from \xpect(valid).toBe(true)\ (documenting bug) to \xpect(valid).toBe(false)\ (bug fixed). The validator now rejects the semantic contradiction at the core layer before it reaches the plugin gate.

## Test Commands and Results

\\\ash
npm run build --workspace=@principles/core          # ✅ pass
npx vitest run packages/principles-core/src/runtime-v2/__tests__/correction-proposal.test.ts  # ✅ 41 passed
npx vitest run packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts  # ✅ 15 passed
npx vitest run packages/openclaw-plugin/tests/hooks/gate-auto-correct.test.ts  # ✅ 14 passed
npx vitest run packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts  # ✅ 11 passed
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  # ✅ 423 passed
npm run verify:merge  # ✅ pass (pre-push gate)
\\\

## Explicitly NOT Implemented

- PRI-200: repair loop
- PRI-202/203/204: other validator gaps
- CLI output validate
- Artifact write
- DiagnosticianOutputV1 changes
- RuleHostWriter activation changes
- Ledger mutation changes
- Event schema changes
- New live mode behaviors