### PR TITLE
fix(plugin-installer): use PowerShell shim for Windows Gateway restart fallback

### DIFF
--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -1073,10 +1073,15 @@ function restartGatewayWindows() {
             execSync('schtasks /Run /TN "OpenClaw Gateway"', { stdio: 'pipe' });
             gatewayStarted = true;
         } catch {
-            // schtasks failed — try direct CLI fallback
-            console.log('   Scheduled task not available, trying direct gateway start...');
+            // schtasks failed — try direct CLI fallback via PowerShell
+            // PowerShell shim resolves paths correctly in Anaconda environments
+            // where cmd /c can produce wrong path prefixes (e.g. conda prefix + npm path)
+            console.log('   Scheduled task not available, trying direct gateway start via PowerShell...');
             try {
-                execSync('start /b cmd /c "openclaw gateway > nul 2>&1"', { stdio: 'pipe', shell: true });
+                execSync(
+                    'powershell -NoProfile -Command "Start-Process -WindowStyle Hidden -NoNewWindow -FilePath \'openclaw\' -ArgumentList \'gateway\'"',
+                    { stdio: 'pipe', timeout: 5000 }
+                );
                 gatewayStarted = true;
             } catch {
                 // Gateway may already be running or no perms — not fatal


### PR DESCRIPTION
## Summary

- Fix Windows Gateway restart failure when Anaconda environment is active
- Replace `cmd /c "openclaw gateway > /dev/null 2>&1"` with PowerShell `Start-Process`
- The CMD shim resolves paths incorrectly in Anaconda environments (produces `D:\ProgramData\anaconda3\Library\c\Users\...\npm\...` paths)
- PowerShell shim uses `Split-Path` which works correctly regardless of PATH pollution

## Test plan

- [ ] Run `node scripts/install.mjs` and check Gateway restarts without the error:
  `Cannot find module 'D:\ProgramData\anaconda3\Library\c\...\openclaw.mjs'`
- [ ] Confirm Gateway is listening on port 18789 after installation

Fixes: Windows Gateway restart failure in Anaconda environments