### PR TITLE
fix(pd-cli): intake candidates after successful diagnose run

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -76,6 +76,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-017 | JSON.stringify on unknown values can throw (BigInt, circular) — preview paths crash | PRI-200 |
 | ERR-018 | repairAttempts records stale initialValidationErrors instead of per-attempt currentErrors | PRI-200 |
 | ERR-019 | schemaCheck failure branch writes next iteration's errors into current attempt's record | PRI-200 |
+| ERR-020 | Commander negated boolean `--no-intake` ignored — checking wrong property name | PRI-217 |
 
 ---
 
@@ -335,9 +336,21 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-020]** | Commander negated boolean `--no-intake` ignored — checking wrong property name
+
+- **What happened**: Added a `--no-intake` CLI flag to skip candidate intake in `pd diagnose run`. The code checked `opts.noIntake` to determine whether to skip intake, but Commander.js negated boolean options are exposed without the `no-` prefix — `--no-intake` sets `opts.intake` (not `opts.noIntake`), defaulting to `true` when not passed and `false` when `--no-intake` is passed. Since `opts.noIntake` was always `undefined`, the `--no-intake` escape hatch was completely ineffective.
+- **Why it's wrong**: The `--no-intake` flag was documented as an escape hatch for debugging, but it silently did nothing. Users running `pd diagnose run --no-intake` would expect candidates to remain at `pending`, but they would still be consumed and written to the ledger, potentially triggering unintended side effects.
+- **Correct approach**: Define the flag as `--intake` (defaulting to `true`), which allows Commander to properly expose `--no-intake` to set it to `false`. Check `opts.intake === false` instead of `opts.noIntake`.
+- **How to prevent**: When using Commander.js negated boolean flags (`--no-*`), always check the property without the `no-` prefix. Add a test that verifies the flag actually works by calling the CLI with the flag and asserting the expected behavior.
+- **Source**: PRI-217 / PR #677 (Codex review)
+- **Date**: 2026-05-22
+- **Recurrence**: None
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 19 |
-| Last updated | 2026-05-21 |
+| Total lessons | 20 |
+| Last updated | 2026-05-22 |
 | Top category | Schema & Type |
 | Recurring errors | 11 |

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -86,7 +86,8 @@ Errors where AI assistants wrote code contradicting architecture docs or ADRs.
 
 | ID | Summary | Source |
 |----|---------|--------|
-| *(No entries yet)* | | |
+| ERR-021 | Handler-only tests miss Commander flag→opts mapping bugs | PRI-217 |
+| ERR-022 | process.exit(1) without return allows fallthrough to intake on failed diagnosis | PRI-217 |
 
 ---
 
@@ -96,7 +97,7 @@ Errors where AI assistants introduced security risks or bypassed safety checks.
 
 | ID | Summary | Source |
 |----|---------|--------|
-| *(No entries yet)* | | |
+| ERR-022 | process.exit(1) without return allows fallthrough to intake on failed diagnosis | PRI-217 |
 
 ---
 
@@ -106,7 +107,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 | ID | Summary | Source |
 |----|---------|--------|
-| *(No entries yet)* | | |
+| ERR-021 | Handler-only tests miss Commander flag→opts mapping bugs | PRI-217 |
 
 ---
 
@@ -348,9 +349,33 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-021]** | Handler-only tests miss Commander flag→opts mapping bugs
+
+- **What happened**: Added `--no-intake` CLI flag to `pd diagnose run`. All tests called `handleDiagnoseRun()` directly with manually constructed `opts` objects, bypassing Commander entirely. This hid two bugs: (1) Commander negated booleans strip the `no-` prefix, so `opts.noIntake` was always `undefined`; (2) `.option('--intake', ...)` does not auto-create `--no-intake`, so `pd diagnose run --no-intake` threw "unknown option".
+- **Why it's wrong**: Handler-level tests prove the handler logic works, but they don't prove the CLI flag actually reaches the handler with the correct property name and value. The gap between Commander parsing and handler invocation was completely untested.
+- **Correct approach**: When adding a new CLI flag, always add Commander wiring tests that: (1) parse the flag through Commander and capture the resulting opts; (2) verify the opts property name matches what the handler checks; (3) verify the default value when the flag is not passed.
+- **How to prevent**: Add a "Commander wiring test" checklist item to the PR template. Every new `.option()` must have a corresponding test that calls `program.parseAsync()` with the flag and asserts the opts shape.
+- **Source**: PRI-217 / PR #677
+- **Date**: 2026-05-22
+- **Recurrence**: None
+
+---
+
+**[ERR-022]** | process.exit(1) without return allows fallthrough to intake on failed diagnosis
+
+- **What happened**: In `handleDiagnoseRun()`, the `result.status !== 'succeeded'` branch called `process.exit(1)` without a subsequent `return`. When `process.exit` is stubbed in tests (or when the handler is called from embedded contexts), execution continues past the exit call into the candidate intake code, potentially writing ledger entries for a failed diagnosis.
+- **Why it's wrong**: `process.exit()` is not guaranteed to halt execution — it can be stubbed, intercepted, or the code may run in a non-Node context. Every `process.exit()` must be followed by `return` to ensure the function exits cleanly even if `process.exit` is no-op'd.
+- **Correct approach**: Always add `return;` after `process.exit()`. This is a defensive coding pattern that prevents fallthrough regardless of whether `process.exit` is intercepted.
+- **How to prevent**: Add an ESLint rule or lefthook check that flags `process.exit()` without a subsequent `return`. Alternatively, use a shared `fatalExit(code)` helper that always throws after exit.
+- **Source**: PRI-217 / PR #677
+- **Date**: 2026-05-22
+- **Recurrence**: None
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 20 |
+| Total lessons | 22 |
 | Last updated | 2026-05-22 |
 | Top category | Schema & Type |
 | Recurring errors | 11 |

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -50,7 +50,7 @@ interface DiagnoseRunOptions {
   baseUrl?: string;
   maxRetries?: number;
   timeoutMs?: number;
-  noIntake?: boolean;
+  intake?: boolean;
 }
 
 /**
@@ -310,7 +310,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     const intakeResults: { candidateId: string; ledgerEntryId?: string; status: string; error?: string; nextAction?: string }[] = [];
     let intakeFailed = false;
 
-    if (opts.noIntake) {
+    if (opts.intake === false) {
       for (const candidate of candidates) {
         intakeResults.push({
           candidateId: candidate.candidateId,
@@ -349,7 +349,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
       const jsonOutput = {
         ...result,
         intake: {
-          enabled: !opts.noIntake,
+          enabled: opts.intake !== false,
           candidates: intakeResults,
         },
       };
@@ -392,7 +392,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
       }
     }
 
-    if (opts.noIntake && candidates.length > 0) {
+    if (opts.intake === false && candidates.length > 0) {
       console.log(`\n  Note: --no-intake was set. Candidates remain at 'pending'.`);
       console.log(`  To intake manually:`);
       for (const c of candidates) {

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -72,6 +72,7 @@ export async function handleDiagnoseStatus(opts: DiagnoseStatusOptions): Promise
     if (!result) {
       console.error(`Task not found: ${opts.taskId}`);
       process.exit(1);
+      return;
     }
 
     if (opts.json) {
@@ -304,6 +305,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
         console.log('');
       }
       process.exit(1);
+      return;
     }
 
     const candidates = await stateManager.getCandidatesByTaskId(opts.taskId);

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -276,8 +276,10 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
       },
     );
 
-    console.log(`\nRunning diagnostician for task: ${opts.taskId}`);
-    console.log(`Workspace: ${workspaceDir}\n`);
+    if (!opts.json) {
+      console.log(`\nRunning diagnostician for task: ${opts.taskId}`);
+      console.log(`Workspace: ${workspaceDir}\n`);
+    }
 
     const result = await diagnoseRun({
       taskId: opts.taskId,
@@ -305,7 +307,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     }
 
     const candidates = await stateManager.getCandidatesByTaskId(opts.taskId);
-    const intakeResults: { candidateId: string; ledgerEntryId?: string; status: string; error?: string }[] = [];
+    const intakeResults: { candidateId: string; ledgerEntryId?: string; status: string; error?: string; nextAction?: string }[] = [];
     let intakeFailed = false;
 
     if (opts.noIntake) {
@@ -337,6 +339,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
             candidateId: candidate.candidateId,
             status: 'intake_failed',
             error: intakeErrorMessage,
+            nextAction: `pd candidate intake --candidate-id ${candidate.candidateId} --workspace "${workspaceDir}"`,
           });
         }
       }

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -21,11 +21,14 @@ import {
   PiAiRuntimeAdapter,
   PDRuntimeError,
   resolveRuntimeConfig,
+  CandidateIntakeService,
   run as diagnoseRun,
   status as diagnoseStatus,
 } from '@principles/core/runtime-v2';
 import type { PDRuntimeAdapter } from '@principles/core/runtime-v2';
+import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import * as path from 'path';
 
 interface DiagnoseStatusOptions {
   taskId: string;
@@ -47,6 +50,7 @@ interface DiagnoseRunOptions {
   baseUrl?: string;
   maxRetries?: number;
   timeoutMs?: number;
+  noIntake?: boolean;
 }
 
 /**
@@ -281,9 +285,73 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
       runner,
     });
 
+    if (result.status !== 'succeeded') {
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`\nResult:`);
+        console.log(`  Status:         ${result.status}`);
+        console.log(`  Task ID:        ${result.taskId}`);
+        if (result.errorCategory) {
+          console.log(`  Error Category: ${result.errorCategory}`);
+        }
+        if (result.failureReason) {
+          console.log(`  Failure Reason: ${result.failureReason}`);
+        }
+        console.log(`  Attempt Count:  ${result.attemptCount}`);
+        console.log('');
+      }
+      process.exit(1);
+    }
+
+    const candidates = await stateManager.getCandidatesByTaskId(opts.taskId);
+    const intakeResults: { candidateId: string; ledgerEntryId?: string; status: string; error?: string }[] = [];
+    let intakeFailed = false;
+
+    if (opts.noIntake) {
+      for (const candidate of candidates) {
+        intakeResults.push({
+          candidateId: candidate.candidateId,
+          status: 'skipped',
+        });
+      }
+    } else {
+      const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: path.join(workspaceDir, '.state') });
+      const intakeService = new CandidateIntakeService({ stateManager, ledgerAdapter });
+
+      for (const candidate of candidates) {
+        try {
+          const entry = await intakeService.intake(candidate.candidateId);
+          if (candidate.status !== 'consumed') {
+            await stateManager.updateCandidateStatus(candidate.candidateId, { status: 'consumed' });
+          }
+          intakeResults.push({
+            candidateId: candidate.candidateId,
+            ledgerEntryId: entry.id,
+            status: 'consumed',
+          });
+        } catch (intakeErr: unknown) {
+          intakeFailed = true;
+          const intakeErrorMessage = intakeErr instanceof Error ? intakeErr.message : String(intakeErr);
+          intakeResults.push({
+            candidateId: candidate.candidateId,
+            status: 'intake_failed',
+            error: intakeErrorMessage,
+          });
+        }
+      }
+    }
+
     if (opts.json) {
-      console.log(JSON.stringify(result, null, 2));
-      if (result.status !== 'succeeded') {
+      const jsonOutput = {
+        ...result,
+        intake: {
+          enabled: !opts.noIntake,
+          candidates: intakeResults,
+        },
+      };
+      console.log(JSON.stringify(jsonOutput, null, 2));
+      if (intakeFailed) {
         process.exit(1);
       }
       return;
@@ -305,16 +373,33 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
         }
       }
     }
-    if (result.errorCategory) {
-      console.log(`  Error Category: ${result.errorCategory}`);
-    }
-    if (result.failureReason) {
-      console.log(`  Failure Reason: ${result.failureReason}`);
-    }
     console.log(`  Attempt Count:  ${result.attemptCount}`);
+
+    if (intakeResults.length > 0) {
+      console.log(`\n  Candidate Intake:`);
+      for (const ir of intakeResults) {
+        if (ir.status === 'consumed') {
+          console.log(`    ${ir.candidateId}: consumed (ledger: ${ir.ledgerEntryId})`);
+        } else if (ir.status === 'skipped') {
+          console.log(`    ${ir.candidateId}: skipped (--no-intake)`);
+        } else if (ir.status === 'intake_failed') {
+          console.log(`    ${ir.candidateId}: INTAKE FAILED — ${ir.error}`);
+          console.log(`      Next action: pd candidate intake --candidate-id ${ir.candidateId} --workspace "${workspaceDir}"`);
+        }
+      }
+    }
+
+    if (opts.noIntake && candidates.length > 0) {
+      console.log(`\n  Note: --no-intake was set. Candidates remain at 'pending'.`);
+      console.log(`  To intake manually:`);
+      for (const c of candidates) {
+        console.log(`    pd candidate intake --candidate-id ${c.candidateId} --workspace "${workspaceDir}"`);
+      }
+    }
+
     console.log('');
 
-    if (result.status !== 'succeeded') {
+    if (intakeFailed) {
       process.exit(1);
     }
   } catch (error: unknown) {

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -281,7 +281,7 @@ diagnoseCmd
   .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
   .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
   .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)
-  .option('--no-intake', 'Skip candidate intake after successful diagnosis (candidates remain pending)')
+  .option('--intake', 'Auto-intake candidates after successful diagnosis (default: true). Use --no-intake to skip.')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleDiagnoseRun(opts);

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -281,7 +281,7 @@ diagnoseCmd
   .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
   .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
   .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)
-  .option('--intake', 'Auto-intake candidates after successful diagnosis (default: true). Use --no-intake to skip.')
+  .option('--no-intake', 'Skip candidate intake after successful diagnosis')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleDiagnoseRun(opts);

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -281,6 +281,7 @@ diagnoseCmd
   .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
   .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
   .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)
+  .option('--no-intake', 'Skip candidate intake after successful diagnosis (candidates remain pending)')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleDiagnoseRun(opts);

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -292,6 +292,7 @@ describe('pd diagnose run — auto-intake after success', () => {
     expect(parsed.intake.candidates[0].status).toBe('consumed');
     expect(parsed.intake.candidates[1].status).toBe('intake_failed');
     expect(parsed.intake.candidates[1].error).toContain('Ledger write failed');
+    expect(parsed.intake.candidates[1].nextAction).toContain('pd candidate intake --candidate-id cand-fail');
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     consoleSpy.mockRestore();
@@ -499,6 +500,59 @@ describe('pd diagnose run — auto-intake after success', () => {
     expect(allOutput).toContain('cand-1: consumed');
     expect(allOutput).toContain('ledger-1');
     expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-10: --json mode outputs exactly one console.log with parseable JSON (no text header leak)', async () => {
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const rawOutput = consoleSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(rawOutput);
+    expect(parsed.status).toBe('succeeded');
+    expect(parsed.intake).toBeDefined();
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-11: --json intake failure nextAction contains executable command with workspace', async () => {
+    const candidates = [
+      { candidateId: 'cand-err', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake.mockImplementation(() => { throw new Error('DB locked'); });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    const rawOutput = consoleSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(rawOutput);
+    const failed = parsed.intake.candidates[0];
+    expect(failed.status).toBe('intake_failed');
+    expect(failed.nextAction).toMatch(/^pd candidate intake --candidate-id cand-err --workspace "/);
+    expect(failed.nextAction).toContain('/tmp/fake-workspace');
+    expect(exitSpy).toHaveBeenCalledWith(1);
 
     consoleSpy.mockRestore();
     exitSpy.mockRestore();

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -313,7 +313,7 @@ describe('pd diagnose run — auto-intake after success', () => {
       workspace: '/tmp/fake-workspace',
       runtime: 'test-double',
       json: true,
-      noIntake: true,
+      intake: false,
     } as DiagnoseRunOptions);
 
     expect(mockIntake).not.toHaveBeenCalled();
@@ -351,7 +351,7 @@ describe('pd diagnose run — auto-intake after success', () => {
       workspace: '/tmp/fake-workspace',
       runtime: 'test-double',
       json: false,
-      noIntake: true,
+      intake: false,
     } as DiagnoseRunOptions);
 
     const allOutput = consoleSpy.mock.calls.map(call => call[0]).join('\n');

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -558,6 +558,35 @@ describe('pd diagnose run — auto-intake after success', () => {
     consoleSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  it('INTAKE-12: failed diagnosis does not trigger intake (process.exit stubbed)', async () => {
+    const { run } = await import('@principles/core/runtime-v2');
+    vi.mocked(run).mockResolvedValueOnce({
+      status: 'failed',
+      taskId: 'test-task-1',
+      errorCategory: 'timeout',
+      failureReason: 'LLM call timed out',
+      attemptCount: 3,
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(mockGetCandidatesByTaskId).not.toHaveBeenCalled();
+    expect(mockIntake).not.toHaveBeenCalled();
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 });
 
 describe('Commander wiring for --no-intake', () => {

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Use vi.hoisted for all mock factories that reference each other
-const { MockRuntimeStateManager } = vi.hoisted(() => {
+const { MockRuntimeStateManager, mockGetCandidatesByTaskId, mockUpdateCandidateStatus } = vi.hoisted(() => {
+  const mockGetCandidatesByTaskId = vi.fn().mockResolvedValue([]);
+  const mockUpdateCandidateStatus = vi.fn().mockResolvedValue(undefined);
+
   class MockRuntimeStateManager {
     initialize = vi.fn().mockResolvedValue(undefined);
     close = vi.fn().mockResolvedValue(undefined);
@@ -12,19 +14,36 @@ const { MockRuntimeStateManager } = vi.hoisted(() => {
       maxAttempts: 3,
       lastError: null,
     });
+    getCandidatesByTaskId = mockGetCandidatesByTaskId;
+    updateCandidateStatus = mockUpdateCandidateStatus;
     connection = {} as Record<string, unknown>;
     taskStore = {};
     runStore = {};
   }
-  return { MockRuntimeStateManager };
+  return { MockRuntimeStateManager, mockGetCandidatesByTaskId, mockUpdateCandidateStatus };
 }, { validateType: true });
 
-// Mock resolveWorkspaceDir FIRST before any other imports
+const { mockIntake, MockCandidateIntakeService } = vi.hoisted(() => {
+  const mockIntake = vi.fn();
+  function MockCandidateIntakeService(this: any) {
+    return { intake: mockIntake };
+  }
+  MockCandidateIntakeService.prototype = {};
+  return { mockIntake, MockCandidateIntakeService };
+});
+
+const { MockPrincipleTreeLedgerAdapter } = vi.hoisted(() => {
+  function MockPrincipleTreeLedgerAdapter(this: any) {
+    return {};
+  }
+  MockPrincipleTreeLedgerAdapter.prototype = {};
+  return { MockPrincipleTreeLedgerAdapter };
+});
+
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
 }));
 
-// Mock @principles/core/runtime-v2
 vi.mock('@principles/core/runtime-v2', () => {
   return {
     RuntimeStateManager: vi.fn().mockImplementation(function () {
@@ -48,6 +67,7 @@ vi.mock('@principles/core/runtime-v2', () => {
         this.name = 'PDRuntimeError';
       }
     },
+    CandidateIntakeService: MockCandidateIntakeService,
     run: vi.fn().mockResolvedValue({
       status: 'succeeded',
       taskId: 'test-task-1',
@@ -67,29 +87,39 @@ vi.mock('@principles/core/runtime-v2', () => {
   };
 });
 
-// Import the command handler AFTER mocks are set up
+vi.mock('../../src/principle-tree-ledger-adapter.js', () => ({
+  PrincipleTreeLedgerAdapter: MockPrincipleTreeLedgerAdapter,
+}));
+
 import { handleDiagnoseRun, type DiagnoseRunOptions } from '../../src/commands/diagnose.js';
+
+const SUCCEEDED_RESULT = {
+  status: 'succeeded' as const,
+  taskId: 'test-task-1',
+  output: {
+    valid: true,
+    diagnosisId: 'diag-123',
+    taskId: 'test-task-1',
+    summary: 'Test diagnosis summary',
+    rootCause: 'Test: test root cause',
+    violatedPrinciples: [],
+    evidence: [],
+    recommendations: [
+      { kind: 'principle', description: 'Always validate tool arguments before execution' },
+    ],
+    confidence: 0.9,
+  },
+  attemptCount: 1,
+};
 
 describe('pd diagnose run --runtime routing', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Re-setup run mock for each test
     const { run } = await import('@principles/core/runtime-v2');
-    vi.mocked(run).mockResolvedValue({
-      status: 'succeeded',
-      taskId: 'test-task-1',
-      output: {
-        valid: true,
-        diagnosisId: 'diag-123',
-        taskId: 'test-task-1',
-        summary: 'Test diagnosis summary',
-        rootCause: 'Test: test root cause',
-        violatedPrinciples: [],
-        evidence: [],
-        recommendations: [],
-        confidence: 0.9,
-      },
-    });
+    vi.mocked(run).mockResolvedValue(SUCCEEDED_RESULT);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockIntake.mockReset();
   });
 
   it('CLI-01: --runtime test-double routes to TestDoubleRuntimeAdapter (regression)', async () => {
@@ -163,10 +193,314 @@ describe('pd diagnose run --runtime routing', () => {
       json: true,
     } as DiagnoseRunOptions);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith("error: unknown runtime kind 'invalid-runtime'");
+    expect(consoleErrorSpy).toHaveBeenCalledWith("error: unknown runtime kind 'invalid-runtime' (supported: openclaw-cli, test-double, pi-ai)");
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+describe('pd diagnose run — auto-intake after success', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { run } = await import('@principles/core/runtime-v2');
+    vi.mocked(run).mockResolvedValue(SUCCEEDED_RESULT);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockIntake.mockReset();
+  });
+
+  it('INTAKE-01: successful diagnose + intake — candidates consumed, JSON includes intake evidence', async () => {
+    const candidates = [
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+      { candidateId: 'cand-2', artifactId: 'art-2', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake
+      .mockResolvedValueOnce({ id: 'ledger-1', title: 'Principle 1', status: 'probation' })
+      .mockResolvedValueOnce({ id: 'ledger-2', title: 'Principle 2', status: 'probation' });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(mockIntake).toHaveBeenCalledTimes(2);
+    expect(mockIntake).toHaveBeenCalledWith('cand-1');
+    expect(mockIntake).toHaveBeenCalledWith('cand-2');
+    expect(mockUpdateCandidateStatus).toHaveBeenCalledTimes(2);
+    expect(mockUpdateCandidateStatus).toHaveBeenCalledWith('cand-1', { status: 'consumed' });
+    expect(mockUpdateCandidateStatus).toHaveBeenCalledWith('cand-2', { status: 'consumed' });
+
+    const jsonOutput = consoleSpy.mock.calls.find(call => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.intake && Array.isArray(parsed.intake.candidates);
+      } catch { return false; }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.intake.enabled).toBe(true);
+    expect(parsed.intake.candidates).toHaveLength(2);
+    expect(parsed.intake.candidates[0].candidateId).toBe('cand-1');
+    expect(parsed.intake.candidates[0].status).toBe('consumed');
+    expect(parsed.intake.candidates[0].ledgerEntryId).toBe('ledger-1');
+    expect(parsed.intake.candidates[1].candidateId).toBe('cand-2');
+    expect(parsed.intake.candidates[1].status).toBe('consumed');
+    expect(parsed.intake.candidates[1].ledgerEntryId).toBe('ledger-2');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-02: successful diagnose + intake failure — exits non-zero with nextAction', async () => {
+    const candidates = [
+      { candidateId: 'cand-ok', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+      { candidateId: 'cand-fail', artifactId: 'art-2', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake
+      .mockResolvedValueOnce({ id: 'ledger-ok', title: 'OK', status: 'probation' })
+      .mockImplementationOnce(() => { throw new Error('Ledger write failed'); });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    const jsonOutput = consoleSpy.mock.calls.find(call => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.intake && Array.isArray(parsed.intake.candidates);
+      } catch { return false; }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.intake.candidates).toHaveLength(2);
+    expect(parsed.intake.candidates[0].status).toBe('consumed');
+    expect(parsed.intake.candidates[1].status).toBe('intake_failed');
+    expect(parsed.intake.candidates[1].error).toContain('Ledger write failed');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-03: --no-intake skips intake, candidates remain pending with advisory', async () => {
+    const candidates = [
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+      noIntake: true,
+    } as DiagnoseRunOptions);
+
+    expect(mockIntake).not.toHaveBeenCalled();
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled();
+
+    const jsonOutput = consoleSpy.mock.calls.find(call => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.intake && Array.isArray(parsed.intake.candidates);
+      } catch { return false; }
+    });
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.intake.enabled).toBe(false);
+    expect(parsed.intake.candidates).toHaveLength(1);
+    expect(parsed.intake.candidates[0].candidateId).toBe('cand-1');
+    expect(parsed.intake.candidates[0].status).toBe('skipped');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-04: --no-intake human-readable output shows advisory with manual intake commands', async () => {
+    const candidates = [
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: false,
+      noIntake: true,
+    } as DiagnoseRunOptions);
+
+    const allOutput = consoleSpy.mock.calls.map(call => call[0]).join('\n');
+    expect(allOutput).toContain('--no-intake');
+    expect(allOutput).toContain('pd candidate intake --candidate-id cand-1');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-05: intake failure human-readable output shows nextAction', async () => {
+    const candidates = [
+      { candidateId: 'cand-fail', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake.mockImplementation(() => { throw new Error('Ledger write failed'); });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: false,
+    } as DiagnoseRunOptions);
+
+    const allOutput = consoleSpy.mock.calls.map(call => call[0]).join('\n');
+    expect(allOutput).toContain('INTAKE FAILED');
+    expect(allOutput).toContain('Next action: pd candidate intake --candidate-id cand-fail');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-06: does not bypass ledger — consumed only set after intake succeeds', async () => {
+    const candidates = [
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake.mockImplementation(() => { throw new Error('Ledger write failed'); });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(mockIntake).toHaveBeenCalledWith('cand-1');
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-07: already-consumed candidate — intake called but updateCandidateStatus skipped', async () => {
+    const candidates = [
+      { candidateId: 'cand-consumed', artifactId: 'art-1', taskId: 'test-task-1', status: 'consumed' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake.mockResolvedValue({ id: 'ledger-existing', title: 'Existing', status: 'probation' });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(mockIntake).toHaveBeenCalledWith('cand-consumed');
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled();
+
+    const jsonOutput = consoleSpy.mock.calls.find(call => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.intake && Array.isArray(parsed.intake.candidates);
+      } catch { return false; }
+    });
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.intake.candidates[0].status).toBe('consumed');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-08: no candidates produced — intake not called, output shows empty intake', async () => {
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(mockIntake).not.toHaveBeenCalled();
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled();
+
+    const jsonOutput = consoleSpy.mock.calls.find(call => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.intake;
+      } catch { return false; }
+    });
+    const parsed = JSON.parse((jsonOutput as [string])[0]);
+    expect(parsed.intake.candidates).toHaveLength(0);
+    expect(parsed.intake.enabled).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INTAKE-09: successful diagnose + intake — human-readable output shows consumed candidates', async () => {
+    const candidates = [
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+    mockIntake.mockResolvedValue({ id: 'ledger-1', title: 'Principle 1', status: 'probation' });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: false,
+    } as DiagnoseRunOptions);
+
+    const allOutput = consoleSpy.mock.calls.map(call => call[0]).join('\n');
+    expect(allOutput).toContain('Candidate Intake');
+    expect(allOutput).toContain('cand-1: consumed');
+    expect(allOutput).toContain('ledger-1');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
     exitSpy.mockRestore();
   });
 });

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
 
 const { MockRuntimeStateManager, mockGetCandidatesByTaskId, mockUpdateCandidateStatus } = vi.hoisted(() => {
   const mockGetCandidatesByTaskId = vi.fn().mockResolvedValue([]);
@@ -556,5 +557,43 @@ describe('pd diagnose run — auto-intake after success', () => {
 
     consoleSpy.mockRestore();
     exitSpy.mockRestore();
+  });
+});
+
+describe('Commander wiring for --no-intake', () => {
+  function createDiagnoseProgram(): { program: Command; capturedOpts: Record<string, unknown> } {
+    const program = new Command();
+    program.exitOverride();
+    const capturedOpts: Record<string, unknown> = {};
+
+    program
+      .command('diagnose')
+      .command('run')
+      .option('--no-intake', 'Skip candidate intake after successful diagnosis')
+      .option('--json', 'Output raw JSON')
+      .action(async (opts) => {
+        Object.assign(capturedOpts, opts);
+      });
+
+    return { program, capturedOpts };
+  }
+
+  it('CMD-01: --no-intake accepted, sets opts.intake === false', async () => {
+    const { program, capturedOpts } = createDiagnoseProgram();
+    await program.parseAsync(['node', 'pd', 'diagnose', 'run', '--no-intake']);
+    expect(capturedOpts.intake).toBe(false);
+  });
+
+  it('CMD-02: default (no flag) → opts.intake === true', async () => {
+    const { program, capturedOpts } = createDiagnoseProgram();
+    await program.parseAsync(['node', 'pd', 'diagnose', 'run']);
+    expect(capturedOpts.intake).toBe(true);
+  });
+
+  it('CMD-03: --intake is not a valid option (Commander rejects it)', async () => {
+    const { program } = createDiagnoseProgram();
+    await expect(
+      program.parseAsync(['node', 'pd', 'diagnose', 'run', '--intake'])
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Why PRI-216 exposed this gap

PRI-216 live validation found that `pd diagnose run` creates Diagnostician candidates but leaves them at `pending` status indefinitely. Production DB showed candidates created at 04:28:36 but not consumed until 04:56:37 after manual intake — a **28-minute workflow gap** where the pipeline was stalled.

The `PainSignalBridge` path (used by `pd pain record`) correctly performs intake-then-consume when `autoIntakeEnabled=true`, but the `pd diagnose run` CLI path (which uses `DiagnosticianRunner` directly) had no intake step at all.

## CLI default chosen

**Auto-intake ON by default.** After `diagnoseRun()` succeeds, the CLI handler automatically:
1. Queries candidates via `stateManager.getCandidatesByTaskId(taskId)`
2. Calls `CandidateIntakeService.intake(candidateId)` for each candidate
3. Updates candidate status to `consumed` (only after intake succeeds)

**`--no-intake` escape hatch** is available for debugging/advanced use. When set, candidates remain at `pending` with a clear advisory message telling the operator exactly what command to run next.

## Candidate status transition semantics

```
pending → (intake succeeds) → consumed
pending → (intake fails)    → pending + error + nextAction
pending → (--no-intake)     → pending + advisory
consumed → (re-run)         → consumed (idempotent, no duplicate update)
```

Key invariant preserved: **`consumed` status is ONLY set after `CandidateIntakeService.intake()` succeeds and creates a ledger entry.** Never bypass the ledger.

## Why DiagnosticianRunner was NOT changed

`DiagnosticianRunner` is a lower-level component that should not know about intake semantics. Intake is a CLI/operator workflow concern — the runner produces candidates, the CLI handler decides what to do with them. This matches the architecture boundary (ERR-011: CLI does I/O orchestration, core stays pure).

## Tests run and results

```
npx vitest run packages/pd-cli/tests/commands/diagnose.test.ts
✓ 13 tests passed (9 new intake tests + 4 existing routing tests)

npx vitest run packages/pd-cli/tests/commands/candidate-intake.test.ts
✓ 11 tests passed (unchanged)

npm run verify:merge
✓ All gates passed (lint, build, typecheck)
```

### New test coverage

| Test | Scenario |
|------|----------|
| INTAKE-01 | Successful diagnose + intake (JSON output with intake evidence) |
| INTAKE-02 | Diagnose success + intake failure (exits non-zero, structured error) |
| INTAKE-03 | `--no-intake` skips intake (JSON shows skipped status) |
| INTAKE-04 | `--no-intake` human-readable advisory with manual intake commands |
| INTAKE-05 | Intake failure human-readable output shows nextAction |
| INTAKE-06 | Does NOT bypass ledger — consumed only set after intake succeeds |
| INTAKE-07 | Already-consumed candidate — intake called, updateCandidateStatus skipped |
| INTAKE-08 | No candidates produced — intake not called, empty intake in output |
| INTAKE-09 | Successful diagnose + intake — human-readable output shows consumed |

## Confirmation

- ✅ `DiagnosticianRunner` was NOT modified
- ✅ `DiagnosticianOutputV1` was NOT modified
- ✅ No frozen legacy files modified
- ✅ No core package changes (all changes in pd-cli)

## Remaining risk

- **Partial intake failure**: If candidate A intakes successfully but candidate B fails, candidate A is consumed while B remains pending. The command exits non-zero with a clear nextAction for B. This is the correct behavior — partial progress is better than all-or-nothing rollback.
- **`--no-intake` discoverability**: The flag is documented in `--help` and in the CLI description, but operators must know it exists. Default behavior (auto-intake) is the safe choice.

## Error Handbook checklist

| ERR | Mitigation |
|-----|------------|
| ERR-002 | Intake failure → fail loud (non-zero exit + nextAction), never silent pending |
| ERR-011 | Changes only in CLI handler, using existing CandidateIntakeService + PrincipleTreeLedgerAdapter |
| ERR-012 | Branch based on latest origin/main (verified before branching) |
| ERR-018/019 | No loop scenario — intake is single-shot, result is fresh from service call |

Closes: PRI-217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 诊断成功后自动执行候选接入（默认启用），将接入汇总并入输出；新增可通过命令行关闭的开关（--no-intake）。
* **Bug Fixes**
  * 仅对未被标记为已消耗的候选执行接入与状态更新；接入任一失败会记录原因并以非零退出码结束。
  * 非 JSON 输出中增加可读的接入失败提示与手动接入命令；JSON 输出包含接入状态与候选详情。
* **Tests**
  * 补充覆盖自动接入、失败处理、跳过已消耗候选、--no-intake 与 JSON 输出等行为的回归测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->