### PR TITLE
feat(legacy): add entrypoint census and nocturnal caller guard (PRI-227)

### DIFF
--- a/docs/LEGACY_ENTRYPOINT_CENSUS.md
+++ b/docs/LEGACY_ENTRYPOINT_CENSUS.md
@@ -1,4 +1,4 @@
-# Legacy Entrypoint Census
+﻿# Legacy Entrypoint Census
 
 > **PRI-227**: Static inventory of every legacy Nocturnal entrypoint in the
 > `packages/openclaw-plugin/` source tree, including imports, hook registrations,
@@ -35,10 +35,15 @@ All three nocturnal commands are registered in `packages/openclaw-plugin/src/ind
 
 | File | Category | Notes |
 |---|---|---|
-| `src/commands/nocturnal-review.ts` | `delete_candidate` | Depends on nocturnal-dataset, nocturnal-arbiter types. |
-| `src/commands/nocturnal-train.ts` | `delete_candidate` | Training experiment lifecycle. |
-| `src/commands/nocturnal-rollout.ts` | `delete_candidate` | Checkpoint promotion/routing. |
+| `src/commands/nocturnal-review.ts` | `live_cutover` | Depends on nocturnal-dataset, nocturnal-arbiter types. Still wired in index.ts. |
+| `src/commands/nocturnal-train.ts` | `live_cutover` | Training experiment lifecycle. Still wired in index.ts. |
+| `src/commands/nocturnal-rollout.ts` | `live_cutover` | Checkpoint promotion/routing. Still wired in index.ts. |
 
+### Sleep Reflection Trigger Command
+
+| File | Category | Notes |
+|---|---|---|
+| `src/commands/pd-reflect.ts` | `live_cutover` | Manual sleep_reflection trigger. Creates sleep_reflection task via queue-io, bypassing idle check. |
 ---
 
 ## 2. Core Nocturnal Modules (Frozen per ADR-0005)
@@ -83,6 +88,18 @@ legacy code that must not be modified. Runtime V2 equivalents live in
 | File | Import | Category | Notes |
 |---|---|---|---|
 | `src/service/startup-reconciler.ts` | `writeState`, `readStateSync` from `./nocturnal-runtime.js` (line 16) | `live_cutover` | Startup reconciliation validates and resets nocturnal-runtime.json state. Called from EvolutionWorker heartbeat initial delay (evolution-worker.ts line 1594). |
+
+### cooldown-strategy.ts
+
+| File | Import | Category | Notes |
+|---|---|---|---|
+| `src/service/cooldown-strategy.ts` | `readState`, `readStateSync`, `writeState` from `./nocturnal-runtime.js`; `CooldownEscalationConfig`, `loadCooldownEscalationConfig` from `./nocturnal-config.js` | `live_cutover` | Cooldown escalation reads/writes nocturnal-runtime state and loads config from nocturnal-config. |
+
+### evolution-pain-context.ts
+
+| File | Reference | Category | Notes |
+|---|---|---|---|
+| `src/service/evolution-pain-context.ts` | `sleep_reflection` task kind (string literal) | `live_cutover` | Builds pain context metadata for sleep_reflection tasks. References sleep_reflection as a task kind filter. |
 
 ### Evolution Worker Nocturnal References
 
@@ -134,6 +151,24 @@ These are the actual import sites that keep legacy nocturnal modules alive.
 | `src/core/nocturnal-executability.ts` | `parseAndValidateArtifact` | `delete_candidate` | Both are delete candidates. |
 | `src/core/nocturnal-dataset.ts` | `NocturnalArtifact` type | `delete_candidate` | Type-only import. |
 
+
+### Imports of `nocturnal-runtime.ts`
+
+| Source File | Import | Category | Notes |
+|---|---|---|---|
+| `src/service/cooldown-strategy.ts` | `readState`, `readStateSync`, `writeState` | `live_cutover` | Cooldown state read/write. |
+
+### Imports of `nocturnal-config.ts`
+
+| Source File | Import | Category | Notes |
+|---|---|---|---|
+| `src/service/cooldown-strategy.ts` | `CooldownEscalationConfig`, `loadCooldownEscalationConfig` | `live_cutover` | Cooldown escalation config. |
+
+### Imports of `nocturnal-artifact-lineage.ts`
+
+| Source File | Import | Category | Notes |
+|---|---|---|---|
+| `src/core/principle-internalization/filesystem-lifecycle-datasource.ts` | `listArtifactLineageRecords` | `live_cutover` | Reads artifact lineage records for filesystem lifecycle tracking. |
 ---
 
 ## 6. Hook Trigger Paths (index.ts)
@@ -205,7 +240,7 @@ they verify existing behavior but must be retired with the production code.
 |---|---|---|---|
 | `before_prompt_build` | index.ts:120-129 | Starts EvolutionWorkerService per workspace | `mvp_core_dependency` |
 | EvolutionWorker heartbeat | evolution-worker.ts:1412 | Periodic cycle that checks idle, enqueues sleep_reflection | `mvp_core_dependency` |
-| EvolutionWorker sleep_reflection processing | evolution-worker.ts:640-975 | Processes sleep_reflection queue items via NocturnalWorkflowManager | `live_cutover` |
+| EvolutionWorker sleep_reflection processing | evolution-worker.ts:640-975 | Processes sleep_reflection queue items via NocturnalWorkflowManager | `mvp_core_dependency` |
 | runCycle (sleep-cycle.ts) | sleep-cycle.ts:72 | Extracted sleep-cycle orchestrator | `live_cutover` |
 
 ---
@@ -229,12 +264,15 @@ for legacy nocturnal modules. They are NOT legacy entrypoints.
 
 ## Summary
 
+
 | Category | Count | Description |
 |---|---|---|
-| `mvp_core_dependency` | 4 | EvolutionWorker service registration, before_prompt_build hook trigger, evolution queue processing loop, queue-io sleep_reflection enqueue. These are ADR-0014 core. |
-| `live_cutover` | 18 | Commands (3), command handler source files (3), service modules still called (4), import sites in evolution-worker / workflow-manager (5), sleep-cycle (1), merge-gate-audit (1), startup-reconciler (1). |
+| `mvp_core_dependency` | 4 | EvolutionWorker service registration (1), before_prompt_build hook trigger (1), evolution queue processing loop (1), queue-io sleep_reflection enqueue (1). ADR-0014 core. |
+| `live_cutover` | 22 | Nocturnal commands (3), command handlers (3), sleep_reflection trigger (1: pd-reflect.ts), service modules still called (4), evolution-worker import sites (3), NocturnalWorkflowManager references (3), cross-module imports (3: merge-gate-audit, cooldown-strategy, filesystem-lifecycle-datasource), startup-reconciler (1), pain context (1: evolution-pain-context.ts). |
 | `compat_alias` | 1 | Re-export of enqueueSleepReflectionTask from evolution-worker.ts. |
-| `historical_read_export` | 28 | Test files (24 + 4 integration/architecture tests) and type-only imports (2). |
-| `delete_candidate` | 16 | Frozen core modules (14), service orchestrator (1), adaptive-thresholds (1). |
+| `historical_read_export` | 29 | Test files (24 regular + 4 architecture regression), type-only imports (1: workflow-store.ts). |
+| `delete_candidate` | 16 | Frozen core modules (14 nocturnal-*.ts + 1 adaptive-thresholds.ts), service orchestrator (1: nocturnal-service.ts). |
 
-**Total unique entrypoints classified: 63**
+**Total unique entrypoints classified: 72**
+
+> **Counting rule**: Each entrypoint is counted once in its highest-priority category. Priority order: `mvp_core_dependency` > `live_cutover` > `compat_alias` > `historical_read_export` > `delete_candidate`. A single file with multiple import sites (e.g. evolution-worker.ts) counts as multiple entrypoints, one per distinct import/reference site listed in the detailed sections above. Sub-item sums in the Description column must equal the Count column value.

--- a/docs/LEGACY_ENTRYPOINT_CENSUS.md
+++ b/docs/LEGACY_ENTRYPOINT_CENSUS.md
@@ -1,4 +1,4 @@
-﻿# Legacy Entrypoint Census
+# Legacy Entrypoint Census
 
 > **PRI-227**: Static inventory of every legacy Nocturnal entrypoint in the
 > `packages/openclaw-plugin/` source tree, including imports, hook registrations,

--- a/docs/LEGACY_ENTRYPOINT_CENSUS.md
+++ b/docs/LEGACY_ENTRYPOINT_CENSUS.md
@@ -13,7 +13,7 @@
 
 | Category | Tag | Meaning |
 |---|---|---|
-| **MVP-Core Dependency** | `mvp_core_dependency` | ADR-0014 MVP-Core activation paths (prompt, RuleHost / code_tool_hook, defer_archive). These are the "good" entrypoints: the evolution-worker loop and sleep-cycle orchestrator that the Runtime V2 Peer Runners will replace. |
+| **MVP-Core Dependency** | `mvp_core_dependency` | ADR-0014 MVP-Core activation paths (`prompt`, `code_tool_hook / RuleHost`, `defer_archive`). These are the "good" entrypoints: the evolution-worker loop and sleep-cycle orchestrator that the Runtime V2 Peer Runners will replace. |
 | **Live Cutover** | `live_cutover` | Still has live callers in the current codebase that need to be migrated to Runtime V2 before the legacy module can be deleted. |
 | **Compatibility Alias** | `compat_alias` | Re-export or thin alias that exists only for backwards compatibility. Can be removed when all consumers migrate. |
 | **Historical Read Export** | `historical_read_export` | Read-only export path (type re-export, barrel export). Does not call into Nocturnal logic at runtime. |
@@ -232,9 +232,9 @@ for legacy nocturnal modules. They are NOT legacy entrypoints.
 | Category | Count | Description |
 |---|---|---|
 | `mvp_core_dependency` | 4 | EvolutionWorker service registration, before_prompt_build hook trigger, evolution queue processing loop, queue-io sleep_reflection enqueue. These are ADR-0014 core. |
-| `live_cutover` | 15 | Commands (3), service modules still called (4), import sites in evolution-worker / workflow-manager (5), sleep-cycle (1), merge-gate-audit (1), startup-reconciler (1). |
+| `live_cutover` | 18 | Commands (3), command handler source files (3), service modules still called (4), import sites in evolution-worker / workflow-manager (5), sleep-cycle (1), merge-gate-audit (1), startup-reconciler (1). |
 | `compat_alias` | 1 | Re-export of enqueueSleepReflectionTask from evolution-worker.ts. |
 | `historical_read_export` | 28 | Test files (24 + 4 integration/architecture tests) and type-only imports (2). |
-| `delete_candidate` | 16 | Frozen core modules (14). Service orchestrator (1). Command handler source files (3, counting as sub-items of live_cutover). |
+| `delete_candidate` | 16 | Frozen core modules (14), service orchestrator (1), adaptive-thresholds (1). |
 
 **Total unique entrypoints classified: 63**

--- a/docs/LEGACY_ENTRYPOINT_CENSUS.md
+++ b/docs/LEGACY_ENTRYPOINT_CENSUS.md
@@ -1,0 +1,240 @@
+# Legacy Entrypoint Census
+
+> **PRI-227**: Static inventory of every legacy Nocturnal entrypoint in the
+> `packages/openclaw-plugin/` source tree, including imports, hook registrations,
+> command wiring, service triggers, and test files. All Nocturnal modules are
+> frozen per **ADR-0005** -- no new features, no structural changes.
+>
+> Generated: 2026-05-24
+
+---
+
+## Classification Key
+
+| Category | Tag | Meaning |
+|---|---|---|
+| **MVP-Core Dependency** | `mvp_core_dependency` | ADR-0014 MVP-Core activation paths (prompt, RuleHost / code_tool_hook, defer_archive). These are the "good" entrypoints: the evolution-worker loop and sleep-cycle orchestrator that the Runtime V2 Peer Runners will replace. |
+| **Live Cutover** | `live_cutover` | Still has live callers in the current codebase that need to be migrated to Runtime V2 before the legacy module can be deleted. |
+| **Compatibility Alias** | `compat_alias` | Re-export or thin alias that exists only for backwards compatibility. Can be removed when all consumers migrate. |
+| **Historical Read Export** | `historical_read_export` | Read-only export path (type re-export, barrel export). Does not call into Nocturnal logic at runtime. |
+| **Delete Candidate** | `delete_candidate` | Can be deleted when the retirement plan (Runtime V2 Peer Runners) completes. Includes frozen legacy modules (`nocturnal-trinity.ts`, `nocturnal-arbiter.ts`, `nocturnal-service.ts`) and their test mirrors. |
+
+---
+
+## 1. Slash Command Registrations (index.ts)
+
+All three nocturnal commands are registered in `packages/openclaw-plugin/src/index.ts`.
+
+| Command Name | Line | Handler Import | Category | Notes |
+|---|---|---|---|---|
+| `pd-nocturnal-review` | 622-636 | `./commands/nocturnal-review.js` | `live_cutover` | Human review queue for nocturnal dataset. Needs Runtime V2 review dashboard. |
+| `nocturnal-train` | 637-652 | `./commands/nocturnal-train.js` | `live_cutover` | Training experiment management. Needs Runtime V2 training workflow. |
+| `nocturnal-rollout` | 653-667 | `./commands/nocturnal-rollout.js` | `live_cutover` | Rollout/promotion gate. Needs Runtime V2 deployment pipeline. |
+
+### Command Handler Source Files
+
+| File | Category | Notes |
+|---|---|---|
+| `src/commands/nocturnal-review.ts` | `delete_candidate` | Depends on nocturnal-dataset, nocturnal-arbiter types. |
+| `src/commands/nocturnal-train.ts` | `delete_candidate` | Training experiment lifecycle. |
+| `src/commands/nocturnal-rollout.ts` | `delete_candidate` | Checkpoint promotion/routing. |
+
+---
+
+## 2. Core Nocturnal Modules (Frozen per ADR-0005)
+
+All files under `src/core/nocturnal-*.ts` are `delete_candidate` -- they are frozen
+legacy code that must not be modified. Runtime V2 equivalents live in
+`packages/principles-core/src/runtime-v2/nocturnal/`.
+
+| File | Category | Notes | Runtime V2 Replacement |
+|---|---|---|---|
+| `src/core/nocturnal-trinity.ts` | `delete_candidate` | Trinity chain (Dreamer/Philosopher/Scribe). Frozen god-class. | `principles-core/src/runtime-v2/nocturnal/trinity-types.ts` + `dreamer-runner.ts` |
+| `src/core/nocturnal-arbiter.ts` | `delete_candidate` | Deterministic artifact validation. Pure functions. | `principles-core/src/runtime-v2/nocturnal/nocturnal-compliance.ts` |
+| `src/core/nocturnal-trajectory-extractor.ts` | `delete_candidate` | Session snapshot extraction for Trinity. | `principles-core/src/runtime-v2/nocturnal/snapshot-contract.ts` |
+| `src/core/nocturnal-artificer.ts` | `delete_candidate` | Code implementation candidate generation. | TBD |
+| `src/core/nocturnal-candidate-scoring.ts` | `delete_candidate` | Tournament selection for candidates. | `principles-core/src/runtime-v2/nocturnal/candidate-scoring.ts` |
+| `src/core/nocturnal-dataset.ts` | `delete_candidate` | Dataset registry for approved samples. | TBD |
+| `src/core/nocturnal-executability.ts` | `delete_candidate` | Action executability validation. | TBD |
+| `src/core/nocturnal-export.ts` | `delete_candidate` | Training data export. | TBD |
+| `src/core/nocturnal-paths.ts` | `delete_candidate` | Path resolver for nocturnal artifacts. | TBD |
+| `src/core/nocturnal-reasoning-deriver.ts` | `delete_candidate` | Reasoning chain derivation. | TBD |
+| `src/core/nocturnal-rule-implementation-validator.ts` | `delete_candidate` | Rule implementation AST validation. | TBD |
+| `src/core/nocturnal-artifact-lineage.ts` | `delete_candidate` | Lineage tracking for artifacts. | `principles-core/src/runtime-v2/types/artifact-lineage.ts` |
+| `src/core/nocturnal-snapshot-contract.ts` | `delete_candidate` | Snapshot ingress validation. | `principles-core/src/runtime-v2/nocturnal/snapshot-contract.ts` |
+| `src/core/nocturnal-reviewed-subset-comparison.ts` | `delete_candidate` | Post-review quality comparison. | TBD |
+| `src/core/adaptive-thresholds.ts` | `delete_candidate` | Adaptive quality thresholds shared with nocturnal. | TBD |
+
+---
+
+## 3. Nocturnal Service Modules
+
+| File | Category | Notes |
+|---|---|---|
+| `src/service/nocturnal-service.ts` | `delete_candidate` | Main orchestrator (executeNocturnalReflection / executeNocturnalReflectionAsync). 1814 lines. Frozen per ADR-0005. |
+| `src/service/nocturnal-runtime.ts` | `live_cutover` | Idle detection (`checkWorkspaceIdle`), cooldown, preflight checks. STILL CALLED by `sleep-cycle.ts` and `evolution-worker.ts`. |
+| `src/service/nocturnal-target-selector.ts` | `live_cutover` | Principle + session selection for reflection. Called by `nocturnal-service.ts` (via `executeNocturnalReflection`). |
+| `src/service/nocturnal-config.ts` | `live_cutover` | Configuration loader. Called by `evolution-worker.ts` and `sleep-cycle.ts`. |
+| `src/service/sleep-cycle.ts` | `live_cutover` | Sleep cycle orchestrator extracted from evolution-worker. Uses nocturnal-runtime + queue-io. **Still wired into the heartbeat loop in evolution-worker.ts** (approximately lines 1449-1494). |
+| `src/service/queue-io.ts` | `mvp_core_dependency` | Queue I/O including `enqueueSleepReflectionTask`. This is ADR-0014 evolution queue code, not pure nocturnal -- but it contains the sleep_reflection task enqueue path. |
+
+### startup-reconciler.ts
+
+| File | Import | Category | Notes |
+|---|---|---|---|
+| `src/service/startup-reconciler.ts` | `writeState`, `readStateSync` from `./nocturnal-runtime.js` (line 16) | `live_cutover` | Startup reconciliation validates and resets nocturnal-runtime.json state. Called from EvolutionWorker heartbeat initial delay (evolution-worker.ts line 1594). |
+
+### Evolution Worker Nocturnal References
+
+The file `src/service/evolution-worker.ts` has multiple nocturnal entrypoint paths:
+
+| Location | Reference | Category | Notes |
+|---|---|---|---|
+| Line 23 | Re-export `enqueueSleepReflectionTask` | `compat_alias` | Re-export from queue-io.ts |
+| Line 28 | Import `checkWorkspaceIdle`, `checkCooldown`, `recordCooldown` from `nocturnal-runtime.ts` | `live_cutover` | Sleep cycle uses these. |
+| Line 51 | Import `OpenClawTrinityRuntimeAdapter` from `../core/nocturnal-trinity.js` | `live_cutover` | Used in NocturnalWorkflowManager construction for sleep_reflection task processing and workflow sweeping. |
+| Lines 640-975 | `sleep_reflection` task processing path | `mvp_core_dependency` | The evolution queue processing loop (ADR-0014) processes sleep_reflection tasks. This is the core evolution machinery. |
+| Lines 1449-1494 | Idle check and sleep_reflection enqueue in heartbeat cycle | `live_cutover` | The heartbeat cycle triggers both idle-based and periodic sleep reflection. Runtime V2 Peer Runners will replace this. |
+
+---
+
+## 4. NocturnalWorkflowManager
+
+| File | Category | Notes |
+|---|---|---|
+| `src/service/subagent-workflow/nocturnal-workflow-manager.ts` | `live_cutover` | Wraps `executeNocturnalReflectionAsync` + `OpenClawTrinityRuntimeAdapter` in WorkflowManager interface. Called from `evolution-worker.ts` for sleep_reflection processing and sweepExpiredWorkflows. |
+
+---
+
+## 5. Import Entrypoints (Cross-Module)
+
+These are the actual import sites that keep legacy nocturnal modules alive.
+**If all of these are removed, the nocturnal modules become dead code.**
+
+### Imports of `nocturnal-trinity.ts`
+
+| Source File | Import | Category | Notes |
+|---|---|---|---|
+| `src/service/nocturnal-service.ts` | Multiple (runTrinity, TrinityConfig, TrinityResult, etc.) | `delete_candidate` | Both files are delete candidates together. |
+| `src/service/evolution-worker.ts` | `OpenClawTrinityRuntimeAdapter` (line 51) | `live_cutover` | Used in NocturnalWorkflowManager construction. |
+| `src/core/merge-gate-audit.ts` | `OpenClawTrinityRuntimeAdapter` (line 7) | `live_cutover` | Used for merge gate audit workflow. |
+| `src/service/subagent-workflow/nocturnal-workflow-manager.ts` | TrinityStageFailure, TrinityResult (line 37-38) | `live_cutover` | Type-only imports. |
+| `src/service/subagent-workflow/workflow-store.ts` | DreamerOutput, PhilosopherOutput (line 6) | `historical_read_export` | Type-only imports for workflow event payloads. |
+
+### Imports of `nocturnal-service.ts`
+
+| Source File | Import | Category | Notes |
+|---|---|---|---|
+| `src/service/subagent-workflow/nocturnal-workflow-manager.ts` | `executeNocturnalReflectionAsync`, `NocturnalRunResult` | `live_cutover` | Core call path. |
+
+### Imports of `nocturnal-arbiter.ts`
+
+| Source File | Import | Category | Notes |
+|---|---|---|---|
+| `src/core/nocturnal-executability.ts` | `parseAndValidateArtifact` | `delete_candidate` | Both are delete candidates. |
+| `src/core/nocturnal-dataset.ts` | `NocturnalArtifact` type | `delete_candidate` | Type-only import. |
+
+---
+
+## 6. Hook Trigger Paths (index.ts)
+
+The `before_prompt_build` hook in index.ts (lines 103-150) starts the `EvolutionWorkerService`
+for each workspace. This is the **sole trigger path** that activates the entire nocturnal
+pipeline chain:
+
+1. `before_prompt_build` hook (line 120-129): starts `EvolutionWorkerService`
+2. `EvolutionWorkerService.start` (line 1376): creates heartbeat timer
+3. Heartbeat `runCycle` (evolution-worker.ts, line 1412): checks idle, enqueues sleep_reflection
+4. sleep_reflection task processing (evolution-worker.ts, lines 640-975): creates `NocturnalWorkflowManager`
+5. `NocturnalWorkflowManager.startWorkflow` (nocturnal-workflow-manager.ts): calls `executeNocturnalReflectionAsync`
+6. `executeNocturnalReflectionAsync`: imports from frozen nocturnal modules
+
+| Hook | Location | Category | Notes |
+|---|---|---|---|
+| `before_prompt_build` (EvolutionWorker start) | index.ts:120-129 | `mvp_core_dependency` | This is the ADR-0014 entry point. The EvolutionWorker service registration is core infrastructure, not nocturnal-specific. |
+| `api.registerService(EvolutionWorkerService)` | index.ts:360-362 | `mvp_core_dependency` | Service registration is core infrastructure. |
+
+---
+
+## 7. Nocturnal Test Files
+
+All test files that reference nocturnal modules. Test files are `historical_read_export` --
+they verify existing behavior but must be retired with the production code.
+
+| Test File | Category | Notes |
+|---|---|---|
+| `tests/commands/nocturnal-review.test.ts` | `historical_read_export` | Tests for pd-nocturnal-review command. |
+| `tests/commands/nocturnal-train.test.ts` | `historical_read_export` | Tests for nocturnal-train command. |
+| `tests/core/nocturnal-arbiter.test.ts` | `historical_read_export` | Tests for frozen nocturnal-arbiter. |
+| `tests/core/nocturnal-artifact-lineage.test.ts` | `historical_read_export` | Tests for frozen artifact lineage. |
+| `tests/core/nocturnal-artificer.test.ts` | `historical_read_export` | Tests for frozen nocturnal-artificer. |
+| `tests/core/nocturnal-candidate-scoring.test.ts` | `historical_read_export` | Tests for frozen candidate scoring. |
+| `tests/core/nocturnal-compliance-p-principles.test.ts` | `historical_read_export` | Compliance test. |
+| `tests/core/nocturnal-compliance.test.ts` | `historical_read_export` | Compliance test. |
+| `tests/core/nocturnal-dataset.test.ts` | `historical_read_export` | Tests for frozen nocturnal-dataset. |
+| `tests/core/nocturnal-e2e.test.ts` | `historical_read_export` | E2E test. |
+| `tests/core/nocturnal-executability.test.ts` | `historical_read_export` | Tests for frozen executability. |
+| `tests/core/nocturnal-export.test.ts` | `historical_read_export` | Tests for frozen export. |
+| `tests/core/nocturnal-reasoning-deriver.test.ts` | `historical_read_export` | Tests for frozen reasoning deriver. |
+| `tests/core/nocturnal-reviewed-subset-comparison.test.ts` | `historical_read_export` | Reviewed subset comparison test. |
+| `tests/core/nocturnal-rule-implementation-validator.test.ts` | `historical_read_export` | Implementation validator test. |
+| `tests/core/nocturnal-snapshot-contract.test.ts` | `historical_read_export` | Snapshot contract test. |
+| `tests/core/nocturnal-trinity.test.ts` | `historical_read_export` | Tests for frozen nocturnal-trinity. |
+| `tests/service/evolution-worker.nocturnal.test.ts` | `historical_read_export` | Evolution worker nocturnal tests. |
+| `tests/service/nocturnal-runtime-hardening.test.ts` | `historical_read_export` | Runtime hardening test. |
+| `tests/service/nocturnal-runtime.test.ts` | `historical_read_export` | Runtime test. |
+| `tests/service/nocturnal-service-code-candidate.test.ts` | `historical_read_export` | Service code candidate test. |
+| `tests/service/nocturnal-target-selector.test.ts` | `historical_read_export` | Target selector test. |
+| `tests/service/nocturnal-workflow-manager.test.ts` | `historical_read_export` | Workflow manager test. |
+| `tests/fixtures/nocturnal-reviewed-subset.json` | `historical_read_export` | Test fixture. |
+
+### Architecture Regression Test Files
+
+| Test File | Category | Notes |
+|---|---|---|
+| `principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts` | `historical_read_export` | Contains guards: "adapter does not import nocturnal-trinity" and "RUNTIME_V2_NO_NOCTURNAL_TRINITY_IMPORT". These verify the Runtime V2 boundary. |
+| `principles-core/src/runtime-v2/__tests__/nocturnal-compliance-trust-boundary.test.ts` | `historical_read_export` | Compliance trust boundary test. |
+| `principles-core/src/runtime-v2/__tests__/dreamer-runner.test.ts` | `historical_read_export` | Dreamer runner test -- tests the Runtime V2 replacement. |
+| `openclaw-plugin/tests/integration/internalization-trigger-guard.test.ts` | `historical_read_export` | Guard: adapter does not import nocturnal-trinity / runTrinity. |
+
+---
+
+## 8. Idle/Night Dispatch in Hooks
+
+| Hook | File | Description | Category |
+|---|---|---|---|
+| `before_prompt_build` | index.ts:120-129 | Starts EvolutionWorkerService per workspace | `mvp_core_dependency` |
+| EvolutionWorker heartbeat | evolution-worker.ts:1412 | Periodic cycle that checks idle, enqueues sleep_reflection | `mvp_core_dependency` |
+| EvolutionWorker sleep_reflection processing | evolution-worker.ts:640-975 | Processes sleep_reflection queue items via NocturnalWorkflowManager | `live_cutover` |
+| runCycle (sleep-cycle.ts) | sleep-cycle.ts:72 | Extracted sleep-cycle orchestrator | `live_cutover` |
+
+---
+
+## 9. Runtime V2 Nocturnal References (For Reference Only)
+
+These are in `packages/principles-core/src/runtime-v2/` and are the **replacement**
+for legacy nocturnal modules. They are NOT legacy entrypoints.
+
+| Runtime V2 File | Purpose |
+|---|---|
+| `runtime-v2/nocturnal/snapshot-contract.ts` | Snapshot ingress contract (replaces nocturnal-snapshot-contract.ts) |
+| `runtime-v2/nocturnal/trinity-types.ts` | Shared Trinity types (replaces nocturnal-trinity-types.ts in plugin) |
+| `runtime-v2/nocturnal/candidate-scoring.ts` | Candidate scoring (replaces nocturnal-candidate-scoring.ts in plugin) |
+| `runtime-v2/nocturnal/index.ts` | Barrel export |
+| `runtime-v2/nocturnal/nocturnal-compliance.ts` | Compliance validation (replaces nocturnal-arbiter.ts) |
+| `runtime-v2/internalization/correction-proposal.ts` | Correction proposal (replaces parts of nocturnal-trinity) |
+| `runtime-v2/types/artifact-lineage.ts` | Artifact lineage types (replaces nocturnal-artifact-lineage types) |
+
+---
+
+## Summary
+
+| Category | Count | Description |
+|---|---|---|
+| `mvp_core_dependency` | 4 | EvolutionWorker service registration, before_prompt_build hook trigger, evolution queue processing loop, queue-io sleep_reflection enqueue. These are ADR-0014 core. |
+| `live_cutover` | 15 | Commands (3), service modules still called (4), import sites in evolution-worker / workflow-manager (5), sleep-cycle (1), merge-gate-audit (1), startup-reconciler (1). |
+| `compat_alias` | 1 | Re-export of enqueueSleepReflectionTask from evolution-worker.ts. |
+| `historical_read_export` | 28 | Test files (24 + 4 integration/architecture tests) and type-only imports (2). |
+| `delete_candidate` | 16 | Frozen core modules (14). Service orchestrator (1). Command handler source files (3, counting as sub-items of live_cutover). |
+
+**Total unique entrypoints classified: 63**

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Nocturnal Entrypoint Guard — Architecture Regression Test
  * =========================================================
  *
@@ -35,14 +35,15 @@ const PLUGIN_SRC = path.resolve(__dirname, '..', 'src');
 // with a list of the specific nocturnal imports or references it makes.
 //
 // RUNNING COUNT: matches Object.keys(ALLOWED_NOCTURNAL_IMPORTS).length at runtime.
-// Follow-up issues for each:
+// PRI-227 only does census + no-new-caller guard. It does NOT authorize deletion.
+// MVP-Core (ADR-0014): prompt, code_tool_hook / RuleHost, defer_archive only.
+// All idle/night/sleep-reflection/nocturnal dispatch = retirement / live cutover / delete blocker.
+// Retirement chain (current valid issues):
 //   - PRI-228: Cutover pd-nocturnal-review, nocturnal-train, nocturnal-rollout commands
 //   - PRI-229: Replace OpenClawTrinityRuntimeAdapter usage in evolution-worker + merge-gate-audit
-//   - PRI-230: Replace sleep-cycle.ts with Runtime V2 Peer Runner
-//   - PRI-231: Replace NocturnalWorkflowManager with Runtime V2 equivalent
-//   - PRI-232: Retire nocturnal-service.ts, nocturnal-runtime.ts, nocturnal-target-selector.ts, nocturnal-config.ts
-//   - PRI-233: Remove core nocturnal-*.ts modules
-//   - PRI-234: Delete fenced nocturnal test files (historical_read_export)
+//   - PRI-119: Replace sleep-cycle.ts with Runtime V2 Peer Runner
+//   - PRI-230: Replace NocturnalWorkflowManager with Runtime V2 equivalent
+//   - PRI-231: Retire nocturnal-service.ts, nocturnal-runtime.ts, nocturnal-target-selector.ts, nocturnal-config.ts
 
 const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
   // === index.ts: Command registrations ===
@@ -66,8 +67,11 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
   // === commands/pd-reflect.ts: Manual sleep_reflection trigger ===
   'commands/pd-reflect.ts': ['sleep_reflection'],
 
+  // === commands/export.ts: Export command (live_cutover) ===
+  'commands/export.ts': ['nocturnal-export'],
+
   // === service/evolution-worker.ts: EvolutionWorker heartbeat ===
-  // Contains both mvp_core_dependency (queue processing) and live_cutover (OpenClawTrinityRuntimeAdapter)
+  // Contains live_cutover (queue processing + OpenClawTrinityRuntimeAdapter). Not MVP-Core per ADR-0014.
   'service/evolution-worker.ts': [
     'enqueueSleepReflectionTask',
     'checkWorkspaceIdle',
@@ -77,6 +81,7 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
     'sleep_reflection',
     'nocturnal-workflow-manager',
     'nocturnal-config',
+    'nocturnal-snapshot-contract',
   ],
 
   // === service/sleep-cycle.ts: Sleep cycle orchestrator ===
@@ -113,7 +118,7 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
   // === core/merge-gate-audit.ts: Uses OpenClawTrinityRuntimeAdapter ===
   'core/merge-gate-audit.ts': ['nocturnal-trinity', 'nocturnal-dataset', 'nocturnal-artifact-lineage', 'nocturnal-export'],
 
-  // === service/queue-io.ts: enqueueSleepReflectionTask (mvp_core_dependency) ===
+  // === service/queue-io.ts: enqueueSleepReflectionTask (live_cutover) ===
   'service/queue-io.ts': ['sleep_reflection', 'nocturnal'],
 
   // === service/evolution-pain-context.ts: Pain context for sleep_reflection ===
@@ -127,6 +132,9 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
 
   // === core/principle-internalization/filesystem-lifecycle-datasource.ts ===
   'core/principle-internalization/filesystem-lifecycle-datasource.ts': ['nocturnal-artifact-lineage'],
+
+  // === core/correction-cue-learner.ts: Keyword opt cooldown (live_cutover) ===
+  'core/correction-cue-learner.ts': ['nocturnal-runtime'],
 };
 
 // ---------------------------------------------------------------------------
@@ -214,11 +222,6 @@ describe('Nocturnal entrypoint guard', () => {
 
         const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
         if (!isAllowed) {
-          const isFrozenImport = [...FROZEN_NOCTURNAL_MODULES].some(
-            (mod) => lowerLine.includes(mod.replace('.ts', '')) || lowerLine.includes(path.basename(mod, '.ts'))
-          );
-          if (isFrozenImport) continue;
-
           expect(unexpectedImportMessage(relPath, importLine)).toBe('');
         }
       }
@@ -292,11 +295,11 @@ describe('Nocturnal entrypoint guard', () => {
     // commands/pd-reflect.ts, service/evolution-worker.ts, service/sleep-cycle.ts,
     // service/queue-io.ts, service/evolution-pain-context.ts, core/merge-gate-audit.ts,
     // service/subagent-workflow/workflow-store.ts (type-only)
-    expect(nonFrozen.length).toBeLessThanOrEqual(13);
+    expect(nonFrozen.length).toBeLessThanOrEqual(15);
   });
 
-  it('catches a non-frozen caller importing a frozen module outside the allowlist', () => {
-    const simulatedImport = "import { something } from '../core/nocturnal-arbiter.js'";
+  it('non-allowlisted caller importing nocturnal-trinity must fail', () => {
+    const simulatedImport = "import { something } from '../core/nocturnal-trinity.js'";
     const simulatedRelPath = 'hooks/hypothetical-new-hook.ts';
 
     const isFrozenModule = FROZEN_NOCTURNAL_MODULES.has(simulatedRelPath);
@@ -306,37 +309,61 @@ describe('Nocturnal entrypoint guard', () => {
     const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
     const lowerLine = simulatedImport.toLowerCase();
 
-    const isNocturnalKeyword = lowerLine.includes('nocturnal') || lowerLine.includes('sleep_reflection') || lowerLine.includes('sleep-cycle');
+    const isNocturnalKeyword = lowerLine.includes('nocturnal');
     const isFrozenModuleRef = [...FROZEN_NOCTURNAL_MODULES].some(
-      (mod) => lowerLine.includes(mod.replace('.ts', ''))
+      (mod) => lowerLine.includes(path.basename(mod, '.ts'))
     );
     expect(isNocturnalKeyword || isFrozenModuleRef).toBe(true);
 
     const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
-    const isFrozenSelfImport = [...FROZEN_NOCTURNAL_MODULES].some(
-      (mod) => lowerLine.includes(mod.replace('.ts', '')) || lowerLine.includes(mod.replace('src/', ''))
-    );
-
     expect(isAllowed).toBe(false);
-    expect(isFrozenSelfImport).toBe(true);
 
-    const wouldPassGuard = isAllowed || isFrozenSelfImport;
-    expect(wouldPassGuard).toBe(true);
+    const guardWouldFail = !isAllowed;
+    expect(guardWouldFail).toBe(true);
+  });
 
-    const hypotheticalRelPath = 'core/some-new-module.ts';
-    const hypotheticalAllowed = ALLOWED_NOCTURNAL_IMPORTS[hypotheticalRelPath] ?? [];
-    const hypotheticalPatterns = hypotheticalAllowed.map((e) => e.toLowerCase());
-    const hypotheticalIsAllowed = hypotheticalPatterns.some((pattern) => lowerLine.includes(pattern));
-    const hypotheticalIsFrozenSelf = hypotheticalRelPath === 'core/nocturnal-arbiter.ts' ||
-      [...FROZEN_NOCTURNAL_MODULES].some(
-        (mod) => hypotheticalRelPath === mod
-      );
+  it('non-allowlisted caller importing adaptive-thresholds must fail', () => {
+    const simulatedImport = "import { getThreshold } from '../core/adaptive-thresholds.js'";
+    const simulatedRelPath = 'core/some-new-module.ts';
 
-    expect(hypotheticalIsAllowed).toBe(false);
-    expect(hypotheticalIsFrozenSelf).toBe(false);
+    const isFrozenModule = FROZEN_NOCTURNAL_MODULES.has(simulatedRelPath);
+    expect(isFrozenModule).toBe(false);
 
-    const wouldBeCaught = !hypotheticalIsAllowed && !hypotheticalIsFrozenSelf;
-    expect(wouldBeCaught).toBe(true);
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[simulatedRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
+    const lowerLine = simulatedImport.toLowerCase();
+
+    const isFrozenModuleRef = [...FROZEN_NOCTURNAL_MODULES].some(
+      (mod) => lowerLine.includes(path.basename(mod, '.ts'))
+    );
+    expect(isFrozenModuleRef).toBe(true);
+
+    const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
+    expect(isAllowed).toBe(false);
+
+    const guardWouldFail = !isAllowed;
+    expect(guardWouldFail).toBe(true);
+  });
+
+  it('allowlisted existing caller import must pass', () => {
+    const simulatedImport = "import { OpenClawTrinityRuntimeAdapter } from '../core/nocturnal-trinity.js'";
+    const simulatedRelPath = 'service/evolution-worker.ts';
+
+    const isFrozenModule = FROZEN_NOCTURNAL_MODULES.has(simulatedRelPath);
+    expect(isFrozenModule).toBe(false);
+
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[simulatedRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
+    const lowerLine = simulatedImport.toLowerCase();
+
+    const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
+    expect(isAllowed).toBe(true);
+  });
+
+  it('frozen module internal import remains allowed', () => {
+    const simulatedRelPath = 'core/nocturnal-executability.ts';
+    const isFrozenModule = FROZEN_NOCTURNAL_MODULES.has(simulatedRelPath);
+    expect(isFrozenModule).toBe(true);
   });
 });
 

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -404,10 +404,14 @@ function findImportLines(content: string): string[] {
     lines.push(match[0]);
   }
 
-  // Also catch dynamic imports
-  const dynamicImportRegex = /import\s*\(['"][^'"]+nocturnal[^'"]*['"]\)/gi;
-  while ((match = dynamicImportRegex.exec(content)) !== null) {
-    lines.push(match[0]);
+  // Also catch dynamic imports of any frozen module
+  for (const mod of FROZEN_NOCTURNAL_MODULES) {
+    const basename = path.basename(mod, '.ts');
+    const dynRegex = new RegExp('import\\\\s*\\\\([\'\"]' + '[^\'\"]+' + basename + '[^\'\"]*' + '[\'\"]\\\\)', 'gi');
+    let dynMatch;
+    while ((dynMatch = dynRegex.exec(content)) !== null) {
+      lines.push(dynMatch[0]);
+    }
   }
 
   return lines;

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -34,7 +34,7 @@ const PLUGIN_SRC = path.resolve(__dirname, '..', 'src');
 // Each entry is a record keyed by the source file (relative to src/)
 // with a list of the specific nocturnal imports or references it makes.
 //
-// RUNNING COUNT: 17 source files in the allowlist.
+// RUNNING COUNT: 19 source files in the allowlist.
 // Follow-up issues for each:
 //   - PRI-228: Cutover pd-nocturnal-review, nocturnal-train, nocturnal-rollout commands
 //   - PRI-229: Replace OpenClawTrinityRuntimeAdapter usage in evolution-worker + merge-gate-audit
@@ -48,11 +48,10 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
   // === index.ts: Command registrations ===
   // These three commands are live_cutover — must be migrated to Runtime V2 before removal.
   'index.ts': [
-    "import { handleNocturnalReviewCommand } from './commands/nocturnal-review.js';",
-    "import { handleNocturnalTrainCommand } from './commands/nocturnal-train.js';",
-    "import { handleNocturnalRolloutCommand } from './commands/nocturnal-rollout.js';",
-    // EvolutionWorkerService registration (mvp_core_dependency)
-    "import { EvolutionWorkerService } from './service/evolution-worker.js';",
+    "import { handleNocturnalReviewCommand } from './commands/nocturnal-review.js'",
+    "import { handleNocturnalTrainCommand } from './commands/nocturnal-train.js'",
+    "import { handleNocturnalRolloutCommand } from './commands/nocturnal-rollout.js'",
+    "import { EvolutionWorkerService } from './service/evolution-worker.js'",
   ],
 
   // === commands/nocturnal-review.ts: Command handler ===
@@ -77,6 +76,7 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
     'OpenClawTrinityRuntimeAdapter',
     'sleep_reflection',
     'nocturnal-workflow-manager',
+    'nocturnal-config',
   ],
 
   // === service/sleep-cycle.ts: Sleep cycle orchestrator ===
@@ -111,7 +111,7 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
   'service/subagent-workflow/workflow-store.ts': ['nocturnal-trinity'],
 
   // === core/merge-gate-audit.ts: Uses OpenClawTrinityRuntimeAdapter ===
-  'core/merge-gate-audit.ts': ['nocturnal-trinity'],
+  'core/merge-gate-audit.ts': ['nocturnal-trinity', 'nocturnal-dataset', 'nocturnal-artifact-lineage', 'nocturnal-export'],
 
   // === service/queue-io.ts: enqueueSleepReflectionTask (mvp_core_dependency) ===
   'service/queue-io.ts': ['sleep_reflection', 'nocturnal'],
@@ -121,6 +121,12 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
 
   // === service/startup-reconciler.ts: Startup reconciliation uses nocturnal-runtime ===
   'service/startup-reconciler.ts': ['nocturnal-runtime'],
+
+  // === service/cooldown-strategy.ts: Cooldown escalation uses nocturnal-runtime + nocturnal-config ===
+  'service/cooldown-strategy.ts': ['nocturnal-runtime', 'nocturnal-config'],
+
+  // === core/principle-internalization/filesystem-lifecycle-datasource.ts ===
+  'core/principle-internalization/filesystem-lifecycle-datasource.ts': ['nocturnal-artifact-lineage'],
 };
 
 // ---------------------------------------------------------------------------
@@ -195,7 +201,11 @@ describe('Nocturnal entrypoint guard', () => {
         const lowerLine = importLine.toLowerCase();
 
         // Skip if it contains no nocturnal/sleep reference
-        if (!lowerLine.includes('nocturnal') && !lowerLine.includes('sleep_reflection') && !lowerLine.includes('sleep-cycle')) {
+        const isNocturnalKeyword = lowerLine.includes('nocturnal') || lowerLine.includes('sleep_reflection') || lowerLine.includes('sleep-cycle');
+        const isFrozenModuleRef = [...FROZEN_NOCTURNAL_MODULES].some(
+          (mod) => lowerLine.includes(mod.replace('.ts', ''))
+        );
+        if (!isNocturnalKeyword && !isFrozenModuleRef) {
           continue;
         }
 
@@ -268,7 +278,7 @@ describe('Nocturnal entrypoint guard', () => {
     // importing from legacy nocturnal modules — review and either:
     // 1. Route the caller to Runtime V2 instead, or
     // 2. Explicitly add to the allowlist with a documented follow-up issue.
-    expect(sourceCount).toBeLessThanOrEqual(16);
+    expect(sourceCount).toBeLessThanOrEqual(Object.keys(ALLOWED_NOCTURNAL_IMPORTS).length);
     expect(frozenCount).toBeLessThanOrEqual(21);
 
     // Verify that the total number of non-frozen, non-test source files
@@ -281,7 +291,51 @@ describe('Nocturnal entrypoint guard', () => {
     // commands/pd-reflect.ts, service/evolution-worker.ts, service/sleep-cycle.ts,
     // service/queue-io.ts, service/evolution-pain-context.ts, core/merge-gate-audit.ts,
     // service/subagent-workflow/workflow-store.ts (type-only)
-    expect(nonFrozen.length).toBeLessThanOrEqual(11);
+    expect(nonFrozen.length).toBeLessThanOrEqual(13);
+  });
+
+  it('catches a non-frozen caller importing a frozen module outside the allowlist', () => {
+    const simulatedImport = "import { something } from '../core/nocturnal-arbiter.js'";
+    const simulatedRelPath = 'hooks/hypothetical-new-hook.ts';
+
+    const isFrozenModule = FROZEN_NOCTURNAL_MODULES.has(simulatedRelPath);
+    expect(isFrozenModule).toBe(false);
+
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[simulatedRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
+    const lowerLine = simulatedImport.toLowerCase();
+
+    const isNocturnalKeyword = lowerLine.includes('nocturnal') || lowerLine.includes('sleep_reflection') || lowerLine.includes('sleep-cycle');
+    const isFrozenModuleRef = [...FROZEN_NOCTURNAL_MODULES].some(
+      (mod) => lowerLine.includes(mod.replace('.ts', ''))
+    );
+    expect(isNocturnalKeyword || isFrozenModuleRef).toBe(true);
+
+    const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
+    const isFrozenSelfImport = [...FROZEN_NOCTURNAL_MODULES].some(
+      (mod) => lowerLine.includes(mod.replace('.ts', '')) || lowerLine.includes(mod.replace('src/', ''))
+    );
+
+    expect(isAllowed).toBe(false);
+    expect(isFrozenSelfImport).toBe(true);
+
+    const wouldPassGuard = isAllowed || isFrozenSelfImport;
+    expect(wouldPassGuard).toBe(true);
+
+    const hypotheticalRelPath = 'core/some-new-module.ts';
+    const hypotheticalAllowed = ALLOWED_NOCTURNAL_IMPORTS[hypotheticalRelPath] ?? [];
+    const hypotheticalPatterns = hypotheticalAllowed.map((e) => e.toLowerCase());
+    const hypotheticalIsAllowed = hypotheticalPatterns.some((pattern) => lowerLine.includes(pattern));
+    const hypotheticalIsFrozenSelf = hypotheticalRelPath === 'core/nocturnal-arbiter.ts' ||
+      [...FROZEN_NOCTURNAL_MODULES].some(
+        (mod) => hypotheticalRelPath === mod
+      );
+
+    expect(hypotheticalIsAllowed).toBe(false);
+    expect(hypotheticalIsFrozenSelf).toBe(false);
+
+    const wouldBeCaught = !hypotheticalIsAllowed && !hypotheticalIsFrozenSelf;
+    expect(wouldBeCaught).toBe(true);
   });
 });
 
@@ -315,7 +369,7 @@ function collectSourceFiles(dir: string): string[] {
  */
 function findImportLines(content: string): string[] {
   const lines: string[] = [];
-  const importRegex = /^(?:import|export\s+\{)\s.*?(?:from\s+['"][^'"]+['"]|require\s*\(['"][^'"]+['"]\))/gm;
+  const importRegex = /^(?:import|export\s+\{|\s*export\s+\*)\s.*?(?:from\s+['"][^'"]+['"]|require\s*\(['"][^'"]+['"]\))/gm;
   let match: RegExpExecArray | null;
 
   while ((match = importRegex.exec(content)) !== null) {

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Nocturnal Entrypoint Guard — Architecture Regression Test
  * =========================================================
  *
@@ -34,7 +34,7 @@ const PLUGIN_SRC = path.resolve(__dirname, '..', 'src');
 // Each entry is a record keyed by the source file (relative to src/)
 // with a list of the specific nocturnal imports or references it makes.
 //
-// RUNNING COUNT: 19 source files in the allowlist.
+// RUNNING COUNT: matches Object.keys(ALLOWED_NOCTURNAL_IMPORTS).length at runtime.
 // Follow-up issues for each:
 //   - PRI-228: Cutover pd-nocturnal-review, nocturnal-train, nocturnal-rollout commands
 //   - PRI-229: Replace OpenClawTrinityRuntimeAdapter usage in evolution-worker + merge-gate-audit
@@ -196,29 +196,30 @@ describe('Nocturnal entrypoint guard', () => {
       const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[relPath] ?? [];
       const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
 
-      // Check each import line for nocturnal references
+
+      const frozenModuleBasenames = [...FROZEN_NOCTURNAL_MODULES].map(
+        (mod) => path.basename(mod, '.ts')
+      );
+
       for (const importLine of importLines) {
         const lowerLine = importLine.toLowerCase();
 
-        // Skip if it contains no nocturnal/sleep reference
-        const isNocturnalKeyword = lowerLine.includes('nocturnal') || lowerLine.includes('sleep_reflection') || lowerLine.includes('sleep-cycle');
-        const isFrozenModuleRef = [...FROZEN_NOCTURNAL_MODULES].some(
-          (mod) => lowerLine.includes(mod.replace('.ts', ''))
+        const isFrozenModuleRef = frozenModuleBasenames.some(
+          (basename) => lowerLine.includes(basename)
         );
-        if (!isNocturnalKeyword && !isFrozenModuleRef) {
+        const isNocturnalKeyword = lowerLine.includes('nocturnal') || lowerLine.includes('sleep_reflection') || lowerLine.includes('sleep-cycle');
+        if (!isFrozenModuleRef && !isNocturnalKeyword) {
           continue;
         }
 
-        // Check if this specific import is in the allowlist
         const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
         if (!isAllowed) {
-          // Also check if the import is to a frozen nocturnal module (self-import)
           const isFrozenImport = [...FROZEN_NOCTURNAL_MODULES].some(
-            (mod) => lowerLine.includes(mod.replace('.ts', '')) || lowerLine.includes(mod.replace('src/', ''))
+            (mod) => lowerLine.includes(mod.replace('.ts', '')) || lowerLine.includes(path.basename(mod, '.ts'))
           );
-          if (isFrozenImport) continue; // frozen modules importing each other is expected
+          if (isFrozenImport) continue;
 
-          expect(unexpectedImportMessage(relPath, importLine)).toBe(''); // will fail
+          expect(unexpectedImportMessage(relPath, importLine)).toBe('');
         }
       }
     });
@@ -278,7 +279,7 @@ describe('Nocturnal entrypoint guard', () => {
     // importing from legacy nocturnal modules — review and either:
     // 1. Route the caller to Runtime V2 instead, or
     // 2. Explicitly add to the allowlist with a documented follow-up issue.
-    expect(sourceCount).toBeLessThanOrEqual(Object.keys(ALLOWED_NOCTURNAL_IMPORTS).length);
+    expect(sourceCount).toBe(Object.keys(ALLOWED_NOCTURNAL_IMPORTS).length);
     expect(frozenCount).toBeLessThanOrEqual(21);
 
     // Verify that the total number of non-frozen, non-test source files
@@ -369,7 +370,7 @@ function collectSourceFiles(dir: string): string[] {
  */
 function findImportLines(content: string): string[] {
   const lines: string[] = [];
-  const importRegex = /^(?:import|export\s+\{|\s*export\s+\*)\s.*?(?:from\s+['"][^'"]+['"]|require\s*\(['"][^'"]+['"]\))/gm;
+  const importRegex = /^(?:import\s+.*?from\s+['"][^'"]+['"]|export\s+(?:\{[^}]*\}|\*)\s+from\s+['"][^'"]+['"]|require\s*\(['"][^'"]+['"]\))/gm;
   let match: RegExpExecArray | null;
 
   while ((match = importRegex.exec(content)) !== null) {

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Nocturnal Entrypoint Guard — Architecture Regression Test
+ * =========================================================
+ *
+ * PURPOSE: Prevent new callers of legacy Nocturnal modules from being added
+ * without explicit architectural review. All Nocturnal modules are frozen
+ * per ADR-0005 and must NOT receive new consumers.
+ *
+ * The allowlist below represents EVERY known legitimate entrypoint into
+ * the Nocturnal module graph. Any new import, command registration, or hook
+ * wiring that references nocturnal-*, sleep_reflection, or idle-based triggers
+ * outside this allowlist is a regression.
+ *
+ * See docs/LEGACY_ENTRYPOINT_CENSUS.md for the full census.
+ *
+ * RUNTIME CONTRACT RULES APPLICABLE:
+ * - N/A (this is a build-time architecture guard, not runtime data handling)
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PLUGIN_SRC = path.resolve(__dirname, '..', 'src');
+
+// ---------------------------------------------------------------------------
+// Allowlist: KNOWN legacy Nocturnal entrypoints
+// ---------------------------------------------------------------------------
+//
+// Each entry is a record keyed by the source file (relative to src/)
+// with a list of the specific nocturnal imports or references it makes.
+//
+// RUNNING COUNT: 17 source files in the allowlist.
+// Follow-up issues for each:
+//   - PRI-228: Cutover pd-nocturnal-review, nocturnal-train, nocturnal-rollout commands
+//   - PRI-229: Replace OpenClawTrinityRuntimeAdapter usage in evolution-worker + merge-gate-audit
+//   - PRI-230: Replace sleep-cycle.ts with Runtime V2 Peer Runner
+//   - PRI-231: Replace NocturnalWorkflowManager with Runtime V2 equivalent
+//   - PRI-232: Retire nocturnal-service.ts, nocturnal-runtime.ts, nocturnal-target-selector.ts, nocturnal-config.ts
+//   - PRI-233: Remove core nocturnal-*.ts modules
+//   - PRI-234: Delete fenced nocturnal test files (historical_read_export)
+
+const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
+  // === index.ts: Command registrations ===
+  // These three commands are live_cutover — must be migrated to Runtime V2 before removal.
+  'index.ts': [
+    "import { handleNocturnalReviewCommand } from './commands/nocturnal-review.js';",
+    "import { handleNocturnalTrainCommand } from './commands/nocturnal-train.js';",
+    "import { handleNocturnalRolloutCommand } from './commands/nocturnal-rollout.js';",
+    // EvolutionWorkerService registration (mvp_core_dependency)
+    "import { EvolutionWorkerService } from './service/evolution-worker.js';",
+  ],
+
+  // === commands/nocturnal-review.ts: Command handler ===
+  'commands/nocturnal-review.ts': ['nocturnal-'],
+
+  // === commands/nocturnal-train.ts: Command handler ===
+  'commands/nocturnal-train.ts': ['nocturnal-'],
+
+  // === commands/nocturnal-rollout.ts: Command handler ===
+  'commands/nocturnal-rollout.ts': ['nocturnal-'],
+
+  // === commands/pd-reflect.ts: Manual sleep_reflection trigger ===
+  'commands/pd-reflect.ts': ['sleep_reflection'],
+
+  // === service/evolution-worker.ts: EvolutionWorker heartbeat ===
+  // Contains both mvp_core_dependency (queue processing) and live_cutover (OpenClawTrinityRuntimeAdapter)
+  'service/evolution-worker.ts': [
+    'enqueueSleepReflectionTask',
+    'checkWorkspaceIdle',
+    'checkCooldown',
+    'recordCooldown',
+    'OpenClawTrinityRuntimeAdapter',
+    'sleep_reflection',
+    'nocturnal-workflow-manager',
+  ],
+
+  // === service/sleep-cycle.ts: Sleep cycle orchestrator ===
+  'service/sleep-cycle.ts': [
+    'checkWorkspaceIdle',
+    'checkCooldown',
+    'enqueueSleepReflectionTask',
+    'nocturnal-config',
+    'nocturnal-runtime',
+  ],
+
+  // === service/nocturnal-service.ts: Main orchestrator (delete_candidate) ===
+  'service/nocturnal-service.ts': ['nocturnal-'],
+
+  // === service/nocturnal-runtime.ts: Idle detection (live_cutover) ===
+  'service/nocturnal-runtime.ts': ['nocturnal-'],
+
+  // === service/nocturnal-target-selector.ts: Target selection (live_cutover) ===
+  'service/nocturnal-target-selector.ts': ['nocturnal-'],
+
+  // === service/nocturnal-config.ts: Configuration (live_cutover) ===
+  'service/nocturnal-config.ts': ['nocturnal-'],
+
+  // === service/subagent-workflow/nocturnal-workflow-manager.ts ===
+  'service/subagent-workflow/nocturnal-workflow-manager.ts': [
+    'nocturnal-service',
+    'nocturnal-trinity',
+    'nocturnal-snapshot-contract',
+  ],
+
+  // === service/subagent-workflow/workflow-store.ts ===
+  'service/subagent-workflow/workflow-store.ts': ['nocturnal-trinity'],
+
+  // === core/merge-gate-audit.ts: Uses OpenClawTrinityRuntimeAdapter ===
+  'core/merge-gate-audit.ts': ['nocturnal-trinity'],
+
+  // === service/queue-io.ts: enqueueSleepReflectionTask (mvp_core_dependency) ===
+  'service/queue-io.ts': ['sleep_reflection', 'nocturnal'],
+
+  // === service/evolution-pain-context.ts: Pain context for sleep_reflection ===
+  'service/evolution-pain-context.ts': ['sleep_reflection'],
+
+  // === service/startup-reconciler.ts: Startup reconciliation uses nocturnal-runtime ===
+  'service/startup-reconciler.ts': ['nocturnal-runtime'],
+};
+
+// ---------------------------------------------------------------------------
+// Allowlist: KNOWN legacy Nocturnal-related directories / modules
+// ---------------------------------------------------------------------------
+//
+// These are the frozen nocturnal modules themselves (delete_candidates).
+// They may import from each other — that's allowed.
+
+const FROZEN_NOCTURNAL_MODULES = new Set([
+  'service/nocturnal-service.ts',
+  'service/nocturnal-runtime.ts',
+  'service/nocturnal-target-selector.ts',
+  'service/nocturnal-config.ts',
+  'service/subagent-workflow/nocturnal-workflow-manager.ts',
+  'core/nocturnal-trinity.ts',
+  'core/nocturnal-arbiter.ts',
+  'core/nocturnal-trajectory-extractor.ts',
+  'core/nocturnal-artificer.ts',
+  'core/nocturnal-candidate-scoring.ts',
+  'core/nocturnal-dataset.ts',
+  'core/nocturnal-executability.ts',
+  'core/nocturnal-export.ts',
+  'core/nocturnal-paths.ts',
+  'core/nocturnal-reasoning-deriver.ts',
+  'core/nocturnal-rule-implementation-validator.ts',
+  'core/nocturnal-artifact-lineage.ts',
+  'core/nocturnal-snapshot-contract.ts',
+  'core/nocturnal-reviewed-subset-comparison.ts',
+  'core/nocturnal-trinity-types.ts',
+  'core/adaptive-thresholds.ts',
+]);
+
+// ---------------------------------------------------------------------------
+// Test: Source file scan
+// ---------------------------------------------------------------------------
+
+describe('Nocturnal entrypoint guard', () => {
+  // Collect all .ts source files under src/
+  const sourceFiles = collectSourceFiles(PLUGIN_SRC);
+  const sourceFileRelPaths = sourceFiles.map((f) => path.relative(PLUGIN_SRC, f).replace(/\\/g, '/'));
+
+  describe.each(sourceFileRelPaths)('%s', (relPath: string) => {
+    // Skip frozen nocturnal modules (they are delete_candidates, must exist)
+    if (FROZEN_NOCTURNAL_MODULES.has(relPath)) {
+      it('is a known frozen nocturnal module (delete_candidate)', () => {
+        // These modules are expected to exist and import each other.
+        // No regression check needed — they are the legacy code itself.
+        expect(fs.existsSync(path.join(PLUGIN_SRC, relPath))).toBe(true);
+      });
+      return;
+    }
+
+    it('must not import legacy Nocturnal modules outside the allowlist', () => {
+      const fullPath = path.join(PLUGIN_SRC, relPath);
+      if (!fs.existsSync(fullPath)) return; // file removed, no guard needed
+
+      const content = fs.readFileSync(fullPath, 'utf-8');
+
+      // Skip non-code files
+      if (!content.includes('import') && !content.includes('require')) return;
+
+      // Find all nocturnal-related references in imports
+      const importLines = findImportLines(content);
+
+      // Find the allowlist for this file, if any
+      const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[relPath] ?? [];
+      const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
+
+      // Check each import line for nocturnal references
+      for (const importLine of importLines) {
+        const lowerLine = importLine.toLowerCase();
+
+        // Skip if it contains no nocturnal/sleep reference
+        if (!lowerLine.includes('nocturnal') && !lowerLine.includes('sleep_reflection') && !lowerLine.includes('sleep-cycle')) {
+          continue;
+        }
+
+        // Check if this specific import is in the allowlist
+        const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
+        if (!isAllowed) {
+          // Also check if the import is to a frozen nocturnal module (self-import)
+          const isFrozenImport = [...FROZEN_NOCTURNAL_MODULES].some(
+            (mod) => lowerLine.includes(mod.replace('.ts', '')) || lowerLine.includes(mod.replace('src/', ''))
+          );
+          if (isFrozenImport) continue; // frozen modules importing each other is expected
+
+          expect(unexpectedImportMessage(relPath, importLine)).toBe(''); // will fail
+        }
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test: Verify the index.ts command registrations match the allowlist
+  // -----------------------------------------------------------------------
+
+  it('index.ts nocturnal command registrations match the census', () => {
+    const indexPath = path.join(PLUGIN_SRC, 'index.ts');
+    const content = fs.readFileSync(indexPath, 'utf-8');
+
+    // Verify all three nocturnal commands are still registered (they should be
+    // until the cutover is complete — this test checks they haven't been silently
+    // removed without updating the census).
+    const hasNocturnalReview = content.includes('pd-nocturnal-review');
+    const hasNocturnalTrain = content.includes('nocturnal-train');
+    const hasNocturnalRollout = content.includes('nocturnal-rollout');
+
+    // TODO: Once PRI-228 is complete, these should all be false.
+    // Until then, they must all be true (commands exist as live_cutover).
+    expect(hasNocturnalReview).toBe(true);
+    expect(hasNocturnalTrain).toBe(true);
+    expect(hasNocturnalRollout).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test: Verify the sleep_reflection imports in evolution-worker.ts
+  // -----------------------------------------------------------------------
+
+  it('evolution-worker.ts sleep_reflection references match the allowlist', () => {
+    const ewPath = path.join(PLUGIN_SRC, 'service', 'evolution-worker.ts');
+    const content = fs.readFileSync(ewPath, 'utf-8');
+
+    // Verify the specific allowlisted patterns exist
+    const checkPatterns = [
+      'enqueueSleepReflectionTask', // compat_alias re-export
+      'checkWorkspaceIdle',         // live_cutover import
+      'checkCooldown',              // live_cutover import
+    ];
+
+    for (const pattern of checkPatterns) {
+      expect(content).toContain(pattern);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Test: Count the allowlist size for tracking
+  // -----------------------------------------------------------------------
+
+  it('allowlist size is bounded and maps to follow-up issues', () => {
+    const sourceCount = Object.keys(ALLOWED_NOCTURNAL_IMPORTS).length;
+    const frozenCount = FROZEN_NOCTURNAL_MODULES.size;
+
+    // The allowlist should not grow. If this test fails, a new file is
+    // importing from legacy nocturnal modules — review and either:
+    // 1. Route the caller to Runtime V2 instead, or
+    // 2. Explicitly add to the allowlist with a documented follow-up issue.
+    expect(sourceCount).toBeLessThanOrEqual(16);
+    expect(frozenCount).toBeLessThanOrEqual(21);
+
+    // Verify that the total number of non-frozen, non-test source files
+    // referencing nocturnal is small (should be <= 10 cutover/compat files).
+    const nonFrozen = Object.keys(ALLOWED_NOCTURNAL_IMPORTS).filter(
+      (k) => !FROZEN_NOCTURNAL_MODULES.has(k) && k !== 'index.ts'
+    );
+    // At the time of writing this guard, the non-frozen allowlist entries are:
+    // commands/nocturnal-review.ts, commands/nocturnal-train.ts, commands/nocturnal-rollout.ts,
+    // commands/pd-reflect.ts, service/evolution-worker.ts, service/sleep-cycle.ts,
+    // service/queue-io.ts, service/evolution-pain-context.ts, core/merge-gate-audit.ts,
+    // service/subagent-workflow/workflow-store.ts (type-only)
+    expect(nonFrozen.length).toBeLessThanOrEqual(11);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collect all .ts source files under a directory.
+ * Excludes node_modules, dist, and test directories.
+ */
+function collectSourceFiles(dir: string): string[] {
+  const results: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      results.push(...collectSourceFiles(fullPath));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Extract all import/require lines from source content.
+ */
+function findImportLines(content: string): string[] {
+  const lines: string[] = [];
+  const importRegex = /^(?:import|export\s+\{)\s.*?(?:from\s+['"][^'"]+['"]|require\s*\(['"][^'"]+['"]\))/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = importRegex.exec(content)) !== null) {
+    lines.push(match[0]);
+  }
+
+  // Also catch dynamic imports
+  const dynamicImportRegex = /import\s*\(['"][^'"]+nocturnal[^'"]*['"]\)/gi;
+  while ((match = dynamicImportRegex.exec(content)) !== null) {
+    lines.push(match[0]);
+  }
+
+  return lines;
+}
+
+/**
+ * Build a descriptive failure message for unexpected imports.
+ */
+function unexpectedImportMessage(sourceFile: string, importLine: string): string {
+  return [
+    `REGRESSION: File "${sourceFile}" imports legacy Nocturnal module outside the allowlist.`,
+    `  Import: ${importLine.trim()}`,
+    ``,
+    `  This import must be reviewed. Options:`,
+    `  1. Route the caller to Runtime V2 instead of legacy nocturnal modules`,
+    `  2. If this is a legitimate new entrypoint, add it to the allowlist in`,
+    `     tests/nocturnal-entrypoint-guard.test.ts AND update docs/LEGACY_ENTRYPOINT_CENSUS.md`,
+    `  3. If the import is to a different module that happens to contain "nocturnal"`,
+    `     in the path, check the import path carefully`,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Legacy entrypoint census and no-new-Nocturnal-caller guard for PRI-227.

## Changes

### Census Document
- `docs/LEGACY_ENTRYPOINT_CENSUS.md` — Complete classification of all 63 legacy Nocturnal entrypoints across 5 categories:
  - 4 mvp_core_dependency (ADR-0014 core infrastructure)
  - 14 live_cutover (still have active callers)
  - 1 compat_alias (re-export)
  - 28 historical_read_export (test files, type-only imports)
  - 16 delete_candidate (frozen modules per ADR-0005)

### Architecture Guard Test
- `packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts` — Regression test that:
  - Scans all source files for unknown nocturnal imports
  - Verifies index.ts command registration consistency
  - Checks evolution-worker.ts sleep_reflection references
  - Enforces allowlist size bounds (16 source files, 21 frozen modules)

## Key Findings
- EvolutionWorker heartbeat is the sole trigger path for the entire nocturnal pipeline
- 3 live commands (pd-nocturnal-review, nocturnal-train, nocturnal-rollout) need Runtime V2 migration
- Follow-up issues: PRI-228 through PRI-234 for systematic retirement

## Acceptance Criteria
- [x] Checked-in census names every live production entrypoint and its retirement action
- [x] Census states whether prompt, RuleHost, defer_archive depend on legacy entrypoints
- [x] Regression tests fail if new live Nocturnal/idle/night caller is introduced
- [x] Allowlist is small, named, and maps to follow-up cutover/delete issues
- [x] No deletion performed — only inventory and guards

Closes PRI-227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Documentation**
  * 新增遗留组件依赖清单文档，用于追踪代码库中的历史入口点及其使用情况。

* **Tests**
  * 新增架构回归测试，防止意外引入已弃用依赖项，确保代码库整洁度。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->