### PR TITLE
test: add test coverage for internalization-job-graph and internalization-task-guards

### DIFF
--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-job-graph.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-job-graph.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateEdge,
+  isAcyclic,
+  getAllowedSuccessors,
+  getAllowedPredecessors,
+  ALLOWED_EDGES,
+  MODEL_TRAINING_CHANNEL,
+  TRAINER_KIND,
+} from '../internalization-job-graph.js';
+
+describe('Internalization Job Graph (PRI-61)', () => {
+  describe('ALLOWED_EDGES', () => {
+    it('defines the expected v1 edges', () => {
+      expect(ALLOWED_EDGES).toEqual([
+        ['dreamer', 'philosopher'],
+        ['philosopher', 'scribe'],
+        ['scribe', 'artificer'],
+        ['artificer', 'evaluator'],
+        ['evaluator', 'rollout_reviewer'],
+        ['rollout_reviewer', 'trainer'],
+      ]);
+    });
+  });
+
+  describe('validateEdge', () => {
+    it('accepts allowed edges', () => {
+      expect(validateEdge('dreamer', 'philosopher')).toBe(true);
+      expect(validateEdge('philosopher', 'scribe')).toBe(true);
+      expect(validateEdge('scribe', 'artificer')).toBe(true);
+      expect(validateEdge('artificer', 'evaluator')).toBe(true);
+      expect(validateEdge('evaluator', 'rollout_reviewer')).toBe(true);
+    });
+
+    it('accepts rollout_reviewer -> trainer with model_training channel', () => {
+      expect(validateEdge('rollout_reviewer', 'trainer', 'model_training')).toBe(true);
+    });
+
+    it('rejects rollout_reviewer -> trainer without model_training channel', () => {
+      expect(validateEdge('rollout_reviewer', 'trainer', 'prompt')).toBe(false);
+      expect(validateEdge('rollout_reviewer', 'trainer')).toBe(false);
+    });
+
+    it('rejects rollout_reviewer -> trainer with other non-model_training channels', () => {
+      expect(validateEdge('rollout_reviewer', 'trainer', 'skill')).toBe(false);
+      expect(validateEdge('rollout_reviewer', 'trainer', 'code_tool_hook')).toBe(false);
+      expect(validateEdge('rollout_reviewer', 'trainer', 'defer_archive')).toBe(false);
+    });
+
+    it('rejects trainer target from non-rollout_reviewer source', () => {
+      expect(validateEdge('evaluator', 'trainer', 'model_training')).toBe(false);
+      expect(validateEdge('dreamer', 'trainer', 'model_training')).toBe(false);
+    });
+
+    it('rejects invalid edges (reverse direction)', () => {
+      expect(validateEdge('philosopher', 'dreamer')).toBe(false);
+      expect(validateEdge('artificer', 'philosopher')).toBe(false);
+      expect(validateEdge('trainer', 'dreamer')).toBe(false);
+    });
+
+    it('rejects edges skipping intermediate runners', () => {
+      expect(validateEdge('dreamer', 'artificer')).toBe(false);
+      expect(validateEdge('philosopher', 'evaluator')).toBe(false);
+    });
+
+    it('rejects same-kind edges (self-loop)', () => {
+      expect(validateEdge('dreamer', 'dreamer')).toBe(false);
+      expect(validateEdge('trainer', 'trainer')).toBe(false);
+    });
+  });
+
+  describe('isAcyclic', () => {
+    it('returns true for empty graph', () => {
+      expect(isAcyclic([])).toBe(true);
+    });
+
+    it('returns true for single edge', () => {
+      expect(isAcyclic([['a', 'b']])).toBe(true);
+    });
+
+    it('returns true for valid DAG', () => {
+      const edges = [
+        ['dreamer', 'philosopher'],
+        ['philosopher', 'scribe'],
+        ['scribe', 'artificer'],
+      ];
+      expect(isAcyclic(edges)).toBe(true);
+    });
+
+    it('returns false for simple cycle', () => {
+      const edges = [
+        ['a', 'b'],
+        ['b', 'a'],
+      ];
+      expect(isAcyclic(edges)).toBe(false);
+    });
+
+    it('returns false for longer cycle', () => {
+      const edges = [
+        ['dreamer', 'philosopher'],
+        ['philosopher', 'scribe'],
+        ['scribe', 'dreamer'],
+      ];
+      expect(isAcyclic(edges)).toBe(false);
+    });
+
+    it('returns true for DAG with multiple branches', () => {
+      const edges = [
+        ['a', 'b'],
+        ['a', 'c'],
+        ['b', 'd'],
+        ['c', 'd'],
+      ];
+      expect(isAcyclic(edges)).toBe(true);
+    });
+
+    it('returns false for cycle in larger graph', () => {
+      const edges = [
+        ['dreamer', 'philosopher'],
+        ['philosopher', 'scribe'],
+        ['scribe', 'artificer'],
+        ['artificer', 'philosopher'],
+      ];
+      expect(isAcyclic(edges)).toBe(false);
+    });
+
+    it('returns false for self-loop', () => {
+      expect(isAcyclic([['a', 'a']])).toBe(false);
+    });
+
+    it('returns true for disconnected DAG components', () => {
+      const edges = [
+        ['a', 'b'],
+        ['c', 'd'],
+      ];
+      expect(isAcyclic(edges)).toBe(true);
+    });
+
+    it('returns false when one disconnected component has a cycle', () => {
+      const edges = [
+        ['a', 'b'],
+        ['c', 'd'],
+        ['d', 'c'],
+      ];
+      expect(isAcyclic(edges)).toBe(false);
+    });
+  });
+
+  describe('getAllowedSuccessors', () => {
+    it('returns correct successor for dreamer', () => {
+      expect(getAllowedSuccessors('dreamer')).toEqual(['philosopher']);
+    });
+
+    it('returns correct successor for philosopher', () => {
+      expect(getAllowedSuccessors('philosopher')).toEqual(['scribe']);
+    });
+
+    it('returns correct successor for scribe', () => {
+      expect(getAllowedSuccessors('scribe')).toEqual(['artificer']);
+    });
+
+    it('returns correct successor for artificer', () => {
+      expect(getAllowedSuccessors('artificer')).toEqual(['evaluator']);
+    });
+
+    it('returns correct successor for evaluator', () => {
+      expect(getAllowedSuccessors('evaluator')).toEqual(['rollout_reviewer']);
+    });
+
+    it('returns trainer as successor of rollout_reviewer', () => {
+      expect(getAllowedSuccessors('rollout_reviewer')).toEqual(['trainer']);
+    });
+
+    it('returns empty array for trainer (terminal node)', () => {
+      expect(getAllowedSuccessors('trainer')).toEqual([]);
+    });
+  });
+
+  describe('getAllowedPredecessors', () => {
+    it('returns empty array for dreamer (source node)', () => {
+      expect(getAllowedPredecessors('dreamer')).toEqual([]);
+    });
+
+    it('returns correct predecessor for philosopher', () => {
+      expect(getAllowedPredecessors('philosopher')).toEqual(['dreamer']);
+    });
+
+    it('returns correct predecessor for scribe', () => {
+      expect(getAllowedPredecessors('scribe')).toEqual(['philosopher']);
+    });
+
+    it('returns correct predecessor for artificer', () => {
+      expect(getAllowedPredecessors('artificer')).toEqual(['scribe']);
+    });
+
+    it('returns correct predecessor for evaluator', () => {
+      expect(getAllowedPredecessors('evaluator')).toEqual(['artificer']);
+    });
+
+    it('returns correct predecessor for rollout_reviewer', () => {
+      expect(getAllowedPredecessors('rollout_reviewer')).toEqual(['evaluator']);
+    });
+
+    it('returns rollout_reviewer as predecessor of trainer', () => {
+      expect(getAllowedPredecessors('trainer')).toEqual(['rollout_reviewer']);
+    });
+  });
+
+  describe('constants', () => {
+    it('MODEL_TRAINING_CHANNEL is model_training', () => {
+      expect(MODEL_TRAINING_CHANNEL).toBe('model_training');
+    });
+
+    it('TRAINER_KIND is trainer', () => {
+      expect(TRAINER_KIND).toBe('trainer');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-job-graph.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-job-graph.test.ts
@@ -75,72 +75,72 @@ describe('Internalization Job Graph (PRI-61)', () => {
     });
 
     it('returns true for single edge', () => {
-      expect(isAcyclic([['a', 'b']])).toBe(true);
+      expect(isAcyclic([['a', 'b'] as const])).toBe(true);
     });
 
     it('returns true for valid DAG', () => {
       const edges = [
-        ['dreamer', 'philosopher'],
-        ['philosopher', 'scribe'],
-        ['scribe', 'artificer'],
+        ['dreamer', 'philosopher'] as const,
+        ['philosopher', 'scribe'] as const,
+        ['scribe', 'artificer'] as const,
       ];
       expect(isAcyclic(edges)).toBe(true);
     });
 
     it('returns false for simple cycle', () => {
       const edges = [
-        ['a', 'b'],
-        ['b', 'a'],
+        ['a', 'b'] as const,
+        ['b', 'a'] as const,
       ];
       expect(isAcyclic(edges)).toBe(false);
     });
 
     it('returns false for longer cycle', () => {
       const edges = [
-        ['dreamer', 'philosopher'],
-        ['philosopher', 'scribe'],
-        ['scribe', 'dreamer'],
+        ['dreamer', 'philosopher'] as const,
+        ['philosopher', 'scribe'] as const,
+        ['scribe', 'dreamer'] as const,
       ];
       expect(isAcyclic(edges)).toBe(false);
     });
 
     it('returns true for DAG with multiple branches', () => {
       const edges = [
-        ['a', 'b'],
-        ['a', 'c'],
-        ['b', 'd'],
-        ['c', 'd'],
+        ['a', 'b'] as const,
+        ['a', 'c'] as const,
+        ['b', 'd'] as const,
+        ['c', 'd'] as const,
       ];
       expect(isAcyclic(edges)).toBe(true);
     });
 
     it('returns false for cycle in larger graph', () => {
       const edges = [
-        ['dreamer', 'philosopher'],
-        ['philosopher', 'scribe'],
-        ['scribe', 'artificer'],
-        ['artificer', 'philosopher'],
+        ['dreamer', 'philosopher'] as const,
+        ['philosopher', 'scribe'] as const,
+        ['scribe', 'artificer'] as const,
+        ['artificer', 'philosopher'] as const,
       ];
       expect(isAcyclic(edges)).toBe(false);
     });
 
     it('returns false for self-loop', () => {
-      expect(isAcyclic([['a', 'a']])).toBe(false);
+      expect(isAcyclic([['a', 'a'] as const])).toBe(false);
     });
 
     it('returns true for disconnected DAG components', () => {
       const edges = [
-        ['a', 'b'],
-        ['c', 'd'],
+        ['a', 'b'] as const,
+        ['c', 'd'] as const,
       ];
       expect(isAcyclic(edges)).toBe(true);
     });
 
     it('returns false when one disconnected component has a cycle', () => {
       const edges = [
-        ['a', 'b'],
-        ['c', 'd'],
-        ['d', 'c'],
+        ['a', 'b'] as const,
+        ['c', 'd'] as const,
+        ['d', 'c'] as const,
       ];
       expect(isAcyclic(edges)).toBe(false);
     });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-task-guards.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-task-guards.test.ts
@@ -29,7 +29,6 @@ function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
     timeoutMs = 60000,
     inputArtifactRefs = [],
     outputArtifactRefs = [],
-    rejectionCount = 0,
   } = overrides;
   return {
     taskId,
@@ -45,7 +44,9 @@ function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
     timeoutMs,
     inputArtifactRefs,
     outputArtifactRefs,
-    rejectionCount,
+    ...('rejectionCount' in overrides
+      ? { rejectionCount: overrides.rejectionCount }
+      : { rejectionCount: 0 }),
   } as PITaskRecord;
 }
 

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-task-guards.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-task-guards.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest';
+import type { PITaskRecord, LineageRef } from '../peer-runner-contracts.js';
+import type { TaskRecord } from '../../task-status.js';
+import {
+  canRetryNow,
+  canAcquireLease,
+  areDependenciesMet,
+  canTransitionTo,
+  isResultRefImmutable,
+  canUpdateLastError,
+  isArtifactRejected,
+  isUnresolvable,
+  recordRejection,
+  DEFAULT_UNRESOLVABLE_THRESHOLD,
+} from '../internalization-task-guards.js';
+
+function makePITask(overrides: Partial<PITaskRecord> = {}): PITaskRecord {
+  const {
+    taskId = 'test-task',
+    taskKind = 'dreamer',
+    status = 'pending',
+    createdAt = new Date().toISOString(),
+    updatedAt = new Date().toISOString(),
+    leaseExpiresAt,
+    attemptCount = 0,
+    maxAttempts = 3,
+    dependencyTaskIds = [],
+    channel = 'prompt',
+    timeoutMs = 60000,
+    inputArtifactRefs = [],
+    outputArtifactRefs = [],
+    rejectionCount = 0,
+  } = overrides;
+  return {
+    taskId,
+    taskKind,
+    status,
+    createdAt,
+    updatedAt,
+    ...(leaseExpiresAt !== undefined && { leaseExpiresAt }),
+    attemptCount,
+    maxAttempts,
+    dependencyTaskIds,
+    channel,
+    timeoutMs,
+    inputArtifactRefs,
+    outputArtifactRefs,
+    rejectionCount,
+  } as PITaskRecord;
+}
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  const {
+    taskId = 'dep-task',
+    status = 'succeeded',
+    createdAt = new Date().toISOString(),
+    updatedAt = new Date().toISOString(),
+    attemptCount = 0,
+    maxAttempts = 3,
+  } = overrides;
+  return {
+    taskId,
+    status,
+    createdAt,
+    updatedAt,
+    attemptCount,
+    maxAttempts,
+  } as TaskRecord;
+}
+
+describe('Internalization Task Guards (PRI-62)', () => {
+  describe('canRetryNow', () => {
+    it('returns true for non-retry_wait status', () => {
+      expect(canRetryNow(makePITask({ status: 'pending' }))).toBe(true);
+      expect(canRetryNow(makePITask({ status: 'leased' }))).toBe(true);
+      expect(canRetryNow(makePITask({ status: 'succeeded' }))).toBe(true);
+      expect(canRetryNow(makePITask({ status: 'failed' }))).toBe(true);
+    });
+
+    it('returns true for retry_wait with no leaseExpiresAt', () => {
+      expect(canRetryNow(makePITask({ status: 'retry_wait', leaseExpiresAt: undefined }))).toBe(true);
+    });
+
+    it('returns true for retry_wait with expired leaseExpiresAt', () => {
+      const nowMs = 1000000;
+      const expiredTime = new Date(nowMs - 60000).toISOString();
+      expect(canRetryNow(makePITask({ status: 'retry_wait', leaseExpiresAt: expiredTime }), nowMs)).toBe(true);
+    });
+
+    it('returns false for retry_wait with future leaseExpiresAt', () => {
+      const nowMs = 1000000;
+      const futureTime = new Date(nowMs + 60000).toISOString();
+      expect(canRetryNow(makePITask({ status: 'retry_wait', leaseExpiresAt: futureTime }), nowMs)).toBe(false);
+    });
+
+    it('returns true for retry_wait with invalid leaseExpiresAt', () => {
+      expect(canRetryNow(makePITask({ status: 'retry_wait', leaseExpiresAt: 'invalid-date' }))).toBe(true);
+    });
+
+    it('returns true for retry_wait at exact boundary (leaseExpiresAt === nowMs)', () => {
+      const nowMs = 1000000;
+      const exactTime = new Date(nowMs).toISOString();
+      expect(canRetryNow(makePITask({ status: 'retry_wait', leaseExpiresAt: exactTime }), nowMs)).toBe(true);
+    });
+  });
+
+  describe('canAcquireLease', () => {
+    it('returns true for pending status', () => {
+      expect(canAcquireLease(makePITask({ status: 'pending' }))).toBe(true);
+    });
+
+    it('returns true for retry_wait status', () => {
+      expect(canAcquireLease(makePITask({ status: 'retry_wait' }))).toBe(true);
+    });
+
+    it('returns false for leased status', () => {
+      expect(canAcquireLease(makePITask({ status: 'leased' }))).toBe(false);
+    });
+
+    it('returns false for succeeded status', () => {
+      expect(canAcquireLease(makePITask({ status: 'succeeded' }))).toBe(false);
+    });
+
+    it('returns false for failed status', () => {
+      expect(canAcquireLease(makePITask({ status: 'failed' }))).toBe(false);
+    });
+  });
+
+  describe('areDependenciesMet', () => {
+    it('returns true for empty dependencyTaskIds', () => {
+      const task = makePITask({ dependencyTaskIds: [] });
+      expect(areDependenciesMet(task, [])).toBe(true);
+    });
+
+    it('returns true when all dependencies are succeeded', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1', 'dep2'] });
+      const dependencies = [
+        makeTask({ taskId: 'dep1', status: 'succeeded' }),
+        makeTask({ taskId: 'dep2', status: 'succeeded' }),
+      ];
+      expect(areDependenciesMet(task, dependencies)).toBe(true);
+    });
+
+    it('returns false when dependency is missing (fail closed)', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1', 'dep2'] });
+      const dependencies = [makeTask({ taskId: 'dep1', status: 'succeeded' })];
+      expect(areDependenciesMet(task, dependencies)).toBe(false);
+    });
+
+    it('returns false when dependency is not succeeded', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1', 'dep2'] });
+      const dependencies = [
+        makeTask({ taskId: 'dep1', status: 'succeeded' }),
+        makeTask({ taskId: 'dep2', status: 'pending' }),
+      ];
+      expect(areDependenciesMet(task, dependencies)).toBe(false);
+    });
+
+    it('returns false when dependency is failed', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1'] });
+      const dependencies = [makeTask({ taskId: 'dep1', status: 'failed' })];
+      expect(areDependenciesMet(task, dependencies)).toBe(false);
+    });
+
+    it('returns false when dependency is leased', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1'] });
+      const dependencies = [makeTask({ taskId: 'dep1', status: 'leased' })];
+      expect(areDependenciesMet(task, dependencies)).toBe(false);
+    });
+
+    it('returns false when dependency is in retry_wait', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1'] });
+      const dependencies = [makeTask({ taskId: 'dep1', status: 'retry_wait' })];
+      expect(areDependenciesMet(task, dependencies)).toBe(false);
+    });
+
+    it('ignores extra dependencies not referenced by task', () => {
+      const task = makePITask({ dependencyTaskIds: ['dep1'] });
+      const dependencies = [
+        makeTask({ taskId: 'dep1', status: 'succeeded' }),
+        makeTask({ taskId: 'dep-extra', status: 'pending' }),
+      ];
+      expect(areDependenciesMet(task, dependencies)).toBe(true);
+    });
+  });
+
+  describe('canTransitionTo', () => {
+    it('allows pending -> leased', () => {
+      expect(canTransitionTo('pending', 'leased')).toBe(true);
+    });
+
+    it('allows leased -> succeeded', () => {
+      expect(canTransitionTo('leased', 'succeeded')).toBe(true);
+    });
+
+    it('allows leased -> retry_wait', () => {
+      expect(canTransitionTo('leased', 'retry_wait')).toBe(true);
+    });
+
+    it('allows leased -> failed', () => {
+      expect(canTransitionTo('leased', 'failed')).toBe(true);
+    });
+
+    it('allows leased -> pending', () => {
+      expect(canTransitionTo('leased', 'pending')).toBe(true);
+    });
+
+    it('allows retry_wait -> pending', () => {
+      expect(canTransitionTo('retry_wait', 'pending')).toBe(true);
+    });
+
+    it('disallows pending -> succeeded', () => {
+      expect(canTransitionTo('pending', 'succeeded')).toBe(false);
+    });
+
+    it('disallows pending -> failed', () => {
+      expect(canTransitionTo('pending', 'failed')).toBe(false);
+    });
+
+    it('disallows pending -> retry_wait', () => {
+      expect(canTransitionTo('pending', 'retry_wait')).toBe(false);
+    });
+
+    it('disallows pending -> pending (self-transition)', () => {
+      expect(canTransitionTo('pending', 'pending')).toBe(false);
+    });
+
+    it('disallows leased -> leased (self-transition)', () => {
+      expect(canTransitionTo('leased', 'leased')).toBe(false);
+    });
+
+    it('disallows retry_wait -> leased', () => {
+      expect(canTransitionTo('retry_wait', 'leased')).toBe(false);
+    });
+
+    it('disallows retry_wait -> succeeded', () => {
+      expect(canTransitionTo('retry_wait', 'succeeded')).toBe(false);
+    });
+
+    it('disallows retry_wait -> failed', () => {
+      expect(canTransitionTo('retry_wait', 'failed')).toBe(false);
+    });
+
+    it('disallows retry_wait -> retry_wait (self-transition)', () => {
+      expect(canTransitionTo('retry_wait', 'retry_wait')).toBe(false);
+    });
+
+    it('disallows succeeded -> any state', () => {
+      expect(canTransitionTo('succeeded', 'pending')).toBe(false);
+      expect(canTransitionTo('succeeded', 'leased')).toBe(false);
+      expect(canTransitionTo('succeeded', 'failed')).toBe(false);
+      expect(canTransitionTo('succeeded', 'retry_wait')).toBe(false);
+    });
+
+    it('disallows failed -> any state', () => {
+      expect(canTransitionTo('failed', 'pending')).toBe(false);
+      expect(canTransitionTo('failed', 'leased')).toBe(false);
+      expect(canTransitionTo('failed', 'succeeded')).toBe(false);
+      expect(canTransitionTo('failed', 'retry_wait')).toBe(false);
+    });
+  });
+
+  describe('isResultRefImmutable', () => {
+    it('returns true when status is succeeded', () => {
+      expect(isResultRefImmutable(makePITask({ status: 'succeeded' }))).toBe(true);
+    });
+
+    it('returns false for other statuses', () => {
+      expect(isResultRefImmutable(makePITask({ status: 'pending' }))).toBe(false);
+      expect(isResultRefImmutable(makePITask({ status: 'leased' }))).toBe(false);
+      expect(isResultRefImmutable(makePITask({ status: 'retry_wait' }))).toBe(false);
+      expect(isResultRefImmutable(makePITask({ status: 'failed' }))).toBe(false);
+    });
+  });
+
+  describe('canUpdateLastError', () => {
+    it('returns true for retry_wait', () => {
+      expect(canUpdateLastError(makePITask({ status: 'retry_wait' }))).toBe(true);
+    });
+
+    it('returns true for failed', () => {
+      expect(canUpdateLastError(makePITask({ status: 'failed' }))).toBe(true);
+    });
+
+    it('returns false for pending', () => {
+      expect(canUpdateLastError(makePITask({ status: 'pending' }))).toBe(false);
+    });
+
+    it('returns false for leased', () => {
+      expect(canUpdateLastError(makePITask({ status: 'leased' }))).toBe(false);
+    });
+
+    it('returns false for succeeded', () => {
+      expect(canUpdateLastError(makePITask({ status: 'succeeded' }))).toBe(false);
+    });
+  });
+
+  describe('isArtifactRejected', () => {
+    it('returns true when validationStatus is rejected', () => {
+      const artifact = {
+        artifactId: 'art-1',
+        artifactKind: 'principle' as const,
+        sourceTaskId: 'task-1',
+        lineageRefs: [] as LineageRef[],
+        validationStatus: 'rejected' as const,
+      };
+      expect(isArtifactRejected(artifact)).toBe(true);
+    });
+
+    it('returns false when validationStatus is validated', () => {
+      const artifact = {
+        artifactId: 'art-1',
+        artifactKind: 'principle' as const,
+        sourceTaskId: 'task-1',
+        lineageRefs: [] as LineageRef[],
+        validationStatus: 'validated' as const,
+      };
+      expect(isArtifactRejected(artifact)).toBe(false);
+    });
+
+    it('returns false when validationStatus is pending', () => {
+      const artifact = {
+        artifactId: 'art-1',
+        artifactKind: 'principle' as const,
+        sourceTaskId: 'task-1',
+        lineageRefs: [] as LineageRef[],
+        validationStatus: 'pending' as const,
+      };
+      expect(isArtifactRejected(artifact)).toBe(false);
+    });
+  });
+
+  describe('Three Strikes Out (PRI-141)', () => {
+    it('DEFAULT_UNRESOLVABLE_THRESHOLD is 3', () => {
+      expect(DEFAULT_UNRESOLVABLE_THRESHOLD).toBe(3);
+    });
+
+    it('isUnresolvable returns false when below threshold', () => {
+      expect(isUnresolvable(makePITask({ rejectionCount: 0 }))).toBe(false);
+      expect(isUnresolvable(makePITask({ rejectionCount: 1 }))).toBe(false);
+      expect(isUnresolvable(makePITask({ rejectionCount: 2 }))).toBe(false);
+    });
+
+    it('isUnresolvable returns true when at threshold', () => {
+      expect(isUnresolvable(makePITask({ rejectionCount: 3 }))).toBe(true);
+    });
+
+    it('isUnresolvable returns true when above threshold', () => {
+      expect(isUnresolvable(makePITask({ rejectionCount: 5 }))).toBe(true);
+    });
+
+    it('isUnresolvable handles undefined rejectionCount', () => {
+      expect(isUnresolvable(makePITask({ rejectionCount: undefined }))).toBe(false);
+    });
+
+    it('isUnresolvable works with custom threshold', () => {
+      expect(isUnresolvable(makePITask({ rejectionCount: 2 }), 2)).toBe(true);
+      expect(isUnresolvable(makePITask({ rejectionCount: 1 }), 2)).toBe(false);
+    });
+
+    it('recordRejection increments rejectionCount', () => {
+      const task = makePITask({ rejectionCount: 2 });
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(3);
+    });
+
+    it('recordRejection handles undefined rejectionCount', () => {
+      const task = makePITask({ rejectionCount: undefined });
+      const result = recordRejection(task);
+      expect(result.rejectionCount).toBe(1);
+    });
+
+    it('recordRejection updates updatedAt', () => {
+      const task = makePITask({ rejectionCount: 0, updatedAt: '2024-01-01T00:00:00.000Z' });
+      const result = recordRejection(task);
+      expect(result.updatedAt).not.toBe('2024-01-01T00:00:00.000Z');
+      expect(new Date(result.updatedAt).getTime()).toBeGreaterThan(0);
+    });
+
+    it('recordRejection does not mutate the original task', () => {
+      const task = makePITask({ rejectionCount: 2 });
+      const result = recordRejection(task);
+      expect(task.rejectionCount).toBe(2);
+      expect(result.rejectionCount).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test suites for two core internalization engine modules that previously lacked test coverage.

## Test Coverage Added

### 1. `internalization-job-graph.test.ts` (35 tests)

**Module**: `packages/principles-core/src/runtime-v2/internalization/internalization-job-graph.ts`

- `ALLOWED_EDGES` constant validation
- `validateEdge()` for allowed/disallowed transitions including `model_training` channel constraint for trainer target
- `isAcyclic()` DAG cycle detection using Kahn algorithm (self-loops, disconnected components, simple/complex cycles)
- `getAllowedSuccessors()` and `getAllowedPredecessors()` queries
- `MODEL_TRAINING_CHANNEL` and `TRAINER_KIND` constants

### 2. `internalization-task-guards.test.ts` (56 tests)

**Module**: `packages/principles-core/src/runtime-v2/internalization/internalization-task-guards.ts`

- `canRetryNow()` with deterministic `nowMs` and boundary conditions
- `canAcquireLease()` for leaseable vs non-leaseable statuses
- `areDependenciesMet()` fail-closed dependency gating
- `canTransitionTo()` full state machine transition matrix including self-transitions and all invalid paths
- `isResultRefImmutable()` and `canUpdateLastError()` immutability guards
- `isArtifactRejected()` with valid `PIArtifactValidationStatus` enum values
- Three Strikes Out (PRI-141): `isUnresolvable`, `recordRejection` with immutability verification

## Risk Reduction

These tests fill coverage gaps in the internalization engine core:

1. **DAG validation** — prevents workflow pipeline cycles that could cause deadlocks
2. **State machine transitions** — enforces strict ADR-0003 transition rules, preventing illegal state changes
3. **Dependency gating** — fail-closed strategy ensures tasks only execute after all dependencies succeed
4. **Three Strikes Out** — prevents infinite retry loops, protecting system resources

## Code Review Fixes Applied

- Use valid `InternalizationChannel` enum values (not `default`)
- Use valid `PIArtifactValidationStatus` enum values (`validated`/`pending`)
- Include all required `TaskRecord` fields in test helpers (`createdAt`, `updatedAt`, `leaseExpiresAt`)
- Properly pass `leaseExpiresAt` through `makePITask` helper
- Add deterministic `nowMs` parameter for time-dependent tests
- Verify `recordRejection` does not mutate original task

## Test Results

```
✓ internalization-job-graph.test.ts   35 tests passed
✓ internalization-task-guards.test.ts  56 tests passed
✓ internalization-state-machine.test.ts 68 tests passed
✓ routing-policy.test.ts                6 tests passed
─────────────────────────────────────────────────────
Total: 165 tests passed, 0 failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 为任务调度和任务守卫模块增加了全面的单元测试覆盖，涵盖边界验证、状态转移逻辑、依赖关系解析、重试机制和任务拒绝处理等关键场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->