### PR TITLE
PRI-199: PITask hydration must reject non-peer taskKind

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
@@ -568,7 +568,7 @@ describe('Attack E2E: LLM output unreliability across pipeline handoffs', () => 
     }
   });
 
-  it('ATTACK-15: PITask with wrong taskKind — hydration accepts non-peer-runner kinds (BUG: should reject)', () => {
+  it('ATTACK-15: PITask with wrong taskKind — hydration rejects non-peer-runner kinds (bug fixed)', () => {
     const task: TaskRecord = {
       taskId: 'task_wrong_kind',
       taskKind: 'diagnostician',
@@ -588,10 +588,9 @@ describe('Attack E2E: LLM output unreliability across pipeline handoffs', () => 
 
     const piTask = hydratePITaskRecord(task);
 
-    expect(piTask).not.toBeNull();
-    if (piTask) {
-      expect(piTask.taskKind).toBe('diagnostician');
-      expect(piTask.channel).toBe('prompt');
-    }
+    // hydratePITaskRecord now rejects non-peer-runner task kinds at the hydration
+    // boundary, closing the gap where a diagnostician task with valid pi_metadata
+    // could be treated as a PITaskRecord by the InternalizationOrchestrator.
+    expect(piTask).toBeNull();
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pitask-metadata.test.ts
@@ -272,20 +272,42 @@ describe('hydratePITaskRecord', () => {
     expect(pi.outputArtifactRefs).toEqual([{ artifactType: 'rule', ref: 'artifact-2' }]);
   });
 
-  it('taskKind not a PeerRunnerKind → still hydrates metadata (isValidPITaskRecord checks taskKind separately)', () => {
-    // The hydration function does NOT check taskKind; that is the adapter's concern.
-    // hydratePITaskRecord only checks that metadata is valid PI metadata.
-    // Note: isValidPITaskRecord() will return false here because taskKind='diagnostician'
-    // is not a PeerRunnerKind — that is intentional; the adapter filters by taskKind first.
+  it('taskKind not a PeerRunnerKind (e.g. diagnostician) → returns null (fail closed)', () => {
+    // hydratePITaskRecord now rejects non-peer task kinds at the hydration boundary.
+    // This closes the Agent-Software Contract gap where a non-PI task with valid
+    // pi_metadata in diagnosticJson could be treated as a PITaskRecord.
     const meta = makeMetadata({ channel: 'defer_archive' });
     const task = makeBaseTaskRecord({ taskId: 'task-diagnostician', taskKind: 'diagnostician' });
     (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
 
     const result = hydratePITaskRecord(task);
-    expect(result).not.toBeNull();
-    expect((result as PITaskRecord).channel).toBe('defer_archive');
-    // isValidPITaskRecord would return false here (diagnostician is not a PeerRunnerKind)
-    // — the adapter's filter pipeline (isPeerRunnerKind first, then hydrate) handles this
+    expect(result).toBeNull();
+  });
+
+  it('every valid PeerRunnerKind still hydrates successfully', () => {
+    const validKinds = ['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'trainer', 'rollout_reviewer'] as const;
+    const meta = makeMetadata({ channel: 'prompt', timeoutMs: 60000 });
+
+    for (const kind of validKinds) {
+      const task = makeBaseTaskRecord({ taskId: `task-${kind}`, taskKind: kind });
+      (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
+
+      const result = hydratePITaskRecord(task);
+      expect(result).not.toBeNull();
+      if (result !== null) {
+        expect(result.taskKind).toBe(kind);
+        expect(result.channel).toBe('prompt');
+        expect(result.timeoutMs).toBe(60000);
+      }
+    }
+  });
+
+  it('diagnostician with valid pi_metadata is rejected', () => {
+    const meta = makeMetadata({ channel: 'prompt', timeoutMs: 60000 });
+    const task = makeBaseTaskRecord({ taskId: 'task-diag-reject', taskKind: 'diagnostician' });
+    (task as Record<string, unknown>).diagnosticJson = createPITaskDiagnosticJson(meta);
+
+    expect(hydratePITaskRecord(task)).toBeNull();
   });
 
   it('parentTaskId and correlationId present → hydrates correctly', () => {

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -31,7 +31,7 @@ import type {
   InternalizationChannel,
   ArtifactRef,
 } from './peer-runner-contracts.js';
-import { isInternalizationChannel } from './peer-runner-contracts.js';
+import { isInternalizationChannel, isPeerRunnerKind } from './peer-runner-contracts.js';
 
 /** Namespace key used inside diagnosticJson to isolate PI metadata. */
 export const PI_METADATA_KEY = 'pi_metadata' as const;
@@ -173,17 +173,22 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
  * Hydrate a raw TaskRecord (as returned by SqliteTaskStore.getTask or listTasks)
  * into a PITaskRecord by reading and parsing its diagnosticJson.
  *
+ * Fail-closed: returns null for any non-peer-runner taskKind (e.g. diagnostician)
+ * even if diagnosticJson contains valid pi_metadata. This prevents the
+ * InternalizationOrchestrator from treating a non-PI task as a PITaskRecord.
+ *
  * Returns null if:
+ *   - taskKind is not a PeerRunnerKind (e.g. diagnostician)
  *   - diagnosticJson is missing or whitespace
  *   - diagnosticJson is not valid JSON
  *   - pi_metadata key is missing or invalid
  *   - Any required PI field fails validation
  *   - Optional field present but not a non-empty string
- *
- * This function does NOT check taskKind — that is the concern of the caller
- * (plugin trigger adapter filters by isPeerRunnerKind before hydration).
  */
 export function hydratePITaskRecord(task: TaskRecord): PITaskRecord | null {
+  // Guard: reject non-peer-runner task kinds — lineage/kind invariant
+  if (!isPeerRunnerKind(task.taskKind)) return null;
+
   // Read diagnosticJson from the runtime object (not typed on TaskRecord)
   const raw = task as Record<string, unknown>;
   const {diagnosticJson} = raw;


### PR DESCRIPTION
## Summary

Symphony control plane created this PR for PRI-199.

## Issue

https://linear.app/principlesdisciple/issue/PRI-199/pitask-hydration-must-reject-non-peer-taskkind

## Notes

The agent edited the workspace only. Symphony performed commit, push, PR creation, and tracker transition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了 hydration 行为：对非 peer-runner 类型任务采用 fail-closed 策略，确保这些任务会被拒绝返回，提升处理安全性与一致性。

* **Tests**
  * 更新并扩展了测试用例，覆盖所有已知有效的 peer-runner 类型，验证接受路径；并单独断言对特定非 peer-runner 类型的拒绝行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->