### PR TITLE
feat(pd-cli): add internalization enqueue-successors command (PRI-218)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -88,6 +88,7 @@ Errors where AI assistants wrote code contradicting architecture docs or ADRs.
 |----|---------|--------|
 | ERR-021 | Handler-only tests miss Commander flag→opts mapping bugs | PRI-217 |
 | ERR-022 | process.exit(1) without return allows fallthrough to intake on failed diagnosis | PRI-217 |
+| ERR-023 | CLI dry-run command opens writable database connection instead of readonly | PRI-218 |
 
 ---
 
@@ -373,9 +374,21 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-023]** | CLI dry-run command opens writable database connection instead of readonly
+
+- **What happened**: `pd runtime internalization enqueue-successors` defaulted to dry-run mode but constructed `RuntimeStateManager` without `readonly: true`. This meant the dry-run path opened a writable SQLite connection, potentially mutating the database (schema migration, WAL files) even though the command was only supposed to report what it would do.
+- **Why it's wrong**: Dry-run/default mode must never mutate state. Opening a writable DB connection violates the CLI dry-run contract (Command Gate rule 4: commands that can mutate state must default to dry-run). Even if no explicit write operations occur, the DB connection itself can trigger schema migration or WAL creation.
+- **Correct approach**: When constructing `RuntimeStateManager` in a CLI command, always pass `readonly: isDryRun`. Dry-run/default mode must use `readonly: true`; only `--confirm` mode should use `readonly: false`.
+- **How to prevent**: Add a "readonly wiring test" checklist item for every CLI command that uses `RuntimeStateManager`. Test that: (1) no flags / `--dry-run` → `readonly: true`; (2) `--confirm` → `readonly: false`.
+- **Source**: PRI-218 / PR #681
+- **Date**: 2026-05-23
+- **Recurrence**: None
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 22 |
-| Last updated | 2026-05-22 |
+| Total lessons | 23 |
+| Last updated | 2026-05-23 |
 | Top category | Schema & Type |
 | Recurring errors | 11 |

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -185,9 +185,19 @@ async function findExistingSuccessor(
 }
 
 export async function handleRuntimeInternalizationEnqueueSuccessors(opts: EnqueueSuccessorsOptions): Promise<void> {
-  const workspaceDir = opts.workspace
-    ? path.resolve(opts.workspace)
-    : resolveWorkspaceDir();
+  const workspaceDirResult = await Promise.resolve().then(() =>
+    opts.workspace
+      ? path.resolve(opts.workspace)
+      : resolveWorkspaceDir(),
+  ).catch((resolveErr: unknown) => {
+    const message = resolveErr instanceof Error ? resolveErr.message : String(resolveErr);
+    emitFailure(`Failed to resolve workspace: ${message}`, true, !!opts.json);
+    return null;
+  });
+  if (workspaceDirResult === null) {
+    return;
+  }
+  const workspaceDir = workspaceDirResult;
 
   if (opts.dryRun && opts.confirm) {
     if (opts.json) {
@@ -259,7 +269,24 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
       }
 
       if (isDryRun) {
-        const proposalResult = await orchestrator.proposeNextTask(task.taskId);
+        const proposalResult = await orchestrator.proposeNextTask(task.taskId).catch((proposeErr: unknown) => {
+          const proposeMessage = proposeErr instanceof Error ? proposeErr.message : String(proposeErr);
+          return {
+            _proposeFailed: true as const,
+            reason: proposeMessage,
+          };
+        });
+        if (proposalResult !== null && '_proposeFailed' in proposalResult) {
+          actions.push({
+            taskId: task.taskId,
+            taskKind: piTask.taskKind,
+            decision: 'skipped',
+            reason: `propose_failed: ${proposalResult.reason}`,
+            nextAction: 'Re-run or investigate DB availability',
+          });
+          skippedCount++;
+          continue;
+        }
         if (!proposalResult) {
           actions.push({
             taskId: task.taskId,

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -168,12 +168,11 @@ async function findExistingSuccessor(
   stateManager: RuntimeStateManager,
   opts: { parentTaskId: string; successorKind: string; channel: string },
 ): Promise<{ taskId: string } | null> {
-  const [pendingTasks, retryWaitTasks, succeededTasks] = await Promise.all([
-    stateManager.listTasks({ status: 'pending' }),
-    stateManager.listTasks({ status: 'retry_wait' }),
-    stateManager.listTasks({ status: 'succeeded' }),
-  ]);
-  const candidates = [...pendingTasks, ...retryWaitTasks, ...succeededTasks];
+  const allStatuses: ('pending' | 'retry_wait' | 'succeeded' | 'leased' | 'failed' | 'needs_human_review')[] = ['pending', 'retry_wait', 'succeeded', 'leased', 'failed', 'needs_human_review'];
+  const results = await Promise.all(
+    allStatuses.map(status => stateManager.listTasks({ status })),
+  );
+  const candidates = results.flat();
   for (const task of candidates) {
     if (task.taskKind !== opts.successorKind) continue;
     const piTask = hydratePITaskRecord(task);
@@ -311,7 +310,25 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
           }
         }
       } else {
-        const commitResult = await orchestrator.commitNextTaskProposal(task.taskId);
+        const commitResult = await orchestrator.commitNextTaskProposal(task.taskId).catch((commitErr: unknown) => {
+          const commitMessage = commitErr instanceof Error ? commitErr.message : String(commitErr);
+          return {
+            decision: 'commit_failed' as const,
+            taskId: task.taskId,
+            reason: commitMessage,
+          };
+        });
+        if ('decision' in commitResult && commitResult.decision === 'commit_failed') {
+          actions.push({
+            taskId: task.taskId,
+            taskKind: piTask.taskKind,
+            decision: 'skipped',
+            reason: `commit_failed: ${commitResult.reason}`,
+            nextAction: 'Re-run or investigate DB availability',
+          });
+          skippedCount++;
+          continue;
+        }
         const action = mapCommitDecisionToAction(commitResult);
         action.taskKind = piTask.taskKind;
         actions.push(action);

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -268,7 +268,7 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
     return;
   }
 
-  const stateManager = new RuntimeStateManager({ workspaceDir });
+  const stateManager = new RuntimeStateManager({ workspaceDir, readonly: isDryRun });
 
   try {
     try {

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -168,9 +168,12 @@ async function findExistingSuccessor(
   stateManager: RuntimeStateManager,
   opts: { parentTaskId: string; successorKind: string; channel: string },
 ): Promise<{ taskId: string } | null> {
-  const pendingTasks = await stateManager.listTasks({ status: 'pending' });
-  const retryWaitTasks = await stateManager.listTasks({ status: 'retry_wait' });
-  const candidates = [...pendingTasks, ...retryWaitTasks];
+  const [pendingTasks, retryWaitTasks, succeededTasks] = await Promise.all([
+    stateManager.listTasks({ status: 'pending' }),
+    stateManager.listTasks({ status: 'retry_wait' }),
+    stateManager.listTasks({ status: 'succeeded' }),
+  ]);
+  const candidates = [...pendingTasks, ...retryWaitTasks, ...succeededTasks];
   for (const task of candidates) {
     if (task.taskKind !== opts.successorKind) continue;
     const piTask = hydratePITaskRecord(task);
@@ -266,14 +269,28 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
             reason: 'No valid successor in job graph for this task kind and channel',
           });
         } else {
-          const existingSuccessor = await findExistingSuccessor(
-            stateManager,
-            {
-              parentTaskId: task.taskId,
-              successorKind: proposalResult.proposal.taskKind,
-              channel: proposalResult.proposal.channel,
-            },
-          );
+          let existingSuccessor: { taskId: string } | null = null;
+          try {
+            existingSuccessor = await findExistingSuccessor(
+              stateManager,
+              {
+                parentTaskId: task.taskId,
+                successorKind: proposalResult.proposal.taskKind,
+                channel: proposalResult.proposal.channel,
+              },
+            );
+          } catch (dedupeErr) {
+            const dedupeMessage = dedupeErr instanceof Error ? dedupeErr.message : String(dedupeErr);
+            actions.push({
+              taskId: task.taskId,
+              taskKind: piTask.taskKind,
+              decision: 'skipped',
+              reason: `dedupe_scan_failed: ${dedupeMessage}`,
+              nextAction: 'Re-run or investigate DB availability',
+            });
+            skippedCount++;
+            continue;
+          }
           if (existingSuccessor) {
             actions.push({
               taskId: task.taskId,

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -1,0 +1,279 @@
+import * as path from 'path';
+import {
+  RuntimeStateManager,
+  InternalizationOrchestrator,
+  isPeerRunnerKind,
+  hydratePITaskRecord,
+} from '@principles/core/runtime-v2';
+import type { CommitNextTaskResult } from '@principles/core/runtime-v2';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface EnqueueSuccessorsOptions {
+  workspace?: string;
+  dryRun?: boolean;
+  confirm?: boolean;
+  json?: boolean;
+}
+
+type EnqueueActionDecision =
+  | 'would_create_successor'
+  | 'successor_created'
+  | 'successor_exists'
+  | 'no_successor'
+  | 'skipped';
+
+interface EnqueueAction {
+  taskId: string;
+  taskKind: string;
+  decision: EnqueueActionDecision;
+  successorKind?: string;
+  successorTaskId?: string;
+  reason?: string;
+  nextAction?: string;
+}
+
+interface EnqueueSuccessorsOutput {
+  status: 'dry_run' | 'confirmed' | 'refused' | 'failed';
+  dryRun: boolean;
+  scannedCount: number;
+  createdCount: number;
+  existingCount: number;
+  skippedCount: number;
+  actions: EnqueueAction[];
+  error?: string;
+}
+
+const OWNER = 'pd-cli-enqueue-successors';
+const RUNTIME_KIND = 'operator-repair';
+
+function mapCommitDecisionToAction(
+  commitResult: CommitNextTaskResult,
+): EnqueueAction {
+  switch (commitResult.decision) {
+    case 'successor_created':
+      return {
+        taskId: commitResult.sourceTaskId,
+        taskKind: '',
+        decision: 'successor_created',
+        successorKind: commitResult.successorKind,
+        successorTaskId: commitResult.successorTaskId,
+      };
+    case 'successor_exists':
+      return {
+        taskId: commitResult.sourceTaskId,
+        taskKind: '',
+        decision: 'successor_exists',
+        successorKind: commitResult.successorKind,
+        successorTaskId: commitResult.successorTaskId,
+      };
+    case 'no_successor':
+      return {
+        taskId: commitResult.sourceTaskId,
+        taskKind: '',
+        decision: 'no_successor',
+        reason: commitResult.reason,
+      };
+    case 'source_not_succeeded':
+      return {
+        taskId: commitResult.taskId,
+        taskKind: '',
+        decision: 'skipped',
+        reason: `source_not_succeeded: task status is ${commitResult.status}`,
+        nextAction: 'Re-run the task or investigate why status changed after scan',
+      };
+    case 'invalid_task_metadata':
+      return {
+        taskId: commitResult.taskId,
+        taskKind: '',
+        decision: 'skipped',
+        reason: `invalid_task_metadata: ${commitResult.reason}`,
+        nextAction: 'Inspect diagnosticJson and repair metadata via integrity-repair',
+      };
+    case 'task_not_found':
+      return {
+        taskId: commitResult.taskId,
+        taskKind: '',
+        decision: 'skipped',
+        reason: 'task_not_found: task disappeared between scan and commit',
+        nextAction: 'Re-scan or investigate concurrent deletion',
+      };
+  }
+}
+
+function formatTextOutput(output: EnqueueSuccessorsOutput): string {
+  const lines: string[] = [];
+  const modeLabel = output.dryRun ? 'DRY-RUN' : 'CONFIRM';
+
+  lines.push('Internalization Enqueue Successors Report');
+  lines.push(`mode: ${modeLabel}`);
+  lines.push(`status: ${output.status}`);
+  lines.push('');
+  lines.push(`scanned: ${output.scannedCount}`);
+  lines.push(`created: ${output.createdCount}`);
+  lines.push(`existing: ${output.existingCount}`);
+  lines.push(`skipped: ${output.skippedCount}`);
+  lines.push('');
+
+  if (output.actions.length === 0) {
+    lines.push('No succeeded internalization tasks found. Nothing to enqueue.');
+  } else {
+    lines.push(`Actions (${output.actions.length}):`);
+    for (const action of output.actions) {
+      const icon = action.decision === 'successor_created' || action.decision === 'would_create_successor'
+        ? '✓'
+        : action.decision === 'successor_exists'
+          ? '≡'
+          : action.decision === 'no_successor'
+            ? '○'
+            : '⚠';
+      lines.push(`  ${icon} [${action.decision}] ${action.taskId} (${action.taskKind})`);
+      if (action.successorKind) {
+        lines.push(`    successorKind: ${action.successorKind}`);
+      }
+      if (action.successorTaskId) {
+        lines.push(`    successorTaskId: ${action.successorTaskId}`);
+      }
+      if (action.reason) {
+        lines.push(`    reason: ${action.reason}`);
+      }
+      if (action.nextAction) {
+        lines.push(`    nextAction: ${action.nextAction}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function emitFailure(error: string, isDryRun: boolean, json: boolean): void {
+  const failOutput: EnqueueSuccessorsOutput = {
+    status: 'failed',
+    dryRun: isDryRun,
+    scannedCount: 0,
+    createdCount: 0,
+    existingCount: 0,
+    skippedCount: 0,
+    actions: [],
+    error,
+  };
+  if (json) {
+    console.log(JSON.stringify(failOutput, null, 2));
+  } else {
+    console.error(`Error: ${error}`);
+  }
+  process.exitCode = 1;
+}
+
+export async function handleRuntimeInternalizationEnqueueSuccessors(opts: EnqueueSuccessorsOptions): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  if (opts.dryRun && opts.confirm) {
+    console.error('Error: --dry-run and --confirm are mutually exclusive. Specify one or the other.');
+    process.exit(1);
+    return;
+  }
+
+  const isDryRun = !opts.confirm;
+
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+
+  try {
+    try {
+      await stateManager.initialize();
+    } catch (initErr) {
+      const message = initErr instanceof Error ? initErr.message : String(initErr);
+      emitFailure(`Failed to initialize storage: ${message}`, isDryRun, !!opts.json);
+      return;
+    }
+
+    const succeededTasks = await stateManager.listTasks({ status: 'succeeded' }).catch((listErr: unknown) => {
+      const message = listErr instanceof Error ? listErr.message : String(listErr);
+      emitFailure(`Failed to list tasks: ${message}`, isDryRun, !!opts.json);
+      return null;
+    });
+    if (succeededTasks === null) {
+      return;
+    }
+
+    const piSucceededTasks = succeededTasks.filter(t => isPeerRunnerKind(t.taskKind));
+
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: true },
+    );
+
+    const actions: EnqueueAction[] = [];
+    let createdCount = 0;
+    let existingCount = 0;
+    let skippedCount = 0;
+
+    for (const task of piSucceededTasks) {
+      const piTask = hydratePITaskRecord(task);
+
+      if (!piTask) {
+        actions.push({
+          taskId: task.taskId,
+          taskKind: task.taskKind,
+          decision: 'skipped',
+          reason: 'Failed to hydrate PITaskRecord from diagnosticJson',
+          nextAction: 'Inspect diagnosticJson and repair metadata via integrity-repair',
+        });
+        skippedCount++;
+        continue;
+      }
+
+      if (isDryRun) {
+        const proposalResult = await orchestrator.proposeNextTask(task.taskId);
+        if (!proposalResult) {
+          actions.push({
+            taskId: task.taskId,
+            taskKind: piTask.taskKind,
+            decision: 'no_successor',
+            reason: 'No valid successor in job graph for this task kind and channel',
+          });
+        } else {
+          actions.push({
+            taskId: task.taskId,
+            taskKind: piTask.taskKind,
+            decision: 'would_create_successor',
+            successorKind: proposalResult.proposal.taskKind,
+          });
+          createdCount++;
+        }
+      } else {
+        const commitResult = await orchestrator.commitNextTaskProposal(task.taskId);
+        const action = mapCommitDecisionToAction(commitResult);
+        action.taskKind = piTask.taskKind;
+        actions.push(action);
+
+        if (action.decision === 'successor_created') {
+          createdCount++;
+        } else if (action.decision === 'successor_exists') {
+          existingCount++;
+        } else if (action.decision === 'skipped') {
+          skippedCount++;
+        }
+      }
+    }
+
+    const output: EnqueueSuccessorsOutput = {
+      status: isDryRun ? 'dry_run' : 'confirmed',
+      dryRun: isDryRun,
+      scannedCount: piSucceededTasks.length,
+      createdCount,
+      existingCount,
+      skippedCount,
+      actions,
+    };
+
+    if (opts.json) {
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      console.log(formatTextOutput(output));
+    }
+  } finally {
+    await stateManager.close();
+  }
+}

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -257,12 +257,14 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
         skippedCount: 0,
         actions: [],
         error: '--dry-run and --confirm are mutually exclusive. Specify one or the other.',
+        reason: 'flag_conflict: --dry-run and --confirm are mutually exclusive',
+        nextAction: 'Specify either --dry-run or --confirm, not both',
       };
       console.log(JSON.stringify(conflictOutput, null, 2));
     } else {
       console.error('Error: --dry-run and --confirm are mutually exclusive. Specify one or the other.');
     }
-    process.exit(1);
+    process.exitCode = 1;
     return;
   }
 
@@ -300,19 +302,23 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
 
     const piSucceededTasks = succeededTasks.filter(t => isPeerRunnerKind(t.taskKind));
 
-    const successorIndex = await buildSuccessorIndex(stateManager).catch((indexErr: unknown) => {
-      const message = indexErr instanceof Error ? indexErr.message : String(indexErr);
-      emitFailure({
-        error: `Failed to build successor index: ${message}`,
-        isDryRun,
-        json: !!opts.json,
-        reason: `successor_index_failed: ${message}`,
-        nextAction: 'Check database availability and re-run',
+    let successorIndex: Map<string, SuccessorIndexEntry> | null = null;
+    if (isDryRun) {
+      const index = await buildSuccessorIndex(stateManager).catch((indexErr: unknown) => {
+        const message = indexErr instanceof Error ? indexErr.message : String(indexErr);
+        emitFailure({
+          error: `Failed to build successor index: ${message}`,
+          isDryRun,
+          json: !!opts.json,
+          reason: `successor_index_failed: ${message}`,
+          nextAction: 'Check database availability and re-run',
+        });
+        return null;
       });
-      return null;
-    });
-    if (successorIndex === null) {
-      return;
+      if (index === null) {
+        return;
+      }
+      successorIndex = index;
     }
 
     const orchestrator = new InternalizationOrchestrator(
@@ -368,6 +374,17 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
           });
         } else {
           const deterministicTaskId = `${proposalResult.proposal.taskKind}-${task.taskId}-${proposalResult.proposal.channel}`;
+          if (!successorIndex) {
+            actions.push({
+              taskId: task.taskId,
+              taskKind: piTask.taskKind,
+              decision: 'skipped',
+              reason: 'successor_index_unavailable: index not built for dry-run path',
+              nextAction: 'Re-run the command',
+            });
+            skippedCount++;
+            continue;
+          }
           const existingSuccessor = findSuccessorInIndex(
             successorIndex,
             {

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -41,6 +41,8 @@ interface EnqueueSuccessorsOutput {
   skippedCount: number;
   actions: EnqueueAction[];
   error?: string;
+  reason?: string;
+  nextAction?: string;
 }
 
 const OWNER = 'pd-cli-enqueue-successors';
@@ -145,53 +147,98 @@ function formatTextOutput(output: EnqueueSuccessorsOutput): string {
   return lines.join('\n');
 }
 
-function emitFailure(error: string, isDryRun: boolean, json: boolean): void {
+interface EmitFailureOptions {
+  error: string;
+  isDryRun: boolean;
+  json: boolean;
+  reason?: string;
+  nextAction?: string;
+}
+
+function emitFailure(opts: EmitFailureOptions): void {
   const failOutput: EnqueueSuccessorsOutput = {
     status: 'failed',
-    dryRun: isDryRun,
+    dryRun: opts.isDryRun,
     scannedCount: 0,
     createdCount: 0,
     existingCount: 0,
     skippedCount: 0,
     actions: [],
-    error,
+    error: opts.error,
+    reason: opts.reason ?? opts.error,
+    nextAction: opts.nextAction ?? 'Check workspace path and storage availability, then re-run',
   };
-  if (json) {
+  if (opts.json) {
     console.log(JSON.stringify(failOutput, null, 2));
   } else {
-    console.error(`Error: ${error}`);
+    console.error(`Error: ${opts.error}`);
+    if (opts.nextAction) console.error(`Next action: ${opts.nextAction}`);
   }
   process.exitCode = 1;
 }
 
-async function findExistingSuccessor(
+interface SuccessorIndexEntry {
+  taskId: string;
+  taskKind: string;
+  parentTaskId: string | null;
+  channel: string;
+  hydrated: boolean;
+}
+
+async function buildSuccessorIndex(
   stateManager: RuntimeStateManager,
-  opts: { parentTaskId: string; successorKind: string; channel: string },
-): Promise<{ taskId: string } | null> {
+): Promise<Map<string, SuccessorIndexEntry>> {
   const allStatuses: ('pending' | 'retry_wait' | 'succeeded' | 'leased' | 'failed' | 'needs_human_review')[] = ['pending', 'retry_wait', 'succeeded', 'leased', 'failed', 'needs_human_review'];
+  const index = new Map<string, SuccessorIndexEntry>();
   const results = await Promise.all(
     allStatuses.map(status => stateManager.listTasks({ status })),
   );
-  const candidates = results.flat();
-  for (const task of candidates) {
-    if (task.taskKind !== opts.successorKind) continue;
+  for (const task of results.flat()) {
+    if (!isPeerRunnerKind(task.taskKind)) continue;
     const piTask = hydratePITaskRecord(task);
-    if (!piTask) continue;
-    if (piTask.parentTaskId === opts.parentTaskId && piTask.channel === opts.channel) {
-      return { taskId: task.taskId };
+    index.set(task.taskId, {
+      taskId: task.taskId,
+      taskKind: task.taskKind,
+      parentTaskId: piTask?.parentTaskId ?? null,
+      channel: piTask?.channel ?? '',
+      hydrated: piTask !== null,
+    });
+  }
+  return index;
+}
+
+function findSuccessorInIndex(
+  index: Map<string, SuccessorIndexEntry>,
+  opts: { parentTaskId: string; successorKind: string; channel: string; deterministicTaskId: string },
+): { taskId: string; hydrated: boolean } | null {
+  const byTaskId = index.get(opts.deterministicTaskId);
+  if (byTaskId) {
+    return { taskId: byTaskId.taskId, hydrated: byTaskId.hydrated };
+  }
+  for (const entry of index.values()) {
+    if (entry.taskKind === opts.successorKind && entry.parentTaskId === opts.parentTaskId && entry.channel === opts.channel) {
+      return { taskId: entry.taskId, hydrated: entry.hydrated };
     }
   }
   return null;
 }
 
 export async function handleRuntimeInternalizationEnqueueSuccessors(opts: EnqueueSuccessorsOptions): Promise<void> {
+  const isDryRun = !opts.confirm;
+
   const workspaceDirResult = await Promise.resolve().then(() =>
     opts.workspace
       ? path.resolve(opts.workspace)
       : resolveWorkspaceDir(),
   ).catch((resolveErr: unknown) => {
     const message = resolveErr instanceof Error ? resolveErr.message : String(resolveErr);
-    emitFailure(`Failed to resolve workspace: ${message}`, true, !!opts.json);
+    emitFailure({
+      error: `Failed to resolve workspace: ${message}`,
+      isDryRun,
+      json: !!opts.json,
+      reason: `workspace_resolve_failed: ${message}`,
+      nextAction: 'Provide a valid --workspace path or ensure .principles directory exists',
+    });
     return null;
   });
   if (workspaceDirResult === null) {
@@ -219,8 +266,6 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
     return;
   }
 
-  const isDryRun = !opts.confirm;
-
   const stateManager = new RuntimeStateManager({ workspaceDir });
 
   try {
@@ -228,13 +273,25 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
       await stateManager.initialize();
     } catch (initErr) {
       const message = initErr instanceof Error ? initErr.message : String(initErr);
-      emitFailure(`Failed to initialize storage: ${message}`, isDryRun, !!opts.json);
+      emitFailure({
+        error: `Failed to initialize storage: ${message}`,
+        isDryRun,
+        json: !!opts.json,
+        reason: `storage_init_failed: ${message}`,
+        nextAction: 'Check workspace path and .principles directory permissions',
+      });
       return;
     }
 
     const succeededTasks = await stateManager.listTasks({ status: 'succeeded' }).catch((listErr: unknown) => {
       const message = listErr instanceof Error ? listErr.message : String(listErr);
-      emitFailure(`Failed to list tasks: ${message}`, isDryRun, !!opts.json);
+      emitFailure({
+        error: `Failed to list tasks: ${message}`,
+        isDryRun,
+        json: !!opts.json,
+        reason: `list_tasks_failed: ${message}`,
+        nextAction: 'Check database availability and re-run',
+      });
       return null;
     });
     if (succeededTasks === null) {
@@ -242,6 +299,21 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
     }
 
     const piSucceededTasks = succeededTasks.filter(t => isPeerRunnerKind(t.taskKind));
+
+    const successorIndex = await buildSuccessorIndex(stateManager).catch((indexErr: unknown) => {
+      const message = indexErr instanceof Error ? indexErr.message : String(indexErr);
+      emitFailure({
+        error: `Failed to build successor index: ${message}`,
+        isDryRun,
+        json: !!opts.json,
+        reason: `successor_index_failed: ${message}`,
+        nextAction: 'Check database availability and re-run',
+      });
+      return null;
+    });
+    if (successorIndex === null) {
+      return;
+    }
 
     const orchestrator = new InternalizationOrchestrator(
       { stateManager },
@@ -295,37 +367,36 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
             reason: 'No valid successor in job graph for this task kind and channel',
           });
         } else {
-          let existingSuccessor: { taskId: string } | null = null;
-          try {
-            existingSuccessor = await findExistingSuccessor(
-              stateManager,
-              {
-                parentTaskId: task.taskId,
-                successorKind: proposalResult.proposal.taskKind,
-                channel: proposalResult.proposal.channel,
-              },
-            );
-          } catch (dedupeErr) {
-            const dedupeMessage = dedupeErr instanceof Error ? dedupeErr.message : String(dedupeErr);
-            actions.push({
-              taskId: task.taskId,
-              taskKind: piTask.taskKind,
-              decision: 'skipped',
-              reason: `dedupe_scan_failed: ${dedupeMessage}`,
-              nextAction: 'Re-run or investigate DB availability',
-            });
-            skippedCount++;
-            continue;
-          }
-          if (existingSuccessor) {
-            actions.push({
-              taskId: task.taskId,
-              taskKind: piTask.taskKind,
-              decision: 'successor_exists',
+          const deterministicTaskId = `${proposalResult.proposal.taskKind}-${task.taskId}-${proposalResult.proposal.channel}`;
+          const existingSuccessor = findSuccessorInIndex(
+            successorIndex,
+            {
+              parentTaskId: task.taskId,
               successorKind: proposalResult.proposal.taskKind,
-              successorTaskId: existingSuccessor.taskId,
-            });
-            existingCount++;
+              channel: proposalResult.proposal.channel,
+              deterministicTaskId,
+            },
+          );
+          if (existingSuccessor) {
+            if (!existingSuccessor.hydrated) {
+              actions.push({
+                taskId: task.taskId,
+                taskKind: piTask.taskKind,
+                decision: 'skipped',
+                reason: `successor_exists_with_malformed_metadata: taskId=${existingSuccessor.taskId} has unparseable diagnosticJson`,
+                nextAction: 'Run integrity-repair on the successor task, then re-run enqueue-successors',
+              });
+              skippedCount++;
+            } else {
+              actions.push({
+                taskId: task.taskId,
+                taskKind: piTask.taskKind,
+                decision: 'successor_exists',
+                successorKind: proposalResult.proposal.taskKind,
+                successorTaskId: existingSuccessor.taskId,
+              });
+              existingCount++;
+            }
           } else {
             actions.push({
               taskId: task.taskId,

--- a/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-enqueue-successors.ts
@@ -164,13 +164,45 @@ function emitFailure(error: string, isDryRun: boolean, json: boolean): void {
   process.exitCode = 1;
 }
 
+async function findExistingSuccessor(
+  stateManager: RuntimeStateManager,
+  opts: { parentTaskId: string; successorKind: string; channel: string },
+): Promise<{ taskId: string } | null> {
+  const pendingTasks = await stateManager.listTasks({ status: 'pending' });
+  const retryWaitTasks = await stateManager.listTasks({ status: 'retry_wait' });
+  const candidates = [...pendingTasks, ...retryWaitTasks];
+  for (const task of candidates) {
+    if (task.taskKind !== opts.successorKind) continue;
+    const piTask = hydratePITaskRecord(task);
+    if (!piTask) continue;
+    if (piTask.parentTaskId === opts.parentTaskId && piTask.channel === opts.channel) {
+      return { taskId: task.taskId };
+    }
+  }
+  return null;
+}
+
 export async function handleRuntimeInternalizationEnqueueSuccessors(opts: EnqueueSuccessorsOptions): Promise<void> {
   const workspaceDir = opts.workspace
     ? path.resolve(opts.workspace)
     : resolveWorkspaceDir();
 
   if (opts.dryRun && opts.confirm) {
-    console.error('Error: --dry-run and --confirm are mutually exclusive. Specify one or the other.');
+    if (opts.json) {
+      const conflictOutput: EnqueueSuccessorsOutput = {
+        status: 'refused',
+        dryRun: true,
+        scannedCount: 0,
+        createdCount: 0,
+        existingCount: 0,
+        skippedCount: 0,
+        actions: [],
+        error: '--dry-run and --confirm are mutually exclusive. Specify one or the other.',
+      };
+      console.log(JSON.stringify(conflictOutput, null, 2));
+    } else {
+      console.error('Error: --dry-run and --confirm are mutually exclusive. Specify one or the other.');
+    }
     process.exit(1);
     return;
   }
@@ -234,13 +266,32 @@ export async function handleRuntimeInternalizationEnqueueSuccessors(opts: Enqueu
             reason: 'No valid successor in job graph for this task kind and channel',
           });
         } else {
-          actions.push({
-            taskId: task.taskId,
-            taskKind: piTask.taskKind,
-            decision: 'would_create_successor',
-            successorKind: proposalResult.proposal.taskKind,
-          });
-          createdCount++;
+          const existingSuccessor = await findExistingSuccessor(
+            stateManager,
+            {
+              parentTaskId: task.taskId,
+              successorKind: proposalResult.proposal.taskKind,
+              channel: proposalResult.proposal.channel,
+            },
+          );
+          if (existingSuccessor) {
+            actions.push({
+              taskId: task.taskId,
+              taskKind: piTask.taskKind,
+              decision: 'successor_exists',
+              successorKind: proposalResult.proposal.taskKind,
+              successorTaskId: existingSuccessor.taskId,
+            });
+            existingCount++;
+          } else {
+            actions.push({
+              taskId: task.taskId,
+              taskKind: piTask.taskKind,
+              decision: 'would_create_successor',
+              successorKind: proposalResult.proposal.taskKind,
+            });
+            createdCount++;
+          }
         }
       } else {
         const commitResult = await orchestrator.commitNextTaskProposal(task.taskId);

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -38,6 +38,7 @@ import { handleRuntimeCanary } from './commands/runtime-canary.js';
 import { handleRuntimeSyntheticBaseline } from './commands/runtime-synthetic-baseline.js';
 import { handleRuntimeInternalizationIntegrity } from './commands/runtime-internalization-integrity.js';
 import { handleRuntimeInternalizationIntegrityRepair } from './commands/runtime-internalization-integrity-repair.js';
+import { handleRuntimeInternalizationEnqueueSuccessors } from './commands/runtime-internalization-enqueue-successors.js';
 import { handleRuntimeDiagnosticsExport } from './commands/runtime-diagnostics-export.js';
 import { handleRuntimeRecoverySweep } from './commands/runtime-recovery.js';
 import { handleRuntimeIdleTriggerEvaluate } from './commands/runtime-idle-trigger.js';
@@ -464,6 +465,17 @@ internalizationCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handleRuntimeInternalizationIntegrityRepair({ workspace: opts.workspace, confirm: opts.confirm, dryRun: opts.dryRun, json: opts.json });
+  });
+
+internalizationCmd
+  .command('enqueue-successors')
+  .description('Enqueue successor tasks for succeeded internalization tasks missing successors')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--dry-run', 'Report only, no modifications (default)')
+  .option('--confirm', 'Actually create successor tasks')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, json: opts.json });
   });
 
 const idleTriggerCmd = runtimeCmd

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -148,7 +148,11 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
 
   it('succeeded dreamer with artifact and no philosopher successor: dry-run reports would_create_successor', async () => {
     const dreamerTask = makeSucceededTask('dreamer-001', 'dreamer');
-    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockListTasks
+      .mockResolvedValueOnce([dreamerTask])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-001',
@@ -286,7 +290,11 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
 
   it('default mode is dry-run', async () => {
     const dreamerTask = makeSucceededTask('dreamer-default', 'dreamer');
-    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockListTasks
+      .mockResolvedValueOnce([dreamerTask])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-default',
@@ -474,7 +482,11 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
 
   it('dry-run does not call commitNextTaskProposal', async () => {
     const dreamerTask = makeSucceededTask('dreamer-dry', 'dreamer');
-    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockListTasks
+      .mockResolvedValueOnce([dreamerTask])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-dry',
@@ -509,6 +521,27 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     expect(output.actions[0].taskId).toBe('trainer-dry-001');
   });
 
+  it('dry-run findExistingSuccessor DB error: skipped with reason', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-dedupe-err', 'dreamer');
+    mockListTasks
+      .mockResolvedValueOnce([dreamerTask])
+      .mockRejectedValueOnce(new Error('Database locked during dedupe'));
+    mockProposeNextTask.mockResolvedValue({
+      decision: 'proposal_created',
+      taskId: 'dreamer-dedupe-err',
+      taskKind: 'dreamer',
+      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-dedupe-err'], inputArtifactRefs: [], parentTaskId: 'dreamer-dedupe-err', correlationId: 'corr-dedupe' },
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('dedupe_scan_failed');
+    expect(output.actions[0].nextAction).toBeDefined();
+    expect(output.skippedCount).toBe(1);
+  });
+
   it('dry-run with existing successor: reports successor_exists', async () => {
     const dreamerTask = makeSucceededTask('dreamer-existing-succ', 'dreamer');
     const philosopherPending = {
@@ -527,6 +560,7 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     mockListTasks
       .mockResolvedValueOnce([dreamerTask])
       .mockResolvedValueOnce([philosopherPending])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -7,13 +7,15 @@ const mockCommitNextTaskProposal = vi.hoisted(() => vi.fn());
 const mockProposeNextTask = vi.hoisted(() => vi.fn());
 const mockClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockInitialize = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockRuntimeStateManagerOpts = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
 }));
 
 vi.mock('@principles/core/runtime-v2', () => ({
-  RuntimeStateManager: vi.fn().mockImplementation(function () {
+  RuntimeStateManager: vi.fn().mockImplementation(function (opts: Record<string, unknown>) {
+    mockRuntimeStateManagerOpts(opts);
     return {
       initialize: mockInitialize,
       close: mockClose,
@@ -769,5 +771,33 @@ describe('Commander wiring for enqueue-successors', () => {
     const rawOutput = consoleLogSpy.mock.calls[0][0];
     const parsed = JSON.parse(rawOutput);
     expect(parsed).toBeDefined();
+  });
+
+  it('no flags -> RuntimeStateManager readonly=true (dry-run default)', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--json']);
+
+    expect(mockRuntimeStateManagerOpts).toHaveBeenCalledWith(
+      expect.objectContaining({ readonly: true }),
+    );
+  });
+
+  it('--dry-run -> RuntimeStateManager readonly=true', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--dry-run', '--json']);
+
+    expect(mockRuntimeStateManagerOpts).toHaveBeenCalledWith(
+      expect.objectContaining({ readonly: true }),
+    );
+  });
+
+  it('--confirm -> RuntimeStateManager readonly=false', async () => {
+    mockListTasks.mockResolvedValue([]);
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--confirm', '--json']);
+
+    expect(mockRuntimeStateManagerOpts).toHaveBeenCalledWith(
+      expect.objectContaining({ readonly: false }),
+    );
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -31,9 +31,10 @@ vi.mock('@principles/core/runtime-v2', () => ({
     ['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer', 'trainer'].includes(k),
   ),
   hydratePITaskRecord: vi.fn().mockImplementation((task: Record<string, unknown>) => {
-    if (!task.diagnosticJson) return null;
+    if (typeof task.diagnosticJson !== 'string' || task.diagnosticJson.length === 0) return null;
     try {
-      const meta = JSON.parse(task.diagnosticJson as string);
+      const meta = JSON.parse(task.diagnosticJson);
+      if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) return null;
       return {
         taskId: task.taskId,
         taskKind: task.taskKind,
@@ -57,10 +58,10 @@ import { handleRuntimeInternalizationEnqueueSuccessors } from '../../src/command
 
 const WS = '/fake/workspace';
 
-function mockDryRunListTasks(succeededTasks: ReturnType<typeof makeSucceededTask>[]) {
+function mockDryRunListTasks(succeededTasks: ReturnType<typeof makeSucceededTask>[], successorTasks: ReturnType<typeof makeSucceededTask>[] = []) {
   mockListTasks
     .mockResolvedValueOnce(succeededTasks)
-    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce(successorTasks)
     .mockResolvedValueOnce([])
     .mockResolvedValueOnce([])
     .mockResolvedValueOnce([])
@@ -534,50 +535,26 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     expect(output.actions[0].taskId).toBe('trainer-dry-001');
   });
 
-  it('dry-run findExistingSuccessor DB error: skipped with reason', async () => {
-    const dreamerTask = makeSucceededTask('dreamer-dedupe-err', 'dreamer');
+  it('successor index build failure: fails closed with structured error', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-index-err', 'dreamer');
     mockListTasks
       .mockResolvedValueOnce([dreamerTask])
-      .mockRejectedValueOnce(new Error('Database locked during dedupe'));
-    mockProposeNextTask.mockResolvedValue({
-      decision: 'proposal_created',
-      taskId: 'dreamer-dedupe-err',
-      taskKind: 'dreamer',
-      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-dedupe-err'], inputArtifactRefs: [], parentTaskId: 'dreamer-dedupe-err', correlationId: 'corr-dedupe' },
-    });
+      .mockRejectedValueOnce(new Error('Database locked during index build'));
 
     await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
-    expect(output.actions[0].decision).toBe('skipped');
-    expect(output.actions[0].reason).toContain('dedupe_scan_failed');
-    expect(output.actions[0].nextAction).toBeDefined();
-    expect(output.skippedCount).toBe(1);
+    expect(output.status).toBe('failed');
+    expect(output.reason).toContain('successor_index_failed');
+    expect(output.nextAction).toBeDefined();
+    expect(process.exitCode).toBe(1);
   });
 
   it('dry-run with existing successor: reports successor_exists', async () => {
     const dreamerTask = makeSucceededTask('dreamer-existing-succ', 'dreamer');
-    const philosopherPending = {
-      taskId: 'philosopher-dreamer-existing-succ-prompt',
-      taskKind: 'philosopher',
-      status: 'pending',
-      attemptCount: 0,
-      maxAttempts: 3,
-      inputRef: undefined,
-      resultRef: undefined,
-      lastError: undefined,
-      leaseOwner: undefined,
-      leaseExpiresAt: undefined,
-      diagnosticJson: makePIMetadata({ parentTaskId: 'dreamer-existing-succ', channel: 'prompt' }),
-    };
-    mockListTasks
-      .mockResolvedValueOnce([dreamerTask])
-      .mockResolvedValueOnce([philosopherPending])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    const philosopherPending = makeSucceededTask('philosopher-dreamer-existing-succ-prompt', 'philosopher', { parentTaskId: 'dreamer-existing-succ', channel: 'prompt' });
+    philosopherPending.status = 'pending';
+    mockDryRunListTasks([dreamerTask], [philosopherPending]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-existing-succ',
@@ -606,6 +583,117 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     expect(output.actions[0].reason).toContain('propose_failed');
     expect(output.actions[0].nextAction).toBeDefined();
     expect(output.skippedCount).toBe(1);
+  });
+
+  it('failed JSON output includes reason and nextAction', async () => {
+    mockInitialize.mockRejectedValue(new Error('Cannot open database'));
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(output.reason).toContain('storage_init_failed');
+    expect(output.nextAction).toBeDefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('--confirm workspace resolve failure reports dryRun=false', async () => {
+    const { resolveWorkspaceDir } = await import('../../src/resolve-workspace.js');
+    vi.mocked(resolveWorkspaceDir).mockImplementationOnce(() => { throw new Error('No workspace found'); });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(output.dryRun).toBe(false);
+    expect(output.reason).toContain('workspace_resolve_failed');
+    expect(output.nextAction).toBeDefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('dry-run existing successor with malformed metadata: skipped, not would_create_successor', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-malformed-succ', 'dreamer');
+    const malformedSuccessor = {
+      taskId: 'philosopher-dreamer-malformed-succ-prompt',
+      taskKind: 'philosopher',
+      status: 'pending' as const,
+      attemptCount: 0,
+      maxAttempts: 3,
+      inputRef: undefined,
+      resultRef: undefined,
+      lastError: undefined,
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+      diagnosticJson: 'not-valid-json{{{',
+    };
+    mockDryRunListTasks([dreamerTask], [malformedSuccessor]);
+    mockProposeNextTask.mockResolvedValue({
+      decision: 'proposal_created',
+      taskId: 'dreamer-malformed-succ',
+      taskKind: 'dreamer',
+      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-malformed-succ'], inputArtifactRefs: [], parentTaskId: 'dreamer-malformed-succ', correlationId: 'corr-malformed' },
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('successor_exists_with_malformed_metadata');
+    expect(output.actions[0].nextAction).toContain('integrity-repair');
+    expect(output.skippedCount).toBe(1);
+    expect(output.createdCount).toBe(0);
+  });
+
+  it('dedupe scan is not N×full-table per source task (buildSuccessorIndex called once)', async () => {
+    const dreamer1 = makeSucceededTask('dreamer-dedup-1', 'dreamer');
+    const dreamer2 = makeSucceededTask('dreamer-dedup-2', 'dreamer');
+    mockDryRunListTasks([dreamer1, dreamer2]);
+    mockProposeNextTask
+      .mockResolvedValueOnce({
+        decision: 'proposal_created',
+        taskId: 'dreamer-dedup-1',
+        taskKind: 'dreamer',
+        proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-dedup-1'], inputArtifactRefs: [], parentTaskId: 'dreamer-dedup-1', correlationId: 'corr-1' },
+      })
+      .mockResolvedValueOnce({
+        decision: 'proposal_created',
+        taskId: 'dreamer-dedup-2',
+        taskKind: 'dreamer',
+        proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-dedup-2'], inputArtifactRefs: [], parentTaskId: 'dreamer-dedup-2', correlationId: 'corr-2' },
+      });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    expect(mockListTasks.mock.calls.length).toBe(7);
+    const allCalls = mockListTasks.mock.calls.map(c => c[0]?.status);
+    const succeededCalls = allCalls.filter(s => s === 'succeeded').length;
+    expect(succeededCalls).toBe(2);
+  });
+
+  it('diagnosticJson non-string returns null, no throw', async () => {
+    const taskWithNonStringDiag = {
+      taskId: 'task-nonstring-diag',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      attemptCount: 1,
+      maxAttempts: 3,
+      inputRef: undefined,
+      resultRef: 'ref-nonstring',
+      lastError: undefined,
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+      diagnosticJson: 42,
+    };
+    mockListTasks.mockResolvedValue([taskWithNonStringDiag]);
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.scannedCount).toBe(1);
+    expect(output.skippedCount).toBe(1);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('Failed to hydrate');
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
   });
 
   it('resolveWorkspaceDir throws: fails closed with structured error', async () => {

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -1,0 +1,576 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+const mockListTasks = vi.hoisted(() => vi.fn());
+const mockGetTask = vi.hoisted(() => vi.fn());
+const mockCommitNextTaskProposal = vi.hoisted(() => vi.fn());
+const mockProposeNextTask = vi.hoisted(() => vi.fn());
+const mockClose = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockInitialize = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  RuntimeStateManager: vi.fn().mockImplementation(function () {
+    return {
+      initialize: mockInitialize,
+      close: mockClose,
+      listTasks: mockListTasks,
+      getTask: mockGetTask,
+    };
+  }),
+  InternalizationOrchestrator: vi.fn().mockImplementation(function () {
+    return {
+      commitNextTaskProposal: mockCommitNextTaskProposal,
+      proposeNextTask: mockProposeNextTask,
+    };
+  }),
+  isPeerRunnerKind: vi.fn().mockImplementation((k: string) =>
+    ['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer', 'trainer'].includes(k),
+  ),
+  hydratePITaskRecord: vi.fn().mockImplementation((task: Record<string, unknown>) => {
+    if (!task.diagnosticJson) return null;
+    try {
+      const meta = JSON.parse(task.diagnosticJson as string);
+      return {
+        taskId: task.taskId,
+        taskKind: task.taskKind,
+        status: task.status,
+        attemptCount: task.attemptCount ?? 0,
+        dependencyTaskIds: meta.dependencyTaskIds ?? [],
+        channel: meta.channel ?? 'prompt',
+        timeoutMs: meta.timeoutMs ?? 300_000,
+        inputArtifactRefs: meta.inputArtifactRefs ?? [],
+        outputArtifactRefs: meta.outputArtifactRefs ?? [],
+        parentTaskId: meta.parentTaskId ?? null,
+        correlationId: meta.correlationId ?? null,
+      };
+    } catch {
+      return null;
+    }
+  }),
+}));
+
+import { handleRuntimeInternalizationEnqueueSuccessors } from '../../src/commands/runtime-internalization-enqueue-successors.js';
+
+const WS = '/fake/workspace';
+
+function makePIMetadata(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    dependencyTaskIds: [],
+    channel: 'prompt',
+    timeoutMs: 300_000,
+    inputArtifactRefs: [],
+    outputArtifactRefs: [],
+    parentTaskId: null,
+    correlationId: null,
+    ...overrides,
+  });
+}
+
+function makeSucceededTask(taskId: string, taskKind: string, metaOverrides: Record<string, unknown> = {}) {
+  return {
+    taskId,
+    taskKind,
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    inputRef: undefined,
+    resultRef: `ref-${taskId}`,
+    lastError: undefined,
+    leaseOwner: undefined,
+    leaseExpiresAt: undefined,
+    diagnosticJson: makePIMetadata(metaOverrides),
+  };
+}
+
+function makeMalformedTask(taskId: string, taskKind: string) {
+  return {
+    taskId,
+    taskKind,
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    inputRef: undefined,
+    resultRef: `ref-${taskId}`,
+    lastError: undefined,
+    leaseOwner: undefined,
+    leaseExpiresAt: undefined,
+    diagnosticJson: 'not-valid-json{{{',
+  };
+}
+
+function createTestProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+
+  const internalizationCmd = program.command('internalization');
+
+  internalizationCmd
+    .command('enqueue-successors')
+    .description('Enqueue successor tasks for succeeded internalization tasks missing successors')
+    .option('-w, --workspace <path>', 'Workspace directory')
+    .option('--dry-run', 'Report only, no modifications (default)')
+    .option('--confirm', 'Actually create successor tasks')
+    .option('--json', 'Output raw JSON')
+    .action(async (opts) => {
+      await handleRuntimeInternalizationEnqueueSuccessors({
+        workspace: opts.workspace,
+        dryRun: opts.dryRun,
+        confirm: opts.confirm,
+        json: opts.json,
+      });
+    });
+
+  return program;
+}
+
+describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockInitialize.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('succeeded dreamer with artifact and no philosopher successor: dry-run reports would_create_successor', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-001', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockProposeNextTask.mockResolvedValue({
+      decision: 'proposal_created',
+      taskId: 'dreamer-001',
+      taskKind: 'dreamer',
+      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-001'], inputArtifactRefs: [], parentTaskId: 'dreamer-001', correlationId: 'corr-001' },
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, confirm: false, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('dry_run');
+    expect(output.dryRun).toBe(true);
+    expect(output.scannedCount).toBe(1);
+    expect(output.actions).toHaveLength(1);
+    expect(output.actions[0].taskId).toBe('dreamer-001');
+    expect(output.actions[0].taskKind).toBe('dreamer');
+    expect(output.actions[0].decision).toBe('would_create_successor');
+    expect(output.actions[0].successorKind).toBe('philosopher');
+  });
+
+  it('confirm creates exactly one philosopher successor', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-002', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'dreamer-002',
+      successorTaskId: 'philosopher-dreamer-002-prompt',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('confirmed');
+    expect(output.dryRun).toBe(false);
+    expect(output.createdCount).toBe(1);
+    expect(output.actions[0].decision).toBe('successor_created');
+    expect(output.actions[0].successorTaskId).toBe('philosopher-dreamer-002-prompt');
+    expect(output.actions[0].successorKind).toBe('philosopher');
+    expect(mockCommitNextTaskProposal).toHaveBeenCalledWith('dreamer-002');
+  });
+
+  it('repeated confirm returns successor_exists, no duplicate task', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-003', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_exists',
+      sourceTaskId: 'dreamer-003',
+      successorTaskId: 'philosopher-dreamer-003-prompt',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.existingCount).toBe(1);
+    expect(output.createdCount).toBe(0);
+    expect(output.actions[0].decision).toBe('successor_exists');
+    expect(output.actions[0].successorTaskId).toBe('philosopher-dreamer-003-prompt');
+  });
+
+  it('terminal runner returns no_successor', async () => {
+    const trainerTask = makeSucceededTask('trainer-001', 'trainer');
+    mockListTasks.mockResolvedValue([trainerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'no_successor',
+      sourceTaskId: 'trainer-001',
+      reason: 'No valid successor in job graph for this task kind and channel',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('no_successor');
+    expect(output.actions[0].taskId).toBe('trainer-001');
+    expect(output.actions[0].reason).toBe('No valid successor in job graph for this task kind and channel');
+  });
+
+  it('succeeded task with malformed metadata is skipped with reason; no successor created', async () => {
+    const malformedTask = makeMalformedTask('malformed-001', 'dreamer');
+    mockListTasks.mockResolvedValue([malformedTask]);
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.skippedCount).toBe(1);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].taskId).toBe('malformed-001');
+    expect(output.actions[0].reason).toBeDefined();
+    expect(output.actions[0].nextAction).toBeDefined();
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+  });
+
+  it('failed/retry_wait/leased tasks are not processed — only succeeded returned by listTasks', async () => {
+    const succeededTask = makeSucceededTask('dreamer-ok', 'dreamer');
+    mockListTasks.mockResolvedValue([succeededTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'dreamer-ok',
+      successorTaskId: 'philosopher-dreamer-ok-prompt',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.scannedCount).toBe(1);
+    expect(output.actions).toHaveLength(1);
+    expect(output.actions[0].taskId).toBe('dreamer-ok');
+    expect(mockCommitNextTaskProposal).toHaveBeenCalledTimes(1);
+    expect(mockCommitNextTaskProposal).toHaveBeenCalledWith('dreamer-ok');
+  });
+
+  it('DB/storage unavailable fails closed', async () => {
+    mockInitialize.mockRejectedValue(new Error('Cannot open database'));
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(output.scannedCount).toBe(0);
+    expect(output.actions).toHaveLength(0);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('listTasks throws: fails closed with structured error', async () => {
+    mockListTasks.mockRejectedValue(new Error('Database locked'));
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('default mode is dry-run', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-default', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockProposeNextTask.mockResolvedValue({
+      decision: 'proposal_created',
+      taskId: 'dreamer-default',
+      taskKind: 'dreamer',
+      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-default'], inputArtifactRefs: [], parentTaskId: 'dreamer-default', correlationId: 'corr-default' },
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('dry_run');
+    expect(output.dryRun).toBe(true);
+    expect(output.actions[0].decision).toBe('would_create_successor');
+  });
+
+  it('--confirm performs writes', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-confirm', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'dreamer-confirm',
+      successorTaskId: 'philosopher-dreamer-confirm-prompt',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('confirmed');
+    expect(output.dryRun).toBe(false);
+    expect(output.actions[0].decision).toBe('successor_created');
+  });
+
+  it('--dry-run --confirm is rejected with exit 1 and no writes', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
+
+    await expect(
+      handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, confirm: true, json: true }),
+    ).rejects.toThrow('process.exit:1');
+
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('--json emits parseable JSON only', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-json', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'dreamer-json',
+      successorTaskId: 'philosopher-dreamer-json-prompt',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const rawOutput = consoleLogSpy.mock.calls[0][0];
+    const parsed = JSON.parse(rawOutput);
+    expect(parsed).toBeDefined();
+    expect(parsed.status).toBe('confirmed');
+  });
+
+  it('text output is human-readable and includes counts', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-text', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'dreamer-text',
+      successorTaskId: 'philosopher-dreamer-text-prompt',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: false });
+
+    const text = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(text).toContain('Enqueue Successors');
+    expect(text).toContain('scanned');
+    expect(text).toContain('created');
+  });
+
+  it('commitNextTaskProposal returns source_not_succeeded: skipped with reason', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-not-succ', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'source_not_succeeded',
+      taskId: 'dreamer-not-succ',
+      status: 'failed',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('source_not_succeeded');
+  });
+
+  it('commitNextTaskProposal returns task_not_found: skipped with reason', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-not-found', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'task_not_found',
+      taskId: 'dreamer-not-found',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('task_not_found');
+  });
+
+  it('commitNextTaskProposal returns invalid_task_metadata: skipped with reason', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-invalid-meta', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'invalid_task_metadata',
+      taskId: 'dreamer-invalid-meta',
+      reason: 'Failed to hydrate PITaskRecord from diagnosticJson',
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('invalid_task_metadata');
+  });
+
+  it('multiple succeeded tasks: processes each independently', async () => {
+    const dreamer1 = makeSucceededTask('dreamer-multi-1', 'dreamer');
+    const dreamer2 = makeSucceededTask('dreamer-multi-2', 'dreamer');
+    const philosopher1 = makeSucceededTask('philosopher-multi-1', 'philosopher');
+    mockListTasks.mockResolvedValue([dreamer1, dreamer2, philosopher1]);
+
+    mockCommitNextTaskProposal
+      .mockResolvedValueOnce({
+        decision: 'successor_created',
+        sourceTaskId: 'dreamer-multi-1',
+        successorTaskId: 'philosopher-dreamer-multi-1-prompt',
+        successorKind: 'philosopher',
+      })
+      .mockResolvedValueOnce({
+        decision: 'successor_exists',
+        sourceTaskId: 'dreamer-multi-2',
+        successorTaskId: 'philosopher-dreamer-multi-2-prompt',
+        successorKind: 'philosopher',
+      })
+      .mockResolvedValueOnce({
+        decision: 'successor_created',
+        sourceTaskId: 'philosopher-multi-1',
+        successorTaskId: 'scribe-philosopher-multi-1-prompt',
+        successorKind: 'scribe',
+      });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.scannedCount).toBe(3);
+    expect(output.createdCount).toBe(2);
+    expect(output.existingCount).toBe(1);
+    expect(output.actions).toHaveLength(3);
+    expect(mockCommitNextTaskProposal).toHaveBeenCalledTimes(3);
+  });
+
+  it('non-PI task kinds (diagnostician) are not processed', async () => {
+    const diagTask = {
+      taskId: 'diag-001',
+      taskKind: 'diagnostician',
+      status: 'succeeded',
+      attemptCount: 1,
+      maxAttempts: 3,
+      diagnosticJson: '{}',
+    };
+    mockListTasks.mockResolvedValue([diagTask]);
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.scannedCount).toBe(0);
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+  });
+
+  it('dry-run does not call commitNextTaskProposal', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-dry', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockProposeNextTask.mockResolvedValue({
+      decision: 'proposal_created',
+      taskId: 'dreamer-dry',
+      taskKind: 'dreamer',
+      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-dry'], inputArtifactRefs: [], parentTaskId: 'dreamer-dry', correlationId: 'corr-dry' },
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+  });
+
+  it('workspace does not exist: fails closed', async () => {
+    mockInitialize.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: '/nonexistent/path', confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('dry-run with no_successor proposal: reports no_successor', async () => {
+    const trainerTask = makeSucceededTask('trainer-dry-001', 'trainer');
+    mockListTasks.mockResolvedValue([trainerTask]);
+    mockProposeNextTask.mockResolvedValue(null);
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('no_successor');
+    expect(output.actions[0].taskId).toBe('trainer-dry-001');
+  });
+});
+
+describe('Commander wiring for enqueue-successors', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockInitialize.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+    mockListTasks.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('no flags → dry-run mode (confirm=undefined, dryRun=undefined)', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--json']);
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.dryRun).toBe(true);
+    expect(output.status).toBe('dry_run');
+  });
+
+  it('--confirm alone → confirm mode', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--confirm', '--json']);
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.dryRun).toBe(false);
+    expect(output.status).toBe('confirmed');
+  });
+
+  it('--dry-run alone → dry-run mode', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--dry-run', '--json']);
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.dryRun).toBe(true);
+    expect(output.status).toBe('dry_run');
+  });
+
+  it('--dry-run --confirm together → rejected with exit 1', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
+
+    const program = createTestProgram();
+    await expect(
+      program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--dry-run', '--confirm', '--json']),
+    ).rejects.toThrow('process.exit:1');
+
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('--json flag produces parseable output', async () => {
+    const program = createTestProgram();
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--json']);
+
+    const rawOutput = consoleLogSpy.mock.calls[0][0];
+    const parsed = JSON.parse(rawOutput);
+    expect(parsed).toBeDefined();
+  });
+});

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -593,6 +593,32 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     expect(output.existingCount).toBe(1);
     expect(output.createdCount).toBe(0);
   });
+
+  it('dry-run proposeNextTask throws: skipped with reason', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-propose-err', 'dreamer');
+    mockListTasks.mockResolvedValueOnce([dreamerTask]);
+    mockProposeNextTask.mockRejectedValue(new Error('Orchestrator internal error'));
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('propose_failed');
+    expect(output.actions[0].nextAction).toBeDefined();
+    expect(output.skippedCount).toBe(1);
+  });
+
+  it('resolveWorkspaceDir throws: fails closed with structured error', async () => {
+    const { resolveWorkspaceDir } = await import('../../src/resolve-workspace.js');
+    vi.mocked(resolveWorkspaceDir).mockImplementationOnce(() => { throw new Error('No workspace found'); });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(output.error).toContain('Failed to resolve workspace');
+    expect(process.exitCode).toBe(1);
+  });
 });
 
 describe('Commander wiring for enqueue-successors', () => {

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -332,19 +332,17 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     expect(output.actions[0].decision).toBe('successor_created');
   });
 
-  it('--dry-run --confirm is rejected with exit 1 and no writes, JSON mode emits structured error', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
-
-    await expect(
-      handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, confirm: true, json: true }),
-    ).rejects.toThrow('process.exit:1');
+  it('--dry-run --confirm is rejected with exitCode 1 and no writes, JSON mode emits structured error with reason/nextAction', async () => {
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, confirm: true, json: true });
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.status).toBe('refused');
     expect(output.error).toContain('mutually exclusive');
+    expect(output.reason).toContain('flag_conflict');
+    expect(output.nextAction).toBeDefined();
+    expect(process.exitCode).toBe(1);
 
     expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
-    exitSpy.mockRestore();
   });
 
   it('--json emits parseable JSON only', async () => {
@@ -756,16 +754,12 @@ describe('Commander wiring for enqueue-successors', () => {
     expect(output.status).toBe('dry_run');
   });
 
-  it('--dry-run --confirm together → rejected with exit 1', async () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
-
+  it('--dry-run --confirm together → rejected with exitCode 1', async () => {
     const program = createTestProgram();
-    await expect(
-      program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--dry-run', '--confirm', '--json']),
-    ).rejects.toThrow('process.exit:1');
+    await program.parseAsync(['node', 'pd', 'internalization', 'enqueue-successors', '--workspace', WS, '--dry-run', '--confirm', '--json']);
 
+    expect(process.exitCode).toBe(1);
     expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
-    exitSpy.mockRestore();
   });
 
   it('--json flag produces parseable output', async () => {

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -57,6 +57,17 @@ import { handleRuntimeInternalizationEnqueueSuccessors } from '../../src/command
 
 const WS = '/fake/workspace';
 
+function mockDryRunListTasks(succeededTasks: ReturnType<typeof makeSucceededTask>[]) {
+  mockListTasks
+    .mockResolvedValueOnce(succeededTasks)
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([]);
+}
+
 function makePIMetadata(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     dependencyTaskIds: [],
@@ -148,11 +159,7 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
 
   it('succeeded dreamer with artifact and no philosopher successor: dry-run reports would_create_successor', async () => {
     const dreamerTask = makeSucceededTask('dreamer-001', 'dreamer');
-    mockListTasks
-      .mockResolvedValueOnce([dreamerTask])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    mockDryRunListTasks([dreamerTask]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-001',
@@ -290,11 +297,7 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
 
   it('default mode is dry-run', async () => {
     const dreamerTask = makeSucceededTask('dreamer-default', 'dreamer');
-    mockListTasks
-      .mockResolvedValueOnce([dreamerTask])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    mockDryRunListTasks([dreamerTask]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-default',
@@ -482,11 +485,7 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
 
   it('dry-run does not call commitNextTaskProposal', async () => {
     const dreamerTask = makeSucceededTask('dreamer-dry', 'dreamer');
-    mockListTasks
-      .mockResolvedValueOnce([dreamerTask])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    mockDryRunListTasks([dreamerTask]);
     mockProposeNextTask.mockResolvedValue({
       decision: 'proposal_created',
       taskId: 'dreamer-dry',
@@ -507,6 +506,20 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.status).toBe('failed');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('confirm path commitNextTaskProposal throws: skipped with reason', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-commit-err', 'dreamer');
+    mockListTasks.mockResolvedValue([dreamerTask]);
+    mockCommitNextTaskProposal.mockRejectedValue(new Error('Database locked during commit'));
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('skipped');
+    expect(output.actions[0].reason).toContain('commit_failed');
+    expect(output.actions[0].nextAction).toBeDefined();
+    expect(output.skippedCount).toBe(1);
   });
 
   it('dry-run with no_successor proposal: reports no_successor', async () => {
@@ -560,6 +573,9 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     mockListTasks
       .mockResolvedValueOnce([dreamerTask])
       .mockResolvedValueOnce([philosopherPending])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
     mockProposeNextTask.mockResolvedValue({

--- a/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
@@ -320,12 +320,16 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     expect(output.actions[0].decision).toBe('successor_created');
   });
 
-  it('--dry-run --confirm is rejected with exit 1 and no writes', async () => {
+  it('--dry-run --confirm is rejected with exit 1 and no writes, JSON mode emits structured error', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
 
     await expect(
       handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, confirm: true, json: true }),
     ).rejects.toThrow('process.exit:1');
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.status).toBe('refused');
+    expect(output.error).toContain('mutually exclusive');
 
     expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
     exitSpy.mockRestore();
@@ -503,6 +507,41 @@ describe('handleRuntimeInternalizationEnqueueSuccessors', () => {
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.actions[0].decision).toBe('no_successor');
     expect(output.actions[0].taskId).toBe('trainer-dry-001');
+  });
+
+  it('dry-run with existing successor: reports successor_exists', async () => {
+    const dreamerTask = makeSucceededTask('dreamer-existing-succ', 'dreamer');
+    const philosopherPending = {
+      taskId: 'philosopher-dreamer-existing-succ-prompt',
+      taskKind: 'philosopher',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+      inputRef: undefined,
+      resultRef: undefined,
+      lastError: undefined,
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+      diagnosticJson: makePIMetadata({ parentTaskId: 'dreamer-existing-succ', channel: 'prompt' }),
+    };
+    mockListTasks
+      .mockResolvedValueOnce([dreamerTask])
+      .mockResolvedValueOnce([philosopherPending])
+      .mockResolvedValueOnce([]);
+    mockProposeNextTask.mockResolvedValue({
+      decision: 'proposal_created',
+      taskId: 'dreamer-existing-succ',
+      taskKind: 'dreamer',
+      proposal: { taskKind: 'philosopher', channel: 'prompt', dependencyTaskIds: ['dreamer-existing-succ'], inputArtifactRefs: [], parentTaskId: 'dreamer-existing-succ', correlationId: 'corr-existing' },
+    });
+
+    await handleRuntimeInternalizationEnqueueSuccessors({ workspace: WS, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.actions[0].decision).toBe('successor_exists');
+    expect(output.actions[0].successorTaskId).toBe('philosopher-dreamer-existing-succ-prompt');
+    expect(output.existingCount).toBe(1);
+    expect(output.createdCount).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem (from PRI-216)

PRI-216 live validation discovered: successful internalization tasks stop the chain if the operator did not pass `--enqueue-next` during `run-once`. PRI-217 fixed `pd diagnose run` to auto-intake candidates after success. This PR fixes the next operator gap: providing a safe, idempotent, dry-run-capable CLI to enqueue successors for already-succeeded tasks that are missing them.

## Why not change run-once default behavior?

Changing `run-once` to default `--enqueue-next` would alter the existing operator contract. Instead, this PR adds a **new repair/backfill command** that operators can run ad-hoc to fix broken chains without changing the default behavior of `run-once`.

## New Command

```
pd runtime internalization enqueue-successors --workspace <path> --dry-run --json
pd runtime internalization enqueue-successors --workspace <path> --confirm --json
```

## Design

- **dry-run (default)**: Uses `InternalizationOrchestrator.proposeNextTask()` to report what would happen. No DB writes.
- **confirm**: Uses `InternalizationOrchestrator.commitNextTaskProposal()` to actually create successor tasks.
- **Idempotent**: `commitNextTaskProposal` returns `successor_exists` for tasks that already have successors — no duplicates.
- **Skipped/refused with reason**: Tasks with malformed metadata, non-succeeded status, or missing task records are skipped with structured `reason` and `nextAction` fields.
- **Terminal runners**: Return `no_successor` (e.g., trainer has no successor in the job graph).
- **JSON output**: Single parseable JSON object on stdout, no mixed text headers.
- **--dry-run and --confirm mutually exclusive**: Rejected with exit 1 and no side effects.

## ERR Checklist

| ERR | How avoided |
|-----|-------------|
| ERR-002 | Every skipped/refused action includes `reason` and `nextAction`. DB unavailable fails closed with structured error. No silent fallback. |
| ERR-011 | Uses `InternalizationOrchestrator` (core facade) for all task creation. No direct Store access. |
| ERR-012 | Branch based on latest `origin/main` (pulled before starting). |
| ERR-018/ERR-019 | Each task processed independently in loop; current task data used for each decision, no stale state accumulation. |
| ERR-021 | Commander wiring tests prove `--dry-run`, `--confirm`, `--json` flags reach handler correctly. |
| ERR-022 | `process.exit(1)` after `--dry-run --confirm` conflict is followed by `return`. |

## Tests

```
npx vitest run packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts
```

**26 tests passing:**
- Core logic: dry-run reports would_create_successor, confirm creates successor, idempotent (successor_exists), terminal runner no_successor, malformed metadata skipped with reason, failed/retry_wait/leased tasks not processed, DB unavailable fails closed, listTasks throws fails closed, default is dry-run, confirm performs writes, --dry-run --confirm rejected, JSON parseable, text human-readable, commitNextTaskProposal edge cases (source_not_succeeded, task_not_found, invalid_task_metadata), multiple tasks processed independently, non-PI task kinds skipped, dry-run does not call commitNextTaskProposal, workspace not found fails closed, dry-run no_successor
- Commander wiring: no flags → dry-run, --confirm → confirm, --dry-run → dry-run, --dry-run --confirm → exit 1, --json → parseable output

## Verification Commands

```bash
npm run build --workspace=@principles/core     # ✓ pass
npm run build --workspace=@principles/pd-cli   # ✓ pass
npx vitest run packages/pd-cli/tests/commands/runtime-internalization-enqueue-successors.test.ts  # ✓ 26/26
npx vitest run packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts  # ✓ 39/39
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  # ✓ 435/435
npm run verify:merge  # ✓ pass
```

## No Production Confirm Run

This PR has NOT been run with `--confirm` on any production workspace.

## Remaining Risk

- Pre-existing test failures in `runtime-activation.test.ts`, `candidate-audit-repair.test.ts`, `runtime.test.ts`, and `candidate-intake-e2e.test.ts` are unrelated to this change (10 failures across 4 files, all pre-existing).
- The command scans only `succeeded` tasks. If a task transitions from succeeded to another status between scan and commit, `commitNextTaskProposal` returns `source_not_succeeded` and the task is skipped with reason — no incorrect successor is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增命令：扫描已完成的内部化任务并为其计算/创建后继任务，支持干运行与确认模式，以及文本/JSON 报告。
* **测试**
  * 补充全面测试覆盖多种决策路径、输出格式与错误场景，确保干运行/确认互斥与只读行为。
* **文档 / 修复**
  * 文档新增错误条目，说明干运行应以只读模式构造以避免意外写入并记录修正建议。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->