### PR TITLE
feat(runtime): add synthetic PD workload baseline (PRI-206)

### DIFF
--- a/packages/pd-cli/src/commands/runtime-synthetic-baseline.ts
+++ b/packages/pd-cli/src/commands/runtime-synthetic-baseline.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import { runSyntheticBaseline } from '@principles/core/runtime-v2';
 import type { SyntheticBaselineSummary } from '@principles/core/runtime-v2';
 
-interface SyntheticBaselineOptions {
+interface CliBaselineOptions {
   workspace?: string;
   json?: boolean;
 }
@@ -35,7 +35,7 @@ function formatTextOutput(summary: SyntheticBaselineSummary): string {
   return lines.join('\n');
 }
 
-export async function handleRuntimeSyntheticBaseline(opts: SyntheticBaselineOptions): Promise<void> {
+export async function handleRuntimeSyntheticBaseline(opts: CliBaselineOptions): Promise<void> {
   const workspaceDir = opts.workspace
     ? path.resolve(opts.workspace)
     : fs.mkdtempSync(path.join(os.tmpdir(), 'pd-synth-baseline-'));

--- a/packages/pd-cli/src/commands/runtime-synthetic-baseline.ts
+++ b/packages/pd-cli/src/commands/runtime-synthetic-baseline.ts
@@ -1,10 +1,10 @@
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import { runSyntheticBaseline } from '@principles/core/runtime-v2';
+import { runSyntheticBaseline } from '../services/synthetic-baseline-runner.js';
 import type { SyntheticBaselineSummary } from '@principles/core/runtime-v2';
 
-interface CliBaselineOptions {
+interface CliSyntheticBaselineOptions {
   workspace?: string;
   json?: boolean;
 }
@@ -35,7 +35,7 @@ function formatTextOutput(summary: SyntheticBaselineSummary): string {
   return lines.join('\n');
 }
 
-export async function handleRuntimeSyntheticBaseline(opts: CliBaselineOptions): Promise<void> {
+export async function handleRuntimeSyntheticBaseline(opts: CliSyntheticBaselineOptions): Promise<void> {
   const workspaceDir = opts.workspace
     ? path.resolve(opts.workspace)
     : fs.mkdtempSync(path.join(os.tmpdir(), 'pd-synth-baseline-'));

--- a/packages/pd-cli/src/commands/runtime-synthetic-baseline.ts
+++ b/packages/pd-cli/src/commands/runtime-synthetic-baseline.ts
@@ -1,0 +1,70 @@
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { runSyntheticBaseline } from '@principles/core/runtime-v2';
+import type { SyntheticBaselineSummary } from '@principles/core/runtime-v2';
+
+interface SyntheticBaselineOptions {
+  workspace?: string;
+  json?: boolean;
+}
+
+function formatTextOutput(summary: SyntheticBaselineSummary): string {
+  const lines: string[] = [];
+  const icon = summary.status === 'passed' ? '✓' : summary.status === 'degraded' ? '⚠' : '✗';
+
+  lines.push('PD Synthetic Workload Baseline');
+  lines.push(`generatedAt: ${summary.generatedAt}`);
+  lines.push(`workspaceMode: ${summary.workspaceMode}`);
+  lines.push(`OVERALL: ${icon} ${summary.status.toUpperCase()}`);
+  lines.push('');
+
+  for (const stage of summary.stages) {
+    const stageIcon = stage.status === 'passed' ? '✓' : stage.status === 'skipped' ? '○' : '✗';
+    lines.push(`  ${stageIcon} ${stage.name}: ${stage.status}`);
+    if (stage.reason) {
+      lines.push(`    reason: ${stage.reason}`);
+    }
+  }
+
+  if (summary.recommendedNextIssue) {
+    lines.push('');
+    lines.push(`Recommended next issue: ${summary.recommendedNextIssue}`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleRuntimeSyntheticBaseline(opts: SyntheticBaselineOptions): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : fs.mkdtempSync(path.join(os.tmpdir(), 'pd-synth-baseline-'));
+  const workspaceMode: 'temp' | 'explicit_workspace' = opts.workspace ? 'explicit_workspace' : 'temp';
+
+  try {
+    const summary = await runSyntheticBaseline({
+      workspaceDir,
+      workspaceMode,
+    });
+
+    if (opts.json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      console.log(formatTextOutput(summary));
+    }
+
+    if (summary.status !== 'passed') {
+      console.error('');
+      console.error(`FAIL: status=${summary.status}`);
+      process.exitCode = 1;
+    }
+  } finally {
+    if (workspaceMode === 'temp') {
+      try {
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup errors on Windows
+      }
+    }
+  }
+}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -35,6 +35,7 @@ import { handleRuntimeInternalizationRunOnce } from './commands/runtime-internal
 import { handleCandidateList, handleCandidateShow, handleCandidateIntake, handleCandidateAudit, handleCandidateRepair, handleCandidateRoute, handleCandidateInternalize, handleCandidateInternalizationBackfill } from './commands/candidate.js';
 import { handleArtifactShow } from './commands/artifact.js';
 import { handleRuntimeCanary } from './commands/runtime-canary.js';
+import { handleRuntimeSyntheticBaseline } from './commands/runtime-synthetic-baseline.js';
 import { handleRuntimeInternalizationIntegrity } from './commands/runtime-internalization-integrity.js';
 import { handleRuntimeInternalizationIntegrityRepair } from './commands/runtime-internalization-integrity-repair.js';
 import { handleRuntimeDiagnosticsExport } from './commands/runtime-diagnostics-export.js';
@@ -298,6 +299,17 @@ runtimeCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleRuntimeCanary({ workspace: opts.workspace, json: opts.json });
+  });
+
+runtimeCmd
+  .command('synthetic')
+  .description('Synthetic workload baseline commands')
+  .command('baseline')
+  .description('Run synthetic PD workload baseline (PRI-206) — deterministic, no LLM required')
+  .option('-w, --workspace <path>', 'Workspace directory (default: temp workspace)')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeSyntheticBaseline({ workspace: opts.workspace, json: opts.json });
   });
 
 runtimeCmd

--- a/packages/pd-cli/src/services/synthetic-baseline-runner.ts
+++ b/packages/pd-cli/src/services/synthetic-baseline-runner.ts
@@ -40,17 +40,17 @@ export async function runSyntheticBaseline(opts: SyntheticBaselineRunnerOptions)
   const stages: SyntheticBaselineStage[] = [];
   const generatedAt = new Date().toISOString();
 
-  const pdDir = path.join(workspaceDir, '.pd');
-  const stateDir = path.join(workspaceDir, '.state');
-  await fs.promises.mkdir(pdDir, { recursive: true });
-  await fs.promises.mkdir(stateDir, { recursive: true });
-
   const painId = `synth-pain-${Date.now()}`;
   const diagnosticianOutput = makeDeterministicDiagnosticianOutput(painId);
 
   let stateManager: RuntimeStateManager | null = null;
 
   try {
+    const pdDir = path.join(workspaceDir, '.pd');
+    const stateDir = path.join(workspaceDir, '.state');
+    await fs.promises.mkdir(pdDir, { recursive: true });
+    await fs.promises.mkdir(stateDir, { recursive: true });
+
     stateManager = new RuntimeStateManager({ workspaceDir });
     await stateManager.initialize();
 

--- a/packages/pd-cli/src/services/synthetic-baseline-runner.ts
+++ b/packages/pd-cli/src/services/synthetic-baseline-runner.ts
@@ -1,0 +1,291 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { RuntimeStateManager } from '@principles/core/runtime-v2';
+import { SqliteContextAssembler } from '@principles/core/runtime-v2';
+import { SqliteHistoryQuery } from '@principles/core/runtime-v2';
+import { StoreEventEmitter } from '@principles/core/runtime-v2';
+import { DiagnosticianRunner } from '@principles/core/runtime-v2';
+import { PassThroughValidator } from '@principles/core/runtime-v2';
+import { SqliteDiagnosticianCommitter } from '@principles/core/runtime-v2';
+import { TestDoubleRuntimeAdapter } from '@principles/core/runtime-v2';
+import { PainSignalBridge } from '@principles/core/runtime-v2';
+import { CandidateIntakeService } from '@principles/core/runtime-v2';
+import { PrincipleTreeLedgerAdapter } from '@principles/core/runtime-v2';
+import { auditCandidateLedgerConsistency } from '@principles/core/runtime-v2';
+import { OperatorHealthReadModel } from '@principles/core/runtime-v2';
+import { createInternalizationQueueReadModel } from '@principles/core/runtime-v2';
+import { createPITaskDiagnosticJson } from '@principles/core/runtime-v2';
+import {
+  computeOverallStatus,
+  boundedEvidence,
+  truncateReason,
+  recommendNextIssue,
+  makeDeterministicDiagnosticianOutput,
+} from '@principles/core/runtime-v2';
+import type {
+  SyntheticBaselineSummary,
+  SyntheticBaselineStage,
+  SyntheticBaselineStageName,
+  SyntheticBaselineFailStage,
+} from '@principles/core/runtime-v2';
+
+export interface SyntheticBaselineRunnerOptions {
+  workspaceDir: string;
+  workspaceMode: 'temp' | 'explicit_workspace';
+  failAfterStage?: SyntheticBaselineFailStage;
+}
+
+export async function runSyntheticBaseline(opts: SyntheticBaselineRunnerOptions): Promise<SyntheticBaselineSummary> {
+  const { workspaceDir, workspaceMode, failAfterStage } = opts;
+  const stages: SyntheticBaselineStage[] = [];
+  const generatedAt = new Date().toISOString();
+
+  const pdDir = path.join(workspaceDir, '.pd');
+  const stateDir = path.join(workspaceDir, '.state');
+  await fs.promises.mkdir(pdDir, { recursive: true });
+  await fs.promises.mkdir(stateDir, { recursive: true });
+
+  const painId = `synth-pain-${Date.now()}`;
+  const diagnosticianOutput = makeDeterministicDiagnosticianOutput(painId);
+
+  let stateManager: RuntimeStateManager | null = null;
+
+  try {
+    stateManager = new RuntimeStateManager({ workspaceDir });
+    await stateManager.initialize();
+
+    if (failAfterStage === 'before_pain_intake') {
+      stages.push({
+        name: 'pain_intake',
+        status: 'failed',
+        reason: truncateReason('Injected failure: pain intake stage forced to fail for testing'),
+      });
+      for (const name of ['diagnostician_task_created', 'candidate_created', 'ledger_consistent', 'internalization_queue_ready', 'canary_health'] as SyntheticBaselineStageName[]) {
+        stages.push({ name, status: 'failed', reason: 'Prerequisite stage pain_intake failed' });
+      }
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const { connection: sqliteConn, taskStore, runStore } = stateManager;
+    const historyQuery = new SqliteHistoryQuery(sqliteConn);
+    const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore);
+    const eventEmitter = new StoreEventEmitter();
+    const committer = new SqliteDiagnosticianCommitter(sqliteConn);
+    const validator = new PassThroughValidator();
+
+    const runtimeAdapter = new TestDoubleRuntimeAdapter(
+      { onFetchOutput: () => ({ runId: `synth-${painId}`, payload: diagnosticianOutput }) },
+      `diagnosis_${painId}`,
+    );
+
+    const runner = new DiagnosticianRunner(
+      {
+        stateManager,
+        contextAssembler,
+        runtimeAdapter,
+        eventEmitter,
+        validator,
+        committer,
+      },
+      {
+        owner: 'synthetic-baseline',
+        runtimeKind: 'test-double',
+        pollIntervalMs: 50,
+        timeoutMs: 10000,
+      },
+    );
+
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir });
+    const intakeService = new CandidateIntakeService({ stateManager, ledgerAdapter });
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner,
+      intakeService,
+      ledgerAdapter,
+      autoIntakeEnabled: true,
+    });
+
+    const bridgeResult = await bridge.onPainDetected({
+      painId,
+      painType: 'tool_failure',
+      source: 'synthetic-baseline',
+      reason: 'Synthetic baseline deterministic pain signal',
+    });
+
+    const painPassed = bridgeResult.status === 'succeeded';
+    stages.push({
+      name: 'pain_intake',
+      status: painPassed ? 'passed' : 'failed',
+      ...(painPassed ? {} : { reason: truncateReason(bridgeResult.message ?? `PainSignalBridge returned status=${bridgeResult.status}`) }),
+      evidence: boundedEvidence({
+        painId: bridgeResult.painId,
+        bridgeStatus: bridgeResult.status,
+      }),
+    });
+
+    if (failAfterStage === 'after_pain_intake') {
+      stages.push({ name: 'diagnostician_task_created', status: 'failed', reason: 'Injected failure: forced fail after pain_intake' });
+      stages.push({ name: 'candidate_created', status: 'failed', reason: 'Prerequisite stage diagnostician_task_created failed' });
+      stages.push({ name: 'ledger_consistent', status: 'failed', reason: 'Prerequisite stage candidate_created failed' });
+      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Prerequisite stage ledger_consistent failed' });
+      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const { taskId } = bridgeResult;
+    const task = await stateManager.getTask(taskId);
+    const taskPassed = task !== null && task.status === 'succeeded';
+    stages.push({
+      name: 'diagnostician_task_created',
+      status: taskPassed ? 'passed' : 'failed',
+      ...(taskPassed ? {} : { reason: truncateReason(`Task ${taskId} not found or not succeeded. task=${task ? task.status : 'null'}`) }),
+      evidence: boundedEvidence({
+        taskId,
+        taskStatus: task?.status ?? 'not_found',
+      }),
+    });
+
+    const candidates = await stateManager.getCandidatesByTaskId(taskId);
+    const candidatePassed = candidates.length > 0;
+    stages.push({
+      name: 'candidate_created',
+      status: candidatePassed ? 'passed' : 'failed',
+      ...(candidatePassed ? {} : { reason: truncateReason(`No candidates found for task ${taskId}`) }),
+      evidence: boundedEvidence({
+        candidateCount: candidates.length,
+        candidateIds: candidates.map(c => c.candidateId).slice(0, 5),
+      }),
+    });
+
+    if (failAfterStage === 'after_candidate_created') {
+      stages.push({ name: 'ledger_consistent', status: 'failed', reason: 'Injected failure: forced fail after candidate_created' });
+      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Prerequisite stage ledger_consistent failed' });
+      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const auditResult = await auditCandidateLedgerConsistency(workspaceDir);
+    const ledgerPassed = auditResult.status === 'ok';
+    stages.push({
+      name: 'ledger_consistent',
+      status: ledgerPassed ? 'passed' : 'failed',
+      ...(ledgerPassed ? {} : { reason: truncateReason(`Ledger audit status=${auditResult.status}. orphanCandidates=${auditResult.orphanCandidateCount} missingLedger=${auditResult.missingLedgerCount}`) }),
+      evidence: boundedEvidence({
+        auditStatus: auditResult.status,
+        consumedCount: auditResult.consumedCount,
+        orphanCandidateCount: auditResult.orphanCandidateCount,
+        missingLedgerCount: auditResult.missingLedgerCount,
+      }),
+    });
+
+    if (failAfterStage === 'after_ledger_consistent') {
+      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Injected failure: forced fail after ledger_consistent' });
+      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const piTaskId = `synth-dreamer-${Date.now()}`;
+    await stateManager.createTask({
+      taskId: piTaskId,
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const { readModel: queueReadModel, close: queueClose } = await createInternalizationQueueReadModel({
+      workspaceDir,
+      readonly: true,
+    });
+    try {
+      const queueSnapshot = await queueReadModel.getSnapshot();
+      const queueReady = queueSnapshot.readyTasks.length > 0;
+      stages.push({
+        name: 'internalization_queue_ready',
+        status: queueReady ? 'passed' : 'failed',
+        ...(queueReady ? {} : { reason: truncateReason(`Queue has no ready tasks. pendingCount=${queueSnapshot.pendingCount} noReadyTasks=${queueSnapshot.noReadyTasks?.reason ?? 'n/a'}`) }),
+        evidence: boundedEvidence({
+          readyCount: queueSnapshot.readyTasks.length,
+          pendingCount: queueSnapshot.pendingCount,
+          noReadyReason: queueSnapshot.noReadyTasks?.reason ?? null,
+        }),
+      });
+    } catch (err) {
+      stages.push({
+        name: 'internalization_queue_ready',
+        status: 'failed',
+        reason: truncateReason(`Queue read model failed: ${err instanceof Error ? err.message : String(err)}`),
+      });
+    } finally {
+      await queueClose();
+    }
+
+    const healthModel = new OperatorHealthReadModel({ workspaceDir });
+    try {
+      const healthSnapshot = await healthModel.getSnapshot();
+      const healthPassed = healthSnapshot.overallStatus === 'healthy' || healthSnapshot.overallStatus === 'degraded';
+      stages.push({
+        name: 'canary_health',
+        status: healthPassed ? 'passed' : 'failed',
+        ...(healthPassed ? {} : { reason: truncateReason(`Operator health: ${healthSnapshot.overallStatus}. Actions: ${healthSnapshot.recommendedActions.join('; ')}`) }),
+        evidence: boundedEvidence({
+          overallStatus: healthSnapshot.overallStatus,
+          recommendedActions: healthSnapshot.recommendedActions.slice(0, 3),
+        }),
+      });
+    } catch (err) {
+      stages.push({
+        name: 'canary_health',
+        status: 'failed',
+        reason: truncateReason(`Health read model failed: ${err instanceof Error ? err.message : String(err)}`),
+      });
+    } finally {
+      await healthModel.close();
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const stageNames: SyntheticBaselineStageName[] = [
+      'pain_intake',
+      'diagnostician_task_created',
+      'candidate_created',
+      'ledger_consistent',
+      'internalization_queue_ready',
+      'canary_health',
+    ];
+    const existingNames = new Set(stages.map(s => s.name));
+    for (const name of stageNames) {
+      if (!existingNames.has(name)) {
+        stages.push({
+          name,
+          status: 'failed',
+          reason: truncateReason(`Unexpected error: ${errorMessage}`),
+        });
+      }
+    }
+  } finally {
+    if (stateManager) {
+      await stateManager.close();
+    }
+  }
+
+  const status = computeOverallStatus(stages);
+  return {
+    status,
+    workspaceMode,
+    generatedAt,
+    stages,
+    recommendedNextIssue: recommendNextIssue(stages),
+  };
+}

--- a/packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts
@@ -232,4 +232,18 @@ describe('handleRuntimeSyntheticBaseline (CLI handler)', () => {
       logSpy.mockRestore();
     }
   });
+
+  it('runner rejection propagates and temp workspace is still cleaned up', async () => {
+    mockRunSyntheticBaseline.mockRejectedValue(new Error('EACCES: permission denied, mkdir'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await expect(handleRuntimeSyntheticBaseline({})).rejects.toThrow('EACCES');
+      const calledDir = mockRunSyntheticBaseline.mock.calls[0][0].workspaceDir;
+      expect(fs.existsSync(calledDir)).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockRunSyntheticBaseline } = vi.hoisted(() => ({
+  mockRunSyntheticBaseline: vi.fn(),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  runSyntheticBaseline: mockRunSyntheticBaseline,
+}));
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { handleRuntimeSyntheticBaseline } from '../../src/commands/runtime-synthetic-baseline.js';
+
+function makePassedSummary() {
+  return {
+    status: 'passed' as const,
+    workspaceMode: 'temp' as const,
+    generatedAt: new Date().toISOString(),
+    stages: [
+      { name: 'pain_intake' as const, status: 'passed' as const },
+      { name: 'diagnostician_task_created' as const, status: 'passed' as const },
+      { name: 'candidate_created' as const, status: 'passed' as const },
+      { name: 'ledger_consistent' as const, status: 'passed' as const },
+      { name: 'internalization_queue_ready' as const, status: 'passed' as const },
+      { name: 'canary_health' as const, status: 'passed' as const },
+    ],
+  };
+}
+
+describe('handleRuntimeSyntheticBaseline (CLI handler)', () => {
+  let tempDir = '';
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-cli-synth-test-'));
+    mockRunSyntheticBaseline.mockReset();
+    process.exitCode = undefined as unknown as number;
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    process.exitCode = originalExitCode;
+  });
+
+  it('uses temp workspace when no workspace specified', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue({
+      ...makePassedSummary(),
+      workspaceMode: 'temp',
+    });
+
+    await handleRuntimeSyntheticBaseline({});
+
+    expect(mockRunSyntheticBaseline).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceMode: 'temp' }),
+    );
+    const calledDir = mockRunSyntheticBaseline.mock.calls[0][0].workspaceDir;
+    expect(calledDir).toContain('pd-synth-baseline-');
+  });
+
+  it('uses explicit workspace when --workspace is provided', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue({
+      ...makePassedSummary(),
+      workspaceMode: 'explicit_workspace',
+    });
+
+    await handleRuntimeSyntheticBaseline({ workspace: tempDir });
+
+    expect(mockRunSyntheticBaseline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: tempDir,
+        workspaceMode: 'explicit_workspace',
+      }),
+    );
+  });
+
+  it('--json output contains status, workspaceMode, generatedAt, stages', async () => {
+    const summary = makePassedSummary();
+    mockRunSyntheticBaseline.mockResolvedValue(summary);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({ json: true });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const output = logSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      expect(parsed).toHaveProperty('status');
+      expect(parsed).toHaveProperty('workspaceMode');
+      expect(parsed).toHaveProperty('generatedAt');
+      expect(parsed).toHaveProperty('stages');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('sets process.exitCode = 1 when status is failed', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue({
+      ...makePassedSummary(),
+      status: 'failed',
+      stages: [
+        { name: 'pain_intake', status: 'failed', reason: 'test failure' },
+        { name: 'diagnostician_task_created', status: 'failed', reason: 'prerequisite' },
+        { name: 'candidate_created', status: 'failed', reason: 'prerequisite' },
+        { name: 'ledger_consistent', status: 'failed', reason: 'prerequisite' },
+        { name: 'internalization_queue_ready', status: 'failed', reason: 'prerequisite' },
+        { name: 'canary_health', status: 'failed', reason: 'prerequisite' },
+      ],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({ workspace: tempDir });
+      expect(process.exitCode).toBe(1);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('sets process.exitCode = 1 when status is degraded', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue({
+      ...makePassedSummary(),
+      status: 'degraded',
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({ workspace: tempDir });
+      expect(process.exitCode).toBe(1);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('cleans up temp workspace on success', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue(makePassedSummary());
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({});
+
+      const calledDir = mockRunSyntheticBaseline.mock.calls[0][0].workspaceDir;
+      expect(fs.existsSync(calledDir)).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('does not delete explicit workspace after run', async () => {
+    fs.mkdirSync(path.join(tempDir, '.pd'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, '.state'), { recursive: true });
+
+    mockRunSyntheticBaseline.mockResolvedValue({
+      ...makePassedSummary(),
+      workspaceMode: 'explicit_workspace',
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({ workspace: tempDir });
+      expect(fs.existsSync(tempDir)).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts
@@ -4,7 +4,7 @@ const { mockRunSyntheticBaseline } = vi.hoisted(() => ({
   mockRunSyntheticBaseline: vi.fn(),
 }));
 
-vi.mock('@principles/core/runtime-v2', () => ({
+vi.mock('../../src/services/synthetic-baseline-runner.js', () => ({
   runSyntheticBaseline: mockRunSyntheticBaseline,
 }));
 
@@ -173,6 +173,61 @@ describe('handleRuntimeSyntheticBaseline (CLI handler)', () => {
     try {
       await handleRuntimeSyntheticBaseline({ workspace: tempDir });
       expect(fs.existsSync(tempDir)).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('injected failure produces structured reason and recommendedNextIssue', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue({
+      status: 'failed',
+      workspaceMode: 'temp',
+      generatedAt: new Date().toISOString(),
+      stages: [
+        { name: 'pain_intake', status: 'failed', reason: 'Injected failure: pain intake stage forced to fail' },
+        { name: 'diagnostician_task_created', status: 'failed', reason: 'Prerequisite stage pain_intake failed' },
+      ],
+      recommendedNextIssue: 'PRI-207: Pain intake pipeline broken — check PainSignalBridge and DiagnosticianRunner',
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({ json: true });
+      const output = logSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      expect(parsed.status).toBe('failed');
+      expect(parsed.recommendedNextIssue).toContain('PRI-207');
+      expect(process.exitCode).toBe(1);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('no RuleHost/autoCorrect evidence, case-insensitive', async () => {
+    mockRunSyntheticBaseline.mockResolvedValue({
+      ...makePassedSummary(),
+      stages: [
+        { name: 'pain_intake', status: 'passed', evidence: { painId: 'test', bridgeStatus: 'succeeded' } },
+        { name: 'diagnostician_task_created', status: 'passed', evidence: { taskId: 't1', taskStatus: 'succeeded' } },
+        { name: 'candidate_created', status: 'passed', evidence: { candidateCount: 1 } },
+        { name: 'ledger_consistent', status: 'passed', evidence: { auditStatus: 'ok' } },
+        { name: 'internalization_queue_ready', status: 'passed', evidence: { readyCount: 1 } },
+        { name: 'canary_health', status: 'passed', evidence: { overallStatus: 'healthy' } },
+      ],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await handleRuntimeSyntheticBaseline({ json: true });
+      const output = logSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      const evidenceStr = JSON.stringify(parsed.stages).toLowerCase();
+      expect(evidenceStr).not.toContain('rulehost');
+      expect(evidenceStr).not.toContain('autocorrect');
     } finally {
       logSpy.mockRestore();
     }

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -3217,4 +3217,3 @@ describe('PRI-192 TraceRefinerAgent shadow contract boundary', () => {
     }
   });
 });
-

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -3217,3 +3217,4 @@ describe('PRI-192 TraceRefinerAgent shadow contract boundary', () => {
     }
   });
 });
+

--- a/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
@@ -125,16 +125,15 @@ describe('Synthetic Baseline (PRI-206)', () => {
       }
     });
 
-    it('recommendedNextIssue is present when status is failed', async () => {
+    it('recommendedNextIssue is present when status is failed or degraded', async () => {
       const result = await runSyntheticBaseline({
         workspaceDir: tempDir,
         workspaceMode: 'temp',
         failAfterStage: 'before_pain_intake',
       });
 
-      if (result.status === 'failed') {
-        expect(result.recommendedNextIssue).toBeTruthy();
-      }
+      expect(result.status).not.toBe('passed');
+      expect(result.recommendedNextIssue).toBeTruthy();
     });
   });
 
@@ -172,7 +171,9 @@ describe('Synthetic Baseline (PRI-206)', () => {
       });
 
       const dbPath = path.join(tempDir, '.pd', 'state.db');
-      if (!fs.existsSync(dbPath)) return;
+      if (!fs.existsSync(dbPath)) {
+        throw new Error(`DB not found at ${dbPath} — baseline should have created it`);
+      }
 
       const sizeAfterBaseline = fs.statSync(dbPath).size;
 
@@ -198,9 +199,9 @@ describe('Synthetic Baseline (PRI-206)', () => {
 
       for (const stage of result.stages) {
         if (stage.evidence) {
-          const evidenceStr = JSON.stringify(stage.evidence);
-          expect(evidenceStr).not.toContain('ruleHost');
-          expect(evidenceStr).not.toContain('autoCorrect');
+          const evidenceStr = JSON.stringify(stage.evidence).toLowerCase();
+          expect(evidenceStr).not.toContain('rulehost');
+          expect(evidenceStr).not.toContain('autocorrect');
         }
       }
     });
@@ -216,9 +217,11 @@ describe('Synthetic Baseline (PRI-206)', () => {
 
       const failedStages = result.stages.filter(s => s.status === 'failed');
       for (const stage of failedStages) {
-        expect(stage.reason).toBeTruthy();
+        if (stage.reason === undefined) {
+          throw new Error(`Stage ${stage.name} is failed but has no reason`);
+        }
         expect(typeof stage.reason).toBe('string');
-        expect((stage.reason as string).length).toBeGreaterThan(0);
+        expect(stage.reason.length).toBeGreaterThan(0);
       }
     });
 
@@ -229,7 +232,7 @@ describe('Synthetic Baseline (PRI-206)', () => {
         failAfterStage: 'after_ledger_consistent',
       });
 
-      expect(['failed', 'degraded']).toContain(result.status);
+      expect(result.status).toBe('degraded');
       const passedStages = result.stages.filter(s => s.status === 'passed');
       const failedStages = result.stages.filter(s => s.status === 'failed');
       expect(passedStages.length).toBeGreaterThan(0);

--- a/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
@@ -178,9 +178,9 @@ describe('Synthetic Baseline pure helpers (PRI-206)', () => {
       expect(output.valid).toBe(true);
       expect(output.confidence).toBe(0.95);
       expect(output.diagnosisId).toBe('synth-diag-test-pain-123');
-      const [rec] = output.recommendations;
-      expect(rec).toBeDefined();
-      expect(rec.kind).toBe('principle');
+      const firstRec = output.recommendations.find(() => true);
+      expect(firstRec).toBeDefined();
+      expect(firstRec?.kind).toBe('principle');
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
@@ -1,40 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-import type { SyntheticBaselineSummary, SyntheticBaselineStage } from '../synthetic-baseline.js';
-import { runSyntheticBaseline, computeOverallStatus, boundedEvidence } from '../synthetic-baseline.js';
+import { describe, it, expect } from 'vitest';
+import type { SyntheticBaselineStage } from '../synthetic-baseline.js';
+import {
+  computeOverallStatus,
+  boundedEvidence,
+  safeStringify,
+  truncateReason,
+  recommendNextIssue,
+  makeDeterministicDiagnosticianOutput,
+} from '../synthetic-baseline.js';
 
-function createTempWorkspace(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-synth-baseline-'));
-  fs.mkdirSync(path.join(dir, '.pd'), { recursive: true });
-  fs.mkdirSync(path.join(dir, '.state'), { recursive: true });
-  return dir;
-}
-
-function destroyWorkspace(dir: string): void {
-  try {
-    fs.rmSync(dir, { recursive: true, force: true });
-  } catch {
-    // ignore cleanup errors on Windows
-  }
-}
-
-function makeStage(status: SyntheticBaselineStage['status'], name: string = 'pain_intake'): SyntheticBaselineStage {
+function makeStage(status: SyntheticBaselineStage['status'], name = 'pain_intake'): SyntheticBaselineStage {
   return { name: name as SyntheticBaselineStage['name'], status };
 }
 
-describe('Synthetic Baseline (PRI-206)', () => {
-  let tempDir = '';
-
-  beforeEach(() => {
-    tempDir = createTempWorkspace();
-  });
-
-  afterEach(() => {
-    destroyWorkspace(tempDir);
-  });
-
+describe('Synthetic Baseline pure helpers (PRI-206)', () => {
   describe('computeOverallStatus', () => {
     it('returns passed when all stages passed', () => {
       const stages = [
@@ -112,7 +91,7 @@ describe('Synthetic Baseline (PRI-206)', () => {
       expect(json).toContain('9007199254740991n');
     });
 
-    it('truncates when multiple fields exceed budget at boundary', () => {
+    it('truncates when many fields exceed budget', () => {
       const evidence: Record<string, unknown> = {};
       for (let i = 0; i < 100; i++) {
         evidence[`field_${String(i).padStart(3, '0')}`] = 'x'.repeat(50);
@@ -123,240 +102,85 @@ describe('Synthetic Baseline (PRI-206)', () => {
     });
   });
 
-  describe('success path', () => {
-    it('all stages pass on temp workspace', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
+  describe('safeStringify', () => {
+    it('handles BigInt', () => {
+      expect(safeStringify(BigInt(123))).toBe('123n');
+    });
 
-      expect(result.status).toBe('passed');
-      expect(result.workspaceMode).toBe('temp');
-      expect(result.generatedAt).toBeTruthy();
-      expect(result.stages).toHaveLength(6);
+    it('handles circular references', () => {
+      const obj: Record<string, unknown> = {};
+      obj.self = obj;
+      expect(safeStringify(obj)).toBe('[unserializable]');
+    });
 
-      const stageNames = result.stages.map(s => s.name);
-      expect(stageNames).toEqual([
-        'pain_intake',
-        'diagnostician_task_created',
-        'candidate_created',
-        'ledger_consistent',
-        'internalization_queue_ready',
-        'canary_health',
-      ]);
+    it('handles undefined', () => {
+      expect(safeStringify(undefined)).toBe('undefined');
+    });
 
-      for (const stage of result.stages) {
-        expect(stage.status).toBe('passed');
-        expect(stage.reason).toBeUndefined();
-      }
+    it('handles null', () => {
+      expect(safeStringify(null)).toBe('null');
+    });
+
+    it('handles Object.create(null)', () => {
+      const obj = Object.create(null);
+      obj.key = 'value';
+      const result = safeStringify(obj);
+      expect(result).toContain('key');
+      expect(result).toContain('value');
+    });
+
+    it('handles normal objects', () => {
+      expect(safeStringify({ a: 1 })).toBe('{"a":1}');
     });
   });
 
-  describe('stage-by-stage failure isolation', () => {
-    it('when pain intake fails, only pain_intake is failed with structured reason', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-        failAfterStage: 'before_pain_intake',
-      });
-
-      expect(result.status).toBe('failed');
-      const painStage = result.stages.find(s => s.name === 'pain_intake');
-      expect(painStage?.status).toBe('failed');
-      expect(painStage?.reason).toBeTruthy();
-
-      const laterStages = result.stages.filter(s => s.name !== 'pain_intake');
-      for (const stage of laterStages) {
-        expect(stage.status).toBe('failed');
-      }
+  describe('truncateReason', () => {
+    it('returns short strings unchanged', () => {
+      expect(truncateReason('short')).toBe('short');
     });
 
-    it('when diagnostician task creation fails, only that stage and later are failed', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-        failAfterStage: 'after_pain_intake',
-      });
-
-      const painStage = result.stages.find(s => s.name === 'pain_intake');
-      expect(painStage?.status).toBe('passed');
-
-      const taskStage = result.stages.find(s => s.name === 'diagnostician_task_created');
-      expect(taskStage?.status).toBe('failed');
-      expect(taskStage?.reason).toBeTruthy();
-
-      const laterStages = result.stages.filter(
-        s => s.name !== 'pain_intake' && s.name !== 'diagnostician_task_created',
-      );
-      for (const stage of laterStages) {
-        expect(stage.status).toBe('failed');
-      }
+    it('truncates long strings with ellipsis', () => {
+      const long = 'x'.repeat(600);
+      const result = truncateReason(long);
+      expect(result.length).toBeLessThanOrEqual(500);
+      expect(result.endsWith('...')).toBe(true);
     });
   });
 
-  describe('JSON output contract', () => {
-    it('output is stable, bounded, and serializable', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      const json = JSON.stringify(result);
-      const parsed = JSON.parse(json) as SyntheticBaselineSummary;
-
-      expect(parsed.status).toBe(result.status);
-      expect(parsed.workspaceMode).toBe(result.workspaceMode);
-      expect(parsed.stages).toHaveLength(result.stages.length);
-
-      for (const stage of parsed.stages) {
-        expect(typeof stage.name).toBe('string');
-        expect(['passed', 'failed', 'skipped']).toContain(stage.status);
-        if (stage.reason !== undefined) {
-          expect(typeof stage.reason).toBe('string');
-          expect(stage.reason.length).toBeLessThanOrEqual(500);
-        }
-        if (stage.evidence !== undefined) {
-          const evidenceJson = JSON.stringify(stage.evidence);
-          expect(evidenceJson.length).toBeLessThanOrEqual(2000);
-        }
-      }
+  describe('recommendNextIssue', () => {
+    it('returns undefined when no stages failed', () => {
+      const stages = [makeStage('passed', 'pain_intake')];
+      expect(recommendNextIssue(stages)).toBeUndefined();
     });
 
-    it('recommendedNextIssue is present when status is failed or degraded', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-        failAfterStage: 'before_pain_intake',
-      });
+    it('returns PRI-207 for failed pain_intake', () => {
+      const stages = [makeStage('failed', 'pain_intake')];
+      expect(recommendNextIssue(stages)).toContain('PRI-207');
+    });
 
-      expect(result.status).not.toBe('passed');
-      expect(result.recommendedNextIssue).toBeTruthy();
+    it('returns PRI-209 for failed ledger_consistent', () => {
+      const stages = [
+        makeStage('passed', 'pain_intake'),
+        makeStage('failed', 'ledger_consistent'),
+      ];
+      expect(recommendNextIssue(stages)).toContain('PRI-209');
+    });
+
+    it('returns PRI-208 for failed canary_health', () => {
+      const stages = [makeStage('failed', 'canary_health')];
+      expect(recommendNextIssue(stages)).toContain('PRI-208');
     });
   });
 
-  describe('workspace safety', () => {
-    it('explicit workspace mode is reflected in output', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'explicit_workspace',
-      });
-
-      expect(result.workspaceMode).toBe('explicit_workspace');
-    });
-
-    it('temp workspace does not modify production paths', async () => {
-      const prodPath = path.join(os.tmpdir(), 'pd-prod-should-not-exist');
-      if (fs.existsSync(prodPath)) {
-        destroyWorkspace(prodPath);
-      }
-
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      expect(result.workspaceMode).toBe('temp');
-      expect(fs.existsSync(prodPath)).toBe(false);
-    });
-  });
-
-  describe('DB integrity across runs', () => {
-    it('second baseline run does not shrink or corrupt existing DB', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      const dbPath = path.join(tempDir, '.pd', 'state.db');
-      if (!fs.existsSync(dbPath)) {
-        throw new Error(`DB not found at ${dbPath} — baseline should have created it`);
-      }
-
-      const sizeAfterBaseline = fs.statSync(dbPath).size;
-
-      const result2 = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      const sizeAfterSecondRun = fs.statSync(dbPath).size;
-
-      expect(result.status).toBe('passed');
-      expect(result2.status).toBe('passed');
-      expect(sizeAfterSecondRun).toBeGreaterThanOrEqual(sizeAfterBaseline);
-    });
-  });
-
-  describe('no live RuleHost correction', () => {
-    it('baseline does not invoke RuleHost or auto-correction', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      for (const stage of result.stages) {
-        if (stage.evidence) {
-          const evidenceStr = JSON.stringify(stage.evidence).toLowerCase();
-          expect(evidenceStr).not.toContain('rulehost');
-          expect(evidenceStr).not.toContain('autocorrect');
-        }
-      }
-    });
-  });
-
-  describe('catch/degrade with structured reason', () => {
-    it('every failed stage has a non-empty reason string', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-        failAfterStage: 'after_pain_intake',
-      });
-
-      const failedStages = result.stages.filter(s => s.status === 'failed');
-      for (const stage of failedStages) {
-        if (stage.reason === undefined) {
-          throw new Error(`Stage ${stage.name} is failed but has no reason`);
-        }
-        expect(typeof stage.reason).toBe('string');
-        expect(stage.reason.length).toBeGreaterThan(0);
-      }
-    });
-
-    it('degraded status is reported when some stages pass and some fail', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-        failAfterStage: 'after_ledger_consistent',
-      });
-
-      expect(result.status).toBe('degraded');
-      const passedStages = result.stages.filter(s => s.status === 'passed');
-      const failedStages = result.stages.filter(s => s.status === 'failed');
-      expect(passedStages.length).toBeGreaterThan(0);
-      expect(failedStages.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('summary output contract', () => {
-    it('default workspace mode is temp when not specified', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      expect(result.workspaceMode).toBe('temp');
-    });
-
-    it('summary contains all required fields', async () => {
-      const result = await runSyntheticBaseline({
-        workspaceDir: tempDir,
-        workspaceMode: 'temp',
-      });
-
-      expect(result).toHaveProperty('status');
-      expect(result).toHaveProperty('workspaceMode');
-      expect(result).toHaveProperty('generatedAt');
-      expect(result).toHaveProperty('stages');
+  describe('makeDeterministicDiagnosticianOutput', () => {
+    it('produces valid DiagnosticianOutputV1', () => {
+      const output = makeDeterministicDiagnosticianOutput('test-pain-123');
+      expect(output.valid).toBe(true);
+      expect(output.confidence).toBe(0.95);
+      expect(output.diagnosisId).toBe('synth-diag-test-pain-123');
+      const [rec] = output.recommendations;
+      expect(rec).toBeDefined();
+      expect(rec.kind).toBe('principle');
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import type { SyntheticBaselineSummary } from '../synthetic-baseline.js';
-import { runSyntheticBaseline } from '../synthetic-baseline.js';
+import type { SyntheticBaselineSummary, SyntheticBaselineStage } from '../synthetic-baseline.js';
+import { runSyntheticBaseline, computeOverallStatus, boundedEvidence } from '../synthetic-baseline.js';
 
 function createTempWorkspace(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-synth-baseline-'));
@@ -20,6 +20,10 @@ function destroyWorkspace(dir: string): void {
   }
 }
 
+function makeStage(status: SyntheticBaselineStage['status'], name: string = 'pain_intake'): SyntheticBaselineStage {
+  return { name: name as SyntheticBaselineStage['name'], status };
+}
+
 describe('Synthetic Baseline (PRI-206)', () => {
   let tempDir = '';
 
@@ -29,6 +33,94 @@ describe('Synthetic Baseline (PRI-206)', () => {
 
   afterEach(() => {
     destroyWorkspace(tempDir);
+  });
+
+  describe('computeOverallStatus', () => {
+    it('returns passed when all stages passed', () => {
+      const stages = [
+        makeStage('passed', 'pain_intake'),
+        makeStage('passed', 'diagnostician_task_created'),
+        makeStage('passed', 'candidate_created'),
+      ];
+      expect(computeOverallStatus(stages)).toBe('passed');
+    });
+
+    it('returns failed when all stages failed', () => {
+      const stages = [
+        makeStage('failed', 'pain_intake'),
+        makeStage('failed', 'diagnostician_task_created'),
+        makeStage('failed', 'candidate_created'),
+      ];
+      expect(computeOverallStatus(stages)).toBe('failed');
+    });
+
+    it('returns degraded when some passed and some failed', () => {
+      const stages = [
+        makeStage('passed', 'pain_intake'),
+        makeStage('failed', 'diagnostician_task_created'),
+      ];
+      expect(computeOverallStatus(stages)).toBe('degraded');
+    });
+
+    it('returns degraded when passed, failed, and skipped are mixed', () => {
+      const stages = [
+        makeStage('passed', 'pain_intake'),
+        makeStage('failed', 'diagnostician_task_created'),
+        makeStage('skipped', 'candidate_created'),
+      ];
+      expect(computeOverallStatus(stages)).toBe('degraded');
+    });
+
+    it('returns degraded when all stages are skipped', () => {
+      const stages = [
+        makeStage('skipped', 'pain_intake'),
+        makeStage('skipped', 'diagnostician_task_created'),
+      ];
+      expect(computeOverallStatus(stages)).toBe('degraded');
+    });
+  });
+
+  describe('boundedEvidence', () => {
+    it('returns evidence as-is when within budget', () => {
+      const evidence = { key: 'value', count: 42 };
+      const result = boundedEvidence(evidence);
+      expect(result).toEqual(evidence);
+    });
+
+    it('truncates evidence with super-long keys', () => {
+      const longKey = 'x'.repeat(1900);
+      const evidence: Record<string, unknown> = {};
+      evidence[longKey] = 'value';
+      const result = boundedEvidence(evidence);
+      const json = JSON.stringify(result);
+      expect(json.length).toBeLessThanOrEqual(2000);
+    });
+
+    it('handles circular references safely', () => {
+      const evidence: Record<string, unknown> = {};
+      evidence.self = evidence;
+      const result = boundedEvidence(evidence);
+      const json = JSON.stringify(result);
+      expect(json.length).toBeLessThanOrEqual(2000);
+    });
+
+    it('handles BigInt values', () => {
+      const evidence: Record<string, unknown> = { bigNum: BigInt(9007199254740991) };
+      const result = boundedEvidence(evidence);
+      const json = JSON.stringify(result);
+      expect(json.length).toBeLessThanOrEqual(2000);
+      expect(json).toContain('9007199254740991n');
+    });
+
+    it('truncates when multiple fields exceed budget at boundary', () => {
+      const evidence: Record<string, unknown> = {};
+      for (let i = 0; i < 100; i++) {
+        evidence[`field_${String(i).padStart(3, '0')}`] = 'x'.repeat(50);
+      }
+      const result = boundedEvidence(evidence);
+      const json = JSON.stringify(result);
+      expect(json.length).toBeLessThanOrEqual(2000);
+    });
   });
 
   describe('success path', () => {
@@ -73,9 +165,7 @@ describe('Synthetic Baseline (PRI-206)', () => {
       expect(painStage?.status).toBe('failed');
       expect(painStage?.reason).toBeTruthy();
 
-      const laterStages = result.stages.filter(
-        s => s.name !== 'pain_intake' && s.status !== 'skipped',
-      );
+      const laterStages = result.stages.filter(s => s.name !== 'pain_intake');
       for (const stage of laterStages) {
         expect(stage.status).toBe('failed');
       }
@@ -94,6 +184,13 @@ describe('Synthetic Baseline (PRI-206)', () => {
       const taskStage = result.stages.find(s => s.name === 'diagnostician_task_created');
       expect(taskStage?.status).toBe('failed');
       expect(taskStage?.reason).toBeTruthy();
+
+      const laterStages = result.stages.filter(
+        s => s.name !== 'pain_intake' && s.name !== 'diagnostician_task_created',
+      );
+      for (const stage of laterStages) {
+        expect(stage.status).toBe('failed');
+      }
     });
   });
 
@@ -163,8 +260,8 @@ describe('Synthetic Baseline (PRI-206)', () => {
     });
   });
 
-  describe('read-only verification', () => {
-    it('verification stages use readonly handles and do not modify DB', async () => {
+  describe('DB integrity across runs', () => {
+    it('second baseline run does not shrink or corrupt existing DB', async () => {
       const result = await runSyntheticBaseline({
         workspaceDir: tempDir,
         workspaceMode: 'temp',
@@ -240,7 +337,7 @@ describe('Synthetic Baseline (PRI-206)', () => {
     });
   });
 
-  describe('CLI handler contract', () => {
+  describe('summary output contract', () => {
     it('default workspace mode is temp when not specified', async () => {
       const result = await runSyntheticBaseline({
         workspaceDir: tempDir,
@@ -250,7 +347,7 @@ describe('Synthetic Baseline (PRI-206)', () => {
       expect(result.workspaceMode).toBe('temp');
     });
 
-    it('--json output contains all required fields', async () => {
+    it('summary contains all required fields', async () => {
       const result = await runSyntheticBaseline({
         workspaceDir: tempDir,
         workspaceMode: 'temp',

--- a/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { SyntheticBaselineSummary } from '../synthetic-baseline.js';
+import { runSyntheticBaseline } from '../synthetic-baseline.js';
+
+function createTempWorkspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-synth-baseline-'));
+  fs.mkdirSync(path.join(dir, '.pd'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.state'), { recursive: true });
+  return dir;
+}
+
+function destroyWorkspace(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors on Windows
+  }
+}
+
+describe('Synthetic Baseline (PRI-206)', () => {
+  let tempDir = '';
+
+  beforeEach(() => {
+    tempDir = createTempWorkspace();
+  });
+
+  afterEach(() => {
+    destroyWorkspace(tempDir);
+  });
+
+  describe('success path', () => {
+    it('all stages pass on temp workspace', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      expect(result.status).toBe('passed');
+      expect(result.workspaceMode).toBe('temp');
+      expect(result.generatedAt).toBeTruthy();
+      expect(result.stages).toHaveLength(6);
+
+      const stageNames = result.stages.map(s => s.name);
+      expect(stageNames).toEqual([
+        'pain_intake',
+        'diagnostician_task_created',
+        'candidate_created',
+        'ledger_consistent',
+        'internalization_queue_ready',
+        'canary_health',
+      ]);
+
+      for (const stage of result.stages) {
+        expect(stage.status).toBe('passed');
+        expect(stage.reason).toBeUndefined();
+      }
+    });
+  });
+
+  describe('stage-by-stage failure isolation', () => {
+    it('when pain intake fails, only pain_intake is failed with structured reason', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+        failAfterStage: 'before_pain_intake',
+      });
+
+      expect(result.status).toBe('failed');
+      const painStage = result.stages.find(s => s.name === 'pain_intake');
+      expect(painStage?.status).toBe('failed');
+      expect(painStage?.reason).toBeTruthy();
+
+      const laterStages = result.stages.filter(
+        s => s.name !== 'pain_intake' && s.status !== 'skipped',
+      );
+      for (const stage of laterStages) {
+        expect(stage.status).toBe('failed');
+      }
+    });
+
+    it('when diagnostician task creation fails, only that stage and later are failed', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+        failAfterStage: 'after_pain_intake',
+      });
+
+      const painStage = result.stages.find(s => s.name === 'pain_intake');
+      expect(painStage?.status).toBe('passed');
+
+      const taskStage = result.stages.find(s => s.name === 'diagnostician_task_created');
+      expect(taskStage?.status).toBe('failed');
+      expect(taskStage?.reason).toBeTruthy();
+    });
+  });
+
+  describe('JSON output contract', () => {
+    it('output is stable, bounded, and serializable', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      const json = JSON.stringify(result);
+      const parsed = JSON.parse(json) as SyntheticBaselineSummary;
+
+      expect(parsed.status).toBe(result.status);
+      expect(parsed.workspaceMode).toBe(result.workspaceMode);
+      expect(parsed.stages).toHaveLength(result.stages.length);
+
+      for (const stage of parsed.stages) {
+        expect(typeof stage.name).toBe('string');
+        expect(['passed', 'failed', 'skipped']).toContain(stage.status);
+        if (stage.reason !== undefined) {
+          expect(typeof stage.reason).toBe('string');
+          expect(stage.reason.length).toBeLessThanOrEqual(500);
+        }
+        if (stage.evidence !== undefined) {
+          const evidenceJson = JSON.stringify(stage.evidence);
+          expect(evidenceJson.length).toBeLessThanOrEqual(2000);
+        }
+      }
+    });
+
+    it('recommendedNextIssue is present when status is failed', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+        failAfterStage: 'before_pain_intake',
+      });
+
+      if (result.status === 'failed') {
+        expect(result.recommendedNextIssue).toBeTruthy();
+      }
+    });
+  });
+
+  describe('workspace safety', () => {
+    it('explicit workspace mode is reflected in output', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'explicit_workspace',
+      });
+
+      expect(result.workspaceMode).toBe('explicit_workspace');
+    });
+
+    it('temp workspace does not modify production paths', async () => {
+      const prodPath = path.join(os.tmpdir(), 'pd-prod-should-not-exist');
+      if (fs.existsSync(prodPath)) {
+        destroyWorkspace(prodPath);
+      }
+
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      expect(result.workspaceMode).toBe('temp');
+      expect(fs.existsSync(prodPath)).toBe(false);
+    });
+  });
+
+  describe('read-only verification', () => {
+    it('verification stages use readonly handles and do not modify DB', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      const dbPath = path.join(tempDir, '.pd', 'state.db');
+      if (!fs.existsSync(dbPath)) return;
+
+      const sizeAfterBaseline = fs.statSync(dbPath).size;
+
+      const result2 = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      const sizeAfterSecondRun = fs.statSync(dbPath).size;
+
+      expect(result.status).toBe('passed');
+      expect(result2.status).toBe('passed');
+      expect(sizeAfterSecondRun).toBeGreaterThanOrEqual(sizeAfterBaseline);
+    });
+  });
+
+  describe('no live RuleHost correction', () => {
+    it('baseline does not invoke RuleHost or auto-correction', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      for (const stage of result.stages) {
+        if (stage.evidence) {
+          const evidenceStr = JSON.stringify(stage.evidence);
+          expect(evidenceStr).not.toContain('ruleHost');
+          expect(evidenceStr).not.toContain('autoCorrect');
+        }
+      }
+    });
+  });
+
+  describe('catch/degrade with structured reason', () => {
+    it('every failed stage has a non-empty reason string', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+        failAfterStage: 'after_pain_intake',
+      });
+
+      const failedStages = result.stages.filter(s => s.status === 'failed');
+      for (const stage of failedStages) {
+        expect(stage.reason).toBeTruthy();
+        expect(typeof stage.reason).toBe('string');
+        expect((stage.reason as string).length).toBeGreaterThan(0);
+      }
+    });
+
+    it('degraded status is reported when some stages pass and some fail', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+        failAfterStage: 'after_ledger_consistent',
+      });
+
+      expect(['failed', 'degraded']).toContain(result.status);
+      const passedStages = result.stages.filter(s => s.status === 'passed');
+      const failedStages = result.stages.filter(s => s.status === 'failed');
+      expect(passedStages.length).toBeGreaterThan(0);
+      expect(failedStages.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('CLI handler contract', () => {
+    it('default workspace mode is temp when not specified', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      expect(result.workspaceMode).toBe('temp');
+    });
+
+    it('--json output contains all required fields', async () => {
+      const result = await runSyntheticBaseline({
+        workspaceDir: tempDir,
+        workspaceMode: 'temp',
+      });
+
+      expect(result).toHaveProperty('status');
+      expect(result).toHaveProperty('workspaceMode');
+      expect(result).toHaveProperty('generatedAt');
+      expect(result).toHaveProperty('stages');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -290,7 +290,7 @@ export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHea
 
 // Synthetic baseline (PRI-206)
 export { runSyntheticBaseline } from './synthetic-baseline.js';
-export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselineStageName, SyntheticBaselineOptions } from './synthetic-baseline.js';
+export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselineStageName, SyntheticBaselineFailStage, SyntheticBaselineOptions } from './synthetic-baseline.js';
 
 // Internalization contracts (PRI-42)
 export type {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -289,7 +289,7 @@ export { OperatorHealthReadModel } from './operator-health-read-model.js';
 export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHealthStatus } from './operator-health-read-model.js';
 
 // Synthetic baseline (PRI-206)
-export { runSyntheticBaseline } from './synthetic-baseline.js';
+export { runSyntheticBaseline, computeOverallStatus, boundedEvidence } from './synthetic-baseline.js';
 export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselineStageName, SyntheticBaselineFailStage, SyntheticBaselineOptions } from './synthetic-baseline.js';
 
 // Internalization contracts (PRI-42)

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -288,6 +288,10 @@ export type { CandidateAuditResult } from './candidate-audit.js';
 export { OperatorHealthReadModel } from './operator-health-read-model.js';
 export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHealthStatus } from './operator-health-read-model.js';
 
+// Synthetic baseline (PRI-206)
+export { runSyntheticBaseline } from './synthetic-baseline.js';
+export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselineStageName, SyntheticBaselineOptions } from './synthetic-baseline.js';
+
 // Internalization contracts (PRI-42)
 export type {
   RuleHostInput,

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -288,8 +288,8 @@ export type { CandidateAuditResult } from './candidate-audit.js';
 export { OperatorHealthReadModel } from './operator-health-read-model.js';
 export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHealthStatus } from './operator-health-read-model.js';
 
-// Synthetic baseline (PRI-206)
-export { runSyntheticBaseline, computeOverallStatus, boundedEvidence } from './synthetic-baseline.js';
+// Synthetic baseline (PRI-206) — pure contract/helpers only; I/O runner lives in pd-cli
+export { computeOverallStatus, boundedEvidence, safeStringify, truncateReason, makeDeterministicDiagnosticianOutput, recommendNextIssue } from './synthetic-baseline.js';
 export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselineStageName, SyntheticBaselineFailStage, SyntheticBaselineOptions } from './synthetic-baseline.js';
 
 // Internalization contracts (PRI-42)

--- a/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
@@ -7,7 +7,6 @@ import { StoreEventEmitter } from './store/event-emitter.js';
 import { DiagnosticianRunner } from './runner/diagnostician-runner.js';
 import { PassThroughValidator } from './runner/diagnostician-validator.js';
 import { SqliteDiagnosticianCommitter } from './store/commit/diagnostician-committer.js';
-import type { SqliteConnection } from './store/sqlite-connection.js';
 import type { DiagnosticianOutputV1 } from './diagnostician-output.js';
 import { TestDoubleRuntimeAdapter } from './adapter/test-double-runtime-adapter.js';
 import { PainSignalBridge } from './pain-signal-bridge.js';
@@ -72,9 +71,14 @@ function safeStringify(value: unknown): string {
   }
 }
 
-function boundedEvidence(evidence: Record<string, unknown>): Record<string, unknown> {
-  const json = JSON.stringify(evidence);
-  if (json.length <= MAX_EVIDENCE_JSON_LENGTH) return evidence;
+export function boundedEvidence(evidence: Record<string, unknown>): Record<string, unknown> {
+  let json: string | null = null;
+  try {
+    json = JSON.stringify(evidence);
+  } catch {
+    // circular or BigInt — fall through to truncation
+  }
+  if (json !== null && json.length <= MAX_EVIDENCE_JSON_LENGTH) return evidence;
   const keys = Object.keys(evidence);
   const truncated: Record<string, unknown> = {};
   let budget = MAX_EVIDENCE_JSON_LENGTH - 2;
@@ -83,7 +87,7 @@ function boundedEvidence(evidence: Record<string, unknown>): Record<string, unkn
     const comma = first ? 0 : 1;
     const entry = `"${key}":${safeStringify(evidence[key])}`;
     if (entry.length + comma <= budget) {
-      truncated[key] = evidence[key];
+      truncated[key] = safeStringify(evidence[key]);
       budget -= entry.length + comma;
       first = false;
     } else {
@@ -91,8 +95,10 @@ function boundedEvidence(evidence: Record<string, unknown>): Record<string, unkn
       break;
     }
   }
-  if (JSON.stringify(truncated).length > MAX_EVIDENCE_JSON_LENGTH) {
-    return { _truncated: true, keys: keys.slice(0, 3) };
+  const truncatedJson = JSON.stringify(truncated);
+  if (truncatedJson.length > MAX_EVIDENCE_JSON_LENGTH) {
+    const safeKeys = keys.slice(0, 3).map(k => k.length > 50 ? k.slice(0, 47) + '...' : k);
+    return { _truncated: true, keys: safeKeys };
   }
   return truncated;
 }
@@ -122,7 +128,7 @@ function makeDeterministicDiagnosticianOutput(painId: string): DiagnosticianOutp
   };
 }
 
-function computeOverallStatus(stages: SyntheticBaselineStage[]): 'passed' | 'failed' | 'degraded' {
+export function computeOverallStatus(stages: SyntheticBaselineStage[]): 'passed' | 'failed' | 'degraded' {
   const hasFailed = stages.some(s => s.status === 'failed');
   const hasSkipped = stages.some(s => s.status === 'skipped');
   const hasPassed = stages.some(s => s.status === 'passed');
@@ -184,9 +190,7 @@ export async function runSyntheticBaseline(opts: SyntheticBaselineOptions): Prom
       return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
     }
 
-    const sqliteConn = (stateManager as unknown as { connection: unknown }).connection as SqliteConnection;
-    const taskStore = (stateManager as unknown as { taskStore: unknown }).taskStore as never;
-    const runStore = (stateManager as unknown as { runStore: unknown }).runStore as never;
+    const { connection: sqliteConn, taskStore, runStore } = stateManager;
     const historyQuery = new SqliteHistoryQuery(sqliteConn);
     const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore);
     const eventEmitter = new StoreEventEmitter();
@@ -194,7 +198,7 @@ export async function runSyntheticBaseline(opts: SyntheticBaselineOptions): Prom
     const validator = new PassThroughValidator();
 
     const runtimeAdapter = new TestDoubleRuntimeAdapter(
-      { onFetchOutput: () => ({ runId: `synth-${painId}`, payload: diagnosticianOutput as unknown as Record<string, unknown> }) },
+      { onFetchOutput: () => ({ runId: `synth-${painId}`, payload: diagnosticianOutput }) },
       `diagnosis_${painId}`,
     );
 

--- a/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
@@ -1,0 +1,401 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { RuntimeStateManager } from './store/runtime-state-manager.js';
+import { SqliteContextAssembler } from './store/context/sqlite-context-assembler.js';
+import { SqliteHistoryQuery } from './store/history/sqlite-history-query.js';
+import { StoreEventEmitter } from './store/event-emitter.js';
+import { DiagnosticianRunner } from './runner/diagnostician-runner.js';
+import { PassThroughValidator } from './runner/diagnostician-validator.js';
+import { SqliteDiagnosticianCommitter } from './store/commit/diagnostician-committer.js';
+import type { SqliteConnection } from './store/sqlite-connection.js';
+import type { DiagnosticianOutputV1 } from './diagnostician-output.js';
+import { TestDoubleRuntimeAdapter } from './adapter/test-double-runtime-adapter.js';
+import { PainSignalBridge } from './pain-signal-bridge.js';
+import { CandidateIntakeService } from './candidate-intake-service.js';
+import { PrincipleTreeLedgerAdapter } from './adapter/principle-tree-ledger-adapter.js';
+import { auditCandidateLedgerConsistency } from './candidate-audit.js';
+import { OperatorHealthReadModel } from './operator-health-read-model.js';
+import { createInternalizationQueueReadModel } from './internalization-queue-read-model.js';
+import { createPITaskDiagnosticJson } from './internalization/pitask-metadata.js';
+
+export type SyntheticBaselineStageName =
+  | 'pain_intake'
+  | 'diagnostician_task_created'
+  | 'candidate_created'
+  | 'ledger_consistent'
+  | 'internalization_queue_ready'
+  | 'canary_health';
+
+export interface SyntheticBaselineStage {
+  name: SyntheticBaselineStageName;
+  status: 'passed' | 'failed' | 'skipped';
+  reason?: string;
+  evidence?: Record<string, unknown>;
+}
+
+export interface SyntheticBaselineSummary {
+  status: 'passed' | 'failed' | 'degraded';
+  workspaceMode: 'temp' | 'explicit_workspace';
+  generatedAt: string;
+  stages: SyntheticBaselineStage[];
+  recommendedNextIssue?: string;
+}
+
+export interface SyntheticBaselineOptions {
+  workspaceDir: string;
+  workspaceMode: 'temp' | 'explicit_workspace';
+  failAfterStage?: string;
+}
+
+const MAX_REASON_LENGTH = 500;
+const MAX_EVIDENCE_JSON_LENGTH = 2000;
+
+function truncateReason(reason: string): string {
+  if (reason.length <= MAX_REASON_LENGTH) return reason;
+  return reason.slice(0, MAX_REASON_LENGTH - 3) + '...';
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    if (typeof value === 'bigint') return `${value}n`;
+    if (value === undefined) return 'undefined';
+    if (value === null) return 'null';
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+function boundedEvidence(evidence: Record<string, unknown>): Record<string, unknown> {
+  const json = JSON.stringify(evidence);
+  if (json.length <= MAX_EVIDENCE_JSON_LENGTH) return evidence;
+  const keys = Object.keys(evidence);
+  const truncated: Record<string, unknown> = {};
+  let budget = MAX_EVIDENCE_JSON_LENGTH;
+  for (const key of keys) {
+    const entry = `"${key}":${safeStringify(evidence[key])}`;
+    if (entry.length <= budget) {
+      truncated[key] = evidence[key];
+      budget -= entry.length;
+    } else {
+      truncated[key] = '[truncated]';
+      break;
+    }
+  }
+  return truncated;
+}
+
+function makeDeterministicDiagnosticianOutput(painId: string): DiagnosticianOutputV1 {
+  return {
+    valid: true,
+    diagnosisId: `synth-diag-${painId}`,
+    taskId: `diagnosis_${painId}`,
+    summary: 'Synthetic baseline: deterministic diagnostician output',
+    rootCause: 'Synthetic baseline: tool failure pattern detected',
+    violatedPrinciples: [],
+    evidence: [
+      {
+        sourceRef: `pain://${painId}`,
+        note: 'Synthetic baseline pain signal evidence',
+      },
+    ],
+    recommendations: [
+      {
+        kind: 'principle',
+        description: 'Synthetic baseline: avoid repeating this tool failure pattern',
+        abstractedPrinciple: 'Synthetic baseline principle: handle tool failures gracefully',
+      },
+    ],
+    confidence: 0.95,
+  };
+}
+
+function computeOverallStatus(stages: SyntheticBaselineStage[]): 'passed' | 'failed' | 'degraded' {
+  const failed = stages.some(s => s.status === 'failed');
+  const skipped = stages.some(s => s.status === 'skipped');
+  if (failed && skipped) return 'failed';
+  if (failed) {
+    const passed = stages.some(s => s.status === 'passed');
+    return passed ? 'degraded' : 'failed';
+  }
+  if (skipped) return 'degraded';
+  return 'passed';
+}
+
+function recommendNextIssue(stages: SyntheticBaselineStage[]): string | undefined {
+  const firstFailed = stages.find(s => s.status === 'failed');
+  if (!firstFailed) return undefined;
+  switch (firstFailed.name) {
+    case 'pain_intake':
+      return 'PRI-207: Pain intake pipeline broken — check PainSignalBridge and DiagnosticianRunner';
+    case 'diagnostician_task_created':
+      return 'PRI-207: Diagnostician task not created — check RuntimeStateManager task creation';
+    case 'candidate_created':
+      return 'PRI-207: Candidate not created — check DiagnosticianCommitter and artifact storage';
+    case 'ledger_consistent':
+      return 'PRI-209: Ledger consistency broken — check CandidateIntakeService and PrincipleTreeLedgerAdapter';
+    case 'internalization_queue_ready':
+      return 'PRI-209: Internalization queue not ready — check IntakeToInternalizationBridge and PI task creation';
+    case 'canary_health':
+      return 'PRI-208: Canary health check failed — check OperatorHealthReadModel and read model infrastructure';
+    default:
+      return undefined;
+  }
+}
+
+export async function runSyntheticBaseline(opts: SyntheticBaselineOptions): Promise<SyntheticBaselineSummary> {
+  const { workspaceDir, workspaceMode, failAfterStage } = opts;
+  const stages: SyntheticBaselineStage[] = [];
+  const generatedAt = new Date().toISOString();
+
+  const pdDir = path.join(workspaceDir, '.pd');
+  const stateDir = path.join(workspaceDir, '.state');
+  fs.mkdirSync(pdDir, { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  const painId = `synth-pain-${Date.now()}`;
+  const diagnosticianOutput = makeDeterministicDiagnosticianOutput(painId);
+
+  let stateManager: RuntimeStateManager | null = null;
+
+  try {
+    stateManager = new RuntimeStateManager({ workspaceDir });
+    await stateManager.initialize();
+
+    if (failAfterStage === 'before_pain_intake') {
+      stages.push({
+        name: 'pain_intake',
+        status: 'failed',
+        reason: truncateReason('Injected failure: pain intake stage forced to fail for testing'),
+      });
+      for (const name of ['diagnostician_task_created', 'candidate_created', 'ledger_consistent', 'internalization_queue_ready', 'canary_health'] as SyntheticBaselineStageName[]) {
+        stages.push({ name, status: 'failed', reason: 'Prerequisite stage pain_intake failed' });
+      }
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const sqliteConn = (stateManager as unknown as { connection: unknown }).connection as SqliteConnection;
+    const taskStore = (stateManager as unknown as { taskStore: unknown }).taskStore as never;
+    const runStore = (stateManager as unknown as { runStore: unknown }).runStore as never;
+    const historyQuery = new SqliteHistoryQuery(sqliteConn);
+    const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore);
+    const eventEmitter = new StoreEventEmitter();
+    const committer = new SqliteDiagnosticianCommitter(sqliteConn);
+    const validator = new PassThroughValidator();
+
+    const runtimeAdapter = new TestDoubleRuntimeAdapter(
+      { onFetchOutput: () => ({ runId: `synth-${painId}`, payload: diagnosticianOutput as unknown as Record<string, unknown> }) },
+      `diagnosis_${painId}`,
+    );
+
+    const runner = new DiagnosticianRunner(
+      {
+        stateManager,
+        contextAssembler,
+        runtimeAdapter,
+        eventEmitter,
+        validator,
+        committer,
+      },
+      {
+        owner: 'synthetic-baseline',
+        runtimeKind: 'test-double',
+        pollIntervalMs: 50,
+        timeoutMs: 10000,
+      },
+    );
+
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir });
+    const intakeService = new CandidateIntakeService({ stateManager, ledgerAdapter });
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner,
+      intakeService,
+      ledgerAdapter,
+      autoIntakeEnabled: true,
+    });
+
+    const bridgeResult = await bridge.onPainDetected({
+      painId,
+      painType: 'tool_failure',
+      source: 'synthetic-baseline',
+      reason: 'Synthetic baseline deterministic pain signal',
+    });
+
+    const painPassed = bridgeResult.status === 'succeeded';
+    stages.push({
+      name: 'pain_intake',
+      status: painPassed ? 'passed' : 'failed',
+      ...(painPassed ? {} : { reason: truncateReason(bridgeResult.message ?? `PainSignalBridge returned status=${bridgeResult.status}`) }),
+      evidence: boundedEvidence({
+        painId: bridgeResult.painId,
+        bridgeStatus: bridgeResult.status,
+      }),
+    });
+
+    if (failAfterStage === 'after_pain_intake') {
+      stages.push({ name: 'diagnostician_task_created', status: 'failed', reason: 'Injected failure: forced fail after pain_intake' });
+      stages.push({ name: 'candidate_created', status: 'failed', reason: 'Prerequisite stage diagnostician_task_created failed' });
+      stages.push({ name: 'ledger_consistent', status: 'failed', reason: 'Prerequisite stage candidate_created failed' });
+      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Prerequisite stage ledger_consistent failed' });
+      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const { taskId } = bridgeResult;
+    const task = await stateManager.getTask(taskId);
+    const taskPassed = task !== null && task.status === 'succeeded';
+    stages.push({
+      name: 'diagnostician_task_created',
+      status: taskPassed ? 'passed' : 'failed',
+      ...(taskPassed ? {} : { reason: truncateReason(`Task ${taskId} not found or not succeeded. task=${task ? task.status : 'null'}`) }),
+      evidence: boundedEvidence({
+        taskId,
+        taskStatus: task?.status ?? 'not_found',
+      }),
+    });
+
+    const candidates = await stateManager.getCandidatesByTaskId(taskId);
+    const candidatePassed = candidates.length > 0;
+    stages.push({
+      name: 'candidate_created',
+      status: candidatePassed ? 'passed' : 'failed',
+      ...(candidatePassed ? {} : { reason: truncateReason(`No candidates found for task ${taskId}`) }),
+      evidence: boundedEvidence({
+        candidateCount: candidates.length,
+        candidateIds: candidates.map(c => c.candidateId).slice(0, 5),
+      }),
+    });
+
+    if (failAfterStage === 'after_candidate_created') {
+      stages.push({ name: 'ledger_consistent', status: 'failed', reason: 'Injected failure: forced fail after candidate_created' });
+      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Prerequisite stage ledger_consistent failed' });
+      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const auditResult = await auditCandidateLedgerConsistency(workspaceDir);
+    const ledgerPassed = auditResult.status === 'ok';
+    stages.push({
+      name: 'ledger_consistent',
+      status: ledgerPassed ? 'passed' : 'failed',
+      ...(ledgerPassed ? {} : { reason: truncateReason(`Ledger audit status=${auditResult.status}. orphanCandidates=${auditResult.orphanCandidateCount} missingLedger=${auditResult.missingLedgerCount}`) }),
+      evidence: boundedEvidence({
+        auditStatus: auditResult.status,
+        consumedCount: auditResult.consumedCount,
+        orphanCandidateCount: auditResult.orphanCandidateCount,
+        missingLedgerCount: auditResult.missingLedgerCount,
+      }),
+    });
+
+    if (failAfterStage === 'after_ledger_consistent') {
+      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Injected failure: forced fail after ledger_consistent' });
+      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
+      const status = computeOverallStatus(stages);
+      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
+    }
+
+    const piTaskId = `synth-dreamer-${Date.now()}`;
+    await stateManager.createTask({
+      taskId: piTaskId,
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const { readModel: queueReadModel, close: queueClose } = await createInternalizationQueueReadModel({
+      workspaceDir,
+      readonly: true,
+    });
+    try {
+      const queueSnapshot = await queueReadModel.getSnapshot();
+      const queueReady = queueSnapshot.readyTasks.length > 0 || queueSnapshot.pendingCount > 0;
+      stages.push({
+        name: 'internalization_queue_ready',
+        status: queueReady ? 'passed' : 'failed',
+        ...(queueReady ? {} : { reason: truncateReason(`Queue has no ready or pending tasks. noReadyTasks=${queueSnapshot.noReadyTasks?.reason ?? 'n/a'}`) }),
+        evidence: boundedEvidence({
+          readyCount: queueSnapshot.readyTasks.length,
+          pendingCount: queueSnapshot.pendingCount,
+          noReadyReason: queueSnapshot.noReadyTasks?.reason ?? null,
+        }),
+      });
+    } catch (err) {
+      stages.push({
+        name: 'internalization_queue_ready',
+        status: 'failed',
+        reason: truncateReason(`Queue read model failed: ${err instanceof Error ? err.message : String(err)}`),
+      });
+    } finally {
+      await queueClose();
+    }
+
+    const healthModel = new OperatorHealthReadModel({ workspaceDir });
+    try {
+      const healthSnapshot = await healthModel.getSnapshot();
+      const healthPassed = healthSnapshot.overallStatus === 'healthy' || healthSnapshot.overallStatus === 'degraded';
+      stages.push({
+        name: 'canary_health',
+        status: healthPassed ? 'passed' : 'failed',
+        ...(healthPassed ? {} : { reason: truncateReason(`Operator health: ${healthSnapshot.overallStatus}. Actions: ${healthSnapshot.recommendedActions.join('; ')}`) }),
+        evidence: boundedEvidence({
+          overallStatus: healthSnapshot.overallStatus,
+          recommendedActions: healthSnapshot.recommendedActions.slice(0, 3),
+        }),
+      });
+    } catch (err) {
+      stages.push({
+        name: 'canary_health',
+        status: 'failed',
+        reason: truncateReason(`Health read model failed: ${err instanceof Error ? err.message : String(err)}`),
+      });
+    } finally {
+      await healthModel.close();
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const stageNames: SyntheticBaselineStageName[] = [
+      'pain_intake',
+      'diagnostician_task_created',
+      'candidate_created',
+      'ledger_consistent',
+      'internalization_queue_ready',
+      'canary_health',
+    ];
+    const existingNames = new Set(stages.map(s => s.name));
+    for (const name of stageNames) {
+      if (!existingNames.has(name)) {
+        stages.push({
+          name,
+          status: 'failed',
+          reason: truncateReason(`Unexpected error: ${errorMessage}`),
+        });
+      }
+    }
+  } finally {
+    if (stateManager) {
+      await stateManager.close();
+    }
+  }
+
+  const status = computeOverallStatus(stages);
+  return {
+    status,
+    workspaceMode,
+    generatedAt,
+    stages,
+    recommendedNextIssue: recommendNextIssue(stages),
+  };
+}

--- a/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
@@ -1,21 +1,4 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { RuntimeStateManager } from './store/runtime-state-manager.js';
-import { SqliteContextAssembler } from './store/context/sqlite-context-assembler.js';
-import { SqliteHistoryQuery } from './store/history/sqlite-history-query.js';
-import { StoreEventEmitter } from './store/event-emitter.js';
-import { DiagnosticianRunner } from './runner/diagnostician-runner.js';
-import { PassThroughValidator } from './runner/diagnostician-validator.js';
-import { SqliteDiagnosticianCommitter } from './store/commit/diagnostician-committer.js';
 import type { DiagnosticianOutputV1 } from './diagnostician-output.js';
-import { TestDoubleRuntimeAdapter } from './adapter/test-double-runtime-adapter.js';
-import { PainSignalBridge } from './pain-signal-bridge.js';
-import { CandidateIntakeService } from './candidate-intake-service.js';
-import { PrincipleTreeLedgerAdapter } from './adapter/principle-tree-ledger-adapter.js';
-import { auditCandidateLedgerConsistency } from './candidate-audit.js';
-import { OperatorHealthReadModel } from './operator-health-read-model.js';
-import { createInternalizationQueueReadModel } from './internalization-queue-read-model.js';
-import { createPITaskDiagnosticJson } from './internalization/pitask-metadata.js';
 
 export type SyntheticBaselineStageName =
   | 'pain_intake'
@@ -55,16 +38,22 @@ export interface SyntheticBaselineOptions {
 const MAX_REASON_LENGTH = 500;
 const MAX_EVIDENCE_JSON_LENGTH = 2000;
 
-function truncateReason(reason: string): string {
+export function truncateReason(reason: string): string {
   if (reason.length <= MAX_REASON_LENGTH) return reason;
   return reason.slice(0, MAX_REASON_LENGTH - 3) + '...';
 }
 
-function safeStringify(value: unknown): string {
+export function safeStringify(value: unknown): string {
   try {
     if (typeof value === 'bigint') return `${value}n`;
     if (value === undefined) return 'undefined';
     if (value === null) return 'null';
+    if (typeof value === 'object' && value !== null) {
+      const proto = Object.getPrototypeOf(value);
+      if (proto === null) {
+        return JSON.stringify(Object.fromEntries(Object.entries(value)));
+      }
+    }
     return JSON.stringify(value);
   } catch {
     return '[unserializable]';
@@ -103,7 +92,7 @@ export function boundedEvidence(evidence: Record<string, unknown>): Record<strin
   return truncated;
 }
 
-function makeDeterministicDiagnosticianOutput(painId: string): DiagnosticianOutputV1 {
+export function makeDeterministicDiagnosticianOutput(painId: string): DiagnosticianOutputV1 {
   return {
     valid: true,
     diagnosisId: `synth-diag-${painId}`,
@@ -137,7 +126,7 @@ export function computeOverallStatus(stages: SyntheticBaselineStage[]): 'passed'
   return 'passed';
 }
 
-function recommendNextIssue(stages: SyntheticBaselineStage[]): string | undefined {
+export function recommendNextIssue(stages: SyntheticBaselineStage[]): string | undefined {
   const firstFailed = stages.find(s => s.status === 'failed');
   if (!firstFailed) return undefined;
   switch (firstFailed.name) {
@@ -156,259 +145,4 @@ function recommendNextIssue(stages: SyntheticBaselineStage[]): string | undefine
     default:
       return undefined;
   }
-}
-
-export async function runSyntheticBaseline(opts: SyntheticBaselineOptions): Promise<SyntheticBaselineSummary> {
-  const { workspaceDir, workspaceMode, failAfterStage } = opts;
-  const stages: SyntheticBaselineStage[] = [];
-  const generatedAt = new Date().toISOString();
-
-  const pdDir = path.join(workspaceDir, '.pd');
-  const stateDir = path.join(workspaceDir, '.state');
-  await fs.promises.mkdir(pdDir, { recursive: true });
-  await fs.promises.mkdir(stateDir, { recursive: true });
-
-  const painId = `synth-pain-${Date.now()}`;
-  const diagnosticianOutput = makeDeterministicDiagnosticianOutput(painId);
-
-  let stateManager: RuntimeStateManager | null = null;
-
-  try {
-    stateManager = new RuntimeStateManager({ workspaceDir });
-    await stateManager.initialize();
-
-    if (failAfterStage === 'before_pain_intake') {
-      stages.push({
-        name: 'pain_intake',
-        status: 'failed',
-        reason: truncateReason('Injected failure: pain intake stage forced to fail for testing'),
-      });
-      for (const name of ['diagnostician_task_created', 'candidate_created', 'ledger_consistent', 'internalization_queue_ready', 'canary_health'] as SyntheticBaselineStageName[]) {
-        stages.push({ name, status: 'failed', reason: 'Prerequisite stage pain_intake failed' });
-      }
-      const status = computeOverallStatus(stages);
-      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
-    }
-
-    const { connection: sqliteConn, taskStore, runStore } = stateManager;
-    const historyQuery = new SqliteHistoryQuery(sqliteConn);
-    const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore);
-    const eventEmitter = new StoreEventEmitter();
-    const committer = new SqliteDiagnosticianCommitter(sqliteConn);
-    const validator = new PassThroughValidator();
-
-    const runtimeAdapter = new TestDoubleRuntimeAdapter(
-      { onFetchOutput: () => ({ runId: `synth-${painId}`, payload: diagnosticianOutput }) },
-      `diagnosis_${painId}`,
-    );
-
-    const runner = new DiagnosticianRunner(
-      {
-        stateManager,
-        contextAssembler,
-        runtimeAdapter,
-        eventEmitter,
-        validator,
-        committer,
-      },
-      {
-        owner: 'synthetic-baseline',
-        runtimeKind: 'test-double',
-        pollIntervalMs: 50,
-        timeoutMs: 10000,
-      },
-    );
-
-    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir });
-    const intakeService = new CandidateIntakeService({ stateManager, ledgerAdapter });
-
-    const bridge = new PainSignalBridge({
-      stateManager,
-      runner,
-      intakeService,
-      ledgerAdapter,
-      autoIntakeEnabled: true,
-    });
-
-    const bridgeResult = await bridge.onPainDetected({
-      painId,
-      painType: 'tool_failure',
-      source: 'synthetic-baseline',
-      reason: 'Synthetic baseline deterministic pain signal',
-    });
-
-    const painPassed = bridgeResult.status === 'succeeded';
-    stages.push({
-      name: 'pain_intake',
-      status: painPassed ? 'passed' : 'failed',
-      ...(painPassed ? {} : { reason: truncateReason(bridgeResult.message ?? `PainSignalBridge returned status=${bridgeResult.status}`) }),
-      evidence: boundedEvidence({
-        painId: bridgeResult.painId,
-        bridgeStatus: bridgeResult.status,
-      }),
-    });
-
-    if (failAfterStage === 'after_pain_intake') {
-      stages.push({ name: 'diagnostician_task_created', status: 'failed', reason: 'Injected failure: forced fail after pain_intake' });
-      stages.push({ name: 'candidate_created', status: 'failed', reason: 'Prerequisite stage diagnostician_task_created failed' });
-      stages.push({ name: 'ledger_consistent', status: 'failed', reason: 'Prerequisite stage candidate_created failed' });
-      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Prerequisite stage ledger_consistent failed' });
-      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
-      const status = computeOverallStatus(stages);
-      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
-    }
-
-    const { taskId } = bridgeResult;
-    const task = await stateManager.getTask(taskId);
-    const taskPassed = task !== null && task.status === 'succeeded';
-    stages.push({
-      name: 'diagnostician_task_created',
-      status: taskPassed ? 'passed' : 'failed',
-      ...(taskPassed ? {} : { reason: truncateReason(`Task ${taskId} not found or not succeeded. task=${task ? task.status : 'null'}`) }),
-      evidence: boundedEvidence({
-        taskId,
-        taskStatus: task?.status ?? 'not_found',
-      }),
-    });
-
-    const candidates = await stateManager.getCandidatesByTaskId(taskId);
-    const candidatePassed = candidates.length > 0;
-    stages.push({
-      name: 'candidate_created',
-      status: candidatePassed ? 'passed' : 'failed',
-      ...(candidatePassed ? {} : { reason: truncateReason(`No candidates found for task ${taskId}`) }),
-      evidence: boundedEvidence({
-        candidateCount: candidates.length,
-        candidateIds: candidates.map(c => c.candidateId).slice(0, 5),
-      }),
-    });
-
-    if (failAfterStage === 'after_candidate_created') {
-      stages.push({ name: 'ledger_consistent', status: 'failed', reason: 'Injected failure: forced fail after candidate_created' });
-      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Prerequisite stage ledger_consistent failed' });
-      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
-      const status = computeOverallStatus(stages);
-      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
-    }
-
-    const auditResult = await auditCandidateLedgerConsistency(workspaceDir);
-    const ledgerPassed = auditResult.status === 'ok';
-    stages.push({
-      name: 'ledger_consistent',
-      status: ledgerPassed ? 'passed' : 'failed',
-      ...(ledgerPassed ? {} : { reason: truncateReason(`Ledger audit status=${auditResult.status}. orphanCandidates=${auditResult.orphanCandidateCount} missingLedger=${auditResult.missingLedgerCount}`) }),
-      evidence: boundedEvidence({
-        auditStatus: auditResult.status,
-        consumedCount: auditResult.consumedCount,
-        orphanCandidateCount: auditResult.orphanCandidateCount,
-        missingLedgerCount: auditResult.missingLedgerCount,
-      }),
-    });
-
-    if (failAfterStage === 'after_ledger_consistent') {
-      stages.push({ name: 'internalization_queue_ready', status: 'failed', reason: 'Injected failure: forced fail after ledger_consistent' });
-      stages.push({ name: 'canary_health', status: 'failed', reason: 'Prerequisite stage internalization_queue_ready failed' });
-      const status = computeOverallStatus(stages);
-      return { status, workspaceMode, generatedAt, stages, recommendedNextIssue: recommendNextIssue(stages) };
-    }
-
-    const piTaskId = `synth-dreamer-${Date.now()}`;
-    await stateManager.createTask({
-      taskId: piTaskId,
-      taskKind: 'dreamer',
-      status: 'pending',
-      attemptCount: 0,
-      maxAttempts: 3,
-      diagnosticJson: createPITaskDiagnosticJson({
-        dependencyTaskIds: [],
-        channel: 'prompt',
-        timeoutMs: 300_000,
-        inputArtifactRefs: [],
-        outputArtifactRefs: [],
-      }),
-    });
-
-    const { readModel: queueReadModel, close: queueClose } = await createInternalizationQueueReadModel({
-      workspaceDir,
-      readonly: true,
-    });
-    try {
-      const queueSnapshot = await queueReadModel.getSnapshot();
-      const queueReady = queueSnapshot.readyTasks.length > 0;
-      stages.push({
-        name: 'internalization_queue_ready',
-        status: queueReady ? 'passed' : 'failed',
-        ...(queueReady ? {} : { reason: truncateReason(`Queue has no ready tasks. pendingCount=${queueSnapshot.pendingCount} noReadyTasks=${queueSnapshot.noReadyTasks?.reason ?? 'n/a'}`) }),
-        evidence: boundedEvidence({
-          readyCount: queueSnapshot.readyTasks.length,
-          pendingCount: queueSnapshot.pendingCount,
-          noReadyReason: queueSnapshot.noReadyTasks?.reason ?? null,
-        }),
-      });
-    } catch (err) {
-      stages.push({
-        name: 'internalization_queue_ready',
-        status: 'failed',
-        reason: truncateReason(`Queue read model failed: ${err instanceof Error ? err.message : String(err)}`),
-      });
-    } finally {
-      await queueClose();
-    }
-
-    const healthModel = new OperatorHealthReadModel({ workspaceDir });
-    try {
-      const healthSnapshot = await healthModel.getSnapshot();
-      const healthPassed = healthSnapshot.overallStatus === 'healthy' || healthSnapshot.overallStatus === 'degraded';
-      stages.push({
-        name: 'canary_health',
-        status: healthPassed ? 'passed' : 'failed',
-        ...(healthPassed ? {} : { reason: truncateReason(`Operator health: ${healthSnapshot.overallStatus}. Actions: ${healthSnapshot.recommendedActions.join('; ')}`) }),
-        evidence: boundedEvidence({
-          overallStatus: healthSnapshot.overallStatus,
-          recommendedActions: healthSnapshot.recommendedActions.slice(0, 3),
-        }),
-      });
-    } catch (err) {
-      stages.push({
-        name: 'canary_health',
-        status: 'failed',
-        reason: truncateReason(`Health read model failed: ${err instanceof Error ? err.message : String(err)}`),
-      });
-    } finally {
-      await healthModel.close();
-    }
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-    const stageNames: SyntheticBaselineStageName[] = [
-      'pain_intake',
-      'diagnostician_task_created',
-      'candidate_created',
-      'ledger_consistent',
-      'internalization_queue_ready',
-      'canary_health',
-    ];
-    const existingNames = new Set(stages.map(s => s.name));
-    for (const name of stageNames) {
-      if (!existingNames.has(name)) {
-        stages.push({
-          name,
-          status: 'failed',
-          reason: truncateReason(`Unexpected error: ${errorMessage}`),
-        });
-      }
-    }
-  } finally {
-    if (stateManager) {
-      await stateManager.close();
-    }
-  }
-
-  const status = computeOverallStatus(stages);
-  return {
-    status,
-    workspaceMode,
-    generatedAt,
-    stages,
-    recommendedNextIssue: recommendNextIssue(stages),
-  };
 }

--- a/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/synthetic-baseline.ts
@@ -26,6 +26,12 @@ export type SyntheticBaselineStageName =
   | 'internalization_queue_ready'
   | 'canary_health';
 
+export type SyntheticBaselineFailStage =
+  | 'before_pain_intake'
+  | 'after_pain_intake'
+  | 'after_candidate_created'
+  | 'after_ledger_consistent';
+
 export interface SyntheticBaselineStage {
   name: SyntheticBaselineStageName;
   status: 'passed' | 'failed' | 'skipped';
@@ -44,7 +50,7 @@ export interface SyntheticBaselineSummary {
 export interface SyntheticBaselineOptions {
   workspaceDir: string;
   workspaceMode: 'temp' | 'explicit_workspace';
-  failAfterStage?: string;
+  failAfterStage?: SyntheticBaselineFailStage;
 }
 
 const MAX_REASON_LENGTH = 500;
@@ -71,16 +77,22 @@ function boundedEvidence(evidence: Record<string, unknown>): Record<string, unkn
   if (json.length <= MAX_EVIDENCE_JSON_LENGTH) return evidence;
   const keys = Object.keys(evidence);
   const truncated: Record<string, unknown> = {};
-  let budget = MAX_EVIDENCE_JSON_LENGTH;
+  let budget = MAX_EVIDENCE_JSON_LENGTH - 2;
+  let first = true;
   for (const key of keys) {
+    const comma = first ? 0 : 1;
     const entry = `"${key}":${safeStringify(evidence[key])}`;
-    if (entry.length <= budget) {
+    if (entry.length + comma <= budget) {
       truncated[key] = evidence[key];
-      budget -= entry.length;
+      budget -= entry.length + comma;
+      first = false;
     } else {
       truncated[key] = '[truncated]';
       break;
     }
+  }
+  if (JSON.stringify(truncated).length > MAX_EVIDENCE_JSON_LENGTH) {
+    return { _truncated: true, keys: keys.slice(0, 3) };
   }
   return truncated;
 }
@@ -111,14 +123,11 @@ function makeDeterministicDiagnosticianOutput(painId: string): DiagnosticianOutp
 }
 
 function computeOverallStatus(stages: SyntheticBaselineStage[]): 'passed' | 'failed' | 'degraded' {
-  const failed = stages.some(s => s.status === 'failed');
-  const skipped = stages.some(s => s.status === 'skipped');
-  if (failed && skipped) return 'failed';
-  if (failed) {
-    const passed = stages.some(s => s.status === 'passed');
-    return passed ? 'degraded' : 'failed';
-  }
-  if (skipped) return 'degraded';
+  const hasFailed = stages.some(s => s.status === 'failed');
+  const hasSkipped = stages.some(s => s.status === 'skipped');
+  const hasPassed = stages.some(s => s.status === 'passed');
+  if (hasFailed && !hasPassed) return 'failed';
+  if (hasFailed || hasSkipped) return 'degraded';
   return 'passed';
 }
 
@@ -150,8 +159,8 @@ export async function runSyntheticBaseline(opts: SyntheticBaselineOptions): Prom
 
   const pdDir = path.join(workspaceDir, '.pd');
   const stateDir = path.join(workspaceDir, '.state');
-  fs.mkdirSync(pdDir, { recursive: true });
-  fs.mkdirSync(stateDir, { recursive: true });
+  await fs.promises.mkdir(pdDir, { recursive: true });
+  await fs.promises.mkdir(stateDir, { recursive: true });
 
   const painId = `synth-pain-${Date.now()}`;
   const diagnosticianOutput = makeDeterministicDiagnosticianOutput(painId);
@@ -321,11 +330,11 @@ export async function runSyntheticBaseline(opts: SyntheticBaselineOptions): Prom
     });
     try {
       const queueSnapshot = await queueReadModel.getSnapshot();
-      const queueReady = queueSnapshot.readyTasks.length > 0 || queueSnapshot.pendingCount > 0;
+      const queueReady = queueSnapshot.readyTasks.length > 0;
       stages.push({
         name: 'internalization_queue_ready',
         status: queueReady ? 'passed' : 'failed',
-        ...(queueReady ? {} : { reason: truncateReason(`Queue has no ready or pending tasks. noReadyTasks=${queueSnapshot.noReadyTasks?.reason ?? 'n/a'}`) }),
+        ...(queueReady ? {} : { reason: truncateReason(`Queue has no ready tasks. pendingCount=${queueSnapshot.pendingCount} noReadyTasks=${queueSnapshot.noReadyTasks?.reason ?? 'n/a'}`) }),
         evidence: boundedEvidence({
           readyCount: queueSnapshot.readyTasks.length,
           pendingCount: queueSnapshot.pendingCount,


### PR DESCRIPTION
## Summary

Implements **Option A: CLI baseline command** for PRI-206.

### Why Option A
The existing `pd runtime uat` requires LLM (MINIMAX_CN_API_KEY) and is not deterministic. The existing `pd runtime canary` is read-only and doesn't drive the chain. A new CLI command fills the gap: it DRIVES the chain using TestDoubleRuntimeAdapter AND verifies each stage.

### Stage Output Contract

```typescript
interface SyntheticBaselineSummary {
  status: 'passed' | 'failed' | 'degraded';
  workspaceMode: 'temp' | 'explicit_workspace';
  generatedAt: string;
  stages: Array<{
    name: 'pain_intake' | 'diagnostician_task_created' | 'candidate_created' | 'ledger_consistent' | 'internalization_queue_ready' | 'canary_health';
    status: 'passed' | 'failed' | 'skipped';
    reason?: string;
    evidence?: Record<string, unknown>;
  }>;
  recommendedNextIssue?: string;
}
```

### Files Changed
- `packages/principles-core/src/runtime-v2/synthetic-baseline.ts` — Core logic: `runSyntheticBaseline()` with 6-stage pipeline
- `packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts` — 13 TDD tests
- `packages/principles-core/src/runtime-v2/index.ts` — Export new types and function
- `packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` — Fix pre-existing TS error
- `packages/pd-cli/src/commands/runtime-synthetic-baseline.ts` — CLI handler
- `packages/pd-cli/src/index.ts` — Register `pd runtime synthetic baseline` command

### Test Commands and Results
```
npm run build --workspace=@principles/core  # PASS
npm run build --workspace=@principles/pd-cli  # PASS
npm run typecheck:openclaw-plugin  # PASS
npx vitest run packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts  # 13/13 PASS
npm run lint  # PASS
npm run verify:merge  # PASS
```

### Temp Workspace Smoke JSON Summary
```json
{
  "status": "passed",
  "workspaceMode": "temp",
  "generatedAt": "2026-05-21T13:23:42.022Z",
  "stages": [
    { "name": "pain_intake", "status": "passed" },
    { "name": "diagnostician_task_created", "status": "passed" },
    { "name": "candidate_created", "status": "passed" },
    { "name": "ledger_consistent", "status": "passed" },
    { "name": "internalization_queue_ready", "status": "passed" },
    { "name": "canary_health", "status": "passed" }
  ]
}
```

### Declarations
- No live RuleHost correction
- No user source mutation
- No DiagnosticianOutputV1 change

### Error Handbook Gate
| ERR | Prevention |
|-----|-----------|
| ERR-002 | Every catch block exposes failure reason via stage.reason or stage.evidence |
| ERR-011 | CLI handler uses read model facades from @principles/core/runtime-v2, never imports RuntimeStateManager directly |
| ERR-012 | Branch based on latest main |
| ERR-014/017 | All JSON output uses safeStringifyPreview for unknown values; evidence fields truncated to 2000 chars |
| ERR-015 | No retry loops in synthetic baseline; each stage is independent |

### Remaining Risks / Follow-up Issues
- The `internalization_queue_ready` stage seeds a PI task directly (not via IntakeToInternalizationBridge) — a follow-up could add bridge integration
- No `--verbose` flag yet for detailed per-stage logging
- The `failAfterStage` option is internal-only (for testing); not exposed via CLI
- Architecture regression test had a pre-existing TS error (fixed in this PR as a drive-by)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增 pd runtime synthetic baseline 命令，支持临时或显式工作区模式，输出 JSON 或可读文本
  * 分阶段汇总运行状态（passed/failed/degraded），在失败时返回非零退出码并提供推荐的后续操作建议
* **Tests**
  * 为合成基线流程增加全面契约测试，覆盖工作区创建/清理、阶段汇总规则与输出稳定性
  * 增加架构回归白名单守护测试

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->