### PR TITLE
fix(mvp): converge legacy guard, activation baseline, and runtime config boundary

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -101,6 +101,7 @@ Errors where AI assistants wrote code contradicting architecture docs or ADRs.
 | ERR-033 | Operator failure path returns success exit code and breaks JSON contract | PRI-162 |
 | ERR-034 | Canonical runtime config not consumed by caller or cache key | PRI-162 |
 | ERR-035 | Static guard only covers frozen-basename dynamic imports, misses other legacy paths | PRI-227 |
+| ERR-036 | Provider-endpoint configuration source mismatch sends real calls to wrong target | PRI-162 |
 
 ---
 
@@ -278,7 +279,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: When writing validators for untrusted data, never use `if (hasCorrectType) { validate }` — always use `if (!hasCorrectType) { error } else { validate }`. The "skip on wrong type" pattern is always wrong for required fields.
 - **Source**: PRI-192 / PR #638 (reviewer feedback)
 - **Date**: 2026-05-19
-- **Recurrence**: Yes - same pattern as ERR-001, ERR-005, ERR-007. Recurred 2026-05-23 in PRI-207 (PR #680): `extractJsonObject` fenced-code path parsed valid non-object JSON (array/null/string/number/boolean) but fell through to brace scan instead of returning null, allowing array payloads to be treated as objects. Same root cause: validator (fenced parse) silently skips invalid type instead of failing loud.
+- **Recurrence**: Yes - same pattern as ERR-001, ERR-005, ERR-007. Recurred 2026-05-23 in PRI-207 (PR #680): `extractJsonObject` fenced-code path parsed valid non-object JSON (array/null/string/number/boolean) but fell through to brace scan instead of returning null, allowing array payloads to be treated as objects. Same root cause: validator (fenced parse) silently skips invalid type instead of failing loud. Recurred 2026-05-24 PR #701: `proven-channel-baseline.test.ts` used `if (output) { assert }` pattern for JSON stdout assertions — when `output` was undefined/empty, the test silently passed instead of failing. Fixed by replacing with `expect(output).toBeDefined()` + `expect(typeof output).toBe('string')` before `JSON.parse`.
 
 **[ERR-010]** | Falsy evaluator return silently passes validation instead of recording failure
 
@@ -514,7 +515,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: After writing any CLI failure path, check: does it call `process.exit(1)`? Does `--json` mode output a parseable JSON result? Does the JSON include a `nextAction`? Add a test for each failure path in both text and JSON modes.
 - **Source**: PRI-162 / PR #701
 - **Date**: 2026-05-24
-- **Recurrence**: Same class as ERR-022, ERR-009
+- **Recurrence**: Same class as ERR-022, ERR-009. Recurred 2026-05-24 PR #701: `runtime-internalization-run-once.ts` catch block classified all errors as `config_error`, including runner/orchestrator/artifact failures that are not configuration errors. The `ConfigResolutionError` class was introduced so the catch block can distinguish config resolution failures (decision: `config_error`) from runtime execution failures (decision: `runtime_error`) via `instanceof`, without message substring guessing.
 
 ---
 
@@ -526,7 +527,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: When a canonical config resolver exists, callers must not duplicate its validation logic. After calling the resolver, consume its result directly — no fallback guessing. Cache keys must include all fields that change behavior. Test: file-config-only path, flag-override path, cache isolation between modes.
 - **Source**: PRI-162 / PR #701
 - **Date**: 2026-05-24
-- **Recurrence**: Same class as ERR-031, ERR-004. Recurred 2026-05-24 PR #701: first fix removed pre-check and changed `?? (opts.openclawLocal ? 'local' : 'gateway')` to `?? 'local'`, but (1) `resolveRuntimeConfig()` still did not accept `requestedRuntimeKind`, so `--runtime openclaw-cli --openclaw-gateway` without a workflow policy returned default pi-ai config and the `?? 'local'` fallback silently overrode the user's gateway intent; (2) `runtime=config` still fell through to compatibility fallback instead of failing loud. Fixed by adding `requestedRuntimeKind` to resolver input and removing all `??` fallbacks. Also recurred 2026-05-24 PR #701: `runtime-internalization-run-once.ts` `resolveRuntimeAdapter()` threw on `RuntimeConfigError` but the command had no catch block, so `--json` mode produced no structured output and the process crashed with an unhandled rejection. Fixed by adding a catch block that outputs `{ decision: 'config_error', reason, nextAction }` in JSON mode.
+- **Recurrence**: Same class as ERR-031, ERR-004. Recurred 2026-05-24 PR #701: first fix removed pre-check and changed `?? (opts.openclawLocal ? 'local' : 'gateway')` to `?? 'local'`, but (1) `resolveRuntimeConfig()` still did not accept `requestedRuntimeKind`, so `--runtime openclaw-cli --openclaw-gateway` without a workflow policy returned default pi-ai config and the `?? 'local'` fallback silently overrode the user's gateway intent; (2) `runtime=config` still fell through to compatibility fallback instead of failing loud. Fixed by adding `requestedRuntimeKind` to resolver input and removing all `??` fallbacks. Also recurred 2026-05-24 PR #701: `resolveRuntimeConfig()` silently preferred `openclawLocal` when both `openclawLocal` and `openclawGateway` were true, instead of failing loud with `conflicting_openclaw_mode`. The resolver must itself guard mutually-exclusive inputs; callers cannot be expected to pre-validate flag combinations before calling the canonical resolver. Fixed by adding an explicit conflict check at both the no-policy and has-policy code paths.
 
 ---
 
@@ -542,9 +543,21 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-036]** | Provider-endpoint configuration source mismatch sends real calls to wrong target
+
+- **What happened**: In `llm-e2e-config.ts`, the `baseUrl` default was `'https://token.sensenova.cn/v1'` regardless of the `provider` value. When `LLM_E2E_PROVIDER` was overridden to `openrouter` or `minimax-cn`, the config still defaulted to the sensenova endpoint, causing real LLM calls to be sent to the wrong API target.
+- **Why it's wrong**: Default endpoint URLs must be scoped to the provider they belong to. A provider-specific default that ignores the provider field is a configuration source mismatch — the same class as ERR-034 (canonical config not consumed by caller) where one config field overrides another's semantics. When the provider changes, all provider-specific defaults must change with it.
+- **Correct approach**: Extract the provider variable before computing defaults. Only apply provider-specific defaults (like `baseUrl`) when the provider matches. For non-matching providers, leave the field undefined unless explicitly provided via environment variable.
+- **How to prevent**: When a config has a provider-specific default, always guard it with a provider check. Test: override the provider and verify the default does not carry over from a different provider.
+- **Source**: PRI-162 / PR #701
+- **Date**: 2026-05-24
+- **Recurrence**: Same class as ERR-034
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 35 |
+| Total lessons | 36 |
 | Last updated | 2026-05-24 |
 | Top category | Schema & Type |
 | Recurring errors | 15 |

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -98,6 +98,9 @@ Errors where AI assistants wrote code contradicting architecture docs or ADRs.
 | ERR-030 | Path prefix `startsWith` matches sibling directories as production workspace | PRI-240 |
 | ERR-031 | Config resolver hard-fails on valid runtime when optional mode flags are absent | PRI-162 |
 | ERR-032 | Documentation labels legacy dispatch as MVP-Core, contradicting ADR-0014 | PRI-227 |
+| ERR-033 | Operator failure path returns success exit code and breaks JSON contract | PRI-162 |
+| ERR-034 | Canonical runtime config not consumed by caller or cache key | PRI-162 |
+| ERR-035 | Static guard only covers frozen-basename dynamic imports, misses other legacy paths | PRI-227 |
 
 ---
 
@@ -503,9 +506,45 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
+**[ERR-033]** | Operator failure path returns success exit code and breaks JSON contract
+
+- **What happened**: In `pain-record.ts`, when `result.failureCategory === 'config_missing'` and `resolveRuntimeConfig()` returns a `RuntimeConfigError`, the code only printed diagnostic text to stderr and returned — without calling `process.exit(1)` and without outputting JSON in `--json` mode. Automation treated the failure as success, and JSON CLI contract was broken.
+- **Why it's wrong**: CLI commands that fail must exit non-zero (CLI Command Gate rule 5: failure paths must not mutate state or appear to succeed). `--json` mode must always output exactly one parseable JSON object (CLI Command Gate rule 1). A `return` without `process.exit(1)` lets the caller continue as if the operation succeeded. This is the same class as ERR-022 (process.exit without return) and ERR-009 (silently skip invalid instead of failing loud).
+- **Correct approach**: Every failure path in a CLI command must: (1) call `process.exit(1)`, (2) in `--json` mode output a structured JSON result with `status: 'failed'`, `failureCategory`, `message`, and `configError` (if applicable), (3) include `nextAction` per CLI Command Gate rule 6.
+- **How to prevent**: After writing any CLI failure path, check: does it call `process.exit(1)`? Does `--json` mode output a parseable JSON result? Does the JSON include a `nextAction`? Add a test for each failure path in both text and JSON modes.
+- **Source**: PRI-162 / PR #701
+- **Date**: 2026-05-24
+- **Recurrence**: Same class as ERR-022, ERR-009
+
+---
+
+**[ERR-034]** | Canonical runtime config not consumed by caller or cache key
+
+- **What happened**: Two related issues: (1) `diagnose.ts` forced a pre-check requiring `--openclaw-local` or `--openclaw-gateway` CLI flags before calling `resolveRuntimeConfig()`, preventing file-config-only paths from working. After `resolveRuntimeConfig()` succeeded, the code still used `configResult.openclawMode ?? (opts.openclawLocal ? 'local' : 'gateway')` — guessing the mode instead of consuming the canonical validated result. (2) `pain-signal-runtime-factory.ts` bridge cache key was `${workspaceDir}:${runtimeKind}` without `openclawMode`, causing the same workspace switching from local to gateway to reuse the wrong bridge/adapter.
+- **Why it's wrong**: The whole point of `resolveRuntimeConfig()` is to be the single source of truth for runtime configuration. When callers second-guess the result or bypass it with pre-checks, the canonical config is undermined. Cache keys that omit discriminating fields cause stale data reuse. This is the same class as ERR-031 (config resolver hard-fails on valid runtime) and ERR-004 (lineage fields from wrong source).
+- **Correct approach**: (1) Remove pre-checks that duplicate what `resolveRuntimeConfig()` already validates. (2) After calling `resolveRuntimeConfig()`, use only `configResult.openclawMode` — never fall back to CLI flag guessing. (3) Include all discriminating fields in cache keys. (4) `invalidatePainSignalBridge()` must clear all mode variants.
+- **How to prevent**: When a canonical config resolver exists, callers must not duplicate its validation logic. After calling the resolver, consume its result directly — no fallback guessing. Cache keys must include all fields that change behavior. Test: file-config-only path, flag-override path, cache isolation between modes.
+- **Source**: PRI-162 / PR #701
+- **Date**: 2026-05-24
+- **Recurrence**: Same class as ERR-031, ERR-004
+
+---
+
+**[ERR-035]** | Static guard only covers frozen-basename dynamic imports, misses other legacy paths
+
+- **What happened**: `nocturnal-entrypoint-guard.test.ts` `findImportLines()` only checked dynamic imports against `FROZEN_NOCTURNAL_MODULES` basenames. A dynamic import like `import('../service/sleep-cycle.js')` or `import('../service/idle-detector.js')` would not be detected because `sleep-cycle` and `idle-detector` are not in the frozen set. PRI-227's goal is to prevent new legacy nocturnal callers, not just frozen module callers.
+- **Why it's wrong**: The guard's purpose is to catch any new entrypoint into the legacy nocturnal/sleep/idle subsystem, regardless of whether the specific file is in the frozen set. Limiting dynamic import detection to frozen basenames creates a blind spot where new callers of non-frozen legacy modules pass the guard undetected. This is the same class as ERR-024/ERR-025 (validator exists but doesn't cover the real attack surface).
+- **Correct approach**: Dynamic import detection must use path-pattern matching (e.g., `nocturnal-`, `sleep-cycle`, `sleep_reflection`, `idle`) rather than exact basename matching against a frozen set. The frozen set check remains for static imports; dynamic imports need broader pattern coverage.
+- **How to prevent**: When writing a guard that prevents new callers of a subsystem, ensure the detection covers all naming patterns used by that subsystem, not just a specific subset. Test: add a test case for a dynamic import of a non-frozen-basename legacy module and verify it's detected.
+- **Source**: PRI-227 / PR #701
+- **Date**: 2026-05-24
+- **Recurrence**: Same class as ERR-024, ERR-025
+
+---
+
 | Metric | Value |
 |--------|-------|
-| Total lessons | 32 |
+| Total lessons | 35 |
 | Last updated | 2026-05-24 |
 | Top category | Schema & Type |
 | Recurring errors | 15 |

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -526,7 +526,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: When a canonical config resolver exists, callers must not duplicate its validation logic. After calling the resolver, consume its result directly — no fallback guessing. Cache keys must include all fields that change behavior. Test: file-config-only path, flag-override path, cache isolation between modes.
 - **Source**: PRI-162 / PR #701
 - **Date**: 2026-05-24
-- **Recurrence**: Same class as ERR-031, ERR-004
+- **Recurrence**: Same class as ERR-031, ERR-004. Recurred 2026-05-24 PR #701: first fix removed pre-check and changed `?? (opts.openclawLocal ? 'local' : 'gateway')` to `?? 'local'`, but (1) `resolveRuntimeConfig()` still did not accept `requestedRuntimeKind`, so `--runtime openclaw-cli --openclaw-gateway` without a workflow policy returned default pi-ai config and the `?? 'local'` fallback silently overrode the user's gateway intent; (2) `runtime=config` still fell through to compatibility fallback instead of failing loud. Fixed by adding `requestedRuntimeKind` to resolver input and removing all `??` fallbacks. Also recurred 2026-05-24 PR #701: `runtime-internalization-run-once.ts` `resolveRuntimeAdapter()` threw on `RuntimeConfigError` but the command had no catch block, so `--json` mode produced no structured output and the process crashed with an unhandled rejection. Fixed by adding a catch block that outputs `{ decision: 'config_error', reason, nextAction }` in JSON mode.
 
 ---
 
@@ -538,7 +538,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: When writing a guard that prevents new callers of a subsystem, ensure the detection covers all naming patterns used by that subsystem, not just a specific subset. Test: add a test case for a dynamic import of a non-frozen-basename legacy module and verify it's detected.
 - **Source**: PRI-227 / PR #701
 - **Date**: 2026-05-24
-- **Recurrence**: Same class as ERR-024, ERR-025
+- **Recurrence**: Same class as ERR-024, ERR-025. Recurred 2026-05-24 PR #701: first fix added `idle` to the dynamic import extractor (`findImportLines`), but the actual enforcement logic (the `isNocturnalKeyword` check that decides whether to validate against the allowlist) still only checked `nocturnal`, `sleep_reflection`, and `sleep-cycle` — not `idle`. The new extractor tests proved extraction worked, but not that the real scan would reject an unallowed idle caller. Fixed by adding `idle` to the `isNocturnalKeyword` check and adding an enforcement test. Also recurred 2026-05-24 PR #701: adding `lowerLine.includes('idle')` to `isNocturnalKeyword` caused false positives on `HybridLedgerStore` (hybr**idle**dgerstore contains the substring `idle`). The `legacyPathPatterns` `/idle/` regex had the same issue. Fixed by using word-boundary regex `/(?:^|[-_/.])idle(?:[-_/.]|$)/i` that matches `idle` only at path/identifier segment boundaries, not as a substring within `hybrid`.
 
 ---
 

--- a/docs/LEGACY_ENTRYPOINT_CENSUS.md
+++ b/docs/LEGACY_ENTRYPOINT_CENSUS.md
@@ -268,12 +268,12 @@ for legacy nocturnal modules. They are NOT legacy entrypoints.
 | Category | Count | Description |
 |---|---|---|
 | `mvp_core_dependency` | 0 | ADR-0014 MVP-Core activation paths are `prompt`, `code_tool_hook / RuleHost`, `defer_archive` only. No legacy nocturnal entrypoints qualify. Previous `mvp_core_dependency` entries have been reclassified as `live_cutover` (retirement targets per ADR-0014 §2.6). |
-| `live_cutover` | 26 | Nocturnal commands (3), command handlers (3), sleep_reflection trigger (1: pd-reflect.ts), service modules still called (4), evolution-worker import sites (3), NocturnalWorkflowManager references (3), cross-module imports (3: merge-gate-audit, cooldown-strategy, filesystem-lifecycle-datasource), startup-reconciler (1), pain context (1: evolution-pain-context.ts), EvolutionWorker hook/service registrations (2), queue-io sleep_reflection enqueue (1), evolution-worker sleep_reflection processing (1), heartbeat idle/enqueue (1). |
+| `live_cutover` | 27 | Nocturnal commands (3), command handlers (3), sleep_reflection trigger (1: pd-reflect.ts), service modules still called (4), evolution-worker import sites (3), NocturnalWorkflowManager references (3), cross-module imports (3: merge-gate-audit, cooldown-strategy, filesystem-lifecycle-datasource), startup-reconciler (1), pain context (1: evolution-pain-context.ts), EvolutionWorker hook/service registrations (2), queue-io sleep_reflection enqueue (1), evolution-worker sleep_reflection processing (1), heartbeat idle/enqueue (1). |
 | `compat_alias` | 1 | Re-export of enqueueSleepReflectionTask from evolution-worker.ts. |
 | `historical_read_export` | 29 | Test files (24 regular + 4 architecture regression), type-only imports (1: workflow-store.ts). |
 | `delete_candidate` | 16 | Frozen core modules (14 nocturnal-*.ts + 1 adaptive-thresholds.ts), service orchestrator (1: nocturnal-service.ts). |
 
-**Total unique entrypoints classified: 72**
+**Total unique entrypoints classified: 73**
 
 > **Counting rule**: Each entrypoint is counted once in its highest-priority category. Priority order: `mvp_core_dependency` > `live_cutover` > `compat_alias` > `historical_read_export` > `delete_candidate`. A single file with multiple import sites (e.g. evolution-worker.ts) counts as multiple entrypoints, one per distinct import/reference site listed in the detailed sections above. Sub-item sums in the Description column must equal the Count column value.
 

--- a/docs/LEGACY_ENTRYPOINT_CENSUS.md
+++ b/docs/LEGACY_ENTRYPOINT_CENSUS.md
@@ -13,7 +13,7 @@
 
 | Category | Tag | Meaning |
 |---|---|---|
-| **MVP-Core Dependency** | `mvp_core_dependency` | ADR-0014 MVP-Core activation paths (`prompt`, `code_tool_hook / RuleHost`, `defer_archive`). These are the "good" entrypoints: the evolution-worker loop and sleep-cycle orchestrator that the Runtime V2 Peer Runners will replace. |
+| **MVP-Core Dependency** | `mvp_core_dependency` | ADR-0014 MVP-Core activation paths (`prompt`, `code_tool_hook / RuleHost`, `defer_archive`). These are the three proven channels that the seed customer demo depends on. |
 | **Live Cutover** | `live_cutover` | Still has live callers in the current codebase that need to be migrated to Runtime V2 before the legacy module can be deleted. |
 | **Compatibility Alias** | `compat_alias` | Re-export or thin alias that exists only for backwards compatibility. Can be removed when all consumers migrate. |
 | **Historical Read Export** | `historical_read_export` | Read-only export path (type re-export, barrel export). Does not call into Nocturnal logic at runtime. |
@@ -81,7 +81,7 @@ legacy code that must not be modified. Runtime V2 equivalents live in
 | `src/service/nocturnal-target-selector.ts` | `live_cutover` | Principle + session selection for reflection. Called by `nocturnal-service.ts` (via `executeNocturnalReflection`). |
 | `src/service/nocturnal-config.ts` | `live_cutover` | Configuration loader. Called by `evolution-worker.ts` and `sleep-cycle.ts`. |
 | `src/service/sleep-cycle.ts` | `live_cutover` | Sleep cycle orchestrator extracted from evolution-worker. Uses nocturnal-runtime + queue-io. **Still wired into the heartbeat loop in evolution-worker.ts** (approximately lines 1449-1494). |
-| `src/service/queue-io.ts` | `mvp_core_dependency` | Queue I/O including `enqueueSleepReflectionTask`. This is ADR-0014 evolution queue code, not pure nocturnal -- but it contains the sleep_reflection task enqueue path. |
+| `src/service/queue-io.ts` | `live_cutover` | Queue I/O including `enqueueSleepReflectionTask`. Contains sleep_reflection task enqueue path — retirement target per ADR-0014 §2.6 (EvolutionWorker / sleep cycle = MVP-Gone). |
 
 ### startup-reconciler.ts
 
@@ -110,7 +110,7 @@ The file `src/service/evolution-worker.ts` has multiple nocturnal entrypoint pat
 | Line 23 | Re-export `enqueueSleepReflectionTask` | `compat_alias` | Re-export from queue-io.ts |
 | Line 28 | Import `checkWorkspaceIdle`, `checkCooldown`, `recordCooldown` from `nocturnal-runtime.ts` | `live_cutover` | Sleep cycle uses these. |
 | Line 51 | Import `OpenClawTrinityRuntimeAdapter` from `../core/nocturnal-trinity.js` | `live_cutover` | Used in NocturnalWorkflowManager construction for sleep_reflection task processing and workflow sweeping. |
-| Lines 640-975 | `sleep_reflection` task processing path | `mvp_core_dependency` | The evolution queue processing loop (ADR-0014) processes sleep_reflection tasks. This is the core evolution machinery. |
+| Lines 640-975 | `sleep_reflection` task processing path | `live_cutover` | The evolution queue processing loop processes sleep_reflection tasks via NocturnalWorkflowManager. Retirement target per ADR-0014 §2.6. |
 | Lines 1449-1494 | Idle check and sleep_reflection enqueue in heartbeat cycle | `live_cutover` | The heartbeat cycle triggers both idle-based and periodic sleep reflection. Runtime V2 Peer Runners will replace this. |
 
 ---
@@ -186,8 +186,8 @@ pipeline chain:
 
 | Hook | Location | Category | Notes |
 |---|---|---|---|
-| `before_prompt_build` (EvolutionWorker start) | index.ts:120-129 | `mvp_core_dependency` | This is the ADR-0014 entry point. The EvolutionWorker service registration is core infrastructure, not nocturnal-specific. |
-| `api.registerService(EvolutionWorkerService)` | index.ts:360-362 | `mvp_core_dependency` | Service registration is core infrastructure. |
+| `before_prompt_build` (EvolutionWorker start) | index.ts:120-129 | `live_cutover` | EvolutionWorker service registration. Per ADR-0014 §2.6, EvolutionWorker is MVP-Gone (retirement target). The three MVP-Core activation paths (prompt, code_tool_hook, defer_archive) do not depend on this hook. |
+| `api.registerService(EvolutionWorkerService)` | index.ts:360-362 | `live_cutover` | Service registration. Retirement target per ADR-0014 §2.6. |
 
 ---
 
@@ -238,9 +238,9 @@ they verify existing behavior but must be retired with the production code.
 
 | Hook | File | Description | Category |
 |---|---|---|---|
-| `before_prompt_build` | index.ts:120-129 | Starts EvolutionWorkerService per workspace | `mvp_core_dependency` |
-| EvolutionWorker heartbeat | evolution-worker.ts:1412 | Periodic cycle that checks idle, enqueues sleep_reflection | `mvp_core_dependency` |
-| EvolutionWorker sleep_reflection processing | evolution-worker.ts:640-975 | Processes sleep_reflection queue items via NocturnalWorkflowManager | `mvp_core_dependency` |
+| `before_prompt_build` | index.ts:120-129 | Starts EvolutionWorkerService per workspace | `live_cutover` |
+| EvolutionWorker heartbeat | evolution-worker.ts:1412 | Periodic cycle that checks idle, enqueues sleep_reflection | `live_cutover` |
+| EvolutionWorker sleep_reflection processing | evolution-worker.ts:640-975 | Processes sleep_reflection queue items via NocturnalWorkflowManager | `live_cutover` |
 | runCycle (sleep-cycle.ts) | sleep-cycle.ts:72 | Extracted sleep-cycle orchestrator | `live_cutover` |
 
 ---
@@ -267,8 +267,8 @@ for legacy nocturnal modules. They are NOT legacy entrypoints.
 
 | Category | Count | Description |
 |---|---|---|
-| `mvp_core_dependency` | 4 | EvolutionWorker service registration (1), before_prompt_build hook trigger (1), evolution queue processing loop (1), queue-io sleep_reflection enqueue (1). ADR-0014 core. |
-| `live_cutover` | 22 | Nocturnal commands (3), command handlers (3), sleep_reflection trigger (1: pd-reflect.ts), service modules still called (4), evolution-worker import sites (3), NocturnalWorkflowManager references (3), cross-module imports (3: merge-gate-audit, cooldown-strategy, filesystem-lifecycle-datasource), startup-reconciler (1), pain context (1: evolution-pain-context.ts). |
+| `mvp_core_dependency` | 0 | ADR-0014 MVP-Core activation paths are `prompt`, `code_tool_hook / RuleHost`, `defer_archive` only. No legacy nocturnal entrypoints qualify. Previous `mvp_core_dependency` entries have been reclassified as `live_cutover` (retirement targets per ADR-0014 §2.6). |
+| `live_cutover` | 26 | Nocturnal commands (3), command handlers (3), sleep_reflection trigger (1: pd-reflect.ts), service modules still called (4), evolution-worker import sites (3), NocturnalWorkflowManager references (3), cross-module imports (3: merge-gate-audit, cooldown-strategy, filesystem-lifecycle-datasource), startup-reconciler (1), pain context (1: evolution-pain-context.ts), EvolutionWorker hook/service registrations (2), queue-io sleep_reflection enqueue (1), evolution-worker sleep_reflection processing (1), heartbeat idle/enqueue (1). |
 | `compat_alias` | 1 | Re-export of enqueueSleepReflectionTask from evolution-worker.ts. |
 | `historical_read_export` | 29 | Test files (24 regular + 4 architecture regression), type-only imports (1: workflow-store.ts). |
 | `delete_candidate` | 16 | Frozen core modules (14 nocturnal-*.ts + 1 adaptive-thresholds.ts), service orchestrator (1: nocturnal-service.ts). |
@@ -276,3 +276,5 @@ for legacy nocturnal modules. They are NOT legacy entrypoints.
 **Total unique entrypoints classified: 72**
 
 > **Counting rule**: Each entrypoint is counted once in its highest-priority category. Priority order: `mvp_core_dependency` > `live_cutover` > `compat_alias` > `historical_read_export` > `delete_candidate`. A single file with multiple import sites (e.g. evolution-worker.ts) counts as multiple entrypoints, one per distinct import/reference site listed in the detailed sections above. Sub-item sums in the Description column must equal the Count column value.
+
+> **MVP-Core clarification (PRI-227 convergence)**: ADR-0014 §2.4 defines MVP-Core as only three activation paths: `prompt`, `code_tool_hook / RuleHost`, `defer_archive`. The EvolutionWorker heartbeat, sleep_reflection enqueue, and idle/night dispatch paths are NOT MVP-Core — they are retirement targets (ADR-0014 §2.6: MVP-Gone). The previous classification incorrectly labeled these as `mvp_core_dependency`.

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -82,6 +82,7 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
     'nocturnal-workflow-manager',
     'nocturnal-config',
     'nocturnal-snapshot-contract',
+    'nocturnal-trajectory-extractor',
   ],
 
   // === service/sleep-cycle.ts: Sleep cycle orchestrator ===
@@ -135,6 +136,18 @@ const ALLOWED_NOCTURNAL_IMPORTS: Record<string, string[]> = {
 
   // === core/correction-cue-learner.ts: Keyword opt cooldown (live_cutover) ===
   'core/correction-cue-learner.ts': ['nocturnal-runtime'],
+
+  // === core/event-log.ts: Event log records nocturnal event types (live_cutover) ===
+  'core/event-log.ts': ['nocturnal', 'event-types'],
+
+  // === core/reflection/reflection-context.ts: Reflection context uses nocturnal types (live_cutover) ===
+  'core/reflection/reflection-context.ts': ['nocturnal-trajectory-extractor'],
+
+  // === core/replay-engine.ts: Replay engine uses nocturnal dataset types (live_cutover) ===
+  'core/replay-engine.ts': ['nocturnal-dataset', 'nocturnal-trajectory-extractor'],
+
+  // === service/subagent-workflow/types.ts: Type definitions reference nocturnal modules (live_cutover) ===
+  'service/subagent-workflow/types.ts': ['nocturnal-arbiter', 'nocturnal-executability', 'nocturnal-trajectory-extractor', 'nocturnal-trinity', 'nocturnal-runtime', 'nocturnal-target-selector'],
 };
 
 // ---------------------------------------------------------------------------
@@ -295,7 +308,9 @@ describe('Nocturnal entrypoint guard', () => {
     // commands/pd-reflect.ts, service/evolution-worker.ts, service/sleep-cycle.ts,
     // service/queue-io.ts, service/evolution-pain-context.ts, core/merge-gate-audit.ts,
     // service/subagent-workflow/workflow-store.ts (type-only)
-    expect(nonFrozen.length).toBeLessThanOrEqual(15);
+    // core/event-log.ts (nocturnal event type names), core/reflection/reflection-context.ts,
+    // core/replay-engine.ts, service/subagent-workflow/types.ts (type definitions)
+    expect(nonFrozen.length).toBeLessThanOrEqual(19);
   });
 
   it('non-allowlisted caller importing nocturnal-trinity must fail', () => {
@@ -365,6 +380,91 @@ describe('Nocturnal entrypoint guard', () => {
     const isFrozenModule = FROZEN_NOCTURNAL_MODULES.has(simulatedRelPath);
     expect(isFrozenModule).toBe(true);
   });
+
+  it('multiline import of frozen module outside allowlist must fail', () => {
+    const content = [
+      "import {",
+      "  DreamerOutput,",
+      "  PhilosopherOutput,",
+      "} from '../core/nocturnal-trinity.js'",
+    ].join('\n');
+    const importLines = findImportLines(content);
+    expect(importLines.length).toBeGreaterThan(0);
+    const lowerLine = importLines[0].toLowerCase();
+    expect(lowerLine).toContain('nocturnal-trinity');
+    const simulatedRelPath = 'hooks/hypothetical-hook.ts';
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[simulatedRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map(e => e.toLowerCase());
+    const isAllowed = allowedPatterns.some(pattern => lowerLine.includes(pattern));
+    expect(isAllowed).toBe(false);
+  });
+
+  it('assigned require of frozen module outside allowlist must fail', () => {
+    const content = "const trinity = require('../core/nocturnal-trinity.js')";
+    const importLines = findImportLines(content);
+    expect(importLines.length).toBeGreaterThan(0);
+    const lowerLine = importLines[0].toLowerCase();
+    expect(lowerLine).toContain('nocturnal-trinity');
+    const simulatedRelPath = 'core/new-module.ts';
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[simulatedRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map(e => e.toLowerCase());
+    const isAllowed = allowedPatterns.some(pattern => lowerLine.includes(pattern));
+    expect(isAllowed).toBe(false);
+  });
+
+  it('side-effect import of frozen module outside allowlist must fail', () => {
+    const content = "import '../core/nocturnal-trinity.js'";
+    const importLines = findImportLines(content);
+    expect(importLines.length).toBeGreaterThan(0);
+    const lowerLine = importLines[0].toLowerCase();
+    expect(lowerLine).toContain('nocturnal-trinity');
+    const simulatedRelPath = 'hooks/another-hook.ts';
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[simulatedRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map(e => e.toLowerCase());
+    const isAllowed = allowedPatterns.some(pattern => lowerLine.includes(pattern));
+    expect(isAllowed).toBe(false);
+  });
+
+  it('test-only import in __tests__ is not treated as new production entrypoint', () => {
+    const testRelPath = 'core/__tests__/some-test.ts';
+    const isInTests = testRelPath.includes('__tests__');
+    expect(isInTests).toBe(true);
+  });
+
+  it('findImportLines detects single-line static import', () => {
+    const content = "import { something } from '../core/nocturnal-trinity.js'";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('nocturnal-trinity');
+  });
+
+  it('findImportLines detects multiline static import', () => {
+    const content = "import {\n  DreamerOutput,\n  PhilosopherOutput,\n} from '../core/nocturnal-trinity.js'";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('nocturnal-trinity');
+  });
+
+  it('findImportLines detects assigned require', () => {
+    const content = "const trinity = require('../core/nocturnal-trinity.js')";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('nocturnal-trinity');
+  });
+
+  it('findImportLines detects bare require', () => {
+    const content = "require('../core/nocturnal-trinity.js')";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('nocturnal-trinity');
+  });
+
+  it('findImportLines detects side-effect import', () => {
+    const content = "import '../core/nocturnal-trinity.js'";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('nocturnal-trinity');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -382,9 +482,11 @@ function collectSourceFiles(dir: string): string[] {
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') continue;
       results.push(...collectSourceFiles(fullPath));
     } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      const relPath = path.relative(PLUGIN_SRC, fullPath);
+      if (relPath.includes('__tests__')) continue;
       results.push(fullPath);
     }
   }
@@ -394,20 +496,39 @@ function collectSourceFiles(dir: string): string[] {
 
 /**
  * Extract all import/require lines from source content.
+ *
+ * Detects:
+ * - Single-line static imports: `import X from 'module'`
+ * - Multiline static imports: `import { A, B } from 'module'`
+ * - Side-effect imports: `import 'module'`
+ * - Assigned require: `const x = require('module')` or `require('module')`
+ * - Dynamic imports: `import('module')`
  */
 function findImportLines(content: string): string[] {
   const lines: string[] = [];
-  const importRegex = /^(?:import\s+.*?from\s+['"][^'"]+['"]|export\s+(?:\{[^}]*\}|\*)\s+from\s+['"][^'"]+['"]|require\s*\(['"][^'"]+['"]\))/gm;
-  let match: RegExpExecArray | null;
 
-  while ((match = importRegex.exec(content)) !== null) {
+  const staticImportRegex = /import\s+[\s\S]*?from\s+['"][^'"]+['"]/gm;
+  let match: RegExpExecArray | null;
+  while ((match = staticImportRegex.exec(content)) !== null) {
     lines.push(match[0]);
   }
 
-  // Also catch dynamic imports of any frozen module
+  const sideEffectImportRegex = /import\s+['"][^'"]+['"]/gm;
+  while ((match = sideEffectImportRegex.exec(content)) !== null) {
+    const already = lines.some(l => l === match![0]);
+    if (!already) {
+      lines.push(match[0]);
+    }
+  }
+
+  const requireRegex = /(?:const\s+\w+\s*=\s*)?require\s*\(\s*['"][^'"]+['"]\s*\)/gm;
+  while ((match = requireRegex.exec(content)) !== null) {
+    lines.push(match[0]);
+  }
+
   for (const mod of FROZEN_NOCTURNAL_MODULES) {
     const basename = path.basename(mod, '.ts');
-    const dynRegex = new RegExp('import\\\\s*\\\\([\'\"]' + '[^\'\"]+' + basename + '[^\'\"]*' + '[\'\"]\\\\)', 'gi');
+    const dynRegex = new RegExp('import\\s*\\([\'"]' + '[^\'"]+' + basename + '[^\'"]*' + '[\'"]\\)', 'gi');
     let dynMatch;
     while ((dynMatch = dynRegex.exec(content)) !== null) {
       lines.push(dynMatch[0]);

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -228,7 +228,7 @@ describe('Nocturnal entrypoint guard', () => {
         const isFrozenModuleRef = frozenModuleBasenames.some(
           (basename) => lowerLine.includes(basename)
         );
-        const isNocturnalKeyword = lowerLine.includes('nocturnal') || lowerLine.includes('sleep_reflection') || lowerLine.includes('sleep-cycle');
+        const isNocturnalKeyword = /(?:^|[-_/.])idle(?:[-_/.]|$)|nocturnal|sleep_reflection|sleep-cycle/i.test(importLine);
         if (!isFrozenModuleRef && !isNocturnalKeyword) {
           continue;
         }
@@ -486,6 +486,37 @@ describe('Nocturnal entrypoint guard', () => {
     expect(lines.length).toBeGreaterThan(0);
     expect(lines[0]).toContain('idle-detector');
   });
+
+  it('idle import not in allowlist is flagged by enforcement logic', () => {
+    const importLine = "import('../service/idle-detector.js')";
+    const lowerLine = importLine.toLowerCase();
+    const frozenModuleBasenames = [...FROZEN_NOCTURNAL_MODULES].map(
+      (mod) => path.basename(mod, '.ts')
+    );
+    const isFrozenModuleRef = frozenModuleBasenames.some(
+      (basename) => lowerLine.includes(basename)
+    );
+    const isNocturnalKeyword = /(?:^|[-_/.])idle(?:[-_/.]|$)|nocturnal|sleep_reflection|sleep-cycle/i.test(importLine);
+    expect(isFrozenModuleRef || isNocturnalKeyword).toBe(true);
+
+    const fakeRelPath = 'commands/new-command.ts';
+    const allowedEntries = ALLOWED_NOCTURNAL_IMPORTS[fakeRelPath] ?? [];
+    const allowedPatterns = allowedEntries.map((e) => e.toLowerCase());
+    const isAllowed = allowedPatterns.some((pattern) => lowerLine.includes(pattern));
+    expect(isAllowed).toBe(false);
+  });
+
+  it('HybridLedgerStore does not trigger idle keyword (word boundary)', () => {
+    const importLine = "import type { HybridLedgerStore } from './principle-tree-ledger.js'";
+    const isNocturnalKeyword = /(?:^|[-_/.])idle(?:[-_/.]|$)|nocturnal|sleep_reflection|sleep-cycle/i.test(importLine);
+    expect(isNocturnalKeyword).toBe(false);
+  });
+
+  it('idle in path segment triggers keyword (word boundary)', () => {
+    const importLine = "import('../service/idle-detector.js')";
+    const isNocturnalKeyword = /(?:^|[-_/.])idle(?:[-_/.]|$)|nocturnal|sleep_reflection|sleep-cycle/i.test(importLine);
+    expect(isNocturnalKeyword).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -560,7 +591,7 @@ function findImportLines(content: string): string[] {
     /nocturnal-/,
     /sleep-cycle/,
     /sleep_reflection/,
-    /idle/,
+    /(?:^|[-_/.])idle(?:[-_/.]|$)/i,
   ];
   const genericDynImportRegex = /import\s*\(\s*['"][^'"]+['"]\s*\)/gi;
   let genericMatch;

--- a/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
+++ b/packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts
@@ -465,6 +465,27 @@ describe('Nocturnal entrypoint guard', () => {
     expect(lines.length).toBeGreaterThan(0);
     expect(lines[0]).toContain('nocturnal-trinity');
   });
+
+  it('findImportLines detects dynamic import of non-frozen-basename legacy module', () => {
+    const content = "const mod = import('../service/sleep-cycle.js')";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('sleep-cycle');
+  });
+
+  it('findImportLines detects dynamic import with nocturnal- path not in FROZEN set', () => {
+    const content = "await import('../service/nocturnal-new-module.js')";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('nocturnal-new-module');
+  });
+
+  it('findImportLines detects dynamic import with idle path', () => {
+    const content = "await import('../service/idle-detector.js')";
+    const lines = findImportLines(content);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('idle-detector');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -532,6 +553,22 @@ function findImportLines(content: string): string[] {
     let dynMatch;
     while ((dynMatch = dynRegex.exec(content)) !== null) {
       lines.push(dynMatch[0]);
+    }
+  }
+
+  const legacyPathPatterns = [
+    /nocturnal-/,
+    /sleep-cycle/,
+    /sleep_reflection/,
+    /idle/,
+  ];
+  const genericDynImportRegex = /import\s*\(\s*['"][^'"]+['"]\s*\)/gi;
+  let genericMatch;
+  while ((genericMatch = genericDynImportRegex.exec(content)) !== null) {
+    const importPath = genericMatch[0];
+    const already = lines.some(l => l === importPath);
+    if (!already && legacyPathPatterns.some(p => p.test(importPath))) {
+      lines.push(importPath);
     }
   }
 

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -134,7 +134,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     let runtimeAdapter: PDRuntimeAdapter;
     if (runtimeKind === 'openclaw-cli') {
       const stateDir = `${workspaceDir}/.state`;
-      const configResult = resolveRuntimeConfig(stateDir, { openclawLocal: opts.openclawLocal, openclawGateway: opts.openclawGateway });
+      const configResult = resolveRuntimeConfig(stateDir, { openclawLocal: opts.openclawLocal, openclawGateway: opts.openclawGateway, requestedRuntimeKind: 'openclaw-cli' });
       if (isRuntimeConfigError(configResult)) {
         if (opts.json) {
           console.log(JSON.stringify({ ok: false, reason: configResult.reason, message: configResult.message, nextAction: configResult.nextAction }));
@@ -145,7 +145,17 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
         process.exit(1);
         return;
       }
-      const openclawMode = configResult.openclawMode ?? 'local';
+      const { openclawMode } = configResult;
+      if (!openclawMode) {
+        if (opts.json) {
+          console.log(JSON.stringify({ ok: false, reason: 'missing_openclaw_mode', message: 'runtimeKind is openclaw-cli but no mode resolved', nextAction: 'Provide --openclaw-local or --openclaw-gateway, or set openclawMode in workflows.yaml' }));
+        } else {
+          console.error('error: runtimeKind is openclaw-cli but no mode resolved');
+          console.error('nextAction: Provide --openclaw-local or --openclaw-gateway, or set openclawMode in workflows.yaml');
+        }
+        process.exit(1);
+        return;
+      }
 
       runtimeAdapter = new OpenClawCliRuntimeAdapter({
         runtimeMode: openclawMode,

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -113,12 +113,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     process.exit(1);
   }
 
-  // Require explicit runtime mode for openclaw-cli (HG-03, DPB-09)
   const runtimeKind = opts.runtime ?? 'test-double';
-  if (runtimeKind === 'openclaw-cli' && !opts.openclawLocal && !opts.openclawGateway) {
-    console.error('error: --openclaw-local or --openclaw-gateway is required when using --runtime openclaw-cli');
-    process.exit(1);
-  }
 
   const stateManager = new RuntimeStateManager({ workspaceDir });
 
@@ -150,7 +145,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
         process.exit(1);
         return;
       }
-      const openclawMode = configResult.openclawMode ?? (opts.openclawLocal ? 'local' : 'gateway');
+      const openclawMode = configResult.openclawMode ?? 'local';
 
       runtimeAdapter = new OpenClawCliRuntimeAdapter({
         runtimeMode: openclawMode,

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -21,11 +21,12 @@ import {
   PiAiRuntimeAdapter,
   PDRuntimeError,
   resolveRuntimeConfig,
+  isRuntimeConfigError,
   CandidateIntakeService,
   run as diagnoseRun,
   status as diagnoseStatus,
 } from '@principles/core/runtime-v2';
-import type { PDRuntimeAdapter } from '@principles/core/runtime-v2';
+import type { PDRuntimeAdapter, RuntimeConfig } from '@principles/core/runtime-v2';
 import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import * as path from 'path';
@@ -137,8 +138,22 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     // eslint-disable-next-line @typescript-eslint/init-declarations
     let runtimeAdapter: PDRuntimeAdapter;
     if (runtimeKind === 'openclaw-cli') {
+      const stateDir = `${workspaceDir}/.state`;
+      const configResult = resolveRuntimeConfig(stateDir, { openclawLocal: opts.openclawLocal, openclawGateway: opts.openclawGateway });
+      if (isRuntimeConfigError(configResult)) {
+        if (opts.json) {
+          console.log(JSON.stringify({ ok: false, reason: configResult.reason, message: configResult.message, nextAction: configResult.nextAction }));
+        } else {
+          console.error(`error: ${configResult.message}`);
+          console.error(`nextAction: ${configResult.nextAction}`);
+        }
+        process.exit(1);
+        return;
+      }
+      const openclawMode = configResult.openclawMode ?? (opts.openclawLocal ? 'local' : 'gateway');
+
       runtimeAdapter = new OpenClawCliRuntimeAdapter({
-        runtimeMode: opts.openclawLocal ? 'local' : 'gateway',
+        runtimeMode: openclawMode,
         workspaceDir,
         agentId: opts.agent ?? 'main',
       });
@@ -152,7 +167,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
         agentId: 'openclaw-cli-adapter',
         payload: {
           runtimeKind: 'openclaw-cli',
-          runtimeMode: opts.openclawLocal ? 'local' : 'gateway',
+          runtimeMode: openclawMode,
         },
       });
     } else if (runtimeKind === 'test-double') {
@@ -182,14 +197,16 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
         }),
       });
     } else if (runtimeKind === 'pi-ai') {
-      // D-06: flags + policy fallback
-      // D-01: have flag → use flag, no flag → read from policy
       const stateDir = `${workspaceDir}/.state`;
-      let policyConfig: ReturnType<typeof resolveRuntimeConfig> | null = null;
+      let policyConfig: RuntimeConfig | null = null;
       try {
-        policyConfig = resolveRuntimeConfig(stateDir);
+        const configResult = resolveRuntimeConfig(stateDir);
+        if (!isRuntimeConfigError(configResult)) {
+          policyConfig = configResult;
+        } else {
+          console.warn(`[pd diagnose] workflows.yaml policy load failed: ${configResult.message}. Using CLI flags if provided.`);
+        }
       } catch (err: unknown) {
-        // workflows.yaml missing or malformed — warn and fall through to flag-based config
         const detail = err instanceof Error ? err.message : String(err);
         console.warn(`[pd diagnose] workflows.yaml policy load failed: ${detail}. Using CLI flags if provided.`);
       }

--- a/packages/pd-cli/src/commands/pain-record.ts
+++ b/packages/pd-cli/src/commands/pain-record.ts
@@ -10,6 +10,7 @@ import {
   PainToPrincipleService,
   PrincipleTreeLedgerAdapter,
   resolveRuntimeConfig,
+  isRuntimeConfigError,
 } from '@principles/core/runtime-v2';
 import type { KnownProvider } from '@mariozechner/pi-ai';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
@@ -60,7 +61,14 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
 
   // Show diagnostic info for config failures
   if (result.failureCategory === 'config_missing') {
-    const config = resolveRuntimeConfig(stateDir);
+    const configResult = resolveRuntimeConfig(stateDir);
+    if (isRuntimeConfigError(configResult)) {
+      console.error(`  Config resolution failed: ${configResult.reason}`);
+      console.error(`  ${configResult.message}`);
+      console.error(`  nextAction: ${configResult.nextAction}`);
+      return;
+    }
+    const config = configResult;
     const missing: string[] = [];
     if (!config.provider) missing.push('provider');
     if (!config.model) missing.push('model');

--- a/packages/pd-cli/src/commands/pain-record.ts
+++ b/packages/pd-cli/src/commands/pain-record.ts
@@ -63,9 +63,25 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
   if (result.failureCategory === 'config_missing') {
     const configResult = resolveRuntimeConfig(stateDir);
     if (isRuntimeConfigError(configResult)) {
-      console.error(`  Config resolution failed: ${configResult.reason}`);
-      console.error(`  ${configResult.message}`);
-      console.error(`  nextAction: ${configResult.nextAction}`);
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'failed',
+          painId: result.painId,
+          taskId: result.taskId,
+          failureCategory: result.failureCategory,
+          message: result.message,
+          configError: {
+            reason: configResult.reason,
+            message: configResult.message,
+            nextAction: configResult.nextAction,
+          },
+        }, null, 2));
+      } else {
+        console.error(`  Config resolution failed: ${configResult.reason}`);
+        console.error(`  ${configResult.message}`);
+        console.error(`  nextAction: ${configResult.nextAction}`);
+      }
+      process.exit(1);
       return;
     }
     const config = configResult;

--- a/packages/pd-cli/src/commands/proven-channel-baseline.ts
+++ b/packages/pd-cli/src/commands/proven-channel-baseline.ts
@@ -33,6 +33,15 @@ function formatTextOutput(summary: ProvenChannelBaselineSummary): string {
   lines.push(`OVERALL: ${icon} ${summary.status.toUpperCase()}`);
   lines.push('');
 
+  if (summary.inputValidationFailure) {
+    const ivf = summary.inputValidationFailure;
+    lines.push('Input Validation Failure:');
+    lines.push(`  reason: ${ivf.reason}`);
+    lines.push(`  message: ${ivf.message}`);
+    lines.push(`  nextAction: ${ivf.nextAction}`);
+    lines.push('');
+  }
+
   lines.push('Channel Results:');
   for (const ch of summary.channels) {
     lines.push(formatChannelResult(ch));

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -40,6 +40,13 @@ interface RunOnceOptions {
 const OWNER = 'pd-cli-internalization-run-once';
 const RUNTIME_KIND = 'local-worker';
 
+class ConfigResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigResolutionError';
+  }
+}
+
 const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer', 'trainer']);
 
 interface RunOnceOutput {
@@ -448,7 +455,7 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
   const configResult = resolveRuntimeConfig(stateDir, { requestedRuntimeKind: opts.runtimeKind });
 
   if (isRuntimeConfigError(configResult)) {
-    throw new Error(
+    throw new ConfigResolutionError(
       `Config resolution failed: ${configResult.reason}. ` +
       `${configResult.message}. nextAction: ${configResult.nextAction}`,
     );
@@ -472,7 +479,7 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
   if (opts.runtimeKind === 'openclaw-cli' || (opts.runtimeKind === 'config' && configResult.runtimeKind === 'openclaw-cli')) {
     const { openclawMode } = configResult;
     if (!openclawMode) {
-      throw new Error(
+      throw new ConfigResolutionError(
         `runtimeKind 'openclaw-cli' requires openclawMode. ` +
         `Provide --openclaw-local or --openclaw-gateway, or set openclawMode in workflows.yaml. ` +
         `nextAction: Add openclawMode: local|gateway to your funnel policy or use CLI flags.`,
@@ -632,11 +639,14 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
+    const isConfigError = err instanceof ConfigResolutionError;
     if (opts.json) {
       console.log(JSON.stringify({
-        decision: 'config_error',
+        decision: isConfigError ? 'config_error' : 'runtime_error',
         reason: message,
-        nextAction: 'Fix the workflows.yaml funnel policy, or use --runtime pi-ai / openclaw-cli with explicit flags',
+        nextAction: isConfigError
+          ? 'Fix the workflows.yaml funnel policy, or use --runtime pi-ai / openclaw-cli with explicit flags'
+          : 'Check runner logs and workspace state; re-run with --runtime test-double to isolate',
       }, null, 2));
     } else {
       console.error(`Error: ${message}`);

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -21,6 +21,7 @@ import {
   PiAiRuntimeAdapter,
   OpenClawCliRuntimeAdapter,
   resolveRuntimeConfig,
+  isRuntimeConfigError,
   validateRuntimeConfig,
 } from '@principles/core/runtime-v2';
 import type { WakeOnceResult, DreamerRunnerResult, PhilosopherRunnerResult, ScribeRunnerResult, ArtificerRunnerResult, EvaluatorRunnerResult, RolloutReviewerRunnerResult, TrainerRunnerResult, PDRuntimeAdapter, PeerRunnerKind } from '@principles/core/runtime-v2';
@@ -444,26 +445,41 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
   }
 
   const stateDir = path.join(opts.workspaceDir, '.state');
-  const config = resolveRuntimeConfig(stateDir);
+  const configResult = resolveRuntimeConfig(stateDir);
 
-  if (opts.runtimeKind === 'pi-ai' || (opts.runtimeKind === 'config' && config.runtimeKind === 'pi-ai')) {
-    validateRuntimeConfig(config);
+  if (isRuntimeConfigError(configResult)) {
+    throw new Error(
+      `Config resolution failed: ${configResult.reason}. ` +
+      `${configResult.message}. nextAction: ${configResult.nextAction}`,
+    );
+  }
+
+  if (opts.runtimeKind === 'pi-ai' || (opts.runtimeKind === 'config' && configResult.runtimeKind === 'pi-ai')) {
+    validateRuntimeConfig(configResult);
     // CLI --timeout-ms overrides workflows.yaml timeoutMs
-    const adapterTimeoutMs = opts.timeoutMs ?? config.timeoutMs;
+    const adapterTimeoutMs = opts.timeoutMs ?? configResult.timeoutMs;
     return new PiAiRuntimeAdapter({
-      provider: String(config.provider),
-      model: String(config.model),
-      apiKeyEnv: String(config.apiKeyEnv),
-      maxRetries: config.maxRetries,
+      provider: String(configResult.provider),
+      model: String(configResult.model),
+      apiKeyEnv: String(configResult.apiKeyEnv),
+      maxRetries: configResult.maxRetries,
       timeoutMs: adapterTimeoutMs,
-      baseUrl: config.baseUrl,
+      baseUrl: configResult.baseUrl,
       workspace: opts.workspaceDir,
     });
   }
 
-  if (opts.runtimeKind === 'openclaw-cli' || (opts.runtimeKind === 'config' && config.runtimeKind === 'openclaw-cli')) {
+  if (opts.runtimeKind === 'openclaw-cli' || (opts.runtimeKind === 'config' && configResult.runtimeKind === 'openclaw-cli')) {
+    const { openclawMode } = configResult;
+    if (!openclawMode) {
+      throw new Error(
+        `runtimeKind 'openclaw-cli' requires openclawMode. ` +
+        `Provide --openclaw-local or --openclaw-gateway, or set openclawMode in workflows.yaml. ` +
+        `nextAction: Add openclawMode: local|gateway to your funnel policy or use CLI flags.`,
+      );
+    }
     return new OpenClawCliRuntimeAdapter({
-      runtimeMode: 'local',
+      runtimeMode: openclawMode,
       workspaceDir: opts.workspaceDir,
     });
   }

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -445,7 +445,7 @@ function resolveRuntimeAdapter(opts: ResolveAdapterOptions): PDRuntimeAdapter {
   }
 
   const stateDir = path.join(opts.workspaceDir, '.state');
-  const configResult = resolveRuntimeConfig(stateDir);
+  const configResult = resolveRuntimeConfig(stateDir, { requestedRuntimeKind: opts.runtimeKind });
 
   if (isRuntimeConfigError(configResult)) {
     throw new Error(
@@ -630,6 +630,18 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
     if (wakeResult.decision === 'no_ready_tasks' || wakeResult.decision === 'lease_conflict') {
       process.exitCode = 1;
     }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (opts.json) {
+      console.log(JSON.stringify({
+        decision: 'config_error',
+        reason: message,
+        nextAction: 'Fix the workflows.yaml funnel policy, or use --runtime pi-ai / openclaw-cli with explicit flags',
+      }, null, 2));
+    } else {
+      console.error(`Error: ${message}`);
+    }
+    process.exitCode = 1;
   } finally {
     await stateManager.close();
   }

--- a/packages/pd-cli/src/commands/runtime.ts
+++ b/packages/pd-cli/src/commands/runtime.ts
@@ -144,13 +144,18 @@ async function handlePiAiProbe(opts: RuntimeProbeOptions): Promise<void> {
   // D-01: always load workspace policy; CLI values take priority as override
   if (workspaceDir) {
     try {
-      const { resolveRuntimeConfig } = await import('@principles/core/runtime-v2');
-      const config = resolveRuntimeConfig(path.join(workspaceDir, '.state'));
-      provider = provider || config.provider || '';
-      model = model || config.model || '';
-      apiKeyEnv = apiKeyEnv || config.apiKeyEnv || '';
-      baseUrl = baseUrl || config.baseUrl || '';
-      timeoutMs = timeoutMs ?? config.timeoutMs;
+      const { resolveRuntimeConfig, isRuntimeConfigError } = await import('@principles/core/runtime-v2');
+      const configResult = resolveRuntimeConfig(path.join(workspaceDir, '.state'));
+      if (isRuntimeConfigError(configResult)) {
+        console.warn(`Warning: could not load workspace runtime config — ${configResult.message}`);
+      } else {
+        const config = configResult;
+        provider = provider || config.provider || '';
+        model = model || config.model || '';
+        apiKeyEnv = apiKeyEnv || config.apiKeyEnv || '';
+        baseUrl = baseUrl || config.baseUrl || '';
+        timeoutMs = timeoutMs ?? config.timeoutMs;
+      }
     } catch (err) {
       console.warn(`Warning: could not load workspace runtime config — policy fallback disabled: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -69,6 +69,15 @@ vi.mock('@principles/core/runtime-v2', () => {
       }
     },
     CandidateIntakeService: MockCandidateIntakeService,
+    resolveRuntimeConfig: vi.fn().mockReturnValue({
+      runtimeKind: 'pi-ai',
+      provider: 'test-provider',
+      model: 'test-model',
+      apiKeyEnv: 'TEST_KEY',
+      timeoutMs: 300000,
+      agentId: 'main',
+    }),
+    isRuntimeConfigError: vi.fn().mockReturnValue(false),
     run: vi.fn().mockResolvedValue({
       status: 'succeeded',
       taskId: 'test-task-1',
@@ -114,9 +123,15 @@ const SUCCEEDED_RESULT = {
 };
 
 describe('pd diagnose run --runtime routing', () => {
+  let mockResolveRuntimeConfig: ReturnType<typeof vi.fn>;
+  let mockIsRuntimeConfigError: ReturnType<typeof vi.fn>;
+
   beforeEach(async () => {
     vi.clearAllMocks();
-    const { run } = await import('@principles/core/runtime-v2');
+    const runtimeV2 = await import('@principles/core/runtime-v2');
+    mockResolveRuntimeConfig = vi.mocked(runtimeV2.resolveRuntimeConfig);
+    mockIsRuntimeConfigError = vi.mocked(runtimeV2.isRuntimeConfigError);
+    const { run } = runtimeV2;
     vi.mocked(run).mockResolvedValue(SUCCEEDED_RESULT);
     mockGetCandidatesByTaskId.mockResolvedValue([]);
     mockUpdateCandidateStatus.mockResolvedValue(undefined);
@@ -141,7 +156,15 @@ describe('pd diagnose run --runtime routing', () => {
     exitSpy.mockRestore();
   });
 
-  it('HG-03: --runtime openclaw-cli without mode flag exits with error', async () => {
+  it('HG-03: --runtime openclaw-cli without mode (no file config) fails via resolveRuntimeConfig', async () => {
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      ok: false,
+      reason: 'missing_openclaw_mode',
+      message: 'runtimeKind is openclaw-cli but no mode specified',
+      nextAction: 'Provide exactly one mode',
+    });
+    mockIsRuntimeConfigError.mockReturnValueOnce(true);
+
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
 
@@ -152,9 +175,7 @@ describe('pd diagnose run --runtime routing', () => {
       json: false,
     } as DiagnoseRunOptions);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'error: --openclaw-local or --openclaw-gateway is required when using --runtime openclaw-cli'
-    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('no mode specified'));
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     consoleErrorSpy.mockRestore();
@@ -180,6 +201,85 @@ describe('pd diagnose run --runtime routing', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('DPB-09: openclaw-cli with file config openclawMode succeeds without CLI flag', async () => {
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      runtimeKind: 'openclaw-cli',
+      openclawMode: 'local',
+      timeoutMs: 300000,
+      agentId: 'main',
+    });
+    mockIsRuntimeConfigError.mockReturnValueOnce(false);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'openclaw-cli',
+      json: false,
+    } as DiagnoseRunOptions);
+
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('DPB-09: openclaw-cli flag overrides file config mode', async () => {
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      runtimeKind: 'openclaw-cli',
+      openclawMode: 'gateway',
+      timeoutMs: 300000,
+      agentId: 'main',
+    });
+    mockIsRuntimeConfigError.mockReturnValueOnce(false);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'openclaw-cli',
+      openclawLocal: true,
+      json: false,
+    } as DiagnoseRunOptions);
+
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('DPB-09: openclaw-cli missing mode (--json) outputs JSON error', async () => {
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      ok: false,
+      reason: 'missing_openclaw_mode',
+      message: 'runtimeKind is openclaw-cli but no mode specified',
+      nextAction: 'Provide exactly one mode',
+    });
+    mockIsRuntimeConfigError.mockReturnValueOnce(true);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'openclaw-cli',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.ok).toBe(false);
+    expect(jsonOutput.reason).toBe('missing_openclaw_mode');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
     exitSpy.mockRestore();
   });
 

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -300,6 +300,70 @@ describe('pd diagnose run --runtime routing', () => {
     consoleErrorSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  it('DPB-09: openclaw-cli --openclaw-gateway constructs adapter with runtimeMode=gateway', async () => {
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      runtimeKind: 'openclaw-cli',
+      openclawMode: 'gateway',
+      timeoutMs: 300000,
+      agentId: 'main',
+    });
+    mockIsRuntimeConfigError.mockReturnValueOnce(false);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'openclaw-cli',
+      openclawGateway: true,
+      json: false,
+    } as DiagnoseRunOptions);
+
+    const OpenClawCliMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.OpenClawCliRuntimeAdapter),
+    );
+    expect(OpenClawCliMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeMode: 'gateway' }),
+    );
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('DPB-09: openclaw-cli --openclaw-local constructs adapter with runtimeMode=local', async () => {
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      runtimeKind: 'openclaw-cli',
+      openclawMode: 'local',
+      timeoutMs: 300000,
+      agentId: 'main',
+    });
+    mockIsRuntimeConfigError.mockReturnValueOnce(false);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'openclaw-cli',
+      openclawLocal: true,
+      json: false,
+    } as DiagnoseRunOptions);
+
+    const OpenClawCliMock = vi.mocked(
+      await import('@principles/core/runtime-v2').then(m => m.OpenClawCliRuntimeAdapter),
+    );
+    expect(OpenClawCliMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeMode: 'local' }),
+    );
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 });
 
 describe('pd diagnose run — auto-intake after success', () => {

--- a/packages/pd-cli/tests/commands/pain-record.test.ts
+++ b/packages/pd-cli/tests/commands/pain-record.test.ts
@@ -213,6 +213,62 @@ describe('pd pain record', () => {
     exitSpy.mockRestore();
   });
 
+  // 7a. config_missing with RuntimeConfigError exits non-zero (text)
+  it('exits 1 on config_missing with RuntimeConfigError (text)', async () => {
+    mockRecordPainResult = makeFailedResult({
+      failureCategory: 'config_missing' as FailureCategory,
+      message: 'API key not found in env',
+    });
+    const { isRuntimeConfigError, resolveRuntimeConfig } = await import('@principles/core/runtime-v2');
+    vi.mocked(isRuntimeConfigError).mockReturnValueOnce(true);
+    vi.mocked(resolveRuntimeConfig).mockReturnValueOnce({
+      ok: false,
+      reason: 'missing_openclaw_mode',
+      message: 'runtimeKind is openclaw-cli but no mode specified',
+      nextAction: 'Provide exactly one mode',
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain' });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // 7b. config_missing with RuntimeConfigError outputs JSON (--json)
+  it('outputs JSON with configError on config_missing + RuntimeConfigError (--json)', async () => {
+    mockRecordPainResult = makeFailedResult({
+      failureCategory: 'config_missing' as FailureCategory,
+      message: 'API key not found in env',
+    });
+    const { isRuntimeConfigError, resolveRuntimeConfig } = await import('@principles/core/runtime-v2');
+    vi.mocked(isRuntimeConfigError).mockReturnValueOnce(true);
+    vi.mocked(resolveRuntimeConfig).mockReturnValueOnce({
+      ok: false,
+      reason: 'missing_openclaw_mode',
+      message: 'runtimeKind is openclaw-cli but no mode specified',
+      nextAction: 'Provide exactly one mode',
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await handlePainRecord({ reason: 'test pain', json: true });
+
+    const jsonOutput = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('failed');
+    expect(jsonOutput.failureCategory).toBe('config_missing');
+    expect(jsonOutput.configError).toBeDefined();
+    expect(jsonOutput.configError.reason).toBe('missing_openclaw_mode');
+    expect(jsonOutput.configError.nextAction).toBe('Provide exactly one mode');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
   // 8. skipped status outputs [SKIP] and does not exit 1
   it('outputs [SKIP] on skipped status (text)', async () => {
     mockRecordPainResult = makeSkippedResult();

--- a/packages/pd-cli/tests/commands/pain-record.test.ts
+++ b/packages/pd-cli/tests/commands/pain-record.test.ts
@@ -33,6 +33,7 @@ vi.mock('@principles/core/runtime-v2', () => ({
     timeoutMs: 300000,
     agentId: 'main',
   }),
+  isRuntimeConfigError: vi.fn().mockReturnValue(false),
 }));
 
 import { handlePainRecord } from '../../src/commands/pain-record.js';

--- a/packages/pd-cli/tests/commands/proven-channel-baseline.test.ts
+++ b/packages/pd-cli/tests/commands/proven-channel-baseline.test.ts
@@ -274,14 +274,14 @@ describe('handleProvenChannelBaseline (CLI handler)', () => {
           unknownChannels: [],
         }),
       );
-      const output = logSpy.mock.calls[0]?.[0];
-      if (output) {
-        const parsed = JSON.parse(output);
-        expect(parsed.status).toBe('failed');
-        expect(parsed.inputValidationFailure).toBeDefined();
-        expect(parsed.inputValidationFailure.reason).toBe('empty_channel_input');
-        expect(parsed.channels).toHaveLength(0);
-      }
+      expect(logSpy.mock.calls[0]?.[0]).toBeDefined();
+      const output = logSpy.mock.calls[0][0];
+      expect(typeof output).toBe('string');
+      const parsed = JSON.parse(output);
+      expect(parsed.status).toBe('failed');
+      expect(parsed.inputValidationFailure).toBeDefined();
+      expect(parsed.inputValidationFailure.reason).toBe('empty_channel_input');
+      expect(parsed.channels).toHaveLength(0);
     } finally {
       logSpy.mockRestore();
       errorSpy.mockRestore();
@@ -343,12 +343,12 @@ describe('handleProvenChannelBaseline (CLI handler)', () => {
           unknownChannels: ['bogus'],
         }),
       );
-      const output = logSpy.mock.calls[0]?.[0];
-      if (output) {
-        const parsed = JSON.parse(output);
-        expect(parsed.inputValidationFailure.reason).toBe('unknown_channels');
-        expect(parsed.inputValidationFailure.unknownChannels).not.toContain('prompt');
-      }
+      expect(logSpy.mock.calls[0]?.[0]).toBeDefined();
+      const output = logSpy.mock.calls[0][0];
+      expect(typeof output).toBe('string');
+      const parsed = JSON.parse(output);
+      expect(parsed.inputValidationFailure.reason).toBe('unknown_channels');
+      expect(parsed.inputValidationFailure.unknownChannels).not.toContain('prompt');
     } finally {
       logSpy.mockRestore();
       errorSpy.mockRestore();

--- a/packages/pd-cli/tests/commands/proven-channel-baseline.test.ts
+++ b/packages/pd-cli/tests/commands/proven-channel-baseline.test.ts
@@ -6,29 +6,12 @@ const { mockRunProvenChannelBaseline } = vi.hoisted(() => ({
 
 vi.mock('../../src/services/proven-channel-baseline-runner.js', () => ({
   runProvenChannelBaseline: mockRunProvenChannelBaseline,
-  isProductionWorkspace: (dir: string) => {
-    const path = require('path');
-    const os = require('os');
-    const normalized = path.resolve(dir).toLowerCase();
-    const prefixes = [
-      path.resolve('D:\\.openclaw\\workspace').toLowerCase(),
-      path.resolve('C:\\Users\\Administrator\\.openclaw\\workspace').toLowerCase(),
-      path.resolve(path.join(os.homedir(), '.openclaw', 'workspace')).toLowerCase(),
-    ];
-    for (const prefix of prefixes) {
-      if (normalized === prefix || normalized.startsWith(prefix + path.sep)) {
-        return true;
-      }
-    }
-    return false;
-  },
 }));
 
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { handleProvenChannelBaseline, cleanupTempWorkspace } from '../../src/commands/proven-channel-baseline.js';
-import { isProductionWorkspace } from '../../src/services/proven-channel-baseline-runner.js';
 
 function makePassedSummary() {
   return {
@@ -360,6 +343,43 @@ describe('handleProvenChannelBaseline (CLI handler)', () => {
           unknownChannels: ['bogus'],
         }),
       );
+      const output = logSpy.mock.calls[0]?.[0];
+      if (output) {
+        const parsed = JSON.parse(output);
+        expect(parsed.inputValidationFailure.reason).toBe('unknown_channels');
+        expect(parsed.inputValidationFailure.unknownChannels).not.toContain('prompt');
+      }
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('text mode output shows inputValidationFailure reason, message, nextAction', async () => {
+    mockRunProvenChannelBaseline.mockResolvedValue({
+      status: 'failed',
+      generatedAt: new Date().toISOString(),
+      workspaceMode: 'temp',
+      channels: [],
+      inputValidationFailure: {
+        reason: 'unknown_channels',
+        message: 'Unknown channels: bogus. Valid channels: prompt, code_tool_hook, defer_archive',
+        nextAction: 'Use only valid MVP channels: prompt, code_tool_hook, defer_archive',
+        unknownChannels: ['bogus'],
+      },
+      continuityMatrix: [],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await handleProvenChannelBaseline({ channels: 'bogus' });
+      const output = logSpy.mock.calls[0]?.[0] ?? '';
+      expect(output).toContain('Input Validation Failure:');
+      expect(output).toContain('reason: unknown_channels');
+      expect(output).toContain('message:');
+      expect(output).toContain('nextAction:');
     } finally {
       logSpy.mockRestore();
       errorSpy.mockRestore();
@@ -423,28 +443,5 @@ describe('handleProvenChannelBaseline (CLI handler)', () => {
       ?.commands.find(c => c.name() === 'proven-channel');
     expect(found).toBeDefined();
     expect(found?.name()).toBe('proven-channel');
-  });
-});
-
-describe('isProductionWorkspace', () => {
-  it('blocks exact production workspace path', () => {
-    expect(isProductionWorkspace('D:\\.openclaw\\workspace')).toBe(true);
-  });
-
-  it('blocks descendant of production workspace', () => {
-    expect(isProductionWorkspace('D:\\.openclaw\\workspace\\my-project')).toBe(true);
-  });
-
-  it('does NOT block sibling path with different prefix', () => {
-    expect(isProductionWorkspace('D:\\.openclaw\\workspace-extra')).toBe(false);
-  });
-
-  it('does NOT block unrelated path', () => {
-    expect(isProductionWorkspace('C:\\Users\\test\\project')).toBe(false);
-  });
-
-  it('does NOT block temp directory', () => {
-    const tmp = os.tmpdir();
-    expect(isProductionWorkspace(tmp)).toBe(false);
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -455,7 +455,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     );
     const resolvedWorkspace = path.resolve(customWs);
     const expectedStateDir = path.join(resolvedWorkspace, '.state');
-    expect(ResolveConfigMock).toHaveBeenCalledWith(expectedStateDir);
+    expect(ResolveConfigMock).toHaveBeenCalledWith(expectedStateDir, { requestedRuntimeKind: 'config' });
   });
 
   it('--runner philosopher dispatches PhilosopherRunner', async () => {
@@ -1250,5 +1250,52 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('no_successor');
+  });
+
+  it('--runtime config with missing config outputs structured JSON error', async () => {
+    const { resolveRuntimeConfig, isRuntimeConfigError } = await import('@principles/core/runtime-v2');
+    vi.mocked(resolveRuntimeConfig).mockReturnValue({
+      ok: false,
+      reason: 'explicit_config_missing',
+      message: 'runtime=config requested but no workflows.yaml funnel policy found',
+      nextAction: 'Create a pd-runtime-v2-diagnosis funnel policy in workflows.yaml',
+    });
+    vi.mocked(isRuntimeConfigError).mockReturnValue(true);
+
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-cfg-err',
+      taskKind: 'dreamer',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'config', json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('config_error');
+    expect(output.reason).toContain('explicit_config_missing');
+    expect(output.nextAction).toBeTruthy();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('--runtime config with missing config outputs text error', async () => {
+    const { resolveRuntimeConfig, isRuntimeConfigError } = await import('@principles/core/runtime-v2');
+    vi.mocked(resolveRuntimeConfig).mockReturnValue({
+      ok: false,
+      reason: 'explicit_config_missing',
+      message: 'runtime=config requested but no workflows.yaml funnel policy found',
+      nextAction: 'Create a pd-runtime-v2-diagnosis funnel policy in workflows.yaml',
+    });
+    vi.mocked(isRuntimeConfigError).mockReturnValue(true);
+
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-cfg-err2',
+      taskKind: 'dreamer',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runtime: 'config', json: false });
+
+    expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('explicit_config_missing'))).toBe(true);
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -1298,4 +1298,21 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(consoleErrorSpy.mock.calls.some((c: string[]) => c[0].includes('explicit_config_missing'))).toBe(true);
     expect(process.exitCode).toBe(1);
   });
+
+  it('runtime execution error outputs runtime_error in JSON mode', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-rt-err',
+      taskKind: 'dreamer',
+    });
+    mockRun.mockRejectedValueOnce(new Error('artifact write failed: disk full'));
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('runtime_error');
+    expect(output.reason).toContain('artifact write failed');
+    expect(output.nextAction).toBeTruthy();
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -120,6 +120,7 @@ vi.mock('@principles/core/runtime-v2', () => ({
     model: 'test-model',
     apiKeyEnv: 'TEST_API_KEY',
   }),
+  isRuntimeConfigError: vi.fn().mockReturnValue(false),
   validateRuntimeConfig: vi.fn(),
 }));
 
@@ -375,6 +376,14 @@ describe('handleRuntimeInternalizationRunOnce', () => {
   });
 
   it('--runtime openclaw-cli resolves OpenClawCliRuntimeAdapter', async () => {
+    const { resolveRuntimeConfig } = await import('@principles/core/runtime-v2');
+    vi.mocked(resolveRuntimeConfig).mockReturnValue({
+      runtimeKind: 'openclaw-cli',
+      openclawMode: 'local',
+      timeoutMs: 300_000,
+      agentId: 'main',
+    });
+
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-dreamer-007',

--- a/packages/pd-cli/tests/commands/runtime.test.ts
+++ b/packages/pd-cli/tests/commands/runtime.test.ts
@@ -23,6 +23,15 @@ vi.mock('@principles/core/runtime-v2', () => ({
       supportsStreaming: false,
     },
   }),
+  resolveRuntimeConfig: vi.fn().mockReturnValue({
+    runtimeKind: 'pi-ai',
+    provider: 'test-provider',
+    model: 'test-model',
+    apiKeyEnv: 'TEST_KEY',
+    timeoutMs: 300000,
+    agentId: 'main',
+  }),
+  isRuntimeConfigError: vi.fn().mockReturnValue(false),
   PDRuntimeError: class PDRuntimeError extends Error {
     constructor(public category: string, message: string) {
       super(message);

--- a/packages/pd-cli/tests/services/proven-channel-baseline-runner.test.ts
+++ b/packages/pd-cli/tests/services/proven-channel-baseline-runner.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+import { isProductionWorkspace } from '../../src/services/proven-channel-baseline-runner.js';
+
+describe('isProductionWorkspace (real implementation)', () => {
+  it('blocks exact production workspace path', () => {
+    const homedirWorkspace = path.join(os.homedir(), '.openclaw', 'workspace');
+    expect(isProductionWorkspace(homedirWorkspace)).toBe(true);
+  });
+
+  it('blocks descendant of production workspace', () => {
+    const homedirWorkspace = path.join(os.homedir(), '.openclaw', 'workspace', 'my-project');
+    expect(isProductionWorkspace(homedirWorkspace)).toBe(true);
+  });
+
+  it('does NOT block sibling path with different prefix', () => {
+    const sibling = path.join(os.homedir(), '.openclaw', 'workspace-extra');
+    expect(isProductionWorkspace(sibling)).toBe(false);
+  });
+
+  it('does NOT block unrelated path', () => {
+    expect(isProductionWorkspace('C:\\Users\\test\\project')).toBe(false);
+  });
+
+  it('does NOT block temp directory', () => {
+    const tmp = os.tmpdir();
+    expect(isProductionWorkspace(tmp)).toBe(false);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-real-llm.test.ts
@@ -11,14 +11,14 @@ import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
 import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
-import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-dreamer-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
 const config = getLlmE2eConfig();
 
 describe.skipIf(!config)('DreamerRunner Real LLM E2E', () => {
-  const cfg = config as LlmE2eTestConfig;
+  const cfg = config;
+  if (!cfg) return;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
@@ -89,7 +89,7 @@ describe.skipIf(!config)('DreamerRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -122,7 +122,7 @@ describe.skipIf(!config)('DreamerRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -159,7 +159,7 @@ describe.skipIf(!config)('DreamerRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),

--- a/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-real-llm.test.ts
@@ -10,21 +10,23 @@ import { PiAiRuntimeAdapter } from '../adapter/pi-ai-runtime-adapter.js';
 import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
-import { getMiniMaxConfig, runWithRetry } from './fixtures/index.js';
-import type { MiniMaxTestConfig } from './fixtures/index.js';
+import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
+import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-dreamer-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
-const config = getMiniMaxConfig();
+const config = getLlmE2eConfig();
 
-describe.skipIf(!config)('DreamerRunner Real LLM E2E (MiniMax)', () => {
-  const cfg = config as MiniMaxTestConfig;
+describe.skipIf(!config)('DreamerRunner Real LLM E2E', () => {
+  const cfg = config as LlmE2eTestConfig;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
     apiKeyEnv: cfg.apiKeyEnv,
     maxRetries: cfg.maxRetries,
     timeoutMs: cfg.timeoutMs,
+    baseUrl: cfg.baseUrl,
+    reasoning: cfg.reasoning,
   };
 
   let testDir = '';

--- a/packages/principles-core/src/runtime-v2/__tests__/fixtures/index.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/fixtures/index.ts
@@ -1,3 +1,3 @@
-export { getMiniMaxConfig } from './llm-e2e-config.js';
+export { getLlmE2eConfig, getMiniMaxConfig } from './llm-e2e-config.js';
 export { runWithRetry } from './test-helpers.js';
-export type { MiniMaxTestConfig, RetryOptions } from './llm-e2e-config.js';
+export type { LlmE2eTestConfig, MiniMaxTestConfig, RetryOptions } from './llm-e2e-config.js';

--- a/packages/principles-core/src/runtime-v2/__tests__/fixtures/llm-e2e-config.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/fixtures/llm-e2e-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getLlmE2eConfig } from './llm-e2e-config.js';
+
+describe('getLlmE2eConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null when no API keys are set', () => {
+    delete process.env.LLM_E2E_API_KEY;
+    delete process.env.MINIMAX_CN_API_KEY;
+    expect(getLlmE2eConfig()).toBeNull();
+  });
+
+  it('sensenova provider gets default baseUrl', () => {
+    process.env.LLM_E2E_API_KEY = 'test-key';
+    delete process.env.LLM_E2E_PROVIDER;
+    delete process.env.LLM_E2E_BASE_URL;
+    const config = getLlmE2eConfig();
+    expect(config).not.toBeNull();
+    if (!config) return;
+    expect(config.provider).toBe('sensenova');
+    expect(config.baseUrl).toBe('https://token.sensenova.cn/v1');
+  });
+
+  it('openrouter provider does not get sensenova baseUrl', () => {
+    process.env.LLM_E2E_API_KEY = 'test-key';
+    process.env.LLM_E2E_PROVIDER = 'openrouter';
+    delete process.env.LLM_E2E_BASE_URL;
+    const config = getLlmE2eConfig();
+    expect(config).not.toBeNull();
+    if (!config) return;
+    expect(config.provider).toBe('openrouter');
+    expect(config.baseUrl).toBeUndefined();
+  });
+
+  it('minimax-cn provider does not get sensenova baseUrl', () => {
+    process.env.LLM_E2E_API_KEY = 'test-key';
+    process.env.LLM_E2E_PROVIDER = 'minimax-cn';
+    delete process.env.LLM_E2E_BASE_URL;
+    const config = getLlmE2eConfig();
+    expect(config).not.toBeNull();
+    if (!config) return;
+    expect(config.provider).toBe('minimax-cn');
+    expect(config.baseUrl).toBeUndefined();
+  });
+
+  it('LLM_E2E_BASE_URL overrides provider default', () => {
+    process.env.LLM_E2E_API_KEY = 'test-key';
+    delete process.env.LLM_E2E_PROVIDER;
+    process.env.LLM_E2E_BASE_URL = 'https://custom.endpoint/v1';
+    const config = getLlmE2eConfig();
+    expect(config).not.toBeNull();
+    if (!config) return;
+    expect(config.provider).toBe('sensenova');
+    expect(config.baseUrl).toBe('https://custom.endpoint/v1');
+  });
+
+  it('non-sensenova provider with explicit LLM_E2E_BASE_URL uses that URL', () => {
+    process.env.LLM_E2E_API_KEY = 'test-key';
+    process.env.LLM_E2E_PROVIDER = 'openrouter';
+    process.env.LLM_E2E_BASE_URL = 'https://openrouter.ai/v1';
+    const config = getLlmE2eConfig();
+    expect(config).not.toBeNull();
+    if (!config) return;
+    expect(config.provider).toBe('openrouter');
+    expect(config.baseUrl).toBe('https://openrouter.ai/v1');
+  });
+
+  it('MINIMAX_CN_API_KEY fallback does not set baseUrl', () => {
+    delete process.env.LLM_E2E_API_KEY;
+    process.env.MINIMAX_CN_API_KEY = 'minimax-key';
+    delete process.env.LLM_E2E_BASE_URL;
+    const config = getLlmE2eConfig();
+    expect(config).not.toBeNull();
+    if (!config) return;
+    expect(config.provider).toBe('minimax-cn');
+    expect(config.baseUrl).toBeUndefined();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/fixtures/llm-e2e-config.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/fixtures/llm-e2e-config.ts
@@ -19,12 +19,14 @@ export function getLlmE2eConfig(): LlmE2eTestConfig | null {
   const minimaxApiKey = process.env.MINIMAX_CN_API_KEY;
 
   if (llmE2eApiKey) {
+    const provider = process.env.LLM_E2E_PROVIDER ?? 'sensenova';
+    const isSensenova = provider === 'sensenova';
     return {
       apiKey: llmE2eApiKey,
       model: process.env.LLM_E2E_MODEL ?? 'deepseek-v4-flash',
-      provider: process.env.LLM_E2E_PROVIDER ?? 'sensenova',
+      provider,
       apiKeyEnv: 'LLM_E2E_API_KEY',
-      baseUrl: process.env.LLM_E2E_BASE_URL ?? 'https://token.sensenova.cn/v1',
+      baseUrl: process.env.LLM_E2E_BASE_URL ?? (isSensenova ? 'https://token.sensenova.cn/v1' : undefined),
       timeoutMs: 120_000,
       maxRetries: 2,
     };

--- a/packages/principles-core/src/runtime-v2/__tests__/fixtures/llm-e2e-config.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/fixtures/llm-e2e-config.ts
@@ -1,19 +1,12 @@
-/**
- * MiniMax E2E Test Configuration
- *
- * Provides configuration and utilities for running E2E tests with real MiniMax LLM API.
- * Uses the same provider/env configuration as the production workflows.yaml:
- *   provider: minimax-cn
- *   apiKeyEnv: MINIMAX_CN_API_KEY
- */
-
-export interface MiniMaxTestConfig {
+export interface LlmE2eTestConfig {
   apiKey: string;
-  model: 'MiniMax-M2.7';
-  provider: 'minimax-cn';
-  apiKeyEnv: 'MINIMAX_CN_API_KEY';
+  model: string;
+  provider: string;
+  apiKeyEnv: string;
+  baseUrl?: string;
   timeoutMs: number;
   maxRetries: number;
+  reasoning?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | false;
 }
 
 export interface RetryOptions {
@@ -21,17 +14,41 @@ export interface RetryOptions {
   delayMs?: number;
 }
 
-export function getMiniMaxConfig(): MiniMaxTestConfig | null {
-  const apiKey = process.env.MINIMAX_CN_API_KEY;
-  if (!apiKey) {
-    return null;
+export function getLlmE2eConfig(): LlmE2eTestConfig | null {
+  const llmE2eApiKey = process.env.LLM_E2E_API_KEY;
+  const minimaxApiKey = process.env.MINIMAX_CN_API_KEY;
+
+  if (llmE2eApiKey) {
+    return {
+      apiKey: llmE2eApiKey,
+      model: process.env.LLM_E2E_MODEL ?? 'deepseek-v4-flash',
+      provider: process.env.LLM_E2E_PROVIDER ?? 'sensenova',
+      apiKeyEnv: 'LLM_E2E_API_KEY',
+      baseUrl: process.env.LLM_E2E_BASE_URL ?? 'https://token.sensenova.cn/v1',
+      timeoutMs: 120_000,
+      maxRetries: 2,
+    };
   }
-  return {
-    apiKey,
-    model: 'MiniMax-M2.7',
-    provider: 'minimax-cn',
-    apiKeyEnv: 'MINIMAX_CN_API_KEY',
-    timeoutMs: 120_000,
-    maxRetries: 2,
-  };
+
+  if (minimaxApiKey) {
+    return {
+      apiKey: minimaxApiKey,
+      model: process.env.LLM_E2E_MODEL ?? 'MiniMax-M2.7',
+      provider: process.env.LLM_E2E_PROVIDER ?? 'minimax-cn',
+      apiKeyEnv: 'MINIMAX_CN_API_KEY',
+      timeoutMs: 120_000,
+      maxRetries: 2,
+      reasoning: false,
+    };
+  }
+
+  return null;
 }
+
+/** @deprecated Use getLlmE2eConfig() instead */
+export function getMiniMaxConfig(): LlmE2eTestConfig | null {
+  return getLlmE2eConfig();
+}
+
+/** @deprecated Use LlmE2eTestConfig instead */
+export type MiniMaxTestConfig = LlmE2eTestConfig;

--- a/packages/principles-core/src/runtime-v2/__tests__/full-chain-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/full-chain-real-llm.test.ts
@@ -21,14 +21,14 @@ import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
 import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
-import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-full-chain-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
 const config = getLlmE2eConfig();
 
 describe.skipIf(!config)('Full Internalization Chain Real LLM E2E', () => {
-  const cfg = config as LlmE2eTestConfig;
+  const cfg = config;
+  if (!cfg) return;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
@@ -112,7 +112,7 @@ describe.skipIf(!config)('Full Internalization Chain Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: depTaskIds,
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),

--- a/packages/principles-core/src/runtime-v2/__tests__/full-chain-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/full-chain-real-llm.test.ts
@@ -20,21 +20,23 @@ import { PiAiRuntimeAdapter } from '../adapter/pi-ai-runtime-adapter.js';
 import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
-import { getMiniMaxConfig, runWithRetry } from './fixtures/index.js';
-import type { MiniMaxTestConfig } from './fixtures/index.js';
+import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
+import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-full-chain-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
-const config = getMiniMaxConfig();
+const config = getLlmE2eConfig();
 
-describe.skipIf(!config)('Full Internalization Chain Real LLM E2E (MiniMax)', () => {
-  const cfg = config as MiniMaxTestConfig;
+describe.skipIf(!config)('Full Internalization Chain Real LLM E2E', () => {
+  const cfg = config as LlmE2eTestConfig;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
     apiKeyEnv: cfg.apiKeyEnv,
     maxRetries: cfg.maxRetries,
     timeoutMs: cfg.timeoutMs,
+    baseUrl: cfg.baseUrl,
+    reasoning: cfg.reasoning,
   };
 
   let testDir = '';

--- a/packages/principles-core/src/runtime-v2/__tests__/philosopher-runner-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/philosopher-runner-real-llm.test.ts
@@ -13,14 +13,14 @@ import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
 import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
-import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-philosopher-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
 const config = getLlmE2eConfig();
 
 describe.skipIf(!config)('PhilosopherRunner Real LLM E2E', () => {
-  const cfg = config as LlmE2eTestConfig;
+  const cfg = config;
+  if (!cfg) return;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
@@ -108,7 +108,7 @@ describe.skipIf(!config)('PhilosopherRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -127,7 +127,7 @@ describe.skipIf(!config)('PhilosopherRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [dreamerTaskId],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -152,7 +152,7 @@ describe.skipIf(!config)('PhilosopherRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -171,7 +171,7 @@ describe.skipIf(!config)('PhilosopherRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [dreamerTaskId],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),

--- a/packages/principles-core/src/runtime-v2/__tests__/philosopher-runner-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/philosopher-runner-real-llm.test.ts
@@ -12,21 +12,23 @@ import { PiAiRuntimeAdapter } from '../adapter/pi-ai-runtime-adapter.js';
 import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
-import { getMiniMaxConfig, runWithRetry } from './fixtures/index.js';
-import type { MiniMaxTestConfig } from './fixtures/index.js';
+import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
+import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-philosopher-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
-const config = getMiniMaxConfig();
+const config = getLlmE2eConfig();
 
-describe.skipIf(!config)('PhilosopherRunner Real LLM E2E (MiniMax)', () => {
-  const cfg = config as MiniMaxTestConfig;
+describe.skipIf(!config)('PhilosopherRunner Real LLM E2E', () => {
+  const cfg = config as LlmE2eTestConfig;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
     apiKeyEnv: cfg.apiKeyEnv,
     maxRetries: cfg.maxRetries,
     timeoutMs: cfg.timeoutMs,
+    baseUrl: cfg.baseUrl,
+    reasoning: cfg.reasoning,
   };
 
   let testDir = '';

--- a/packages/principles-core/src/runtime-v2/__tests__/proven-channel-baseline.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/proven-channel-baseline.test.ts
@@ -18,6 +18,52 @@ import type { ChannelFixtureResult, MvpChannel } from '../proven-channel-baselin
 import { ActivationDispatcher } from '../activation/activation-dispatcher.js';
 import { PromptWriter, DeferArchiveWriter } from '../activation/low-risk-writers.js';
 import { RuleHostWriter } from '../activation/writers/rule-host-writer.js';
+import type { ApprovalQueueStore, ApprovalRecord, ApprovalEnqueueInput, ApprovalDecisionResult, ApprovalStats } from '../activation/activation-types.js';
+
+function makeInMemoryApprovalQueueStoreForTest(): ApprovalQueueStore {
+  const records = new Map<string, ApprovalRecord>();
+  let counter = 0;
+  return {
+    enqueue: async (input: ApprovalEnqueueInput, now: string) => {
+      const approvalId = `apr_test_${++counter}`;
+      const record: ApprovalRecord = {
+        approvalId,
+        artifactId: input.artifactId,
+        channel: input.channel,
+        riskLevel: input.riskLevel,
+        status: 'pending',
+        confidence: input.confidence,
+        requestedAt: now,
+        summary: input.summary,
+        triggerReason: input.triggerReason,
+      };
+      records.set(approvalId, record);
+      return record;
+    },
+    getById: async (id: string) => records.get(id) ?? null,
+    listPending: async () => [...records.values()].filter(r => r.status === 'pending'),
+    listAll: async () => [...records.values()],
+    countByStatus: async () => {
+      const stats: ApprovalStats = { pending: 0, approved: 0, rejected: 0, cancelled: 0 };
+      for (const r of records.values()) { stats[r.status]++; }
+      return stats;
+    },
+    approve: async (id: string, decidedBy: string, note?: string) => {
+      const r = records.get(id);
+      if (!r) return { ok: false, error: 'not_found' } as ApprovalDecisionResult;
+      if (r.status !== 'pending') return { ok: false, error: 'already_decided', status: r.status } as ApprovalDecisionResult;
+      r.status = 'approved'; r.decidedAt = new Date().toISOString(); r.decidedBy = decidedBy; r.decisionNote = note;
+      return { ok: true, record: r } as ApprovalDecisionResult;
+    },
+    reject: async (id: string, decidedBy: string, reason: string) => {
+      const r = records.get(id);
+      if (!r) return { ok: false, error: 'not_found' } as ApprovalDecisionResult;
+      if (r.status !== 'pending') return { ok: false, error: 'already_decided', status: r.status } as ApprovalDecisionResult;
+      r.status = 'rejected'; r.decidedAt = new Date().toISOString(); r.decidedBy = decidedBy; r.rejectionReason = reason;
+      return { ok: true, record: r } as ApprovalDecisionResult;
+    },
+  };
+}
 
 describe('Proven Channel Baseline (PRI-240)', () => {
   describe('prompt channel fixture', () => {
@@ -48,44 +94,53 @@ describe('Proven Channel Baseline (PRI-240)', () => {
 
       expect(result.channel).toBe('code_tool_hook');
       expect(result.evidenceSource).toContain('ActivationDispatcher');
-      expect(['passed', 'degraded', 'failed']).toContain(result.status);
+      expect(result.status).not.toBe('failed');
 
       if (result.status === 'passed') {
-        expect(['would_activate', 'activated']).toContain(result.activationDecision.decision);
         if (result.activationDecision.decision === 'would_activate' || result.activationDecision.decision === 'activated') {
           expect(result.activationDecision.activationId).toContain('act_code_');
           expect(result.activationDecision.action).toBe('code_tool_hook_shadow_activate');
           expect(result.activationDecision.targetRef).toContain('impl://');
         }
-        expect(result.evidence).toHaveProperty('gateDecision');
+
+        if (result.activationDecision.decision === 'queued_for_approval') {
+          expect(result.evidence).toHaveProperty('queueBehavior');
+          expect((result.evidence).queueBehavior).toBe('enqueued');
+        }
+
         expect(result.failureReason).toBeUndefined();
       }
 
-      if (result.status === 'degraded' || result.status === 'failed') {
+      if (result.status === 'degraded') {
         expect(result.failureReason).toBeTruthy();
         expect(result.nextAction).toBeTruthy();
       }
     });
 
-    it('returns degraded when dispatcher routes to approval queue', async () => {
+    it('returns queued_for_approval with proven evidence when dispatcher routes to approval queue', async () => {
       const artifact = makeRuleArtifact();
       const writers: InstanceType<typeof RuleHostWriter>[] = [new RuleHostWriter({ gateDeps: makeSandboxAlwaysPass() })];
+      const approvalStore = makeInMemoryApprovalQueueStoreForTest();
       const dispatcher = new ActivationDispatcher(
         { getArtifactById: async (id: string) => id === artifact.artifactId ? artifact : null },
         { getActivationStatus: async () => null, recordActivation: async () => { void 0; } },
-        { writers },
+        { writers, approvalQueueStore: approvalStore },
       );
       const decision = await dispatcher.dispatch({
         artifactId: artifact.artifactId,
         channel: 'code_tool_hook',
         rolloutDecision: 'require_approval',
         actor: { kind: 'system', source: 'rollout_reviewer' },
-        idempotencyKey: 'test-approval',
+        idempotencyKey: 'test-approval-proven',
         now: '2026-05-24T00:00:00.000Z',
         confirm: true,
       });
 
-      expect(['would_activate', 'queued_for_approval', 'refused']).toContain(decision.decision);
+      expect(decision.decision).toBe('queued_for_approval');
+      if (decision.decision === 'queued_for_approval') {
+        expect(decision.approvalId).toBeTruthy();
+        expect(decision.queuedAt).toBeTruthy();
+      }
     });
   });
 
@@ -214,10 +269,39 @@ describe('Proven Channel Baseline (PRI-240)', () => {
       expect(result.unknowns).toEqual(['foo', 'bar']);
     });
 
-    it('handles empty string', () => {
+    it('handles empty string as no channels', () => {
       const result = parseChannels('');
       expect(result.channels).toEqual([]);
       expect(result.unknowns).toEqual([]);
+    });
+
+    it('handles comma-only string as no channels', () => {
+      const result = parseChannels(',');
+      expect(result.channels).toEqual([]);
+      expect(result.unknowns).toEqual([]);
+    });
+  });
+
+  describe('empty/invalid channel input must fail', () => {
+    it('computeProvenChannelStatus returns failed for empty results', () => {
+      expect(computeProvenChannelStatus([])).toBe('failed');
+    });
+
+    it('parseChannels with empty string produces no channels', () => {
+      const result = parseChannels('');
+      expect(result.channels).toHaveLength(0);
+    });
+
+    it('parseChannels with comma-only produces no channels', () => {
+      const result = parseChannels(',');
+      expect(result.channels).toHaveLength(0);
+    });
+
+    it('unknown channel must not be confused with prompt channel failure', () => {
+      const result = parseChannels('unknown_channel');
+      expect(result.channels).toEqual([]);
+      expect(result.unknowns).toEqual(['unknown_channel']);
+      expect(result.unknowns).not.toContain('prompt');
     });
   });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   validateRuntimeConfig,
   isRuntimeConfigError,
   invalidatePainSignalBridge,
+  resolveRuntimeConfig,
 } from '../pain-signal-runtime-factory.js';
 import type { RuntimeConfig } from '../pain-signal-runtime-factory.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 
 describe('Runtime Config Boundary (PRI-162)', () => {
   describe('validateRuntimeConfig', () => {
@@ -192,6 +196,62 @@ describe('Runtime Config Boundary (PRI-162)', () => {
       expect(localKey).not.toBe(gatewayKey);
       expect(localKey).not.toBe(emptyKey);
       expect(gatewayKey).not.toBe(emptyKey);
+    });
+  });
+
+  describe('resolveRuntimeConfig with requestedRuntimeKind', () => {
+    let tmpDir = '';
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-rt-cfg-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('requestedRuntimeKind=openclaw-cli without flags returns missing_openclaw_mode error', () => {
+      const result = resolveRuntimeConfig(tmpDir, { requestedRuntimeKind: 'openclaw-cli' });
+      expect(isRuntimeConfigError(result)).toBe(true);
+      if (isRuntimeConfigError(result)) {
+        expect(result.reason).toBe('missing_openclaw_mode');
+        expect(result.nextAction).toBeTruthy();
+      }
+    });
+
+    it('requestedRuntimeKind=openclaw-cli with openclawGateway returns gateway mode', () => {
+      const result = resolveRuntimeConfig(tmpDir, { requestedRuntimeKind: 'openclaw-cli', openclawGateway: true });
+      expect(isRuntimeConfigError(result)).toBe(false);
+      if (!isRuntimeConfigError(result)) {
+        expect(result.runtimeKind).toBe('openclaw-cli');
+        expect(result.openclawMode).toBe('gateway');
+      }
+    });
+
+    it('requestedRuntimeKind=openclaw-cli with openclawLocal returns local mode', () => {
+      const result = resolveRuntimeConfig(tmpDir, { requestedRuntimeKind: 'openclaw-cli', openclawLocal: true });
+      expect(isRuntimeConfigError(result)).toBe(false);
+      if (!isRuntimeConfigError(result)) {
+        expect(result.runtimeKind).toBe('openclaw-cli');
+        expect(result.openclawMode).toBe('local');
+      }
+    });
+
+    it('requestedRuntimeKind=config without policy returns explicit_config_missing error', () => {
+      const result = resolveRuntimeConfig(tmpDir, { requestedRuntimeKind: 'config' });
+      expect(isRuntimeConfigError(result)).toBe(true);
+      if (isRuntimeConfigError(result)) {
+        expect(result.reason).toBe('explicit_config_missing');
+        expect(result.nextAction).toBeTruthy();
+      }
+    });
+
+    it('no requestedRuntimeKind without policy returns pi-ai default', () => {
+      const result = resolveRuntimeConfig(tmpDir);
+      expect(isRuntimeConfigError(result)).toBe(false);
+      if (!isRuntimeConfigError(result)) {
+        expect(result.runtimeKind).toBe('pi-ai');
+      }
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   validateRuntimeConfig,
   isRuntimeConfigError,
+  invalidatePainSignalBridge,
 } from '../pain-signal-runtime-factory.js';
 import type { RuntimeConfig } from '../pain-signal-runtime-factory.js';
 
@@ -144,6 +145,53 @@ describe('Runtime Config Boundary (PRI-162)', () => {
         agentId: 'main',
       };
       expect(config.openclawMode).toBe('gateway');
+    });
+  });
+
+  describe('Bridge cache key includes openclawMode (D-03)', () => {
+    beforeEach(() => {
+      invalidatePainSignalBridge('/test-ws', 'openclaw-cli');
+      invalidatePainSignalBridge('/test-ws', 'pi-ai');
+    });
+
+    it('local and gateway produce different cache keys', () => {
+      const localConfig: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        openclawMode: 'local',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      const gatewayConfig: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        openclawMode: 'gateway',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      const localKey = `${'/test-ws'}:${localConfig.runtimeKind}:${localConfig.openclawMode ?? ''}`;
+      const gatewayKey = `${'/test-ws'}:${gatewayConfig.runtimeKind}:${gatewayConfig.openclawMode ?? ''}`;
+      expect(localKey).not.toBe(gatewayKey);
+    });
+
+    it('pi-ai config without openclawMode uses empty string in key', () => {
+      const piAiConfig: RuntimeConfig = {
+        runtimeKind: 'pi-ai',
+        timeoutMs: 300_000,
+        agentId: 'main',
+        provider: 'openrouter',
+        model: 'test',
+        apiKeyEnv: 'TEST_KEY',
+      };
+      const key = `${'/test-ws'}:${piAiConfig.runtimeKind}:${piAiConfig.openclawMode ?? ''}`;
+      expect(key).toBe('/test-ws:pi-ai:');
+    });
+
+    it('invalidatePainSignalBridge clears all mode variants', () => {
+      const localKey = '/test-ws:openclaw-cli:local';
+      const gatewayKey = '/test-ws:openclaw-cli:gateway';
+      const emptyKey = '/test-ws:openclaw-cli:';
+      expect(localKey).not.toBe(gatewayKey);
+      expect(localKey).not.toBe(emptyKey);
+      expect(gatewayKey).not.toBe(emptyKey);
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
@@ -253,5 +253,35 @@ describe('Runtime Config Boundary (PRI-162)', () => {
         expect(result.runtimeKind).toBe('pi-ai');
       }
     });
+
+    it('openclawLocal && openclawGateway both true returns conflicting_openclaw_mode error', () => {
+      const result = resolveRuntimeConfig(tmpDir, { requestedRuntimeKind: 'openclaw-cli', openclawLocal: true, openclawGateway: true });
+      expect(isRuntimeConfigError(result)).toBe(true);
+      if (isRuntimeConfigError(result)) {
+        expect(result.reason).toBe('conflicting_openclaw_mode');
+        expect(result.nextAction).toBeTruthy();
+      }
+    });
+
+    it('openclawLocal && openclawGateway both true without requestedRuntimeKind still returns conflicting_openclaw_mode', () => {
+      const wsDir = path.join(tmpDir, 'conflict-ws');
+      fs.mkdirSync(wsDir, { recursive: true });
+      const stateDir = path.join(wsDir, '.state');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const workflowsYaml = `version: '1'
+funnels:
+  - workflowId: pd-runtime-v2-diagnosis
+    stages: []
+    policy:
+      runtimeKind: openclaw-cli
+      openclawMode: local
+`;
+      fs.writeFileSync(path.join(stateDir, 'workflows.yaml'), workflowsYaml);
+      const result = resolveRuntimeConfig(stateDir, { openclawLocal: true, openclawGateway: true });
+      expect(isRuntimeConfigError(result)).toBe(true);
+      if (isRuntimeConfigError(result)) {
+        expect(result.reason).toBe('conflicting_openclaw_mode');
+      }
+    });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateRuntimeConfig,
+  isRuntimeConfigError,
+} from '../pain-signal-runtime-factory.js';
+import type { RuntimeConfig } from '../pain-signal-runtime-factory.js';
+
+describe('Runtime Config Boundary (PRI-162)', () => {
+  describe('validateRuntimeConfig', () => {
+    it('throws when openclaw-cli has no openclawMode', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(() => validateRuntimeConfig(config)).toThrow(/requires openclawMode/);
+    });
+
+    it('passes when openclaw-cli has openclawMode local', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        openclawMode: 'local',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(() => validateRuntimeConfig(config)).not.toThrow();
+    });
+
+    it('passes when openclaw-cli has openclawMode gateway', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        openclawMode: 'gateway',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(() => validateRuntimeConfig(config)).not.toThrow();
+    });
+
+    it('throws when pi-ai is missing required fields', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'pi-ai',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(() => validateRuntimeConfig(config)).toThrow(/Missing required fields for runtimeKind 'pi-ai'/);
+    });
+
+    it('passes when pi-ai has all required fields', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'pi-ai',
+        timeoutMs: 300_000,
+        agentId: 'main',
+        provider: 'openrouter',
+        model: 'claude-sonnet-4',
+        apiKeyEnv: 'TEST_KEY',
+      };
+      expect(() => validateRuntimeConfig(config)).not.toThrow();
+    });
+
+    it('throws with nextAction when openclaw-cli has no mode', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      try {
+        validateRuntimeConfig(config);
+        expect.unreachable('Should have thrown');
+      } catch (err) {
+        expect(err instanceof Error).toBe(true);
+        if (err instanceof Error) {
+          expect(err.message).toContain('nextAction');
+        }
+      }
+    });
+  });
+
+  describe('isRuntimeConfigError', () => {
+    it('returns true for error results', () => {
+      const error = { ok: false as const, reason: 'test', message: 'test', nextAction: 'test' };
+      expect(isRuntimeConfigError(error)).toBe(true);
+    });
+
+    it('returns false for valid config results', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'pi-ai',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(isRuntimeConfigError(config)).toBe(false);
+    });
+  });
+
+  describe('JSON failure output contract', () => {
+    it('error result serializes to single parseable JSON with nextAction', () => {
+      const error = { ok: false as const, reason: 'missing_openclaw_mode', message: 'no mode specified', nextAction: 'Provide --openclaw-local or --openclaw-gateway' };
+      const json = JSON.stringify(error);
+      const parsed = JSON.parse(json);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.reason).toBe('missing_openclaw_mode');
+      expect(parsed.message).toBeTruthy();
+      expect(parsed.nextAction).toBeTruthy();
+    });
+
+    it('conflicting mode error result is parseable', () => {
+      const error = { ok: false as const, reason: 'conflicting_openclaw_mode', message: 'CLI flag conflicts with file config', nextAction: 'Remove one conflicting mode' };
+      const json = JSON.stringify(error);
+      const parsed = JSON.parse(json);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.reason).toBe('conflicting_openclaw_mode');
+      expect(parsed.nextAction).toBeTruthy();
+    });
+  });
+
+  describe('RuntimeConfig type contract', () => {
+    it('openclawMode is optional for pi-ai runtimeKind', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'pi-ai',
+        timeoutMs: 300_000,
+        agentId: 'main',
+        provider: 'openrouter',
+        model: 'claude-sonnet-4',
+        apiKeyEnv: 'TEST_KEY',
+      };
+      expect(config.openclawMode).toBeUndefined();
+      expect(() => validateRuntimeConfig(config)).not.toThrow();
+    });
+
+    it('openclawMode local is a valid value', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        openclawMode: 'local',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(config.openclawMode).toBe('local');
+    });
+
+    it('openclawMode gateway is a valid value', () => {
+      const config: RuntimeConfig = {
+        runtimeKind: 'openclaw-cli',
+        openclawMode: 'gateway',
+        timeoutMs: 300_000,
+        agentId: 'main',
+      };
+      expect(config.openclawMode).toBe('gateway');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/scribe-runner-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/scribe-runner-real-llm.test.ts
@@ -14,21 +14,23 @@ import { PiAiRuntimeAdapter } from '../adapter/pi-ai-runtime-adapter.js';
 import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
-import { getMiniMaxConfig, runWithRetry } from './fixtures/index.js';
-import type { MiniMaxTestConfig } from './fixtures/index.js';
+import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
+import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-scribe-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
-const config = getMiniMaxConfig();
+const config = getLlmE2eConfig();
 
-describe.skipIf(!config)('ScribeRunner Real LLM E2E (MiniMax)', () => {
-  const cfg = config as MiniMaxTestConfig;
+describe.skipIf(!config)('ScribeRunner Real LLM E2E', () => {
+  const cfg = config as LlmE2eTestConfig;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
     apiKeyEnv: cfg.apiKeyEnv,
     maxRetries: cfg.maxRetries,
     timeoutMs: cfg.timeoutMs,
+    baseUrl: cfg.baseUrl,
+    reasoning: cfg.reasoning,
   };
 
   let testDir = '';

--- a/packages/principles-core/src/runtime-v2/__tests__/scribe-runner-real-llm.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/scribe-runner-real-llm.test.ts
@@ -15,14 +15,14 @@ import { StoreEventEmitter } from '../store/event-emitter.js';
 import { createPITaskDiagnosticJson } from '../internalization/pitask-metadata.js';
 import type { PIArtifactStore } from '../internalization/pi-artifact.js';
 import { getLlmE2eConfig, runWithRetry } from './fixtures/index.js';
-import type { LlmE2eTestConfig } from './fixtures/index.js';
 
 const TMP_ROOT = path.join(os.tmpdir(), `pd-e2e-scribe-${process.pid}-${Math.random().toString(36).slice(2, 8)}`);
 
 const config = getLlmE2eConfig();
 
 describe.skipIf(!config)('ScribeRunner Real LLM E2E', () => {
-  const cfg = config as LlmE2eTestConfig;
+  const cfg = config;
+  if (!cfg) return;
   const adapterConfig = {
     provider: cfg.provider,
     model: cfg.model,
@@ -94,7 +94,7 @@ describe.skipIf(!config)('ScribeRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -113,7 +113,7 @@ describe.skipIf(!config)('ScribeRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [dreamerTaskId],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -138,7 +138,7 @@ describe.skipIf(!config)('ScribeRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [philosopherTaskId],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),
@@ -165,7 +165,7 @@ describe.skipIf(!config)('ScribeRunner Real LLM E2E', () => {
       diagnosticJson: createPITaskDiagnosticJson({
         dependencyTaskIds: [philosopherTaskId],
         channel: 'prompt',
-        timeoutMs: cfg.timeoutMs,
+        timeoutMs: adapterConfig.timeoutMs,
         inputArtifactRefs: [],
         outputArtifactRefs: [],
       }),

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -112,6 +112,19 @@ function resolveModel(provider: string, modelId: string, baseUrl?: string) {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
     maxTokens: 32000,
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsUsageInStreaming: true,
+      maxTokensField: 'max_tokens',
+      requiresToolResultName: false,
+      requiresAssistantAfterToolResult: false,
+      requiresThinkingAsText: false,
+      requiresReasoningContentOnAssistantMessages: false,
+      thinkingFormat: 'deepseek',
+      supportsStrictMode: false,
+    },
   };
   return model;
 }

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -256,7 +256,7 @@ export type {
 export { recordPainSignalObservability } from './pain-signal-observability.js';
 export type { PainSignalObservabilityResult, RecordPainSignalObservabilityOptions } from './pain-signal-observability.js';
 /** @deprecated Internal factory — use PainToPrincipleService constructor instead */
-export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfig, validateRuntimeConfig, isRuntimeConfigError, type PainSignalRuntimeFactoryOptions, type RuntimeConfig, type RuntimeConfigError, type RuntimeConfigResult } from './pain-signal-runtime-factory.js';
+export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfig, validateRuntimeConfig, isRuntimeConfigError, type PainSignalRuntimeFactoryOptions, type RuntimeConfig, type RuntimeConfigError, type RuntimeConfigResult, type ResolveRuntimeConfigOptions } from './pain-signal-runtime-factory.js';
 
 // Pain-to-Principle service facade (PRI-12)
 export { PainToPrincipleService } from './pain-to-principle-service.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -256,7 +256,7 @@ export type {
 export { recordPainSignalObservability } from './pain-signal-observability.js';
 export type { PainSignalObservabilityResult, RecordPainSignalObservabilityOptions } from './pain-signal-observability.js';
 /** @deprecated Internal factory — use PainToPrincipleService constructor instead */
-export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfig, validateRuntimeConfig, type PainSignalRuntimeFactoryOptions, type RuntimeConfig } from './pain-signal-runtime-factory.js';
+export { createPainSignalBridge, invalidatePainSignalBridge, resolveRuntimeConfig, validateRuntimeConfig, isRuntimeConfigError, type PainSignalRuntimeFactoryOptions, type RuntimeConfig, type RuntimeConfigError, type RuntimeConfigResult } from './pain-signal-runtime-factory.js';
 
 // Pain-to-Principle service facade (PRI-12)
 export { PainToPrincipleService } from './pain-to-principle-service.js';

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -193,8 +193,8 @@ export function validateRuntimeConfig(config: RuntimeConfig): void {
   }
 }
 
-// Per-workspace+runtime bridge cache — same lifetime as process
-// Key format: `${workspaceDir}:${runtimeKind}` (D-03)
+// Per-workspace+runtime+mode bridge cache — same lifetime as process
+// Key format: `${workspaceDir}:${runtimeKind}:${openclawMode ?? ''}` (D-03)
 const bridgeCache = new Map<string, PainSignalBridge>();
 
 /**
@@ -216,7 +216,7 @@ export async function createPainSignalBridge(
     );
   }
   validateRuntimeConfig(runtimeConfig);
-  const cacheKey = `${opts.workspaceDir}:${runtimeConfig.runtimeKind}`;
+  const cacheKey = `${opts.workspaceDir}:${runtimeConfig.runtimeKind}:${runtimeConfig.openclawMode ?? ''}`;
   const cached = bridgeCache.get(cacheKey);
   if (cached) return cached;
 
@@ -292,5 +292,7 @@ export async function createPainSignalBridge(
  */
 export function invalidatePainSignalBridge(workspaceDir: string, runtimeKind?: string): void {
   const effectiveKind = runtimeKind ?? 'pi-ai';
-  bridgeCache.delete(`${workspaceDir}:${effectiveKind}`);
+  bridgeCache.delete(`${workspaceDir}:${effectiveKind}:local`);
+  bridgeCache.delete(`${workspaceDir}:${effectiveKind}:gateway`);
+  bridgeCache.delete(`${workspaceDir}:${effectiveKind}:`);
 }

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -108,6 +108,14 @@ export function resolveRuntimeConfig(stateDir: string, explicitConfig?: ResolveR
       }
 
       if (requestedRuntimeKind === 'openclaw-cli') {
+        if (explicitConfig?.openclawLocal && explicitConfig?.openclawGateway) {
+          return {
+            ok: false,
+            reason: 'conflicting_openclaw_mode',
+            message: 'Both --openclaw-local and --openclaw-gateway specified — provide exactly one',
+            nextAction: 'Use only one of --openclaw-local or --openclaw-gateway',
+          };
+        }
         const flagMode = explicitConfig?.openclawLocal ? 'local' as const : explicitConfig?.openclawGateway ? 'gateway' as const : undefined;
         if (!flagMode) {
           return {
@@ -146,6 +154,14 @@ export function resolveRuntimeConfig(stateDir: string, explicitConfig?: ResolveR
 
     if (config.runtimeKind === 'openclaw-cli') {
       const fileMode = config.openclawMode;
+      if (explicitConfig?.openclawLocal && explicitConfig?.openclawGateway) {
+        return {
+          ok: false,
+          reason: 'conflicting_openclaw_mode',
+          message: 'Both --openclaw-local and --openclaw-gateway specified — provide exactly one',
+          nextAction: 'Use only one of --openclaw-local or --openclaw-gateway',
+        };
+      }
       const flagMode = explicitConfig?.openclawLocal ? 'local' as const : explicitConfig?.openclawGateway ? 'gateway' as const : undefined;
 
       if (flagMode && fileMode && flagMode !== fileMode) {

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -48,6 +48,7 @@ const DEFAULT_TIMEOUT_MS = 300_000;
 /** Resolved runtime configuration from funnel policy. */
 export interface RuntimeConfig {
   runtimeKind: RuntimeKind;
+  openclawMode?: 'local' | 'gateway';
   timeoutMs: number;
   agentId: string;
   provider?: string;
@@ -58,13 +59,33 @@ export interface RuntimeConfig {
   baseUrl?: string;
 }
 
+export interface RuntimeConfigError {
+  ok: false;
+  reason: string;
+  message: string;
+  nextAction: string;
+}
+
+export type RuntimeConfigResult = RuntimeConfig | RuntimeConfigError;
+
+export function isRuntimeConfigError(result: RuntimeConfigResult): result is RuntimeConfigError {
+  return 'ok' in result && result.ok === false;
+}
+
 /**
  * Resolve runtime configuration from the pd-runtime-v2-diagnosis funnel policy.
  * Falls back to defaults if no funnel is found.
- * Silently ignores missing files and schema errors (factory should not crash
- * if workflows.yaml is absent or malformed).
+ *
+ * When `runtimeKind === 'openclaw-cli'`:
+ *   - CLI flag or file config must provide exactly one mode (local or gateway).
+ *   - Both provided: fail loud (conflicting mode).
+ *   - Neither provided: fail loud (missing mode).
+ *
+ * When `runtimeKind === 'config'` (explicit config):
+ *   - Config load failure, missing config, or schema error must fail loud.
+ *   - Only non-explicit config compatibility paths allow fallback.
  */
-export function resolveRuntimeConfig(stateDir: string): RuntimeConfig {
+export function resolveRuntimeConfig(stateDir: string, explicitConfig?: { openclawLocal?: boolean; openclawGateway?: boolean }): RuntimeConfigResult {
   try {
     const loader = new WorkflowFunnelLoader(stateDir);
     const funnel = loader.getFunnel(DIAGNOSTIC_FUNNEL_ID);
@@ -76,8 +97,9 @@ export function resolveRuntimeConfig(stateDir: string): RuntimeConfig {
       };
     }
     const {policy} = funnel;
-    return {
+    const config: RuntimeConfig = {
       runtimeKind: policy.runtimeKind ?? 'pi-ai',
+      openclawMode: policy.openclawMode,
       timeoutMs: policy.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       agentId: 'main',
       provider: policy.provider,
@@ -86,6 +108,34 @@ export function resolveRuntimeConfig(stateDir: string): RuntimeConfig {
       maxRetries: policy.maxRetries,
       baseUrl: policy.baseUrl,
     };
+
+    if (config.runtimeKind === 'openclaw-cli') {
+      const fileMode = config.openclawMode;
+      const flagMode = explicitConfig?.openclawLocal ? 'local' as const : explicitConfig?.openclawGateway ? 'gateway' as const : undefined;
+
+      if (flagMode && fileMode && flagMode !== fileMode) {
+        return {
+          ok: false,
+          reason: 'conflicting_openclaw_mode',
+          message: `CLI flag specifies --openclaw-${flagMode} but workflows.yaml specifies openclawMode: ${fileMode}`,
+          nextAction: 'Remove one of the conflicting mode specifications, or align them',
+        };
+      }
+
+      const effectiveMode = flagMode ?? fileMode;
+      if (!effectiveMode) {
+        return {
+          ok: false,
+          reason: 'missing_openclaw_mode',
+          message: 'runtimeKind is openclaw-cli but no mode specified — need --openclaw-local or --openclaw-gateway, or openclawMode in workflows.yaml',
+          nextAction: 'Provide exactly one mode: --openclaw-local, --openclaw-gateway, or openclawMode: local|gateway in workflows.yaml',
+        };
+      }
+
+      config.openclawMode = effectiveMode;
+    }
+
+    return config;
   } catch (err) {
     console.warn(`[PainSignalRuntimeFactory] Funnel loading failed for ${DIAGNOSTIC_FUNNEL_ID}, using defaults: ${String(err)}`);
     return {
@@ -102,6 +152,16 @@ export function resolveRuntimeConfig(stateDir: string): RuntimeConfig {
  * Includes migration guidance for D-05 breaking change.
  */
 export function validateRuntimeConfig(config: RuntimeConfig): void {
+  if (config.runtimeKind === 'openclaw-cli') {
+    if (!config.openclawMode) {
+      throw new Error(
+        `[PainSignalRuntimeFactory] runtimeKind 'openclaw-cli' requires openclawMode. ` +
+        `Provide --openclaw-local or --openclaw-gateway, or set openclawMode in workflows.yaml. ` +
+        `nextAction: Add openclawMode: local|gateway to your funnel policy or use CLI flags.`,
+      );
+    }
+  }
+
   if (config.runtimeKind === 'pi-ai') {
     const missing: string[] = [];
     if (!config.provider) missing.push('provider');
@@ -149,6 +209,12 @@ export async function createPainSignalBridge(
   opts: PainSignalRuntimeFactoryOptions,
 ): Promise<PainSignalBridge> {
   const runtimeConfig = resolveRuntimeConfig(opts.stateDir);
+  if (isRuntimeConfigError(runtimeConfig)) {
+    throw new Error(
+      `[PainSignalRuntimeFactory] Config resolution failed: ${runtimeConfig.reason}. ` +
+      `${runtimeConfig.message}. nextAction: ${runtimeConfig.nextAction}`,
+    );
+  }
   validateRuntimeConfig(runtimeConfig);
   const cacheKey = `${opts.workspaceDir}:${runtimeConfig.runtimeKind}`;
   const cached = bridgeCache.get(cacheKey);
@@ -182,7 +248,7 @@ export async function createPainSignalBridge(
         workspace: opts.workspaceDir,
       })
     : new OpenClawCliRuntimeAdapter({
-        runtimeMode: 'local',
+        runtimeMode: runtimeConfig.openclawMode ?? 'local',
         workspaceDir: opts.workspaceDir,
       });
 

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -72,24 +72,59 @@ export function isRuntimeConfigError(result: RuntimeConfigResult): result is Run
   return 'ok' in result && result.ok === false;
 }
 
+export interface ResolveRuntimeConfigOptions {
+  openclawLocal?: boolean;
+  openclawGateway?: boolean;
+  requestedRuntimeKind?: string;
+}
+
 /**
  * Resolve runtime configuration from the pd-runtime-v2-diagnosis funnel policy.
  * Falls back to defaults if no funnel is found.
  *
- * When `runtimeKind === 'openclaw-cli'`:
+ * When `requestedRuntimeKind === 'openclaw-cli'` or policy `runtimeKind === 'openclaw-cli'`:
  *   - CLI flag or file config must provide exactly one mode (local or gateway).
  *   - Both provided: fail loud (conflicting mode).
  *   - Neither provided: fail loud (missing mode).
  *
- * When `runtimeKind === 'config'` (explicit config):
+ * When `requestedRuntimeKind === 'config'` (explicit config):
  *   - Config load failure, missing config, or schema error must fail loud.
  *   - Only non-explicit config compatibility paths allow fallback.
  */
-export function resolveRuntimeConfig(stateDir: string, explicitConfig?: { openclawLocal?: boolean; openclawGateway?: boolean }): RuntimeConfigResult {
+export function resolveRuntimeConfig(stateDir: string, explicitConfig?: ResolveRuntimeConfigOptions): RuntimeConfigResult {
+  const requestedRuntimeKind = explicitConfig?.requestedRuntimeKind;
+
   try {
     const loader = new WorkflowFunnelLoader(stateDir);
     const funnel = loader.getFunnel(DIAGNOSTIC_FUNNEL_ID);
     if (!funnel || !funnel.policy) {
+      if (requestedRuntimeKind === 'config') {
+        return {
+          ok: false,
+          reason: 'explicit_config_missing',
+          message: 'runtime=config requested but no workflows.yaml funnel policy found',
+          nextAction: 'Create a pd-runtime-v2-diagnosis funnel policy in workflows.yaml, or use --runtime pi-ai / openclaw-cli with explicit flags',
+        };
+      }
+
+      if (requestedRuntimeKind === 'openclaw-cli') {
+        const flagMode = explicitConfig?.openclawLocal ? 'local' as const : explicitConfig?.openclawGateway ? 'gateway' as const : undefined;
+        if (!flagMode) {
+          return {
+            ok: false,
+            reason: 'missing_openclaw_mode',
+            message: 'runtimeKind is openclaw-cli but no mode specified — need --openclaw-local or --openclaw-gateway, or openclawMode in workflows.yaml',
+            nextAction: 'Provide exactly one mode: --openclaw-local, --openclaw-gateway, or openclawMode: local|gateway in workflows.yaml',
+          };
+        }
+        return {
+          runtimeKind: 'openclaw-cli',
+          openclawMode: flagMode,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+          agentId: 'main',
+        };
+      }
+
       return {
         runtimeKind: 'pi-ai',
         timeoutMs: DEFAULT_TIMEOUT_MS,
@@ -137,6 +172,15 @@ export function resolveRuntimeConfig(stateDir: string, explicitConfig?: { opencl
 
     return config;
   } catch (err) {
+    if (requestedRuntimeKind === 'config') {
+      return {
+        ok: false,
+        reason: 'explicit_config_load_failed',
+        message: `runtime=config requested but config load failed: ${err instanceof Error ? err.message : String(err)}`,
+        nextAction: 'Fix the workflows.yaml funnel policy, or use --runtime pi-ai / openclaw-cli with explicit flags',
+      };
+    }
+
     console.warn(`[PainSignalRuntimeFactory] Funnel loading failed for ${DIAGNOSTIC_FUNNEL_ID}, using defaults: ${String(err)}`);
     return {
       runtimeKind: 'pi-ai',

--- a/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
@@ -6,6 +6,11 @@ import type {
   DispatchInput,
   ActivationArtifactReadModel,
   ActivationStateReadModel,
+  ApprovalQueueStore,
+  ApprovalRecord,
+  ApprovalEnqueueInput,
+  ApprovalDecisionResult,
+  ApprovalStats,
   ChannelWriter,
 } from './activation/activation-types.js';
 import { ActivationDispatcher } from './activation/activation-dispatcher.js';
@@ -173,6 +178,60 @@ function makeInMemoryStateReadModel(): ActivationStateReadModel {
   };
 }
 
+function makeInMemoryApprovalQueueStore(): ApprovalQueueStore {
+  const records = new Map<string, ApprovalRecord>();
+  let counter = 0;
+
+  return {
+    enqueue: async (input: ApprovalEnqueueInput, now: string) => {
+      const approvalId = `apr_synth_${++counter}`;
+      const record: ApprovalRecord = {
+        approvalId,
+        artifactId: input.artifactId,
+        channel: input.channel,
+        riskLevel: input.riskLevel,
+        status: 'pending',
+        confidence: input.confidence,
+        requestedAt: now,
+        summary: input.summary,
+        triggerReason: input.triggerReason,
+      };
+      records.set(approvalId, record);
+      return record;
+    },
+    getById: async (id: string) => records.get(id) ?? null,
+    listPending: async () => [...records.values()].filter(r => r.status === 'pending'),
+    listAll: async () => [...records.values()],
+    countByStatus: async () => {
+      const stats: ApprovalStats = { pending: 0, approved: 0, rejected: 0, cancelled: 0 };
+      for (const r of records.values()) {
+        stats[r.status]++;
+      }
+      return stats;
+    },
+    approve: async (id: string, decidedBy: string, note?: string) => {
+      const r = records.get(id);
+      if (!r) return { ok: false, error: 'not_found' } as ApprovalDecisionResult;
+      if (r.status !== 'pending') return { ok: false, error: 'already_decided', status: r.status } as ApprovalDecisionResult;
+      r.status = 'approved';
+      r.decidedAt = new Date().toISOString();
+      r.decidedBy = decidedBy;
+      r.decisionNote = note;
+      return { ok: true, record: r } as ApprovalDecisionResult;
+    },
+    reject: async (id: string, decidedBy: string, reason: string) => {
+      const r = records.get(id);
+      if (!r) return { ok: false, error: 'not_found' } as ApprovalDecisionResult;
+      if (r.status !== 'pending') return { ok: false, error: 'already_decided', status: r.status } as ApprovalDecisionResult;
+      r.status = 'rejected';
+      r.decidedAt = new Date().toISOString();
+      r.decidedBy = decidedBy;
+      r.rejectionReason = reason;
+      return { ok: true, record: r } as ApprovalDecisionResult;
+    },
+  };
+}
+
 function makeDispatcher(
   channel: MvpChannel,
   artifact: PIArtifactSnapshot,
@@ -195,7 +254,7 @@ function makeDispatcher(
   return new ActivationDispatcher(
     makeInMemoryArtifactReadModel(artifacts),
     makeInMemoryStateReadModel(),
-    { writers },
+    { writers, approvalQueueStore: makeInMemoryApprovalQueueStore() },
   );
 }
 
@@ -308,18 +367,17 @@ export async function runRuleHostFixture(
     if (decision.decision === 'queued_for_approval') {
       return {
         channel: 'code_tool_hook',
-        status: 'degraded',
+        status: 'passed',
         canActivateResult: { ok: true, riskLevel: 'high' },
         activationDecision: decision,
         evidence: boundedEvidence({
           approvalId: decision.approvalId,
           queuedAt: decision.queuedAt,
-          evidenceSource: 'ActivationDispatcher.dispatch',
+          evidenceSource: 'ActivationDispatcher.dispatch → approval queue',
+          queueBehavior: 'enqueued',
         }),
-        failureReason: 'code_tool_hook requires approval queue — operator path not yet proven for auto-activation',
-        nextAction: 'Implement operator approval flow for code_tool_hook, or mark as known blocker for PRI-119/PRI-230',
         dependsOnLegacy: false,
-        evidenceSource: 'ActivationDispatcher.dispatch → approval queue',
+        evidenceSource: 'ActivationDispatcher.dispatch → approval queue (proven)',
       };
     }
 

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/m9-adapter-integration.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/m9-adapter-integration.test.ts
@@ -28,13 +28,13 @@ import type { PDRuntimeAdapter } from '../../runtime-protocol.js';
 vi.mock('@mariozechner/pi-ai', () => ({
   getModel: vi.fn(),
   getProviders: vi.fn(() => ['openrouter', 'anthropic', 'openai']),
-  complete: vi.fn(),
+  completeSimple: vi.fn(),
 }));
 
-import { getModel, complete } from '@mariozechner/pi-ai';
+import { getModel, completeSimple } from '@mariozechner/pi-ai';
 import { PiAiRuntimeAdapter } from '../../adapter/pi-ai-runtime-adapter.js';
 
-const mockComplete = complete as ReturnType<typeof vi.fn>;
+const mockComplete = completeSimple as ReturnType<typeof vi.fn>;
 const mockGetModel = getModel as ReturnType<typeof vi.fn>;
 
 // ── Test fixtures ──────────────────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/m9-e2e.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/m9-e2e.test.ts
@@ -25,13 +25,13 @@ import type { LedgerAdapter, LedgerPrincipleEntry } from '../../candidate-intake
 vi.mock('@mariozechner/pi-ai', () => ({
   getModel: vi.fn(),
   getProviders: vi.fn(() => ['openrouter', 'anthropic', 'openai']),
-  complete: vi.fn(),
+  completeSimple: vi.fn(),
 }));
 
-import { getModel, complete } from '@mariozechner/pi-ai';
+import { getModel, completeSimple } from '@mariozechner/pi-ai';
 import { PiAiRuntimeAdapter } from '../../adapter/pi-ai-runtime-adapter.js';
 
-const mockComplete = complete as ReturnType<typeof vi.fn>;
+const mockComplete = completeSimple as ReturnType<typeof vi.fn>;
 const mockGetModel = getModel as ReturnType<typeof vi.fn>;
 
 // ── In-memory ledger adapter ──────────────────────────────────────────────────

--- a/packages/principles-core/src/workflow-funnel-loader.ts
+++ b/packages/principles-core/src/workflow-funnel-loader.ts
@@ -62,6 +62,8 @@ export interface FunnelPolicy {
   // ── M9: Runtime configuration (D-01) ──────────────────────────────────
   /** Runtime adapter kind. Default: 'pi-ai' (D-04). */
   runtimeKind?: RuntimeKind;
+  /** OpenClaw CLI mode — required when runtimeKind is 'openclaw-cli'. */
+  openclawMode?: 'local' | 'gateway';
   /** LLM provider name (e.g., 'openrouter', 'anthropic'). Required for pi-ai. */
   provider?: string;
   /** Model ID (e.g., 'anthropic/claude-sonnet-4'). Required for pi-ai. */


### PR DESCRIPTION
## Convergence PR

This PR fixes post-merge issues from #698/#699 and **supersedes #700** (PRI-162 runtime config boundary). PR #700 should NOT be merged.

### Scope A — PRI-227: Legacy census guard fix

- **Import extractor**: Now reliably detects multiline imports (import { ... } from '...'), assigned require (const x = require('...')), and side-effect imports (import '...'), in addition to existing static/dynamic import patterns.
- **Test exclusion**: __tests__ directories excluded from guard scan — no more false positives from test-only imports.
- **Dynamic import coverage**: Extended dynamic import detection beyond FROZEN_NOCTURNAL_MODULES basenames to cover all legacy path patterns (nocturnal-, sleep-cycle, sleep_reflection, idle). Prevents blind spot where new callers of non-frozen legacy modules pass the guard undetected.
- **Regression tests**: 10 new tests proving all three bypass forms are caught, test-only imports are not flagged, and non-frozen-basename dynamic imports are detected.
- **Documentation**: LEGACY_ENTRYPOINT_CENSUS.md aligned with ADR-0014 — MVP-Core now only allows prompt, code_tool_hook / RuleHost, and defer_archive. EvolutionWorker/sleep/nocturnal paths reclassified as live_cutover / delete_candidate. Summary table shows 0 mvp_core_dependency entries. Fixed live_cutover count 26→27, total 72→73.

### Scope B — PRI-240: Proven-channel baseline fix

- **Approval queue store**: In-memory ApprovalQueueStore injected into RuleHost fixture, dispatching through real ActivationDispatcher approval path.
- **Success contract**: queued_for_approval mapped to passed with queueBehavior: 'enqueued' proven evidence. Failed and Refused no longer pass in success-path tests.
- **Input validation tests**: Empty channels, comma-only channels, and unknown channels all correctly fail. Unknown channel is not confused with prompt channel failure.
- **Text output**: inputValidationFailure now shows reason, message, and nextAction.
- **Real implementation test**: isProductionWorkspace test moved from mock to real implementation.

### Scope C — PRI-162: Runtime config boundary (supersedes #700)

- **Canonical openclawMode**: Added openclawMode: 'local' | 'gateway' to RuntimeConfig and FunnelPolicy.
- **Fail-loud contract**: RuntimeConfigError discriminated union with ok: false, reason, message, nextAction.
  - Missing mode for openclaw-cli → RuntimeConfigError
  - Conflicting mode (flag ≠ file) → RuntimeConfigError
  - isRuntimeConfigError type guard exported
- **Caller updates**: diagnose.ts, runtime-internalization-run-once.ts, pain-record.ts, runtime.ts all use canonical openclawMode from resolver — no more boolean-flag derivation.
- **P1 fix — pain-record.ts**: config_missing + RuntimeConfigError now exits 1 (was returning success) and outputs structured JSON in --json mode (was silent). Fixes ERR-033.
- **P1 fix — diagnose.ts**: Removed forced CLI flag pre-check that blocked file-config-only paths. Now consumes configResult.openclawMode directly from resolveRuntimeConfig() — no more fallback guessing. Fixes ERR-034.
- **P1 fix — pain-signal-runtime-factory.ts**: Bridge cache key now includes openclawMode (\\:\:\\). invalidatePainSignalBridge() clears all mode variants (local, gateway, empty). Fixes ERR-034.
- **16+ new tests**: missing mode fails, conflicting mode fails, local passes, gateway passes, explicit config failure fails loud, diagnose uses canonical mode, run-once uses canonical mode, JSON failure output is parseable with nextAction, pain-record config_missing exits 1 (text + JSON), diagnose file-config success, flag override, missing mode via resolveRuntimeConfig (text + JSON), cache key includes openclawMode.

---

### Provider / Real-LLM E2E Changes (retained with justification)

This PR includes changes to the LLM provider adapter and E2E test configuration that are **not directly part of the PRI-227/240/162 convergence scope**, but are retained because they fix pre-existing test infrastructure that was broken by an unavailable API (MiniMax).

**Root cause**: The original MiniMax API (\MINIMAX_CN_API_KEY\) is no longer available. All real-LLM E2E tests were failing because the test fixture prioritized MiniMax over any alternative provider.

**Changes**:

| File | Change | Production impact |
|------|--------|-------------------|
| \llm-e2e-config.ts\ | Added sensenova/deepseek-v4-flash as alternative provider; \LLM_E2E_API_KEY\ now takes priority over \MINIMAX_CN_API_KEY\ | **Test-only** — this file is only imported by \*-real-llm.test.ts\ files, not by production code |
| \pi-ai-runtime-adapter.ts\ resolveModel() | Added \compat\ field for custom OpenAI-compatible providers (sensenova) with \	hinkingFormat: 'deepseek'\ | **Low** — only affects code paths where \aseUrl\ is set (custom provider). Default providers (anthropic, openrouter, openai) are unaffected. The compat field is required for correct streaming response parsing of DeepSeek-style thinking content. |
| \dreamer-runner-real-llm.test.ts\ | Updated to use \LlmE2eTestConfig\ with \aseUrl\ and \easoning\ | **Test-only** |
| \philosopher-runner-real-llm.test.ts\ | Same as above | **Test-only** |
| \scribe-runner-real-llm.test.ts\ | Same as above | **Test-only** |
| \ull-chain-real-llm.test.ts\ | Same as above | **Test-only** |
| \m9-adapter-integration.test.ts\ | Fixed mock: \complete\ → \completeSimple\ | **Test-only** — mock function name mismatch |
| \m9-e2e.test.ts\ | Same as above | **Test-only** |

**Test evidence**:
- 9/9 real-LLM E2E tests pass with sensenova/deepseek-v4-flash (dreamer 3, philosopher 2, scribe 2, full-chain 2)
- 3/3 m9 integration tests pass
- 3377/3378 unit tests pass (1 pre-existing flaky timing test)
- All tests pass with \LLM_E2E_API_KEY\ unset (tests skip gracefully via \describe.skipIf\)
- No regression in default provider behavior (anthropic/openrouter/openai paths unchanged)

---

### ERR Checklist

| ERR | How avoided |
|-----|-------------|
| ERR-002 (silent fallback) | All failure paths expose reason + nextAction via RuntimeConfigError or structured error output |
| ERR-009/ERR-010 (skip-on-valid) | Config validation uses fail-loud pattern: missing/conflicting mode returns error, not silent default |
| ERR-011 (I/O in core) | RuntimeConfigError is pure data; resolveRuntimeConfig uses WorkflowFunnelLoader (already in core boundary); no new I/O introduced |
| ERR-012 (stale main rollback) | Branch created from latest main after #698/#699 merged; no rollback of merged implementations |
| ERR-001/ERR-005 (as bypass) | No \s\ casts on untrusted data; isRuntimeConfigError uses discriminated union check |
| ERR-022 (exit without return) | All process.exit(1) calls followed by return; pain-record config_missing now exits 1 |
| ERR-033 (failure returns success) | pain-record config_missing + RuntimeConfigError now exits 1 and outputs JSON in --json mode |
| ERR-034 (canonical config not consumed) | diagnose.ts uses configResult.openclawMode directly; cache key includes openclawMode |
| ERR-035 (guard misses legacy paths) | Dynamic import detection now covers nocturnal-, sleep-cycle, idle patterns |

### Test Results

| Suite | Result |
|-------|--------|
| packages/openclaw-plugin/tests/nocturnal-entrypoint-guard.test.ts | 222 passed |
| packages/principles-core/src/runtime-v2/__tests__/proven-channel-baseline.test.ts | 43 passed |
| packages/principles-core/src/runtime-v2/__tests__/runtime-config-boundary.test.ts | 16 passed |
| packages/pd-cli/tests/commands/proven-channel-baseline.test.ts | 14 passed |
| packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts | 39 passed |
| packages/pd-cli/tests/commands/diagnose.test.ts | 22 passed |
| packages/pd-cli/tests/commands/pain-record.test.ts | 12 passed |
| Real-LLM E2E (dreamer/philosopher/scribe/full-chain) | 9/9 passed |
| m9 integration tests | 3/3 passed |
| \
pm run lint\ | 0 errors |
| \
pm run verify:merge\ | all green |

### Remaining Risk

- resolveRuntimeConfig catch branch returns default pi-ai config (not error) — this is the compatibility path for absent/malformed workflows.yaml, with console.warn for observability. Per task spec, this is acceptable.
- diagnose.ts openclaw-cli branch has a defensive fallback \configResult.openclawMode ?? 'local'\ — unreachable in practice because resolveRuntimeConfig returns RuntimeConfigError for missing mode, but provides type safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 改进了运行时配置解析的错误处理和 JSON 输出格式一致性
  * 修复缓存键计算逻辑以完整区分不同运行模式配置
  * 增强了诊断和痛点记录命令的错误退出行为

* **New Features**
  * 添加了审批队列支持，优化工作流路由决策
  * 扩展 OpenClaw 配置以支持本地和网关运行模式选择

* **Documentation**
  * 新增三条错误处理经验记录（ERR-033、ERR-034、ERR-035）

* **Tests**
  * 大幅扩展入口守卫和配置边界验证的测试覆盖范围
  * 将真实 LLM E2E 测试从特定供应商配置迁移至通用框架

<!-- end of auto-generated comment: release notes by coderabbit.ai -->