### PR TITLE
fix(plugin-installer): increase Gateway restart port wait from 15s to 30s

### DIFF
--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -1079,7 +1079,7 @@ function restartGatewayWindows() {
             console.log('   Scheduled task not available, trying direct gateway start via PowerShell...');
             try {
                 execSync(
-                    'powershell -NoProfile -Command "Start-Process -WindowStyle Hidden -NoNewWindow -FilePath \'openclaw\' -ArgumentList \'gateway\'"',
+                    'powershell -NoProfile -Command "Start-Process -WindowStyle Hidden -FilePath \'openclaw\' -ArgumentList \'gateway\'"',
                     { stdio: 'pipe', timeout: 5000 }
                 );
                 gatewayStarted = true;
@@ -1090,7 +1090,7 @@ function restartGatewayWindows() {
 
         // Wait for gateway to be listening on port (同步等待，不异步)
         const port = 18789;
-        const deadline = Date.now() + 15000; // 缩短等待时间，避免卡住
+        const deadline = Date.now() + 30000; // Gateway 初始化可能需要 20+ 秒 (如 Windows schtasks 重启)
         let gatewayListening = false;
 
         while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

- Increase Gateway restart port-wait timeout from 15s to 30s
- On Windows, `schtasks`-triggered Gateway initialization takes ~20-25 seconds
- The 15s window was timing out, causing the installer to falsely report
  "Gateway restart failed" even though the Gateway starts successfully
  moments after the timeout expires

## Test plan

- [ ] Run `node scripts/install.mjs` and confirm Gateway restart reports success
- [ ] Gateway should be listening on port 18789 after installer finishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了 Windows 网关的启动稳定性。优化了 PowerShell 启动命令参数设置，并调整了网关初始化的超时等待时间，从约 15 秒延长至约 30 秒，以适应各种不同的启动场景和系统条件。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->