### PR TITLE
fix(core): use distinct painId count for dedupe invariant evaluation (PRI-208)

### DIFF
--- a/packages/pd-cli/src/services/pain-flood-simulation-runner.ts
+++ b/packages/pd-cli/src/services/pain-flood-simulation-runner.ts
@@ -26,6 +26,7 @@ import {
   formatContextBudgetSummary,
   truncateReason,
   FLOOD_SCENARIO_EXPECTATIONS,
+  computeMaxAllowedTasks,
 } from '@principles/core/runtime-v2';
 
 export interface PainFloodSimulationRunnerOptions {
@@ -107,10 +108,7 @@ async function runScenario(
   const deltaCandidates = candidatesAfter - candidatesBefore;
 
   const expectation = FLOOD_SCENARIO_EXPECTATIONS[scenarioName];
-  const maxFromRatio = Math.ceil(painSignals.length * expectation.maxTaskRatio);
-  const maxAllowedTasks = expectation.maxTaskCount != null
-    ? Math.min(maxFromRatio, expectation.maxTaskCount)
-    : maxFromRatio;
+  const maxAllowedTasks = computeMaxAllowedTasks(painSignals, expectation);
   const dedupeViolation = deltaTasks > maxAllowedTasks;
 
   const passed = errors.length === 0 && !dedupeViolation;

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-flood-simulation.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-flood-simulation.test.ts
@@ -9,6 +9,7 @@ import {
   maxEvidencePreviewLength,
   safeStringify,
   FLOOD_SCENARIO_EXPECTATIONS,
+  computeMaxAllowedTasks,
 } from '../pain-flood-simulation.js';
 
 function makeStage(overrides: Partial<PainFloodStage> & { scenarioName: PainFloodStage['scenarioName']; status: PainFloodStage['status'] }): PainFloodStage {
@@ -258,6 +259,55 @@ describe('PainFloodSimulation pure helpers (PRI-208)', () => {
         expect(exp.description.length).toBeGreaterThan(0);
         expect(exp.maxTaskRatio).toBeGreaterThan(0);
       }
+    });
+  });
+
+  describe('computeMaxAllowedTasks', () => {
+    const sharedSignals = (count: number, distinctCount: number) =>
+      Array.from({ length: count }, (_, i) => ({ painId: `p-${i % distinctCount}` }));
+
+    it('identical flood: all signals create new tasks => exceeds maxTaskCount (not healthy)', () => {
+      const signals = sharedSignals(10, 10); // 10 distinct painIds, each should produce task
+      const max = computeMaxAllowedTasks(signals, FLOOD_SCENARIO_EXPECTATIONS.identical_flood);
+      // maxTaskCount=1 hard cap: ceil(10*1)=10, min(10,1)=1
+      expect(max).toBe(1);
+    });
+
+    it('stress: duplicate portion all create new tasks => exceeds distinct count (not healthy)', () => {
+      const signals = sharedSignals(50, 50); // all distinct, no dedupe possible
+      const max = computeMaxAllowedTasks(signals, FLOOD_SCENARIO_EXPECTATIONS.stress_test);
+      // maxTaskRatio=1: ceil(50*1)=50 — all 50 distinct painIds could each produce a task
+      expect(max).toBe(50);
+    });
+
+    it('identical flood: sharing one painId produces at most 1 task (healthy)', () => {
+      const signals = sharedSignals(10, 1); // 1 distinct painId, bridge will dedupe
+      const max = computeMaxAllowedTasks(signals, FLOOD_SCENARIO_EXPECTATIONS.identical_flood);
+      // maxTaskCount=1: ceil(1*1)=1, min(1,1)=1
+      expect(max).toBe(1);
+    });
+
+    it('stress: distinct painId count sets ceiling — duplicates dont expand it (healthy)', () => {
+      const signals = sharedSignals(50, 33); // 33 distinct painIds, 17 duplicates
+      const max = computeMaxAllowedTasks(signals, FLOOD_SCENARIO_EXPECTATIONS.stress_test);
+      // ceil(33*1)=33 — distinct count, not total input count
+      expect(max).toBe(33);
+      // If all 50 signals create tasks, 50 > 33 → violation caught
+      expect(50 > max).toBe(true);
+    });
+
+    it('duplicate_submission: all distinct => maxTaskCount=1 caps it', () => {
+      const signals = sharedSignals(5, 5);
+      const max = computeMaxAllowedTasks(signals, FLOOD_SCENARIO_EXPECTATIONS.duplicate_submission);
+      // ceil(5*0.5)=3, min(3,1)=1
+      expect(max).toBe(1);
+    });
+
+    it('similar_flood: each unique painId allows one task', () => {
+      const signals = sharedSignals(10, 10);
+      const max = computeMaxAllowedTasks(signals, FLOOD_SCENARIO_EXPECTATIONS.similar_flood);
+      // ceil(10*1)=10
+      expect(max).toBe(10);
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-flood-simulation.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-flood-simulation.test.ts
@@ -263,8 +263,15 @@ describe('PainFloodSimulation pure helpers (PRI-208)', () => {
   });
 
   describe('computeMaxAllowedTasks', () => {
-    const sharedSignals = (count: number, distinctCount: number) =>
-      Array.from({ length: count }, (_, i) => ({ painId: `p-${i % distinctCount}` }));
+    const sharedSignals = (count: number, distinctCount: number) => {
+      if (distinctCount <= 0) throw new Error('distinctCount must be positive');
+      return Array.from({ length: count }, (_, i) => ({ painId: `p-${i % distinctCount}` }));
+    };
+
+    it('returns 0 for empty signals', () => {
+      const max = computeMaxAllowedTasks([], FLOOD_SCENARIO_EXPECTATIONS.identical_flood);
+      expect(max).toBe(0);
+    });
 
     it('identical flood: all signals create new tasks => exceeds maxTaskCount (not healthy)', () => {
       const signals = sharedSignals(10, 10); // 10 distinct painIds, each should produce task

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -296,6 +296,7 @@ export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselin
 export {
   computeFloodStatus, computeFloodTotals, formatContextBudgetSummary, recommendFloodNextIssue,
   boundedFloodEvidence, maxEvidencePreviewLength, FLOOD_SCENARIO_EXPECTATIONS,
+  computeMaxAllowedTasks,
 } from './pain-flood-simulation.js';
 export type { PainFloodSimulationSummary, PainFloodStage, PainFloodScenarioName, PainFloodSimulationOptions, PainFloodScenarioExpectation } from './pain-flood-simulation.js';
 

--- a/packages/principles-core/src/runtime-v2/pain-flood-simulation.ts
+++ b/packages/principles-core/src/runtime-v2/pain-flood-simulation.ts
@@ -158,6 +158,17 @@ export function computeFloodStatus(stages: PainFloodStage[]): 'healthy' | 'degra
   return 'healthy';
 }
 
+export function computeMaxAllowedTasks(
+  painSignals: { painId: string }[],
+  expectation: PainFloodScenarioExpectation,
+): number {
+  const distinctPainIdCount = new Set(painSignals.map(s => s.painId)).size;
+  const maxFromRatio = Math.ceil(distinctPainIdCount * expectation.maxTaskRatio);
+  return expectation.maxTaskCount != null
+    ? Math.min(maxFromRatio, expectation.maxTaskCount)
+    : maxFromRatio;
+}
+
 export function formatContextBudgetSummary(maxPreviewLength: number): string {
   if (maxPreviewLength <= 0) return 'no evidence produced';
   if (maxPreviewLength <= 100) return `bounded (max ${maxPreviewLength} chars)`;


### PR DESCRIPTION
## Summary

Fix `stress_test` dedupe invariant where `maxTaskRatio=1` allowed complete dedupe failure to pass.

**Root cause:** `runScenario()` computed `maxFromRatio = ceil(totalSignalCount * maxTaskRatio)`. For stress_test with 50 signals and maxTaskRatio=1, maxAllowedTasks=50 — even if all 50 signals created new tasks, no violation was detected.

**Fix:** New pure function `computeMaxAllowedTasks()` in core that uses **distinct painId count** (not total signal count) as the ratio basis. For stress_test with 50 signals but 33 distinct painIds, maxAllowedTasks=33 — deltaTasks=50 correctly triggers violation.

### Changes

| File | Change |
|------|--------|
| `principles-core/.../pain-flood-simulation.ts` | New `computeMaxAllowedTasks()` pure function |
| `principles-core/.../index.ts` | Export added |
| `pd-cli/.../pain-flood-simulation-runner.ts` | Runner uses the function |
| `principles-core/.../pain-flood-simulation.test.ts` | 7 new tests (6 invariant + 1 empty boundary) |

### Scenarios affected

| Scenario | Before | After |
|----------|--------|-------|
| identical_flood all-new tasks | pass (maxTaskCount=1 cap already OK) | unchanged |
| stress_test all-new tasks | **pass** (50 ≤ 50) | **fail** (50 > 33) |
| normal dedup paths | pass | pass |

## Code Review

- 0 CRITICAL / 0 HIGH findings
- ERR-001/002/012 all clear
- Boundary test added for empty signals

## Test plan

- [x] `npx vitest run packages/principles-core/.../pain-flood-simulation.test.ts` — 42 passed
- [x] `npx vitest run packages/pd-cli/tests/commands/runtime-pain-flood-simulation.test.ts` — 16 passed
- [x] `npm run verify:merge` — green (build, lint, typecheck)