### PR TITLE
docs: add MVP-First pivot ADR-0014, new ADRs 0008-0013, and roadmap updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,57 @@
 # AGENTS.md — OpenAI Codex CLI Instructions
 
+## ⚠️ MVP-First Stage — Read First (2026-05-24)
+
+**PD is in MVP-First stage** (ADR-0014). Goal: invite the first real seed customer within 4-6 weeks. **All architectural expansion is paused.** Before starting ANY work:
+
+1. Read [`docs/adr/0014-mvp-first-strategy-and-product-pivot.md`](docs/adr/0014-mvp-first-strategy-and-product-pivot.md) (MVP-First Strategy)
+2. Read [`docs/plans/2026-05-roadmap/07-mvp-first-pivot.md`](docs/plans/2026-05-roadmap/07-mvp-first-pivot.md) (execution doc)
+3. Read [`docs/plans/post-mvp-conditional-roadmap.md`](docs/plans/post-mvp-conditional-roadmap.md) (deferred work restart conditions)
+
+If a Linear issue or earlier doc instructs you to implement **Attribution Pipeline / WorkspaceLearningSummary / Probation Window / BALM / LRAS / GAP / MissionScheduler / Trainer / model_training channel / pre-existing Phase 1C or Phase 1D work**, **STOP** and verify against post-mvp-conditional-roadmap.md whether the restart conditions are met. They almost certainly are not.
+
+### MVP Three Questions (mandatory for every new issue)
+
+Before opening a new Linear issue or starting a non-MVP-listed PR, answer all three:
+
+1. **What happens if we DON'T do this?** Will anyone bring it up again 30 days from now? If you cannot answer, the issue is rejected.
+2. **How is it observed?** After implementation, how does the user verify it works? UI? CLI command? Log? If there is no observable path, the issue is rejected.
+3. **How is it disabled?** If after deployment we discover it's wrong, what's the disable path? Feature flag? PR revert? **Anything that requires PR revert MUST ship with a feature flag from day one.**
+
+### MVP-Core / MVP-Quiet / MVP-Gone Triage
+
+Every PD subsystem falls into one of three buckets (see ADR-0014 §2.4-§2.6):
+
+- **MVP-Core**: required for story A' (4-channel demo). Touch with care.
+- **MVP-Quiet**: code remains, but feature flag is **default off** and not surfaced in UI / docs. After 6 months of no activation, becomes MVP-Gone.
+- **MVP-Gone**: deleted or archived to reduce code volume.
+
+**Adding a new feature to MVP-Core REQUIRES maintainer's explicit approval.** Default for unsolicited new code is MVP-Quiet (off + flag-registered).
+
+### Feature Flag Registration
+
+Every new subsystem / hook / writer / reader must be registered in `{workspace}/.pd/feature-flags.yaml` with:
+- `category: core | quiet | gone | legacy_retire`
+- `enabled: true | false` (Quiet = false by default)
+- `since: <YYYY-MM-DD>` (when added)
+
+PRs that introduce new functional code without flag registration are rejected.
+
+### Anti-pattern Triggers
+
+The following phrases in an issue or PR description are **automatic stop signals**. Verify with maintainer before proceeding:
+
+- "为未来铺路" / "for future extensibility"
+- "为完整性" / "for completeness"
+- "AHE 论文又出了新进展" / "based on new research"
+- "这个 ADR 当时是 Accepted" / "this ADR was Accepted"
+- "review 时觉得这块缺失" / "during review I noticed X is missing"
+- "为下个 Phase 准备" / "prep for next Phase"
+
+These are **maintainer-driven completeness anxiety**, not external user signal. PD does not act on them during MVP stage.
+
+---
+
 ## Mandatory Pre-Task Reading
 
 Before starting ANY coding task on this project, you MUST read `docs/ERROR_EXPERIENCE_HANDBOOK.md`. This file records real errors caught in code reviews. Reading it prevents you from repeating mistakes.

--- a/docs/adr/0008-built-in-agent-lifecycle-manager.md
+++ b/docs/adr/0008-built-in-agent-lifecycle-manager.md
@@ -1,0 +1,48 @@
+# ADR-0008: Built-in Agent Lifecycle Manager (BALM)
+
+> **状态**: Accepted (实施延后至 Phase 2 — 见 v2.0 修订)
+> **日期**: 2026-05-16
+> **相关**: COMPONENTS.md, INTERNALIZATION_PIPELINE.md
+
+> **2026-05-24 v2.0 修订**: 本 ADR 的 `Accepted` 状态保持不变，但**实施被显式延后**到 Phase 2，准入门槛由 [docs/plans/2026-05-roadmap/02-roadmap.md §7](../plans/2026-05-roadmap/02-roadmap.md) 强制：必须先完成 Phase 1C/1D（特别是 Attribution Pipeline 在生产 workspace 累计 ≥ 50 个 verdict 且校准通过 false positive < 5%）。在该门槛达成前，禁止启动本 ADR 涉及的实施工作；如有 Linear 工单引用本 ADR 要求即时实施，先与维护者确认门槛状态。本修订理由见 [ADR-0013](./0013-attribution-pipeline-and-decision-observability.md) 与 [06-ahe-informed-architecture-review.md](../plans/2026-05-roadmap/06-ahe-informed-architecture-review.md) §2.2。
+
+
+## 1. 背景与痛点 (Context)
+
+在目前的架构中，内部的 7 大 Peer Runners（Dreamer, Philosopher, Scribe, Artificer 等）通过硬编码的方式在代码中实例化。这导致了几个问题：
+1. **身份与配置分散**：Agent 的提示词、支持的工具列表、优先使用的模型运行时（如 Claude Code 或 Gemini CLI）散落在各个文件中，难以集中管理和更新。
+2. **多后端适配困难**：系统逐渐需要支持更多的底层驱动（OpenClaw, Claude Code, Codex, Gemini 等），如果在 Runner 里硬编码适配器调用，将导致核心领域层与外围基础设施严重耦合。
+3. **缺乏版本控制**：内部代理的变更是极其危险的，目前没有机制对内置代理进行版本化管理和灰度测试。
+
+## 2. 决策详情 (Decisions)
+
+我们决定引入 **Built-in Agent Lifecycle Manager (BALM)** 子系统，统一接管所有内置代理的生命周期。
+
+### 2.1 声明式代理清单 (Agent Manifests)
+所有的内置代理不再通过代码硬性构建，而是必须通过声明式的 YAML 清单进行定义。例如 `diagnostician.agent.yaml`。
+该 Manifest 包含：
+- 代理的唯一身份 (Identity / ID)
+- 版本号 (Version)
+- 系统提示词模板 (System Prompt Template)
+- 所需工具权限列表 (Required Tool Permissions)
+- 偏好的运行时环境 (Preferred Runtimes)
+
+### 2.2 集中式注册表与解析器
+- 建立 `BuiltInAgentRegistry` 统一加载和缓存所有的 Agent Manifest。
+- 建立 `AgentRuntimeResolver`。当系统需要唤醒某个 Agent 时，它会根据 Manifest 中的能力要求（Caps）和工作区当前的配置，自动为其匹配并分配最合适的 `PDRuntimeAdapter`（如 `ClaudeCodeRuntimeAdapter` 或 `OpenCodeRuntimeAdapter`）。
+
+### 2.3 严格的不变量约束 (Invariants)
+- `BALM-1`：所有内置代理必须有对应的 Manifest 文件，绝对禁止匿名或即兴实例化的 Peer Runner。
+- `BALM-2`：Peer Runner 不得直接 `import` 任何 `Adapter` 的底层实现类。所有底层驱动的获取必须通过 BALM 依赖注入进行解析。
+- `BALM-3`：Agent 的基础 Prompt 必须从 Manifest 加载，严禁在 TypeScript 源码中硬编码。
+
+## 3. 架构收益 (Consequences)
+
+### 积极影响 (Pros)
+- **极度解耦**：Peer Runners 现在变成了纯粹的业务状态流转器，彻底摆脱了与大模型厂商 API 或特定 CLI 工具的耦合。
+- **可插拔运行时**：能够非常轻松地接入新的底层驱动（例如接入未来新出的 Hermes 终端）。
+- **统一治理**：架构师可以直接通过审查 YAML 文件来把控所有内部 AI 代理的权限和性格，这使得系统审计变得直观可见。
+
+### 潜在风险 (Cons / Mitigations)
+- *风险*：YAML 文件的加载可能成为新的故障点，尤其是语法错误。
+- *缓解*：在启动时或打包阶段（Build Phase）使用专门的 TypeBox Schema 强制校验所有的 Manifest 文件，拒绝启动格式错误的配置。

--- a/docs/adr/0009-long-running-agent-session.md
+++ b/docs/adr/0009-long-running-agent-session.md
@@ -1,0 +1,48 @@
+# ADR-0009: Long-Running Agent Session (LRAS)
+
+> **状态**: Accepted (实施延后至 Phase 2 — 见 v2.0 修订)
+> **日期**: 2026-05-16
+> **相关**: COMPONENTS.md, DATA_ARCHITECTURE.md
+
+> **2026-05-24 v2.0 修订**: 本 ADR 的 `Accepted` 状态保持不变，但**实施被显式延后**到 Phase 2，准入门槛见 [docs/plans/2026-05-roadmap/02-roadmap.md §7](../plans/2026-05-roadmap/02-roadmap.md)。在 Phase 1C/1D 完成（特别是 Attribution Pipeline 校准通过）前禁止启动实施。理由见 [ADR-0013](./0013-attribution-pipeline-and-decision-observability.md) 与 [06-ahe-informed-architecture-review.md](../plans/2026-05-roadmap/06-ahe-informed-architecture-review.md) §2.2。
+
+
+## 1. 背景与痛点 (Context)
+
+PD 系统此前的代理调用模式（如 OpenClaw 的单次调度）是一种“一锤子买卖”。每次请求都有着严格的超时限制（通常 30 秒到 3 分钟）。
+然而，对于架构级的重构、复杂的环境配置或是涉及多个子系统的大规模诊断（Dreamer/Artificer 的工作），Agent 需要进行长时间的探索、反复试错和查阅文档。现有的短生命周期模式导致：
+1. Agent 经常在工作进行到一半时被强行掐断（Timeout）。
+2. 被切断后再次唤醒时，完全丢失了上一轮的“工作记忆（Scratchpad）”，导致陷入无尽的重试死循环（Rework Loop）。
+
+## 2. 决策详情 (Decisions)
+
+我们决定将内部 AI 代理的执行范式从“单次响应（Request-Response）”升级为 **Long-Running Agent Session (LRAS)** 模式。
+
+### 2.1 长程会话基座 (Session Base)
+- **最低时长保障**：默认的内部代理工作周期（Session）从分钟级提升至以“10分钟起步，可达数小时”。不再因为单次 LLM 响应超时而销毁任务。
+- **会话持久化**：引入 `AgentSession` 服务，每次会话启动时都会被分配唯一的 `session_id`。
+
+### 2.2 状态恢复与检查点 (Checkpoints & Recovery)
+- **数据库扩表**：新增 `agent_session_checkpoints` 状态表。
+- **高频存档**：每当 Agent 执行了关键决策（如工具调用完毕、子阶段完成），系统强制将其当前的状态（State）、工作草稿（Scratchpad）和历史动作（Tool Call History）序列化保存为一个 Checkpoint。
+- **崩溃恢复 (Recovery Sweep)**：如果宿主进程意外崩溃，`RecoverySweep` 在下次启动时会扫描未完成的 Session，并从最近的一个 Checkpoint 自动“读档”继续执行。
+
+### 2.3 自愈与反馈回灌 (Self-Validation & Log Backflow)
+- **赋予 Agent PD 级元工具 (Meta-tools)**：将 PD 系统的部分能力包装为工具开放给 LRAS 代理（如 `pd_validate_output`, `pd_fetch_recent_logs`, `pd_schema_check`）。
+- 代理在完成阶段性代码修改后，可以自己调用 `pd_validate_output` 进行在线校验。
+- 如果构建失败，`LogBackflow` 服务会自动捕获异常并将日志脱敏后“倒灌”给代理，让其自行修复，无需中断整个长程任务。
+
+### 2.4 不变量约束 (Invariants)
+- `LRAS-1`：每一个启动的 LRAS session 在结束前，至少必须产生 1 个物理落盘的 Checkpoint。
+- `LRAS-2`：代理所使用的 `SelfValidationTools` 必须绝对保证没有副作用（只读模式），以防代理在校验阶段破坏真实环境。
+- `LRAS-3`：`LogBackflow` 倒灌的日志必须经过脱敏层（Log Sanitizer），防止将敏感环境变量泄露入提示词中。
+
+## 3. 架构收益 (Consequences)
+
+### 积极影响 (Pros)
+- **真正的系统级干预能力**：Agent 终于可以承接耗时数小时的超大重构任务，不再受限于框架超时。
+- **极强的韧性 (Resilience)**：基于 Checkpoint 的状态机让系统无惧意外重启。
+
+### 潜在风险 (Cons / Mitigations)
+- *风险*：长程会话如果不加节制，可能会导致 Token 消耗失控，形成天价账单。
+- *缓解*：必须结合 Performance Budgets（预算限制），每个 Session 设定硬性的 Token/美元 上限，一旦触顶强制抛出异常并冻结。

--- a/docs/adr/0010-goal-aligned-pain-signal.md
+++ b/docs/adr/0010-goal-aligned-pain-signal.md
@@ -1,0 +1,62 @@
+# ADR-0010: Goal-Aligned Pain Signal (GAP)
+
+> **状态**: Accepted (Layer 3 三层信号架构已生效；Layer 1/2 GAP Generator 实施延后至 Phase 2)
+> **日期**: 2026-05-16
+> **相关**: INTERNALIZATION_PIPELINE.md, DOMAIN_MODEL.md, DATA_ARCHITECTURE.md
+
+> **2026-05-24 v2.0 修订**: 本 ADR 的三层信号架构（Layer 1/2/3）原则保持不变，但 **Layer 1 GAPSignalGenerator + Mission/Objective/KeyResult 数据模型实施被延后**到 Phase 2，准入门槛见 [docs/plans/2026-05-roadmap/02-roadmap.md §7](../plans/2026-05-roadmap/02-roadmap.md)。Phase 1C/1D 期间，pain category 仍只来自 Layer 3 (tool_failure/empathy_inferred) + Layer 2 (user_correction)；attribution 不依赖 Layer 1。理由见 [06-ahe-informed-architecture-review.md](../plans/2026-05-roadmap/06-ahe-informed-architecture-review.md) §2.3（无 mission 数据时强行实现会变 mock）。
+
+
+## 1. 背景与痛点 (Context)
+
+PD 系统原本的设计中，任何底层的工具调用失败（例如 `git push` 冲突，或者少传了一个参数）都会无差别地生成 `PainSignal` 并触发 Diagnostician 的反思。
+这导致了严重的**“反思噪音 (Reflection Noise)”**：
+1. 系统生成了大量极度局部的、低价值的底层补丁规则（Rule），导致 Ledger 迅速膨胀。
+2. 这些碎片化的问题往往在下一步的重试中自然解决，根本不配触发昂贵的系统级诊断。
+3. Agent 失去了“宏观目标感”。它在不断修补坑洼，但忘记了它原本到底要走到哪里去。
+
+## 2. 决策详情 (Decisions)
+
+我们决定引入 **Goal-Aligned Pain (GAP) 架构**，对痛点信号的生成和触发机制进行彻底的分层降级。
+
+### 2.1 三层信号架构 (Three-Layer Signal Architecture)
+痛点被严格划分为三个层级，且**剥夺最底层信号独立触发诊断的权利**：
+
+*   **Layer 1（主信号 / 目标驱动）**：
+    *   **类型**：`mission_failed`, `mission_stalled`, `okr_drift`, `decision_skipped`, `rework_loop`。
+    *   **触发**：**✅ 独立触发** Diagnostician。
+    *   **来源**：由后端的 `GAPSignalGenerator` 每日或基于里程碑扫描生成。只有当长程目标受到实质性阻碍时才拉响最高警报。
+*   **Layer 2（强信号 / 用户反馈）**：
+    *   **类型**：`explicit_user_complaint`, `user_correction`。
+    *   **触发**：**✅ 独立触发** Diagnostician。
+    *   **来源**：人类用户的显式介入与干预。
+*   **Layer 3（辅助信号 / 基础设施失败）**：
+    *   **类型**：`tool_failure`, `empathy_inferred`。
+    *   **触发**：**❌ 禁止独立触发** Diagnostician。
+    *   **来源**：底层的 Hook 拦截报错。它们只能静静地躺在数据库中，作为后续 Layer 1/2 报警时的“附属作案证据（Evidence）”。
+
+### 2.2 目标管理子系统 (Goals Subsystem)
+为了支撑 Layer 1 的报警，我们需要建立真实的结构化目标管理模型。
+在 SQLite 数据库中引入 3 张核心表：
+1.  **`objectives`**：高维 OKR 季度目标。
+2.  **`key_results`**：可量化的关键结果指标（附带自动测量 Query）。
+3.  **`missions`**：具体的长程任务（关联到 Objective，拥有明确的预期周期和状态）。
+
+### 2.3 决策卫生门控 (Decision Hygiene Gate)
+- 当 Agent 企图执行高影响/破坏性的决策（如放弃目标、彻底重构）时，强制拦截并转入 `DecisionHygieneGate`。
+- 如果是 `high/critical` 影响，强制进行额外的深度分析流程；普通行为则仅作警告提醒。
+
+### 2.4 不变量约束 (Invariants)
+- `GAP-1`：Layer 3 信号不得独立触发 Diagnostician，由 GAP Generator 聚合。
+- `HYGIENE-1`：High/critical 影响必须强制通过 DecisionHygieneGate。
+
+## 3. 架构收益 (Consequences)
+
+### 积极影响 (Pros)
+- **终结无意义的反思**：大幅缩减无价值的诊断任务，集中算力解决真正的战略级痛点（Mission 失败）。
+- **真正的自治感**：系统终于知道“我在为了什么目标服务”，而不仅仅是一个被动的报错监控器。
+- **GFI 内核极简**：Global Friction Index 不再需要做复杂的多源加权，只需要做“上层报警 + 下层证据”的组装。
+
+### 潜在风险 (Cons / Mitigations)
+- *风险*：如何准确判断一个 Mission 是 `stalled`（停滞）而非正在努力进行中？
+- *缓解*：依托于 ADR-0011 引入的 MissionScheduler，基于时间预算（Time Budget）和最近 N 个 Checkpoint 的进展向量进行数学判定。

--- a/docs/adr/0011-three-tier-task-model-and-mission-scheduler.md
+++ b/docs/adr/0011-three-tier-task-model-and-mission-scheduler.md
@@ -1,10 +1,12 @@
 # ADR-0011: Three-Tier Task Model and MissionScheduler
 
-> **状态**: Accepted
+> **状态**: Accepted (实施延后至 Phase 2/3 — 见 v2.0 修订)
 > **日期**: 2026-05-16
 > **相关**: COMPONENTS.md, DATA_ARCHITECTURE.md
 
 > **2026-05-23 修订**: [ADR-0012](./0012-runtime-v2-standalone-scheduling-and-legacy-retirement.md) 规定 `MissionScheduler` 如继续实施，必须是 PD-owned、host-agnostic 的显式调度边界。本文提及 `IdleTrigger` 作为唤醒来源的部分已废止；不得建设 OpenClaw idle/night 触发适配器。
+> **2026-05-24 v2.0 修订**: 本 ADR 的三层任务模型实施被进一步延后至 Phase 2/3。当前 PRI-162 的 PD-owned explicit scheduling boundary 已经满足 Runtime V2 的执行需求，不需要 MissionScheduler 即可推进 Phase 1C/1D。准入门槛见 [docs/plans/2026-05-roadmap/02-roadmap.md §7](../plans/2026-05-roadmap/02-roadmap.md)。理由见 [06-ahe-informed-architecture-review.md](../plans/2026-05-roadmap/06-ahe-informed-architecture-review.md) §2.3。
+
 
 ## 1. 背景与痛点 (Context)
 

--- a/docs/adr/0013-attribution-pipeline-and-decision-observability.md
+++ b/docs/adr/0013-attribution-pipeline-and-decision-observability.md
@@ -1,0 +1,369 @@
+# ADR-0013: Attribution Pipeline and Decision Observability
+
+> **Status**: ⚠️ **Superseded by ADR-0014 — Deferred**（2026-05-24）
+> **Date**: 2026-05-24（initial Proposed → Deferred 同日）
+> **Reason for Defer**: PD 进入 MVP-First 阶段（ADR-0014）。Attribution Pipeline 的实施依赖真实种子客户的使用数据；在零外部用户的情况下构建会变成基于推演的 mock。
+> **Restart Conditions**: 见 [docs/plans/post-mvp-conditional-roadmap.md §1](../plans/post-mvp-conditional-roadmap.md)
+> **Original Status**: Proposed
+> **Influenced by**: AHE (Agentic Harness Engineering, 2026-04 preprint) — three-pillar observability model
+
+> **重要提示**：本 ADR 的概念分析仍然有价值（特别是 §3.1.1 PrincipleScopeSignature 与 §3.1.2 BaselineRateProvider 的 baseline 设计），保留作为未来重启时的输入。但**当前不实施**。任何 Linear issue 引用本 ADR 要求即时实施时，必须先核对 post-mvp-conditional-roadmap.md §1 的重启条件是否真实满足，并先与维护者确认。
+
+
+## 1. Context
+
+PD 的 Pain → Diagnosis → Internalization → Activation 链路已落地并通过 baseline / live / chaos 验证。但系统在"激活之后"立即失明：一个 principle 被注入 prompt 或一个 RuleHost 实现被启用之后，PD 没有任何机制衡量：
+
+1. 它声称要消除的痛苦类别在后续观测窗口内是否真的减少了；
+2. 同一窗口内是否引入了新类别的痛苦；
+3. 它和其他 active principles 之间是否在打架。
+
+这导致几个具体的失控：
+
+- L1 容量只能依靠 LRU + cap = 12（PRI-139）兜底——无效但被频繁触发的原则会一直占住 cap。
+- 三振出局（PRI-141）只能捕获**人类显式拒绝**的循环失败，沉默无效不可见。
+- Pruning 决策依赖 `lifecycleEvidence`，但 evidence 是启发式估算，没有"实证测量"。
+- Diagnostician 是无记忆的——每次跑都从空白开始，反复发明同类原则。
+
+把这一缺口对照 AHE 论文的三支柱框架，缺的是 **Decision Observability**：每个激活动作必须是可证伪契约，下一轮观测裁决 keep / improve / rollback。
+
+## 2. Decision
+
+引入 **Attribution Pipeline** 作为 PD 的第四条数据流，与 Pain / Internalization / Activation 流水线并列。
+
+```
+[active principle X]
+       │
+       ▼ (固定观测窗口)
+[ActivationOutcomeAttribution]
+   ├ painsEliminated:   该 principle 声称要消除的类别中实际减少了多少
+   ├ painsIntroduced:   同一窗口内新增的、可归因到该 principle 的痛苦
+   ├ adherenceObserved: 实际行为与原则触发条件的偏差
+   ├ conflictWith[]:    与哪些其他 active principles 在同窗口被同时违反
+   └ verdict:           confirmed | uncertain | regressed
+       │
+       ├──────────────────┬──────────────────┐
+       ▼                  ▼                  ▼
+   auto-archive       update            re-diagnose
+   (regressed)        adherence/        (uncertain → 重新挂诊断任务)
+                      learning summary
+                      (confirmed)
+```
+
+同时引入两个支撑组件：
+
+- **WorkspaceLearningSummary**：跨会话的元经验视图，注入下一轮 Diagnostician prompt。
+- **Activation Probation Window**：approval → fully active 之间的过渡态，attribution 数据决定是否真正成 active。
+
+## 3. Architecture
+
+### 3.1 新组件清单
+
+| 组件 | 类型 | 包 | 状态 |
+|------|------|---|------|
+| `AttributionWindowScheduler` | 🔵 Service | core | 待建 |
+| `ActivationOutcomeAttribution` | 📋 Schema + 🟡 Store | core | 待建 |
+| `PainAttributionResolver` | 🔧 Util | core | 待建 |
+| `PrincipleScopeSignature` | 📋 Schema | core | 待建 |
+| `BaselineRateProvider` | 🔵 Service | core | 待建 |
+| `ConflictDetector` | 🔧 Util | core | 待建 |
+| `AttributionVerdictDispatcher` | 🔵 Service | core | 待建 |
+| `WorkspaceLearningSummaryReadModel` | 🟣 ReadModel | core | 待建 |
+| `LearningSummaryPromptInjector` | 🔧 Util | core | 待建 |
+| `ProbationActiveStateMachine` | 🔧 Util | core | 待建 |
+| `BundledProvenanceTagger` | 🔧 Util | core | 待建 |
+| `AttributionShadowMode` | 🔵 Service | core | 待建（启动期默认开启）|
+
+### 3.1.1 PrincipleScopeSignature（关键：决定 attribution 怎么归因）
+
+> **设计动机（v2.0 review 补充）**: 仅靠 `PainCategory` 这种粗类（tool_failure/user_correction）做归因会让所有 tool_failure pain 互相错配。我们需要一个**更细的等价类签名**来判定"两个 pain 是不是同一类"。
+
+```typescript
+interface PrincipleScopeSignature {
+  /** 粗类，来自 GAP layer（兜底信号） */
+  painCategory: PainCategory;
+  /** 工具范围：principle 声称要影响的工具集 */
+  affectedToolNames: string[];
+  /** 触发条件的归一化指纹，例如 "tool_call::write_file::path_under(/etc/)" */
+  triggerFingerprint: string;
+  /** 原则 derivedFromPainIds 中各 painId 的根因哈希集合（用于精确 mat ching）|
+  rootCauseHashes: string[];
+}
+
+// 两个 pain 属于同一 scope 的判定（按 v 优先级）
+//   v1 (强): rootCauseHashes 交集非空（相同根因）
+//   v2 (中): triggerFingerprint 一致 + painCategory 一致
+//   v3 (弱): 仅 painCategory 一致 → 不计入归因（噪声过大）
+```
+
+**重要**: MVP (PRI-232) 只用 v1 + v2；v3 一律不计入归因。如果某 principle 没有可计算的 rootCauseHashes（旧数据 / bundled 默认信号缺失），整个 principle 不进入 attribution（保守 fail-safe）。
+
+### 3.1.2 BaselineRateProvider（关键：解决 PRRR baseline 定义）
+
+PRRR 的核心难题是：激活后没法和"未激活时的同一刻同 agent"对比，因为时间不可回。我们使用**三段式 baseline**：
+
+| Baseline 策略 | 适用条件 | 计算方法 |
+|--------------|---------|---------|
+| **B-Pre**：激活前等长窗口 | 工作区有 ≥ 1 个完整 pre-activation 窗口的同 scope pain 数据 | 取 principle 激活前 N 个工具调用的同 scope pain 计数 |
+| **B-Workspace**：工作区滚动均值 | B-Pre 不可用（新工作区 / pain 太少） | 取过去 14 天工作区内同 scope pain 的滚动 P50 速率 |
+| **B-None**：无 baseline | 工作区数据严重不足（< 10 同 scope pain in 14d） | verdict 强制 = uncertain（不下结论）|
+
+实施细节：
+
+```typescript
+type BaselineKind = 'pre_activation' | 'workspace_rolling' | 'none';
+
+interface BaselineSnapshot {
+  kind: BaselineKind;
+  paneSize: number;              // baseline 窗口长度（工具调用数）
+  painCountInPane: number;       // baseline 期内同 scope pain 数
+  ratePerThousand: number;       // 归一化速率
+  capturedAt: string;
+  fallbackReason?: string;       // 如果不是 pre_activation 为什么 fall back
+}
+
+// PRRR 计算（修订版）
+interface PRRRComputeInput {
+  baseline: BaselineSnapshot;
+  observed: { painCountInWindow: number; windowSize: number };
+}
+
+function computePRRR(input: PRRRComputeInput): PRRRResult {
+  // 边界 1: baseline.kind === 'none' → verdict='uncertain'
+  // 边界 2: baseline.painCountInPane === 0 → 不能除零
+  //          降级为绝对数比较：if observed.painCount > 0 → verdict='regressed'
+  //                            else verdict='confirmed' with low confidence
+  // 边界 3: observed.rate > baseline.rate → 负 PRRR → verdict='regressed'
+  //          PRRR 字段截断到 [-1, 1] 区间
+  // 标准: PRRR = max(-1, min(1, 1 - observed.rate / baseline.rate))
+}
+```
+
+### 3.1.3 painsIntroduced 归因规则
+
+新增的 pain **不**自动归责给所有 active principles。唯一被归因为"X 引入"的条件：
+
+1. 该 pain 发生在工具调用 T 之中
+2. principle X 的 trigger 条件在生成 T 的 trajectory 段被命中（actually fired）
+3. 同窗口内没有其他更新的 active principle 在该 pain 上有更紧匹配的 trigger
+
+如果同窗口被多个 principle 命中且没有"更紧匹配"的判别能力，pain 计为"shared"——不计入任何单一 principle 的 painsIntroduced，但记录到工作区级 `sharedPainEvents` 字段供 R5 冲突检测使用。
+
+实施保守优先：**MVP 阶段，painsIntroduced 计数仅在条件 1 + 条件 2 严格满足时计入**；模糊归因 → 不计入。这意味着 MVP 的 verdict=regressed 会保守低估 false positive。
+
+### 3.2 数据契约
+
+```typescript
+type AttributionVerdict =
+  | { kind: 'confirmed'; pRecurrenceReduction: number; adherenceObserved: number }
+  | { kind: 'uncertain'; reason: 'insufficient_signal' | 'window_too_short'; nextWindowAt: string }
+  | { kind: 'regressed'; painDeltaIntroduced: number; conflictWith: string[]; rationale: string };
+
+interface ActivationOutcomeAttribution {
+  attributionId: string;          // 确定性: hash(principleId, windowId)
+  principleId: string;
+  windowId: string;               // 例如 "2026-05-24T10:00Z..2026-05-24T11:00Z" 或 "tools_500..tools_600"
+  windowKind: 'time' | 'tool_count' | 'pain_count';
+  windowStartAt: string;
+  windowEndAt: string;
+  paneSizes: { before: number; after: number };
+  painsEliminatedCategories: PainCategoryDelta[];   // 该原则 derivedFromPainIds 对应类别
+  painsIntroducedCategories: PainCategoryDelta[];   // 同窗口内新增类别
+  adherenceObserved: number;       // 0..1, 基于 trajectory 中触发条件的实际命中
+  conflictWith: ConflictPair[];
+  verdict: AttributionVerdict;
+  evidenceTraceRefs: string[];     // 指向 trajectory 关键证据
+  computedAt: string;
+}
+
+interface PainCategoryDelta {
+  category: string;            // PainCategory enum
+  countBefore: number;
+  countAfter: number;
+  delta: number;               // negative = improved
+}
+
+interface ConflictPair {
+  otherPrincipleId: string;
+  conflictKind: 'co_violated' | 'mutually_exclusive_action' | 'same_trigger_different_action';
+  observationCount: number;
+}
+```
+
+### 3.3 状态机扩展
+
+`LedgerPrincipleEntry.status` 从原 5 状态扩展为 6 状态：
+
+```
+candidate ──→ probation ──→ probation_active ──→ active ──→ archived
+                                  │                  │           ▲
+                                  │                  │           │
+                                  │                  │           ├── verdict=regressed (auto, evolved only)
+                                  │                  │           ├── human reject from active
+                                  │                  │           └── manual archive command
+                                  │                  │
+                                  │                  └─→ probation_active (refresh window)
+                                  │                       (rare; manual override only)
+                                  │
+                                  ├── verdict=confirmed ─→ active
+                                  ├── verdict=regressed ─→ archived
+                                  ├── verdict=uncertain (×3) ─→ probation_review (new sub-status, manual queue)
+                                  └── human reject from probation_active ─→ archived
+```
+
+**关键设计澄清（v2.0 review 补充）**:
+
+- **MVP 兼容路径**: PRI-232 MVP 只发 `regressed`。在 PRI-232 → PRI-235 过渡期间，MVP 会发 `verdict=confirmed_no_baseline`（一种特殊 confirmed），让 PRI-235 引入的 STATE-2 在仅 MVP 已部署、PRI-232 升级版尚未上线时仍能让 principle 升到 active，避免永久卡住。
+
+- **probation_review 子状态**: uncertain × 3 后进入此状态，等待人工 review。pd-console 显示。本 ADR 不展开实现，作为 PRI-236 后续延伸。
+
+新增不变量（修订版）：
+
+- `STATE-1`：`probation → active` 必须经过 `probation_active`，时间或工具调用次数 ≥ 配置最小值。
+- `STATE-2`：`probation_active → active` 仅在以下任一条件时合法：
+  - attribution `verdict.kind ∈ {'confirmed', 'confirmed_no_baseline'}`，**或**
+  - 操作员显式发起 `pd activation promote --confirm`（写审计日志）
+- `STATE-3`：`probation_active → archived` 唯一合法路径是 attribution `verdict=regressed` 或人工 reject。
+- `STATE-4`：`active → archived (auto)` 必须由 attribution verdict=regressed + provenance=evolved 同时满足。
+- `STATE-5`：任何被 attribution 错误归档的 principle，**必须可由人工通过 `pd principle restore <id> --confirm` 恢复至 probation_active（不是直接 active）**，并且 restore 操作记录在审计日志，下次 attribution 自动跳过该 principle 一个完整窗口（防止立即被同类 verdict 再次归档）。
+
+### 3.4 观测窗口策略
+
+| 通道 | 默认窗口 kind | 默认窗口大小 | 最小 verdict 样本 |
+|-----|--------------|------------|----------------|
+| prompt | tool_count | 100 工具调用 | 至少 5 次 trigger 命中 |
+| skill | tool_count | 200 工具调用 | 至少 5 次 trigger 命中 |
+| code_tool_hook | tool_count | 50 工具调用（更高频） | 至少 3 次 gate 决策 |
+| model_training | time | N/A — 模型训练通道不进入 attribution（独立评估）|
+| defer_archive | N/A — 不需要 |
+
+如果窗口结束时样本不足，verdict=uncertain，自动延长一次窗口；连续 3 次 uncertain 视为低价值 → 进入人工 review 队列。
+
+### 3.5 Attribution 何时不适用
+
+以下情况 attribution 不进行裁决：
+
+- principle.provenance = `bundled`（PD 项目级预装的基础原则）
+- principle 创建时间 < 24h（避免噪声）
+- 工作区内总 pain count 过低（最近 24h < 10）→ 整个工作区 attribution 暂停
+- principle 缺少有效 PrincipleScopeSignature（rootCauseHashes 为空且 triggerFingerprint 不可计算）→ 整个 principle 永远 verdict=uncertain，进入人工 review 队列
+- principle 在过去 30 天内被 `pd principle restore` 恢复过 → 跳过下一个完整窗口（防止 attribution 抖动）
+
+### 3.5.1 Shadow Mode（MVP 默认开启）★ 新增
+
+> **设计动机（v2.0 review 补充）**: AHE 论文实证 attribution 自身也会有错（regression precision 仅 11.8%）。直接上 auto-archive 是高风险。MVP 必须先 shadow 验证。
+
+实施分三阶段：
+
+1. **Shadow Mode（默认 30 天）**：Attribution 计算并写入 `activation_outcome_attributions`，但 `verdict=regressed` **不**触发 auto-archive；只发 telemetry + 在 pd-console 上展示"如果上线会被归档"的列表，由人工抽样校准。
+2. **Half-live（默认 30 天）**：仅对 confidence ≥ 0.9（多窗口连续 regressed）+ provenance=evolved 的 principle 触发 auto-archive；其他仍走 shadow。
+3. **Full-live**：condition 1+2 数据通过校准（人工抽样 false positive < 5%）后启用全量 auto-archive。
+
+| 配置 | 默认值 | 描述 |
+|-----|-------|------|
+| `attribution.shadow_mode` | `true` (启动时) | 开/关 shadow |
+| `attribution.shadow_min_verdicts_before_live` | 50 | 至少 50 个 verdict 通过抽样后才能切到 live |
+| `attribution.shadow_max_false_positive_rate` | 0.05 | 抽样 false positive 超阈值禁止切 live |
+| `attribution.regress_confidence_threshold` | 0.7 (shadow) / 0.9 (half-live) | regressed 触发 archive 的最低 confidence |
+
+shadow → half-live → full-live 切换必须人工 `pd attribution mode set --confirm`，不允许自动升级。
+
+### 3.6 与现有组件的关系（更新）
+
+| 现有组件 | 关系 |
+|---------|------|
+| `LifecycleEvidence` (现) | 保留；其字段 `lastTriggeredAt`、`triggerCount` 由 attribution 自动维护 |
+| `RoutingPolicy` (现) | 保留；新增对 attribution `confidence` 信号的读取 |
+| `RolloutReviewerRunner` (现) | **不变**——它仍负责"激活前"判断；attribution 是"激活后"裁决 |
+| `PruningReadModel` (现) | 保留作为人工 review 入口；attribution 是其自动化版本 |
+| `ApprovalQueue` (现) | 保留；approve 后进入 probation_active 而非直接 active |
+| `Auto-Promotion by Confidence (PRI-145)` | **协调 (v2.0 修订)**：PRI-145 当前在 RolloutReviewer 阶段跳过 approval。本 ADR 改为：跳过 approval 仍允许，但**不**跳过 probation_active 阶段——所有自动通过的 principle 仍要先进入 probation 受 attribution 验证。即 `auto-promotion` 仅替代 *human approval*，不替代 *probation window*。需要在 PRI-235 中显式实现这一协调。 |
+| `RejectionFeedbackService` (PRI-148) | 保留；它处理"人工显式 reject"；attribution 处理"沉默无效" |
+| `ThreeStrikesOut` (PRI-141) | 保留；它在 dreamer 创建前；attribution 在激活后；二者互补 |
+
+### 3.7 archivedReason 规范化（避免双路径冲突）★ 新增
+
+PD 现在有 4 个 archive 来源，每个必须使用规范化前缀：
+
+| 来源 | archivedReason 前缀 | 触发者 |
+|------|-------------------|--------|
+| Attribution auto-archive | `attribution_regressed:{windowId}` | system (PRI-232) |
+| 人工 reject from approval queue | `human_rejected:{userId}:{approvalId}` | actor=human (PRI-148) |
+| 人工 pruning review approve | `pruning_review:{reviewId}:{userId}` | actor=human (existing) |
+| 操作员手工归档 | `manual_archive:{userId}:{reason}` | actor=human (existing) |
+| LRU eviction (cap 触发) | `lru_eviction:{evictedAt}` | system (PRI-139) |
+
+**冲突处理**：如果一条 principle 在同一时间收到两个 archive 信号（例如 attribution=regressed 与人工 reject 同时），**人工优先**；attribution 写入会检测当前 status 并在 `status=archived` 时跳过（idempotent no-op），不重写 archivedReason。
+
+## 4. Why this and not alternatives
+
+| 替代方案 | 拒绝理由 |
+|---------|---------|
+| 让 Diagnostician 自归因（每次出 verdict） | AHE 数据：fix prediction precision 33.7% 但 regression precision 仅 11.8%。Diagnostician 对副作用是盲的；归因必须由"系统裁决"而非"代理自评" |
+| 完全依靠人工 Pruning Action | 人工瓶颈，无法跟上每个 active principle 的窗口；阻塞 R3 闭合 |
+| 把 attribution 直接嵌入 RolloutReviewer | RolloutReviewer 是激活前；attribution 是激活后；语义混淆会让审计困难 |
+| 不做 probation_active，直接复用 lifecycleEvidence | 缺少"已批准但试运行中"的明确语义；UI 与权限边界都会乱 |
+| 把 attribution 数据写入新物理目录 | 违反 PRI-205 决议；继续走 SQLite metadata + JSON ledger |
+
+## 5. Consequences
+
+### Positive
+
+- L1 容量自动收敛到"实际有效原则集"，R3（Decoupling Loop）真正闭合。
+- Pruning Pipeline 不再依赖人工启发式 review；只在 attribution=uncertain 三次时才升级到人工。
+- Diagnostician 跨会话有记忆，避免重复发明同类原则。
+- 决策可观测性补齐 → PD 第一次具备完整的 AHE 三支柱。
+
+### Negative / Cost
+
+- 增加每个 active principle 的存储开销（每个窗口一个 attribution 记录）。缓解：attribution append-only 但提供周期归档。
+- 新增对 trajectory 数据的可靠读出依赖（PRI-118 必须先做扎实）。
+- WorkspaceLearningSummary 注入会增加 Diagnostician prompt 长度。缓解：summary 严格 token 预算（默认 ≤ 500 token），超出时 LRU 截断最旧的 verdict。
+
+## 6. Guardrails
+
+新增架构守护测试断言：
+
+- `ATTRIBUTION-1`：Attribution Pipeline 不得直接修改 `Ledger.principles[id].status`；必须通过 `ActivationDispatcher.deactivate(reason='attribution_regressed:<windowId>')`。
+- `ATTRIBUTION-2`：Attribution verdict 写入幂等键 = `(principleId, windowId)`；重复写返回 `ALREADY_COMPUTED`。
+- `ATTRIBUTION-3`：Attribution 不得读取/修改 `provenance=bundled` 的 principle；不得对缺少 PrincipleScopeSignature 的 principle 下 `regressed` 裁决。
+- `ATTRIBUTION-4`（新增）：Shadow mode 下 verdict=regressed **不得**触发 ActivationDispatcher.deactivate。架构守护测试用 mock dispatcher 校验。
+- `ATTRIBUTION-5`（新增）：archivedReason 必须命中表 §3.7 中规范化前缀的 enum。
+- `ATTRIBUTION-6`（新增）：在同一 principle 已 status=archived 时，attribution 写入必须是 idempotent no-op（不更新 archivedReason）。
+- `LEARN-1`：`WorkspaceLearningSummary` 是只读视图，禁止写入 API。
+- `LEARN-2`：`LearningSummaryPromptInjector` 必须强制 token 预算（默认 500），超出时按时间倒序截断。
+- `LEARN-3`（新增）：summary 缺失 / 计算失败时，Diagnostician prompt 仍应可用（fail-open with structured warning），不允许因 summary 失败 fail-close 阻塞 Diagnostician。
+- `STATE-1` 至 `STATE-5`：见 §3.3。
+- `RESTORE-1`（新增）：`pd principle restore` 命令成功后，下次 attribution 必须跳过该 principle 一个完整窗口。
+- `BUNDLED-1`：见 PRI-234；attribution + auto-archive 都必须跳过 bundled。
+
+## 7. Implementation phases（修订版）
+
+按 docs/plans/2026-05-roadmap/06-ahe-informed-architecture-review.md §5 执行：
+
+1. **Phase 1C-1: Attribution Shadow MVP**（PRI-232）
+   - 计算并写入 verdict
+   - **强制 shadow mode**，不触发 auto-archive
+   - 30 天观察期 + 至少 50 个 verdict 经人工抽样
+   - 退出条件：抽样 false positive < 5%
+
+2. **Phase 1C-2: Attribution Half-live**（PRI-232 第二阶段，可拆为独立 issue）
+   - 仅 confidence ≥ 0.9 + provenance=evolved 触发 auto-archive
+   - 还需要 PRI-234 (provenance) 完成
+
+3. **Phase 1D-1**：WorkspaceLearningSummary（PRI-233）+ Bundled provenance（PRI-234）+ Probation Window（PRI-235）
+
+4. **Phase 1D-2**：Pruning Action MVP via Attribution（PRI-236）— 替代当前的"等待独立人工 Pruning Action"。要求 Phase 1C-2 通过抽样校准。
+
+## 8. Out of scope
+
+- 不引入 LLM-based attribution。verdict 只来自结构化 trajectory + pain delta；不做"让另一个 LLM 评判"。
+- 不引入 cross-workspace attribution。learning 是工作区局部的；跨工作区聚合是 Phase 3+ 议题。
+- 不替代 ApprovalQueue 或 RejectionFeedback。这些都保留。
+
+## 9. References
+
+- AHE: "Agentic Harness Engineering: Observability-Driven Automatic Evolution of Coding-Agent Harnesses"（特别是 §3.3 Decision Observability 与 §4.4.2 Self-Attribution Reliability）
+- ADR-0006 §2.6 RejectionFeedback（本 ADR 的姐妹流程）
+- ADR-0010 GAP（attribution 的 pain category 取自此处）
+- PD_System_Dynamics_Model.md R3/R4/R5（本 ADR 是 R4 在工程层的具象化）

--- a/docs/adr/0014-mvp-first-strategy-and-product-pivot.md
+++ b/docs/adr/0014-mvp-first-strategy-and-product-pivot.md
@@ -1,0 +1,225 @@
+# ADR-0014: MVP-First Strategy and Product Pivot to Behavior Character Internalization
+
+> **Status**: Accepted
+> **Date**: 2026-05-24
+> **Supersedes**: ADR-0013 (Attribution Pipeline) — deferred, not abandoned. See §6.
+> **Reframes**: ADR-0006 (5-channel activation) priorities. See §4.
+> **Defers**: ADR-0008 (BALM), ADR-0009 (LRAS), ADR-0010 (GAP), ADR-0011 (MissionScheduler) — see post-mvp-conditional-roadmap.md
+> **Drives**: docs/plans/2026-05-roadmap/07-mvp-first-pivot.md (execution)
+
+## 1. Context
+
+PD 项目已经积累了大量子系统：5 个激活通道（其中 2 个 writer 待建）、7 个 Peer Runner、Pain pipeline、Internalization pipeline、Activation pipeline、5 个 ReadModel、3+ 个 Adapter、BALM/LRAS/GAP/MissionScheduler 4 个未实施 ADR、Attribution Pipeline 提案……
+
+项目的复杂度已经超过单人理解能力的阈值。维护者（一人 + AI 助手）每日产出 3-4 个 PRI 的速度让这种膨胀加速。同时：
+
+- **零真实外部用户**。所有 pain signal 来自合成 baseline 或维护者本人。
+- **后端为主，缺乏 UI 验证路径**。维护者形容为"蒙眼开车"。
+- **功能间耦合深**，难以孤立验证某个子系统的真实价值。
+- **下线机制缺失**。每个新功能都被加进来，没有功能曾经被关闭过。
+
+进一步审视，发现一个根本性的产品误读：之前推荐的"AI 不再犯同类错误"故事（PainSignal → Diagnostician → prompt 注入 → 拦截）实际上是**工具级错误的处理**——这个层次属于 OpenClaw / Claude Code 自身的职责，不是 PD 的差异化价值。
+
+## 2. Decision
+
+PD 进入 **MVP-First 阶段**。所有架构演进暂停，目标是在 **4-6 周内邀请第一个真实种子客户**。
+
+### 2.1 产品定位重新校准
+
+PD 的真正治理对象是 AI agent 的 **行为品格**——跨会话、跨任务、稳定的性格性偏差，而不是单次工具调用失败。
+
+```
+错误层次              处理者                            PD 是否关心
+─────────────────────────────────────────────────────────────────
+工具级（参数错、命令失败）   OpenClaw / Claude Code 自身       否
+任务级（同类任务反复失败）   per-session memory                次要
+行为模式级（跨会话品格偏差） PD ★                              主要
+```
+
+具体例子：
+- "AI 在不可逆操作前缺乏确认习惯" — PD 关心
+- "AI 在重构时偏激进而非保守" — PD 关心
+- "git push 失败" — PD 不关心（OpenClaw 处理）
+- "命令缺少 --confirm 参数" — PD 不关心
+
+### 2.2 MVP 故事 A'：把零散教训沉淀成稳定品格
+
+**演示路径**（4-6 周内必须可被外部用户走完）：
+
+```
+[多次相似情境的失败 / 人工纠正 / 风险接近]
+                         ↓
+              PainSignal 累积同类信号
+                         ↓
+              Diagnostician 识别"这不是单次失败，是模式"
+                         ↓
+       Dreamer + Scribe 把模式抽象为 Principle 候选
+                         ↓
+       人工在 pd-console 审核 → 决定走哪个通道
+                         ↓
+        ┌─────────────┬─────────────┬─────────────┐
+        ▼             ▼             ▼             ▼
+     Prompt      Skill         RuleHost      defer_archive
+   (软提示)    (主动工作流)   (硬拦截)        (优雅退场)
+        │             │             │
+        └─────────────┴─────────────┘
+                      ↓
+          代理在下一轮真实任务中表现出新品格
+```
+
+**4 个通道全部进 MVP-Core**——这是 PD 与"prompt 模板管理器"的本质区别。
+
+### 2.3 三档分类法（取代之前的"留/砍"二元）
+
+| 档位 | 含义 | 处理 |
+|------|------|------|
+| **MVP-Core** | 故事 A' 演示链路必需 | 保留并打磨；feature flag 默认开 |
+| **MVP-Quiet** | 留代码但**关闭默认 + 不进入 UI / 文档** | feature flag 默认关；6 个月无激活则 MVP-Gone |
+| **MVP-Gone** | 删除或归档 | 直接减少代码量 |
+
+**关键原则**：MVP-Quiet 是**可逆的隔离**，不是删除。代码保留，flag 关闭。这让"减法"不那么痛苦——我们只是减少**用户和维护者大脑里的概念数量**，不破坏系统完整性。
+
+### 2.4 MVP-Core 清单（保留并打磨）
+
+| 子系统 | 备注 |
+|-------|------|
+| Pain capture (hook) + PainSignal | 已落地 |
+| Diagnostician + DiagnosticianRunner | 已落地 |
+| CandidateIntake + LedgerPrincipleEntry | 已落地 |
+| **Dreamer + Scribe + Artificer** Runner | 已落地。Artificer 是 skill / RuleHost 的产出源 |
+| **prompt 通道** + LedgerPromptWriter | 已落地 |
+| **defer_archive 通道** + LedgerArchiveWriter | 已落地 |
+| **skill 通道** + SkillFileWriter | **待建**（MVP 必交付） |
+| **code_tool_hook 通道** + RuleHostWriter | 已落地 (PRI-146) |
+| Approval Queue + pd-console approvals 页 | 部分落地 |
+| pd-console 三页（Pain / Principle / Approval）| 待精简 |
+| pd-cli 核心命令 (`pd diagnose run` / `pd status` / `pd trace show` / `pd activation list`) | 已落地 |
+| PainChainReadModel | 已落地 |
+
+### 2.5 MVP-Quiet 清单（关闭，留代码）
+
+| 子系统 | 关闭理由 |
+|-------|---------|
+| Philosopher / Evaluator / RolloutReviewer Runner | Dreamer + Scribe 产出粗糙但人工审批可纠正；这 3 个 Runner 是"质量打磨链" |
+| GFI (Global Friction Index) | 内部决策有用，但用户不可见，不在故事 A' 内 |
+| Focus History 详细注入 | 让 prompt 更"聪明"但更不可解释。MVP 的 prompt 注入应该可读、单一原则 |
+| Thinking OS injection | 同上 |
+| Empathy keyword matcher | 同上 |
+| Layer 3 信号源 `empathy_inferred` | 推断本身可能错；保留 explicit user_correction |
+| Shadow Observation / Local Worker Routing | OpenClaw 内部优化，外部用户不可见 |
+| Central Sync Service | 跨工作区，MVP 单 workspace |
+| message-sanitize hook | COMPONENTS.md 自标"建议删除" |
+| Trajectory Collector（默认开关）| 评估后决定；如果 PainChain 不依赖则关闭 |
+
+### 2.6 MVP-Gone 清单（删除/归档）
+
+| 子系统 | 处理 |
+|-------|------|
+| Nocturnal Trinity / Arbiter / Service / Artificer | ADR-0012 已决定退役（PRI-227~231）|
+| OpenClaw IdleTrigger / sleep cycle / night mode | 同上 |
+| Evolution Worker | 同上 |
+| Trainer Runner / model_training 通道 / TrainingExporter (待建) | LoRA 不在 MVP 故事内 |
+
+## 3. Implementation MVP Track（取代 Phase 1C/1D）
+
+按 docs/plans/2026-05-roadmap/07-mvp-first-pivot.md §5 执行：15 个 issue / docs，4-6 周。
+
+```
+Week 1-2: 减法 + 4 通道闭环验证
+  MVP-1  scope decision doc
+  MVP-2  cancel/defer 旧 issues
+  MVP-3  feature flags + MVP-Quiet 关闭
+  MVP-4  4 通道 synthetic 冒烟
+  MVP-5  AGENTS.md "MVP 三问"
+  MVP-6  Nocturnal 退役（PRI-227 + PRI-230 继续）
+
+Week 3-4: 用户旅程 + 4 通道演示
+  MVP-7  SkillFileWriter 实施
+  MVP-8  pd-console 4 通道审批 UI
+  MVP-9  pd-console 三页化
+  MVP-10 Demo workspace + 故事 A' 4 通道
+
+Week 5-6: 安装 + 邀请
+  MVP-11 pd-cli 一键安装
+  MVP-12 GETTING-STARTED 用户视角重写
+  MVP-13 故事 A' 录屏 + 文字
+  MVP-14 多环境冒烟
+  MVP-15 邀请第一个种子客户
+```
+
+## 4. ADR-0006 (5-channel activation) 关系澄清
+
+ADR-0006 的 5 通道设计**不变**。本 ADR 仅调整 MVP 优先级：
+
+| 通道 | ADR-0006 状态 | MVP 状态 |
+|------|--------------|---------|
+| prompt | Active | MVP-Core |
+| defer_archive | Active | MVP-Core |
+| skill | 待建 | **MVP-Core**（必交付）|
+| code_tool_hook (RuleHost) | Active (基础)| MVP-Core |
+| model_training | 待建 | **MVP-Gone**（不在 MVP）|
+
+ADR-0006 的不变量（所有人工审批、二次确认、shadow mode）全部保留。
+
+## 5. AGENTS.md 强制约束（落地后）
+
+每个新 issue 在 PR 启动前必须答 **MVP 三问**：
+
+1. **不做会怎样？** 30 天后还有人提吗？如果答不出，issue 拒收。
+2. **怎么观察？** 实施后用户怎么验证它在工作？UI 看？CLI 命令？日志？无可观察方式拒收。
+3. **怎么关闭？** 实施后如果发现不好用，关闭路径？feature flag 还是 PR revert？只能 revert 的必须带 flag 一起来。
+
+每个新功能在 commit 前必须**先在 feature-flags.yaml 注册**。无 flag 注册的 PR 拒收。
+
+## 6. ADR-0013 (Attribution Pipeline) 处置
+
+ADR-0013 标记为 **Superseded by ADR-0014 — Deferred**：
+
+- 状态从 Proposed → Deferred
+- 概念保留作为未来回顾输入
+- 实施重启条件：见 docs/plans/post-mvp-conditional-roadmap.md（满足 ≥3 个种子客户使用 ≥1 月 + 客户反馈"原则越来越多变慢"+ active count 稳定 ≥10）
+- 在重启条件满足前，禁止任何 issue 引用 ADR-0013 要求即时实施
+
+## 7. PD_System_Dynamics_Model v2.0 处置
+
+v2.0 引入的 R4 Attribution Loop / R5 Conflict Detection / PRRR 北极星指标 / 8 杠杆排序，**全部标记为 deferred concepts**。v1.0 概念蓝图（R1/B1/R3）保留作为产品哲学叙事使用。重启条件同 ADR-0013。
+
+## 8. Consequences
+
+### Positive
+
+- 复杂度立即停止增长
+- MVP-Quiet 关闭后用户/维护者认知负担降低
+- 4-6 周内具备真实外部反馈能力
+- "下线机制"从隐性变显性
+- 故事 A'（行为品格内化）保留 PD 的差异化定位
+
+### Negative / Cost
+
+- 已落地的 Philosopher / Evaluator / RolloutReviewer 维护成本短期不消失（只是 flag 关闭）
+- SkillFileWriter 仍需新写代码（MVP 必交付）
+- pd-console 三页化需要回退 / 隐藏现有页面，可能临时影响维护者本人体验
+- 需要严格执行"MVP 三问"，否则会被新提案绕过
+
+### Neutral
+
+- ADR-0008/9/10/11/13 全部 deferred 而非取消，未来路径保留
+- v2.0 系统动力学概念保留为思考资产
+
+## 9. Anti-patterns Prevented
+
+本 ADR 同时预防几种已观察到的反模式：
+
+1. **"完整性焦虑"驱动的功能扩张** — MVP-Quiet 用 flag 而非删除化解
+2. **"为未来铺路"的抽象超前** — MVP 三问中的"不做会怎样"压制
+3. **AI 助手快速产出导致的复杂度膨胀** — 三档分类强制 PR scope
+4. **后端无 UI 验证盲飞** — Demo workspace + pd-console 三页化解决
+5. **下线机制缺失** — feature-flags.yaml 注册 + AGENTS.md 三问
+
+## 10. References
+
+- docs/plans/2026-05-roadmap/07-mvp-first-pivot.md (本 ADR 的执行文档)
+- docs/plans/post-mvp-conditional-roadmap.md (deferred 工作的重启条件表)
+- ADR-0006 (5-channel activation, 优先级被本 ADR 调整)
+- ADR-0013 (Attribution Pipeline, 被本 ADR superseded)
+- ADR-0012 (Runtime V2-only, 仍生效；Nocturnal 退役继续)

--- a/docs/architecture/PD_System_Dynamics_Model.md
+++ b/docs/architecture/PD_System_Dynamics_Model.md
@@ -1,0 +1,361 @@
+# 重构硅基生命：基于系统动力学视角的 Principles Disciple (PD) 项目解构与建模
+
+**文档状态**: Active / 战略级思考资产（v2.0 Attribution / PRRR 概念已 deferred）
+**初版日期**: 2026-04-29
+**v2.0 修订日期**: 2026-05-24（v2.0 即日 deferred — 见下）
+**核心视角**: 系统动力学 (System Dynamics) & 架构工程
+
+---
+
+## ⚠️ v2.0 状态注记（2026-05-24）
+
+本文 v2.0 引入的 R4 Attribution Loop / R5 Conflict Detection / PRRR 北极星指标 / 8 杠杆排序 / Anti-pattern 守护，**全部标记为 deferred concepts**：
+
+- **不在 MVP 路径上**：见 [ADR-0014](../adr/0014-mvp-first-strategy-and-product-pivot.md) 与 [07-mvp-first-pivot.md](../plans/2026-05-roadmap/07-mvp-first-pivot.md)。
+- **重启条件**：见 [post-mvp-conditional-roadmap.md §1](../plans/post-mvp-conditional-roadmap.md)（Attribution）和 §2（LearningSummary）。
+- **保留理由**：v2.0 的概念分析（特别是"Decision Observability 缺失"诊断）仍然成立，是未来重启时的关键设计输入。
+
+**当前生效的部分**：v1.0 的 R1 / B1 / R3 三回路概念蓝图，作为 PD 产品哲学叙事使用。MVP 阶段不引入 R4/R5 工程约束。
+
+任何 AI 助手读到本文时，**不要按 v2.0 §9 的不变量实施**；MVP 阶段的真正约束在 ADR-0014 + AGENTS.md "MVP 三问"。
+
+---
+
+
+
+## 1. 引言：什么是 Principles Disciple (PD)？
+
+### 1.1 从"工具"到"思考伙伴"
+当前的 AI Agent 大多被设计为"无状态的执行工具"——它们在每次会话中醒来，执行指令，并在上下文重置后忘记一切。它们的错误不产生教训，它们的努力也不产生积淀。
+
+**Principles Disciple (PD)** 的诞生正是为了打破这一局限。PD 是一个为 AI Agent 设计的**原则演化系统（Principle-Evolution System）**。它赋予了 AI "从痛苦中学习"的能力：系统通过捕获执行过程中的失败和用户的纠正（Pain Signals），进行自我反思与诊断（Diagnostician），提炼出指导未来行为的原则（Principles），将其内化为 Agent 的"本能"，**并验证内化是否真正减少了同类痛苦**。
+
+### 1.2 为什么需要系统动力学（SD）视角？
+随着 PD 项目的推进，传统的软件工程（SE）和深度学习（DL）理论逐渐暴露出局限性：
+- **SE 的局限**：代码是静态的，而 PD 的"规则"是由 LLM 动态生成的，这种紧耦合、非线性的逻辑碰撞无法用传统的模块化思维解决。
+- **DL 的局限**：模型微调周期长，无法满足 PD 追求的"单样本即时演化"需求。
+
+**系统动力学（System Dynamics）** 擅长处理"非线性、多反馈、长延迟"的复杂系统。通过 SD 视角，我们将 PD 视为一个由**存量（Stocks）、流量（Flows）和反馈回路（Feedback Loops）** 组成的二阶控制系统，而 v2.0 修订强调一点：**没有 Attribution，所有正反馈回路都会失控；Attribution 是把开环系统改造成真正闭环的关键支撑**。
+
+---
+
+## 2. 系统建模：PD 的核心"资产"与"负债" (Stocks)
+
+在系统动力学中，存量是系统状态的载体。PD 系统的运行，本质上是以下五大核心存量的相互博弈：
+
+1. **🧠 有效原则库 (Validated Principle Stock) —— 【核心资产】**
+   - **定义**：经过 Attribution 验证、PRRR > 0 的活跃原则集合。
+   - **v2.0 关键变化**：v1.0 把"原则有效性"作为指标。v2.0 直接把"有效"作为存量定义的前置——未经验证的原则只是 *probation_active*，不计入资产。
+2. **📉 上下文压力 (Context Pressure) —— 【核心负债】**
+   - **定义**：active principle 注入 LLM Prompt 占用的 token 总量 / 上下文窗口。
+   - **表现**：高于 0.5 时 LLM 指令遵从能力骤降。
+3. **🛡️ 用户信任资本 (User Trust Capital) —— 【环境杠杆】**
+   - **定义**：人类对 Agent 自主决策的信任程度。
+   - **表现**：决定 Approval 通过率与 Probation 窗口长度。
+4. **⚙️ 内化深度 (Internalization Depth) —— 【解压阀】**
+   - **定义**：同等业务能力中已落到 L2/L3 的比例 / 仍在 L1 prompt 的比例。
+5. **📚 元经验存量 (Meta-Experience Stock) —— 【新增/Phase 1D 实施】**
+   - **定义**：跨会话沉淀的"PD 自己关于自己的知识"——哪些类别的原则反复无效、哪些通道实证最有效、哪些工作区特征对应哪些处方。
+   - **v2.0 关键变化**：原 v1.0 完全忽视该存量。它由 `WorkspaceLearningSummary` 维护，是 R4 反哺 Diagnostician 的载体。
+
+---
+
+## 3. 五大核心反馈回路 (Feedback Loops)
+
+PD 系统的生与死，由以下五个相互交织的反馈环决定。其中 R4、R5 是 v2.0 新增。
+
+### 🔄 R1：进化增强回路 (Flywheel - 正反馈)
+PD 成长的动力源泉，遵循《原则》一书的第一性原理：**Pain + Reflection = Progress**。
+
+- **运行逻辑**：Agent 失败 `(Pain) ↑` → 诊断生成原则 `(Principle) ↑` → 行为修正 `(Performance) ↑` → 信任增加 `(Trust) ↑` → 探索更复杂任务 → 暴露更深层痛苦 `(Pain) ↑`。
+
+### ⚠️ B1：复杂度阻尼回路 (Ceiling - 负反馈)
+悬在 PD 头顶的"达摩克利斯之剑"，解释了为什么"原则越多，Agent 反而越笨"。
+
+- **运行逻辑**：原则过多 `(Principle Count) ↑` → 上下文超载 `(Context Pressure) ↑` → 推理质量下降 `(Reasoning Quality) ↓` → 新的、无意义的错误 `(Synthetic Pain) ↑`。
+
+### 💡 R3：知识内化减压回路 (Decoupling Loop - 破局点)
+通过"内化"释放上下文压力。
+
+- **运行逻辑**：active principle → 编译成 hard rule（L2 RuleHost 实现）→ context pressure ↓。
+- **v1.0 的虚假闭合**：v1.0 假设 hard rule 一旦存在就自动取代 soft principle。实际上没有度量"hard rule 是否真的减少了同类痛苦"。如果 hard rule 无效，soft principle 不会被剪枝，反而堆积。
+
+### 🔬 R4 [NEW]：归因验证回路 (Attribution Loop) ★ v2.0 关键新增
+这是补全 R3 闭合的关键。
+
+- **运行逻辑**：active principle → 进入观测窗口（默认 100 工具调用）→ 测量 PRRR（pain recurrence reduction rate）→ verdict
+  - `verdict=confirmed` → 该 principle 留任，更新 adherence + meta-experience stock
+  - `verdict=uncertain` → 延长一次窗口；连续 3 次 uncertain 升级到人工 review
+  - `verdict=regressed` → 自动归档（auto-archive），不需要人工
+- **作用**：让 R3 真正闭合（无效的 soft principle 会被自动剪枝），让 B1 有质量兜底（不只是数量 cap）。
+
+### ⚔️ R5 [NEW]：冲突检测回路 (Conflict Detection Loop)
+当 active principle 接近 cap 时，相互矛盾的 principle 会让 LLM 指令遵从能力崩溃。
+
+- **运行逻辑**：每个 attribution 窗口结束 → 计算 `conflictPair` 矩阵（哪些 principle 在同一 trajectory 中被同时违反 / 触发条件重叠但 action 矛盾）→ conflict_score ↑ → 触发 PrincipleArbitration（合并 / 重写 / 取舍其中一个）。
+- **作用**：B1 的二级兜底，让 cap 之内的 principle 互相正交。
+
+### 总图：五回路结构（修订版）
+
+```
+                       ┌───────────────────────────────────────┐
+                       │  R1: Flywheel (+)                     │
+                       │  Pain → Principle → Performance →     │
+                       │  Trust → New exploration → Pain       │
+                       └───────────────────────────────────────┘
+                                       │
+                                       ▼
+                       ┌───────────────────────────────────────┐
+                       │  B1: Ceiling (−)                      │
+                       │  Principles → Context → Reasoning ↓ → │
+                       │  Synthetic Pain                       │
+                       └───────────────────────────────────────┘
+                                       ▲
+                                       │ (减压)
+                                       │
+        ┌──────────────────────────────┴──────────────────────────────┐
+        │                                                             │
+        ▼                                                             │
+┌────────────────────┐                  ┌────────────────────────┐    │
+│  R3: Decoupling    │                  │  R4: Attribution (NEW) │    │
+│  Soft → Hard 内化  │  ←── 闭合于 ───  │  Verdict → Auto Prune  │────┘
+│  Context Pressure ↓│                  │  / Confirm / Re-diagnose│
+└────────────────────┘                  └────────────────────────┘
+                                                  │
+                                                  ▼
+                                       ┌────────────────────────┐
+                                       │  R5: Conflict Detect.  │
+                                       │  Pair-wise violation → │
+                                       │  PrincipleArbitration  │
+                                       └────────────────────────┘
+```
+
+---
+
+## 4. 核心 KPI 树：PRRR 是唯一结果指标
+
+### 4.1 Pain Recurrence Reduction Rate (PRRR)
+
+```
+PRRR(P, window) = 1 − ( count(painId ∈ derivedCategories(P), window_after) /
+                        count(painId ∈ derivedCategories(P), window_before) )
+
+其中：
+  P = 某 active principle
+  derivedCategories(P) = P.derivedFromPainIds 对应的 PainCategory 集合
+  window_before = P 激活前的等长观测窗口
+  window_after  = P 激活后的等长观测窗口
+```
+
+**所有其他指标都应该为此指标服务**，因为：
+
+- 原则数量是过程指标，不是结果指标。
+- token 节省是经济性指标，不是有效性指标。
+- adherence rate 在没有 PRRR 校准时是误导性的——一个"被严格遵守但毫无效果"的原则不应被嘉奖。
+- L1 容量本身没有意义——5 个有效原则远胜 12 个杂乱原则。
+
+### 4.2 KPI 树
+
+```
+PRRR (root, lagging)
+├── Pain Inflow Rate (leading, 上游)
+│   ├── GAP Layer 1 rate (mission_failed / okr_drift)
+│   ├── User correction rate
+│   └── Tool failure recurrence rate
+│
+├── Internalization Depth (leading, 内部健康)
+│   ├── L2 internalization ratio = count(L2 active rules) / count(L1 active principles + L2 rules)
+│   └── Bundled vs Evolved ratio (避免归因被预装件污染)
+│
+├── Attribution Health (leading, 反馈质量)
+│   ├── verdict=confirmed rate
+│   ├── verdict=regressed rate (auto-archive 触发率)
+│   └── verdict=uncertain → human escalation rate
+│
+└── Context Pressure (leading, 容量负债)
+    ├── L1 prompt token / context window
+    └── conflict_score (pair-wise from R5)
+```
+
+**OKR 的根**应当是：在固定 base model 下，让某一类典型 painId 的 PRRR 在 30 天内达到 ≥ 0.5。
+
+---
+
+## 5. 核心杠杆识别（按 ROI 排序）
+
+| 杠杆 | 影响 | ROI | 当前状态 |
+|------|------|-----|---------|
+| **L1: Attribution Pipeline (R4)** | 让 R3 真正闭合，自动剪枝无效原则；让 PRRR 可计算 | ⭐⭐⭐⭐⭐ | ❌ 未建（PRI-232 待建）|
+| **L2: WorkspaceLearningSummary (元经验存量)** | 跨会话记忆；避免 Diagnostician 反复发明同类原则 | ⭐⭐⭐⭐ | ❌ 未建（PRI-233 待建）|
+| **L3: RuleHost 通道闭环 (L2 内化主路径)** | 把 ROI 最高的内化层做透；承接绝大部分高价值原则 | ⭐⭐⭐⭐ | ⚠️ RuleHostWriter 已有；shadow replay 有；缺真实工作区高频投放与 PRRR 数据 |
+| **L4: RejectionFeedback (人工拒绝闭环)** | 关闭"显式拒绝 → 重新学习"最后一公里 | ⭐⭐⭐⭐ | ❌ 未建（PRI-148 待建）|
+| **L5: Bundled vs Evolved 资产分离** | 让 attribution 干净；避免预装件污染 PRRR | ⭐⭐⭐ | ❌ 未建（PRI-234 待建）|
+| **L6: Activation Probation Window** | 让 approve 不直接成 active；attribution 决定 promote | ⭐⭐⭐ | ❌ 未建（PRI-235 待建）|
+| **L7: Nocturnal/idle 退役（PRI-227~231）** | 删除 ~5000 行 dead code，CI 收敛 | ⭐⭐⭐ | 进行中 |
+| **L8: BALM Diagnostician + Dreamer 最小骨架** | 让 Agent manifest 化；只做最小两个，避免过度抽象 | ⭐⭐ | ❌ 未建；建议推迟到 Phase 2 |
+
+**未列入但常被讨论的**（明确推迟）：
+
+- SkillFileWriter / TrainingExporter：通道产出价值未实证，等 L1-L4 数据稳定后再评估
+- GAP Layer 1 信号生成器：需要 mission/objective 数据；强行实现会变 mock
+- MissionScheduler 三层模型：当前没有 mission 数据；attribution 的工作量级与"mission" 不同步
+- 完整 BALM 7 个 manifest：先做 2 个验证机制，其余按需
+
+---
+
+## 6. 三类内化路线 (Three Internalization Routes) — 与 v1.0 的对照
+
+> v1.0 的描述基本正确，v2.0 仅增加"如何度量是否成功"。
+
+### L1: 软内化 (Prompt / Skill / SOP)
+- **载体**：System Prompt、Skill 文档、SOP。
+- **机制**：`Diagnostician` 产出文本建议，经 PromptBuilder / Skill 文档固化。
+- **特点**：**见效快，但极其昂贵**。属于系统的**短期记忆**。
+- **v2.0 增量**：每个 L1 原则激活后必须经过 Activation Probation Window，attribution 决定保留 / 归档。**没有 attribution 的 L1 通道是不可持续的**——这是 PD_System_Dynamics_Model v1.0 缺失的关键约束。
+
+### L2: 硬内化 (Code / Hook / Tool)
+- **载体**：RuleHost implementation、OpenClaw Hook、Custom Tool。
+- **机制**：`PrincipleCompiler` / Internalization Engine 转译为执行逻辑，由 `RuleHost` / Hook / Tool 在 `before_tool_call` 物理拦截。
+- **特点**：**低耗、确定性强**。属于系统的**肌肉记忆**。
+- **v2.0 增量**：L2 的 attribution 窗口比 L1 更短（默认 50 工具调用），因为命中频率更高、信号更密。AHE 论文实证 L2 (tool/middleware) 是承载收益的核心层。
+
+### L3: 模型与参数化 (Model Parameter / LoRA)
+- **载体**：LoRA、Fine-tuned Checkpoint、Preference Model。
+- **机制**：累积高质量样本 → `model_training` → 固化到模型权重。
+- **特点**：**隐性本能**。
+- **v2.0 增量**：L3 不进入实时 attribution；它在外部训练系统中评估，并通过单独的 `model_deployment_registry` 管理 checkpoint 部署。
+
+---
+
+## 7. 从"脑首分离"到 Runtime v2 的全面接管
+
+> 与 v1.0 一致。重点在 v2.0 修订：v1.0 在结尾说"通过系统动力学的推演，PD 接下来的核心优化方向应该聚焦于：增强动态剪枝 + 提升硬转化率"——这两个方向都正确，但**实现路径**已经更新：
+
+- "动态剪枝" → 由 **Attribution-driven auto-archive (R4)** 实现，不再依赖人工 Pruning Action 排到 Phase 3 之后
+- "硬转化率" → 由 **L2 (RuleHost) 通道闭环 + Attribution PRRR 数据** 共同推动；不再只优化 Diagnostician prompt
+
+---
+
+## 8. 系统动力学建模图表 (SD Modeling Diagrams)
+
+### 8.1 因果回路图 (Causal Loop Diagram, CLD) — v2.0 修订版
+
+```mermaid
+graph TD
+    Pain["痛苦信号 (Pain Signals)"]
+    Diag["诊断引擎 (Diagnostician)"]
+    Soft["L1 软原则存量 (Active Soft Principles)"]
+    Hard["L2 硬规则存量 (Active Hard Rules)"]
+    Context["上下文压力 (Context Pressure)"]
+    Reasoning["LLM 推理能力 (Reasoning Quality)"]
+    PRRR["痛苦复发减少率 (PRRR)"]
+    LearnSum["元经验存量 (Learning Summary)"]
+    Verdict["归因裁决 (Attribution Verdict)"]
+    Conflict["冲突分数 (Conflict Score)"]
+    Trust["系统自主权 (Autonomy/Trust)"]
+
+    %% R1: Flywheel
+    Pain -->|+| Diag
+    LearnSum -->|+ 注入指导| Diag
+    Diag -->|+ 生成| Soft
+    Diag -->|+ 编译| Hard
+    Soft -->|+ 短期效果| PRRR
+    Hard -->|+ 持续效果| PRRR
+    PRRR -->|+| Trust
+    Trust -->|+ 探索新| Pain
+
+    %% B1: Ceiling
+    Soft -->|+| Context
+    Context -->|-| Reasoning
+    Reasoning -->|- 误用导致| Pain
+
+    %% R3: Decoupling
+    Hard -.剪枝替代.-> Soft
+
+    %% R4 NEW: Attribution Loop
+    Soft -->|进入观测窗口| Verdict
+    Hard -->|进入观测窗口| Verdict
+    Verdict -->|verdict=confirmed +| LearnSum
+    Verdict -->|verdict=regressed -| Soft
+    Verdict -->|verdict=regressed -| Hard
+
+    %% R5 NEW: Conflict Detection
+    Soft -->|pair-wise check| Conflict
+    Conflict -->|高时仲裁 -| Soft
+
+    classDef new fill:#fff8dc,stroke:#daa520,stroke-width:2px;
+    class Verdict,LearnSum,Conflict,PRRR new;
+```
+
+### 8.2 存量流量图 (Stock and Flow Diagram, SFD) — v2.0 修订版
+
+```mermaid
+flowchart LR
+    %% Stocks
+    S_Soft["[存量] L1 软原则库\n(Validated Soft Principles)"]
+    S_Hard["[存量] L2 硬规则\n(Validated Hard Rules)"]
+    S_Learn["[存量] 元经验\n(Learning Summary) ★NEW"]
+    S_Context["[存量] 上下文压力\n(Context Pressure)"]
+
+    %% Flows
+    F_GenSoft("流量: 软原则生成率")
+    F_GenHard("流量: 硬规则生成率")
+    F_AutoPrune("流量: 自动剪枝率\n(Attribution=regressed) ★NEW")
+    F_LearnUpdate("流量: 经验沉淀率\n(Attribution=confirmed) ★NEW")
+    F_Conflict("流量: 冲突仲裁淘汰率 ★NEW")
+
+    %% Sources/Sinks
+    Src1((Pain源))
+    Sink1((auto-archive))
+    Sink2((merge/rewrite))
+
+    %% Connections
+    Src1 -->|F_GenSoft| S_Soft
+    Src1 -->|F_GenHard| S_Hard
+    S_Soft -->|F_AutoPrune| Sink1
+    S_Hard -->|F_AutoPrune| Sink1
+    S_Soft -->|F_Conflict| Sink2
+    S_Soft -->|F_LearnUpdate| S_Learn
+    S_Hard -->|F_LearnUpdate| S_Learn
+    S_Learn -.信息回流.-> F_GenSoft
+    S_Learn -.信息回流.-> F_GenHard
+
+    %% Auxiliary
+    V_PRRR("PRRR 测量")
+    S_Soft -.attribution window.-> V_PRRR
+    S_Hard -.attribution window.-> V_PRRR
+    V_PRRR -.决定.-> F_AutoPrune
+    V_PRRR -.决定.-> F_LearnUpdate
+
+    S_Soft -.贡献 token.-> S_Context
+```
+
+*图解说明 (v2.0)*：
+1. v1.0 中"软原则" → "硬规则" 是**直接箭头**，v2.0 把这层拆开，让两者从同一 Pain 源各自演化，并各自经过 Attribution。
+2. **元经验存量（S_Learn）是新增的核心节点**，它是从 verdict=confirmed 累积的浓缩观察，回流到下一轮 Diagnostician 的生成函数中。
+3. **F_AutoPrune（自动剪枝）由 PRRR 测量直接决定**，不再依赖"人工启发式 review"。
+4. **F_Conflict（冲突仲裁淘汰）** 是 R5 在 SFD 上的具象化——同一组互相矛盾的原则会被 Arbitration 合并/重写。
+
+---
+
+## 9. 不变量与守护（v2.0 新增）
+
+为确保上述模型在工程层不被绕开，必须在架构守护测试中加入以下不变量：
+
+| 不变量 | 含义 |
+|-------|------|
+| `SD-1: PRRR-driven pruning` | 任何 `active → archived (auto)` 转换必须可追溯到一条 attribution verdict=regressed |
+| `SD-2: Probation-bridge` | `probation → active` 必须经过 `probation_active`，禁止跳过 |
+| `SD-3: Bundled isolation` | `provenance=bundled` 的 principle 不进入 attribution 计算，避免污染 PRRR |
+| `SD-4: Learning summary read-only` | `WorkspaceLearningSummary` 是只读视图；Diagnostician 只能读，不能反向写 |
+| `SD-5: Conflict score visible` | 任何 active principle 集合的 pair-wise conflict 数据可被 pd-cli / pd-console 查询 |
+
+详见 ADR-0013 §6 与 docs/plans/2026-05-roadmap/06-ahe-informed-architecture-review.md §4.4。
+
+---
+
+## 10. 结语
+
+> **v1.0 把 PD 描述为"基于痛苦学习的演化系统"。v2.0 进一步指出：没有 Attribution 的演化系统不是真正闭环——它只是不断生长的开环放大器。PRRR 是 PD 唯一应该追逐的北极星指标。所有其他度量（原则数、token、信任）都是过程指标。当某条原则不能贡献 PRRR，它就应该被 Attribution Pipeline 自动归档；当某条原则与其他原则冲突，它就应该被 Conflict Detection 仲裁。系统动力学不是描述工具，是约束工具——它告诉我们，缺哪一块，整个塔就会塌。**
+
+下一步实施路径见 `docs/plans/2026-05-roadmap/06-ahe-informed-architecture-review.md` §5。

--- a/docs/plans/2026-05-roadmap/02-roadmap.md
+++ b/docs/plans/2026-05-roadmap/02-roadmap.md
@@ -1,100 +1,131 @@
-# 02 - 路线图：Runtime V2 收敛与价值闭环
+# 02 - 路线图：MVP-First Track（Runtime V2 收敛 + 种子客户验证）
 
-> **更新日期**: 2026-05-23
+> **更新日期**: 2026-05-24（v3.0 — MVP-First Pivot）
 > **基准**: `origin/main` = `6d8fa62e`
-> **主决策**: [ADR-0012](../../adr/0012-runtime-v2-standalone-scheduling-and-legacy-retirement.md)
+> **主决策**:
+> - [ADR-0014](../../adr/0014-mvp-first-strategy-and-product-pivot.md) **★ MVP-First Strategy（当前主决策）**
+> - [ADR-0012](../../adr/0012-runtime-v2-standalone-scheduling-and-legacy-retirement.md)（Runtime V2-only，仍生效）
+> - [ADR-0013](../../adr/0013-attribution-pipeline-and-decision-observability.md)（已 Superseded by ADR-0014, deferred）
+> **执行文档**: [`07-mvp-first-pivot.md`](./07-mvp-first-pivot.md)
+> **被推迟工作的重启条件**: [`post-mvp-conditional-roadmap.md`](../post-mvp-conditional-roadmap.md)
 
-## 1. Phase 状态
+## 0. 一句话状态
 
-| Phase | 状态 | 当前结论 |
-|-------|------|----------|
-| Phase 0: low-risk E2E | Done | 已打通并有真实/合成验证 |
-| Phase 1A: L2 / RuleHost safety | Done for implementation | 保留运行验证，不继续扩展基础设施 |
-| Phase 1B: stability and consolidation | In progress | 稳定性/chaos 交付完成大部；转入 legacy/idle/plugin 退役 |
-| Phase 1C: human feedback | Partial | UI 已有；RejectionFeedback 未闭环 |
-| Phase 2+ | Paused | 待 Phase 1 的单一路径与真实价值闭环成立 |
+> **PD 进入 MVP 阶段。所有架构演进暂停。4-6 周内邀请第一个真实种子客户。**
 
-## 2. Phase 1B 新主线：删除重复执行系统
+## 1. Phase 状态总表
 
-目标不是“把 legacy 优雅保养好”，而是**尽快只剩一条可诊断的 Runtime V2 路径**。
+| Phase | 状态 | 说明 |
+|-------|------|------|
+| Phase 0: low-risk E2E | Done | Pain → Activation 基础路径已验证 |
+| Phase 1A: L2 / RuleHost safety | Done | RuleHostWriter / sandbox / approval 已落地 |
+| Phase 1B P1: stability baseline | Done | PRI-200~225 完成 |
+| Phase 1B P2: Nocturnal retirement | In progress | PRI-227~231，作为 MVP 期减法继续 |
+| ~~Phase 1C: value loop closure (Attribution)~~ | **Cancelled / Deferred** | ADR-0014 取消；重启条件见 post-mvp §1 |
+| ~~Phase 1D: lean foundations~~ | **Cancelled / Deferred** | 同上；重启条件见 post-mvp §2-§5 |
+| **MVP Track** | **Active** | **Week 1-6，故事 A' 验证** |
+| Phase 2+ (BALM/LRAS/GAP/MissionScheduler) | Hold | 准入门槛改为外部反馈驱动；见 post-mvp §7-§10 |
 
-```text
-ADR / backlog alignment (PRI-226)
-        |
-        +--> PD config + SDK/operator scheduling boundary
-        |           |
-        |           v
-        +--> EvolutionWorker / NocturnalWorkflow cutover
-                    |
-          +---------+---------+
-          v                   v
- historical read/export   commands and execution retirement
- isolation                     |
-                               v
-                       test/CI contraction
+## 2. MVP Track 6 周路线图
+
+详见 [07-mvp-first-pivot.md §5](./07-mvp-first-pivot.md)。摘要：
+
+```
+Week 1-2 减法 + 4 通道闭环
+  PRI-MVP-1  scope decision (docs)
+  PRI-MVP-2  cancel/defer 旧 issues (Linear)
+  PRI-MVP-3  feature flags 系统 + MVP-Quiet 关闭
+  PRI-MVP-4  4 通道 synthetic 冒烟
+  PRI-MVP-5  AGENTS.md "MVP 三问"
+  PRI-MVP-6  Nocturnal 退役继续（PRI-227 + PRI-230）
+
+Week 3-4 用户旅程 + 4 通道演示
+  PRI-MVP-7  SkillFileWriter 实施
+  PRI-MVP-8  pd-console 4 通道审批 UI
+  PRI-MVP-9  pd-console 三页化（Pain / Principle / Approval）
+  PRI-MVP-10 Demo workspace + 故事 A' 4 通道演示
+
+Week 5-6 安装 + 邀请
+  PRI-MVP-11 pd-cli 一键安装
+  PRI-MVP-12 GETTING-STARTED 用户视角重写
+  PRI-MVP-13 故事 A' 录屏
+  PRI-MVP-14 多环境冒烟（Win/Mac/Linux）
+  PRI-MVP-15 邀请第一个种子客户
 ```
 
-### 2.1 必须执行的退役切片
+## 3. MVP-Core / MVP-Quiet / MVP-Gone 清单
 
-| 顺序 | 工作 | 目的 | 执行风险 |
-|------|------|------|----------|
-| 1 | PRI-226 roadmap/ADR/Linear alignment | 防止代理按旧设计继续造 idle/nocturnal 功能 | Docs only |
-| 2 | PD-owned config/SDK scheduling boundary | 允许显式调度，不依赖 OpenClaw idle | High |
-| 3 | EvolutionWorker/Nocturnal workflow cutover | 删除 live legacy caller | High |
-| 4 | Historical Nocturnal read/export isolation | 保留确有数据价值的只读能力 | Medium |
-| 5 | Delete legacy execution and commands | 删除 Trinity/Arbiter/Service/Artificer 重复执行路径 | High |
-| 6 | Contract/test/CI contraction | 删除只保护已退役路径的测试并量化 CI 改善 | Medium |
+详见 [ADR-0014 §2.4 / §2.5 / §2.6](../../adr/0014-mvp-first-strategy-and-product-pivot.md)。摘要：
 
-### 2.2 退出标准
+**MVP-Core**: Pain capture / Diagnostician / CandidateIntake / Dreamer + Scribe + Artificer / 4 个激活通道（含待建 SkillFileWriter）/ Approval Queue / pd-console 三页 / pd-cli 核心命令。
 
-- OpenClaw plugin 不再启动 Nocturnal business execution 或 idle/night scheduler。
-- Runtime V2 可通过 PD-owned config/SDK/operator entrypoint 启动、排队、恢复和观察。
-- `nocturnal-trinity.ts`、`nocturnal-arbiter.ts`、`nocturnal-artificer.ts`、`nocturnal-service.ts` 的重复执行逻辑已删除。
-- 历史读取如保留，模块为 read-only、有限、独立且有数据存在证据。
-- 删除对应 obsolete tests 后，保留的 Runtime V2 E2E/chaos/migration tests 全部通过，并记录 CI 时间变化。
+**MVP-Quiet（关闭，留代码）**: Philosopher / Evaluator / RolloutReviewer / GFI / Focus History / Thinking OS / Empathy keyword / empathy_inferred / Shadow Observation / Local Worker Routing / Central Sync / message-sanitize / Trajectory Collector（评估）。
 
-## 3. Phase 1C：必须并行推进的价值闭环
+**MVP-Gone（删除/归档）**: Nocturnal 全套 / IdleTrigger / sleep cycle / EvolutionWorker / Trainer / model_training。
 
-`PRI-148` 不因 legacy retirement 而失去优先级。没有 rejection feedback，系统即使成功生成规则，也无法从用户否决中学习。
+## 4. MVP Track 风险
 
-| 工作 | 依赖 | 结果 |
-|------|------|------|
-| PRI-148 RejectionFeedback Service | 已有 ApprovalQueue/UI 与 RuleHost 基础 | reject -> structured feedback -> new Dreamer task / unresolvable outcome |
-| Production feedback-loop UAT（待创建） | PRI-148 | 在真实 workspace 证明 rejection 反馈链 |
+详见 07-mvp-first-pivot.md §6。要点：
 
-## 4. 保留但必须重写范围的旧 issues
+- 风险 1：4 通道演示比单通道难 3-5 倍 → 优先砍 skill 通道，3 → 2 通道是最低底线
+- 风险 2：RuleHost / Skill 概念门槛高 → MVP-13 录屏视频不能省，用客户真实规则演示
+- 风险 5：MVP-Quiet 关闭可能 break 现有功能 → 关闭后立即跑完整测试套件
 
-| Issue | 处理 |
-|-------|------|
-| PRI-118 | 保留；对齐 SourceTrace/FullTrace 已完成事实，只负责 plugin trajectory I/O facade / evidence boundary |
-| PRI-119 | 改为执行 cutover，不再仅 inventory 或“保持用户行为不变”地长期保留双轨 |
-| PRI-120 | 后置；FocusHistory 不阻塞 legacy execution 退役 |
-| PRI-150 | 拆分为 schema inventory + 小规模迁移，不做 bulk move |
-| PRI-154 | 改为 Runtime V2 pipeline event visibility，不再补充 legacy evolution 事件 |
-| PRI-162 | 改为 pure config contract + adapter loading；禁止 core 读 YAML/env/filesystem |
-| PRI-184 | 改为退役和关键 contract 的 missing guard audit；不增加无意义占位测试 |
+## 5. 旧路线图段落处置
 
-## 5. 明确取消/取代
+以下段落已被本文件取代，保留作历史档案查阅：
 
-| 项目 | 理由 |
-|------|------|
-| OpenClaw IdleTrigger/night-mode 继续开发 | 产品不再需要，且增加插件耦合与复杂状态 |
-| PRI-149 旧标题所表达的“已完成删除” | 交付内容实际为 CLI boundary migration，删除仍需新的 cutover 序列 |
-| PRI-175 至 PRI-181 原样实施 | 大多围绕即将退役的 legacy workflow；需取消或重定义 |
-| Phase 2 MissionScheduler 基于 IdleTrigger 的描述 | 调度器应 PD-owned 且 host-agnostic，不能以 idle trigger 为入口 |
+- ~~§3 Phase 1C: 必须并行推进的价值闭环~~ → 全部 cancelled / deferred（PRI-148 进 Phase 2 待外部反馈）
+- ~~§4 Phase 1D: 精简底座~~ → 全部 cancelled / deferred
+- ~~§5 保留但必须重写范围的旧 issues~~ → 部分仍生效（PRI-118 / PRI-120 / PRI-121），见 §6
+- ~~§6 明确取消/取代~~ → 仍生效，转入 ADR-0014 Anti-pattern 列表
+- ~~§7 Phase 准入门槛~~ → 已被 ADR-0014 §3 / 07 §9 取代
+- ~~§8 Issue 分配建议~~ → 已被 07 §5 取代
 
-## 6. Issue 分配建议
+## 6. 仍生效的非 MVP issues
 
-手工强 AI：
+以下 issues 不属于 MVP Track 但**仍可作为减法 / 守护工作**继续：
 
-- PRI-148。
-- 配置/SDK 调度 boundary。
-- EvolutionWorker/Nocturnal workflow cutover。
-- legacy execution 删除与真实 workspace smoke。
+| Issue | 状态 | 处置 |
+|-------|------|------|
+| PRI-227 | Todo | MVP 期继续，作为 PRI-MVP-6 的一部分 |
+| PRI-228 | Backlog | MVP 后再评估 |
+| PRI-229 | Backlog | MVP 后再评估 |
+| PRI-230 | Backlog | MVP 期继续，作为 PRI-MVP-6 的一部分 |
+| PRI-231 | Backlog | MVP 后再评估（CI 收缩）|
+| PRI-118 | Todo | 降级为 backlog；不在 MVP 路径，但 trajectory facade 仍有 long-term 价值 |
+| PRI-119 | Todo | MVP 期可执行（Nocturnal cutover 的关键步骤）|
+| PRI-148 | Todo | 降级为 backlog；MVP 用 Approval reject 简单路径，RejectionFeedback 待外部需求 |
+| PRI-150 | Backlog | MVP 后再评估 |
+| PRI-154 | Backlog | MVP 后再评估 |
+| PRI-162 | Todo | MVP 期可执行（PD-owned scheduling 是减法）|
+| PRI-183 | Todo | docs only，MVP 期完成 |
 
-Symphony 可处理：
+## 7. 不再分配 / 不再优先
 
-- Docs/ADR 对齐后续检查。
-- 静态 forbidden-import guards。
-- 退役后 CI/test inventory 与删除候选报告。
-- PRI-183 文档修订（先更新其描述）。
+| 不做的事 | 理由 |
+|---------|------|
+| 完整实施 ADR-0006 全 5 通道 | model_training 通道不在 MVP；其他 4 个通道已 MVP-Core |
+| BALM / LRAS / GAP / MissionScheduler 任何实施 | 等外部反馈触发；见 post-mvp §7-§10 |
+| Attribution / WorkspaceLearningSummary / Provenance / Probation Window | 同上；见 post-mvp §1-§5 |
+| 完整 7-Runner 链路投资 | Philosopher / Evaluator / RolloutReviewer 在 MVP-Quiet；等外部反馈 |
+| 跨 workspace 任何功能 | MVP 单 workspace |
+| 任何"为下个 Phase 铺路"的抽象 | AGENTS.md "MVP 三问" 拦截 |
+
+## 8. 立即执行（按顺序）
+
+详见 [07-mvp-first-pivot.md §10](./07-mvp-first-pivot.md)。当前进度：
+
+1. ✅ ADR-0014 已写
+2. ✅ post-mvp-conditional-roadmap.md 已写
+3. ✅ 07-mvp-first-pivot.md 已写
+4. ✅ ADR-0013 顶部 Superseded 注记
+5. ✅ 06-评审 顶部 Superseded 注记
+6. ✅ PD_System_Dynamics_Model.md v2.0 deferred 注记
+7. ✅ 02-roadmap.md 修订（本文件）
+8. ⏳ README.md 修订
+9. ⏳ AGENTS.md 修订（MVP 三问 + 三档分类）
+10. ⏳ Linear: cancel PRI-233 / PRI-235 / PRI-236
+11. ⏳ Linear: PRI-232 改 staleness-only
+12. ⏳ Linear: PRI-234 改 hold
+13. ⏳ Linear: 创建 PRI-MVP-1 至 MVP-15

--- a/docs/plans/2026-05-roadmap/03-linear-sync-plan.md
+++ b/docs/plans/2026-05-roadmap/03-linear-sync-plan.md
@@ -66,3 +66,289 @@
 - `Why now`: Runtime V2 已经通过 baseline/live/chaos 验证，双轨已从风险缓冲变为成本和故障来源。
 - `Retirement rule`: caller cutover before deletion; historical reading read-only only.
 - `Not allowed`: no new idle/night/nocturnal features, no broad unrelated refactor.
+
+
+---
+
+## 7. Phase 1C / 1D 新增工单（v2.0 — 2026-05-24 修订）
+
+> **背景**: ADR-0013 (Attribution Pipeline) + 06-ahe-informed-architecture-review.md 引入 Phase 1C/1D 主线。下列 issue 必须在 Linear 上新建。
+
+### 7.1 新建 issue 模板
+
+#### PRI-232: Attribution Pipeline MVP
+
+**Title**: Attribution Pipeline MVP — close the activation feedback loop with PRRR-driven verdict
+
+**Priority**: Urgent (P1)
+
+**Description**:
+
+```markdown
+## Context
+
+ADR-0013 introduces the Attribution Pipeline as PD's missing fourth pipeline. Without it, the Decoupling Loop (R3 in PD_System_Dynamics_Model.md) is falsely closed: PD cannot tell whether an activated principle actually reduces same-category pain or whether it introduces new pain categories.
+
+This issue delivers the MVP of the Attribution Pipeline. It is the highest-leverage work in Phase 1C.
+
+## Goal
+
+Implement the smallest end-to-end attribution loop that:
+
+1. Detects window completion for each `active` (or `probation_active`) principle (default: 100 tool calls per principle, configurable per channel).
+2. Computes `PRRR (Pain Recurrence Reduction Rate)` per pain category derived from the principle.
+3. Emits `ActivationOutcomeAttribution` records with verdict ∈ { confirmed, uncertain, regressed }.
+4. Wires `verdict=regressed` to `ActivationDispatcher.deactivate(reason='attribution_regressed')` (auto-archive, no human review needed for MVP).
+
+## Out of scope (future issues)
+
+- WorkspaceLearningSummary injection into Diagnostician prompts → PRI-233.
+- Probation Window state machine → PRI-235.
+- Auto-promotion on `verdict=confirmed` → keep manual; MVP only auto-archives `regressed`.
+- Conflict detection (R5) → separate issue after MVP stabilizes.
+
+## Required design constraints
+
+- Attribution must be append-only and idempotent on `(principleId, windowId)`.
+- Attribution must read trajectory through PRI-118's evidence facade (not direct trajectory storage).
+- Attribution must skip `provenance=bundled` principles (PRI-234 supplies the field; before that ships, treat all as evolved with documented backfill plan).
+- Architecture guards: ATTRIBUTION-1, ATTRIBUTION-2, ATTRIBUTION-3 from ADR-0013 §6.
+
+## Acceptance criteria
+
+1. New core module `runtime-v2/attribution/` with `AttributionWindowScheduler`, `ActivationOutcomeAttribution` schema, `AttributionVerdictDispatcher`, attribution store.
+2. SQLite schema `activation_outcome_attributions` table with idempotent insert.
+3. Architecture regression tests for ATTRIBUTION-1/2/3.
+4. Synthetic baseline test: inject a fake regressing principle, run 100 synthetic tool calls, verify it gets auto-archived with verdict=regressed and a written rationale.
+5. Production canary on at least 1 real workspace with at least 1 attribution verdict (any verdict kind).
+6. PR body reports: verdict count, archive count, false-positive count (manual sample of 5 verdicts).
+
+## Suitable executor
+
+Strong AI (manual dispatch). High-risk core change; requires careful contract testing.
+
+## Dependency
+
+- PRI-118 trajectory I/O facade (must merge first or be developed in parallel with explicit handoff)
+- ADR-0013 (already proposed in this PR cycle)
+
+## Related ERR entries
+
+- Apply ERR-001/005/007/009 (as bypasses validation) to the verdict schema parsing.
+- Apply ERR-015/018/019 (stale loop state) to the window-tracking logic.
+```
+
+#### PRI-233: WorkspaceLearningSummary contract & Diagnostician memory injection
+
+**Title**: WorkspaceLearningSummary — cross-session meta-experience for Diagnostician memory
+
+**Priority**: High (P2)
+
+**Description**:
+
+```markdown
+## Context
+
+ADR-0013 introduces WorkspaceLearningSummary as PD's missing meta-experience stock. Today, Diagnostician runs from scratch on every pain signal, with no memory of past attribution verdicts. This causes rediscovery of same-category principles and degrades efficiency.
+
+## Goal
+
+Define and implement a read-only `WorkspaceLearningSummaryReadModel` that consolidates the most recent N (default 20) attribution verdicts and exposes them as a token-budgeted prompt fragment for injection into Diagnostician prompts.
+
+## Required design constraints
+
+- Pure read model. No writes from outside attribution pipeline.
+- Token budget enforced at injection time (default ≤ 500 tokens, hard).
+- LRU-truncated to most recent verdicts when over budget.
+- Each summary entry must include: principleId hash, pain category, verdict kind, recurrence delta, key rationale phrase.
+- LEARN-1, LEARN-2 architecture guards (ADR-0013 §6).
+
+## Acceptance criteria
+
+1. New `WorkspaceLearningSummaryReadModel` in core.
+2. New `LearningSummaryPromptInjector` util used by `DiagnosticianPromptBuilder`.
+3. Architecture regression tests for LEARN-1, LEARN-2.
+4. Diagnostician prompt with summary injection passes existing baseline tests (no regression on synthetic baseline).
+5. Diagnostician explicitly references summary in at least 1 synthetic eval case where past verdict contradicts current evidence.
+
+## Dependency
+
+PRI-232 (must produce verdicts before this can be exercised).
+
+## Suitable executor
+
+Strong AI; medium risk.
+```
+
+#### PRI-234: Bundled vs Evolved principle provenance
+
+**Title**: Bundled vs Evolved provenance — separate PD project assets from per-workspace evolution
+
+**Priority**: Medium (P2)
+
+**Description**:
+
+```markdown
+## Context
+
+PD ships with bundled principles, skills, and thinking models that are common across all workspaces. Today these are indistinguishable from per-workspace evolved principles, which contaminates attribution and pruning decisions.
+
+## Goal
+
+Add a `provenance: 'bundled' | 'evolved'` field to LedgerPrincipleEntry (and PIArtifact where relevant), tag all current bundled assets at install time, and ensure attribution + pruning pipelines skip bundled entries.
+
+## Required design constraints
+
+- Default for new entries: `evolved`.
+- Backfill CLI: `pd ledger backfill-provenance --workspace <path> --json` (read-only by default; --confirm to apply).
+- `provenance=bundled` entries are immune from auto-archive but still counted in context pressure.
+- Architecture guard: BUNDLED-1 (ADR-0013 §6).
+- L1 cap counts bundled and evolved separately (configurable).
+
+## Acceptance criteria
+
+1. Schema added with TypeBox validation.
+2. Backfill CLI tested on synthetic workspace.
+3. Architecture regression test BUNDLED-1.
+4. Documentation: a list of all current PD-bundled principle/skill ids.
+
+## Suitable executor
+
+Symphony or strong AI; low complexity, schema + tagging exercise.
+```
+
+#### PRI-235: Activation Probation Window
+
+**Title**: Activation Probation Window — bridge approval and full activation with attribution gate
+
+**Priority**: High (P2)
+
+**Description**:
+
+```markdown
+## Context
+
+Today, an approved PIArtifact moves directly from `pending` to `active`. ADR-0013 introduces a Probation Window: approve → `probation_active` → (attribution verdict=confirmed) → `active` or → (verdict=regressed) → `archived`.
+
+## Goal
+
+Implement the `probation_active` ledger status, the state machine guards (STATE-1..STATE-4 from ADR-0013), and configurable window size (default: 50 tool calls for code_tool_hook, 100 for prompt/skill).
+
+## Required design constraints
+
+- STATE-1..STATE-4 must be enforced at LedgerWriter, not advisory.
+- pd-console UI must clearly show "Approved — In probation (N calls remaining)" status.
+- Per-channel probation window configurable in `activation.yaml`.
+- Manual override: `pd activation promote <principleId> --confirm` allowed for emergencies (audited).
+
+## Acceptance criteria
+
+1. Schema migration for new state.
+2. Architecture regression tests STATE-1..STATE-4.
+3. pd-console UI updated.
+4. Synthetic baseline: probation principle is auto-archived on regressed verdict in window.
+
+## Dependency
+
+PRI-232 (attribution must exist to evaluate verdict).
+
+## Suitable executor
+
+Strong AI; touches state machine, ledger schema, and UI.
+```
+
+#### PRI-236: Pruning Action MVP via Attribution
+
+**Title**: Pruning Action MVP — auto-archive regressed evolved principles via Attribution
+
+**Priority**: Medium (P3)
+
+**Description**:
+
+```markdown
+## Context
+
+Pruning Action has been deferred for months. ADR-0013 + PRI-232 + PRI-234 + PRI-235 together deliver the prerequisites: with attribution verdict and provenance separation in place, regressed evolved principles can be auto-archived without human review.
+
+## Goal
+
+Wire the Attribution verdict=regressed → ActivationDispatcher.deactivate path for `provenance=evolved` principles only. Bundled remains immune. Manual Pruning Review log (existing) stays available for evolved principles that have been uncertain ≥ 3 windows.
+
+## Required design constraints
+
+- SD-1 invariant: any `active → archived (auto)` must trace to a verdict=regressed.
+- Bundled principles never auto-archive.
+- Manual review log remains the path for verdict=uncertain ≥ 3 windows.
+
+## Acceptance criteria
+
+1. End-to-end: synthetic regressing principle → window completes → verdict=regressed → archived → ledger reflects archivedReason='attribution_regressed'.
+2. Architecture regression tests SD-1.
+3. pd canary surfaces attribution-driven archive count.
+
+## Dependency
+
+PRI-232 + PRI-234 + PRI-235.
+
+## Suitable executor
+
+Strong AI; small scope but touches activation state.
+```
+
+### 7.2 现有 issue 的描述追加（comment-only update）
+
+追加给以下 issues 一段评论：
+
+#### PRI-148 — 加注 comment
+
+```text
+[2026-05-24 v2.0 update]
+
+Decision source: ADR-0013 (Attribution Pipeline) + 06-ahe-informed-architecture-review.md.
+
+Scope clarification: this issue handles the **explicit human rejection** branch only. The **silent ineffectiveness** branch is owned by PRI-232 (Attribution Pipeline MVP). When this issue completes, it should:
+
+- accept reject input
+- create new Dreamer task with correctionHints
+- write structured RejectionFeedback record
+
+It must NOT try to implement value-loop verification on its own; that is PRI-232's role. Together they close the full feedback loop.
+
+No change to current acceptance criteria or priority.
+```
+
+#### PRI-118 — 加注 comment
+
+```text
+[2026-05-24 v2.0 update]
+
+Additional consumer: PRI-232 (Attribution Pipeline MVP) requires reliable trajectory read-out for verdict computation. The evidence read facade defined here MUST satisfy attribution's needs (window-bounded reads of pain signals + tool call sequence). Coordinate scope with PRI-232 before merging.
+```
+
+#### PRI-183 — 加注 comment
+
+```text
+[2026-05-24 v2.0 update]
+
+Scope correction: PRUNING_PIPELINE.md must reflect the dual-track design (post ADR-0013):
+
+1. Attribution-driven auto-archive (verdict=regressed, evolved-only) — primary path
+2. Manual Pruning Review log — secondary path for verdict=uncertain ≥ 3 windows
+
+Do not describe pruning as a "human-only" pipeline. The document should land before PRI-236 implementation.
+```
+
+### 7.3 立即可执行的 Linear API 调用清单
+
+执行人员（用户或 AI 助手）按下列顺序运行：
+
+```
+1. Create PRI-232 (Attribution Pipeline MVP) — Urgent
+2. Create PRI-233 (WorkspaceLearningSummary)
+3. Create PRI-234 (Bundled vs Evolved provenance)
+4. Create PRI-235 (Activation Probation Window)
+5. Create PRI-236 (Pruning Action MVP via Attribution)
+6. Comment on PRI-148, PRI-118, PRI-183 with the texts above
+```
+
+参见仓库 `.pd/tmp/linear-create-phase1cd-issues.ps1`（自动化脚本）。

--- a/docs/plans/2026-05-roadmap/04-risks-and-mitigations.md
+++ b/docs/plans/2026-05-roadmap/04-risks-and-mitigations.md
@@ -222,3 +222,21 @@
 2. **P2 风险**：本登记册 + 团队 sync 提及
 3. **P1 风险**：本登记册 + 团队 sync 提及 + 在 issue 中明确标注
 4. **P0 风险**：触发后立即停止当前阶段，专门 issue 处理
+
+
+---
+
+## Phase 1C/1D 新增风险（v2.0 — 2026-05-24）
+
+源自 ADR-0013 与 06-ahe-informed-architecture-review.md。
+
+| ID | 风险 | 评级 | 应对 |
+|----|------|------|------|
+| R-16 | Attribution verdict 不可靠（窗口太短 / pain category 映射错） | P1 | MVP 只做 auto-archive 不做 auto-promote；至少 50 个 verdict 与人工 sample 一致再扩张 |
+| R-17 | LearningSummary 注入让 Diagnostician 偏向"上次说过的"，缺乏多样性 | P2 | summary 是 evidence 而非命令；prompt 强制要求"如果与历史一致请引用，如果不一致请说明" |
+| R-18 | Bundled vs Evolved 分离时，存量 ledger 缺 provenance 字段 | P2 | 默认 evolved（最严格）；提供 backfill CLI 一次性纠正；缺失字段不会自动归档 |
+| R-19 | Activation Probation Window 让用户感觉"approve 了但没生效" | P2 | UI 明确显示"已批准 - 试运行中（剩余 N 次工具调用）"；提供"立即提升"快捷入口（高风险通道仍需二次审批）|
+| R-20 | Phase 1C 抢先 Phase 1B P2 (Nocturnal 删除)，导致返工 | P2 | Phase 1B P2 (PRI-227~231) 与 Phase 1C 可并行：前者由 Symphony / 静态 inventory；后者由强 AI |
+| R-21 | Attribution Pipeline 增加 SQLite 写入压力 | P3 | append-only + 周期归档；监控 db 大小；超出阈值时压缩老 attribution 为 monthly summary |
+| R-22 | "PRRR 是唯一结果指标"被误读为忽视其他维度（如 token 节省） | P3 | KPI 树明确把 token / context / adherence 作为 leading indicator；PRRR 是 lagging |
+| R-23 | Phase 2 BALM/LRAS/GAP/MissionScheduler 同期立项已存在 ADR | P2 | ADR-0008/0009/0010/0011 不撤销，但路线图明确 Phase 2 准入门槛（PRRR 数据 + 50 verdict + Phase 1B P2 完成）|

--- a/docs/plans/2026-05-roadmap/06-ahe-informed-architecture-review.md
+++ b/docs/plans/2026-05-roadmap/06-ahe-informed-architecture-review.md
@@ -1,0 +1,411 @@
+# 06 - AHE 论文启发下的架构评审与系统瘦身蓝图
+
+> **状态**: ⚠️ **Superseded by ADR-0014 + 07-mvp-first-pivot.md**（2026-05-24）
+> **原状态**: Active / Strategic
+> **被取代原因**: 本评审建议引入 Attribution Pipeline + Phase 1C/1D 等 5 个新 issue，违反了项目的实际阶段（零外部用户、维护者认知负担已饱和）。重新对齐 MVP-First 后，本文档的"诊断"部分仍有价值（特别是 §1 三支柱框架、§2 缺陷识别、§3 系统动力学补强），但**所有"实施建议"全部 deferred**。
+> **替代文档**: [`07-mvp-first-pivot.md`](./07-mvp-first-pivot.md)、[`docs/adr/0014-mvp-first-strategy-and-product-pivot.md`](../../adr/0014-mvp-first-strategy-and-product-pivot.md)
+> **保留理由**: 本文中的"PD 缺失第三支柱（Decision Observability）"诊断仍然成立。当 MVP 验证完成后，post-mvp-conditional-roadmap.md §1 的触发条件满足时，本文是重启 Attribution Pipeline 的关键输入。
+
+---
+
+> **以下原文保留作历史档案。任何 AI 助手或维护者读到本文时，请直接跳到 07-mvp-first-pivot.md，不要按本文 §5 的"立即行动清单"实施。**
+
+---
+
+
+---
+
+## 0. 阅读指引（TL;DR）
+
+本文回答四个问题：
+
+1. **PD 当前架构有哪些不足、可优化空间在哪？** → §2
+2. **PD 系统最核心的价值链路、要素、杠杆是什么？** → §3
+3. **如何让模块正交、清晰、易维护？** → §4
+4. **下一阶段实施计划与工单调整建议是什么？** → §5
+
+**最重要的结论**（一句话）：
+
+> PD 当前缺失"决策可观测性（Decision Observability）"——一个原则被激活后，没有任何机制度量它是否真的减少了它声称要消除的痛苦类别、是否制造了新痛苦。这是导致 L1 prompt 容量螺旋失控、原则相互冲突无法察觉的根因，必须作为 Phase 1C/1D 的最高优先级补齐。
+
+---
+
+## 1. AHE 论文对 PD 的启发：三个支柱框架
+
+AHE 把 coding-agent harness 的自动演化看作一个由**三个可观测性支柱**支撑的闭环：
+
+| AHE 支柱 | 含义 | AHE 的具体实现 |
+|---------|------|--------------|
+| **Component Observability** | 每个可编辑组件在文件级别独立可见、可还原 | 7 类组件（system_prompt / tool_desc / tool_impl / middleware / skill / sub_agent / long_term_memory）作为独立文件 |
+| **Experience Observability** | trace 不是日志，是被结构化、分层的"证据语料库" | per-task report + benchmark-level overview + drill-down 原始 trace |
+| **Decision Observability** | 每个 edit 必须自带 falsifiable prediction，下一轮验证 | change manifest 含 `predicted_fixes` + `risk_tasks`，下一轮按 task delta 裁决 keep/improve/rollback |
+
+### 1.1 PD 当前在三个支柱上的覆盖度
+
+| 支柱 | PD 现状 | 评估 |
+|------|---------|------|
+| Component Observability | 5 通道（prompt / skill / code_tool_hook / model_training / defer_archive）+ Ledger 树形结构 | ✅ 大致对齐，结构清晰 |
+| Experience Observability | PainSignal → DiagnosticianOutput → CandidateIntake；PainChainReadModel 提供回溯 | ⚠️ **部分**——侧重"前向链路"，但缺少"分层 + drill-down"形态供下一轮 Diagnostician 直接消费 |
+| Decision Observability | **完全缺失** | ❌ 致命 |
+
+PD 自己的 `LifecycleEvidence` 与 `RolloutReviewer` 看上去像是"决策可观测"，但它们只解决了**激活前**的判断（应该激活吗？），完全没有解决**激活后**的验证（激活之后真的有效吗？）。
+
+### 1.2 AHE 论文中对 PD 直接有用的具体洞见
+
+| 论文洞见 | 数据 / 论据 | 对 PD 的含义 |
+|----------|-----------|-------------|
+| **System prompt 单独使用会回归** | -2.3 pp aggregate | L1 通道是 ROI 最低的。PD 当前的"默认走 prompt 通道"是路径依赖 |
+| **Tool / Middleware / Long-term memory 才是承载收益的层** | 单独使用各 +2.2 / +7.6 / +5.6 pp | PD 应把投资重心转向 L2 (RuleHost)。Long-term memory 是 PD **缺失**的组件 |
+| **组件交互非加性，会相互冲突** | 三个单组件之和 +11.1 pp，但 full AHE 只 +7.3 pp | PD 必须建立"原则间冲突 / 冗余检测"机制；当前完全没有 |
+| **Fix prediction 5× random，Regression prediction 仅 2× random** | 33.7% / 11.8% precision | Diagnostician 自归因可作为"目标声明"，但**不能作为"安全声明"**——副作用必须由系统裁决 |
+| **Minimal seed 是归因的前提** | 任何预装组件都污染归因 | PD 当前每个 workspace 预装大量内置 thinking models / skills，无法区分"内置"与"演化产出"。这是归因的死敌 |
+| **Decision observability 让 edit 变成 falsifiable contract** | 每 edit 携带 manifest，下轮验证 keep/improve/rollback | PD 必须把每次激活变成"可证伪契约"——这是新加的核心组件 |
+
+---
+
+## 2. PD 当前架构的不足与优化空间
+
+### 2.1 致命缺陷：缺失 Attribution Pipeline（决策可观测性）
+
+**症状**：
+
+- L1 active principles 数量持续上升只能靠 LRU + cap = 12 兜底（PRI-139）
+- 三振出局（PRI-141）只能捕获**人类显式拒绝**的失败循环，无法捕获**沉默无效**
+- 当一个原则被激活后，系统没有任何反馈通道告诉它"我消除了 painId X、Y、Z；但同时引入了 painId A、B"
+- Pruning Pipeline 的修剪决策依赖 `lifecycleEvidence`，但 evidence 本身是基于"启发式"而非"实证测量"
+
+**根因**：PD 的循环是 `pain → principle → activation`，但**没有 `activation → next-round pain delta → re-evaluate principle`** 这一闭环。
+
+**对系统动力学的影响**：
+
+- 自己的 PD_System_Dynamics_Model.md 中的 R3（知识内化减压回路）实际上是**虚假闭合**——它假设硬规则会自动取代软原则，但没有度量"硬规则真的在减少同类痛苦吗？"
+- B1（复杂度阻尼回路）当前只能通过容量 cap 强制兜底，没有质量信号
+
+**修复方案**（细节见 ADR-0013 草案）：
+
+引入第四条流水线 `Attribution Pipeline`：
+
+```
+[Activation N round]
+       │
+       ▼ (一个固定的观测窗口，例如 100 个工具调用 / 24 小时 / 50 个 painId)
+[ActivationOutcomeAttribution]
+   ├ pain_delta_eliminated: 该 principle 声称要消除的痛苦类别中实际减少了多少
+   ├ pain_delta_introduced: 同一观测窗口内是否引入了新类别痛苦
+   ├ adherence_observed: 实际行为与原则的偏差程度
+   └ verdict: confirmed | uncertain | regressed
+       │
+       ▼ Drives:
+       ├ Auto-pruning（regressed 自动归档）
+       ├ Adherence rate update（替代当前的启发式估算）
+       └ Next-round Diagnostician context（"上一轮你说要修 X，结果 Y" 反馈）
+```
+
+### 2.2 二级不足：架构与代码的若干漂移
+
+| 问题 | 现状 | 优化方向 |
+|------|------|---------|
+| **Long-term Memory 缺失** | PD 的 Ledger 是单条原则集合，没有"跨会话沉淀的元经验"的载体 | 引入 `WorkspaceLearningSummary`（不是新原则；是关于"PD 自己"的元数据。详见 §3.4）|
+| **Workspace 预装件污染归因** | 每个 workspace 启动时预装 thinking_models / built-in skills | 引入"演化前 vs 演化后"标记。基础 skill/principle 必须打 `provenance: bundled` 标签，不参与 attribution |
+| **5 通道激活规模膨胀风险** | ADR-0006 设计了 5 通道，但 skill / training 通道的实际产出价值未实证 | 暂停 SkillFileWriter / TrainingExporter 实施，先把 prompt + RuleHost (code) 两个通道闭环做扎实 |
+| **BALM/LRAS/GAP/MissionScheduler 同时立项** | ADR-0008/0009/0010/0011 同期 Accepted，给 Phase 2 立了 4 个大坑 | 严格排序：先 Attribution → 再 BALM 最小骨架 → 暂停 LRAS/GAP/MissionScheduler 直到价值闭环数据可量化 |
+| **Plugin 仍是 god-package** | openclaw-plugin/src/core/ 122 个文件，混杂 hook / domain logic / I/O | 按 ADR-0012 退役 Nocturnal 后再做精细化迁移；不要在 legacy 删除前重构 |
+| **Diagnostician 输出空间未受 Long-term Memory 约束** | Diagnostician 每次都从空白开始推理 | Diagnostician prompt 应注入 "WorkspaceLearningSummary"（最近 N 轮 attribution verdict 的浓缩），避免重复发明同类原则 |
+| **没有"种子最小化原则"** | PD 项目级有大量基础原则。新工作区从空开始也会装载这些 | 立 ADR：bundled assets vs evolved assets 必须可区分；attribution 只对 evolved assets 生效 |
+
+### 2.3 不应继续投入的方向
+
+| 方向 | 理由 | 处置 |
+|------|------|------|
+| **完整实施 ADR-0006 全 5 通道** | skill/training 通道的产出收益未实证 | skill/training writer 暂缓；prompt + RuleHost 闭环先达成 |
+| **Phase 2 BALM 全套 7 个 manifest** | 当前内化产出尚未稳定，每个 Runner 各做 manifest 是过度抽象 | 先做 Diagnostician + Dreamer 两个 manifest 验证机制，其余按需扩展 |
+| **MissionScheduler 三层模型** | 当前没有 mission/objective 数据；建模没有真实 workload | Phase 3 才考虑；当前的 "explicit Runtime V2 scheduling boundary"（PRI-162）已经够用 |
+| **GAP Layer 1 信号生成器** | 没有 mission 数据时无法实现；强行实现会变 mock | 与 Mission/Objective 一起 Phase 3 |
+| **新增物理目录（如 .pd/evidence/）** | 已被 PRI-205 否决；attribution 应使用现有 SQLite metadata | 沿用 PRI-205 决议 |
+
+---
+
+## 3. PD 核心价值链路与杠杆识别
+
+### 3.1 重新校准核心价值链路
+
+PD 的真实价值不是"积累原则"，而是"**让代理在同一类失败上越来越少出错**"。
+
+可量化的核心指标（应作为 OKR 的根）：
+
+```
+PD 核心 KPI = Pain Recurrence Reduction Rate (PRRR)
+            = 1 - (后窗口同类 painId 数 / 前窗口同类 painId 数)
+
+后窗口 = 某 principle 激活后 N 个工具调用周期
+前窗口 = 该 principle 激活前 N 个工具调用周期
+```
+
+**所有其他指标都应该为此指标服务**：
+
+- 原则数量、token 节省、adherence rate、L1 容量 …… 这些都是过程指标
+- 唯一的结果指标是 PRRR
+
+如果某个原则的 PRRR 接近 0 甚至为负，无论它如何"被遵守"、token 多省，它都应该被归档。
+
+### 3.2 系统动力学最小核心要素（精简版）
+
+PD 系统真正的核心要素只有 5 个，其他都是衍生：
+
+| 要素 | 定义 | 单位 |
+|------|------|------|
+| **Pain Inflow Rate** | 每单位时间新增 painId 速率（按 GAP layer 分层）| painIds / hour |
+| **Active Principle Count** | 当前 status=active 的原则数 | count |
+| **Pain Recurrence Reduction Rate (PRRR)** | 见 §3.1 | ratio |
+| **L2 Internalization Ratio** | 同义功能在 L2 实现 / 在 L1 prompt 实现 | ratio |
+| **Context Pressure** | active principle 注入的总 token 数 / LLM 上下文窗口 | ratio |
+
+### 3.3 三个核心反馈回路（修订）
+
+修订 PD_System_Dynamics_Model.md 中的回路结构。原文档识别了 3 个回路（R1/B1/R3），还需要新增 2 个：
+
+```
+R1: Flywheel（已存在）
+   pain ↑ → principle ↑ → success ↑ → trust ↑ → (新探索) pain ↑
+
+B1: Ceiling（已存在）
+   principle count ↑ → context pressure ↑ → reasoning quality ↓ → (新错误) pain ↑
+
+R3: Decoupling（已存在但虚假闭合）
+   active principle → 编译 → hard rule ↑ → context pressure ↓
+   (虚假之处：缺一环——hard rule 真的有效吗？)
+
+R4 [NEW]: Attribution Loop（必须新增）
+   active principle → next-round pain delta → verdict (confirmed/uncertain/regressed)
+                                                  │
+                                  ┌───────────────┼───────────────┐
+                                  ▼               ▼               ▼
+                              auto-prune    keep+adherence    re-diagnose
+                              (regressed)   (confirmed)       (uncertain)
+
+R5 [NEW]: Conflict Detection Loop（必须新增）
+   active principle pair → 同窗口内是否同时被违反？是否相互矛盾？
+   → conflict_score ↑ → 触发 PrincipleArbitration（取舍 / 合并 / 重写）
+```
+
+R4 是**关键新增**：它是 R3 真正闭合的前置条件，也是 B1 的有效兜底（无效原则被自动归档，不再压榨 context）。
+
+R5 是次要新增，但是 PD 接近 cap 时的核心质量门控。
+
+### 3.4 核心杠杆识别（按 ROI 排序）
+
+| 杠杆 | 影响 | ROI |
+|------|------|-----|
+| **L1: 引入 Attribution Pipeline** | 让 L1 容量自动降到"有效原则集"，让 R3 真正闭合 | ⭐⭐⭐⭐⭐ |
+| **L2: 引入 WorkspaceLearningSummary** | 跨会话元经验沉淀，避免 Diagnostician 反复发明同类原则 | ⭐⭐⭐⭐ |
+| **L3: 完成 RuleHost (code_tool_hook) 通道闭环** | 把 ROI 最高的 L2 通道做透，承接绝大部分高价值原则 | ⭐⭐⭐⭐ |
+| **L4: 完成 RejectionFeedback (PRI-148)** | 关闭"人工拒绝 → 重新学习"的最后一公里 | ⭐⭐⭐⭐ |
+| **L5: Bundled vs Evolved 资产分离** | 让 attribution 干净；让"PD 项目原则"与"工作区演化原则"互不污染 | ⭐⭐⭐ |
+| **L6: 完成 Nocturnal/idle 退役（PRI-227~231）** | 删除 ~5000 行 dead code，CI 收敛 | ⭐⭐⭐ |
+| **L7: PRI-118 Trajectory I/O facade** | Attribution 需要可靠的 trace 读出 | ⭐⭐ |
+| **L8: BALM Diagnostician + Dreamer 最小骨架** | 让 Agent manifest 化，但只做最小两个 | ⭐⭐ |
+
+未列入：SkillFileWriter / TrainingExporter / GAP Layer 1 / MissionScheduler / 完整 BALM 7 个 manifest。这些都应推迟到 PRRR 数据稳定后再评估。
+
+---
+
+## 4. 系统边界与模块正交化
+
+### 4.1 当前边界问题
+
+读了 ADR-0012 + COMPONENTS.md + PD_SYSTEM_ARCHITECTURE.md 后，PD 的边界已经相当清晰，但还有三个具体的混乱点：
+
+| 边界混乱 | 具体表现 | 修复方向 |
+|---------|---------|---------|
+| **Pruning ↔ Activation 边界** | Pruning 是"激活后的反向决策"，但当前 PruningReadModel 与 ActivationDispatcher 没有显式通讯 | Attribution Pipeline 出 verdict=regressed → 直接进 Pruning Action 队列；不再依赖人工 review log |
+| **Diagnostician ↔ next-round Diagnostician 边界** | 每次 Diagnostician 跑都是"无记忆的"，看到的只是当前 painId 上下文 | 引入 WorkspaceLearningSummary 作为可注入的 "Diagnostician memory" |
+| **Approval ↔ ActivationDispatcher 边界** | Approval 通过 = 激活立即生效。但激活立即生效就立即进入 attribution 窗口，没有 staging 期 | 引入 `Activation Probation Window`（默认 50 工具调用）：approve 后先进 probation，期间 attribution 数据决定是否真正成 `active` |
+
+### 4.2 重新定义的 4 大流水线（取代当前 5 条）
+
+PD_ARCHITECTURE_OVERVIEW.md 当前列了 5 条数据流（Pain / Internalization / Activation / Operations / Pruning）。**Operations 不是流水线，是横切**；**Pruning 应该是 Attribution 的下游**。
+
+合理的精简：
+
+```
+                   ┌────────────────────┐
+                   │  1. Pain Pipeline  │
+                   │  痛苦捕获 → 原则候选 │
+                   └─────────┬──────────┘
+                             ▼
+                   ┌────────────────────┐
+                   │ 2. Internalization │
+                   │  原则 → 实现工件     │
+                   └─────────┬──────────┘
+                             ▼
+                   ┌────────────────────┐
+                   │ 3. Activation      │
+                   │  实现工件 → 实际生效  │
+                   └─────────┬──────────┘
+                             ▼
+                   ┌────────────────────┐
+                   │ 4. Attribution     │  ★ 新增（替代 Pruning）
+                   │  生效 → 测量 → 裁决  │
+                   └────┬──────────┬────┘
+                        │          │
+            ┌───────────┘          └─────────────┐
+            ▼ (regressed)                         ▼ (confirmed)
+       Auto Prune                       Update LearningSummary
+       (回 Activation status=archived)   (反哺下一轮 Diagnostician)
+```
+
+**Operations** 不是流水线，是横切关注点（pd-cli / pd-console 的读写边界）。
+**Pruning** 不是独立流水线，是 Attribution 的执行子图。
+
+### 4.3 4 大流水线的边界契约（强制）
+
+| 流水线 | Owner | 输入 | 输出 | 不允许做 |
+|-------|-------|------|------|---------|
+| Pain | core | PainSignal | LedgerPrincipleEntry(probation) | 修改激活状态、写 PIArtifact |
+| Internalization | core | LedgerPrincipleEntry(probation) | PIArtifact(validated) | 修改 active 状态、写 ledger |
+| Activation | core | PIArtifact(validated) | ledger.principle.status=active+probation_active | **直接 status=active**（必须先 probation_active）|
+| Attribution | core | active principles + new pain signals | verdict + adherence + recurrence | 直接修改 ledger（必须通过 ActivationDispatcher.deactivate）|
+
+新增状态 `probation_active`：从 approve 通过到 attribution 窗口结束之间的过渡态。期间该 principle 已注入 prompt，但 LedgerWriter 不会回退到 archive 之外的状态。
+
+### 4.4 Anti-pattern 清单（CI 守护）
+
+新增架构守护测试断言：
+
+| 守护 | 含义 |
+|------|------|
+| `ATTRIBUTION-1` | Attribution Pipeline 不得直接改 Ledger.status 字段；必须经过 ActivationDispatcher.deactivate |
+| `ATTRIBUTION-2` | Attribution 输出必须可幂等重放（基于 (principleId, observationWindowId)）|
+| `LEARN-1` | WorkspaceLearningSummary 是 read-only 视图，不能被 Diagnostician 修改 |
+| `BUNDLED-1` | provenance=bundled 的 principle 不得进入 attribution / pruning 队列 |
+| `STAGE-1` | 任何 principle 从 probation → active 必须经过 probation_active 中间态，时间 ≥ 配置最小窗口 |
+
+---
+
+## 5. 实施计划（Phase 1C/1D + 工单调整）
+
+### 5.1 严格顺序
+
+```
+[已完成]
+Phase 1A — L2 / RuleHost safety   ✅
+Phase 1B (P1) — stability baseline ✅ (PRI-200~225)
+
+[正在做的事]
+Phase 1B (P2) — Nocturnal retirement (PRI-226 done; 227 todo; 228-231 backlog)
+
+[新优先级建议]
+Phase 1C — Value loop closure
+   ├── PRI-148 RejectionFeedback (existing, raise priority)
+   └── ★ NEW: Attribution Pipeline MVP (proposed: PRI-232)
+
+Phase 1D — Lean foundations for Phase 2 readiness
+   ├── ★ NEW: WorkspaceLearningSummary contract (proposed: PRI-233)
+   ├── ★ NEW: Bundled vs Evolved provenance separation (proposed: PRI-234)
+   ├── PRI-118 Trajectory evidence facade (existing, scope confirm)
+   └── ★ NEW: Activation Probation Window (proposed: PRI-235)
+
+[Phase 2 准入门槛]
+Phase 1C+1D 完成、Attribution 出过至少 50 个 verdict 后，才允许启动 Phase 2 (BALM minimal)
+```
+
+### 5.2 工单清单（建议在 Linear 上的具体动作）
+
+#### A. 提升优先级 / 加紧执行
+
+| Issue | 当前状态 | 建议动作 |
+|-------|---------|---------|
+| PRI-148 | Todo, P2 | **保持 P2，不需要提升**——Attribution Pipeline (PRI-232) 是它的更优解；148 仍需，但范围收窄到"接收 reject → 创建 Dreamer task"，不再要求自己实现学习闭环 |
+| PRI-227 | Todo, P2 | 保持，作为 Nocturnal 退役链的入口 |
+| PRI-162 | Todo, P2 | 保持 |
+
+#### B. 新建（建议在 Linear 创建以下 issues）
+
+| 新 Issue | 优先级 | 范围 | 估时 |
+|---------|-------|------|------|
+| **PRI-232: Attribution Pipeline MVP** | P1 (Urgent) | 引入 ActivationOutcomeAttribution + verdict + auto-archive on regressed。最小窗口先 100 工具调用 | 2-3 周 |
+| **PRI-233: WorkspaceLearningSummary contract & Diagnostician memory injection** | P2 | 定义 LearningSummary schema，在 Diagnostician prompt 中注入最近 N 个 attribution verdict | 1 周 |
+| **PRI-234: Bundled vs Evolved principle provenance** | P2 | LedgerPrincipleEntry 增加 `provenance: bundled\|evolved` 字段；attribution 只对 evolved 生效；bundled cap 独立计数 | 1 周 |
+| **PRI-235: Activation Probation Window** | P2 | 引入 status=probation_active；approve 后默认 50 工具调用 / 24 小时窗口；窗口期间 attribution 决定 promote 或 archive | 1.5 周 |
+| **PRI-236: Pruning Action MVP via Attribution** | P3 | 替代当前的"独立人工 Pruning Action"——把 attribution verdict=regressed 的 principle 自动 archived，bypass 人工审批（仅对 evolved，且必须先 probation_active 状态过期）| 1 周 |
+
+#### C. 重写范围（把过时描述改对）
+
+| Issue | 修改 |
+|-------|------|
+| PRI-150 | 在 PRI-118 / PRI-232 / PRI-234 完成后再启动；当前描述已对，加一行依赖 |
+| PRI-154 | 描述已对，确认 attribution telemetry 是其覆盖范围之一 |
+| PRI-183 | 修改：PRUNING_PIPELINE.md 文档应描述"Attribution-driven pruning + 人工 review log"双轨，不再是只有人工 |
+| PRI-118 | 已 Todo，确认其 evidence read facade 必须满足 Attribution Pipeline 的读取需求 |
+| PRI-121 | PeerRunner harness 抽取——延后到 Phase 2，且必须在 BALM 设计后再做（否则会和 BALM 重复） |
+| PRI-204 | CertifiedAgentOutput contract——延后到 Phase 2，与 BALM 一起规划 |
+| PRI-202 / PRI-203 | pd CLI output validate / artifact write——保留为 Phase 1D 的工程支线，但优先级低于 Attribution |
+
+#### D. 取消 / 标记 superseded
+
+| Issue | 原因 |
+|-------|------|
+| 已有的 PRI-175~181 已经 Cancelled，无需操作 |
+| 无新 cancellation |
+
+### 5.3 风险登记（追加到 04-risks-and-mitigations.md）
+
+| ID | 风险 | 评级 | 应对 |
+|----|------|------|------|
+| R-16 | Attribution Pipeline 的 verdict 不可靠（窗口太短 / pain 类型映射错误） | P1 | 先在合成 baseline (PRI-206) 上跑，至少 50 个 verdict 与人工标注一致再上线；初期只做 auto-archive，不做 auto-promote |
+| R-17 | WorkspaceLearningSummary 注入让 Diagnostician 偏向"上次说过的"，缺乏多样性 | P2 | summary 是 evidence 而非命令；Diagnostician prompt 强制要求"如果与历史一致请引用，如果不一致请说明" |
+| R-18 | Bundled 与 Evolved 分离实施时，存量 ledger 缺少 provenance，需要 backfill | P2 | provenance 缺失默认按 evolved 处理（最严格）；提供 `pd ledger backfill-provenance` CLI 一次性纠正 |
+| R-19 | Activation Probation Window 让用户感觉"approve 了但没生效" | P2 | UI 明确显示"已批准 - 试运行中（剩余 N 次工具调用）"；console 提供"立即提升"快捷入口（高风险通道仍需二次审批）|
+| R-20 | Phase 1C 抢先 Phase 1B Nocturnal 删除会导致返工 | P2 | Phase 1B P2 (PRI-227~231) 与 Phase 1C 可并行：前者由 Symphony / 静态 inventory 完成；后者由强 AI 完成 |
+
+---
+
+## 6. 与现有文档的同步动作
+
+| 文档 | 动作 |
+|------|------|
+| `PD_System_Dynamics_Model.md` | **重写** —— 加入 R4/R5 回路，明确 PRRR 为唯一结果指标，识别 8 个杠杆 |
+| `PD_ARCHITECTURE_OVERVIEW.md` | 修订 §4 五条数据流 → 四条数据流（Pruning 并入 Attribution）+ 新增 Attribution Pipeline 章节 |
+| `INTERNALIZATION_PIPELINE.md` | 增加 §11 "Activation Probation Window" 与 §12 "Attribution Hand-off" |
+| `ACTIVATION_CHANNELS.md` | 增加 `probation_active` 状态机；明确每通道的 probation 窗口配置默认值 |
+| `COMPONENTS.md` | 新增 4 个 Attribution 组件 + WorkspaceLearningSummary + ProvenanceTagger |
+| `02-roadmap.md` | 增加 Phase 1C / Phase 1D；明确 Phase 2 准入门槛 |
+| `03-linear-sync-plan.md` | 加入新建 PRI-232~236 / 修订 PRI-148/183/118 的具体话术 |
+| `04-risks-and-mitigations.md` | 追加 R-16~R-20 |
+| `docs/adr/0013-attribution-pipeline.md` | **新建 ADR** |
+
+---
+
+## 7. AHE 论文里**没有照单全收**的部分
+
+为了避免误用，明确标记我们**不**借鉴 AHE 的几个具体设计：
+
+| AHE 做法 | 不照搬的理由 |
+|---------|-------------|
+| Evolve Agent 自主修改 system prompt / tool / middleware 实现 | PD 的"演化代理"是 Diagnostician + 7 个 Peer Runner，不是单个全权代理；架构上分离的优势是更可控 |
+| 让 Agent 自己 git commit 并自己回滚 | PD 的 ledger 已经是 append-only + 状态机，不需要 git 作为底层；rollback 通过 deactivate 完成 |
+| 把整个 NexAU framework 暴露给 Evolve Agent 修改 | PD 严格区分 core / plugin / cli，不允许 Diagnostician 修改 core 代码。这是 ADR-0012 的红线 |
+| 用 Agent Debugger 把 trace 当作文件系统供另一个 Agent 探索 | PD 已有 PainChainReadModel / FullTrace，结构化程度高于自由探索；不需要再做一个 trace agent |
+| Per-iteration k=2 rollouts 做 pass@1 | PD 不是 benchmark 系统，没有"pass@1"概念；对应的是 PRRR |
+
+借鉴的是**模式**（三支柱、falsifiable contract、minimal seed、ablation 方法论），不是**实现**。
+
+---
+
+## 8. 立即行动清单
+
+执行顺序（每个动作都是独立的 commit / PR）：
+
+1. ✅ 提交本评审文档（本 PR）
+2. 提交 ADR-0013 草案（Attribution Pipeline）→ 见 `docs/adr/0013-attribution-pipeline-and-decision-observability.md`
+3. 重写 `PD_System_Dynamics_Model.md`（加入 R4/R5 + PRRR + 8 个杠杆）
+4. 修订 `02-roadmap.md`（加入 Phase 1C/1D + 顺序约束）
+5. 修订 `03-linear-sync-plan.md`（PRI-232~236 模板 + PRI-148/183/118 重写话术）
+6. 通过 Linear API 创建 PRI-232~236 + 修订 PRI-148/183 描述
+7. 把 `04-risks-and-mitigations.md` 追加 R-16~R-20
+
+---
+
+## 9. 一句话总结
+
+> **PD 当前已经能从痛苦学到原则，但还没有学会"判断自己学到的东西到底有没有用"。Attribution Pipeline 是补全这一闭环的最后一块拼图。在它之前，所有其他扩张（BALM / LRAS / GAP / MissionScheduler）都是建在沙地上的塔。**

--- a/docs/plans/2026-05-roadmap/07-mvp-first-pivot.md
+++ b/docs/plans/2026-05-roadmap/07-mvp-first-pivot.md
@@ -1,0 +1,214 @@
+# 07 - MVP-First Pivot：从技术深化转向种子客户验证
+
+> **状态**: Active / 取代 06 / 取代 Phase 1C/1D
+> **日期**: 2026-05-24
+> **决策来源**: ADR-0014（MVP-First Strategy and Product Pivot）
+> **关联文档**: docs/plans/post-mvp-conditional-roadmap.md（被推迟工作的重启条件）
+
+## 0. 一句话总结
+
+> **PD 进入 MVP 阶段：4-6 周内具备邀请第一个真实种子客户的能力。所有架构演进暂停。所有"为未来铺路"工作 deferred。复杂度立即停止增长，开始减法。**
+
+## 1. 战略重置（与 06 文档的对比）
+
+| 维度 | 06 (AHE-informed review) | 07 (MVP-First Pivot) |
+|------|------------------------|---------------------|
+| 心智模型 | "成熟产品的精益化" | "未验证产品的 PMF 寻找" |
+| 优先级 | Attribution Pipeline 是最高杠杆 | 种子客户是最高杠杆 |
+| 新增组件 | 9 个（Attribution / LearningSummary / Probation / 等）| 0 个（除 SkillFileWriter）|
+| 新增不变量 | 12 个（ATTRIBUTION-* / STATE-* / 等）| 0 个 |
+| 新增 issue | PRI-232~236（5 个）| MVP-1 至 MVP-15（15 个，多为减法或 docs）|
+| 新增 ADR | ADR-0013（Attribution）| ADR-0014（MVP-First）|
+| 时间预期 | Phase 1C/1D ≈ 2-3 个月 | MVP Track 4-6 周 |
+
+## 2. 产品定位重新校准
+
+**PD 不治理工具级错误**。这是 OpenClaw / Claude Code 的职责。
+
+```
+错误层次              处理者                              PD 是否关心
+─────────────────────────────────────────────────────────────────
+工具级（参数错、命令失败）   OpenClaw / Claude Code 自身         否
+任务级（同类任务反复失败）   per-session memory                  次要
+行为模式级（跨会话品格偏差） PD ★                                主要
+```
+
+详见 ADR-0014 §2.1。
+
+## 3. MVP 故事 A'：把零散教训沉淀成稳定品格
+
+```
+[多次相似情境的失败 / 人工纠正 / 风险接近]
+                         ↓
+              PainSignal 累积同类信号
+                         ↓
+              Diagnostician 识别"模式而非单次"
+                         ↓
+       Dreamer + Scribe (+ Artificer) 把模式抽象为 Principle 候选
+                         ↓
+       人工在 pd-console 审核 → 决定走哪个通道
+                         ↓
+        ┌─────────────┬─────────────┬─────────────┐
+        ▼             ▼             ▼             ▼
+     Prompt      Skill         RuleHost      defer_archive
+   (软提示)    (主动工作流)   (硬拦截)        (优雅退场)
+        │             │             │
+        └─────────────┴─────────────┘
+                      ↓
+          代理在下一轮真实任务中表现出新品格
+```
+
+**4 个通道全部进 MVP-Core**——这是 PD 与"prompt 模板管理器"的本质区别。
+
+## 4. MVP-Core / MVP-Quiet / MVP-Gone 完整清单
+
+详见 ADR-0014 §2.4 / §2.5 / §2.6。摘要：
+
+**MVP-Core**:
+- Pain capture / Diagnostician / CandidateIntake / Ledger
+- Dreamer + Scribe + Artificer Runner
+- 4 个激活通道（含待建 SkillFileWriter）
+- Approval Queue + pd-console 三页
+
+**MVP-Quiet（关闭，留代码）**:
+- Philosopher / Evaluator / RolloutReviewer Runner
+- GFI / Focus History / Thinking OS / Empathy keyword
+- empathy_inferred 信号源
+- Shadow Observation / Local Worker Routing
+- Central Sync / message-sanitize
+- Trajectory Collector（评估后决定）
+
+**MVP-Gone（删除/归档）**:
+- Nocturnal 全套（PRI-227~231 继续）
+- IdleTrigger / sleep cycle / EvolutionWorker
+- Trainer / model_training 通道 / TrainingExporter
+
+## 5. MVP Track 路线图
+
+### Week 1-2: 减法 + 4 通道闭环验证
+
+| Issue | 内容 | 估时 | 形式 |
+|-------|------|------|------|
+| **PRI-MVP-1** | MVP scope 决议文档（三档清单 + 故事 A'）| 1 天 | docs only |
+| **PRI-MVP-2** | Cancel/defer 旧 issues（PRI-232/233/235/236 cancel；PRI-234 hold；PRI-118 降级）| 0.5 天 | Linear API |
+| **PRI-MVP-3** | Feature flags 系统 + MVP-Quiet 默认关闭 | 5-7 天 | 1 PR |
+| **PRI-MVP-4** | 4 通道 synthetic 冒烟（每通道 1 fixture）| 5-7 天 | 1 PR |
+| **PRI-MVP-5** | AGENTS.md "MVP 三问" + 三档分类 | 0.5 天 | docs only |
+| **PRI-MVP-6** | Nocturnal 退役继续（PRI-227 + PRI-230）| 5-7 天 | 与上面并行 |
+
+### Week 3-4: 用户旅程 + 4 通道演示
+
+| Issue | 内容 | 估时 | 形式 |
+|-------|------|------|------|
+| **PRI-MVP-7** | SkillFileWriter 实施（channel=skill）| 5-7 天 | 1 PR |
+| **PRI-MVP-8** | pd-console 4 通道审批 UI 完整化 | 5-7 天 | 1 PR |
+| **PRI-MVP-9** | pd-console 三页化（Pain / Principle / Approval）| 3-5 天 | 1 PR |
+| **PRI-MVP-10** | Demo workspace + 故事 A' 4 通道演示 | 7-10 天 | 1 PR |
+
+### Week 5-6: 安装 + 邀请
+
+| Issue | 内容 | 估时 | 形式 |
+|-------|------|------|------|
+| **PRI-MVP-11** | pd-cli 一键安装（`npx create-principles-disciple` 兼容 AI 助手安装路径）| 3-5 天 | 1 PR |
+| **PRI-MVP-12** | GETTING-STARTED 用户视角重写 | 3-5 天 | docs |
+| **PRI-MVP-13** | 故事 A' 录屏 + 文字解释（5-8 分钟）| 2-3 天 | 内容产出 |
+| **PRI-MVP-14** | 多环境冒烟（Win/Mac/Linux）| 3-5 天 | 多个小 PR |
+| **PRI-MVP-15** | 邀请第一个种子客户（A + C 画像各 1 个）| 0.5 天 | 沟通 |
+
+## 6. 风险与缓解
+
+### 风险 1：4 通道演示比单通道难 3-5 倍
+
+每个通道有独立审批 UI、独立 demo 场景、独立回滚路径。skill 通道还需要新写 SkillFileWriter。如果 Week 3-4 进度落后：
+
+**优先砍 skill 通道**（按"已完成度"和"演示直观度"）：
+```
+prompt > defer_archive > RuleHost > skill
+（保留度从高到低）
+```
+
+如果只能演示 3 个通道，砍 skill；如果只能演示 2 个，砍 skill + RuleHost；prompt + defer_archive 是绝对底线。
+
+### 风险 2：RuleHost / Skill 概念门槛高于 prompt 注入
+
+种子客户特别是非研究者画像可能听不懂"硬拦截"是什么。**缓解：MVP-13 录屏视频不能省**，且必须用 **客户自己的真实团队规则** 做演示输入（不要用抽象哲学）。
+
+### 风险 3：故事 A' "行为品格内化"是更深的概念
+
+抽象说服力低。**缓解：演示时不讲哲学，先让客户给 PD 注入一个具体的 "我团队的工作风格规则"，然后展示 AI 在没注入和注入后的行为差别。**
+
+### 风险 4：Week 3-4 SkillFileWriter 实施风险
+
+skill 通道是唯一一个还需要新写代码的 MVP-Core 工作。如果实施超时，必须果断砍掉 skill 通道并接受"3 通道演示"，而不是延期发布。
+
+### 风险 5：MVP-Quiet 关闭可能 break 现有功能
+
+GFI / Focus History 等已被现有代码依赖。**缓解：feature flag 默认关闭后，立即跑完整测试套件 + synthetic baseline。任何 break 必须 fix 或恢复 default 为 on（视严重程度）。**
+
+### 风险 6：种子客户邀请时间无法控制
+
+你认识的开发者朋友可能没空。**缓解**：MVP-15 不是技术 issue，是社交动作；备用方案是把视频 + GETTING-STARTED 公开发布，等自然反馈。
+
+## 7. AGENTS.md 强制约束（PRI-MVP-5 落地后生效）
+
+每个新 issue 在 PR 启动前必须答 **MVP 三问**：
+
+1. **不做会怎样？** 30 天后还有人提吗？
+2. **怎么观察？** UI / CLI / 日志 哪个能看到它在工作？
+3. **怎么关闭？** feature flag 还是 PR revert？
+
+每个新功能在 commit 前必须**先在 feature-flags.yaml 注册**。无 flag 注册的 PR 拒收。
+
+## 8. 与已有文档的关系
+
+| 文档 | 处置 |
+|------|------|
+| 06-ahe-informed-architecture-review.md | 标 Superseded by ADR-0014 / 07-mvp-first-pivot.md，不删 |
+| ADR-0013 (Attribution Pipeline) | 标 Superseded by ADR-0014, Deferred；重启条件见 post-mvp-conditional-roadmap.md §1 |
+| ADR-0008/0009/0010/0011 | 已标 deferred；不变 |
+| PD_System_Dynamics_Model.md v2.0 | v2.0 概念标 deferred；R1/B1/R3 v1.0 概念蓝图保留 |
+| 02-roadmap.md | Phase 1C/1D 段落标 superseded；重写 |
+| README.md | 改为 MVP Track 入口 |
+| 04-risks-and-mitigations.md | R-16~R-23 标 deferred；新增 MVP Track 风险 |
+| 05-integrated-stability-and-refactoring-blueprint.md | 保留作为稳定性基线参考 |
+
+## 9. Phase 2/3 准入门槛（重新定义）
+
+之前的"Phase 2 = BALM/LRAS/GAP/MissionScheduler" 模型不再适用。新的 Phase 准入门槛是**外部反馈驱动**：
+
+```
+MVP Track 完成 (Week 6 末)
+        │
+        ▼
+[种子客户 1-3 个使用 ≥ 1 个月]
+        │
+        ▼
+"种子反馈期" 的实际反馈分流
+        │
+        ├─→ "PD 没用" / "我看不到价值" → 产品定位重审，不进 Phase 2
+        ├─→ "原则越来越多变慢" → 启动 §1 Attribution Pipeline (post-mvp 第 1 项)
+        ├─→ "想换 backend" → 启动 §7 BALM
+        ├─→ "Diagnostician 超时" → 启动 §8 LRAS
+        ├─→ "想根据 OKR 过滤反思" → 启动 §9 GAP
+        └─→ "原则太粗糙" → 启动 §6 完整 7-Runner
+```
+
+**没有反馈就没有 Phase 2**。维护者本人的"洁癖" / "完整性焦虑" / "完美主义" 不算反馈。
+
+## 10. 立即执行清单（按顺序）
+
+1. ✅ ADR-0014 已写
+2. ✅ post-mvp-conditional-roadmap.md 已写
+3. ✅ 07-mvp-first-pivot.md 已写（本文档）
+4. 在 ADR-0013 顶部加 Superseded 注记
+5. 在 06-ahe-informed-architecture-review.md 顶部加 Superseded 注记
+6. 在 PD_System_Dynamics_Model.md 顶部加 v2.0 deferred 注记，恢复 v1.0 视图
+7. 修订 02-roadmap.md（删除 Phase 1C/1D，改为 MVP Track）
+8. 修订 README.md（改入口）
+9. 修订 AGENTS.md（加 MVP 三问 + 三档分类）
+10. Linear: cancel PRI-233 / PRI-235 / PRI-236
+11. Linear: 改 PRI-232 描述为 staleness-only 极小版
+12. Linear: 改 PRI-234 为 hold + 加注重启条件
+13. Linear: 创建 PRI-MVP-1 至 MVP-15
+
+文档完成后才动 Linear，避免重复修订。

--- a/docs/plans/2026-05-roadmap/README.md
+++ b/docs/plans/2026-05-roadmap/README.md
@@ -1,65 +1,67 @@
 # PD 项目路线图：2026-05 版
 
-> **状态**: Active / realigned for Phase 1B retirement
-> **更新日期**: 2026-05-23
-> **基准代码**: `origin/main` = `6d8fa62e`（PRI-225 / PR #693 已合并）
-> **决策修订**: [ADR-0012](../../adr/0012-runtime-v2-standalone-scheduling-and-legacy-retirement.md)
+> **状态**: Active / **MVP-First Track**
+> **更新日期**: 2026-05-24（v3.0 — MVP-First Pivot）
+> **基准代码**: `origin/main` = `6d8fa62e`
+> **主决策**:
+> - **[ADR-0014](../../adr/0014-mvp-first-strategy-and-product-pivot.md)（MVP-First Strategy）★ 当前主决策**
+> - [ADR-0012](../../adr/0012-runtime-v2-standalone-scheduling-and-legacy-retirement.md)（Runtime V2-only，仍生效）
+> - [ADR-0013](../../adr/0013-attribution-pipeline-and-decision-observability.md)（已 Superseded by ADR-0014, deferred）
+> **执行文档**: [`07-mvp-first-pivot.md`](./07-mvp-first-pivot.md)
+> **被推迟工作的重启条件**: [`../post-mvp-conditional-roadmap.md`](../post-mvp-conditional-roadmap.md)
 
 ## 当前结论
 
-PD 已不再处于“先证明 Runtime V2 是否可行”的阶段。已经完成的 baseline、live validation、repair、integrity 和 RuleHost 安全工作，足以把 Runtime V2 定为唯一前进路径。
+PD 进入 **MVP-First 阶段**。所有架构演进暂停，目标是在 **4-6 周内邀请第一个真实种子客户**。
 
-本路线图现在聚焦两项目标：
+**产品定位重新校准**：PD 不治理工具级错误（这是 OpenClaw / Claude Code 的职责），PD 治理的是 **AI agent 的"行为品格"**——跨会话、跨任务的稳定性格性偏差。
 
-1. **闭合真实价值循环**：补齐人工 rejection feedback，并持续用真实 workspace/UAT 验证 pain -> internalization -> activation/feedback。
-2. **快速减少维护面**：停止保留重复的 OpenClaw Nocturnal/idle/night 执行链，先切断生产入口，再删除 legacy 实现和只保护该路径的测试。
-
-## 决策变化：为什么现在要删除 legacy
-
-旧策略将 `nocturnal-trinity.ts`、`nocturnal-arbiter.ts`、`nocturnal-service.ts` 标记为冻结，是为了在 Runtime V2 未证明前避免破坏唯一可能的运行路径。
-
-现在证据改变了：
-
-- Runtime V2 的核心 pipeline、synthetic baseline、live intake、repair/recovery 和安全守卫已落地。
-- legacy 主执行文件仍约 4,800 行，并且 `EvolutionWorkerService` 与 Nocturnal 命令仍会造成第二控制平面。
-- 双轨代码增加 CI 时间、评审范围和故障定位歧义。
-- PD 没有需要长期兼容的外部用户；继续保留重复执行链的收益低于成本。
-- OpenClaw 空闲/夜间触发不再是产品需求。PD 内置代理应由 PD 的配置、SDK、operator command 或未来 scheduler 驱动，而不是与 gateway idle 状态绑定。
-
-因此，“冻结”现在只表示**不再向 legacy 增加功能**，不表示永久保留。退役工作本身是 Phase 1B 的主线。
+**MVP 故事 A'**：把零散教训沉淀成稳定品格。演示链路覆盖 4 个激活通道（prompt / skill / RuleHost / defer_archive），保住 PD 与"prompt 模板管理器"的本质区别。
 
 ## 文档导航
 
 | 文档 | 用途 |
 |------|------|
 | [01-current-state.md](./01-current-state.md) | 当前已合并能力与残留负债 |
-| [02-roadmap.md](./02-roadmap.md) | 新 Phase 顺序、依赖与退出标准 |
-| [03-linear-sync-plan.md](./03-linear-sync-plan.md) | Linear 更新/新建/取消清单 |
-| [04-risks-and-mitigations.md](./04-risks-and-mitigations.md) | 风险登记，部分 IdleTrigger 条目待按 ADR-0012 清理 |
-| [05-integrated-stability-and-refactoring-blueprint.md](./05-integrated-stability-and-refactoring-blueprint.md) | 已完成稳定性基线及新退役策略 |
+| [02-roadmap.md](./02-roadmap.md) | MVP Track 总图 + Phase 状态 |
+| [03-linear-sync-plan.md](./03-linear-sync-plan.md) | Linear 工单同步（部分被 07 取代）|
+| [04-risks-and-mitigations.md](./04-risks-and-mitigations.md) | 风险登记（含 MVP Track 风险）|
+| [05-integrated-stability-and-refactoring-blueprint.md](./05-integrated-stability-and-refactoring-blueprint.md) | 稳定性基线参考 |
+| ~~[06-ahe-informed-architecture-review.md](./06-ahe-informed-architecture-review.md)~~ | **Superseded by 07**；保留作历史档案 |
+| **[07-mvp-first-pivot.md](./07-mvp-first-pivot.md) ★** | **MVP-First 当前执行文档** |
+| [`../post-mvp-conditional-roadmap.md`](../post-mvp-conditional-roadmap.md) ★ | 被推迟工作的重启条件清单 |
 
 ## 阶段状态
 
 | 阶段 | 状态 | 说明 |
 |------|------|------|
-| Phase 0: low-risk pipeline | Done | Pain -> activation 的基础路径已验证 |
-| Phase 1A: L2 / RuleHost safety | Functionally done | RuleHostWriter、sandbox/gate、approval UI/context、full trace/refiner 已落地 |
-| Phase 1B: stability + runtime consolidation | In progress | 206-225 稳定性主线已完成；下一主线是 legacy/idle/plugin 退役 |
-| Phase 1C: feedback loop | Partial | Approval UI 已完成；`PRI-148` RejectionFeedback 仍需实施 |
-| Phase 2+ | Hold | 仅允许整理定义；在 Phase 1 价值闭环和退役完成前不扩建 |
+| Phase 0: low-risk pipeline | Done | Pain → Activation 基础路径已验证 |
+| Phase 1A: L2 / RuleHost safety | Done | RuleHostWriter / sandbox / approval 已落地 |
+| Phase 1B P1: stability baseline | Done | PRI-200~225 完成 |
+| Phase 1B P2: Nocturnal retirement | In progress | PRI-227~231 作为 MVP 期减法继续 |
+| ~~Phase 1C: value loop closure~~ | Cancelled / Deferred | ADR-0014 取消；重启条件见 post-mvp §1 |
+| ~~Phase 1D: lean foundations~~ | Cancelled / Deferred | 同上 |
+| **MVP Track (Week 1-6)** | **Active** | **4 通道演示 + 种子客户邀请** |
+| Phase 2+ (BALM/LRAS/GAP/MissionScheduler) | Hold | 准入门槛改为外部反馈驱动 |
 
 ## 立即执行顺序
 
-1. `PRI-226`：路线图/ADR/Linear 对齐（本次文档工作）。
-2. `PRI-148`：RejectionFeedback 闭环，确保人工拒绝能进入新一轮学习。
-3. Runtime V2-only retirement sequence：显式调度/config boundary -> EvolutionWorker/Nocturnal cutover -> 历史读取隔离 -> 删除执行代码 -> 测试收缩。
-4. `PRI-118`：更新为 trajectory evidence I/O boundary，支持唯一 Runtime V2 路径的可观测性。
-5. `PRI-154`：更新为 Runtime V2 pipeline event logging，不再补 legacy evolution pipeline。
+1. ✅ ADR-0014 + post-mvp-conditional-roadmap + 07-mvp-first-pivot 已写
+2. ✅ ADR-0013 / 06-评审 / SD-v2.0 顶部 Superseded 注记
+3. ✅ 02-roadmap.md 修订（删除 Phase 1C/1D 主线）
+4. ⏳ README.md（本文件）
+5. ⏳ AGENTS.md 修订（MVP 三问 + 三档分类）
+6. ⏳ Linear: cancel PRI-233 / PRI-235 / PRI-236
+7. ⏳ Linear: PRI-232 改 staleness-only 极小版
+8. ⏳ Linear: PRI-234 改 hold + 加注重启条件
+9. ⏳ Linear: 创建 PRI-MVP-1 至 MVP-15
 
-## AI 执行纪律
+## AI 执行纪律（v3.0 强化）
 
-- 开工前读取 `AGENTS.md`、`CLAUDE.md`、`docs/ERROR_EXPERIENCE_HANDBOOK.md` 和 ADR-0012。
-- 若 issue 提到新增 Nocturnal 执行、OpenClaw idle/night scheduling 或保留双轨，必须停止并要求修订 issue。
-- legacy retirement PR 只能按“切 caller -> 验证 -> 删除”顺序，不得先删除仍有生产引用的文件。
+- 开工前读取 `AGENTS.md`、`CLAUDE.md`、`docs/ERROR_EXPERIENCE_HANDBOOK.md`、`ADR-0014`、`07-mvp-first-pivot.md`、`post-mvp-conditional-roadmap.md`。
+- 任何 issue 引用 ADR-0013 / 06-评审 / SD-v2.0 / Phase 1C/1D 要求"现在实施"，必须停止并核对 ADR-0014 与 post-mvp-conditional-roadmap.md 的重启条件。
+- 每个新 issue 必须答 **MVP 三问**：不做会怎样 / 怎么观察 / 怎么关闭。答不出 issue 拒收。
+- 每个新功能 commit 前必须先在 `feature-flags.yaml` 注册，无 flag 注册的 PR 拒收。
+- 任何"为未来 Phase 铺路"的抽象、"为完整性"添加的组件、"为优雅"做的重构，全部要求维护者本人确认。
+- legacy retirement PR 只能按"切 caller → 验证 → 删除"顺序，不得先删除仍有生产引用的文件。
 - 删除代码的 PR 必须同时删除无价值的重复测试，并说明保留哪些迁移/E2E/chaos tests。
-- 不将新的 host/workspace 发现逻辑塞入 plugin；配置/调度应向 PD-owned SDK/config boundary 收敛。

--- a/docs/plans/post-mvp-conditional-roadmap.md
+++ b/docs/plans/post-mvp-conditional-roadmap.md
@@ -1,0 +1,289 @@
+# Post-MVP Conditional Roadmap
+
+> **Status**: Active
+> **Date**: 2026-05-24
+> **Owner**: ADR-0014 (MVP-First Strategy)
+> **Purpose**: 给所有"概念正确但当前不实施"的工作一个明确的**重启条件**和**预期收益**。任何 AI 助手或维护者在想"启动 X"前，必须先核对本表的触发条件是否真实满足。
+
+## 0. 使用规则
+
+1. 本文档的工作**全部默认状态：Hold**
+2. 启动前必须满足"重启条件"全部 bullets
+3. 启动前必须更新本文档，把"启动状态"改为 In Progress 并附时间戳和触发证据
+4. 任何 Linear issue 引用本表的工作时，issue 描述必须包含触发条件验证 checklist
+5. 6 个月不重启的工作进入 **annual review**：判断是否仍然 relevant；如不 relevant 则关闭
+
+---
+
+## 1. Attribution Pipeline / PRRR 体系（原 PRI-232 大版本）
+
+**Hold reason**: 没有真实使用数据时构建会变 mock；MVP 阶段用人工审批替代自动归因。
+
+**重启条件**（**全部满足**才启动）:
+- [ ] ≥3 个种子客户使用 PD ≥ 1 个月
+- [ ] 至少 1 个客户明确反馈："PD 加了原则但没用" 或 "原则越来越多让 LLM 变慢"
+- [ ] 客户工作区 active principle 数量稳定 ≥ 10
+- [ ] 至少 50 个真实生产 painId 已被处理（非 synthetic）
+
+**启动后预期收益**:
+- 让"无效原则自动归档"成为产品差异化卖点
+- 解决"长期使用后系统臃肿"问题
+- L1 容量自动收敛到"实际有效原则集"
+- Pruning 决策从启发式变为实证驱动
+
+**关联文档**: ADR-0013（已 Superseded but Deferred）；PD_System_Dynamics_Model.md v2.0（deferred concepts）
+
+**估时**: 2-3 周（启动时基于实际反馈重新拆 issue）
+
+---
+
+## 2. WorkspaceLearningSummary（原 PRI-233）
+
+**Hold reason**: Diagnostician 当前已经够用；跨会话记忆是优化，不是必需。
+
+**重启条件**:
+- [ ] Attribution Pipeline 已重启并运行 ≥ 1 个月（即 §1 的依赖）
+- [ ] Diagnostician 输出已被 ≥ 2 个种子客户在工单/反馈中明确说"重复了"或"没记忆"
+- [ ] 至少 3 个 painId 在历史日志中显示反复触发同类 diagnosis
+
+**启动后预期收益**:
+- Diagnostician 跨会话不重复发明同类原则
+- 减少 Diagnostician token 消耗
+- 让 PD 表现出"持续学习"的可见特征
+
+**估时**: 1-1.5 周
+
+---
+
+## 3. Bundled vs Evolved provenance（原 PRI-234）
+
+**Hold reason**: 没卡到 cap 之前是装饰；当前 cap=12 远未触及。
+
+**重启条件**（任一满足即可）:
+- [ ] active principles 数量在某个工作区稳定 ≥ 10 持续 ≥ 2 周
+- [ ] 至少 3 次发生 LRU 自动驱逐
+- [ ] 种子客户报告"我添加的原则被自动删了"或"我搞不清哪个是 PD 自带的"
+
+**启动后预期收益**:
+- 用户演化的原则与 PD 出厂原则可区分
+- LRU 驱逐策略可优先保留用户演化产物
+- 后续 Attribution 能干净地只对 evolved 生效
+
+**估时**: 1 周
+
+---
+
+## 4. Activation Probation Window（原 PRI-235）
+
+**Hold reason**: 没有真实事故前是 over-engineering。
+
+**重启条件**:
+- [ ] 出现过 ≥ 1 次"approve 后立即发现是 false positive"的真实事故
+- [ ] 维护者或种子客户反馈"批准后想反悔但找不到入口"
+
+**启动后预期收益**:
+- approve 操作有反悔窗口（默认 50-100 工具调用）
+- 降低 RuleHost 通道的部署风险
+- 与 Attribution（如果已重启）联动实现自动 promote/archive
+
+**估时**: 1-1.5 周
+
+---
+
+## 5. Pruning Action MVP via Attribution（原 PRI-236）
+
+**Hold reason**: 完全依赖 Attribution Pipeline。
+
+**重启条件**:
+- [ ] §1 Attribution Pipeline 已重启并通过 ≥ 30 天 shadow mode + ≥ 50 verdicts + 抽样 false positive < 5%
+- [ ] §3 Bundled provenance 已重启并完成 backfill
+
+**启动后预期收益**:
+- 完整的 R3 Decoupling Loop 闭合
+- 自动减少 prompt 容量压力
+- 取代当前的人工 Pruning Action 待办
+
+**估时**: 1 周
+
+---
+
+## 6. Internalization 完整 7-Runner 链路（Philosopher / Evaluator / RolloutReviewer 重启）
+
+**Hold reason**: MVP 用 Dreamer + Scribe + Artificer + 人工审批就够；这 3 个 Runner 是质量打磨链。
+
+**重启条件**:
+- [ ] 种子客户反馈"原则太粗糙"或"想看到原则的多版本演化"
+- [ ] 维护者发现 Dreamer 输出的 candidate 在审批阶段被拒绝率 > 30%
+- [ ] 至少 1 次出现"两个候选原则相互矛盾，需要 RolloutReviewer 仲裁"的场景
+
+**启动后预期收益**:
+- 自动化原则质量打磨
+- 降低人工审批工作量
+- 支持原则多版本对比
+
+**估时**: 已落地，仅需 flag 翻开 + 流程验证 1 周
+
+---
+
+## 7. BALM — Built-in Agent Lifecycle Manager（ADR-0008）
+
+**Hold reason**: 当前所有 Runner 用单一 PDRuntimeAdapter；多 backend 不在 MVP 演示路径。
+
+**重启条件**:
+- [ ] 种子客户主动要求："我能不能换 Claude / Gemini 跑 Diagnostician"
+- [ ] 支持的代理后端 ≥ 3 个有真实需求
+- [ ] 至少 1 个客户因为 backend 限制选择不使用 PD
+
+**启动后预期收益**:
+- 多 backend 解耦
+- 内置 Agent 可声明式版本化管理
+- Prompt 集中治理
+
+**估时**: 2-3 周（含至少 2 个 RuntimeAdapter 实施）
+
+---
+
+## 8. LRAS — Long-Running Agent Session（ADR-0009）
+
+**Hold reason**: 没遇到 Diagnostician 超时事故前是空抽象。
+
+**重启条件**:
+- [ ] 种子客户报告"Diagnostician 跑到一半超时"≥ 2 次
+- [ ] 真实生产 trajectory 显示某个 task 自然耗时 > 5 分钟
+- [ ] 至少 1 次出现"长任务被中断后重启从零开始"的事故
+
+**启动后预期收益**:
+- 长程 Agent 会话（小时级）
+- 检查点恢复
+- Self-validation tools
+
+**估时**: 2-3 周
+
+---
+
+## 9. GAP — Goal-Aligned Pain + Mission/Objective（ADR-0010）
+
+**Hold reason**: 没有用户输入 OKR 时是 mock；Layer 3（empathy + tool failure）当前已够用。
+
+**重启条件**:
+- [ ] 种子客户主动要求"我希望 PD 能根据我的 OKR 判断哪些 pain 重要"
+- [ ] 至少 1 个客户已在使用 PD 时手动维护过类似目标列表
+- [ ] PainSignal 总量 > 100/天（噪声达到值得过滤的阈值）
+
+**启动后预期收益**:
+- 反思噪音大幅减少
+- 集中算力解决战略级痛点
+- 系统具备目标感
+
+**估时**: 2-3 周（含数据模型 + GAPSignalGenerator）
+
+---
+
+## 10. MissionScheduler 三层任务模型（ADR-0011）
+
+**Hold reason**: 当前 PRI-162 的 PD-owned explicit scheduling 已满足 Runtime V2 执行需求。
+
+**重启条件**:
+- [ ] 同时存在 ≥ 3 个并发 mission
+- [ ] 出现过任务依赖死锁或饥饿事故
+- [ ] §9 GAP 已重启且产出 Mission 实体
+
+**启动后预期收益**:
+- DAG 任务调度
+- 优先级抢占
+- Mission 状态自动收敛
+
+**估时**: 2-3 周
+
+---
+
+## 11. TrainingExporter / LoRA model_training 通道
+
+**Hold reason**: MVP 故事 A' 不涉及微调；当前是科研项目 vibe。
+
+**重启条件**:
+- [ ] 种子客户中 ≥ 1 个有真实微调需求
+- [ ] 数据量积累 ≥ 1000 个高质量样本
+- [ ] 维护者已就模型部署 / 评估 / 回滚有明确策略
+
+**启动后预期收益**:
+- 完整 L3 内化路径
+- 行为品格固化到模型权重
+
+**估时**: 3-4 周（含外部训练系统集成）
+
+---
+
+## 12. Skill 通道之外的高级 skill 管理（自动 skill 命名 / skill 合并 / skill 版本控制）
+
+**Hold reason**: MVP 只演示"PD 把 Principle 写成 SKILL.md"；高级管理需要使用反馈。
+
+**重启条件**:
+- [ ] SkillFileWriter 已上线 ≥ 1 月
+- [ ] 至少 1 个工作区累计 skill 数量 > 5
+- [ ] 种子客户反馈"skills 多了之后管理混乱"
+
+**启动后预期收益**:
+- skill 自动版本化
+- 跨 skill 合并 / 拆分
+
+**估时**: 1-2 周
+
+---
+
+## 13. 监督学习与归因诊断的高级特性（CertifiedAgentOutput / Shadow contracts / 等）
+
+**Hold reason**: 现有 PRI-204 在 Backlog；属于"为未来铺路"的抽象。
+
+**重启条件**:
+- [ ] 种子客户中有人在用 GoldenTrace 系统
+- [ ] 至少 1 次发生 GoldenTrace 验证失败但 LLM 输出是"看起来对"的场景
+- [ ] §1 Attribution Pipeline 已重启
+
+**启动后预期收益**:
+- LLM 输出可作为 shadow evidence 而非 authoritative
+- 归因信号可结合代理自陈
+
+**估时**: 2-3 周
+
+---
+
+## 14. 跨工作区 Attribution / 中央 Sync / 多用户协作
+
+**Hold reason**: MVP 单工作区；多用户场景属于 Phase 3+。
+
+**重启条件**:
+- [ ] 种子客户中有团队级用户（≥ 2 人共享 PD 配置）
+- [ ] §1 Attribution 已运行
+- [ ] 至少 1 次出现"我这个 workspace 有的原则在另一个 workspace 没有"的事故
+
+**启动后预期收益**:
+- 团队级原则共享
+- 跨工作区 PRRR 聚合
+
+**估时**: 4-6 周（含数据同步协议设计）
+
+---
+
+## 15. Annual Review 流程
+
+每年 5 月（项目年度起点）执行：
+
+1. 对每个 Hold 工作核对触发条件
+2. 6 个月连续未触发的工作 → 评估是否永久关闭
+3. 触发条件已变化的 → 修订条件
+4. 新增 Hold 工作 → 加入本文档（必须有触发条件）
+
+---
+
+## 16. 反模式警告
+
+以下情况 **不**算重启条件满足：
+
+- ❌ "我觉得现在该做了"
+- ❌ "AHE 论文又出了新进展"
+- ❌ "我 review 代码时觉得这块缺失"
+- ❌ "为了下个 Phase 铺路"
+- ❌ "这个 ADR 当时是 Accepted 的，应该实施"
+
+只有 **从外部用户来的真实信号** 才算触发。维护者自己的"洁癖驱动" / "完整性驱动" / "完美主义驱动" 全部不满足触发条件。


### PR DESCRIPTION
## Summary

- **ADR-0014**: MVP-First Strategy and Product Pivot — architectural pause, MVP-Core/Quiet/Gone triage, feature flag registration
- **ADR-0008/0009/0010**: Built-in Agent Lifecycle Manager, Long-Running Agent Session, Goal-Aligned Pain Signal (deferred to post-MVP)
- **ADR-0013**: Attribution Pipeline and Decision Observability (deferred)
- **AGENTS.md**: MVP-First stage instructions, Three Questions triage, anti-pattern triggers for AI agents
- **Roadmap updates**: AHE-informed architecture review, MVP-First pivot plan, post-MVP conditional restart docs
- **PD_System_Dynamics_Model**: system dynamics architecture documentation

## Changes

15 files, +2543 / −125 lines

## Test plan

- [x] `verify:merge` gate passed (generated-artifacts, lint, build, typecheck)
- [x] `protect-main` hook passed
- [x] No code changes — docs and AGENTS.md only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了产品路线图，调整战略重点至 MVP-First 策略，将在 4-6 周内完成首个种子客户验证演示。
  * 通过功能分级（MVP-Core / MVP-Quiet / MVP-Gone）简化 MVP 阶段的功能范围。
  * 新增架构决策文档，包括属性管道、长时会话、目标对齐信号等后续阶段延期实施的设计。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->