### PR TITLE
fix(pd-cli): support pending candidates in internalization backfill (PRI-219)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -87,6 +87,7 @@ Errors where AI assistants wrote code contradicting architecture docs or ADRs.
 | ID | Summary | Source |
 |----|---------|--------|
 | ERR-021 | Handler-only tests miss Commander flag→opts mapping bugs | PRI-217 |
+| ERR-024 | Error catch block zeroes partial computation results instead of preserving them | PRI-208 |
 | ERR-022 | process.exit(1) without return allows fallthrough to intake on failed diagnosis | PRI-217 |
 | ERR-023 | CLI dry-run command opens writable database connection instead of readonly | PRI-218 |
 
@@ -386,9 +387,22 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-024]** | Error catch block zeroes partial computation results instead of preserving them
+
+- **What happened**: In `pain-flood-simulation-runner.ts`, the catch block for the main simulation loop set all aggregate counters (`inputPainCount`, `acceptedPainCount`, `skippedDuplicateCount`, `candidateCount`, `taskCount`) to zero, even though the `stages` array still contained data from scenarios that completed successfully before the error. This produced internally inconsistent output where `stages` showed completed work but top-level counters reported zero.
+- **Why it's wrong**: When an error occurs after partial computation, zeroing aggregate counters fabricates data — it claims nothing happened when some scenarios actually completed. This violates ERR-002 (graceful degradation must include a reason) and makes error output unobservable and internally inconsistent. Consumers that check top-level counters get a misleading picture.
+- **Correct approach**: Use the existing `computeFloodTotals(stages)` helper to derive aggregate counters from the actual completed stages, preserving partial results. The error status still signals failure, but the metrics reflect reality.
+- **How to prevent**: When writing catch blocks that return error/fallback results, never fabricate default values for metrics that can be derived from partial computation state. Always compute from actual data. Review all catch blocks that set counters/summaries to zero or default values and verify whether partial data is available.
+- **Source**: PRI-208 / PR #684
+- **Date**: 2026-05-23
+- **Recurrence**: None
+- **Related**: ERR-002 (silent fallback), ERR-018/ERR-019 (stale loop state)
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 23 |
+| Total lessons | 24 |
 | Last updated | 2026-05-23 |
 | Top category | Schema & Type |
 | Recurring errors | 11 |

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -87,7 +87,6 @@ Errors where AI assistants wrote code contradicting architecture docs or ADRs.
 | ID | Summary | Source |
 |----|---------|--------|
 | ERR-021 | Handler-only tests miss Commander flag→opts mapping bugs | PRI-217 |
-| ERR-024 | Error catch block zeroes partial computation results instead of preserving them | PRI-208 |
 | ERR-022 | process.exit(1) without return allows fallthrough to intake on failed diagnosis | PRI-217 |
 | ERR-023 | CLI dry-run command opens writable database connection instead of readonly | PRI-218 |
 
@@ -387,22 +386,9 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
-**[ERR-024]** | Error catch block zeroes partial computation results instead of preserving them
-
-- **What happened**: In `pain-flood-simulation-runner.ts`, the catch block for the main simulation loop set all aggregate counters (`inputPainCount`, `acceptedPainCount`, `skippedDuplicateCount`, `candidateCount`, `taskCount`) to zero, even though the `stages` array still contained data from scenarios that completed successfully before the error. This produced internally inconsistent output where `stages` showed completed work but top-level counters reported zero.
-- **Why it's wrong**: When an error occurs after partial computation, zeroing aggregate counters fabricates data — it claims nothing happened when some scenarios actually completed. This violates ERR-002 (graceful degradation must include a reason) and makes error output unobservable and internally inconsistent. Consumers that check top-level counters get a misleading picture.
-- **Correct approach**: Use the existing `computeFloodTotals(stages)` helper to derive aggregate counters from the actual completed stages, preserving partial results. The error status still signals failure, but the metrics reflect reality.
-- **How to prevent**: When writing catch blocks that return error/fallback results, never fabricate default values for metrics that can be derived from partial computation state. Always compute from actual data. Review all catch blocks that set counters/summaries to zero or default values and verify whether partial data is available.
-- **Source**: PRI-208 / PR #684
-- **Date**: 2026-05-23
-- **Recurrence**: None
-- **Related**: ERR-002 (silent fallback), ERR-018/ERR-019 (stale loop state)
-
----
-
 | Metric | Value |
 |--------|-------|
-| Total lessons | 24 |
+| Total lessons | 23 |
 | Last updated | 2026-05-23 |
 | Top category | Schema & Type |
 | Recurring errors | 11 |

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -695,47 +695,85 @@ interface CandidateBackfillOptions {
   json?: boolean;
   dryRun?: boolean;
   confirm?: boolean;
+  includePending?: boolean;
 }
 
 interface BackfillCandidateResult {
   candidateId: string;
   route: string;
-  status: 'would_create' | 'created' | 'existing' | 'deferred' | 'error';
+  status: 'would_create' | 'created' | 'existing' | 'deferred' | 'error' | 'would_intake_and_create' | 'intake_failed' | 'intake_succeeded_existing_task';
   taskId?: string;
   channel?: string;
   reason?: string;
+  statusBefore?: string;
+  statusAfter?: string;
+  intakeDecision?: 'would_intake' | 'intake_succeeded' | 'intake_failed' | 'skipped' | 'not_needed';
+  seedDecision?: 'would_seed' | 'seeded' | 'existing' | 'skipped' | 'not_needed';
+  nextAction?: string;
 }
 
 interface BackfillOutput {
   mode: 'dry-run' | 'confirm';
   totalConsumed: number;
+  totalPending: number;
   missingDreamerTask: number;
   alreadyHaveTask: number;
   deferred: number;
   created: number;
+  intakeSucceeded: number;
+  intakeFailed: number;
   errors: number;
   results: BackfillCandidateResult[];
 }
 
 function createBackfillRemediationResult(output: BackfillOutput): RemediationResult {
   const actions = output.results
-    .filter((result) => result.status === 'would_create' || result.status === 'created')
-    .map((result) => remediationAction({
-      action: result.status === 'created' ? 'create_dreamer_task' : 'would_create_dreamer_task',
-      targetId: result.candidateId,
-      previousState: 'consumed_candidate_without_dreamer',
-      nextState: result.status === 'created' ? 'dreamer_task_created' : 'dreamer_task_would_be_created',
-      reason: result.reason ?? `Backfill ${result.status === 'created' ? 'created' : 'would create'} dreamer task${result.taskId ? ` ${result.taskId}` : ''}`,
-    }));
+    .filter((result) => result.status === 'would_create' || result.status === 'created' || result.status === 'would_intake_and_create' || result.status === 'intake_failed' || result.status === 'intake_succeeded_existing_task')
+    .map((result) => {
+      if (result.status === 'would_intake_and_create') {
+        return remediationAction({
+          action: 'would_intake_and_create_dreamer_task',
+          targetId: result.candidateId,
+          previousState: 'pending_candidate_without_dreamer',
+          nextState: 'dreamer_task_would_be_created',
+          reason: result.reason ?? `Backfill would intake pending candidate and create dreamer task${result.taskId ? ` ${result.taskId}` : ''}`,
+        });
+      }
+      if (result.status === 'intake_failed') {
+        return remediationAction({
+          action: 'intake_failed',
+          targetId: result.candidateId,
+          previousState: 'pending_candidate',
+          nextState: 'pending_candidate_intake_failed',
+          reason: result.reason ?? `Backfill intake failed for pending candidate`,
+        });
+      }
+      if (result.status === 'intake_succeeded_existing_task') {
+        return remediationAction({
+          action: 'intake_succeeded_existing_task',
+          targetId: result.candidateId,
+          previousState: 'pending_candidate',
+          nextState: 'consumed_candidate_with_existing_dreamer',
+          reason: result.reason ?? `Backfill intake succeeded but dreamer task already exists`,
+        });
+      }
+      return remediationAction({
+        action: result.status === 'created' ? 'create_dreamer_task' : 'would_create_dreamer_task',
+        targetId: result.candidateId,
+        previousState: 'consumed_candidate_without_dreamer',
+        nextState: result.status === 'created' ? 'dreamer_task_created' : 'dreamer_task_would_be_created',
+        reason: result.reason ?? `Backfill ${result.status === 'created' ? 'created' : 'would create'} dreamer task${result.taskId ? ` ${result.taskId}` : ''}`,
+      });
+    });
 
   return createRemediationResult({
     mode: output.mode === 'confirm' ? 'confirm' : 'dry_run',
     repairedCount: output.created,
-    skippedCount: output.alreadyHaveTask + output.deferred + output.errors,
+    skippedCount: output.alreadyHaveTask + output.deferred + output.errors + output.intakeFailed,
     actions,
-    warnings: output.errors > 0 ? [`${output.errors} candidate(s) could not be backfilled.`] : [],
-    status: output.errors > 0 && output.created === 0 ? 'error' : undefined,
-    safeToConfirm: output.mode === 'dry-run' && output.missingDreamerTask > 0 && output.errors === 0,
+    warnings: output.errors > 0 ? [`${output.errors} candidate(s) could not be backfilled.`] : (output.intakeFailed > 0 ? [`${output.intakeFailed} pending candidate(s) intake failed.`] : []),
+    status: (output.errors > 0 || output.intakeFailed > 0) && output.created === 0 ? 'error' : undefined,
+    safeToConfirm: output.mode === 'dry-run' && (output.missingDreamerTask > 0 || output.totalPending > 0) && output.errors === 0,
   });
 }
 
@@ -743,11 +781,12 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
   if (opts.dryRun && opts.confirm) {
     console.error('Error: --dry-run and --confirm are mutually exclusive');
     process.exit(1);
+    return;
   }
 
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
-  const stateManager = new RuntimeStateManager({ workspaceDir });
   const isConfirm = opts.confirm ?? false;
+  const stateManager = new RuntimeStateManager({ workspaceDir, readonly: !isConfirm });
 
   try {
     await stateManager.initialize();
@@ -758,13 +797,23 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
       "SELECT candidate_id FROM principle_candidates WHERE status = 'consumed'"
     ).all() as { candidate_id: string }[];
 
+    let pendingRows: { candidate_id: string }[] = [];
+    if (opts.includePending) {
+      pendingRows = db.prepare(
+        "SELECT candidate_id FROM principle_candidates WHERE status = 'pending'"
+      ).all() as { candidate_id: string }[];
+    }
+
     const output: BackfillOutput = {
       mode: isConfirm ? 'confirm' : 'dry-run',
       totalConsumed: consumedRows.length,
+      totalPending: pendingRows.length,
       missingDreamerTask: 0,
       alreadyHaveTask: 0,
       deferred: 0,
       created: 0,
+      intakeSucceeded: 0,
+      intakeFailed: 0,
       errors: 0,
       results: [],
     };
@@ -775,7 +824,7 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
       const candidate = await stateManager.getCandidate(candidateId);
       if (!candidate) {
         output.errors++;
-        output.results.push({ candidateId, route: 'unknown', status: 'error', reason: 'Candidate not found in DB' });
+        output.results.push({ candidateId, route: 'unknown', status: 'error', reason: 'Candidate not found in DB', statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'skipped', nextAction: 'Investigate why consumed candidate is missing from DB' });
         continue;
       }
 
@@ -796,7 +845,7 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
         const reason = bridgeDecision.decision === 'already_exists'
           ? `Task ${bridgeDecision.taskId} already exists`
           : bridgeDecision.reason;
-        output.results.push({ candidateId, route: decision.route, status: 'deferred', reason });
+        output.results.push({ candidateId, route: decision.route, status: 'deferred', reason, statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'skipped' });
         continue;
       }
 
@@ -815,14 +864,14 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
           } catch { /* best-effort */ }
         }
         output.alreadyHaveTask++;
-        output.results.push({ candidateId, route: decision.route, status: 'existing', taskId: existingTask.taskId, channel });
+        output.results.push({ candidateId, route: decision.route, status: 'existing', taskId: existingTask.taskId, channel, statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'existing' });
         continue;
       }
 
       output.missingDreamerTask++;
 
       if (!isConfirm) {
-        output.results.push({ candidateId, route: decision.route, status: 'would_create', taskId, channel });
+        output.results.push({ candidateId, route: decision.route, status: 'would_create', taskId, channel, statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'would_seed' });
         continue;
       }
 
@@ -830,7 +879,7 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
         const seed = buildDreamerTaskSeed(bridgeInput);
         if ('decision' in seed) {
           output.errors++;
-          output.results.push({ candidateId, route: decision.route, status: 'error', reason: (seed as { reason: string }).reason });
+          output.results.push({ candidateId, route: decision.route, status: 'error', reason: (seed as { reason: string }).reason, statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'skipped', nextAction: 'Investigate bridge seed failure' });
           continue;
         }
 
@@ -844,10 +893,109 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
         });
 
         output.created++;
-        output.results.push({ candidateId, route: decision.route, status: 'created', taskId: task.taskId, channel });
+        output.results.push({ candidateId, route: decision.route, status: 'created', taskId: task.taskId, channel, statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'seeded' });
       } catch (err) {
         output.errors++;
-        output.results.push({ candidateId, route: decision.route, status: 'error', reason: err instanceof Error ? err.message : String(err) });
+        output.results.push({ candidateId, route: decision.route, status: 'error', reason: err instanceof Error ? err.message : String(err), statusBefore: 'consumed', statusAfter: 'consumed', intakeDecision: 'not_needed', seedDecision: 'skipped', nextAction: 'Investigate dreamer task creation failure' });
+      }
+    }
+
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: path.join(workspaceDir, '.state') });
+    const intakeService = new CandidateIntakeService({ stateManager, ledgerAdapter });
+
+    for (const row of pendingRows) {
+      const candidateId = row.candidate_id;
+
+      const candidate = await stateManager.getCandidate(candidateId);
+      if (!candidate) {
+        output.errors++;
+        output.results.push({ candidateId, route: 'unknown', status: 'error', reason: 'Pending candidate not found in DB', statusBefore: 'pending', statusAfter: 'pending', intakeDecision: 'skipped', seedDecision: 'skipped', nextAction: 'Investigate why pending candidate is missing from DB' });
+        continue;
+      }
+
+      const recommendation = resolveCandidateRecommendation(candidate, stateManager, candidateId);
+      const decision = decideInternalizationRoute(recommendation as Parameters<typeof decideInternalizationRoute>[0]);
+
+      const bridgeInput = {
+        candidateId,
+        recommendationKind: recommendation.kind,
+        route: decision.route,
+        ready: decision.ready,
+      };
+
+      const bridgeDecision = computeBridgeDecision(bridgeInput);
+
+      if (bridgeDecision.decision !== 'seeded') {
+        output.deferred++;
+        const reason = bridgeDecision.decision === 'already_exists'
+          ? `Task ${bridgeDecision.taskId} already exists`
+          : bridgeDecision.reason;
+        output.results.push({ candidateId, route: decision.route, status: 'deferred', reason, statusBefore: 'pending', statusAfter: 'pending', intakeDecision: 'skipped', seedDecision: 'skipped', nextAction: 'Investigate why bridge decision is not seeded' });
+        continue;
+      }
+
+      const {channel} = bridgeDecision;
+      const {taskId} = bridgeDecision;
+
+      if (!isConfirm) {
+        output.missingDreamerTask++;
+        output.results.push({ candidateId, route: decision.route, status: 'would_intake_and_create', taskId, channel, statusBefore: 'pending', statusAfter: 'consumed', intakeDecision: 'would_intake', seedDecision: 'would_seed', nextAction: 'Run with --confirm to intake and seed' });
+        continue;
+      }
+
+      const intakeEntry = await intakeService.intake(candidateId).catch((intakeErr: unknown) => {
+        output.intakeFailed++;
+        const intakeReason = intakeErr instanceof CandidateIntakeError
+          ? `Intake failed [${(intakeErr as { code?: string }).code ?? 'unknown'}]: ${intakeErr.message}`
+          : `Intake failed: ${intakeErr instanceof Error ? intakeErr.message : String(intakeErr)}`;
+        output.results.push({ candidateId, route: decision.route, status: 'intake_failed', reason: intakeReason, statusBefore: 'pending', statusAfter: 'pending', intakeDecision: 'intake_failed', seedDecision: 'skipped', nextAction: 'Fix intake issue and re-run backfill' });
+        return null;
+      });
+
+      if (!intakeEntry) {
+        continue;
+      }
+
+      try {
+        await updateCandidateStatus(stateManager, candidateId, 'consumed');
+      } catch (statusErr) {
+        const statusMsg = `Ledger write succeeded (entry ${intakeEntry.id}) but DB status update failed: ${statusErr instanceof Error ? statusErr.message : String(statusErr)}`;
+        output.intakeFailed++;
+        output.results.push({ candidateId, route: decision.route, status: 'intake_failed', reason: statusMsg, statusBefore: 'pending', statusAfter: 'pending', intakeDecision: 'intake_failed', seedDecision: 'skipped', nextAction: 'Candidate may be in inconsistent state — check ledger and DB manually' });
+        continue;
+      }
+
+      output.intakeSucceeded++;
+
+      const existingTask = await stateManager.getTask(taskId);
+      if (existingTask) {
+        output.alreadyHaveTask++;
+        output.results.push({ candidateId, route: decision.route, status: 'intake_succeeded_existing_task', taskId: existingTask.taskId, channel, statusBefore: 'pending', statusAfter: 'consumed', intakeDecision: 'intake_succeeded', seedDecision: 'existing', reason: `Intake succeeded but dreamer task ${existingTask.taskId} already exists` });
+        continue;
+      }
+
+      try {
+        const seed = buildDreamerTaskSeed(bridgeInput);
+        if ('decision' in seed) {
+          output.errors++;
+          output.results.push({ candidateId, route: decision.route, status: 'error', reason: (seed as { reason: string }).reason, statusBefore: 'pending', statusAfter: 'consumed', intakeDecision: 'intake_succeeded', seedDecision: 'skipped', nextAction: 'Intake succeeded but dreamer seed failed — candidate is consumed, re-run backfill for consumed candidates' });
+          continue;
+        }
+
+        const task = await stateManager.createTask({
+          taskId: seed.taskId,
+          taskKind: seed.taskKind,
+          status: seed.status,
+          attemptCount: seed.attemptCount,
+          maxAttempts: seed.maxAttempts,
+          diagnosticJson: seed.diagnosticJson,
+        });
+
+        output.created++;
+        output.results.push({ candidateId, route: decision.route, status: 'created', taskId: task.taskId, channel, statusBefore: 'pending', statusAfter: 'consumed', intakeDecision: 'intake_succeeded', seedDecision: 'seeded' });
+      } catch (err) {
+        output.errors++;
+        output.results.push({ candidateId, route: decision.route, status: 'error', reason: err instanceof Error ? err.message : String(err), statusBefore: 'pending', statusAfter: 'consumed', intakeDecision: 'intake_succeeded', seedDecision: 'skipped', nextAction: 'Intake succeeded but dreamer task creation failed — candidate is consumed, re-run backfill for consumed candidates' });
       }
     }
 
@@ -859,23 +1007,31 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
       console.log(`  status:              ${remediation.status}`);
       console.log(`  safe_to_confirm:     ${remediation.safeToConfirm}`);
       console.log(`  total_consumed:      ${output.totalConsumed}`);
+      if (opts.includePending) {
+        console.log(`  total_pending:       ${output.totalPending}`);
+      }
       console.log(`  missing_dreamer:     ${output.missingDreamerTask}`);
       console.log(`  already_have_task:   ${output.alreadyHaveTask}`);
       console.log(`  deferred:            ${output.deferred}`);
       if (isConfirm) {
         console.log(`  created:             ${output.created}`);
         console.log(`  errors:              ${output.errors}`);
+        if (opts.includePending) {
+          console.log(`  intake_succeeded:    ${output.intakeSucceeded}`);
+          console.log(`  intake_failed:       ${output.intakeFailed}`);
+        }
       }
       for (const r of output.results) {
-        console.log(`  ${r.candidateId}: ${r.status} (${r.route})${r.taskId ? ` → ${r.taskId}` : ''}${r.reason ? ` — ${r.reason}` : ''}`);
+        const prefix = r.statusBefore === 'pending' ? '[pending]' : '[consumed]';
+        console.log(`  ${prefix} ${r.candidateId}: ${r.status} (${r.route})${r.taskId ? ` → ${r.taskId}` : ''}${r.reason ? ` — ${r.reason}` : ''}`);
       }
-      if (!isConfirm && output.missingDreamerTask > 0) {
-        console.log(`\n  (use --confirm to create missing dreamer tasks)`);
+      if (!isConfirm && (output.missingDreamerTask > 0 || output.totalPending > 0)) {
+        console.log(`\n  (use --confirm to create missing dreamer tasks${opts.includePending ? ' and intake pending candidates' : ''})`);
       }
       console.log('');
     }
 
-    if (output.missingDreamerTask > 0 && !isConfirm) {
+    if ((output.missingDreamerTask > 0 || output.totalPending > 0) && !isConfirm) {
       process.exitCode = 1;
     }
   } finally {

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -505,7 +505,7 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
 
     // Update DB status — this must succeed; if it fails, exit non-zero
     try {
-      await updateCandidateStatus({ stateManager, candidateId: opts.candidateId, targetStatus: 'consumed' });
+      await updateCandidateStatus({ stateManager, candidateId: opts.candidateId, targetStatus: 'consumed', expectedCurrentStatus: 'pending' });
     } catch (err) {
       const msg = `Ledger write succeeded (entry ${entry.id}) but DB status update failed: ${err instanceof Error ? err.message : String(err)}. ` +
         `Candidate ${opts.candidateId} may be in inconsistent state.`;

--- a/packages/pd-cli/src/commands/candidate.ts
+++ b/packages/pd-cli/src/commands/candidate.ts
@@ -73,17 +73,31 @@ interface AuditResult {
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
 /** Update candidate status. Sets consumed_at when status='consumed'. */
-async function updateCandidateStatus(stateManager: RuntimeStateManager, candidateId: string, status: string): Promise<void> {
+interface UpdateCandidateStatusOptions {
+  stateManager: RuntimeStateManager;
+  candidateId: string;
+  targetStatus: string;
+  expectedCurrentStatus?: string;
+}
+
+async function updateCandidateStatus(opts: UpdateCandidateStatusOptions): Promise<void> {
+  const { stateManager, candidateId, targetStatus, expectedCurrentStatus } = opts;
   const db = stateManager.connection;
   const now = new Date().toISOString();
-  if (status === 'consumed') {
-    db.getDb().prepare(
-      'UPDATE principle_candidates SET status = ?, consumed_at = ? WHERE candidate_id = ?'
-    ).run(status, now, candidateId);
+  if (targetStatus === 'consumed') {
+    const result = db.getDb().prepare(
+      'UPDATE principle_candidates SET status = ?, consumed_at = ? WHERE candidate_id = ? AND status = ?'
+    ).run(targetStatus, now, candidateId, expectedCurrentStatus ?? targetStatus);
+    if (result.changes === 0) {
+      throw new Error(`Guarded transition failed: candidate ${candidateId} is not in expected status '${expectedCurrentStatus ?? targetStatus}'`);
+    }
   } else {
-    db.getDb().prepare(
-      'UPDATE principle_candidates SET status = ? WHERE candidate_id = ?'
-    ).run(status, candidateId);
+    const result = db.getDb().prepare(
+      'UPDATE principle_candidates SET status = ? WHERE candidate_id = ? AND status = ?'
+    ).run(targetStatus, candidateId, expectedCurrentStatus ?? targetStatus);
+    if (result.changes === 0) {
+      throw new Error(`Guarded transition failed: candidate ${candidateId} is not in expected status '${expectedCurrentStatus ?? targetStatus}'`);
+    }
   }
 }
 
@@ -491,7 +505,7 @@ export async function handleCandidateIntake(opts: CandidateIntakeOptions): Promi
 
     // Update DB status — this must succeed; if it fails, exit non-zero
     try {
-      await updateCandidateStatus(stateManager, opts.candidateId, 'consumed');
+      await updateCandidateStatus({ stateManager, candidateId: opts.candidateId, targetStatus: 'consumed' });
     } catch (err) {
       const msg = `Ledger write succeeded (entry ${entry.id}) but DB status update failed: ${err instanceof Error ? err.message : String(err)}. ` +
         `Candidate ${opts.candidateId} may be in inconsistent state.`;
@@ -939,7 +953,7 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
 
       if (!isConfirm) {
         output.missingDreamerTask++;
-        output.results.push({ candidateId, route: decision.route, status: 'would_intake_and_create', taskId, channel, statusBefore: 'pending', statusAfter: 'consumed', intakeDecision: 'would_intake', seedDecision: 'would_seed', nextAction: 'Run with --confirm to intake and seed' });
+        output.results.push({ candidateId, route: decision.route, status: 'would_intake_and_create', taskId, channel, statusBefore: 'pending', statusAfter: 'pending', intakeDecision: 'would_intake', seedDecision: 'would_seed', nextAction: 'Run with --confirm to intake and seed' });
         continue;
       }
 
@@ -957,7 +971,7 @@ export async function handleCandidateInternalizationBackfill(opts: CandidateBack
       }
 
       try {
-        await updateCandidateStatus(stateManager, candidateId, 'consumed');
+        await updateCandidateStatus({ stateManager, candidateId, targetStatus: 'consumed', expectedCurrentStatus: 'pending' });
       } catch (statusErr) {
         const statusMsg = `Ledger write succeeded (entry ${intakeEntry.id}) but DB status update failed: ${statusErr instanceof Error ? statusErr.message : String(statusErr)}`;
         output.intakeFailed++;

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -732,9 +732,10 @@ candidateInternalizationCmd
   .option('-w, --workspace <path>', 'Workspace directory')
   .option('--dry-run', 'Report only, no modifications (default)')
   .option('--confirm', 'Actually create missing dreamer tasks')
+  .option('--include-pending', 'Include pending candidates (intake first, then seed dreamer)')
   .option('--json', 'Output as JSON')
   .action(async (opts) => {
-    await handleCandidateInternalizationBackfill({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, json: opts.json });
+    await handleCandidateInternalizationBackfill({ workspace: opts.workspace, dryRun: opts.dryRun, confirm: opts.confirm, includePending: opts.includePending, json: opts.json });
   });
 
 // ── Artifact inspection commands ────────────────────────────────────────────

--- a/packages/pd-cli/tests/commands/candidate-intake.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-intake.test.ts
@@ -11,7 +11,7 @@ const { mockStateManager, mockAdapter, mockService, MockRuntimeStateManager, Moc
     connection: {
       getDb: () => ({
         prepare: () => ({
-          run: vi.fn(),
+          run: vi.fn().mockReturnValue({ changes: 1 }),
         }),
       }),
     },
@@ -494,5 +494,96 @@ describe('pd candidate intake', () => {
     );
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('guarded transition: UPDATE uses WHERE status = pending for intake path', async () => {
+    const mockCandidate = {
+      candidateId: 'valid-id',
+      artifactId: 'artifact-1',
+      taskId: 'task-1',
+      title: 'Test Principle',
+      description: 'Test description',
+      status: 'pending',
+    };
+    const mockEntry = {
+      id: 'ledger-entry-1',
+      title: 'Test Principle',
+      text: 'Test text',
+      status: 'probation',
+    };
+
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate);
+    mockService.intake.mockResolvedValue(mockEntry);
+
+    const capturedPrepareCalls: { sql: string; runArgs: unknown[] }[] = [];
+    const originalConnection = mockStateManager.connection;
+    mockStateManager.connection = {
+      getDb: () => ({
+        prepare: (sql: string) => ({
+          run: (...args: unknown[]) => {
+            capturedPrepareCalls.push({ sql, runArgs: args });
+            return { changes: 1 };
+          },
+        }),
+      }),
+    };
+
+    try {
+      await handleCandidateIntake({
+        candidateId: 'valid-id',
+        workspace: '/tmp/test-workspace',
+        json: true,
+      });
+
+      const updateCall = capturedPrepareCalls.find(c => c.sql.includes('UPDATE'));
+      expect(updateCall).toBeDefined();
+      expect(updateCall!.sql).toContain('AND status = ?');
+      expect(updateCall!.runArgs[0]).toBe('consumed');
+      expect(updateCall!.runArgs[3]).toBe('pending');
+    } finally {
+      mockStateManager.connection = originalConnection;
+    }
+  });
+
+  it('guarded transition: intake fails when candidate is not pending', async () => {
+    const mockCandidate = {
+      candidateId: 'valid-id',
+      artifactId: 'artifact-1',
+      taskId: 'task-1',
+      title: 'Test Principle',
+      description: 'Test description',
+      status: 'pending',
+    };
+    const mockEntry = {
+      id: 'ledger-entry-1',
+      title: 'Test Principle',
+      text: 'Test text',
+      status: 'probation',
+    };
+
+    mockStateManager.getCandidate.mockResolvedValue(mockCandidate);
+    mockService.intake.mockResolvedValue(mockEntry);
+
+    const originalConnection = mockStateManager.connection;
+    mockStateManager.connection = {
+      getDb: () => ({
+        prepare: (sql: string) => ({
+          run: () => ({ changes: 0 }),
+        }),
+      }),
+    };
+
+    try {
+      await handleCandidateIntake({
+        candidateId: 'valid-id',
+        workspace: '/tmp/test-workspace',
+        json: true,
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Guarded transition failed'));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      mockStateManager.connection = originalConnection;
+    }
   });
 });

--- a/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
@@ -8,6 +8,7 @@ const mockGetTask = vi.hoisted(() => vi.fn());
 const mockCreateTask = vi.hoisted(() => vi.fn());
 const mockUpdateTaskDiagnosticJson = vi.hoisted(() => vi.fn());
 const mockPrepareAll = vi.hoisted(() => vi.fn());
+const mockPrepareRun = vi.hoisted(() => vi.fn());
 const mockRuntimeStateManagerOpts = vi.hoisted(() => vi.fn());
 const mockIntake = vi.hoisted(() => vi.fn());
 const mockExistsForCandidate = vi.hoisted(() => vi.fn());
@@ -40,7 +41,7 @@ vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
         updateTaskDiagnosticJson: mockUpdateTaskDiagnosticJson,
         connection: {
           getDb: () => ({
-            prepare: (sql: string) => ({ all: () => mockPrepareAll(sql), get: vi.fn(), run: vi.fn() }),
+            prepare: (sql: string) => ({ all: () => mockPrepareAll(sql), get: vi.fn(), run: () => mockPrepareRun(sql) }),
           }),
         },
       };
@@ -131,6 +132,7 @@ function setupDefaultMocks(): void {
     if (sql.includes("'pending'")) return [];
     return [];
   });
+  mockPrepareRun.mockReturnValue({ changes: 1 });
   mockGetCandidate.mockImplementation((id: string) =>
     Promise.resolve({
       candidateId: id,
@@ -195,7 +197,7 @@ describe('pd candidate internalization backfill', () => {
       candidateId: 'cand-pending-1',
       status: 'would_intake_and_create',
       statusBefore: 'pending',
-      statusAfter: 'consumed',
+      statusAfter: 'pending',
       intakeDecision: 'would_intake',
       seedDecision: 'would_seed',
     });
@@ -275,6 +277,34 @@ describe('pd candidate internalization backfill', () => {
       intakeDecision: 'intake_succeeded',
       seedDecision: 'existing',
     });
+    expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('guarded transition: status update fails when candidate is not pending', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+    mockPrepareRun.mockImplementation((sql: string) => {
+      if (sql.includes('UPDATE')) return { changes: 0 };
+      return { changes: 1 };
+    });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, includePending: true, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.details.intakeFailed).toBe(1);
+    expect(output.details.created).toBe(0);
+    expect(output.details.results).toHaveLength(1);
+    expect(output.details.results[0]).toMatchObject({
+      candidateId: 'cand-pending-1',
+      statusBefore: 'pending',
+      statusAfter: 'pending',
+      intakeDecision: 'intake_failed',
+      seedDecision: 'skipped',
+    });
+    expect(output.details.results[0].reason).toContain('Guarded transition failed');
     expect(mockCreateTask).not.toHaveBeenCalled();
   });
 

--- a/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
+++ b/packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
 
 const mockInitialize = vi.hoisted(() => vi.fn());
 const mockClose = vi.hoisted(() => vi.fn());
@@ -6,21 +7,30 @@ const mockGetCandidate = vi.hoisted(() => vi.fn());
 const mockGetTask = vi.hoisted(() => vi.fn());
 const mockCreateTask = vi.hoisted(() => vi.fn());
 const mockUpdateTaskDiagnosticJson = vi.hoisted(() => vi.fn());
-const mockAll = vi.hoisted(() => vi.fn());
+const mockPrepareAll = vi.hoisted(() => vi.fn());
+const mockRuntimeStateManagerOpts = vi.hoisted(() => vi.fn());
+const mockIntake = vi.hoisted(() => vi.fn());
+const mockExistsForCandidate = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn((workspace?: string) => workspace ?? '/fake/workspace'),
 }));
 
 vi.mock('../../src/principle-tree-ledger-adapter.js', () => ({
-  PrincipleTreeLedgerAdapter: vi.fn(),
+  PrincipleTreeLedgerAdapter: vi.fn().mockImplementation(function () {
+    return {
+      intake: mockIntake,
+      existsForCandidate: mockExistsForCandidate,
+    };
+  }),
 }));
 
 vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
   const original = await importOriginal() as Record<string, unknown>;
   return {
     ...original,
-    RuntimeStateManager: vi.fn().mockImplementation(function () {
+    RuntimeStateManager: vi.fn().mockImplementation(function (opts: Record<string, unknown>) {
+      mockRuntimeStateManagerOpts(opts);
       return {
         initialize: mockInitialize,
         close: mockClose,
@@ -30,17 +40,41 @@ vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
         updateTaskDiagnosticJson: mockUpdateTaskDiagnosticJson,
         connection: {
           getDb: () => ({
-            prepare: () => ({ all: mockAll, get: vi.fn(), run: vi.fn() }),
+            prepare: (sql: string) => ({ all: () => mockPrepareAll(sql), get: vi.fn(), run: vi.fn() }),
           }),
         },
       };
     }),
+    CandidateIntakeService: vi.fn().mockImplementation(function () {
+      return { intake: mockIntake };
+    }),
+    CandidateIntakeError: class CandidateIntakeError extends Error {
+      code: string;
+      constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = 'CandidateIntakeError';
+      }
+    },
     decideInternalizationRoute: vi.fn(() => ({
       ready: true,
       route: 'principle-ledger',
       reason: 'ready',
       missingFields: [],
       nextAction: 'internalize',
+    })),
+    computeBridgeDecision: vi.fn(() => ({
+      decision: 'seeded',
+      taskId: 'dreamer-cand-1-prompt',
+      channel: 'prompt',
+    })),
+    buildDreamerTaskSeed: vi.fn(() => ({
+      taskId: 'dreamer-cand-1-prompt',
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+      diagnosticJson: '{}',
     })),
     createRemediationResult: vi.fn((input: { mode: string; status?: string; safeToConfirm?: boolean; repairedCount?: number; skippedCount?: number; actions?: unknown[]; warnings?: unknown[] }) => ({
       mode: input.mode,
@@ -59,29 +93,198 @@ vi.mock('@principles/core/runtime-v2', async (importOriginal) => {
 
 import { handleCandidateInternalizationBackfill } from '../../src/commands/candidate.js';
 
-describe('pd candidate internalization backfill remediation contract', () => {
+function createBackfillTestProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+
+  const candidateCmd = program.command('candidate');
+  const internalizationCmd = candidateCmd.command('internalization');
+
+  internalizationCmd
+    .command('backfill')
+    .description('Backfill dreamer tasks for consumed candidates')
+    .option('-w, --workspace <path>', 'Workspace directory')
+    .option('--dry-run', 'Report only, no modifications (default)')
+    .option('--confirm', 'Actually create missing dreamer tasks')
+    .option('--include-pending', 'Include pending candidates (intake first, then seed dreamer)')
+    .option('--json', 'Output as JSON')
+    .action(async (opts) => {
+      await handleCandidateInternalizationBackfill({
+        workspace: opts.workspace,
+        dryRun: opts.dryRun,
+        confirm: opts.confirm,
+        includePending: opts.includePending,
+        json: opts.json,
+      });
+    });
+
+  return program;
+}
+
+const WS = '/fake/workspace';
+
+function setupDefaultMocks(): void {
+  mockInitialize.mockResolvedValue(undefined);
+  mockClose.mockResolvedValue(undefined);
+  mockPrepareAll.mockImplementation((sql: string) => {
+    if (sql.includes("'consumed'")) return [{ candidate_id: 'cand-consumed-1' }];
+    if (sql.includes("'pending'")) return [];
+    return [];
+  });
+  mockGetCandidate.mockImplementation((id: string) =>
+    Promise.resolve({
+      candidateId: id,
+      description: `candidate ${id}`,
+      sourceRecommendationJson: JSON.stringify({ kind: 'principle', description: `candidate ${id}` }),
+    }),
+  );
+  mockGetTask.mockResolvedValue(null);
+  mockCreateTask.mockImplementation((input: { taskId: string }) =>
+    Promise.resolve({ taskId: input.taskId }),
+  );
+  mockIntake.mockResolvedValue({ id: 'ledger-entry-1' });
+  mockExistsForCandidate.mockReturnValue(null);
+}
+
+describe('pd candidate internalization backfill', () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockInitialize.mockResolvedValue(undefined);
-    mockClose.mockResolvedValue(undefined);
-    mockAll.mockReturnValue([{ candidate_id: 'cand-1' }]);
-    mockGetCandidate.mockResolvedValue({
-      candidateId: 'cand-1',
-      description: 'candidate',
-      sourceRecommendationJson: JSON.stringify({ kind: 'principle', description: 'candidate' }),
-    });
-    mockGetTask.mockResolvedValue(null);
-    mockCreateTask.mockResolvedValue({ taskId: 'dreamer-cand-1-prompt' });
+    setupDefaultMocks();
     process.exitCode = 0;
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  it('dry-run JSON uses shared remediation contract and does not create tasks', async () => {
-    await handleCandidateInternalizationBackfill({ workspace: '/fake/workspace', dryRun: true, json: true });
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it('default (no --include-pending) only processes consumed candidates', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [{ candidate_id: 'cand-consumed-1' }];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.details.totalConsumed).toBe(1);
+    expect(output.details.totalPending).toBe(0);
+    expect(output.details.results).toHaveLength(1);
+    expect(output.details.results[0].candidateId).toBe('cand-consumed-1');
+  });
+
+  it('--include-pending --dry-run discovers pending candidates but zero mutation', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, includePending: true, dryRun: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.details.totalConsumed).toBe(0);
+    expect(output.details.totalPending).toBe(1);
+    expect(output.details.results).toHaveLength(1);
+    expect(output.details.results[0]).toMatchObject({
+      candidateId: 'cand-pending-1',
+      status: 'would_intake_and_create',
+      statusBefore: 'pending',
+      statusAfter: 'consumed',
+      intakeDecision: 'would_intake',
+      seedDecision: 'would_seed',
+    });
+    expect(mockIntake).not.toHaveBeenCalled();
+    expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('--include-pending --confirm: pending -> intake -> seed dreamer', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, includePending: true, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.details.intakeSucceeded).toBe(1);
+    expect(output.details.created).toBe(1);
+    expect(output.details.results).toHaveLength(1);
+    expect(output.details.results[0]).toMatchObject({
+      candidateId: 'cand-pending-1',
+      status: 'created',
+      statusBefore: 'pending',
+      statusAfter: 'consumed',
+      intakeDecision: 'intake_succeeded',
+      seedDecision: 'seeded',
+    });
+    expect(mockIntake).toHaveBeenCalledWith('cand-pending-1');
+    expect(mockCreateTask).toHaveBeenCalled();
+  });
+
+  it('intake failure: no seed, no fake consumed, returns reason/nextAction', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+    mockIntake.mockRejectedValue(new Error('Artifact not found for candidate'));
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, includePending: true, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.details.intakeFailed).toBe(1);
+    expect(output.details.created).toBe(0);
+    expect(output.details.results).toHaveLength(1);
+    expect(output.details.results[0]).toMatchObject({
+      candidateId: 'cand-pending-1',
+      status: 'intake_failed',
+      statusBefore: 'pending',
+      statusAfter: 'pending',
+      intakeDecision: 'intake_failed',
+      seedDecision: 'skipped',
+      nextAction: 'Fix intake issue and re-run backfill',
+    });
+    expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('duplicate confirm: no duplicate dreamer task (idempotent)', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+    mockGetTask.mockResolvedValue({ taskId: 'dreamer-cand-pending-1-prompt' });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, includePending: true, confirm: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
+    expect(output.details.intakeSucceeded).toBe(1);
+    expect(output.details.alreadyHaveTask).toBe(1);
+    expect(output.details.created).toBe(0);
+    expect(output.details.results).toHaveLength(1);
+    expect(output.details.results[0]).toMatchObject({
+      candidateId: 'cand-pending-1',
+      status: 'intake_succeeded_existing_task',
+      intakeDecision: 'intake_succeeded',
+      seedDecision: 'existing',
+    });
+    expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('consumed candidate original behavior regression unchanged', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [{ candidate_id: 'cand-consumed-1' }];
+      return [];
+    });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, dryRun: true, json: true });
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
     expect(output).toMatchObject({
@@ -90,30 +293,158 @@ describe('pd candidate internalization backfill remediation contract', () => {
       safeToConfirm: true,
       repairedCount: 0,
     });
-    expect(output.actions[0]).toMatchObject({ action: 'would_create_dreamer_task', targetId: 'cand-1' });
-    expect(output.details.missingDreamerTask).toBe(1);
+    expect(output.details.results[0]).toMatchObject({
+      candidateId: 'cand-consumed-1',
+      status: 'would_create',
+      intakeDecision: 'not_needed',
+      seedDecision: 'would_seed',
+    });
     expect(mockCreateTask).not.toHaveBeenCalled();
-  });
-
-  it('confirm JSON reports changed after creating missing dreamer task', async () => {
-    await handleCandidateInternalizationBackfill({ workspace: '/fake/workspace', confirm: true, json: true });
-
-    const output = JSON.parse(consoleLogSpy.mock.calls[0][0] as string);
-    expect(output.mode).toBe('confirm');
-    expect(output.status).toBe('changed');
-    expect(output.repairedCount).toBe(1);
-    expect(mockCreateTask).toHaveBeenCalled();
   });
 
   it('rejects --dry-run and --confirm together before writing', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
 
     await expect(
-      handleCandidateInternalizationBackfill({ workspace: '/fake/workspace', dryRun: true, confirm: true, json: true }),
+      handleCandidateInternalizationBackfill({ workspace: WS, dryRun: true, confirm: true, json: true }),
     ).rejects.toThrow('process.exit:1');
 
     expect(mockCreateTask).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
     exitSpy.mockRestore();
+  });
+
+  it('--json output is single parseable object with required fields per candidate', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [{ candidate_id: 'cand-consumed-1' }];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+
+    await handleCandidateInternalizationBackfill({ workspace: WS, includePending: true, dryRun: true, json: true });
+
+    const rawOutput = consoleLogSpy.mock.calls[0][0] as string;
+    const output = JSON.parse(rawOutput);
+    expect(output).toBeDefined();
+
+    for (const result of output.details.results) {
+      expect(result).toHaveProperty('candidateId');
+      expect(result).toHaveProperty('statusBefore');
+      expect(result).toHaveProperty('statusAfter');
+      expect(result).toHaveProperty('intakeDecision');
+      expect(result).toHaveProperty('seedDecision');
+    }
+  });
+
+  it('exit path: process.exit(1) after flag conflict does not continue to mutation', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit:${code}`); });
+
+    await expect(
+      handleCandidateInternalizationBackfill({ workspace: WS, dryRun: true, confirm: true }),
+    ).rejects.toThrow('process.exit:1');
+
+    expect(mockIntake).not.toHaveBeenCalled();
+    expect(mockCreateTask).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});
+
+describe('Commander wiring for backfill --include-pending', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockInitialize.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [];
+      return [];
+    });
+    mockGetCandidate.mockImplementation((id: string) =>
+      Promise.resolve({
+        candidateId: id,
+        description: `candidate ${id}`,
+        sourceRecommendationJson: JSON.stringify({ kind: 'principle', description: `candidate ${id}` }),
+      }),
+    );
+    mockGetTask.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    process.exitCode = 0;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('no flags -> dry-run mode, includePending undefined', async () => {
+    const program = createBackfillTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'internalization', 'backfill', '--workspace', WS, '--json']);
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.details.mode).toBe('dry-run');
+    expect(output.details.totalPending).toBe(0);
+  });
+
+  it('--include-pending -> includePending=true', async () => {
+    mockPrepareAll.mockImplementation((sql: string) => {
+      if (sql.includes("'consumed'")) return [];
+      if (sql.includes("'pending'")) return [{ candidate_id: 'cand-pending-1' }];
+      return [];
+    });
+    mockGetCandidate.mockResolvedValue({
+      candidateId: 'cand-pending-1',
+      description: 'test',
+      sourceRecommendationJson: JSON.stringify({ kind: 'principle', description: 'test' }),
+    });
+
+    const program = createBackfillTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'internalization', 'backfill', '--workspace', WS, '--include-pending', '--dry-run', '--json']);
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.details.totalPending).toBe(1);
+  });
+
+  it('--dry-run -> RuntimeStateManager readonly=true', async () => {
+    const program = createBackfillTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'internalization', 'backfill', '--workspace', WS, '--dry-run', '--json']);
+
+    expect(mockRuntimeStateManagerOpts).toHaveBeenCalledWith(
+      expect.objectContaining({ readonly: true }),
+    );
+  });
+
+  it('--confirm -> RuntimeStateManager readonly=false', async () => {
+    const program = createBackfillTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'internalization', 'backfill', '--workspace', WS, '--confirm', '--json']);
+
+    expect(mockRuntimeStateManagerOpts).toHaveBeenCalledWith(
+      expect.objectContaining({ readonly: false }),
+    );
+  });
+
+  it('--dry-run --confirm together -> rejected', async () => {
+    const program = createBackfillTestProgram();
+    try {
+      await program.parseAsync(['node', 'pd', 'candidate', 'internalization', 'backfill', '--workspace', WS, '--dry-run', '--confirm', '--json']);
+    } catch {
+      // process.exit throws via exitOverride or handler throws
+    }
+
+    expect(mockCreateTask).not.toHaveBeenCalled();
+    expect(mockIntake).not.toHaveBeenCalled();
+  });
+
+  it('no flags -> RuntimeStateManager readonly=true (dry-run default)', async () => {
+    const program = createBackfillTestProgram();
+    await program.parseAsync(['node', 'pd', 'candidate', 'internalization', 'backfill', '--workspace', WS, '--json']);
+
+    expect(mockRuntimeStateManagerOpts).toHaveBeenCalledWith(
+      expect.objectContaining({ readonly: true }),
+    );
   });
 });


### PR DESCRIPTION
## PRI-216 Production Gap

PRI-216 live validation found that pending candidates created by `pd diagnose run` or other operator paths remain outside internalization because the existing backfill only queries `status = 'consumed'`. Historical or operationally-produced pending candidates cannot safely enter the pipeline:

```
pending -> intake/ledger committed -> consumed -> dreamer seeded
```

## Default Behavior: Consumed-Only (Unchanged)

Without `--include-pending`, the backfill behaves exactly as before — only consumed candidates are queried and processed. No implicit expansion of operator mutation scope.

## `--include-pending` Dry-Run / Confirm State Transition Contract

| Mode | Pending candidates | Consumed candidates |
|------|-------------------|-------------------|
| `--include-pending --dry-run` | Report planned intake + seed, zero mutation | Same as current dry-run |
| `--include-pending --confirm` | Intake -> update status -> seed dreamer | Same as current confirm |

### Intake-Before-Consumed Invariant

Pending candidates MUST go through `CandidateIntakeService.intake()` before any status update or dreamer seed. The flow is:

1. `intakeService.intake(candidateId)` — writes ledger entry
2. `updateCandidateStatus(stateManager, candidateId, 'consumed')` — updates DB status
3. `stateManager.createTask(seed)` — seeds dreamer task

If intake fails: no status update, no dreamer seed, structured reason + nextAction returned.
If status update fails after intake: reported as intake_failed with note about inconsistent state.
If dreamer seed fails after intake+status: candidate is consumed, re-running consumed-only backfill will retry.

### Idempotency and Dry-Run Readonly

- **Idempotent**: Re-running `--confirm` does not create duplicate dreamer tasks. Already-existing tasks are detected via `stateManager.getTask(taskId)`.
- **Dry-run readonly**: `RuntimeStateManager` is constructed with `readonly: !isConfirm`. Dry-run/default opens a readonly DB connection.

## ERR Checklist

| ERR | How Avoided |
|-----|-------------|
| ERR-002 | Every skip/failure path returns structured `reason` + `nextAction` in JSON output |
| ERR-011 | All intake/DB/ledger writes stay in `candidate.ts` (pd-cli); core provides pure functions only |
| ERR-012 | Branch created from latest `origin/main` (includes PR #680, #681, #682) |
| ERR-018/ERR-019 | Each candidate action records `statusBefore` from fresh DB read, `statusAfter` from actual post-intake state |
| ERR-020 | `--include-pending` registered as positive flag; check `opts.includePending === true`; parser wiring tests added |
| ERR-021 | Commander `program.parseAsync()` tests for all flag combinations |
| ERR-022 | `process.exit(1)` followed by `return`; exit-path test proves no subsequent mutation |
| ERR-023 | `RuntimeStateManager` constructed with `readonly: !isConfirm`; dry-run never opens writable DB |

## Test Commands and Results

```bash
npm run build --workspace=@principles/core          # pass
npm run build --workspace=@principles/pd-cli         # pass
npx vitest run packages/pd-cli/tests/commands/candidate-internalization-backfill.test.ts  # 15/15 pass
npm run verify:merge                                 # pass
```

### Test Matrix (15 tests covering 10 required cases)

1. Default (no `--include-pending`) only processes consumed candidates
2. `--include-pending --dry-run` discovers pending, zero mutation
3. `--include-pending --confirm`: pending -> intake -> seed dreamer
4. Intake failure: no seed, no fake consumed, returns reason/nextAction
5. Duplicate confirm: no duplicate dreamer task (idempotent)
6. Consumed candidate original behavior regression unchanged
7. `--dry-run --confirm` rejected before any mutation
8. `--json` output single parseable object with required fields per candidate
9. Exit path: `process.exit(1)` after flag conflict does not continue to mutation
10. Commander wiring: default, `--include-pending`, `--dry-run`, `--confirm`, invalid combo, readonly construction

## Real Workspace Dry-Run Summary

```bash
node packages/pd-cli/dist/index.js candidate internalization backfill \
  --workspace "D:\.openclaw\workspace" --include-pending --dry-run --json
```

Result: 5 consumed candidates (4 existing + 1 deferred), 0 pending candidates, zero mutation. JSON output is single parseable object with all required fields.

**No production `--confirm` was executed.** Any real confirm requires manual approval.

## Remaining Risk

- If a pending candidate sourceRecommendationJson is malformed, resolveCandidateRecommendation may throw — this is handled by the existing error path but not specifically tested for pending candidates.
- Provider timeout handling is out of scope (PRI-220).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 候选项国际化回填命令新增 `--include-pending` 选项，支持处理待处理候选项并自动执行相关操作

* **改进**
  * 增强了候选项处理的状态跟踪和结果报告能力
  * 改进了命令的错误处理和验证逻辑

* **测试**
  * 扩展并重构了候选项国际化回填功能的测试覆盖范围

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->