### PR TITLE
docs: harden AI PR review workflow

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -5,7 +5,7 @@ description: Deep PR code review with automated issue detection, reviewer feedba
 
 # PR Review
 
-Deep PR code review with 7-phase workflow covering parallel info fetch, diff-based review, triage, fix, verify, push, and CI gate check.
+Deep PR code review with an iterative fetch → triage → fix → verify → push → re-fetch loop. The goal is to remove the user from the reviewer-comment relay path: once invoked on a PR, the reviewer agent must fetch comments itself, fix every valid P0/P1/P2 issue, push, and re-check until no blocking findings remain.
 
 ## When to Trigger
 
@@ -18,20 +18,30 @@ Deep PR code review with 7-phase workflow covering parallel info fetch, diff-bas
 
 ### Phase 1: Gather
 
-Fetch PR info in parallel:
-- PR diff (`gh pr diff`)
-- PR metadata (`gh pr view --json`)
-- Reviewer comments (`gh api repos/{owner}/{repo}/pulls/{number}/comments`)
-- CI status (`gh pr checks`)
-- Changed files list
+Fetch PR info in parallel. Retry GitHub API failures at least 2 times before asking the user to paste comments:
+- PR diff (`gh pr diff <PR>`)
+- Changed files (`gh pr diff <PR> --name-only`)
+- PR metadata (`gh pr view <PR> --json comments,reviews,latestReviews,files,statusCheckRollup,mergeable,headRefName,baseRefName`)
+- Review comments (`gh api repos/:owner/:repo/pulls/<PR>/comments --paginate`)
+- Issue comments (`gh api repos/:owner/:repo/issues/<PR>/comments --paginate`)
+- CI status (`gh pr checks <PR>` or the `statusCheckRollup` payload)
+
+Stop early and report if the PR diff contains unrelated files or stale-main rollback risk.
 
 ### Phase 2: Triage Review Comments
 
 Classify each reviewer comment:
-- **Real bug**: Must fix — code is incorrect or breaks functionality
-- **Style preference**: Optional — suggest but don't block
-- **Misunderstanding**: Respond with explanation, no code change needed
+- **P0/P1/P2 real bug**: Must fix — code is incorrect, unsafe, unobservable, or breaks project contracts
+- **P3/nit/style preference**: Optional — fix if cheap, otherwise defer with reason
+- **Duplicate**: Already fixed or covered by another finding
+- **Misunderstanding**: No code change; respond with exact code/test evidence
 - **AI coding error**: If the error was made by an AI assistant → invoke `record-error` skill after fixing
+
+Maintain a review ledger in the final report:
+- total comments fetched
+- valid fixed
+- deferred with reason
+- duplicates/misunderstandings with evidence
 
 ### Phase 3: Deep Diff Review
 
@@ -43,6 +53,14 @@ Review the diff against a structured checklist:
 - Performance: N+1 queries, unnecessary re-renders, blocking operations
 - Testing: Missing tests for changed behavior
 
+For CLI/operator changes under `packages/pd-cli/src/commands/**` or CLI registration, also apply the CLI gate:
+- `--json` emits exactly one parseable JSON object on stdout
+- every `process.exit(...)` path immediately `return`s or throws
+- failure paths do not continue into DB/ledger/artifact side effects when `process.exit` is stubbed
+- Commander `--no-*`, `--dry-run`, and `--confirm` behavior has parser or command-registration tests
+- failed/degraded/refused JSON outputs include structured reason and nextAction
+- state mutation happens through the intended service path, not direct status flipping
+
 ### Phase 4: Fix Real Issues
 
 Fix only real bugs and required changes:
@@ -51,23 +69,33 @@ Fix only real bugs and required changes:
 3. Add regression tests for each fix
 4. Run local build + lint + typecheck
 
+Do not expand scope. Do not refactor adjacent code unless required to fix the finding. Do not touch frozen legacy files unless the user explicitly approves.
+
 ### Phase 5: Verify
 
-Run the full verification suite:
+Run the relevant verification suite first, then the repository merge gate when available:
 ```bash
-npm run build && npm run test && npm run lint
+npm run verify:merge
 ```
 
 If failures: fix and re-verify until green.
 
-### Phase 6: Push & CI Gate
+For narrow local debugging, run the smallest test command that covers the fix before the full gate.
+
+### Phase 6: Push, Re-fetch, and CI Gate
 
 ```bash
 git push
-gh pr checks --watch
+gh pr view <PR> --json comments,reviews,latestReviews,files,statusCheckRollup
+gh api repos/:owner/:repo/pulls/<PR>/comments --paginate
+gh api repos/:owner/:repo/issues/<PR>/comments --paginate
+gh pr checks <PR>
 ```
 
-Wait for CI to pass. If CI fails: read logs, fix, push again.
+After every push, re-fetch comments and checks. If new valid P0/P1/P2 comments appear, return to Phase 2. A PR is not ready until:
+- no valid unresolved P0/P1/P2 comments remain
+- required CI checks are green, or any failing check is explained as unrelated infrastructure
+- the final report states that comments were re-fetched after the last push
 
 ### Phase 6.5: Record Errors (MANDATORY)
 
@@ -88,10 +116,14 @@ Steps:
 ### Phase 7: Report
 
 Summarize:
+- PR URL and issue ID
+- Review loop counts: comments fetched, valid fixed, deferred, duplicates/misunderstandings
 - Issues found and fixed
-- Issues deferred (with reason)
-- CI status
-- Remaining reviewer comments to address
+- Issues deferred, with reason and follow-up if needed
+- Tests and CI status
+- For CLI/operator PRs: JSON-only stdout, exit-path, flag-wiring, and failure no-mutation evidence
+- Whether `record-error` was invoked, or "No real issues found — skipping record-error"
+- Remaining risk
 
 **Do NOT merge the PR.** User merges manually.
 
@@ -108,8 +140,11 @@ When Phase 2 or 3 identifies an AI coding error:
 - [ ] PR diff and metadata gathered
 - [ ] Reviewer comments triaged
 - [ ] Deep diff review completed
+- [ ] CLI/operator gate applied when relevant
 - [ ] Real issues fixed with regression tests
 - [ ] Build + lint + test pass locally
+- [ ] Changes pushed
+- [ ] PR comments and checks re-fetched after the last push
 - [ ] CI gate passes
 - [ ] Real issues recorded via `record-error` (Phase 6.5) — or explicitly noted "no real issues"
 - [ ] Report delivered

--- a/.agents/skills/record-error/SKILL.md
+++ b/.agents/skills/record-error/SKILL.md
@@ -5,7 +5,7 @@ description: Record AI coding assistant errors into the Error Experience Handboo
 
 # Record Error
 
-Record AI coding assistant errors into `docs/ERROR_EXPERIENCE_HANDBOOK.md` so all AI assistants learn from past mistakes.
+Record AI coding assistant errors into `docs/ERROR_EXPERIENCE_HANDBOOK.md` so all AI assistants learn from past mistakes. The handbook is a compact pattern library, not an incident log. Prefer updating an existing generalized lesson over adding a new one.
 
 ## Trigger Conditions
 
@@ -16,32 +16,100 @@ Record AI coding assistant errors into `docs/ERROR_EXPERIENCE_HANDBOOK.md` so al
 
 ## Workflow
 
-### Step 1: Classify
+### Step 1: Normalize the Incident
 
-Read the error category table in `references/categories.md` and assign one of:
+Write the incident in one sentence:
+
+```text
+The assistant <action> in <context>, which caused <risk>.
+```
+
+Then extract the generalized failure mode:
+
+```text
+When <general condition>, assistants must <preventive rule>, otherwise <general risk>.
+```
+
+Do not proceed until the failure mode is broader than a single file, function, or PR.
+
+### Step 2: Similarity and Recurrence Gate
+
+Before assigning a new number, read:
+- `docs/ERROR_EXPERIENCE_HANDBOOK.md`
+- `references/categories.md`
+- `references/entry-format.md`
+
+Search existing entries for:
+- same violated invariant
+- same missing validation pattern
+- same workflow failure
+- same prevention rule
+- same affected boundary or contract
+
+Choose exactly one action:
+
+1. **Update recurrence** — if an existing ERR already teaches the same prevention rule.
+2. **Broaden existing entry** — if an existing ERR is too narrow but covers the same root cause.
+3. **Add new ERR** — only if the prevention rule is materially different from all existing entries.
+
+New ERR entries are forbidden when they only change the file name, command name, or symptom while sharing the same root cause.
+
+### Step 3: Quality Gate
+
+Every new or updated lesson must pass all checks:
+
+- **Generalized**: title names the failure mode, not just the incident.
+- **Actionable**: "How to prevent" can be checked during PR review in under 30 seconds.
+- **Testable**: includes a regression test or static guard that would catch recurrence.
+- **Bounded**: one root cause per entry; one new ERR per root cause per PR.
+- **Linked**: references related ERR IDs when this belongs to a pattern group.
+- **Non-duplicative**: explains why this is not covered by an existing ERR, or updates that ERR instead.
+
+If these checks fail, do not add a new ERR. Update recurrence or broaden an existing entry.
+
+### Step 4: Classify
+
+Read the error category table in `references/categories.md` and assign one primary category:
 1. Architecture Boundary | 2. Missing Tests | 3. Schema & Type | 4. Doc & Spec Drift | 5. Security | 6. Process & Workflow
 
-### Step 2: Assign Number
+If the incident spans categories, choose the category of the prevention rule, not the symptom.
+
+### Step 5: Assign Number (Only for New ERR)
 
 Read handbook Statistics section. Next = `ERR-{total+1}`, zero-padded to at least 3 digits (ERR-001 through ERR-999). If total exceeds 999, extend to 4 digits (ERR-1000).
 
-### Step 3: Linear Comment
+If updating recurrence or broadening an existing entry, keep the existing ERR number.
+
+### Step 6: Linear Comment
 
 Add comment on the related Linear issue using the entry format in `references/entry-format.md`. Use the Linear MCP save_comment tool with the issue ID.
 
-### Step 4: Tag Issue
+### Step 7: Tag Issue
 
 Add `lesson-learned` label via the Linear MCP save_issue tool with `labels: ["lesson-learned"]`.
 
-### Step 5: Edit Handbook
+### Step 8: Edit Handbook
 
 Edit `docs/ERROR_EXPERIENCE_HANDBOOK.md`:
 
-1. Add row to the relevant category table: `| ERR-XXX | <summary> | <issue ID> |`
-2. Add detailed entry in "Detailed Entries" section (use format from Step 3)
-3. Update Statistics: increment Total lessons, update Last updated, update Top category if needed, increment Recurring errors if recurrence
+For a new ERR:
+1. Add row to the relevant category table: `| ERR-XXX | <generalized summary> | <issue ID> |`
+2. Add detailed entry in "Detailed Entries" section using `references/entry-format.md`
+3. Update Statistics: increment Total lessons, update Last updated, update Top category if needed
 
-### Step 6: Commit & PR
+For recurrence:
+1. Update the existing detailed entry's `Recurrence` field with date, issue, and short note
+2. Add the source issue to the category row if useful
+3. Update Statistics: Last updated and Recurring errors
+
+For broadening:
+1. Rename the summary if needed to make it less incident-specific
+2. Update "How to prevent" to cover the broader rule
+3. Add the new incident to Recurrence
+
+Do not create multiple entries for several comments that share one root cause. Group them into one generalized entry.
+
+### Step 9: Commit & PR
 
 ```bash
 git checkout -b docs/err-XXX
@@ -57,16 +125,22 @@ gh pr create --title "docs: add ERR-XXX to error experience handbook" --body "Re
 
 When pr-review triage finds an AI error:
 1. Complete the pr-review fix cycle first
-2. Then invoke record-error to capture the lesson
-3. pr-review fixes the immediate issue; record-error prevents recurrence
+2. Group all review findings by root cause
+3. Invoke record-error once per root cause, not once per comment
+4. Prefer recurrence updates over new ERR entries when the prevention rule already exists
+5. pr-review fixes the immediate issue; record-error prevents recurrence
 
 ## Checklist
 
-- [ ] Error classified (category 1-6)
-- [ ] ERR-XXX assigned (sequential, zero-padded)
+- [ ] Incident normalized into a generalized failure mode
+- [ ] Existing ERR entries checked for same root cause/prevention rule
+- [ ] Decision made: recurrence update, broaden existing, or new ERR
+- [ ] Quality gate passed (generalized, actionable, testable, bounded, linked, non-duplicative)
+- [ ] Error classified by prevention rule (category 1-6)
+- [ ] ERR-XXX assigned only if new entry is justified
 - [ ] Linear comment added (full entry format)
 - [ ] `lesson-learned` label applied
-- [ ] Category table row added
-- [ ] Detailed entry added
+- [ ] Category table row added or existing row updated
+- [ ] Detailed entry added or recurrence/broadening updated
 - [ ] Statistics updated
 - [ ] Commit + PR created (NOT merged)

--- a/.agents/skills/record-error/references/categories.md
+++ b/.agents/skills/record-error/references/categories.md
@@ -3,8 +3,12 @@
 | Category | Description | Examples |
 |----------|-------------|----------|
 | 1. Architecture Boundary | Violated core/plugin boundary or architectural constraints | Put I/O logic in core, put pure logic in plugin |
-| 2. Missing Tests & Verification | Skipped required testing or verification steps | Didn't run tests, didn't add regression test |
+| 2. Missing Tests & Verification | Skipped required testing or verification steps | Didn't run tests, didn't add regression test, tested handler but not CLI parser wiring |
 | 3. Schema & Type Mistakes | Incorrect schemas, missed type safety, broke type contracts | Used `any`, wrong interface shape |
 | 4. Documentation & Spec Drift | Code contradicts architecture docs or ADRs | Ignored ADR-0005, wrote code against documented decision |
 | 5. Security & Safety | Introduced security risks or bypassed safety checks | Hardcoded secrets, skipped auth check |
-| 6. Process & Workflow | Didn't read context, didn't follow workflow | Skipped handbook, didn't check graphify first |
+| 6. Process & Workflow | Didn't read context or failed to follow review/operation workflow | Skipped handbook, didn't check graphify first, stopped after first push without re-fetching PR comments |
+
+## Classification Rule
+
+Classify by the prevention rule, not by the symptom. For example, a CLI flag bug caused by missing parser tests belongs to "Missing Tests & Verification"; a CLI flag bug caused by misunderstanding Commander's negated boolean semantics belongs to "Schema & Type Mistakes" or "Process & Workflow" only if the prevention rule is type validation or workflow enforcement.

--- a/.agents/skills/record-error/references/entry-format.md
+++ b/.agents/skills/record-error/references/entry-format.md
@@ -7,9 +7,18 @@ Use this format for Linear comments and handbook detailed entries:
 
 - **What happened**: <what the AI assistant did wrong>
 - **Why it's wrong**: <violated constraint, unread doc, or root cause>
+- **Generalized failure mode**: When <general condition>, assistants must <preventive rule>, otherwise <general risk>
 - **Correct approach**: <what should have been done instead>
-- **How to prevent**: <concrete check or rule>
+- **How to prevent**: <concrete check or rule that can be applied during PR review>
+- **Regression guard**: <test/static check/review checklist item that catches recurrence>
+- **Related ERRs**: <existing ERR IDs in the same pattern group, or "None">
 - **Source**: <Linear issue ID, e.g., PRI-147>
 - **Date**: <YYYY-MM-DD>
 - **Recurrence**: <if same pattern recurred, note date and issue>
 ```
+
+Quality requirements:
+
+- The summary must describe the reusable failure mode, not just the file or PR.
+- "How to prevent" must be actionable in under 30 seconds.
+- Do not add a new ERR if an existing entry has the same prevention rule; update recurrence instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,18 @@ All code that handles untrusted data (parsed JSON, LLM output, DB `diagnosticJso
 
 **Enforcement**: Code review must check every rule that applies to the changed code. If a rule is N/A, state why.
 
+## CLI / Operator Command Gate
+
+Apply this gate to every change touching `packages/pd-cli/src/commands/**`, CLI registration, remediation commands, queue/run commands, or operator workflows.
+
+1. **JSON mode is strict**: `--json` output must be exactly one parseable JSON object on stdout. No banners, headings, explanatory text, or mixed stdout logs.
+2. **Exit paths must stop execution**: after `process.exit(...)` inside an async handler, immediately `return` or throw. Tests that stub `process.exit` must prove no later DB/ledger/artifact side effects happen.
+3. **Negated flags need parser tests**: Commander `--no-*` flags must be registered as `--no-name` and read as `opts.name === false`. Add parser-level tests, not only handler tests.
+4. **Dry-run/confirm semantics are mandatory**: commands that can mutate state must default to dry-run unless the established command contract says otherwise. `--dry-run` and `--confirm` must be mutually exclusive when both exist.
+5. **Failure paths must not mutate state**: failed diagnoses, failed validation, unsupported runners, missing input, and non-succeeded upstream stages must not intake, enqueue, write artifacts, update ledger, or create successors.
+6. **Operator output needs next action**: every degraded/refused/failed CLI result must include a structured reason and next action in JSON output.
+7. **Test the real command wiring**: when behavior depends on Commander options, add a command-registration or parser test that exercises the actual flags.
+
 ## Build & Test
 
 ```bash
@@ -90,6 +102,12 @@ The `record-error` skill handles: classify → number → Linear comment → tag
 
 Before handing off a PR (pushing, creating PR, or reporting completion), execute this checklist:
 
+**Self-review/fix loop**
+- A PR is not ready just because code was pushed. It is ready only after the fetch → fix → verify → re-fetch loop has no valid unresolved P0/P1/P2 findings and required checks are green.
+- After every push that addresses review feedback, fetch PR reviews/comments/checks again. Do not ask the user to relay comments unless GitHub API access fails after at least 2 retries.
+- Classify each review comment as: fixed, deferred with reason, duplicate, or misunderstanding with evidence. Put this classification in the PR comment or completion report.
+- If a real bug was found, run the Error Recording workflow before final handoff.
+
 **Fetch and resolve PR comments**
 - `gh pr view <PR> --json comments,reviews,latestReviews,files,statusCheckRollup`
 - `gh api repos/:owner/:repo/pulls/<PR>/comments --paginate`
@@ -112,8 +130,9 @@ Before handing off a PR (pushing, creating PR, or reporting completion), execute
 **Final summary**
 Include in the PR body or completion report:
 - Relevant ERR checklist (which ERR entries were considered and how avoided)
-- PR comments handled (count and resolution)
+- PR comments handled (total fetched, valid fixed, deferred, duplicates/misunderstandings)
 - Tests run (which commands, what results)
+- For CLI/operator changes: JSON-mode check, exit-path check, flag-wiring tests, and mutation/no-mutation evidence
 - Remaining risk (known issues, skipped coverage, trade-offs)
 
 ## Key Files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,18 @@ All code that handles untrusted data (parsed JSON, LLM output, DB `diagnosticJso
 
 **Enforcement**: Code review must check every rule that applies to the changed code. If a rule doesn't apply, state why.
 
+## CLI / Operator Command Gate
+
+Apply this gate to every change touching `packages/pd-cli/src/commands/**`, CLI registration, remediation commands, queue/run commands, or operator workflows.
+
+1. **JSON mode is strict**: `--json` output must be exactly one parseable JSON object on stdout. No banners, headings, explanatory text, or mixed stdout logs.
+2. **Exit paths must stop execution**: after `process.exit(...)` inside an async handler, immediately `return` or throw. Tests that stub `process.exit` must prove no later DB/ledger/artifact side effects happen.
+3. **Negated flags need parser tests**: Commander `--no-*` flags must be registered as `--no-name` and read as `opts.name === false`. Add parser-level tests, not only handler tests.
+4. **Dry-run/confirm semantics are mandatory**: commands that can mutate state must default to dry-run unless the established command contract says otherwise. `--dry-run` and `--confirm` must be mutually exclusive when both exist.
+5. **Failure paths must not mutate state**: failed diagnoses, failed validation, unsupported runners, missing input, and non-succeeded upstream stages must not intake, enqueue, write artifacts, update ledger, or create successors.
+6. **Operator output needs next action**: every degraded/refused/failed CLI result must include a structured reason and next action in JSON output.
+7. **Test the real command wiring**: when behavior depends on Commander options, add a command-registration or parser test that exercises the actual flags.
+
 ## Key Conventions
 
 ### File Naming
@@ -168,6 +180,12 @@ All code that handles untrusted data (parsed JSON, LLM output, DB `diagnosticJso
 
 Before handing off a PR (pushing, creating PR, or reporting completion), execute this checklist:
 
+**Self-review/fix loop**
+- A PR is not ready just because code was pushed. It is ready only after the fetch → fix → verify → re-fetch loop has no valid unresolved P0/P1/P2 findings and required checks are green.
+- After every push that addresses review feedback, fetch PR reviews/comments/checks again. Do not ask the user to relay comments unless GitHub API access fails after at least 2 retries.
+- Classify each review comment as: fixed, deferred with reason, duplicate, or misunderstanding with evidence. Put this classification in the PR comment or completion report.
+- If a real bug was found, run the Error Recording workflow before final handoff.
+
 **Fetch and resolve PR comments**
 - `gh pr view <PR> --json comments,reviews,latestReviews,files,statusCheckRollup`
 - `gh api repos/:owner/:repo/pulls/<PR>/comments --paginate`
@@ -190,8 +208,9 @@ Before handing off a PR (pushing, creating PR, or reporting completion), execute
 **Final summary**
 Include in the PR body or completion report:
 - Relevant ERR checklist (which ERR entries were considered and how avoided)
-- PR comments handled (count and resolution)
+- PR comments handled (total fetched, valid fixed, deferred, duplicates/misunderstandings)
 - Tests run (which commands, what results)
+- For CLI/operator changes: JSON-mode check, exit-path check, flag-wiring tests, and mutation/no-mutation evidence
 - Remaining risk (known issues, skipped coverage, trade-offs)
 
 ## Key Files


### PR DESCRIPTION
## Summary
- Harden the local `pr-review` skill into an iterative fetch/fix/verify/push/re-fetch loop
- Harden the `record-error` skill so the Error Experience Handbook stays a generalized pattern library instead of a growing incident log
- Add compact CLI/operator gates to `AGENTS.md` and `CLAUDE.md` for JSON stdout, `process.exit` fallthrough, Commander flags, dry-run/confirm, and failure no-mutation checks

## Why
Recent AI-authored PRs repeatedly needed multiple user-relayed review rounds for the same classes of issues: mixed JSON stdout, missing `return` after `process.exit`, Commander `--no-*` wiring mistakes, and failure paths continuing into state mutation.

The fix is not just more documentation. The `pr-review` skill now has to run the loop itself, and `record-error` now has to generalize or merge lessons instead of blindly adding new ERR entries.

## Verification
- `git diff --check`
- pre-push `npm run verify:merge` passed

## Scope
Workflow/skill/process only. No runtime code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新内部 AI 评审代理的工作流程文档，强化了拉取请求评审的迭代式闭环流程和 CLI 命令变更的验证规则。
  * 优化错误记录流程的文档结构，明确了错误归类、预防规则和质量要求。
  * 补充了开发指南中关于 CLI/运维命令的输出格式和状态管理要求。

*注：本次更新为内部流程文档优化，无直接的用户功能变更。*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->