### PR TITLE
fix(runtime-v2): surface malformed internalization metadata (PRI-225)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -173,7 +173,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: Never use `as` array type casts on untrusted JSON arrays without validating element types first. Always apply element-wise type guards when preserving data from invalid payloads.
 - **Source**: PRI-191
 - **Date**: 2026-05-19
-- **Recurrence**: Yes - 2026-05-23 PRI-209 (PR #689): `extractPIMetadata()` used `as Record<string, unknown>` on `JSON.parse` result. `dependencyTaskIds` non-string elements passed through without filtering. Fixed by replacing `as Record` with `readOwnProperty` helper and `Array.from().filter()` for element-wise validation.
+- **Recurrence**: Yes - 2026-05-23 PRI-209 (PR #689): `extractPIMetadata()` used `as Record<string, unknown>` on `JSON.parse` result. `dependencyTaskIds` non-string elements passed through without filtering. Fixed by replacing `as Record` with `readOwnProperty` helper and `Array.from().filter()` for element-wise validation. Also 2026-05-23 PRI-225 (PR #693): `result.dependencyTaskIds = depIds as string[]` on already-validated array bypassed type system. Fixed by constructing `validatedDependencyTaskIds: string[]` with element-wise `typeof` check and push, no `as` assertion.
 
 ---
 
@@ -209,7 +209,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: For any agent contract that processes trace data, add explicit lineage field validation: `sourceTaskId`, `sourcePainId`, `sourceRunIds` must match the deterministic trace.
 - **Source**: PRI-192 / PR #638 (Codex review)
 - **Date**: 2026-05-19
-- **Recurrence**: Yes - 2026-05-23 PRI-209 (PR #689): `result_ref` points to an artifact whose `task_id` differs from the owning task, but the read model only checked artifact kind-level existence instead of per-dependency lineage. This caused dependency B's missing artifact to be misclassified as `lineage_mismatch` when dependency A had a matching artifact. Fixed by implementing true `lineage_mismatch` detection (query `SELECT task_id FROM artifacts WHERE artifact_id = ?` and compare with owning task's `task_id`) and distinguishing from `missing_dreamer_pi_artifact` (no artifact found at all) and `result_ref_missing_artifact` (result_ref points to nonexistent artifact).
+- **Recurrence**: Yes - 2026-05-23 PRI-209 (PR #689): `result_ref` points to an artifact whose `task_id` differs from the owning task, but the read model only checked artifact kind-level existence instead of per-dependency lineage. This caused dependency B's missing artifact to be misclassified as `lineage_mismatch` when dependency A had a matching artifact. Fixed by implementing true `lineage_mismatch` detection (query `SELECT task_id FROM artifacts WHERE artifact_id = ?` and compare with owning task's `task_id`) and distinguishing from `missing_dreamer_pi_artifact` (no artifact found at all) and `result_ref_missing_artifact` (result_ref points to nonexistent artifact). Also 2026-05-23 PRI-225 (PR #693): Malformed metadata was re-interpreted as topology failure — philosopher with `dependencyTaskIds: ['dreamer-1', 42]` and existing dreamer-1 got `philosopher_dependency_unverifiable` because the dependency check only accepted `status === 'parsed'`. Fixed by using `bestEffortParentIds` for topology verification when metadata is malformed, while still emitting `metadata_malformed`.
 
 ---
 
@@ -409,7 +409,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: For every PR that adds defensive logic, verify that at least one test exercises the production path that would invoke the defense. If no production path calls the new code, the PR must not claim to provide defense. Review trigger: any PR where the diff adds a new module but does not modify any existing production code to call it.
 - **Source**: PRI-209 / PR #689
 - **Date**: 2026-05-23
-- **Recurrence**: Yes - 2026-05-23 PRI-209 (PR #689): Healthy baseline test used `expect(['ok', 'degraded']).toContain(overallStatus)`, allowing `degraded` to pass. This meant a regression that introduced new warning-level broken links in the healthy path would not be caught. The test proved the code didn't crash, but not that the healthy path remained healthy. Fixed by tightening to `expect(overallStatus).toBe('ok')`.
+- **Recurrence**: Yes - 2026-05-23 PRI-209 (PR #689): Healthy baseline test used `expect(['ok', 'degraded']).toContain(overallStatus)`, allowing `degraded` to pass. This meant a regression that introduced new warning-level broken links in the healthy path would not be caught. The test proved the code didn't crash, but not that the healthy path remained healthy. Fixed by tightening to `expect(overallStatus).toBe('ok')`. Also 2026-05-23 PRI-225 (PR #693): `bestEffortParentIds` was added to `PIMetadataParseResult.malformed` but not wired into the philosopher dependency check. The dependency check only accepted `status === 'parsed'`, so malformed metadata with extractable parent IDs still produced `philosopher_dependency_unverifiable`. Test proved `bestEffortParentIds` was populated correctly, but not that the production path used it for topology verification. Fixed by adding `else if (philMeta.status === 'malformed')` branch in the dependency check.
 
 ---
 

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -3574,3 +3574,12 @@ describe('PRI-215 synthetic baseline architecture boundary', () => {
   });
 });
 
+describe('PRI-225: No unsafe type assertions on untrusted metadata arrays', () => {
+  it('INTEGRITY_READ_MODEL_NO_AS_STRING_ARRAY: internalization-chain-integrity-read-model.ts must not use `as string[]` on untrusted data', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization-chain-integrity-read-model.ts'), 'utf-8');
+    expect(src).not.toContain('as string[]');
+  });
+});
+

--- a/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-attack.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-attack.test.ts
@@ -174,14 +174,25 @@ describe('Chain Integrity Attack Tests (PRI-209)', () => {
   it('malformed metadata: extractPIMetadata returns discriminated union', () => {
     expect(extractPIMetadata(null).status).toBe('missing');
     expect(extractPIMetadata('').status).toBe('missing');
-    expect(extractPIMetadata('not-json{{{').status).toBe('malformed');
-    expect(extractPIMetadata('42').status).toBe('malformed');
-    expect(extractPIMetadata('"hello"').status).toBe('malformed');
-    expect(extractPIMetadata('[]').status).toBe('malformed');
+    const notJson = extractPIMetadata('not-json{{{');
+    expect(notJson.status).toBe('malformed');
+    if (notJson.status === 'malformed') { expect(notJson.bestEffortParentIds).toEqual([]); }
+    const num = extractPIMetadata('42');
+    expect(num.status).toBe('malformed');
+    if (num.status === 'malformed') { expect(num.bestEffortParentIds).toEqual([]); }
+    const str = extractPIMetadata('"hello"');
+    expect(str.status).toBe('malformed');
+    const arr = extractPIMetadata('[]');
+    expect(arr.status).toBe('malformed');
     expect(extractPIMetadata('{}').status).toBe('missing');
-    expect(extractPIMetadata('{"parentTaskId":42}').status).toBe('malformed');
-    expect(extractPIMetadata('{"dependencyTaskIds":"not-array"}').status).toBe('malformed');
-    expect(extractPIMetadata('{"dependencyTaskIds":[42,true]}').status).toBe('malformed');
+    const ptNum = extractPIMetadata('{"parentTaskId":42}');
+    expect(ptNum.status).toBe('malformed');
+    if (ptNum.status === 'malformed') { expect(ptNum.bestEffortParentIds).toEqual([]); }
+    const depStr = extractPIMetadata('{"dependencyTaskIds":"not-array"}');
+    expect(depStr.status).toBe('malformed');
+    const depMixed = extractPIMetadata('{"dependencyTaskIds":[42,true]}');
+    expect(depMixed.status).toBe('malformed');
+    if (depMixed.status === 'malformed') { expect(depMixed.bestEffortParentIds).toEqual([]); }
     const parsed = extractPIMetadata('{"parentTaskId":"t1","dependencyTaskIds":["t2"]}');
     expect(parsed.status).toBe('parsed');
     if (parsed.status === 'parsed') {
@@ -193,8 +204,11 @@ describe('Chain Integrity Attack Tests (PRI-209)', () => {
     if (nested.status === 'parsed') {
       expect(nested.parentTaskId).toBe('t3');
     }
-    expect(extractPIMetadata('{"pi_metadata":{"parentTaskId":123}}').status).toBe('malformed');
-    expect(extractPIMetadata('{"dependencyTaskIds":["t1",42,"t3"]}').status).toBe('malformed');
+    const nestedBad = extractPIMetadata('{"pi_metadata":{"parentTaskId":123}}');
+    expect(nestedBad.status).toBe('malformed');
+    const depMixedValid = extractPIMetadata('{"dependencyTaskIds":["t1",42,"t3"]}');
+    expect(depMixedValid.status).toBe('malformed');
+    if (depMixedValid.status === 'malformed') { expect(depMixedValid.bestEffortParentIds).toEqual(['t1', 't3']); }
   });
 
   it('inherited property "constructor" is not read as pi_metadata', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-attack.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-attack.test.ts
@@ -171,26 +171,35 @@ describe('Chain Integrity Attack Tests (PRI-209)', () => {
     expect(broken?.recommendedAction.length).toBeGreaterThan(0);
   });
 
-  it('malformed metadata: extractPIMetadata with null, invalid JSON, missing fields', () => {
-    expect(extractPIMetadata(null)).toEqual({});
-    expect(extractPIMetadata('')).toEqual({});
-    expect(extractPIMetadata('not-json{{{')).toEqual({});
-    expect(extractPIMetadata('42')).toEqual({});
-    expect(extractPIMetadata('"hello"')).toEqual({});
-    expect(extractPIMetadata('[]')).toEqual({});
-    expect(extractPIMetadata('{}')).toEqual({});
-    expect(extractPIMetadata('{"parentTaskId":42}')).toEqual({});
-    expect(extractPIMetadata('{"dependencyTaskIds":"not-array"}')).toEqual({});
-    expect(extractPIMetadata('{"dependencyTaskIds":[42,true]}')).toEqual({});
-    expect(extractPIMetadata('{"parentTaskId":"t1","dependencyTaskIds":["t2"]}')).toEqual({ parentTaskId: 't1', dependencyTaskIds: ['t2'] });
-    expect(extractPIMetadata('{"pi_metadata":{"parentTaskId":"t3"}}')).toEqual({ parentTaskId: 't3' });
-    expect(extractPIMetadata('{"pi_metadata":{"parentTaskId":123}}')).toEqual({});
-    expect(extractPIMetadata('{"dependencyTaskIds":["t1",42,"t3"]}')).toEqual({ dependencyTaskIds: ['t1', 't3'] });
+  it('malformed metadata: extractPIMetadata returns discriminated union', () => {
+    expect(extractPIMetadata(null).status).toBe('missing');
+    expect(extractPIMetadata('').status).toBe('missing');
+    expect(extractPIMetadata('not-json{{{').status).toBe('malformed');
+    expect(extractPIMetadata('42').status).toBe('malformed');
+    expect(extractPIMetadata('"hello"').status).toBe('malformed');
+    expect(extractPIMetadata('[]').status).toBe('malformed');
+    expect(extractPIMetadata('{}').status).toBe('missing');
+    expect(extractPIMetadata('{"parentTaskId":42}').status).toBe('malformed');
+    expect(extractPIMetadata('{"dependencyTaskIds":"not-array"}').status).toBe('malformed');
+    expect(extractPIMetadata('{"dependencyTaskIds":[42,true]}').status).toBe('malformed');
+    const parsed = extractPIMetadata('{"parentTaskId":"t1","dependencyTaskIds":["t2"]}');
+    expect(parsed.status).toBe('parsed');
+    if (parsed.status === 'parsed') {
+      expect(parsed.parentTaskId).toBe('t1');
+      expect(parsed.dependencyTaskIds).toEqual(['t2']);
+    }
+    const nested = extractPIMetadata('{"pi_metadata":{"parentTaskId":"t3"}}');
+    expect(nested.status).toBe('parsed');
+    if (nested.status === 'parsed') {
+      expect(nested.parentTaskId).toBe('t3');
+    }
+    expect(extractPIMetadata('{"pi_metadata":{"parentTaskId":123}}').status).toBe('malformed');
+    expect(extractPIMetadata('{"dependencyTaskIds":["t1",42,"t3"]}').status).toBe('malformed');
   });
 
   it('inherited property "constructor" is not read as pi_metadata', () => {
     const result = extractPIMetadata(JSON.stringify({ constructor: 'malicious' }));
-    expect(result).toEqual({});
+    expect(result.status).toBe('missing');
   });
 
   it('unrelated artifact: artifact with different sourceTaskId → task reports missing, not mismatch', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts
@@ -414,6 +414,33 @@ describe('Chain Integrity — Real Production Path', () => {
     const malformed = result.brokenLinks.find(l => l.type === 'metadata_malformed' && l.taskId === 'phil-null');
     expect(malformed).toBeUndefined();
   });
+
+  it('philosopher with mixed dependencyTaskIds → metadata_malformed but no false missing_philosopher_successor (PRI-225)', () => {
+    insertCandidate({ candidateId: 'c-be', taskId: 'dreamer-be', status: 'consumed', sourceRunId: 'run-be' });
+    insertTask({
+      taskId: 'dreamer-be',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      diagnosticJson: JSON.stringify({ candidateId: 'c-be' }),
+    });
+    insertRun({ runId: 'run-be', taskId: 'dreamer-be', executionStatus: 'succeeded' });
+    insertPIArtifact({ artifactId: 'pi-be', artifactKind: 'principle', sourceTaskId: 'dreamer-be' });
+    insertTask({
+      taskId: 'phil-be',
+      taskKind: 'philosopher',
+      status: 'pending',
+      diagnosticJson: JSON.stringify({ dependencyTaskIds: ['dreamer-be', 42] }),
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir });
+    const result = model.check();
+
+    const malformed = result.brokenLinks.find(l => l.type === 'metadata_malformed' && l.taskId === 'phil-be');
+    expect(malformed).toBeDefined();
+
+    const missingSuccessor = result.brokenLinks.find(l => l.type === 'missing_philosopher_successor' && l.taskId === 'dreamer-be');
+    expect(missingSuccessor).toBeUndefined();
+  });
 });
 
 describe('extractPIMetadata — PIMetadataParseResult contract (PRI-225)', () => {
@@ -534,12 +561,40 @@ describe('extractPIMetadata — PIMetadataParseResult contract (PRI-225)', () =>
     expect(r.status).toBe('malformed');
     if (r.status === 'malformed') {
       expect(r.reason).toContain('dependencyTaskIds');
+      expect(r.bestEffortParentIds).toEqual(['valid']);
     }
   });
 
   it('dependencyTaskIds with all non-string elements → malformed', () => {
     const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: [42, null, true] }));
     expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.bestEffortParentIds).toEqual([]);
+    }
+  });
+
+  it('parentTaskId is number → malformed, bestEffortParentIds empty', () => {
+    const r = extractPIMetadata(JSON.stringify({ parentTaskId: 42 }));
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.bestEffortParentIds).toEqual([]);
+    }
+  });
+
+  it('malformed JSON → bestEffortParentIds empty', () => {
+    const r = extractPIMetadata('not-json{{{');
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.bestEffortParentIds).toEqual([]);
+    }
+  });
+
+  it('malformed with valid parentTaskId + invalid dependencyTaskIds → bestEffortParentIds includes parentTaskId', () => {
+    const r = extractPIMetadata(JSON.stringify({ parentTaskId: 'dreamer-1', dependencyTaskIds: [42] }));
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.bestEffortParentIds).toEqual(['dreamer-1']);
+    }
   });
 
   it('empty object → missing (no pi metadata fields)', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts
@@ -441,6 +441,32 @@ describe('Chain Integrity — Real Production Path', () => {
     const missingSuccessor = result.brokenLinks.find(l => l.type === 'missing_philosopher_successor' && l.taskId === 'dreamer-be');
     expect(missingSuccessor).toBeUndefined();
   });
+
+  it('pending philosopher with mixed dependencyTaskIds and existing dreamer → metadata_malformed but no philosopher_dependency_unverifiable (PRI-225)', () => {
+    insertTask({
+      taskId: 'dreamer-dep',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      diagnosticJson: JSON.stringify({ candidateId: 'c-dep' }),
+    });
+    insertRun({ runId: 'run-dep', taskId: 'dreamer-dep', executionStatus: 'succeeded' });
+    insertPIArtifact({ artifactId: 'pi-dep', artifactKind: 'principle', sourceTaskId: 'dreamer-dep' });
+    insertTask({
+      taskId: 'phil-dep',
+      taskKind: 'philosopher',
+      status: 'pending',
+      diagnosticJson: JSON.stringify({ dependencyTaskIds: ['dreamer-dep', 42] }),
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir });
+    const result = model.check();
+
+    const malformed = result.brokenLinks.find(l => l.type === 'metadata_malformed' && l.taskId === 'phil-dep');
+    expect(malformed).toBeDefined();
+
+    const unverifiable = result.brokenLinks.find(l => l.type === 'philosopher_dependency_unverifiable' && l.taskId === 'phil-dep');
+    expect(unverifiable).toBeUndefined();
+  });
 });
 
 describe('extractPIMetadata — PIMetadataParseResult contract (PRI-225)', () => {
@@ -627,6 +653,27 @@ describe('extractPIMetadata — PIMetadataParseResult contract (PRI-225)', () =>
     expect(r.status).toBe('malformed');
     if (r.status === 'malformed') {
       expect(r.reason.length).toBeLessThan(200);
+    }
+  });
+
+  it('valid dependencyTaskIds returns validated string[] without type assertion', () => {
+    const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: ['t1', 't2'] }));
+    expect(r.status).toBe('parsed');
+    if (r.status === 'parsed') {
+      expect(Array.isArray(r.dependencyTaskIds)).toBe(true);
+      expect(r.dependencyTaskIds).toEqual(['t1', 't2']);
+      for (const id of r.dependencyTaskIds ?? []) {
+        expect(typeof id).toBe('string');
+      }
+    }
+  });
+
+  it('dependencyTaskIds with non-string still fails loud regardless of bestEffortParentIds', () => {
+    const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: ['valid', 42, 'also-valid'] }));
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.reason).toContain('dependencyTaskIds');
+      expect(r.bestEffortParentIds).toEqual(['valid', 'also-valid']);
     }
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { InternalizationChainIntegrityReadModel, extractPIMetadata } from '../internalization-chain-integrity-read-model.js';
+import type { PIMetadataParseResult } from '../internalization-chain-integrity-read-model.js';
 import { InternalizationIntegrityRemediation } from '../internalization-integrity-remediation.js';
 
 const SCHEMA = `
@@ -332,82 +333,245 @@ describe('Chain Integrity — Real Production Path', () => {
     expect(columnNames).toContain('task_id');
     expect(columnNames).not.toContain('source_task_id');
   });
+
+  it('task with malformed diagnosticJson → metadata_malformed broken link (PRI-225)', () => {
+    insertCandidate({ candidateId: 'c-mf', taskId: 'dreamer-mf', status: 'consumed', sourceRunId: 'run-mf' });
+    insertTask({
+      taskId: 'dreamer-mf',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      diagnosticJson: JSON.stringify({ candidateId: 'c-mf' }),
+    });
+    insertRun({ runId: 'run-mf', taskId: 'dreamer-mf', executionStatus: 'succeeded' });
+    insertPIArtifact({ artifactId: 'pi-mf', artifactKind: 'principle', sourceTaskId: 'dreamer-mf' });
+    insertTask({
+      taskId: 'phil-mf',
+      taskKind: 'philosopher',
+      status: 'pending',
+      diagnosticJson: 'not-json{{{',
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir });
+    const result = model.check();
+
+    const malformed = result.brokenLinks.find(l => l.type === 'metadata_malformed' && l.taskId === 'phil-mf');
+    expect(malformed).toBeDefined();
+    expect(malformed?.severity).toBe('warning');
+    expect(malformed?.reason.length).toBeGreaterThan(0);
+    expect(malformed?.recommendedAction.length).toBeGreaterThan(0);
+  });
+
+  it('task with dependencyTaskIds containing non-strings → metadata_malformed (PRI-225)', () => {
+    insertTask({
+      taskId: 'phil-mixed',
+      taskKind: 'philosopher',
+      status: 'pending',
+      diagnosticJson: JSON.stringify({ dependencyTaskIds: ['valid', 42] }),
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir });
+    const result = model.check();
+
+    const malformed = result.brokenLinks.find(l => l.type === 'metadata_malformed' && l.taskId === 'phil-mixed');
+    expect(malformed).toBeDefined();
+  });
+
+  it('healthy chain with valid metadata → no metadata_malformed broken links (PRI-225)', () => {
+    insertCandidate({ candidateId: 'c-healthy', taskId: 'dreamer-healthy', status: 'consumed', sourceRunId: 'run-healthy' });
+    insertTask({
+      taskId: 'dreamer-healthy',
+      taskKind: 'dreamer',
+      status: 'succeeded',
+      diagnosticJson: JSON.stringify({ candidateId: 'c-healthy' }),
+    });
+    insertRun({ runId: 'run-healthy', taskId: 'dreamer-healthy', executionStatus: 'succeeded' });
+    insertPIArtifact({ artifactId: 'pi-healthy', artifactKind: 'principle', sourceTaskId: 'dreamer-healthy' });
+    insertTask({
+      taskId: 'phil-healthy',
+      taskKind: 'philosopher',
+      status: 'pending',
+      diagnosticJson: JSON.stringify({ parentTaskId: 'dreamer-healthy', dependencyTaskIds: ['dreamer-healthy'] }),
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir });
+    const result = model.check();
+
+    expect(result.overallStatus).toBe('ok');
+    expect(result.brokenLinks.some(l => l.type === 'metadata_malformed')).toBe(false);
+  });
+
+  it('null diagnosticJson on philosopher → missing (not malformed), no metadata_malformed (PRI-225)', () => {
+    insertTask({
+      taskId: 'phil-null',
+      taskKind: 'philosopher',
+      status: 'pending',
+      diagnosticJson: null,
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir });
+    const result = model.check();
+
+    const malformed = result.brokenLinks.find(l => l.type === 'metadata_malformed' && l.taskId === 'phil-null');
+    expect(malformed).toBeUndefined();
+  });
 });
 
-describe('extractPIMetadata — malformed inputs', () => {
-  it('null → {}', () => {
-    expect(extractPIMetadata(null)).toEqual({});
+describe('extractPIMetadata — PIMetadataParseResult contract (PRI-225)', () => {
+  it('null diagnosticJson → missing', () => {
+    const r = extractPIMetadata(null);
+    expect(r.status).toBe('missing');
   });
 
-  it('invalid JSON → {}', () => {
-    expect(extractPIMetadata('not-json')).toEqual({});
+  it('empty string diagnosticJson → missing', () => {
+    const r = extractPIMetadata('');
+    expect(r.status).toBe('missing');
   });
 
-  it('JSON array → {}', () => {
-    expect(extractPIMetadata('[1,2,3]')).toEqual({});
+  it('valid top-level metadata → parsed', () => {
+    const r: PIMetadataParseResult = extractPIMetadata(JSON.stringify({ parentTaskId: 't1', dependencyTaskIds: ['t2'] }));
+    expect(r.status).toBe('parsed');
+    if (r.status === 'parsed') {
+      expect(r.parentTaskId).toBe('t1');
+      expect(r.dependencyTaskIds).toEqual(['t2']);
+    }
   });
 
-  it('JSON primitive → {}', () => {
-    expect(extractPIMetadata('42')).toEqual({});
-    expect(extractPIMetadata('"hello"')).toEqual({});
-    expect(extractPIMetadata('true')).toEqual({});
-  });
-
-  it('object without pi_metadata → extracts parentTaskId/dependencyTaskIds from root', () => {
-    const result = extractPIMetadata(JSON.stringify({ parentTaskId: 't1', dependencyTaskIds: ['t2'] }));
-    expect(result).toEqual({ parentTaskId: 't1', dependencyTaskIds: ['t2'] });
-  });
-
-  it('object with pi_metadata → extracts from nested', () => {
-    const result = extractPIMetadata(JSON.stringify({
+  it('valid nested pi_metadata → parsed', () => {
+    const r: PIMetadataParseResult = extractPIMetadata(JSON.stringify({
       pi_metadata: { parentTaskId: 't1', dependencyTaskIds: ['t2', 't3'] },
     }));
-    expect(result).toEqual({ parentTaskId: 't1', dependencyTaskIds: ['t2', 't3'] });
+    expect(r.status).toBe('parsed');
+    if (r.status === 'parsed') {
+      expect(r.parentTaskId).toBe('t1');
+      expect(r.dependencyTaskIds).toEqual(['t2', 't3']);
+    }
   });
 
-  it('dependencyTaskIds with non-string elements → filters them out', () => {
-    const result = extractPIMetadata(JSON.stringify({
-      dependencyTaskIds: ['t1', 42, null, 't2', true, { x: 1 }],
-    }));
-    expect(result).toEqual({ dependencyTaskIds: ['t1', 't2'] });
+  it('valid metadata with only parentTaskId → parsed', () => {
+    const r = extractPIMetadata(JSON.stringify({ parentTaskId: 't1' }));
+    expect(r.status).toBe('parsed');
+    if (r.status === 'parsed') {
+      expect(r.parentTaskId).toBe('t1');
+      expect(r.dependencyTaskIds).toBeUndefined();
+    }
   });
 
-  it('dependencyTaskIds with all non-string elements → omitted', () => {
-    const result = extractPIMetadata(JSON.stringify({
-      dependencyTaskIds: [42, null, true],
-    }));
-    expect(result).toEqual({});
+  it('valid metadata with only dependencyTaskIds → parsed', () => {
+    const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: ['t1'] }));
+    expect(r.status).toBe('parsed');
+    if (r.status === 'parsed') {
+      expect(r.parentTaskId).toBeUndefined();
+      expect(r.dependencyTaskIds).toEqual(['t1']);
+    }
   });
 
-  it('parentTaskId non-string → omitted', () => {
-    const result = extractPIMetadata(JSON.stringify({ parentTaskId: 123 }));
-    expect(result).toEqual({});
+  it('malformed JSON → malformed with reason', () => {
+    const r = extractPIMetadata('not-json{{{');
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.reason.length).toBeGreaterThan(0);
+    }
   });
 
-  it('pi_metadata is null → {}', () => {
-    const result = extractPIMetadata(JSON.stringify({ pi_metadata: null }));
-    expect(result).toEqual({});
+  it('JSON array → malformed', () => {
+    const r = extractPIMetadata('[1,2,3]');
+    expect(r.status).toBe('malformed');
   });
 
-  it('pi_metadata is array → {}', () => {
-    const result = extractPIMetadata(JSON.stringify({ pi_metadata: [1, 2] }));
-    expect(result).toEqual({});
+  it('JSON number → malformed', () => {
+    const r = extractPIMetadata('42');
+    expect(r.status).toBe('malformed');
   });
 
-  it('empty object → {}', () => {
-    const result = extractPIMetadata('{}');
-    expect(result).toEqual({});
+  it('JSON string → malformed', () => {
+    const r = extractPIMetadata('"hello"');
+    expect(r.status).toBe('malformed');
   });
 
-  it('object with only unrelated fields → {}', () => {
-    const result = extractPIMetadata(JSON.stringify({ foo: 'bar', baz: 42 }));
-    expect(result).toEqual({});
+  it('JSON boolean → malformed', () => {
+    const r = extractPIMetadata('true');
+    expect(r.status).toBe('malformed');
   });
 
-  it('inherited property "constructor" is not read as parentTaskId', () => {
+  it('pi_metadata is array → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ pi_metadata: [1, 2] }));
+    expect(r.status).toBe('malformed');
+  });
+
+  it('pi_metadata is number → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ pi_metadata: 42 }));
+    expect(r.status).toBe('malformed');
+  });
+
+  it('pi_metadata is string → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ pi_metadata: 'bad' }));
+    expect(r.status).toBe('malformed');
+  });
+
+  it('pi_metadata is null → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ pi_metadata: null }));
+    expect(r.status).toBe('malformed');
+  });
+
+  it('parentTaskId is number → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ parentTaskId: 42 }));
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.reason).toContain('parentTaskId');
+    }
+  });
+
+  it('dependencyTaskIds is string → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: 'x' }));
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.reason).toContain('dependencyTaskIds');
+    }
+  });
+
+  it('dependencyTaskIds with mixed valid and invalid elements → malformed (not partially accepted)', () => {
+    const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: ['valid', 42] }));
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.reason).toContain('dependencyTaskIds');
+    }
+  });
+
+  it('dependencyTaskIds with all non-string elements → malformed', () => {
+    const r = extractPIMetadata(JSON.stringify({ dependencyTaskIds: [42, null, true] }));
+    expect(r.status).toBe('malformed');
+  });
+
+  it('empty object → missing (no pi metadata fields)', () => {
+    const r = extractPIMetadata('{}');
+    expect(r.status).toBe('missing');
+  });
+
+  it('object with only unrelated fields → missing', () => {
+    const r = extractPIMetadata(JSON.stringify({ foo: 'bar', baz: 42 }));
+    expect(r.status).toBe('missing');
+  });
+
+  it('inherited parentTaskId is not read as legitimate metadata', () => {
     const obj = Object.create({ parentTaskId: 'inherited' });
     obj.ownField = 'value';
-    const result = extractPIMetadata(JSON.stringify(obj));
-    expect(result.parentTaskId).toBeUndefined();
+    const r = extractPIMetadata(JSON.stringify(obj));
+    expect(r.status).toBe('missing');
+  });
+
+  it('inherited dependencyTaskIds is not read as legitimate metadata', () => {
+    const obj = Object.create({ dependencyTaskIds: ['inherited'] });
+    obj.ownField = 'value';
+    const r = extractPIMetadata(JSON.stringify(obj));
+    expect(r.status).toBe('missing');
+  });
+
+  it('malformed reason does not leak full diagnosticJson payload', () => {
+    const longPayload = 'x'.repeat(500);
+    const r = extractPIMetadata(longPayload);
+    expect(r.status).toBe('malformed');
+    if (r.status === 'malformed') {
+      expect(r.reason.length).toBeLessThan(200);
+    }
   });
 });

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -915,7 +915,7 @@ export type { SchemaConformanceResult, SchemaConformanceTableResult, SchemaConfo
 // ── Internalization Chain Integrity Read Model (PRI-97) ─────────────────────
 
 export { InternalizationChainIntegrityReadModel, extractPIMetadata } from './internalization-chain-integrity-read-model.js';
-export type { BrokenLink, ChainIntegrityResult, InternalizationChainIntegrityReadModelOptions } from './internalization-chain-integrity-read-model.js';
+export type { BrokenLink, ChainIntegrityResult, InternalizationChainIntegrityReadModelOptions, PIMetadataParseResult } from './internalization-chain-integrity-read-model.js';
 
 export { InternalizationIntegrityRemediation } from './internalization-integrity-remediation.js';
 export type { InternalizationIntegrityRemediationOptions } from './internalization-integrity-remediation.js';

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -36,35 +36,82 @@ function readOwnProperty(obj: object, key: string): unknown {
   return undefined;
 }
 
-export function extractPIMetadata(diagJson: string | null): { parentTaskId?: string; dependencyTaskIds?: string[] } {
-  if (!diagJson) return {};
+export type PIMetadataParseResult =
+  | { status: 'missing' }
+  | {
+      status: 'parsed';
+      parentTaskId?: string;
+      dependencyTaskIds?: string[];
+    }
+  | {
+      status: 'malformed';
+      reason: string;
+    };
+
+const REASON_MAX_LENGTH = 120;
+
+function truncateReason(raw: string): string {
+  if (raw.length <= REASON_MAX_LENGTH) return raw;
+  return raw.slice(0, REASON_MAX_LENGTH - 3) + '...';
+}
+
+function safeJsonParse(json: string): { status: 'ok'; value: unknown } | { status: 'malformed'; reason: string } {
   try {
-    const parsed: unknown = JSON.parse(diagJson);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+    return { status: 'ok', value: JSON.parse(json) };
+  } catch {
+    return { status: 'malformed', reason: truncateReason('diagnosticJson is not valid JSON') };
+  }
+}
 
-    let meta: unknown = parsed;
-    const piMeta = readOwnProperty(parsed, 'pi_metadata');
-    if (piMeta !== undefined) {
-      meta = piMeta;
-    }
-    if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) return {};
+export function extractPIMetadata(diagJson: string | null): PIMetadataParseResult {
+  if (!diagJson) return { status: 'missing' };
 
-    const result: { parentTaskId?: string; dependencyTaskIds?: string[] } = {};
-    const parentTaskId = readOwnProperty(meta, 'parentTaskId');
-    if (typeof parentTaskId === 'string') {
-      result.parentTaskId = parentTaskId;
+  const parsed = safeJsonParse(diagJson);
+  if (parsed.status === 'malformed') return parsed;
+
+  if (typeof parsed.value !== 'object' || parsed.value === null || Array.isArray(parsed.value)) {
+    return { status: 'malformed', reason: truncateReason('diagnosticJson parsed to non-object') };
+  }
+
+  let meta: object = parsed.value;
+  const piMeta = readOwnProperty(parsed.value, 'pi_metadata');
+  if (piMeta !== undefined) {
+    if (typeof piMeta !== 'object' || piMeta === null || Array.isArray(piMeta)) {
+      return { status: 'malformed', reason: truncateReason('pi_metadata is not an object') };
     }
-    const depIds = readOwnProperty(meta, 'dependencyTaskIds');
-    if (Array.isArray(depIds)) {
-      const validated = Array.from(depIds).filter((id: unknown): id is string => typeof id === 'string');
-      if (validated.length > 0) {
-        result.dependencyTaskIds = validated;
+    meta = piMeta;
+  }
+
+  const parentTaskId = readOwnProperty(meta, 'parentTaskId');
+  const depIds = readOwnProperty(meta, 'dependencyTaskIds');
+
+  if (parentTaskId !== undefined && typeof parentTaskId !== 'string') {
+    return { status: 'malformed', reason: truncateReason('parentTaskId is not a string') };
+  }
+
+  if (depIds !== undefined) {
+    if (!Array.isArray(depIds)) {
+      return { status: 'malformed', reason: truncateReason('dependencyTaskIds is not an array') };
+    }
+    for (let i = 0; i < depIds.length; i++) {
+      if (typeof depIds[i] !== 'string') {
+        return { status: 'malformed', reason: truncateReason('dependencyTaskIds contains non-string element') };
       }
     }
-    return result;
-  } catch {
-    return {};
   }
+
+  if (parentTaskId === undefined && depIds === undefined) {
+    return { status: 'missing' };
+  }
+
+  const result: { status: 'parsed'; parentTaskId?: string; dependencyTaskIds?: string[] } = { status: 'parsed' };
+  if (typeof parentTaskId === 'string') {
+    result.parentTaskId = parentTaskId;
+  }
+  if (Array.isArray(depIds)) {
+    result.dependencyTaskIds = depIds as string[];
+  }
+  return result;
 }
 
 export class InternalizationChainIntegrityReadModel {
@@ -168,7 +215,10 @@ export class InternalizationChainIntegrityReadModel {
 
         const hasPhilosopherSuccessor = philosopherTasks.some(pt => {
           const meta = extractPIMetadata(pt.diagnostic_json);
-          return meta.parentTaskId === dreamerTask.task_id || meta.dependencyTaskIds?.includes(dreamerTask.task_id);
+          if (meta.status === 'parsed') {
+            return meta.parentTaskId === dreamerTask.task_id || meta.dependencyTaskIds?.includes(dreamerTask.task_id);
+          }
+          return false;
         });
         if (!hasPhilosopherSuccessor) {
           brokenLinks.push({
@@ -182,10 +232,20 @@ export class InternalizationChainIntegrityReadModel {
       }
 
       for (const philosopherTask of philosopherTasks) {
+        const philMeta = extractPIMetadata(philosopherTask.diagnostic_json);
+        if (philMeta.status === 'malformed') {
+          brokenLinks.push({
+            type: 'metadata_malformed',
+            severity: 'warning',
+            taskId: philosopherTask.task_id,
+            reason: philMeta.reason,
+            recommendedAction: 'Investigate diagnostic_json corruption. Re-seed task with valid metadata or clear diagnostic_json.',
+          });
+        }
+
         if (philosopherTask.status === 'pending' || philosopherTask.status === 'leased') {
           let hasDreamerDependency = false;
-          const philMeta = extractPIMetadata(philosopherTask.diagnostic_json);
-          if (philMeta.dependencyTaskIds && philMeta.dependencyTaskIds.length > 0) {
+          if (philMeta.status === 'parsed' && philMeta.dependencyTaskIds && philMeta.dependencyTaskIds.length > 0) {
             hasDreamerDependency = philMeta.dependencyTaskIds.some((id: string) => taskMap.has(id) && taskMap.get(id)?.task_kind === 'dreamer');
           }
 

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -46,6 +46,7 @@ export type PIMetadataParseResult =
   | {
       status: 'malformed';
       reason: string;
+      bestEffortParentIds: string[];
     };
 
 const REASON_MAX_LENGTH = 120;
@@ -63,21 +64,39 @@ function safeJsonParse(json: string): { status: 'ok'; value: unknown } | { statu
   }
 }
 
+function extractBestEffortParentIds(meta: object): string[] {
+  const ids: string[] = [];
+  const parentTaskId = readOwnProperty(meta, 'parentTaskId');
+  if (typeof parentTaskId === 'string') {
+    ids.push(parentTaskId);
+  }
+  const depIds = readOwnProperty(meta, 'dependencyTaskIds');
+  if (Array.isArray(depIds)) {
+    for (const id of depIds) {
+      if (typeof id === 'string') {
+        ids.push(id);
+      }
+    }
+  }
+  return ids;
+}
+
 export function extractPIMetadata(diagJson: string | null): PIMetadataParseResult {
   if (!diagJson) return { status: 'missing' };
 
   const parsed = safeJsonParse(diagJson);
-  if (parsed.status === 'malformed') return parsed;
+  if (parsed.status === 'malformed') return { ...parsed, bestEffortParentIds: [] };
 
   if (typeof parsed.value !== 'object' || parsed.value === null || Array.isArray(parsed.value)) {
-    return { status: 'malformed', reason: truncateReason('diagnosticJson parsed to non-object') };
+    return { status: 'malformed', reason: truncateReason('diagnosticJson parsed to non-object'), bestEffortParentIds: [] };
   }
 
   let meta: object = parsed.value;
   const piMeta = readOwnProperty(parsed.value, 'pi_metadata');
   if (piMeta !== undefined) {
     if (typeof piMeta !== 'object' || piMeta === null || Array.isArray(piMeta)) {
-      return { status: 'malformed', reason: truncateReason('pi_metadata is not an object') };
+      const bestEffort = extractBestEffortParentIds(parsed.value);
+      return { status: 'malformed', reason: truncateReason('pi_metadata is not an object'), bestEffortParentIds: bestEffort };
     }
     meta = piMeta;
   }
@@ -86,16 +105,19 @@ export function extractPIMetadata(diagJson: string | null): PIMetadataParseResul
   const depIds = readOwnProperty(meta, 'dependencyTaskIds');
 
   if (parentTaskId !== undefined && typeof parentTaskId !== 'string') {
-    return { status: 'malformed', reason: truncateReason('parentTaskId is not a string') };
+    const bestEffort = extractBestEffortParentIds(meta);
+    return { status: 'malformed', reason: truncateReason('parentTaskId is not a string'), bestEffortParentIds: bestEffort };
   }
 
   if (depIds !== undefined) {
     if (!Array.isArray(depIds)) {
-      return { status: 'malformed', reason: truncateReason('dependencyTaskIds is not an array') };
+      const bestEffort = extractBestEffortParentIds(meta);
+      return { status: 'malformed', reason: truncateReason('dependencyTaskIds is not an array'), bestEffortParentIds: bestEffort };
     }
     for (let i = 0; i < depIds.length; i++) {
       if (typeof depIds[i] !== 'string') {
-        return { status: 'malformed', reason: truncateReason('dependencyTaskIds contains non-string element') };
+        const bestEffort = extractBestEffortParentIds(meta);
+        return { status: 'malformed', reason: truncateReason('dependencyTaskIds contains non-string element'), bestEffortParentIds: bestEffort };
       }
     }
   }
@@ -217,6 +239,9 @@ export class InternalizationChainIntegrityReadModel {
           const meta = extractPIMetadata(pt.diagnostic_json);
           if (meta.status === 'parsed') {
             return meta.parentTaskId === dreamerTask.task_id || meta.dependencyTaskIds?.includes(dreamerTask.task_id);
+          }
+          if (meta.status === 'malformed') {
+            return meta.bestEffortParentIds.includes(dreamerTask.task_id);
           }
           return false;
         });

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -131,7 +131,15 @@ export function extractPIMetadata(diagJson: string | null): PIMetadataParseResul
     result.parentTaskId = parentTaskId;
   }
   if (Array.isArray(depIds)) {
-    result.dependencyTaskIds = depIds as string[];
+    const validatedDependencyTaskIds: string[] = [];
+    for (const id of depIds) {
+      if (typeof id === 'string') {
+        validatedDependencyTaskIds.push(id);
+      }
+    }
+    if (validatedDependencyTaskIds.length > 0) {
+      result.dependencyTaskIds = validatedDependencyTaskIds;
+    }
   }
   return result;
 }
@@ -272,6 +280,8 @@ export class InternalizationChainIntegrityReadModel {
           let hasDreamerDependency = false;
           if (philMeta.status === 'parsed' && philMeta.dependencyTaskIds && philMeta.dependencyTaskIds.length > 0) {
             hasDreamerDependency = philMeta.dependencyTaskIds.some((id: string) => taskMap.has(id) && taskMap.get(id)?.task_kind === 'dreamer');
+          } else if (philMeta.status === 'malformed' && philMeta.bestEffortParentIds.length > 0) {
+            hasDreamerDependency = philMeta.bestEffortParentIds.some((id: string) => taskMap.has(id) && taskMap.get(id)?.task_kind === 'dreamer');
           }
 
           if (!hasDreamerDependency) {

--- a/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
@@ -201,6 +201,10 @@ export class InternalizationIntegrityRemediation {
           if (meta.parentTaskId) {
             philosopherParentIds.add(meta.parentTaskId);
           }
+        } else if (meta.status === 'malformed') {
+          for (const id of meta.bestEffortParentIds) {
+            philosopherParentIds.add(id);
+          }
         }
       }
 
@@ -259,6 +263,10 @@ export class InternalizationIntegrityRemediation {
         const meta = extractPIMetadata(pt.diagnostic_json);
         if (meta.status === 'parsed') {
           if (meta.dependencyTaskIds?.includes(dreamerTaskId) || meta.parentTaskId === dreamerTaskId) {
+            return pt.task_id;
+          }
+        } else if (meta.status === 'malformed') {
+          if (meta.bestEffortParentIds.includes(dreamerTaskId)) {
             return pt.task_id;
           }
         }

--- a/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts
@@ -192,13 +192,15 @@ export class InternalizationIntegrityRemediation {
       const philosopherParentIds = new Set<string>();
       for (const pt of philosopherTasks) {
         const meta = extractPIMetadata(pt.diagnostic_json);
-        if (meta.dependencyTaskIds) {
-          for (const depId of meta.dependencyTaskIds) {
-            philosopherParentIds.add(depId);
+        if (meta.status === 'parsed') {
+          if (meta.dependencyTaskIds) {
+            for (const depId of meta.dependencyTaskIds) {
+              philosopherParentIds.add(depId);
+            }
           }
-        }
-        if (meta.parentTaskId) {
-          philosopherParentIds.add(meta.parentTaskId);
+          if (meta.parentTaskId) {
+            philosopherParentIds.add(meta.parentTaskId);
+          }
         }
       }
 
@@ -255,8 +257,10 @@ export class InternalizationIntegrityRemediation {
 
       for (const pt of philosopherTasks) {
         const meta = extractPIMetadata(pt.diagnostic_json);
-        if (meta.dependencyTaskIds?.includes(dreamerTaskId) || meta.parentTaskId === dreamerTaskId) {
-          return pt.task_id;
+        if (meta.status === 'parsed') {
+          if (meta.dependencyTaskIds?.includes(dreamerTaskId) || meta.parentTaskId === dreamerTaskId) {
+            return pt.task_id;
+          }
         }
       }
 


### PR DESCRIPTION
## Why the `{}` fallback was insufficient

`extractPIMetadata()` returned `{}` for both "no metadata was written" and "metadata is corrupt/malformed". This violated Runtime Contract Rule 9 (ERR-002): graceful degradation must include a reason. Callers (including `check()` and remediation) could not distinguish between a legitimately missing field and data corruption, making it impossible to detect or diagnose malformed diagnosticJson.

## New parse result public contract

```ts
export type PIMetadataParseResult =
  | { status: 'missing' }        // null/empty diagnosticJson, or object with no PI metadata fields
  | { status: 'parsed'; parentTaskId?: string; dependencyTaskIds?: string[] }  // valid metadata
  | { status: 'malformed'; reason: string }  // corrupt/untrusted data with diagnostic reason
```

Key behaviors:
- `null` / empty string → `missing`
- Valid JSON with valid fields → `parsed`
- Invalid JSON, non-object `pi_metadata`, type-invalid fields → `malformed` with bounded reason
- `dependencyTaskIds` with ANY non-string element → `malformed` (not partially accepted — avoids ERR-005)
- Inherited prototype properties are NOT read as legitimate metadata (Object.hasOwn semantics)
- `reason` is capped at 120 chars to prevent payload leakage (ERR-014/ERR-017)

## `metadata_malformed` broken link semantics

When `extractPIMetadata()` returns `malformed` for a philosopher task, `check()` emits:
- `type: 'metadata_malformed'`
- `severity: 'warning'` — malformed metadata is observable but does not block the chain
- `taskId` — the task with corrupt metadata
- `reason` — the specific parse failure (bounded)
- `recommendedAction` — actionable guidance

## PRI-209 lineage semantics preserved

The following PRI-209 classifications are **unchanged**:
- `result_ref` → nonexistent artifact → `result_ref_missing_artifact`
- `result_ref` → artifact with wrong `task_id` → `lineage_mismatch`
- No principle artifact for succeeded dreamer → `missing_dreamer_pi_artifact`
- Healthy complete chain → `overallStatus === 'ok'`

## ERR Checklist

| ERR | How avoided |
|-----|-------------|
| ERR-001 | No `as` casts on untrusted parsed JSON; `safeJsonParse` returns `unknown` with runtime narrowing |
| ERR-002 | `malformed` always includes a `reason`; no silent `{}` fallback |
| ERR-005 | `dependencyTaskIds` with non-string elements → `malformed`, not filtered subset |
| ERR-008 | PRI-209 lineage semantics unchanged; `metadata_malformed` is a new separate type |
| ERR-009 | `parentTaskId: 42` / `dependencyTaskIds: 'x'` → `malformed` with reason, not silently omitted |
| ERR-026 | Test schemas continue using PRAGMA assertions for column alignment |

## Files Modified

- `packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts` — New `PIMetadataParseResult` type, rewritten `extractPIMetadata()`, `metadata_malformed` in `check()`
- `packages/principles-core/src/runtime-v2/internalization-integrity-remediation.ts` — Migrated 2 callers to handle discriminated union
- `packages/principles-core/src/runtime-v2/index.ts` — Export `PIMetadataParseResult` type
- `packages/principles-core/src/runtime-v2/__tests__/chain-integrity-real-path.test.ts` — New tests for parse contract + `metadata_malformed` integration
- `packages/principles-core/src/runtime-v2/__tests__/chain-integrity-attack.test.ts` — Updated to discriminated union assertions

## Test Commands and Results

```bash
npm run build --workspace=@principles/core            # pass
npx vitest run chain-integrity-real-path.test.ts       # 38 passed
npx vitest run chain-integrity-attack.test.ts          # 11 passed
npx vitest run architecture-regression.test.ts         # 438 passed
npm run lint                                           # pass
npm run verify:merge                                   # pass
```

## Remaining Risk

- `metadata_malformed` is only emitted for philosopher tasks (the only task kind that calls `extractPIMetadata`). Other task kinds with malformed `diagnosticJson` are not yet detected. This is by design — scope is limited to the existing metadata parsing path.
- Remediation does not auto-fix malformed metadata — it skips tasks with `malformed` status (consistent with prior behavior but now observable via the read model).

Closes: PRI-225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强了诊断元数据解析能力，可准确区分元数据状态（缺失/有效/格式错误）
  * 改进了链完整性验证逻辑，对格式错误的元数据提供最优努力的恢复匹配

* **Bug 修复**
  * 优化了关键路径的错误处理，增强系统在异常数据场景下的稳定性

* **文档**
  * 更新了错误处理文档，补充已知问题的追踪记录

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->