### PR TITLE
test(runtime): validate live pain intake to internalization bridge

### DIFF
--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -62,12 +62,26 @@ function buildRecommendedActions(checks: CanaryCheck[]): string[] {
       case 'pruning_orphans':
         actions.push('Run `pd runtime pruning orphans --workspace <path> --dry-run` to inspect orphan candidates.');
         break;
-      case 'internalization_queue':
-        actions.push('Check internalization queue for blocked or dependency-failed tasks.');
+      case 'internalization_queue': {
+        const queueDetails = check.details as InternalizationQueueSnapshot | undefined;
+        if (queueDetails && queueDetails.noReadyTasks?.reason === 'no_candidates' && queueDetails.noReadyTasks.inspectedCount === 0) {
+          actions.push('No internalization tasks found. If candidates exist, run `pd candidate internalization backfill --dry-run` to check, then `--confirm` to create dreamer tasks.');
+        } else {
+          actions.push('Check internalization queue for blocked or dependency-failed tasks.');
+        }
         break;
-      case 'runtime_health':
-        actions.push('Review runtime health snapshot for specific failure categories.');
+      }
+      case 'runtime_health': {
+        const details = check.details as OperatorHealthSnapshot | undefined;
+        if (details && details.totalTaskCount === 0) {
+          actions.push('Runtime V2 pipeline has never been exercised. Run `pd pain record --reason "test" --workspace <path>` to trigger the pain-to-principle chain.');
+        } else if (details && details.painChain.lastSuccessfulChain === null) {
+          actions.push('Run `pd runtime uat --workspace <path> --count 3` to establish baseline.');
+        } else {
+          actions.push('Review runtime health snapshot for specific failure categories.');
+        }
         break;
+      }
       case 'pd_shim_info':
         actions.push('Verify pd CLI installation and sync-plugin configuration.');
         break;

--- a/packages/principles-core/src/runtime-v2/__tests__/operator-health-cold-start-guard.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/operator-health-cold-start-guard.test.ts
@@ -115,4 +115,16 @@ describe('OperatorHealthReadModel — cold-start vs. real degradation', () => {
     expect(snapshot.overallStatus).toBe('healthy');
     expect(snapshot.painChain.lastSuccessfulChain).not.toBeNull();
   });
+
+  it('provides cold-start recommendedAction when zero tasks exist and DB is present', async () => {
+    const { model } = createModel(null, cleanPruning(), 0);
+
+    const snapshot = await model.getSnapshot();
+    await model.close();
+
+    expect(snapshot.overallStatus).toBe('healthy');
+    expect(snapshot.recommendedActions).toContainEqual(
+      expect.stringContaining('pain record')
+    );
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/operator-health-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/operator-health-read-model.test.ts
@@ -67,7 +67,7 @@ describe('OperatorHealthReadModel.getSnapshot', () => {
   });
 
   it('returns healthy when all checks pass', async () => {
-    const { model, painChain, pruning } = createModel();
+    const { model, painChain, pruning } = createModel(1);
     painChain.getLastSuccessfulChain.mockResolvedValue(healthyChain());
     pruning.getHealthSummary.mockReturnValue(cleanPruning());
 

--- a/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/operator-health-read-model.ts
@@ -234,6 +234,10 @@ export class OperatorHealthReadModel {
       recommendedActions.push('Run `pd runtime uat --workspace <path> --count 3` to establish baseline.');
     }
 
+    if (totalTaskCount === 0 && dbExists) {
+      recommendedActions.push('Runtime V2 pipeline has never been exercised. Run `pd pain record --reason "test" --workspace <path>` to trigger the pain-to-principle chain.');
+    }
+
     return {
       generatedAt,
       workspace: this.workspaceDir,

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -178,6 +178,9 @@ export class PainSignalBridge {
       for (const candidate of candidates) {
         const intakeResult = await this.intakeService.intake(candidate.candidateId);
         ledgerEntryIds.push(intakeResult.id);
+        if (candidate.status !== 'consumed') {
+          await this.stateManager.updateCandidateStatus(candidate.candidateId, { status: 'consumed' });
+        }
       }
     }
     // HG-4: When autoIntakeEnabled=false, chain runs but intake is skipped
@@ -253,6 +256,9 @@ export class PainSignalBridge {
       for (const candidate of candidates) {
         const ledgerEntry = this.ledgerAdapter.existsForCandidate(candidate.candidateId);
         if (ledgerEntry) ledgerEntryIds.push(ledgerEntry.id);
+        if (candidate.status !== 'consumed' && ledgerEntry) {
+          await this.stateManager.updateCandidateStatus(candidate.candidateId, { status: 'consumed' });
+        }
       }
       if (ledgerEntryIds.length === 0) {
         return {

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/pain-signal-bridge.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/pain-signal-bridge.test.ts
@@ -49,6 +49,7 @@ function makeMockStateManager(overrides: {
     getCandidatesByTaskId: async () => overrides.candidates ?? [],
     getRunsByTask: async () => overrides.runs ?? ([] as any),
     getTask: async () => ({ taskId: TASK_ID, status: 'succeeded', leaseExpiresAt: null } as any),
+    updateCandidateStatus: async () => { /* noop mock */ },
   } as unknown as RuntimeStateManager;
 }
 

--- a/packages/principles-core/src/runtime-v2/store/candidate/candidate-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/candidate/candidate-store.ts
@@ -38,4 +38,5 @@ export interface CandidateStore {
    *          or its current status did not match `expectedStatus`.
    */
   transitionCandidateStatus(candidateId: string, expectedStatus: CandidateRecord['status'], newStatus: CandidateRecord['status']): Promise<boolean>;
+
 }


### PR DESCRIPTION
## PRI-216: Live pain intake to internalization bridge validation

### ERR Checklist
- **ERR-002**: Every degraded/no-op path needs a structured reason → Fixed: cold-start recommendedAction added to OperatorHealthReadModel and canary
- **ERR-004/ERR-008**: Lineage fields must be consistent → N/A: no lineage field changes
- **ERR-011/ERR-012**: No core/plugin boundary violation → Verified: all changes are in core and CLI
- **ERR-014/ERR-017**: Bounded evidence and safe serialization → N/A: no evidence/preview changes
- **ERR-018/ERR-019**: No stale loop state → N/A: no retry/repair loop changes

### Initial Production State Summary
- `.pd/state.db`: tasks=0, runs=0, artifacts=0, candidates=0 (Runtime V2 never exercised)
- `.state/trajectory.db`: pain_events=213, tool_calls=8514, sessions=1671 (legacy path works)
- `workflows.yaml`: present with pi-ai runtime config (sensenova-cn/deepseek-v4-flash)
- `SENSENOVA_API_KEY`: set
- Canary: degraded (pruning watchCount=13, no recommendedAction for cold-start)

### Temp Workspace Experiment Results

**Before fix** (temp workspace with workflows.yaml):
- `pd pain record` → succeeded, created diagnostician task + 5 candidates
- `candidate audit` → consumedCount=0 (candidates NOT marked as consumed)
- `internalization queue` → no_candidates, inspectedCount=0
- `canary` → healthy (temp workspace has no pruning watch items)

**After fix** (temp workspace with workflows.yaml):
- `pd pain record` → succeeded, created diagnostician task + 5 candidates
- `candidate audit` → consumedCount=5 ✅ (candidates now marked as consumed)
- `internalization queue` → no_candidates (expected: dreamer tasks not auto-created)
- `canary` → healthy, lastSuccessfulChain populated ✅

### Five Investigation Questions

1. **Why is the production internalization queue empty?**
   The Runtime V2 pipeline has never been exercised in production. The `.pd/state.db` has 0 tasks. Pain events exist only in the legacy `.state/trajectory.db`. The bridge (`PainSignalBridge`) requires runtime config in `workflows.yaml` to create diagnostician tasks. The production workspace HAS the config, but the bridge was never triggered because the openclaw-plugin pain hook calls `emitPainDetectedEvent()` which may have failed silently before the config was added.

2. **Does live pain recording create a diagnostician task?**
   YES, when `workflows.yaml` with runtime config is present. `PainToPrincipleService.recordPain()` creates a diagnostician task via `PainSignalBridge`. Without config, it returns `failed` with `failureCategory: config_missing`.

3. **Does a diagnostician output create a candidate and ledger entry?**
   YES. When `autoIntakeEnabled: true` (default), the bridge calls `CandidateIntakeService.intake()` for each candidate, creating ledger entries. **Bug fixed**: candidates were not marked as `consumed` in the DB after intake. Now they are.

4. **Does a consumed/approved candidate become a Dreamer task automatically?**
   NO. It requires operator commands:
   - `pd candidate internalization backfill --dry-run` to check
   - `pd candidate internalization backfill --confirm` to create dreamer tasks
   This is expected operator workflow, not a missing bridge.

5. **Is the current gap expected operator workflow or a missing bridge?**
   **Both**: (a) Missing bridge: PainSignalBridge did not update candidate status to `consumed` after intake (fixed). (b) Expected operator workflow: dreamer tasks are not auto-created from consumed candidates — operator must run `pd candidate internalization backfill --confirm`.

### Root Cause and Minimal Fixes

**Fix B (bridge missing)**: `PainSignalBridge.onPainDetected()` now calls `stateManager.updateCandidateStatus(candidateId, { status: 'consumed' })` after `intakeService.intake()`, matching the CLI handler behavior. Also added to `buildExistingResult` path for backward compatibility.

**Fix A (diagnostics/recommendedAction missing)**: Canary `runtime_health` check now provides specific recommendedAction for cold-start (0 tasks) and no-candidates states. Canary `internalization_queue` check now suggests `pd candidate internalization backfill` when queue is empty.

**Fix C (read model misleading)**: `OperatorHealthReadModel` now adds a cold-start recommendedAction when `totalTaskCount === 0` and DB exists, guiding operators to run `pd pain record` to exercise the pipeline.

### Tests Run and Results
- `npm run build --workspace=@principles/core` ✅
- `npm run build --workspace=@principles/pd-cli` ✅
- `npm run typecheck:openclaw-plugin` ✅
- `npx vitest run packages/principles-core/src/runtime-v2/__tests__/synthetic-baseline.test.ts` ✅ (23 tests)
- `npx vitest run packages/principles-core/src/runtime-v2/__tests__/full-trace-contract.test.ts` ✅ (54 tests)
- `npx vitest run packages/principles-core/src/runtime-v2/__tests__/operator-health-cold-start-guard.test.ts` ✅ (4 tests, including new cold-start recommendedAction test)
- `npx vitest run packages/pd-cli/tests/commands/runtime-synthetic-baseline.test.ts` ✅ (10 tests)
- `npm run verify:merge` ✅

### Remaining Risk
- Production workspace still has 0 Runtime V2 tasks. Operator needs to trigger a pain signal (via `pd pain record` or OpenClaw frontend) to exercise the pipeline.
- Dreamer tasks are not auto-created from consumed candidates. This is expected but the operator needs to know to run `pd candidate internalization backfill --confirm`.
- The openclaw-plugin pain hook may have been failing silently before `workflows.yaml` was added. No logs were found to confirm this hypothesis.

### Next Blocker
- Need operator to trigger a live pain signal in the production workspace (via OpenClaw frontend or `pd pain record`) to confirm the full chain works end-to-end in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加了冷启动场景的推荐操作提示，当检测到 Runtime V2 pipeline 尚未执行过任务时提供指导。

* **Bug 修复**
  * 改进了运行时诊断建议，为队列阻塞和运行健康状态提供更精准的排查提示。
  * 优化了候选项状态更新逻辑，避免重复的状态写入操作。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->