### PR TITLE
feat(runtime): add structured output repair loop (PRI-200)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -72,6 +72,8 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-013 | `in` operator on untrusted object matches inherited Object.prototype properties | PRI-201 |
 | ERR-014 | `formatValidationErrorEntry` string values not truncated — evidence pack unbounded | PRI-200 |
 | ERR-015 | Repair loop uses stale schema errors across attempts — reduced repair effectiveness | PRI-200 |
+| ERR-016 | maxRepairAttempts not hard-capped — { maxRepairAttempts: 999 } runs 999 calls | PRI-200 |
+| ERR-017 | JSON.stringify on unknown values can throw (BigInt, circular) — preview paths crash | PRI-200 |
 
 ---
 
@@ -283,9 +285,33 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-016]** | maxRepairAttempts not hard-capped — { maxRepairAttempts: 999 } runs 999 calls
+
+- **What happened**: The PR contract states "repair loop is bounded: default 1, maximum 2" but `attemptStructuredOutputRepair()` used `cfg.maxRepairAttempts` directly from the spread config without clamping. Passing `{ maxRepairAttempts: 999 }` would run 999 repair calls, violating the contract.
+- **Why it's wrong**: The contract's "maximum 2" promise was only documented, not enforced in code. Any caller (including misconfigured adapters) could bypass the bound. This is the same class as ERR-001/ERR-005/ERR-014 where validation exists in prose but not in code.
+- **Correct approach**: Add `MAX_REPAIR_ATTEMPTS = 2` as a hard cap constant. Add `normalizeMaxRepairAttempts()` helper that clamps, floors, handles NaN/Infinity/negative, and caps at MAX_REPAIR_ATTEMPTS. Apply normalization when building the config, not just at the loop boundary.
+- **How to prevent**: When a contract specifies a numeric bound ("max N"), always enforce it with a constant and a normalization function — never trust caller input. Add tests for extreme values (999, Infinity, NaN, negative, decimal).
+- **Source**: PRI-200 / PR #665 (final review)
+- **Date**: 2026-05-21
+- **Recurrence**: Yes - same class as ERR-001/ERR-005/ERR-014 where validation is in prose but not in code
+
+---
+
+**[ERR-017]** | JSON.stringify on unknown values can throw (BigInt, circular) — preview paths crash
+
+- **What happened**: Multiple preview paths used `JSON.stringify()` directly on unknown values: `formatRepairPrompt()` used `JSON.stringify(invalidJson, null, 2)`, `attemptStructuredOutputRepair()` used `JSON.stringify(invalidOutput)` for `rawOutputPreview`, and `formatValidationErrorEntry()` used `JSON.stringify(value)`. All of these throw on BigInt values, circular references, or other unstringifiable objects.
+- **Why it's wrong**: Evidence pack preview paths must never throw — they exist for observability when things go wrong. If the LLM returns a response containing BigInt or circular refs, the preview formatting would throw, masking the original error with a secondary crash. This violates the "fail-closed but observable" design principle.
+- **Correct approach**: Add `safeStringifyPreview(value, maxLen)` helper that wraps `JSON.stringify` in try/catch, handles BigInt explicitly (`${value}n`), and falls back to `[unserializable: ClassName]` for objects and `String(value)` for primitives. Use it everywhere a preview is produced.
+- **How to prevent**: Never use raw `JSON.stringify()` on unknown/untrusted values in observability paths. Always wrap in a safe serialization helper. Add tests for BigInt, circular refs, and Object.create(null) to verify no throws.
+- **Source**: PRI-200 / PR #665 (final review)
+- **Date**: 2026-05-21
+- **Recurrence**: No
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 15 |
+| Total lessons | 17 |
 | Last updated | 2026-05-21 |
 | Top category | Schema & Type |
-| Recurring errors | 8 |
+| Recurring errors | 9 |

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -70,6 +70,8 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-009 | Validator silently skips missing/malformed required array fields instead of failing loud | PRI-192 |
 | ERR-010 | Falsy evaluator return silently passes validation instead of recording failure | PRI-172 |
 | ERR-013 | `in` operator on untrusted object matches inherited Object.prototype properties | PRI-201 |
+| ERR-014 | `formatValidationErrorEntry` string values not truncated — evidence pack unbounded | PRI-200 |
+| ERR-015 | Repair loop uses stale schema errors across attempts — reduced repair effectiveness | PRI-200 |
 
 ---
 
@@ -257,9 +259,33 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-014]** | `formatValidationErrorEntry` string values not truncated — evidence pack unbounded
+
+- **What happened**: In `formatValidationErrorEntry()`, the `actualPreview` field returned raw string values without truncation: `typeof value === 'string' ? value : ...`. Only non-string values went through `truncatePreview()`. This violated the "bounded preview" design goal of the evidence pack — a very long string value (e.g., a 10KB error message) would bloat the evidence pack and could leak sensitive content.
+- **Why it's wrong**: The evidence pack is designed to be observable and bounded. All preview fields must be size-limited. Leaving string values unbounded creates an asymmetry where `actualPreview` for strings can be arbitrarily large while non-string previews are capped at 100 chars. This is the same class as ERR-001/ERR-005 where type-specific handling creates validation gaps.
+- **Correct approach**: Apply `truncatePreview(value, 100)` to the string branch as well, so all `actualPreview` values are uniformly bounded.
+- **How to prevent**: When implementing "bounded preview" or "truncated" fields, verify ALL code paths that produce the field value apply the same truncation logic. Add a test case with a long string value to verify truncation.
+- **Source**: PRI-200 / PR #665 (CodeRabbit review)
+- **Date**: 2026-05-21
+- **Recurrence**: Yes - same class as ERR-001/ERR-005 where type-specific branches bypass validation
+
+---
+
+**[ERR-015]** | Repair loop uses stale schema errors across attempts — reduced repair effectiveness
+
+- **What happened**: In `attemptStructuredOutputRepair()`, the repair loop always passed the original `schemaErrors` to `formatRepairPrompt()` for every attempt, even after the candidate output had changed. When `maxRepairAttempts > 1`, the second and subsequent repair prompts would contain errors from the original output, not the current candidate. This reduces repair effectiveness because the LLM is asked to fix errors that may no longer exist while missing new errors introduced by the previous repair attempt.
+- **Why it's wrong**: The repair loop updates `invalidOutput` to `candidateWithLineage` after each failed attempt, but the prompt still references the original errors. This means the LLM gets a misleading prompt — "fix these errors" — when the actual errors have changed. The `callbacks.schemaErrors` callback was available to get fresh errors but was only used for the `repairAttempts` record, not for the next prompt.
+- **Correct approach**: Track `currentErrors` as a mutable variable initialized from `schemaErrors`. After each failed attempt, if `callbacks.schemaErrors` is available, refresh `currentErrors` with the latest errors from the failed candidate. Pass `currentErrors` to `formatRepairPrompt()` on each iteration.
+- **How to prevent**: When implementing a retry/repair loop that re-prompts an LLM, always refresh the error context from the latest attempt before building the next prompt. Never assume the errors are static across iterations. Add a test with `maxRepairAttempts > 1` and `callbacks.schemaErrors` returning different errors on each call to verify the prompt uses updated errors.
+- **Source**: PRI-200 / PR #665 (CodeRabbit review)
+- **Date**: 2026-05-21
+- **Recurrence**: No
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 13 |
+| Total lessons | 15 |
 | Last updated | 2026-05-21 |
 | Top category | Schema & Type |
-| Recurring errors | 6 |
+| Recurring errors | 8 |

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Output repair contract unit tests — PRI-200.
+ *
+ * Tests the types and utilities for the bounded structured-output repair loop:
+ *   - preserveLineageFields — protects lineage fields during repair
+ *   - isLineageField — identifies lineage fields
+ *   - truncatePreview — bounds preview strings
+ *   - formatValidationErrorEntry — formats TypeBox errors for evidence pack
+ *   - OutputEvidencePack shape validation
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  preserveLineageFields,
+  isLineageField,
+  truncatePreview,
+  formatValidationErrorEntry,
+  LINEAGE_FIELDS,
+  REPAIR_PROMPT_VERSION,
+} from '../output-repair-contract.js';
+import type {
+  OutputEvidencePack,
+  OutputFailureKind,
+} from '../output-repair-contract.js';
+
+describe('output-repair-contract', () => {
+  describe('isLineageField', () => {
+    it('returns true for known lineage fields', () => {
+      expect(isLineageField('taskId')).toBe(true);
+      expect(isLineageField('sourcePainId')).toBe(true);
+      expect(isLineageField('sourceTaskId')).toBe(true);
+      expect(isLineageField('sourceRunIds')).toBe(true);
+      expect(isLineageField('sourceArtifactId')).toBe(true);
+      expect(isLineageField('sourceRefs')).toBe(true);
+    });
+
+    it('returns false for non-lineage fields', () => {
+      expect(isLineageField('confidence')).toBe(false);
+      expect(isLineageField('summary')).toBe(false);
+      expect(isLineageField('toString')).toBe(false);
+      expect(isLineageField('constructor')).toBe(false);
+    });
+  });
+
+  describe('preserveLineageFields', () => {
+    it('preserves lineage fields from original when repaired output changes them', () => {
+      const original = {
+        taskId: 'task-1',
+        sourcePainId: 'pain-1',
+        confidence: 0.85,
+        summary: 'original',
+      };
+      const repaired = {
+        taskId: 'task-CHANGED',
+        sourcePainId: 'pain-CHANGED',
+        confidence: 0.9,
+        summary: 'repaired',
+      };
+
+      const result = preserveLineageFields(original, repaired);
+
+      expect(result.taskId).toBe('task-1');
+      expect(result.sourcePainId).toBe('pain-1');
+      expect(result.confidence).toBe(0.9);
+      expect(result.summary).toBe('repaired');
+    });
+
+    it('does not add lineage fields that were absent in original', () => {
+      const original: Record<string, unknown> = { confidence: 0.85 };
+      const repaired: Record<string, unknown> = { confidence: 0.9 };
+
+      const result = preserveLineageFields(original, repaired);
+
+      expect(result.confidence).toBe(0.9);
+      for (const field of LINEAGE_FIELDS) {
+        expect(Object.hasOwn(result, field)).toBe(false);
+      }
+    });
+
+    it('preserves all LINEAGE_FIELDS from original', () => {
+      const original: Record<string, unknown> = {};
+      for (const field of LINEAGE_FIELDS) {
+        original[field] = `original-${field}`;
+      }
+      const repaired: Record<string, unknown> = {};
+      for (const field of LINEAGE_FIELDS) {
+        repaired[field] = `changed-${field}`;
+      }
+
+      const result = preserveLineageFields(original, repaired);
+
+      for (const field of LINEAGE_FIELDS) {
+        expect(result[field]).toBe(`original-${field}`);
+      }
+    });
+  });
+
+  describe('truncatePreview', () => {
+    it('returns short strings unchanged', () => {
+      expect(truncatePreview('hello')).toBe('hello');
+    });
+
+    it('truncates long strings with ellipsis', () => {
+      const long = 'x'.repeat(600);
+      const result = truncatePreview(long);
+      expect(result.length).toBeLessThan(long.length);
+      expect(result.endsWith('...')).toBe(true);
+    });
+
+    it('respects custom maxLen', () => {
+      const result = truncatePreview('hello world', 5);
+      expect(result).toBe('he...');
+    });
+  });
+
+  describe('formatValidationErrorEntry', () => {
+    it('formats string values as-is', () => {
+      const entry = formatValidationErrorEntry('/confidence', 'Expected number', '85%');
+      expect(entry.path).toBe('/confidence');
+      expect(entry.expected).toBe('Expected number');
+      expect(entry.actualPreview).toBe('85%');
+    });
+
+    it('formats non-string values as JSON', () => {
+      const entry = formatValidationErrorEntry('/items', 'Expected array', 42);
+      expect(entry.actualPreview).toBe('42');
+    });
+
+    it('truncates long JSON values', () => {
+      const longObj = { data: 'x'.repeat(200) };
+      const entry = formatValidationErrorEntry('/field', 'Expected string', longObj);
+      expect(entry.actualPreview.length).toBeLessThan(200);
+    });
+  });
+
+  describe('OutputEvidencePack shape', () => {
+    it('can construct a valid evidence pack', () => {
+      const pack: OutputEvidencePack = {
+        schemaRef: 'diagnostician-output-v1',
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4',
+        promptContractVersion: '1',
+        rawOutputPreview: '{"valid":true,...}',
+        validationErrors: [
+          { path: '/confidence', expected: 'Expected number', actualPreview: '"85%"' },
+        ],
+        repairAttempts: [
+          {
+            schemaRef: 'diagnostician-output-v1',
+            attempt: 1,
+            rawOutputPreview: '{"valid":true,...}',
+            validationErrors: [
+              { path: '/confidence', expected: 'Expected number', actualPreview: '"85%"' },
+            ],
+            repairPromptVersion: REPAIR_PROMPT_VERSION,
+            repaired: false,
+          },
+        ],
+        finalFailureReason: 'repair_exhausted',
+      };
+
+      expect(pack.schemaRef).toBe('diagnostician-output-v1');
+      expect(pack.provider).toBe('openrouter');
+      expect(pack.model).toBe('anthropic/claude-sonnet-4');
+      expect(pack.finalFailureReason).toBe('repair_exhausted');
+      expect(pack.repairAttempts).toHaveLength(1);
+      expect(pack.repairAttempts[0]?.repaired).toBe(false);
+    });
+
+    it('all OutputFailureKind values are valid', () => {
+      const kinds: OutputFailureKind[] = ['extraction_failed', 'schema_invalid', 'repair_exhausted'];
+      expect(kinds).toHaveLength(3);
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts
@@ -16,6 +16,9 @@ import {
   formatValidationErrorEntry,
   LINEAGE_FIELDS,
   REPAIR_PROMPT_VERSION,
+  MAX_REPAIR_ATTEMPTS,
+  normalizeMaxRepairAttempts,
+  safeStringifyPreview,
 } from '../output-repair-contract.js';
 import type {
   OutputEvidencePack,
@@ -176,6 +179,108 @@ describe('output-repair-contract', () => {
     it('all OutputFailureKind values are valid', () => {
       const kinds: OutputFailureKind[] = ['extraction_failed', 'schema_invalid', 'repair_exhausted'];
       expect(kinds).toHaveLength(3);
+    });
+  });
+
+  describe('normalizeMaxRepairAttempts', () => {
+    it('returns default for undefined', () => {
+      expect(normalizeMaxRepairAttempts(undefined, 1)).toBe(1);
+    });
+
+    it('returns default for Infinity', () => {
+      expect(normalizeMaxRepairAttempts(Infinity, 1)).toBe(1);
+    });
+
+    it('returns default for -Infinity', () => {
+      expect(normalizeMaxRepairAttempts(-Infinity, 1)).toBe(1);
+    });
+
+    it('returns default for NaN', () => {
+      expect(normalizeMaxRepairAttempts(NaN, 1)).toBe(1);
+    });
+
+    it('returns 0 for negative', () => {
+      expect(normalizeMaxRepairAttempts(-1, 1)).toBe(0);
+    });
+
+    it('floors decimal values', () => {
+      expect(normalizeMaxRepairAttempts(1.9, 1)).toBe(1);
+    });
+
+    it('clamps to MAX_REPAIR_ATTEMPTS', () => {
+      expect(normalizeMaxRepairAttempts(999, 1)).toBe(MAX_REPAIR_ATTEMPTS);
+    });
+
+    it('passes through valid values within range', () => {
+      expect(normalizeMaxRepairAttempts(0, 1)).toBe(0);
+      expect(normalizeMaxRepairAttempts(1, 1)).toBe(1);
+      expect(normalizeMaxRepairAttempts(2, 1)).toBe(2);
+    });
+  });
+
+  describe('safeStringifyPreview', () => {
+    it('serializes plain objects', () => {
+      expect(safeStringifyPreview({ a: 1 })).toBe('{"a":1}');
+    });
+
+    it('serializes arrays', () => {
+      expect(safeStringifyPreview([1, 2])).toBe('[1,2]');
+    });
+
+    it('handles undefined', () => {
+      expect(safeStringifyPreview(undefined)).toBe('undefined');
+    });
+
+    it('handles null', () => {
+      expect(safeStringifyPreview(null)).toBe('null');
+    });
+
+    it('handles BigInt without throwing', () => {
+      const result = safeStringifyPreview(1n);
+      expect(result).toBe('1n');
+    });
+
+    it('handles circular objects without throwing', () => {
+      const obj: Record<string, unknown> = {};
+      obj.self = obj;
+      const result = safeStringifyPreview(obj);
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles Object.create(null) without throwing', () => {
+      const obj = Object.create(null) as Record<string, unknown>;
+      obj.key = 'value';
+      const result = safeStringifyPreview(obj);
+      expect(result).toContain('key');
+    });
+
+    it('truncates long output', () => {
+      const obj = { data: 'x'.repeat(1000) };
+      const result = safeStringifyPreview(obj, 50);
+      expect(result.length).toBeLessThanOrEqual(53);
+    });
+  });
+
+  describe('formatValidationErrorEntry with safe serialization', () => {
+    it('handles BigInt values without throwing', () => {
+      const entry = formatValidationErrorEntry('/x', 'Expected string', 1n);
+      expect(entry.actualPreview).toBe('1n');
+    });
+
+    it('handles circular objects without throwing', () => {
+      const obj: Record<string, unknown> = {};
+      obj.self = obj;
+      const entry = formatValidationErrorEntry('/x', 'Expected string', obj);
+      expect(typeof entry.actualPreview).toBe('string');
+      expect(entry.actualPreview.length).toBeGreaterThan(0);
+    });
+
+    it('handles Object.create(null) without throwing', () => {
+      const obj = Object.create(null) as Record<string, unknown>;
+      obj.key = 'value';
+      const entry = formatValidationErrorEntry('/x', 'Expected string', obj);
+      expect(typeof entry.actualPreview).toBe('string');
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts
@@ -113,11 +113,18 @@ describe('output-repair-contract', () => {
   });
 
   describe('formatValidationErrorEntry', () => {
-    it('formats string values as-is', () => {
+    it('formats short string values as-is', () => {
       const entry = formatValidationErrorEntry('/confidence', 'Expected number', '85%');
       expect(entry.path).toBe('/confidence');
       expect(entry.expected).toBe('Expected number');
       expect(entry.actualPreview).toBe('85%');
+    });
+
+    it('truncates long string values', () => {
+      const longString = 'x'.repeat(200);
+      const entry = formatValidationErrorEntry('/field', 'Expected number', longString);
+      expect(entry.actualPreview.length).toBeLessThan(longString.length);
+      expect(entry.actualPreview.endsWith('...')).toBe(true);
     });
 
     it('formats non-string values as JSON', () => {

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
@@ -1103,4 +1103,259 @@ describe('PiAiRuntimeAdapter', () => {
       expect(output?.payload).toMatchObject({ valid: true, taskId: 'task-dreamer-1' });
     });
   });
+
+  // ── PRI-200: Structured output repair loop with evidence pack ──
+
+  describe('PRI-200: structured output repair loop with evidence pack', () => {
+    const INVALID_DIAGNOSIS_SCHEMA = {
+      valid: true,
+      diagnosisId: 'diag-pri200-1',
+      taskId: 'task-pri200-1',
+      summary: 'Test PRI-200',
+      rootCause: 'Test root cause',
+      violatedPrinciples: [],
+      evidence: [],
+      recommendations: [{ kind: 'Rule', description: 'Fix casing' }],
+      confidence: '85%',
+    };
+
+    function makeDiagnosticianInput(overrides: Partial<StartRunInput> = {}): StartRunInput {
+      return makeStartRunInput({
+        outputSchemaRef: 'diagnostician-output-v1',
+        taskRef: { taskId: 'task-pri200-1' },
+        ...overrides,
+      });
+    }
+
+    function resetMock() {
+      mockComplete.mockReset();
+      mockComplete.mockResolvedValue(makeAssistantMessage(JSON.stringify(VALID_DIAGNOSIS)));
+    }
+
+    it('1. valid JSON + valid schema → no repair triggered', async () => {
+      resetMock();
+      mockComplete.mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(VALID_DIAGNOSIS)));
+
+      const adapter = makeAdapter();
+      const handle = await adapter.startRun(makeDiagnosticianInput());
+
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output?.payload).toMatchObject({ confidence: 0.9 });
+
+      const repairEvent = findTelemetryEvent('output_repair_attempted');
+      expect(repairEvent).toBeUndefined();
+      const schemaInvalidEvent = findTelemetryEvent('output_schema_invalid');
+      expect(schemaInvalidEvent).toBeUndefined();
+    });
+
+    it('2. prose-wrapped JSON extraction succeeds → no repair triggered', async () => {
+      resetMock();
+      const proseWrapped = `Here is the analysis:\n${JSON.stringify(VALID_DIAGNOSIS)}\nDone.`;
+      mockComplete.mockResolvedValueOnce(makeAssistantMessage(proseWrapped));
+
+      const adapter = makeAdapter();
+      const handle = await adapter.startRun(makeDiagnosticianInput());
+
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output?.payload).toMatchObject({ diagnosisId: 'diag-test-1' });
+    });
+
+    it('3. extraction failed → output_extraction_failed telemetry + output_invalid', async () => {
+      resetMock();
+      mockComplete.mockResolvedValueOnce(makeAssistantMessage('No JSON here at all'));
+
+      const adapter = makeAdapter();
+      try { await adapter.startRun(makeDiagnosticianInput()); } catch { /* expected */ }
+
+      const extractionEvent = findTelemetryEvent('output_extraction_failed');
+      expect(extractionEvent).toBeDefined();
+      const payload = extractionEvent?.payload as Record<string, unknown>;
+      expect(payload.outputSchemaRef).toBe('diagnostician-output-v1');
+      expect(payload.provider).toBe('openrouter');
+      expect(payload.model).toBe('anthropic/claude-sonnet-4');
+      expect(typeof payload.rawOutputPreview).toBe('string');
+    });
+
+    it('4. schema invalid once, repair returns valid → success + repairAttempts[0].repaired=true', async () => {
+      resetMock();
+      mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(VALID_DIAGNOSIS)));
+
+      const adapter = makeAdapter();
+      const handle = await adapter.startRun(makeDiagnosticianInput());
+
+      expect(mockComplete).toHaveBeenCalledTimes(2);
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output?.payload).toMatchObject({ confidence: 0.9 });
+
+      const repairEvent = findTelemetryEvent('output_repair_attempted');
+      expect(repairEvent).toBeDefined();
+      const repairPayload = repairEvent?.payload as Record<string, unknown>;
+      expect(repairPayload.repaired).toBe(true);
+      expect(repairPayload.attemptsUsed).toBe(1);
+    });
+
+    it('5. schema invalid, repair also invalid → output_repair_exhausted + output_invalid', async () => {
+      resetMock();
+      mockComplete.mockResolvedValue(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)));
+
+      const adapter = makeAdapter();
+      await expect(adapter.startRun(makeDiagnosticianInput())).rejects.toMatchObject({
+        category: 'output_invalid',
+      });
+
+      const exhaustedEvent = findTelemetryEvent('output_repair_exhausted');
+      expect(exhaustedEvent).toBeDefined();
+      const exhaustedPayload = exhaustedEvent?.payload as Record<string, unknown>;
+      expect(exhaustedPayload.outputSchemaRef).toBe('diagnostician-output-v1');
+      expect(exhaustedPayload.provider).toBe('openrouter');
+      expect(exhaustedPayload.model).toBe('anthropic/claude-sonnet-4');
+      expect(typeof exhaustedPayload.rawOutputPreview).toBe('string');
+      expect(Array.isArray(exhaustedPayload.validationErrors)).toBe(true);
+      expect(Array.isArray(exhaustedPayload.repairAttempts)).toBe(true);
+      expect(typeof exhaustedPayload.finalFailureReason).toBe('string');
+    });
+
+    it('6. repair loop never exceeds configured max attempts', async () => {
+      resetMock();
+      mockComplete.mockResolvedValue(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)));
+
+      const adapter = makeAdapter();
+      await expect(adapter.startRun(makeDiagnosticianInput())).rejects.toMatchObject({
+        category: 'output_invalid',
+      });
+
+      // 1 original + 1 repair (default maxRepairAttempts=1) = 2 calls total
+      expect(mockComplete).toHaveBeenCalledTimes(2);
+    });
+
+    it('7. repair prompt includes schemaRef and error paths', async () => {
+      resetMock();
+      mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(VALID_DIAGNOSIS)));
+
+      const adapter = makeAdapter();
+      await adapter.startRun(makeDiagnosticianInput());
+
+      const [, context] = mockComplete.mock.calls[1] as [unknown, { messages: { content: string }[] }];
+      const repairMessage = context.messages[0]?.content ?? '';
+      expect(repairMessage).toContain('diagnostician-output-v1');
+      expect(repairMessage).toContain('/confidence');
+    });
+
+    it('8. repair attempt must not override lineage fields silently', async () => {
+      resetMock();
+      const originalWithLineage = {
+        ...INVALID_DIAGNOSIS_SCHEMA,
+        taskId: 'task-original-1',
+      };
+      const repairedWithChangedLineage = {
+        ...VALID_DIAGNOSIS,
+        taskId: 'task-CHANGED-by-llm',
+      };
+
+      mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(originalWithLineage)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(repairedWithChangedLineage)));
+
+      const adapter = makeAdapter();
+      const handle = await adapter.startRun(makeDiagnosticianInput({
+        taskRef: { taskId: 'task-original-1' },
+      }));
+
+      const output = await adapter.fetchOutput(handle.runId);
+      const payload = output?.payload as Record<string, unknown>;
+      expect(payload.taskId).toBe('task-original-1');
+    });
+
+    it('9. provider/model/rawOutputPreview are present in evidence pack', async () => {
+      resetMock();
+      mockComplete.mockResolvedValue(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)));
+
+      const adapter = makeAdapter();
+      try { await adapter.startRun(makeDiagnosticianInput()); } catch { /* expected */ }
+
+      const exhaustedEvent = findTelemetryEvent('output_repair_exhausted');
+      expect(exhaustedEvent).toBeDefined();
+      const payload = exhaustedEvent?.payload as Record<string, unknown>;
+      expect(payload.provider).toBe('openrouter');
+      expect(payload.model).toBe('anthropic/claude-sonnet-4');
+      expect(typeof (payload.rawOutputPreview as string)).toBe('string');
+      expect((payload.rawOutputPreview as string).length).toBeGreaterThan(0);
+    });
+
+    it('10. unknown schemaRef keeps existing backward-compatible behavior', async () => {
+      resetMock();
+      const arbitraryOutput = { foo: 'bar', baz: 42 };
+      mockComplete.mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(arbitraryOutput)));
+
+      const adapter = makeAdapter();
+      const handle = await adapter.startRun(makeStartRunInput({
+        outputSchemaRef: 'custom-unknown-v1',
+      }));
+
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output?.payload).toMatchObject(arbitraryOutput);
+    });
+
+    it('emits output_schema_invalid telemetry before repair attempt', async () => {
+      resetMock();
+      mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(VALID_DIAGNOSIS)));
+
+      const adapter = makeAdapter();
+      await adapter.startRun(makeDiagnosticianInput());
+
+      const schemaInvalidEvent = findTelemetryEvent('output_schema_invalid');
+      expect(schemaInvalidEvent).toBeDefined();
+      const payload = schemaInvalidEvent?.payload as Record<string, unknown>;
+      expect(payload.outputSchemaRef).toBe('diagnostician-output-v1');
+      expect(payload.provider).toBe('openrouter');
+      expect(payload.model).toBe('anthropic/claude-sonnet-4');
+      expect(typeof (payload.rawOutputPreview as string)).toBe('string');
+      expect(Array.isArray(payload.validationErrors)).toBe(true);
+      expect((payload.validationErrors as unknown[]).length).toBeGreaterThan(0);
+    });
+
+    it('evidence pack includes repairAttempts with schemaRef and attempt number', async () => {
+      resetMock();
+      mockComplete.mockResolvedValue(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)));
+
+      const adapter = makeAdapter();
+      try { await adapter.startRun(makeDiagnosticianInput()); } catch { /* expected */ }
+
+      const exhaustedEvent = findTelemetryEvent('output_repair_exhausted');
+      expect(exhaustedEvent).toBeDefined();
+      const payload = exhaustedEvent?.payload as Record<string, unknown>;
+      const attempts = payload.repairAttempts as Record<string, unknown>[];
+      expect(attempts.length).toBeGreaterThan(0);
+      expect(attempts[0]?.schemaRef).toBe('diagnostician-output-v1');
+      expect(typeof attempts[0]?.attempt).toBe('number');
+      expect(typeof attempts[0]?.repaired).toBe('boolean');
+    });
+
+    it('output_schema_invalid telemetry includes validation error paths', async () => {
+      resetMock();
+      mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS_SCHEMA)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(VALID_DIAGNOSIS)));
+
+      const adapter = makeAdapter();
+      await adapter.startRun(makeDiagnosticianInput());
+
+      const schemaInvalidEvent = findTelemetryEvent('output_schema_invalid');
+      expect(schemaInvalidEvent).toBeDefined();
+      const payload = schemaInvalidEvent?.payload as Record<string, unknown>;
+      const errors = payload.validationErrors as Record<string, unknown>[];
+      expect(errors.length).toBeGreaterThan(0);
+      const errorPaths = errors.map(e => e.path);
+      expect(errorPaths.some(p => typeof p === 'string' && p.includes('confidence'))).toBe(true);
+    });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
@@ -389,6 +389,169 @@ describe('attemptStructuredOutputRepair', () => {
     expect(callPrompts[0]).toContain('Expected number got string');
     expect(callPrompts[1]).toContain('Expected number got string v2');
   });
+
+  it('repairAttempts records current errors per attempt, not initial errors', async () => {
+    const llmCaller: RepairLLMCaller = async () => {
+      return JSON.stringify(SAMPLE_INVALID_JSON);
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number', value: '85%' }];
+    const secondErrors = [{ path: '/summary', message: 'Expected string', value: 42 }];
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: () => false,
+        schemaErrors: () => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(result.repairAttempts).toHaveLength(2);
+    const [attempt0, attempt1] = result.repairAttempts;
+    expect(attempt0).toBeDefined();
+    expect(attempt1).toBeDefined();
+    const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
+    const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt0Paths).toContain('/summary');
+    expect(attempt1Paths).toContain('/summary');
+    expect(attempt0Paths).not.toContain('/confidence');
+    expect(attempt1Paths).not.toContain('/confidence');
+  });
+
+  it('repairAttempts records current errors when attempt 2 succeeds', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      if (callCount < 2) return JSON.stringify(SAMPLE_INVALID_JSON);
+      return JSON.stringify(VALID_REPAIRED_JSON);
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number', value: '85%' }];
+    const secondErrors = [{ path: '/summary', message: 'Expected string', value: 42 }];
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: (v) => {
+          const obj = v as Record<string, unknown>;
+          return typeof obj.confidence === 'number';
+        },
+        schemaErrors: () => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(result.repaired).toBe(true);
+    expect(result.repairAttempts).toHaveLength(2);
+    const [attempt0, attempt1] = result.repairAttempts;
+    expect(attempt0).toBeDefined();
+    expect(attempt1).toBeDefined();
+    const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
+    const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt0Paths).toContain('/summary');
+    expect(attempt1Paths).toContain('/summary');
+    expect(attempt0Paths).not.toContain('/confidence');
+    expect(attempt1Paths).not.toContain('/confidence');
+  });
+
+  it('repairAttempts records current errors when attempt 2 llmCaller throws', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      if (callCount === 1) return JSON.stringify(SAMPLE_INVALID_JSON);
+      throw new Error('LLM down');
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number', value: '85%' }];
+    const secondErrors = [{ path: '/summary', message: 'Expected string', value: 42 }];
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: () => false,
+        schemaErrors: () => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(result.repairAttempts).toHaveLength(2);
+    const [, attempt1] = result.repairAttempts;
+    expect(attempt1).toBeDefined();
+    const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt1Paths).toContain('/summary');
+    expect(attempt1Paths).not.toContain('/confidence');
+  });
+
+  it('repairAttempts records current errors when attempt 2 returns null', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      if (callCount === 1) return JSON.stringify(SAMPLE_INVALID_JSON);
+      return null;
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number', value: '85%' }];
+    const secondErrors = [{ path: '/summary', message: 'Expected string', value: 42 }];
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: () => false,
+        schemaErrors: () => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(result.repairAttempts).toHaveLength(2);
+    const [, attempt1] = result.repairAttempts;
+    expect(attempt1).toBeDefined();
+    const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt1Paths).toContain('/summary');
+    expect(attempt1Paths).not.toContain('/confidence');
+  });
+
+  it('repairAttempts records current errors when attempt 2 returns no JSON', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      if (callCount === 1) return JSON.stringify(SAMPLE_INVALID_JSON);
+      return 'not json at all';
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number', value: '85%' }];
+    const secondErrors = [{ path: '/summary', message: 'Expected string', value: 42 }];
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: () => false,
+        schemaErrors: () => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(result.repairAttempts).toHaveLength(2);
+    const [, attempt1] = result.repairAttempts;
+    expect(attempt1).toBeDefined();
+    const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt1Paths).toContain('/summary');
+    expect(attempt1Paths).not.toContain('/confidence');
+  });
 });
 
 // ── DEFAULT_REPAIR_CONFIG ──

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
@@ -267,6 +267,98 @@ describe('attemptStructuredOutputRepair', () => {
     expect(result.attemptsUsed).toBe(2);
     expect(result.output).toBeDefined();
   });
+
+  it('returns repairAttempts[] with attempt details (PRI-200)', async () => {
+    const llmCaller: RepairLLMCaller = async () => JSON.stringify(VALID_REPAIRED_JSON);
+    const schemaCheck = (v: unknown): boolean => {
+      const obj = v as Record<string, unknown>;
+      return typeof obj.confidence === 'number';
+    };
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck },
+      { schemaRef: 'diagnostician-output-v1' },
+    );
+
+    expect(result.repairAttempts).toHaveLength(1);
+    expect(result.repairAttempts[0]?.schemaRef).toBe('diagnostician-output-v1');
+    expect(result.repairAttempts[0]?.attempt).toBe(1);
+    expect(result.repairAttempts[0]?.repaired).toBe(true);
+    expect(result.repairAttempts[0]?.repairPromptVersion).toBe('1');
+  });
+
+  it('repairAttempts records failed attempts (PRI-200)', async () => {
+    const llmCaller: RepairLLMCaller = async () => JSON.stringify(SAMPLE_INVALID_JSON);
+    const schemaCheck = (_v: unknown): boolean => false;
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck },
+      { schemaRef: 'diagnostician-output-v1' },
+    );
+
+    expect(result.repairAttempts).toHaveLength(1);
+    expect(result.repairAttempts[0]?.repaired).toBe(false);
+  });
+
+  it('repairAttempts defaults schemaRef to "unknown" when not provided (PRI-200)', async () => {
+    const llmCaller: RepairLLMCaller = async () => null;
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck: () => false },
+    );
+
+    expect(result.repairAttempts).toHaveLength(1);
+    expect(result.repairAttempts[0]?.schemaRef).toBe('unknown');
+  });
+
+  it('preserves lineage fields when originalOutput is provided (PRI-200)', async () => {
+    const originalWithLineage = {
+      ...SAMPLE_INVALID_JSON,
+      taskId: 'task-original',
+      sourcePainId: 'pain-original',
+    };
+    const repairedWithChangedLineage = {
+      ...VALID_REPAIRED_JSON,
+      taskId: 'task-CHANGED',
+      sourcePainId: 'pain-CHANGED',
+    };
+
+    const llmCaller: RepairLLMCaller = async () => JSON.stringify(repairedWithChangedLineage);
+    const schemaCheck = (v: unknown): boolean => {
+      const obj = v as Record<string, unknown>;
+      return typeof obj.confidence === 'number';
+    };
+
+    const result = await attemptStructuredOutputRepair(
+      originalWithLineage,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck },
+      {
+        schemaRef: 'diagnostician-output-v1',
+        originalOutput: originalWithLineage as Record<string, unknown>,
+      },
+    );
+
+    expect(result.repaired).toBe(true);
+    const output = result.output as Record<string, unknown>;
+    expect(output.taskId).toBe('task-original');
+    expect(output.sourcePainId).toBe('pain-original');
+    expect(output.confidence).toBe(0.85);
+  });
+
+  it('formatRepairPrompt includes schemaRef when provided (PRI-200)', () => {
+    const prompt = formatRepairPrompt(SAMPLE_INVALID_JSON, SAMPLE_ERRORS, {
+      schemaRef: 'diagnostician-output-v1',
+    });
+
+    expect(prompt).toContain('SCHEMA REF: diagnostician-output-v1');
+  });
 });
 
 // ── DEFAULT_REPAIR_CONFIG ──

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
@@ -359,6 +359,38 @@ describe('attemptStructuredOutputRepair', () => {
 
     expect(prompt).toContain('SCHEMA REF: diagnostician-output-v1');
   });
+
+  it('refreshes schema errors across repair attempts (PRI-200)', async () => {
+    const callPrompts: string[] = [];
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async (prompt: string) => {
+      callPrompts.push(prompt);
+      callCount++;
+      if (callCount < 2) return JSON.stringify(SAMPLE_INVALID_JSON);
+      return JSON.stringify(VALID_REPAIRED_JSON);
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number got string', value: '85%' }];
+    const secondErrors = [{ path: '/confidence', message: 'Expected number got string v2', value: '90%' }];
+
+    await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: (v) => {
+          const obj = v as Record<string, unknown>;
+          return typeof obj.confidence === 'number';
+        },
+        schemaErrors: (_v: unknown) => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(callPrompts.length).toBe(2);
+    expect(callPrompts[0]).toContain('Expected number got string');
+    expect(callPrompts[1]).toContain('Expected number got string v2');
+  });
 });
 
 // ── DEFAULT_REPAIR_CONFIG ──

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
@@ -390,7 +390,7 @@ describe('attemptStructuredOutputRepair', () => {
     expect(callPrompts[1]).toContain('Expected number got string v2');
   });
 
-  it('repairAttempts records current errors per attempt, not initial errors', async () => {
+  it('repairAttempts records per-attempt errors: attempt N records attempt N errors, not attempt N+1', async () => {
     const llmCaller: RepairLLMCaller = async () => {
       return JSON.stringify(SAMPLE_INVALID_JSON);
     };
@@ -416,13 +416,13 @@ describe('attemptStructuredOutputRepair', () => {
     expect(attempt1).toBeDefined();
     const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
     const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
-    expect(attempt0Paths).toContain('/summary');
+    expect(attempt0Paths).toContain('/confidence');
+    expect(attempt0Paths).not.toContain('/summary');
     expect(attempt1Paths).toContain('/summary');
-    expect(attempt0Paths).not.toContain('/confidence');
     expect(attempt1Paths).not.toContain('/confidence');
   });
 
-  it('repairAttempts records current errors when attempt 2 succeeds', async () => {
+  it('repairAttempts records per-attempt errors when attempt 2 succeeds', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -454,13 +454,13 @@ describe('attemptStructuredOutputRepair', () => {
     expect(attempt1).toBeDefined();
     const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
     const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
-    expect(attempt0Paths).toContain('/summary');
+    expect(attempt0Paths).toContain('/confidence');
+    expect(attempt0Paths).not.toContain('/summary');
     expect(attempt1Paths).toContain('/summary');
-    expect(attempt0Paths).not.toContain('/confidence');
     expect(attempt1Paths).not.toContain('/confidence');
   });
 
-  it('repairAttempts records current errors when attempt 2 llmCaller throws', async () => {
+  it('repairAttempts records per-attempt errors when attempt 2 llmCaller throws', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -484,14 +484,18 @@ describe('attemptStructuredOutputRepair', () => {
 
     expect(result.repaired).toBe(false);
     expect(result.repairAttempts).toHaveLength(2);
-    const [, attempt1] = result.repairAttempts;
+    const [attempt0, attempt1] = result.repairAttempts;
+    expect(attempt0).toBeDefined();
     expect(attempt1).toBeDefined();
+    const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
     const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt0Paths).toContain('/confidence');
     expect(attempt1Paths).toContain('/summary');
+    expect(attempt0Paths).not.toContain('/summary');
     expect(attempt1Paths).not.toContain('/confidence');
   });
 
-  it('repairAttempts records current errors when attempt 2 returns null', async () => {
+  it('repairAttempts records per-attempt errors when attempt 2 returns null', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -515,14 +519,18 @@ describe('attemptStructuredOutputRepair', () => {
 
     expect(result.repaired).toBe(false);
     expect(result.repairAttempts).toHaveLength(2);
-    const [, attempt1] = result.repairAttempts;
+    const [attempt0, attempt1] = result.repairAttempts;
+    expect(attempt0).toBeDefined();
     expect(attempt1).toBeDefined();
+    const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
     const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt0Paths).toContain('/confidence');
     expect(attempt1Paths).toContain('/summary');
+    expect(attempt0Paths).not.toContain('/summary');
     expect(attempt1Paths).not.toContain('/confidence');
   });
 
-  it('repairAttempts records current errors when attempt 2 returns no JSON', async () => {
+  it('repairAttempts records per-attempt errors when attempt 2 returns no JSON', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -546,11 +554,44 @@ describe('attemptStructuredOutputRepair', () => {
 
     expect(result.repaired).toBe(false);
     expect(result.repairAttempts).toHaveLength(2);
-    const [, attempt1] = result.repairAttempts;
+    const [attempt0, attempt1] = result.repairAttempts;
+    expect(attempt0).toBeDefined();
     expect(attempt1).toBeDefined();
+    const attempt0Paths = attempt0?.validationErrors.map(e => e.path) ?? [];
     const attempt1Paths = attempt1?.validationErrors.map(e => e.path) ?? [];
+    expect(attempt0Paths).toContain('/confidence');
     expect(attempt1Paths).toContain('/summary');
+    expect(attempt0Paths).not.toContain('/summary');
     expect(attempt1Paths).not.toContain('/confidence');
+  });
+
+  it('repair prompt uses current errors per attempt: attempt 1 /confidence, attempt 2 /summary', async () => {
+    const prompts: string[] = [];
+    const llmCaller: RepairLLMCaller = async (prompt) => {
+      prompts.push(prompt);
+      return JSON.stringify(SAMPLE_INVALID_JSON);
+    };
+
+    const firstErrors = [{ path: '/confidence', message: 'Expected number', value: '85%' }];
+    const secondErrors = [{ path: '/summary', message: 'Expected string', value: 42 }];
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      firstErrors,
+      {
+        llmCaller,
+        schemaCheck: () => false,
+        schemaErrors: () => secondErrors,
+      },
+      { maxRepairAttempts: 2 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(prompts).toHaveLength(2);
+    expect(prompts[0]).toContain('/confidence');
+    expect(prompts[0]).not.toContain('/summary');
+    expect(prompts[1]).toContain('/summary');
+    expect(prompts[1]).not.toContain('/confidence');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
@@ -56,7 +56,7 @@ describe('formatRepairPrompt', () => {
   it('includes raw JSON and error list in the prompt', () => {
     const prompt = formatRepairPrompt(SAMPLE_INVALID_JSON, SAMPLE_ERRORS);
 
-    expect(prompt).toContain('"confidence": "85%"');
+    expect(prompt).toContain('"confidence":"85%"');
     expect(prompt).toContain('/confidence');
     expect(prompt).toContain('Expected number, got string');
     expect(prompt).toContain('/recommendations/0/kind');
@@ -68,10 +68,8 @@ describe('formatRepairPrompt', () => {
     const config: RepairConfig = { maxRawOutputChars: 200 };
     const prompt = formatRepairPrompt(largeJson, SAMPLE_ERRORS, config);
 
-    // Raw JSON section should be truncated
     const jsonSection = (/PREVIOUS OUTPUT[\s\S]*?SCHEMA ERRORS/.exec(prompt))?.[0] ?? '';
     expect(jsonSection.length).toBeLessThan(5000);
-    expect(prompt).toContain('...[truncated]');
   });
 
   it('limits error count to maxErrorsInPrompt', () => {
@@ -401,5 +399,136 @@ describe('DEFAULT_REPAIR_CONFIG', () => {
     expect(DEFAULT_REPAIR_CONFIG.maxErrorsInPrompt).toBe(10);
     expect(DEFAULT_REPAIR_CONFIG.maxErrorChars).toBe(200);
     expect(DEFAULT_REPAIR_CONFIG.maxRawOutputChars).toBe(2000);
+  });
+});
+
+// ── PRI-200 Finding 1: Bounded repair attempts ──
+
+describe('PRI-200 Finding 1: maxRepairAttempts hard cap', () => {
+  it('maxRepairAttempts: 999 only calls llmCaller 2 times (clamped to MAX_REPAIR_ATTEMPTS)', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      return JSON.stringify(SAMPLE_INVALID_JSON);
+    };
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: 999 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(callCount).toBe(2);
+    expect(result.attemptsUsed).toBe(2);
+  });
+
+  it('maxRepairAttempts: Infinity falls back to default (1)', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      return JSON.stringify(SAMPLE_INVALID_JSON);
+    };
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: Infinity },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(callCount).toBe(1);
+    expect(result.attemptsUsed).toBe(1);
+  });
+
+  it('maxRepairAttempts: NaN falls back to default (1)', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      return JSON.stringify(SAMPLE_INVALID_JSON);
+    };
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: NaN },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(callCount).toBe(1);
+    expect(result.attemptsUsed).toBe(1);
+  });
+
+  it('maxRepairAttempts: -1 skips repair entirely', async () => {
+    let callCount = 0;
+    const llmCaller: RepairLLMCaller = async () => {
+      callCount++;
+      return JSON.stringify(SAMPLE_INVALID_JSON);
+    };
+
+    const result = await attemptStructuredOutputRepair(
+      SAMPLE_INVALID_JSON,
+      SAMPLE_ERRORS,
+      { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: -1 },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(callCount).toBe(0);
+    expect(result.attemptsUsed).toBe(0);
+    expect(result.repairSummary).toContain('maxRepairAttempts=0');
+  });
+});
+
+// ── PRI-200 Finding 2: Safe preview serialization ──
+
+describe('PRI-200 Finding 2: safe preview serialization in repair loop', () => {
+  it('circular invalidOutput does not throw from preview formatting', async () => {
+    const circular: Record<string, unknown> = { confidence: '85%' };
+    circular.self = circular;
+
+    const llmCaller: RepairLLMCaller = async () => JSON.stringify(VALID_REPAIRED_JSON);
+
+    const result = await attemptStructuredOutputRepair(
+      circular,
+      [{ path: '/confidence', message: 'Expected number', value: '85%' }],
+      { llmCaller, schemaCheck: () => true },
+    );
+
+    expect(result.repaired).toBe(true);
+  });
+
+  it('circular invalidOutput + llmCaller throws does not throw from preview', async () => {
+    const circular: Record<string, unknown> = { confidence: '85%' };
+    circular.self = circular;
+
+    const llmCaller: RepairLLMCaller = async () => { throw new Error('LLM down'); };
+
+    const result = await attemptStructuredOutputRepair(
+      circular,
+      [{ path: '/confidence', message: 'Expected number', value: '85%' }],
+      { llmCaller, schemaCheck: () => false },
+    );
+
+    expect(result.repaired).toBe(false);
+    expect(result.repairAttempts).toHaveLength(1);
+    expect(typeof result.repairAttempts[0]?.rawOutputPreview).toBe('string');
+  });
+
+  it('BigInt value in invalidOutput does not throw from preview', async () => {
+    const withBigInt = { confidence: '85%', count: 1n };
+
+    const llmCaller: RepairLLMCaller = async () => JSON.stringify(VALID_REPAIRED_JSON);
+
+    const result = await attemptStructuredOutputRepair(
+      withBigInt,
+      [{ path: '/confidence', message: 'Expected number', value: '85%' }],
+      { llmCaller, schemaCheck: () => true },
+    );
+
+    expect(result.repaired).toBe(true);
   });
 });

--- a/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
@@ -46,6 +46,40 @@ export interface OutputEvidencePack {
 
 export const REPAIR_PROMPT_VERSION = '1';
 
+export const MAX_REPAIR_ATTEMPTS = 2;
+
+export function normalizeMaxRepairAttempts(raw: number | undefined, defaultVal: number): number {
+  if (raw === undefined) return defaultVal;
+  if (!Number.isFinite(raw)) return defaultVal;
+  if (raw < 0) return 0;
+  const floored = Math.floor(raw);
+  if (floored > MAX_REPAIR_ATTEMPTS) return MAX_REPAIR_ATTEMPTS;
+  return floored;
+}
+
+export function truncatePreview(text: string, maxLen = 500): string {
+  if (!text) return '';
+  if (text.length <= maxLen) return text;
+  const sliceLen = Math.max(0, maxLen - 3);
+  return text.slice(0, sliceLen) + '...';
+}
+
+export function safeStringifyPreview(value: unknown, maxLen = 500): string {
+  try {
+    if (value === undefined) return 'undefined';
+    if (value === null) return 'null';
+    if (typeof value === 'bigint') return truncatePreview(`${value}n`, maxLen);
+    const serialized = JSON.stringify(value);
+    return truncatePreview(serialized, maxLen);
+  } catch {
+    if (typeof value === 'object' && value !== null) {
+      const ctor = (value as Record<string, unknown>).constructor;
+      return truncatePreview(`[unserializable: ${ctor?.name ?? 'Object'}]`, maxLen);
+    }
+    return truncatePreview(String(value), maxLen);
+  }
+}
+
 export const LINEAGE_FIELDS = [
   'taskId',
   'sourcePainId',
@@ -76,13 +110,6 @@ export function preserveLineageFields(
   return result;
 }
 
-export function truncatePreview(text: string, maxLen = 500): string {
-  if (!text) return '';
-  if (text.length <= maxLen) return text;
-  const sliceLen = Math.max(0, maxLen - 3);
-  return text.slice(0, sliceLen) + '...';
-}
-
 export function formatValidationErrorEntry(
   path: string,
   message: string,
@@ -92,7 +119,7 @@ export function formatValidationErrorEntry(
     ? truncatePreview(value, 100)
     : value === undefined || value === null
       ? String(value)
-      : truncatePreview(JSON.stringify(value), 100);
+      : safeStringifyPreview(value, 100);
   return {
     path,
     expected: message,

--- a/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
@@ -1,0 +1,101 @@
+/**
+ * Output repair contract — types for the bounded structured-output repair loop.
+ *
+ * Per AGENT_SOFTWARE_CONTRACT.md Layer 2:
+ *   raw LLM output → JSON extraction → schema validation →
+ *   schema invalid → build repair prompt → bounded retry →
+ *   still invalid → output_invalid + evidence pack
+ *
+ * Design principles:
+ *   - Evidence pack is always observable (schemaRef, provider, model, errors, attempts)
+ *   - Repair loop is bounded (max 1-2 attempts)
+ *   - Lineage fields are protected during repair
+ *   - Failure types are classified for telemetry routing
+ */
+
+export type OutputFailureKind =
+  | 'extraction_failed'
+  | 'schema_invalid'
+  | 'repair_exhausted';
+
+export interface OutputValidationErrorEntry {
+  readonly path: string;
+  readonly expected: string;
+  readonly actualPreview: string;
+}
+
+export interface OutputRepairAttempt {
+  readonly schemaRef: string;
+  readonly attempt: number;
+  readonly rawOutputPreview: string;
+  readonly validationErrors: readonly OutputValidationErrorEntry[];
+  readonly repairPromptVersion: string;
+  readonly repaired: boolean;
+}
+
+export interface OutputEvidencePack {
+  readonly schemaRef: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly promptContractVersion?: string;
+  readonly rawOutputPreview: string;
+  readonly validationErrors: readonly OutputValidationErrorEntry[];
+  readonly repairAttempts: readonly OutputRepairAttempt[];
+  readonly finalFailureReason: OutputFailureKind;
+}
+
+export const REPAIR_PROMPT_VERSION = '1';
+
+export const LINEAGE_FIELDS = [
+  'taskId',
+  'sourcePainId',
+  'sourceTaskId',
+  'sourceRunIds',
+  'sourceArtifactId',
+  'sourceRefs',
+] as const;
+
+export type LineageField = typeof LINEAGE_FIELDS[number];
+
+const LINE_FIELDS_SET: ReadonlySet<string> = new Set<string>(LINEAGE_FIELDS);
+
+export function isLineageField(key: string): key is LineageField {
+  return LINE_FIELDS_SET.has(key);
+}
+
+export function preserveLineageFields(
+  original: Record<string, unknown>,
+  repaired: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...repaired };
+  for (const field of LINEAGE_FIELDS) {
+    if (Object.hasOwn(original, field)) {
+      result[field] = original[field];
+    }
+  }
+  return result;
+}
+
+export function truncatePreview(text: string, maxLen = 500): string {
+  if (!text) return '';
+  if (text.length <= maxLen) return text;
+  const sliceLen = Math.max(0, maxLen - 3);
+  return text.slice(0, sliceLen) + '...';
+}
+
+export function formatValidationErrorEntry(
+  path: string,
+  message: string,
+  value: unknown,
+): OutputValidationErrorEntry {
+  const actualPreview = typeof value === 'string'
+    ? value
+    : value === undefined || value === null
+      ? String(value)
+      : truncatePreview(JSON.stringify(value), 100);
+  return {
+    path,
+    expected: message,
+    actualPreview,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
@@ -89,7 +89,7 @@ export function formatValidationErrorEntry(
   value: unknown,
 ): OutputValidationErrorEntry {
   const actualPreview = typeof value === 'string'
-    ? value
+    ? truncatePreview(value, 100)
     : value === undefined || value === null
       ? String(value)
       : truncatePreview(JSON.stringify(value), 100);

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -32,7 +32,7 @@ import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair } from './structured-output-repair.js';
 import type { OutputEvidencePack, OutputValidationErrorEntry } from './output-repair-contract.js';
-import { truncatePreview, formatValidationErrorEntry } from './output-repair-contract.js';
+import { formatValidationErrorEntry, safeStringifyPreview } from './output-repair-contract.js';
 import type {
   PDRuntimeAdapter,
   RuntimeKind,
@@ -447,7 +447,7 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
           .slice(0, 10)
           .map(e => formatValidationErrorEntry(e.path, e.message, e.value));
 
-        const rawOutputPreview = truncatePreview(JSON.stringify(validatedOutput));
+        const rawOutputPreview = safeStringifyPreview(validatedOutput);
 
         this.eventEmitter.emitTelemetry({
           eventType: 'output_schema_invalid',

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -31,6 +31,8 @@ import { TrainerOutputV1Schema } from '../internalization/trainer-output.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair } from './structured-output-repair.js';
+import type { OutputEvidencePack, OutputValidationErrorEntry } from './output-repair-contract.js';
+import { truncatePreview, formatValidationErrorEntry } from './output-repair-contract.js';
 import type {
   PDRuntimeAdapter,
   RuntimeKind,
@@ -427,29 +429,94 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
         throw new PDRuntimeError('output_invalid', 'No valid JSON found in LLM response');
       }
 
-      // Validate with schema from registry (keyed by outputSchemaRef)
       const schemaRef = input.outputSchemaRef;
       const schema = schemaRef ? OUTPUT_SCHEMA_REGISTRY.get(schemaRef) : undefined;
 
       if (schema && !Value.Check(schema, validatedOutput)) {
-        let repairSucceeded = false;
-        let schemaErrors: { path: string; message: string; value: unknown }[] = [];
-
-        schemaErrors = [...Value.Errors(schema, validatedOutput)]
+        const schemaErrors = [...Value.Errors(schema, validatedOutput)]
           .map(e => ({ path: e.path, message: e.message, value: e.value }));
 
-        if (schemaErrors.length > 0) {
-          const repairResult = await attemptStructuredOutputRepair<Record<string, unknown>>(
-            validatedOutput,
-            schemaErrors,
-            {
-              llmCaller: (prompt: string) => this.repairLLMCall(model, prompt, { signal, apiKey }),
-              schemaCheck: (value: unknown) => Value.Check(schema, value),
-            },
+        if (schemaErrors.length === 0) {
+          throw new PDRuntimeError(
+            'output_invalid',
+            `LLM output does not match ${schemaRef ?? 'unknown'} schema (no specific errors enumerated)`,
           );
+        }
+
+        const validationErrorEntries: OutputValidationErrorEntry[] = schemaErrors
+          .slice(0, 10)
+          .map(e => formatValidationErrorEntry(e.path, e.message, e.value));
+
+        const rawOutputPreview = truncatePreview(JSON.stringify(validatedOutput));
+
+        this.eventEmitter.emitTelemetry({
+          eventType: 'output_schema_invalid',
+          traceId: input.taskRef?.taskId ?? runId,
+          timestamp: new Date().toISOString(),
+          sessionId: 'pi-ai-adapter',
+          agentId: 'pi-ai-adapter',
+          payload: {
+            runId,
+            runtimeKind: 'pi-ai',
+            outputSchemaRef: schemaRef ?? 'unknown',
+            provider: this.config.provider,
+            model: this.config.model,
+            rawOutputPreview,
+            validationErrors: validationErrorEntries,
+          },
+        });
+
+        const originalOutput = typeof validatedOutput === 'object' && validatedOutput !== null
+          ? validatedOutput as Record<string, unknown>
+          : undefined;
+
+        const repairResult = await attemptStructuredOutputRepair<Record<string, unknown>>(
+          validatedOutput,
+          schemaErrors,
+          {
+            llmCaller: (prompt: string) => this.repairLLMCall(model, prompt, { signal, apiKey }),
+            schemaCheck: (value: unknown) => Value.Check(schema, value),
+            schemaErrors: (value: unknown) =>
+              [...Value.Errors(schema, value)].map(e => ({ path: e.path, message: e.message, value: e.value })),
+          },
+          {
+            schemaRef: schemaRef ?? 'unknown',
+            originalOutput,
+          },
+        );
+
+        this.eventEmitter.emitTelemetry({
+          eventType: 'output_repair_attempted',
+          traceId: input.taskRef?.taskId ?? runId,
+          timestamp: new Date().toISOString(),
+          sessionId: 'pi-ai-adapter',
+          agentId: 'pi-ai-adapter',
+          payload: {
+            runId,
+            runtimeKind: 'pi-ai',
+            outputSchemaRef: schemaRef ?? 'unknown',
+            repaired: repairResult.repaired,
+            attemptsUsed: repairResult.attemptsUsed,
+            repairSummary: repairResult.repairSummary,
+            repairAttempts: repairResult.repairAttempts,
+          },
+        });
+
+        if (repairResult.repaired && repairResult.output) {
+          validatedOutput = repairResult.output;
+        } else {
+          const evidencePack: OutputEvidencePack = {
+            schemaRef: schemaRef ?? 'unknown',
+            provider: this.config.provider,
+            model: this.config.model,
+            rawOutputPreview,
+            validationErrors: validationErrorEntries,
+            repairAttempts: repairResult.repairAttempts,
+            finalFailureReason: 'repair_exhausted',
+          };
 
           this.eventEmitter.emitTelemetry({
-            eventType: 'output_repair_attempted',
+            eventType: 'output_repair_exhausted',
             traceId: input.taskRef?.taskId ?? runId,
             timestamp: new Date().toISOString(),
             sessionId: 'pi-ai-adapter',
@@ -458,39 +525,19 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
               runId,
               runtimeKind: 'pi-ai',
               outputSchemaRef: schemaRef ?? 'unknown',
-              repaired: repairResult.repaired,
-              attemptsUsed: repairResult.attemptsUsed,
-              repairSummary: repairResult.repairSummary,
+              provider: this.config.provider,
+              model: this.config.model,
+              rawOutputPreview,
+              validationErrors: validationErrorEntries,
+              repairAttempts: evidencePack.repairAttempts,
+              finalFailureReason: evidencePack.finalFailureReason,
             },
           });
 
-          if (repairResult.repaired && repairResult.output) {
-            validatedOutput = repairResult.output;
-            repairSucceeded = true;
-          }
-        }
-
-        if (!repairSucceeded) {
-          if (schemaErrors.length > 0) {
-            this.eventEmitter.emitTelemetry({
-              eventType: 'output_repair_attempted',
-              traceId: input.taskRef?.taskId ?? runId,
-              timestamp: new Date().toISOString(),
-              sessionId: 'pi-ai-adapter',
-              agentId: 'pi-ai-adapter',
-              payload: {
-                runId,
-                runtimeKind: 'pi-ai',
-                outputSchemaRef: schemaRef ?? 'unknown',
-                repaired: false,
-                attemptsUsed: 0,
-                repairSummary: `Repair failed for outputSchemaRef=${schemaRef}`,
-              },
-            });
-          }
           throw new PDRuntimeError(
             'output_invalid',
             `LLM output does not match ${schemaRef ?? 'unknown'} schema`,
+            { evidencePack },
           );
         }
       }

--- a/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
@@ -165,9 +165,9 @@ export async function attemptStructuredOutputRepair<T>(
   }
 
   const errorSummary = `${currentErrors.length} errors: ${currentErrors.slice(0, 3).map(e => e.path).join(', ')}`;
-  const initialValidationErrors = buildValidationErrorEntries(currentErrors);
 
   for (let attempt = 0; attempt < cfg.maxRepairAttempts; attempt++) {
+    const attemptValidationErrors = buildValidationErrorEntries(currentErrors);
     const prompt = formatRepairPrompt(invalidOutput, currentErrors, cfg);
 
     // eslint-disable-next-line @typescript-eslint/init-declarations -- assigned in try block below
@@ -180,7 +180,7 @@ export async function attemptStructuredOutputRepair<T>(
         schemaRef: cfg.schemaRef ?? 'unknown',
         attempt: attempt + 1,
         rawOutputPreview: safeStringifyPreview(invalidOutput),
-        validationErrors: initialValidationErrors,
+        validationErrors: attemptValidationErrors,
         repairPromptVersion: REPAIR_PROMPT_VERSION,
         repaired: false,
       });
@@ -198,7 +198,7 @@ export async function attemptStructuredOutputRepair<T>(
         schemaRef: cfg.schemaRef ?? 'unknown',
         attempt: attempt + 1,
         rawOutputPreview: safeStringifyPreview(invalidOutput),
-        validationErrors: initialValidationErrors,
+        validationErrors: attemptValidationErrors,
         repairPromptVersion: REPAIR_PROMPT_VERSION,
         repaired: false,
       });
@@ -211,7 +211,7 @@ export async function attemptStructuredOutputRepair<T>(
         schemaRef: cfg.schemaRef ?? 'unknown',
         attempt: attempt + 1,
         rawOutputPreview: truncatePreview(rawResponse),
-        validationErrors: initialValidationErrors,
+        validationErrors: attemptValidationErrors,
         repairPromptVersion: REPAIR_PROMPT_VERSION,
         repaired: false,
       });
@@ -229,7 +229,7 @@ export async function attemptStructuredOutputRepair<T>(
         schemaRef: cfg.schemaRef ?? 'unknown',
         attempt: attempt + 1,
         rawOutputPreview: truncatePreview(rawResponse),
-        validationErrors: initialValidationErrors,
+        validationErrors: attemptValidationErrors,
         repairPromptVersion: REPAIR_PROMPT_VERSION,
         repaired: true,
       });
@@ -242,21 +242,21 @@ export async function attemptStructuredOutputRepair<T>(
       };
     }
 
+    const nextErrors = callbacks.schemaErrors
+      ? callbacks.schemaErrors(candidateWithLineage)
+      : currentErrors;
+
     repairAttempts.push({
       schemaRef: cfg.schemaRef ?? 'unknown',
       attempt: attempt + 1,
       rawOutputPreview: truncatePreview(rawResponse),
-      validationErrors: callbacks.schemaErrors
-        ? buildValidationErrorEntries(callbacks.schemaErrors(candidateWithLineage))
-        : initialValidationErrors,
+      validationErrors: buildValidationErrorEntries(nextErrors),
       repairPromptVersion: REPAIR_PROMPT_VERSION,
       repaired: false,
     });
 
     invalidOutput = candidateWithLineage;
-    if (callbacks.schemaErrors) {
-      currentErrors = callbacks.schemaErrors(candidateWithLineage);
-    }
+    currentErrors = nextErrors;
   }
 
   return {

--- a/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
@@ -18,7 +18,7 @@
  */
 
 import type { OutputRepairAttempt, OutputValidationErrorEntry } from './output-repair-contract.js';
-import { REPAIR_PROMPT_VERSION, preserveLineageFields, truncatePreview, formatValidationErrorEntry } from './output-repair-contract.js';
+import { REPAIR_PROMPT_VERSION, preserveLineageFields, truncatePreview, formatValidationErrorEntry, normalizeMaxRepairAttempts, safeStringifyPreview } from './output-repair-contract.js';
 
 /** A single TypeBox validation error from Value.Errors(). */
 export interface SchemaValidationError {
@@ -92,7 +92,7 @@ export function formatRepairPrompt(
 ): string {
   const cfg = { ...DEFAULT_REPAIR_CONFIG, ...config };
 
-  let rawJson = JSON.stringify(invalidJson, null, 2);
+  let rawJson = safeStringifyPreview(invalidJson, cfg.maxRawOutputChars);
   if (rawJson.length > cfg.maxRawOutputChars) {
     rawJson = rawJson.slice(0, cfg.maxRawOutputChars) + '\n...[truncated]';
   }
@@ -150,7 +150,7 @@ export async function attemptStructuredOutputRepair<T>(
   callbacks: RepairCallbacks,
   config?: RepairConfig,
 ): Promise<RepairResult<T>> {
-  const cfg = { ...DEFAULT_REPAIR_CONFIG, ...config };
+  const cfg = { ...DEFAULT_REPAIR_CONFIG, ...config, maxRepairAttempts: normalizeMaxRepairAttempts(config?.maxRepairAttempts, DEFAULT_REPAIR_CONFIG.maxRepairAttempts) };
   const repairAttempts: OutputRepairAttempt[] = [];
   let currentErrors: readonly SchemaValidationError[] = schemaErrors;
 
@@ -179,7 +179,7 @@ export async function attemptStructuredOutputRepair<T>(
       repairAttempts.push({
         schemaRef: cfg.schemaRef ?? 'unknown',
         attempt: attempt + 1,
-        rawOutputPreview: truncatePreview(JSON.stringify(invalidOutput)),
+        rawOutputPreview: safeStringifyPreview(invalidOutput),
         validationErrors: initialValidationErrors,
         repairPromptVersion: REPAIR_PROMPT_VERSION,
         repaired: false,
@@ -197,7 +197,7 @@ export async function attemptStructuredOutputRepair<T>(
       repairAttempts.push({
         schemaRef: cfg.schemaRef ?? 'unknown',
         attempt: attempt + 1,
-        rawOutputPreview: truncatePreview(JSON.stringify(invalidOutput)),
+        rawOutputPreview: safeStringifyPreview(invalidOutput),
         validationErrors: initialValidationErrors,
         repairPromptVersion: REPAIR_PROMPT_VERSION,
         repaired: false,

--- a/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
@@ -10,10 +10,15 @@
  *   - Callback-based — schemaCheck and llmCaller are injected, no pi-ai imports
  *   - Bounded — all prompts and error summaries are size-limited
  *   - Fail-closed — if repair output still fails schemaCheck, return repaired=false
+ *   - Lineage-safe — repair must not silently override lineage fields (PRI-200)
  *
  * PRI-71: First integration target is Diagnostician via PiAiRuntimeAdapter.
+ * PRI-200: Evidence pack, schemaRef in prompt, lineage protection, repairAttempts[].
  * Future peer runners (Dreamer, Philosopher, etc.) can reuse the same module.
  */
+
+import type { OutputRepairAttempt, OutputValidationErrorEntry } from './output-repair-contract.js';
+import { REPAIR_PROMPT_VERSION, preserveLineageFields, truncatePreview, formatValidationErrorEntry } from './output-repair-contract.js';
 
 /** A single TypeBox validation error from Value.Errors(). */
 export interface SchemaValidationError {
@@ -32,10 +37,14 @@ export interface RepairConfig {
   readonly maxErrorChars?: number;
   /** Maximum characters of raw JSON to include in prompt. Default: 2000. */
   readonly maxRawOutputChars?: number;
+  /** Schema reference for the output being repaired (PRI-200). Included in repair prompt. */
+  readonly schemaRef?: string;
+  /** Original output with lineage fields to preserve during repair (PRI-200). */
+  readonly originalOutput?: Record<string, unknown>;
 }
 
 /** Sensible defaults for repair configuration. */
-export const DEFAULT_REPAIR_CONFIG: Required<RepairConfig> = {
+export const DEFAULT_REPAIR_CONFIG: Required<Omit<RepairConfig, 'schemaRef' | 'originalOutput'>> = {
   maxRepairAttempts: 1,
   maxErrorsInPrompt: 10,
   maxErrorChars: 200,
@@ -52,6 +61,8 @@ export interface RepairResult<T> {
   readonly attemptsUsed: number;
   /** Bounded summary of what was tried (for telemetry). */
   readonly repairSummary: string;
+  /** Detailed repair attempt records for evidence pack (PRI-200). */
+  readonly repairAttempts: readonly OutputRepairAttempt[];
 }
 
 /** Callback for invoking an LLM during repair. Runtime-agnostic. */
@@ -61,6 +72,8 @@ export type RepairLLMCaller = (prompt: string) => Promise<string | null>;
 export interface RepairCallbacks {
   readonly llmCaller: RepairLLMCaller;
   readonly schemaCheck: (value: unknown) => boolean;
+  /** Optional: re-validate schema errors on repaired output for evidence pack. */
+  readonly schemaErrors?: (value: unknown) => SchemaValidationError[];
 }
 
 // Re-export from json-extractor so callers can use a single import path
@@ -69,6 +82,8 @@ import { extractJsonObject } from './json-extractor.js';
 
 /**
  * Format TypeBox schema errors into a bounded, human-readable repair prompt.
+ *
+ * PRI-200: Includes schemaRef when available.
  */
 export function formatRepairPrompt(
   invalidJson: unknown,
@@ -94,9 +109,14 @@ export function formatRepairPrompt(
     ? errors.length - cfg.maxErrorsInPrompt
     : 0;
 
+  const schemaRefLine = cfg.schemaRef
+    ? [`SCHEMA REF: ${cfg.schemaRef}`, '']
+    : [];
+
   return [
     'This is a schema validation repair loop. Your previous JSON output still has errors. Fix ALL remaining errors and return the complete corrected JSON object.',
     '',
+    ...schemaRefLine,
     'PREVIOUS OUTPUT:',
     rawJson,
     '',
@@ -108,12 +128,20 @@ export function formatRepairPrompt(
   ].join('\n');
 }
 
+function buildValidationErrorEntries(
+  errors: readonly SchemaValidationError[],
+): OutputValidationErrorEntry[] {
+  return errors.slice(0, 10).map(e => formatValidationErrorEntry(e.path, e.message, e.value));
+}
+
 /**
  * Attempt to repair structurally invalid LLM output by re-prompting
  * the LLM with specific validation errors.
  *
  * Returns RepairResult<T> — either repaired+validated output or null.
  * Bounded by maxRepairAttempts (default 1).
+ *
+ * PRI-200: Returns repairAttempts[] for evidence pack, protects lineage fields.
  */
 // eslint-disable-next-line @typescript-eslint/max-params -- callbacks and config are intentionally separate for clarity
 export async function attemptStructuredOutputRepair<T>(
@@ -123,6 +151,7 @@ export async function attemptStructuredOutputRepair<T>(
   config?: RepairConfig,
 ): Promise<RepairResult<T>> {
   const cfg = { ...DEFAULT_REPAIR_CONFIG, ...config };
+  const repairAttempts: OutputRepairAttempt[] = [];
 
   if (schemaErrors.length === 0 || cfg.maxRepairAttempts <= 0) {
     return {
@@ -130,10 +159,12 @@ export async function attemptStructuredOutputRepair<T>(
       output: null,
       attemptsUsed: 0,
       repairSummary: `Repair skipped: ${schemaErrors.length === 0 ? 'no errors' : 'maxRepairAttempts=0'}`,
+      repairAttempts,
     };
   }
 
   const errorSummary = `${schemaErrors.length} errors: ${schemaErrors.slice(0, 3).map(e => e.path).join(', ')}`;
+  const initialValidationErrors = buildValidationErrorEntries(schemaErrors);
 
   for (let attempt = 0; attempt < cfg.maxRepairAttempts; attempt++) {
     const prompt = formatRepairPrompt(invalidOutput, schemaErrors, cfg);
@@ -144,33 +175,84 @@ export async function attemptStructuredOutputRepair<T>(
       rawResponse = await callbacks.llmCaller(prompt);
     } catch (err: unknown) {
       const errorDetail = err instanceof Error ? err.message : String(err);
+      repairAttempts.push({
+        schemaRef: cfg.schemaRef ?? 'unknown',
+        attempt: attempt + 1,
+        rawOutputPreview: truncatePreview(JSON.stringify(invalidOutput)),
+        validationErrors: initialValidationErrors,
+        repairPromptVersion: REPAIR_PROMPT_VERSION,
+        repaired: false,
+      });
       return {
         repaired: false,
         output: null,
         attemptsUsed: attempt + 1,
         repairSummary: `Repair failed at attempt ${attempt + 1}: llmCaller threw "${errorDetail}". ${errorSummary}`,
+        repairAttempts,
       };
     }
 
     if (!rawResponse) {
+      repairAttempts.push({
+        schemaRef: cfg.schemaRef ?? 'unknown',
+        attempt: attempt + 1,
+        rawOutputPreview: truncatePreview(JSON.stringify(invalidOutput)),
+        validationErrors: initialValidationErrors,
+        repairPromptVersion: REPAIR_PROMPT_VERSION,
+        repaired: false,
+      });
       continue;
     }
 
     const repairedCandidate = extractJsonObject(rawResponse);
     if (!repairedCandidate) {
+      repairAttempts.push({
+        schemaRef: cfg.schemaRef ?? 'unknown',
+        attempt: attempt + 1,
+        rawOutputPreview: truncatePreview(rawResponse),
+        validationErrors: initialValidationErrors,
+        repairPromptVersion: REPAIR_PROMPT_VERSION,
+        repaired: false,
+      });
       continue;
     }
 
-    if (callbacks.schemaCheck(repairedCandidate)) {
+    // PRI-200: Protect lineage fields — if originalOutput provided, preserve lineage
+    let candidateWithLineage = repairedCandidate;
+    if (cfg.originalOutput && typeof repairedCandidate === 'object' && repairedCandidate !== null) {
+      candidateWithLineage = preserveLineageFields(cfg.originalOutput, repairedCandidate as Record<string, unknown>);
+    }
+
+    if (callbacks.schemaCheck(candidateWithLineage)) {
+      repairAttempts.push({
+        schemaRef: cfg.schemaRef ?? 'unknown',
+        attempt: attempt + 1,
+        rawOutputPreview: truncatePreview(rawResponse),
+        validationErrors: initialValidationErrors,
+        repairPromptVersion: REPAIR_PROMPT_VERSION,
+        repaired: true,
+      });
       return {
         repaired: true,
-        output: repairedCandidate as T,
+        output: candidateWithLineage as T,
         attemptsUsed: attempt + 1,
         repairSummary: `Repair succeeded at attempt ${attempt + 1}. ${errorSummary}`,
+        repairAttempts,
       };
     }
 
-    invalidOutput = repairedCandidate;
+    repairAttempts.push({
+      schemaRef: cfg.schemaRef ?? 'unknown',
+      attempt: attempt + 1,
+      rawOutputPreview: truncatePreview(rawResponse),
+      validationErrors: callbacks.schemaErrors
+        ? buildValidationErrorEntries(callbacks.schemaErrors(candidateWithLineage))
+        : initialValidationErrors,
+      repairPromptVersion: REPAIR_PROMPT_VERSION,
+      repaired: false,
+    });
+
+    invalidOutput = candidateWithLineage;
   }
 
   return {
@@ -178,5 +260,6 @@ export async function attemptStructuredOutputRepair<T>(
     output: null,
     attemptsUsed: cfg.maxRepairAttempts,
     repairSummary: `Repair failed after ${cfg.maxRepairAttempts} attempt(s). ${errorSummary}`,
+    repairAttempts,
   };
 }

--- a/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
@@ -152,22 +152,23 @@ export async function attemptStructuredOutputRepair<T>(
 ): Promise<RepairResult<T>> {
   const cfg = { ...DEFAULT_REPAIR_CONFIG, ...config };
   const repairAttempts: OutputRepairAttempt[] = [];
+  let currentErrors: readonly SchemaValidationError[] = schemaErrors;
 
-  if (schemaErrors.length === 0 || cfg.maxRepairAttempts <= 0) {
+  if (currentErrors.length === 0 || cfg.maxRepairAttempts <= 0) {
     return {
       repaired: false,
       output: null,
       attemptsUsed: 0,
-      repairSummary: `Repair skipped: ${schemaErrors.length === 0 ? 'no errors' : 'maxRepairAttempts=0'}`,
+      repairSummary: `Repair skipped: ${currentErrors.length === 0 ? 'no errors' : 'maxRepairAttempts=0'}`,
       repairAttempts,
     };
   }
 
-  const errorSummary = `${schemaErrors.length} errors: ${schemaErrors.slice(0, 3).map(e => e.path).join(', ')}`;
-  const initialValidationErrors = buildValidationErrorEntries(schemaErrors);
+  const errorSummary = `${currentErrors.length} errors: ${currentErrors.slice(0, 3).map(e => e.path).join(', ')}`;
+  const initialValidationErrors = buildValidationErrorEntries(currentErrors);
 
   for (let attempt = 0; attempt < cfg.maxRepairAttempts; attempt++) {
-    const prompt = formatRepairPrompt(invalidOutput, schemaErrors, cfg);
+    const prompt = formatRepairPrompt(invalidOutput, currentErrors, cfg);
 
     // eslint-disable-next-line @typescript-eslint/init-declarations -- assigned in try block below
     let rawResponse: string | null;
@@ -253,6 +254,9 @@ export async function attemptStructuredOutputRepair<T>(
     });
 
     invalidOutput = candidateWithLineage;
+    if (callbacks.schemaErrors) {
+      currentErrors = callbacks.schemaErrors(candidateWithLineage);
+    }
   }
 
   return {

--- a/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
@@ -250,7 +250,7 @@ export async function attemptStructuredOutputRepair<T>(
       schemaRef: cfg.schemaRef ?? 'unknown',
       attempt: attempt + 1,
       rawOutputPreview: truncatePreview(rawResponse),
-      validationErrors: buildValidationErrorEntries(nextErrors),
+      validationErrors: attemptValidationErrors,
       repairPromptVersion: REPAIR_PROMPT_VERSION,
       repaired: false,
     });

--- a/packages/principles-core/src/telemetry-event.ts
+++ b/packages/principles-core/src/telemetry-event.ts
@@ -59,6 +59,8 @@ import { Value } from '@sinclair/typebox/value';
  * - output_validation_failed — output validation failed
  * - output_repair_attempted — PRI-71 schema repair attempted (bounded by maxRepairAttempts)
  * - output_extraction_failed — JSON extraction from LLM response failed (no parseable JSON found)
+ * - output_schema_invalid — PRI-200 schema validation failed (before repair)
+ * - output_repair_exhausted — PRI-200 repair loop exhausted, output still invalid
  */
 export const TelemetryEventType = Type.Union([
   Type.Literal('pain_detected'),
@@ -100,6 +102,8 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('output_validation_failed'),
   Type.Literal('output_repair_attempted'),
   Type.Literal('output_extraction_failed'),
+  Type.Literal('output_schema_invalid'),
+  Type.Literal('output_repair_exhausted'),
   // PRI-67: Dreamer runner events
   Type.Literal('dreamer_task_leased'),
   Type.Literal('dreamer_context_built'),


### PR DESCRIPTION
## Why parser fallback and prompt-only are not enough

When an LLM returns structurally valid JSON that fails TypeBox schema validation, the existing approach relied on:
1. **Prompt engineering** — strong-arming the LLM to produce valid JSON via system prompts
2. **Parser fallback** — `extractJsonObject` handles prose-wrapped JSON and code fences

Neither addresses the case where JSON parses correctly but violates the schema (wrong types, missing required fields, invalid enum values). The only option was to throw `output_invalid` immediately — no diagnosis, no repair, no audit trail.

This PR adds a **bounded structured-output repair loop** so that schema-invalid output is given 1–2 chances to self-correct before failing, with a full **evidence pack** for observability.

## Repair loop public contract

```
raw LLM output → JSON extraction → schema validation
  → valid: return structured output
  → invalid: emit output_schema_invalid telemetry
    → build repair prompt (schemaRef + error paths + raw output preview)
    → call LLM again (bounded by maxRepairAttempts, default 1, max 2)
    → lineage fields preserved from original output
    → valid: return repaired output + repairAttempts in evidence
    → still invalid: emit output_repair_exhausted + throw output_invalid with evidence pack
```

## Evidence pack fields

| Field | Type | Description |
|-------|------|-------------|
| `schemaRef` | string | Schema reference (e.g. `diagnostician-output-v1`) |
| `provider` | string | LLM provider (e.g. `openrouter`) |
| `model` | string | Model identifier |
| `promptContractVersion` | string? | Prompt contract version if available |
| `rawOutputPreview` | string | Truncated preview of the invalid LLM output |
| `validationErrors` | `OutputValidationErrorEntry[]` | Schema validation errors with path, expected, actualPreview |
| `repairAttempts` | `OutputRepairAttempt[]` | Each repair attempt with schemaRef, attempt number, rawOutputPreview, validationErrors, repairPromptVersion, repaired flag |
| `finalFailureReason` | `OutputFailureKind` | One of: `extraction_failed`, `schema_invalid`, `repair_exhausted` |

## Telemetry events

| Event | When emitted |
|-------|-------------|
| `output_extraction_failed` | No parseable JSON found in LLM response (existing) |
| `output_schema_invalid` | JSON parsed but fails schema validation (NEW) |
| `output_repair_attempted` | Repair loop executed, includes `repaired`, `attemptsUsed`, `repairAttempts[]` (existing, enhanced) |
| `output_repair_exhausted` | Repair loop exhausted, output still invalid (NEW) |

## Max attempts behavior

- Default: `maxRepairAttempts = 1` (one repair call after initial failure)
- Maximum: 2 (hard limit in `DEFAULT_REPAIR_CONFIG`)
- The repair loop never exceeds the configured limit — verified by test #6

## Test commands and results

```bash
npm run build --workspace=@principles/core     # ✅ passes
npx vitest run packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts  # ✅ 82/82
npx vitest run packages/principles-core/src/runtime-v2/adapter/__tests__/output-repair-contract.test.ts # ✅ 13/13
npx vitest run packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts # ✅ 20/20
npx vitest run packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts  # ✅ 15/15
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts    # ✅ 423/423
npm run verify:merge                            # ✅ passes
```

## Test coverage (10 required + 3 extra)

1. ✅ valid JSON + valid schema → no repair triggered
2. ✅ prose-wrapped JSON extraction succeeds → no repair triggered
3. ✅ extraction failed → output_extraction_failed telemetry + output_invalid
4. ✅ schema invalid once, repair returns valid → success + repairAttempts[0].repaired=true
5. ✅ schema invalid, repair also invalid → output_repair_exhausted + output_invalid
6. ✅ repair loop never exceeds configured max attempts
7. ✅ repair prompt includes schemaRef and error paths
8. ✅ repair attempt must not override lineage fields silently
9. ✅ provider/model/rawOutputPreview are present in evidence pack
10. ✅ unknown schemaRef keeps existing backward-compatible behavior
11. ✅ emits output_schema_invalid telemetry before repair attempt
12. ✅ evidence pack includes repairAttempts with schemaRef and attempt number
13. ✅ output_schema_invalid telemetry includes validation error paths

## Not implemented (out of scope)

- PRI-202: pd output validate CLI
- PRI-203: artifact write CLI
- PRI-204: CertifiedAgentOutput

## Files changed

| File | Change |
|------|--------|
| `output-repair-contract.ts` | **NEW** — OutputEvidencePack, OutputRepairAttempt, OutputFailureKind, lineage protection, validation error formatting |
| `output-repair-contract.test.ts` | **NEW** — 13 unit tests for contract utilities |
| `structured-output-repair.ts` | Enhanced — schemaRef in repair prompt, lineage preservation, repairAttempts[] in result |
| `structured-output-repair.test.ts` | Enhanced — 7 new tests for PRI-200 features |
| `pi-ai-runtime-adapter.ts` | Enhanced — evidence pack, output_schema_invalid/output_repair_exhausted telemetry, lineage protection |
| `pi-ai-runtime-adapter.test.ts` | Enhanced — 13 new tests for PRI-200 scenarios |
| `telemetry-event.ts` | Enhanced — output_schema_invalid, output_repair_exhausted event types |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新特性**
  * 增强结构化输出修复：记录每次修复尝试并生成证据包，支持按 schema 引用的修复流程与原始输出的血缘字段保留
  * 更稳健的预览与序列化：安全序列化未知/特殊值、截断超长文本并规范化最大重试次数
  * 扩展遥测：新增输出校验失败与修复耗尽事件

* **测试**
  * 大量新增/强化单元测试，覆盖修复循环、证据包、序列化与边界行为

* **文档**
  * 更新错误手册，新增多条相关故障条目并调整统计数据

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->