### PR TITLE
feat(mvp): add loadable feature flag registry for MVP-Quiet paths (PRI-239)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19471,12 +19471,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@principles/core": "^0.1.0",
-        "commander": "^12.0.0"
+        "commander": "^12.0.0",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "pd": "dist/index.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"

--- a/packages/pd-cli/package.json
+++ b/packages/pd-cli/package.json
@@ -14,9 +14,11 @@
   },
   "dependencies": {
     "@principles/core": "^0.1.0",
-    "commander": "^12.0.0"
+    "commander": "^12.0.0",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -57,9 +57,15 @@ function buildRecommendedActions(checks: CanaryCheck[]): string[] {
       case 'candidate_audit':
         actions.push('Run `pd candidate audit --workspace <path> --json` for details.');
         break;
-      case 'gfi_snapshot':
-        actions.push('Investigate GFI sessions — consider cleanup or session lifecycle review.');
+      case 'gfi_snapshot': {
+        const gfiDetails = check.details as { warnings?: string[]; configPath?: string } | undefined;
+        if (gfiDetails && gfiDetails.warnings && gfiDetails.warnings.length > 0) {
+          actions.push(`Review .pd/feature-flags.yaml and rerun \`pd runtime features --workspace <path> --json\`.`);
+        } else {
+          actions.push('Investigate GFI sessions — consider cleanup or session lifecycle review.');
+        }
         break;
+      }
       case 'pruning_orphans':
         actions.push('Run `pd runtime pruning orphans --workspace <path> --dry-run` to inspect orphan candidates.');
         break;

--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -134,13 +134,18 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
         const featureFlags = loadEffectiveFeatureFlags(workspaceDir);
         const gfiFlag = featureFlags.flags.gfi;
         if (!gfiFlag || !gfiFlag.enabled) {
-          const warningSuffix = featureFlags.warnings.length > 0
-            ? ` (warnings: ${featureFlags.warnings.join('; ')})`
-            : '';
+          if (featureFlags.warnings.length > 0) {
+            return {
+              name: 'gfi_snapshot',
+              status: 'degraded',
+              summary: `GFI disabled but config has warnings: ${featureFlags.warnings.join('; ')}`,
+              details: { warnings: featureFlags.warnings, configPath: featureFlags.configPath },
+            };
+          }
           return {
             name: 'gfi_snapshot',
             status: 'healthy',
-            summary: `GFI feature flag disabled — skipping snapshot.${warningSuffix}`,
+            summary: 'GFI feature flag disabled — skipping snapshot.',
           };
         }
         const sessionDir = path.join(workspaceDir, '.state', 'sessions');

--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { OperatorHealthReadModel, SchemaConformanceReadModel, PruningReadModel, createInternalizationQueueReadModel, auditCandidateLedgerConsistency, buildGfiWorkspaceSnapshot, classifyGfiWorkspaceHealth } from '@principles/core/runtime-v2';
 import type { OperatorHealthSnapshot, SchemaConformanceResult, OrphanDetectionResult, InternalizationQueueSnapshot, GfiWorkspaceSnapshot, CandidateAuditResult } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import { loadEffectiveFeatureFlags } from '../services/feature-flag-loader.js';
 
 export interface CanaryCheck {
   name: string;
@@ -130,6 +131,15 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
     })(),
     (async (): Promise<CanaryCheck> => {
       try {
+        const featureFlags = loadEffectiveFeatureFlags(workspaceDir);
+        const gfiFlag = featureFlags.flags.gfi;
+        if (!gfiFlag || !gfiFlag.enabled) {
+          return {
+            name: 'gfi_snapshot',
+            status: 'healthy',
+            summary: 'GFI feature flag disabled — skipping snapshot.',
+          };
+        }
         const sessionDir = path.join(workspaceDir, '.state', 'sessions');
         const fs = await import('fs');
         const sessions: { sessionId: string; currentGfi: number; lastActivityAt: number; consecutiveErrors: number }[] = [];

--- a/packages/pd-cli/src/commands/runtime-canary.ts
+++ b/packages/pd-cli/src/commands/runtime-canary.ts
@@ -134,10 +134,13 @@ export async function runCanaryChecks(workspaceDir: string): Promise<CanaryOutpu
         const featureFlags = loadEffectiveFeatureFlags(workspaceDir);
         const gfiFlag = featureFlags.flags.gfi;
         if (!gfiFlag || !gfiFlag.enabled) {
+          const warningSuffix = featureFlags.warnings.length > 0
+            ? ` (warnings: ${featureFlags.warnings.join('; ')})`
+            : '';
           return {
             name: 'gfi_snapshot',
             status: 'healthy',
-            summary: 'GFI feature flag disabled — skipping snapshot.',
+            summary: `GFI feature flag disabled — skipping snapshot.${warningSuffix}`,
           };
         }
         const sessionDir = path.join(workspaceDir, '.state', 'sessions');

--- a/packages/pd-cli/src/commands/runtime-features.ts
+++ b/packages/pd-cli/src/commands/runtime-features.ts
@@ -1,0 +1,94 @@
+import * as path from 'path';
+import { loadEffectiveFeatureFlags } from '../services/feature-flag-loader.js';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+export interface FeatureFlagsStatusOutput {
+  source: string;
+  configPath: string;
+  flags: {
+    id: string;
+    category: string;
+    enabled: boolean;
+    since: string;
+    description?: string;
+  }[];
+  warnings: string[];
+  totalFlags: number;
+  enabledCount: number;
+  disabledCount: number;
+}
+
+interface FeaturesOptions {
+  workspace?: string;
+  json?: boolean;
+}
+
+export function buildFeatureFlagsStatus(workspaceDir: string): FeatureFlagsStatusOutput {
+  const effective = loadEffectiveFeatureFlags(workspaceDir);
+  const flags = Object.values(effective.flags);
+  const enabledCount = flags.filter(f => f.enabled).length;
+
+  return {
+    source: effective.source,
+    configPath: effective.configPath,
+    flags: flags.map(f => ({
+      id: f.id,
+      category: f.category,
+      enabled: f.enabled,
+      since: f.since,
+      ...(f.description ? { description: f.description } : {}),
+    })),
+    warnings: effective.warnings,
+    totalFlags: flags.length,
+    enabledCount,
+    disabledCount: flags.length - enabledCount,
+  };
+}
+
+function formatTextOutput(output: FeatureFlagsStatusOutput): string {
+  const lines: string[] = [];
+
+  lines.push('PD Feature Flags Status');
+  lines.push(`source: ${output.source}`);
+  lines.push(`config: ${output.configPath}`);
+  lines.push('');
+
+  const categoryOrder = ['core', 'quiet', 'gone', 'legacy_retire'] as const;
+  for (const category of categoryOrder) {
+    const categoryFlags = output.flags.filter(f => f.category === category);
+    if (categoryFlags.length === 0) continue;
+
+    lines.push(`  ${category.toUpperCase()} (${categoryFlags.length})`);
+    for (const flag of categoryFlags) {
+      const icon = flag.enabled ? '+' : '-';
+      lines.push(`    [${icon}] ${flag.id} (since ${flag.since})${flag.description ? ` — ${flag.description}` : ''}`);
+    }
+    lines.push('');
+  }
+
+  lines.push(`Total: ${output.totalFlags} flags, ${output.enabledCount} enabled, ${output.disabledCount} disabled`);
+
+  if (output.warnings.length > 0) {
+    lines.push('');
+    lines.push('Warnings:');
+    for (const warning of output.warnings) {
+      lines.push(`  [!] ${warning}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleRuntimeFeaturesStatus(opts: FeaturesOptions): Promise<void> {
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  const output = buildFeatureFlagsStatus(workspaceDir);
+
+  if (opts.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    console.log(formatTextOutput(output));
+  }
+}

--- a/packages/pd-cli/src/commands/runtime-features.ts
+++ b/packages/pd-cli/src/commands/runtime-features.ts
@@ -3,6 +3,7 @@ import { loadEffectiveFeatureFlags } from '../services/feature-flag-loader.js';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
 export interface FeatureFlagsStatusOutput {
+  status: 'ok' | 'degraded';
   source: string;
   configPath: string;
   flags: {
@@ -16,6 +17,8 @@ export interface FeatureFlagsStatusOutput {
   totalFlags: number;
   enabledCount: number;
   disabledCount: number;
+  reason?: string;
+  nextAction?: string;
 }
 
 interface FeaturesOptions {
@@ -27,8 +30,10 @@ export function buildFeatureFlagsStatus(workspaceDir: string): FeatureFlagsStatu
   const effective = loadEffectiveFeatureFlags(workspaceDir);
   const flags = Object.values(effective.flags);
   const enabledCount = flags.filter(f => f.enabled).length;
+  const hasWarnings = effective.warnings.length > 0;
 
   return {
+    status: hasWarnings ? 'degraded' : 'ok',
     source: effective.source,
     configPath: effective.configPath,
     flags: flags.map(f => ({
@@ -42,6 +47,10 @@ export function buildFeatureFlagsStatus(workspaceDir: string): FeatureFlagsStatu
     totalFlags: flags.length,
     enabledCount,
     disabledCount: flags.length - enabledCount,
+    ...(hasWarnings ? {
+      reason: `Config warnings: ${effective.warnings.join('; ')}`,
+      nextAction: 'Review feature-flags.yaml for malformed overrides or unknown flags',
+    } : {}),
   };
 }
 

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -45,6 +45,7 @@ import { handleRuntimeRecoverySweep } from './commands/runtime-recovery.js';
 import { handleRuntimeIdleTriggerEvaluate } from './commands/runtime-idle-trigger.js';
 import { handleRuntimeActivationDispatch } from './commands/runtime-activation.js';
 import { handleProvenChannelBaseline } from './commands/proven-channel-baseline.js';
+import { handleRuntimeFeaturesStatus } from './commands/runtime-features.js';
 
 const program = new Command();
 
@@ -347,6 +348,18 @@ synthCmd
       workspace: opts.workspace,
       json: opts.json,
       channels: opts.channels,
+    });
+  });
+
+runtimeCmd
+  .command('features')
+  .description('Show feature flag status (PRI-239)')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handleRuntimeFeaturesStatus({
+      workspace: opts.workspace,
+      json: opts.json,
     });
   });
 

--- a/packages/pd-cli/src/services/feature-flag-loader.ts
+++ b/packages/pd-cli/src/services/feature-flag-loader.ts
@@ -10,6 +10,8 @@ import type { EffectiveFeatureFlags } from '@principles/core/runtime-v2';
 export const FEATURE_FLAGS_CONFIG_FILENAME = 'feature-flags.yaml';
 export const FEATURE_FLAGS_CONFIG_DIR = '.pd';
 
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export function getFeatureFlagsConfigPath(workspaceDir: string): string {
   return path.join(workspaceDir, FEATURE_FLAGS_CONFIG_DIR, FEATURE_FLAGS_CONFIG_FILENAME);
 }
@@ -41,16 +43,27 @@ export function loadEffectiveFeatureFlags(workspaceDir: string): EffectiveFeatur
     };
   }
 
-  const parsedRecord: Record<string, unknown> = {};
+  const parsedRecord: Record<string, unknown> = Object.create(null);
+  const warnings: string[] = [];
   for (const key of Object.keys(parsed)) {
+    if (DANGEROUS_KEYS.has(key)) {
+      warnings.push(`feature-flags.yaml: dangerous key '${key}' rejected`);
+      continue;
+    }
     if (Object.hasOwn(parsed, key)) {
       parsedRecord[key] = (parsed as Record<string, unknown>)[key];
     }
   }
 
-  return computeEffectiveFlags(
+  const result = computeEffectiveFlags(
     parsedRecord,
     DEFAULT_FEATURE_FLAGS,
     configPath,
   );
+
+  if (warnings.length > 0) {
+    result.warnings = [...warnings, ...result.warnings];
+  }
+
+  return result;
 }

--- a/packages/pd-cli/src/services/feature-flag-loader.ts
+++ b/packages/pd-cli/src/services/feature-flag-loader.ts
@@ -41,8 +41,15 @@ export function loadEffectiveFeatureFlags(workspaceDir: string): EffectiveFeatur
     };
   }
 
+  const parsedRecord: Record<string, unknown> = {};
+  for (const key of Object.keys(parsed)) {
+    if (Object.hasOwn(parsed, key)) {
+      parsedRecord[key] = (parsed as Record<string, unknown>)[key];
+    }
+  }
+
   return computeEffectiveFlags(
-    parsed as Record<string, unknown>,
+    parsedRecord,
     DEFAULT_FEATURE_FLAGS,
     configPath,
   );

--- a/packages/pd-cli/src/services/feature-flag-loader.ts
+++ b/packages/pd-cli/src/services/feature-flag-loader.ts
@@ -1,0 +1,49 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import {
+  computeEffectiveFlags,
+  DEFAULT_FEATURE_FLAGS,
+} from '@principles/core/runtime-v2';
+import type { EffectiveFeatureFlags } from '@principles/core/runtime-v2';
+
+export const FEATURE_FLAGS_CONFIG_FILENAME = 'feature-flags.yaml';
+export const FEATURE_FLAGS_CONFIG_DIR = '.pd';
+
+export function getFeatureFlagsConfigPath(workspaceDir: string): string {
+  return path.join(workspaceDir, FEATURE_FLAGS_CONFIG_DIR, FEATURE_FLAGS_CONFIG_FILENAME);
+}
+
+export function loadEffectiveFeatureFlags(workspaceDir: string): EffectiveFeatureFlags {
+  const configPath = getFeatureFlagsConfigPath(workspaceDir);
+
+  if (!fs.existsSync(configPath)) {
+    return computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
+  }
+
+  const raw = fs.readFileSync(configPath, 'utf8');
+
+  // eslint-disable-next-line @typescript-eslint/init-declarations -- reassigned in try block below
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+  } catch {
+    return {
+      ...computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath),
+      warnings: ['feature-flags.yaml: YAML parse error, using defaults'],
+    };
+  }
+
+  if (parsed === null || parsed === undefined || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      ...computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath),
+      warnings: ['feature-flags.yaml: expected a mapping, using defaults'],
+    };
+  }
+
+  return computeEffectiveFlags(
+    parsed as Record<string, unknown>,
+    DEFAULT_FEATURE_FLAGS,
+    configPath,
+  );
+}

--- a/packages/pd-cli/src/services/feature-flag-loader.ts
+++ b/packages/pd-cli/src/services/feature-flag-loader.ts
@@ -12,6 +12,10 @@ export const FEATURE_FLAGS_CONFIG_DIR = '.pd';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 export function getFeatureFlagsConfigPath(workspaceDir: string): string {
   return path.join(workspaceDir, FEATURE_FLAGS_CONFIG_DIR, FEATURE_FLAGS_CONFIG_FILENAME);
 }
@@ -50,8 +54,8 @@ export function loadEffectiveFeatureFlags(workspaceDir: string): EffectiveFeatur
       warnings.push(`feature-flags.yaml: dangerous key '${key}' rejected`);
       continue;
     }
-    if (Object.hasOwn(parsed, key)) {
-      parsedRecord[key] = (parsed as Record<string, unknown>)[key];
+    if (Object.hasOwn(parsed, key) && isRecord(parsed)) {
+      parsedRecord[key] = parsed[key];
     }
   }
 

--- a/packages/pd-cli/tests/commands/runtime-canary.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-canary.test.ts
@@ -45,6 +45,17 @@ vi.mock('@principles/core/runtime-v2', () => ({
   classifyGfiWorkspaceHealth: mockClassifyGfiHealth,
 }));
 
+vi.mock('../../src/services/feature-flag-loader.js', () => ({
+  loadEffectiveFeatureFlags: vi.fn().mockReturnValue({
+    source: 'defaults',
+    configPath: '/fake/workspace/.pd/feature-flags.yaml',
+    flags: {
+      gfi: { id: 'gfi', category: 'quiet', enabled: true, since: '2026-05-24' },
+    },
+    warnings: [],
+  }),
+}));
+
 import { runCanaryChecks } from '../../src/commands/runtime-canary.js';
 
 const WS = '/fake/workspace';

--- a/packages/pd-cli/tests/commands/runtime-canary.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-canary.test.ts
@@ -57,6 +57,7 @@ vi.mock('../../src/services/feature-flag-loader.js', () => ({
 }));
 
 import { runCanaryChecks } from '../../src/commands/runtime-canary.js';
+import { loadEffectiveFeatureFlags } from '../../src/services/feature-flag-loader.js';
 
 const WS = '/fake/workspace';
 
@@ -264,5 +265,76 @@ describe('runCanaryChecks', () => {
     expect(result.internalizationQueueSummary?.nextReadyTaskKind).toBeNull();
     expect(result.internalizationQueueSummary?.nextReadyTaskId).toBeNull();
     expect(result.internalizationQueueSummary?.noReadyReason).toBe('all_hydration_failed');
+  });
+
+  describe('GFI config warning degraded status', () => {
+    it('returns healthy when GFI disabled with no warnings', async () => {
+      vi.mocked(loadEffectiveFeatureFlags).mockReturnValue({
+        source: 'defaults',
+        configPath: `${WS}/.pd/feature-flags.yaml`,
+        flags: {
+          gfi: { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24' },
+        },
+        warnings: [],
+      });
+
+      const result = await runCanaryChecks(WS);
+      const gfiCheck = result.checks.find(c => c.name === 'gfi_snapshot');
+
+      expect(gfiCheck?.status).toBe('healthy');
+      expect(gfiCheck?.summary).toContain('disabled');
+    });
+
+    it('returns degraded when GFI disabled but config has warnings (malformed YAML)', async () => {
+      vi.mocked(loadEffectiveFeatureFlags).mockReturnValue({
+        source: 'defaults',
+        configPath: `${WS}/.pd/feature-flags.yaml`,
+        flags: {
+          gfi: { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24' },
+        },
+        warnings: ['feature-flags.yaml: YAML parse error, using defaults'],
+      });
+
+      const result = await runCanaryChecks(WS);
+      const gfiCheck = result.checks.find(c => c.name === 'gfi_snapshot');
+
+      expect(gfiCheck?.status).toBe('degraded');
+      expect(gfiCheck?.summary).toContain('warnings');
+      expect(gfiCheck?.details).toBeDefined();
+    });
+
+    it('returns degraded when GFI disabled but config has malformed override warning', async () => {
+      vi.mocked(loadEffectiveFeatureFlags).mockReturnValue({
+        source: 'workspace_file',
+        configPath: `${WS}/.pd/feature-flags.yaml`,
+        flags: {
+          gfi: { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24' },
+        },
+        warnings: ["flag 'gfi': malformed override kept default (enabled must be boolean)"],
+      });
+
+      const result = await runCanaryChecks(WS);
+      const gfiCheck = result.checks.find(c => c.name === 'gfi_snapshot');
+
+      expect(gfiCheck?.status).toBe('degraded');
+    });
+
+    it('runs GFI snapshot when flag enabled with no warnings', async () => {
+      vi.mocked(loadEffectiveFeatureFlags).mockReturnValue({
+        source: 'workspace_file',
+        configPath: `${WS}/.pd/feature-flags.yaml`,
+        flags: {
+          gfi: { id: 'gfi', category: 'quiet', enabled: true, since: '2026-05-24' },
+        },
+        warnings: [],
+      });
+
+      const result = await runCanaryChecks(WS);
+      const gfiCheck = result.checks.find(c => c.name === 'gfi_snapshot');
+
+      expect(gfiCheck?.status).toBe('healthy');
+      expect(gfiCheck?.summary).toContain('OK');
+      expect(mockBuildGfiSnapshot).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-canary.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-canary.test.ts
@@ -301,6 +301,7 @@ describe('runCanaryChecks', () => {
       expect(gfiCheck?.status).toBe('degraded');
       expect(gfiCheck?.summary).toContain('warnings');
       expect(gfiCheck?.details).toBeDefined();
+      expect(result.recommendedNextActions.some(a => a.includes('feature-flags.yaml'))).toBe(true);
     });
 
     it('returns degraded when GFI disabled but config has malformed override warning', async () => {
@@ -317,6 +318,7 @@ describe('runCanaryChecks', () => {
       const gfiCheck = result.checks.find(c => c.name === 'gfi_snapshot');
 
       expect(gfiCheck?.status).toBe('degraded');
+      expect(result.recommendedNextActions.some(a => a.includes('feature-flags.yaml') || a.includes('pd runtime features'))).toBe(true);
     });
 
     it('runs GFI snapshot when flag enabled with no warnings', async () => {
@@ -335,6 +337,28 @@ describe('runCanaryChecks', () => {
       expect(gfiCheck?.status).toBe('healthy');
       expect(gfiCheck?.summary).toContain('OK');
       expect(mockBuildGfiSnapshot).toHaveBeenCalled();
+    });
+
+    it('recommends session lifecycle review for GFI session issues (not config)', async () => {
+      vi.mocked(loadEffectiveFeatureFlags).mockReturnValue({
+        source: 'defaults',
+        configPath: `${WS}/.pd/feature-flags.yaml`,
+        flags: {
+          gfi: { id: 'gfi', category: 'quiet', enabled: true, since: '2026-05-24' },
+        },
+        warnings: [],
+      });
+      mockClassifyGfiHealth.mockReturnValue({
+        status: 'degraded',
+        reason: '5 stale sessions found',
+        staleGfiDegradedThreshold: 40,
+      });
+
+      const result = await runCanaryChecks(WS);
+      const gfiCheck = result.checks.find(c => c.name === 'gfi_snapshot');
+
+      expect(gfiCheck?.status).toBe('degraded');
+      expect(result.recommendedNextActions.some(a => a.includes('GFI sessions') || a.includes('session lifecycle'))).toBe(true);
     });
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-features.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-features.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { buildFeatureFlagsStatus } from '../../src/commands/runtime-features.js';
+import { loadEffectiveFeatureFlags } from '../../src/services/feature-flag-loader.js';
+
+describe('buildFeatureFlagsStatus', () => {
+  it('returns status ok with clean config (no config file)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
+    try {
+      const output = buildFeatureFlagsStatus(tmpDir);
+      expect(output.status).toBe('ok');
+      expect(output.reason).toBeUndefined();
+      expect(output.nextAction).toBeUndefined();
+      expect(output.warnings).toEqual([]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns status degraded with reason/nextAction when warnings present', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
+    const configDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'feature-flags.yaml'), 'gfi:\n  enabled: "yes"\n', 'utf8');
+
+    try {
+      const output = buildFeatureFlagsStatus(tmpDir);
+      expect(output.status).toBe('degraded');
+      expect(output.reason).toBeDefined();
+      expect(output.nextAction).toBeDefined();
+      expect(output.warnings.length).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('JSON output contains all required fields', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
+    try {
+      const output = buildFeatureFlagsStatus(tmpDir);
+      const json = JSON.stringify(output);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.status).toBe('ok');
+      expect(parsed.source).toBe('defaults');
+      expect(parsed.configPath).toBeTruthy();
+      expect(parsed.flags).toBeInstanceOf(Array);
+      expect(parsed.warnings).toBeInstanceOf(Array);
+      expect(typeof parsed.totalFlags).toBe('number');
+      expect(typeof parsed.enabledCount).toBe('number');
+      expect(typeof parsed.disabledCount).toBe('number');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('YAML loader integration', () => {
+  it('rejects __proto__ key in YAML', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
+    const configDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'feature-flags.yaml'),
+      '"__proto__":\n  enabled: true\n',
+      'utf8',
+    );
+
+    try {
+      const result = loadEffectiveFeatureFlags(tmpDir);
+      expect(result.warnings.some(w => w.includes('__proto__'))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles malformed YAML gracefully', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
+    const configDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'feature-flags.yaml'), 'gfi: [unterminated', 'utf8');
+
+    try {
+      const result = loadEffectiveFeatureFlags(tmpDir);
+      expect(result.warnings.some(w => w.includes('YAML'))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('enables GFI via valid YAML config', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
+    const configDir = path.join(tmpDir, '.pd');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'feature-flags.yaml'),
+      'gfi:\n  enabled: true\n',
+      'utf8',
+    );
+
+    try {
+      const result = loadEffectiveFeatureFlags(tmpDir);
+      expect(result.flags.gfi).toBeDefined();
+      if (result.flags.gfi) {
+        expect(result.flags.gfi.enabled).toBe(true);
+      }
+      expect(result.source).toBe('workspace_file');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -3603,11 +3603,11 @@ describe('PRI-239: Feature flag registry architecture boundary', () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'feature-flags', 'feature-flag-contract.ts'), 'utf-8');
-    expect(src).not.toContain("from 'node:fs'");
-    expect(src).not.toContain("from 'node:path'");
-    expect(src).not.toContain("from 'fs'");
-    expect(src).not.toContain("from 'path'");
-    expect(src).not.toContain("from 'js-yaml'");
+    expect(src).not.toMatch(/from\s+['"]node:fs['"]/);
+    expect(src).not.toMatch(/from\s+['"]node:path['"]/);
+    expect(src).not.toMatch(/from\s+['"]fs['"]/);
+    expect(src).not.toMatch(/from\s+['"]path['"]/);
+    expect(src).not.toMatch(/from\s+['"]js-yaml['"]/);
   });
 
   it('CORE_NO_RUNTIME_CLASSES: feature-flag-contract.ts does not import runtime orchestration classes', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -158,6 +158,9 @@ const REQUIRED_SOURCE_FILES = [
   'activation/writers/index.ts',
   // PRI-215
   'synthetic-baseline.ts',
+  // PRI-239
+  'feature-flags/feature-flag-contract.ts',
+  'feature-flags/index.ts',
 ] as const;
 
 // ── PRI-212: Plugin core anti-growth guard ────────────────────────────────────
@@ -414,6 +417,8 @@ const REQUIRED_TEST_FILES = [
   '../activation/writers/__tests__/rule-host-writer.test.ts',
   // PRI-215
   'synthetic-baseline.test.ts',
+  // PRI-239
+  '../feature-flags/__tests__/feature-flag-contract.test.ts',
 ];
 
 const REQUIRED_DOC_FILES: string[] = [];
@@ -473,6 +478,9 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     'mergeDecisions',
     // PRI-149 Tier 2
     'createRecoverySweepService',
+    // PRI-239
+    'validateFeatureFlagRaw',
+    'computeEffectiveFlags',
   ];
 
   for (const name of REQUIRED_EXPORTS) {
@@ -3580,6 +3588,68 @@ describe('PRI-225: No unsafe type assertions on untrusted metadata arrays', () =
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'internalization-chain-integrity-read-model.ts'), 'utf-8');
     expect(src).not.toContain('as string[]');
+  });
+});
+
+// ── PRI-239: Feature flag registry architecture boundary ──────────────────
+//
+// Core: packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+// I/O Loader: packages/pd-cli/src/services/feature-flag-loader.ts
+// CLI Command: packages/pd-cli/src/commands/runtime-features.ts
+// Consumption: packages/pd-cli/src/commands/runtime-canary.ts (GFI check)
+
+describe('PRI-239: Feature flag registry architecture boundary', () => {
+  it('CORE_NO_NODE_IO: feature-flag-contract.ts does not import Node I/O modules', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'feature-flags', 'feature-flag-contract.ts'), 'utf-8');
+    expect(src).not.toContain("from 'node:fs'");
+    expect(src).not.toContain("from 'node:path'");
+    expect(src).not.toContain("from 'fs'");
+    expect(src).not.toContain("from 'path'");
+    expect(src).not.toContain("from 'js-yaml'");
+  });
+
+  it('CORE_NO_RUNTIME_CLASSES: feature-flag-contract.ts does not import runtime orchestration classes', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'feature-flags', 'feature-flag-contract.ts'), 'utf-8');
+    expect(src).not.toContain('RuntimeStateManager');
+    expect(src).not.toContain('InternalizationOrchestrator');
+    expect(src).not.toContain('SqliteConnection');
+  });
+
+  it('IO_LOADER_OUTSIDE_CORE: I/O loader exists at pd-cli/src/services/feature-flag-loader.ts', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(
+      resolve(__dirname, '../../../../pd-cli/src/services/feature-flag-loader.ts'),
+    )).toBe(true);
+  });
+
+  it('CLI_COMMAND_OUTSIDE_CORE: CLI command exists at pd-cli/src/commands/runtime-features.ts', async () => {
+    const { existsSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    expect(existsSync(
+      resolve(__dirname, '../../../../pd-cli/src/commands/runtime-features.ts'),
+    )).toBe(true);
+  });
+
+  it('FROZEN_LEGACY_UNTOUCHED: ADR-0005 frozen files are not imported by feature-flag-contract.ts', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'feature-flags', 'feature-flag-contract.ts'), 'utf-8');
+    expect(src).not.toContain('nocturnal-trinity');
+    expect(src).not.toContain('nocturnal-arbiter');
+    expect(src).not.toContain('nocturnal-service');
+  });
+
+  it('CONSUMPTION_WIRED: runtime-canary.ts imports feature flag loader', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '../../../../pd-cli/src/commands/runtime-canary.ts'), 'utf-8');
+    expect(src).toContain('feature-flag-loader');
+    expect(src).toContain('loadEffectiveFeatureFlags');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateFeatureFlagRaw,
+  computeEffectiveFlags,
+  DEFAULT_FEATURE_FLAGS,
+  type FeatureFlagCategory,
+  VALID_CATEGORIES,
+} from '../feature-flag-contract.js';
+
+describe('validateFeatureFlagRaw', () => {
+  it('accepts valid flag with all fields', () => {
+    const raw = {
+      id: 'gfi',
+      category: 'quiet',
+      enabled: false,
+      since: '2026-05-24',
+      description: 'Global Friction Index session scoring',
+    };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.id).toBe('gfi');
+      expect(result.value.category).toBe('quiet');
+      expect(result.value.enabled).toBe(false);
+      expect(result.value.since).toBe('2026-05-24');
+      expect(result.value.description).toBe('Global Friction Index session scoring');
+    }
+  });
+
+  it('accepts valid flag without description', () => {
+    const raw = {
+      id: 'gfi',
+      category: 'quiet',
+      enabled: false,
+      since: '2026-05-24',
+    };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects non-object input', () => {
+    const result = validateFeatureFlagRaw('not an object', 'test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects null input', () => {
+    const result = validateFeatureFlagRaw(null, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects array input', () => {
+    const result = validateFeatureFlagRaw([], 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects missing id', () => {
+    const raw = { category: 'quiet', enabled: false, since: '2026-05-24' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some(e => e.includes('id'))).toBe(true);
+    }
+  });
+
+  it('rejects non-string id', () => {
+    const raw = { id: 42, category: 'quiet', enabled: false, since: '2026-05-24' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects empty id', () => {
+    const raw = { id: '', category: 'quiet', enabled: false, since: '2026-05-24' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects invalid category', () => {
+    const raw = { id: 'gfi', category: 'invalid', enabled: false, since: '2026-05-24' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some(e => e.includes('category'))).toBe(true);
+    }
+  });
+
+  it('accepts all valid categories', () => {
+    const categories: FeatureFlagCategory[] = ['core', 'quiet', 'gone', 'legacy_retire'];
+    for (const category of categories) {
+      const raw = { id: `test-${category}`, category, enabled: true, since: '2026-05-24' };
+      const result = validateFeatureFlagRaw(raw, `test-${category}`);
+      expect(result.ok, `category ${category} should be valid`).toBe(true);
+    }
+  });
+
+  it('rejects non-boolean enabled', () => {
+    const raw = { id: 'gfi', category: 'quiet', enabled: 'false', since: '2026-05-24' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects missing enabled', () => {
+    const raw = { id: 'gfi', category: 'quiet', since: '2026-05-24' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects missing since', () => {
+    const raw = { id: 'gfi', category: 'quiet', enabled: false };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-string since', () => {
+    const raw = { id: 'gfi', category: 'quiet', enabled: false, since: 20260524 };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects empty since', () => {
+    const raw = { id: 'gfi', category: 'quiet', enabled: false, since: '' };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-string description when present', () => {
+    const raw = { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24', description: 42 };
+    const result = validateFeatureFlagRaw(raw, 'test');
+    expect(result.ok).toBe(false);
+  });
+
+  it('includes source key in errors for traceability', () => {
+    const result = validateFeatureFlagRaw({ id: 42 }, 'my-flag');
+    if (!result.ok) {
+      expect(result.source).toBe('my-flag');
+    }
+  });
+});
+
+describe('computeEffectiveFlags', () => {
+  it('returns defaults when no user flags provided', () => {
+    const result = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    expect(result.source).toBe('defaults');
+    expect(result.configPath).toBe('/test/.pd/feature-flags.yaml');
+    expect(Object.keys(result.flags).length).toBeGreaterThan(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('returns workspace_file source when user flags are provided', () => {
+    const userFlags = {
+      gfi: { enabled: true, since: '2026-05-24' },
+    };
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    expect(result.source).toBe('workspace_file');
+  });
+
+  it('does not allow enabling quiet flags from malformed input', () => {
+    const userFlags = {
+      gfi: { enabled: 'yes', since: '2026-05-24' },
+    };
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    const gfiFlag = result.flags.gfi;
+    expect(gfiFlag).toBeDefined();
+    // Malformed enabled field must NOT enable a quiet flag
+    if (gfiFlag) {
+      expect(gfiFlag.enabled).toBe(false);
+    }
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('does not allow enabling unknown flags', () => {
+    const userFlags = {
+      totally_made_up: { category: 'quiet', enabled: true, since: '2026-05-24' },
+    };
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    expect(result.flags.totally_made_up).toBeUndefined();
+    expect(result.warnings.some(w => w.includes('totally_made_up'))).toBe(true);
+  });
+
+  it('preserves core flags as enabled regardless of user config', () => {
+    const promptDefault = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'prompt');
+    if (!promptDefault) return;
+    const userFlags = {
+      prompt: { enabled: false, since: '2026-01-01' },
+    };
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    const promptFlag = result.flags.prompt;
+    if (promptFlag) {
+      expect(promptFlag.enabled).toBe(true);
+    }
+    expect(result.warnings.some(w => w.includes('core') || w.includes('prompt'))).toBe(true);
+  });
+
+  it('allows explicit enable of quiet flag with valid input', () => {
+    const userFlags = {
+      gfi: { enabled: true, since: '2026-05-24' },
+    };
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    const gfiFlag = result.flags.gfi;
+    if (gfiFlag) {
+      expect(gfiFlag.enabled).toBe(true);
+    }
+  });
+
+  it('default-off quiet flags are disabled when no config', () => {
+    const result = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    const quietFlags = Object.values(result.flags).filter(f => f.category === 'quiet');
+    for (const flag of quietFlags) {
+      expect(flag.enabled, `quiet flag ${flag.id} should default off`).toBe(false);
+    }
+  });
+
+  it('core flags are enabled by default', () => {
+    const result = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    const coreFlags = Object.values(result.flags).filter(f => f.category === 'core');
+    for (const flag of coreFlags) {
+      expect(flag.enabled, `core flag ${flag.id} should default on`).toBe(true);
+    }
+  });
+
+  it('gone flags are always disabled regardless of config', () => {
+    const goneDefault = DEFAULT_FEATURE_FLAGS.find(f => f.category === 'gone');
+    if (!goneDefault) return;
+    const userFlags = {
+      [goneDefault.id]: { enabled: true, since: '2026-05-24' },
+    };
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    const goneFlag = result.flags[goneDefault.id];
+    if (goneFlag) {
+      expect(goneFlag.enabled).toBe(false);
+    }
+  });
+});
+
+describe('DEFAULT_FEATURE_FLAGS', () => {
+  it('contains prompt core flag', () => {
+    const prompt = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'prompt');
+    expect(prompt).toBeDefined();
+    if (prompt) {
+      expect(prompt.category).toBe('core');
+      expect(prompt.enabled).toBe(true);
+    }
+  });
+
+  it('contains code_tool_hook core flag', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'code_tool_hook');
+    expect(flag).toBeDefined();
+    if (flag) {
+      expect(flag.category).toBe('core');
+      expect(flag.enabled).toBe(true);
+    }
+  });
+
+  it('contains defer_archive core flag', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'defer_archive');
+    expect(flag).toBeDefined();
+    if (flag) {
+      expect(flag.category).toBe('core');
+      expect(flag.enabled).toBe(true);
+    }
+  });
+
+  it('contains gfi quiet flag (default off)', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'gfi');
+    expect(flag).toBeDefined();
+    if (flag) {
+      expect(flag.category).toBe('quiet');
+      expect(flag.enabled).toBe(false);
+    }
+  });
+
+  it('all flags have valid since dates', () => {
+    for (const flag of DEFAULT_FEATURE_FLAGS) {
+      expect(flag.since, `flag ${flag.id} since`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it('all flags have valid categories', () => {
+    for (const flag of DEFAULT_FEATURE_FLAGS) {
+      expect(VALID_CATEGORIES).toContain(flag.category);
+    }
+  });
+
+  it('no duplicate flag ids', () => {
+    const ids = DEFAULT_FEATURE_FLAGS.map(f => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('has description for every flag', () => {
+    for (const flag of DEFAULT_FEATURE_FLAGS) {
+      expect(flag.description, `flag ${flag.id} needs description`).toBeDefined();
+      expect(typeof flag.description).toBe('string');
+      if (flag.description) {
+        expect(flag.description.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('VALID_CATEGORIES', () => {
+  it('contains exactly core, quiet, gone, legacy_retire', () => {
+    expect(VALID_CATEGORIES).toEqual(['core', 'quiet', 'gone', 'legacy_retire']);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
@@ -304,3 +304,45 @@ describe('VALID_CATEGORIES', () => {
     expect(VALID_CATEGORIES).toEqual(['core', 'quiet', 'gone', 'legacy_retire']);
   });
 });
+
+describe('prototype pollution defense', () => {
+  it('rejects constructor key in user flags', () => {
+    const userFlags: Record<string, unknown> = { constructor: { enabled: true } };
+    const result = computeEffectiveFlags(
+      userFlags,
+      DEFAULT_FEATURE_FLAGS,
+      '/test/.pd/feature-flags.yaml',
+    );
+    expect(result.warnings.some(w => w.includes('constructor'))).toBe(true);
+  });
+
+  it('rejects prototype key in user flags', () => {
+    const userFlags: Record<string, unknown> = { prototype: { enabled: true } };
+    const result = computeEffectiveFlags(
+      userFlags,
+      DEFAULT_FEATURE_FLAGS,
+      '/test/.pd/feature-flags.yaml',
+    );
+    expect(result.warnings.some(w => w.includes('prototype'))).toBe(true);
+  });
+
+  it('rejects __proto__ when passed as explicit enumerable key', () => {
+    const userFlags: Record<string, unknown> = {};
+    Object.defineProperty(userFlags, '__proto__', {
+      value: { enabled: true },
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    const result = computeEffectiveFlags(userFlags, DEFAULT_FEATURE_FLAGS, '/test/.pd/feature-flags.yaml');
+    expect(result.warnings.some(w => w.includes('__proto__'))).toBe(true);
+  });
+
+  it('Object.hasOwn used for override reads (not in operator)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'feature-flag-contract.ts'), 'utf-8');
+    const overrideReads = src.match(/Object\.hasOwn\(/g);
+    expect(overrideReads && overrideReads.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -8,6 +8,8 @@
 export const VALID_CATEGORIES = ['core', 'quiet', 'gone', 'legacy_retire'] as const;
 export type FeatureFlagCategory = (typeof VALID_CATEGORIES)[number];
 
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export interface FeatureFlagDefinition {
   id: string;
   category: FeatureFlagCategory;
@@ -95,19 +97,8 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
 
   // MVP-Quiet — default disabled, opt-in via config
+  // Only flags with real consumption paths are registered (PRI-239 constraint)
   { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Global Friction Index session scoring' },
-  { id: 'thinking_os', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Thinking OS injection in prompts' },
-  { id: 'focus_history', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Focus history compression for context' },
-  { id: 'empathy_keyword', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Empathy keyword matching system' },
-  { id: 'philosopher', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Philosopher peer runner for principle extraction' },
-  { id: 'evaluator', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Evaluator peer runner for principle review' },
-  { id: 'rollout_reviewer', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Rollout reviewer peer runner for L2 registration' },
-  { id: 'shadow_observation', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Shadow observation registry for passive learning' },
-  { id: 'local_worker_routing', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Local worker routing for task dispatch' },
-  { id: 'central_sync', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Central sync for cross-workspace coordination' },
-  { id: 'message_sanitize', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Message sanitization for LLM output safety' },
-  { id: 'trajectory_collector', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Trajectory collector for session replay' },
-  { id: 'skill_channel', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Skill channel for internalization pipeline' },
 
   // MVP-Gone — permanently disabled, cannot be re-enabled
   { id: 'nocturnal', category: 'gone', enabled: false, since: '2026-05-24', description: 'Nocturnal trinity pipeline (retired)' },
@@ -123,19 +114,23 @@ export function computeEffectiveFlags(
 ): EffectiveFeatureFlags {
   const warnings: string[] = [];
   const flags: Record<string, FeatureFlagDefinition> = {};
-  const hasUserFlags = Object.keys(userFlags).length > 0;
+
+  const safeKeys = Object.keys(userFlags).filter(key => {
+    if (DANGEROUS_KEYS.has(key)) {
+      warnings.push(`flag '${key}': dangerous key rejected`);
+      return false;
+    }
+    return true;
+  });
+  const hasUserFlags = safeKeys.length > 0;
 
   for (const def of defaults) {
-    const userEntry = userFlags[def.id];
-
-    // No user override → use default as-is
-    if (userEntry === undefined) {
+    if (!Object.hasOwn(userFlags, def.id) || DANGEROUS_KEYS.has(def.id)) {
       flags[def.id] = { ...def };
       continue;
     }
 
-    // Validate user override — user config provides {enabled, since}, not full definition
-    const override = userEntry;
+    const override = userFlags[def.id];
     const isPlainObj = override !== null && override !== undefined && typeof override === 'object' && !Array.isArray(override);
     const enabledValue = isPlainObj && Object.hasOwn(override, 'enabled')
       ? (override as Record<string, unknown>).enabled
@@ -173,7 +168,7 @@ export function computeEffectiveFlags(
   }
 
   // Warn about unknown flags
-  for (const key of Object.keys(userFlags)) {
+  for (const key of safeKeys) {
     if (!Object.hasOwn(flags, key)) {
       warnings.push(`flag '${key}': unknown flag ignored`);
     }

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -1,0 +1,182 @@
+/**
+ * Feature Flag Contract — PRI-239
+ *
+ * Pure types and validators for the MVP-Quiet feature flag registry.
+ * No I/O — YAML loading lives in pd-cli.
+ */
+
+export const VALID_CATEGORIES = ['core', 'quiet', 'gone', 'legacy_retire'] as const;
+export type FeatureFlagCategory = (typeof VALID_CATEGORIES)[number];
+
+export interface FeatureFlagDefinition {
+  id: string;
+  category: FeatureFlagCategory;
+  enabled: boolean;
+  since: string;
+  description?: string;
+}
+
+export interface EffectiveFeatureFlags {
+  flags: Record<string, FeatureFlagDefinition>;
+  source: 'defaults' | 'workspace_file';
+  configPath: string;
+  warnings: string[];
+}
+
+export interface ValidationResultOk {
+  ok: true;
+  value: FeatureFlagDefinition;
+}
+
+export interface ValidationResultErr {
+  ok: false;
+  errors: string[];
+  source: string;
+}
+
+export type ValidationResult = ValidationResultOk | ValidationResultErr;
+
+export function validateFeatureFlagRaw(raw: unknown, source: string): ValidationResult {
+  const errors: string[] = [];
+
+  if (raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, errors: ['input must be a non-null object'], source };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.id !== 'string' || obj.id.length === 0) {
+    errors.push('id must be a non-empty string');
+  }
+
+  if (!VALID_CATEGORIES.includes(obj.category as FeatureFlagCategory)) {
+    errors.push(`category must be one of: ${VALID_CATEGORIES.join(', ')}`);
+  }
+
+  if (typeof obj.enabled !== 'boolean') {
+    errors.push('enabled must be a boolean');
+  }
+
+  if (typeof obj.since !== 'string' || obj.since.length === 0) {
+    errors.push('since must be a non-empty string');
+  }
+
+  if (obj.description !== undefined && typeof obj.description !== 'string') {
+    errors.push('description must be a string when present');
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors, source };
+  }
+
+  const value: FeatureFlagDefinition = {
+    id: obj.id as string,
+    category: obj.category as FeatureFlagCategory,
+    enabled: obj.enabled as boolean,
+    since: obj.since as string,
+  };
+
+  if (obj.description !== undefined) {
+    value.description = obj.description as string;
+  }
+
+  return { ok: true, value };
+}
+
+export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
+  // MVP-Core — always enabled, cannot be disabled
+  { id: 'prompt', category: 'core', enabled: true, since: '2026-05-24', description: 'Prompt injection for principle application' },
+  { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
+  { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
+
+  // MVP-Quiet — default disabled, opt-in via config
+  { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Global Friction Index session scoring' },
+  { id: 'thinking_os', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Thinking OS injection in prompts' },
+  { id: 'focus_history', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Focus history compression for context' },
+  { id: 'empathy_keyword', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Empathy keyword matching system' },
+  { id: 'philosopher', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Philosopher peer runner for principle extraction' },
+  { id: 'evaluator', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Evaluator peer runner for principle review' },
+  { id: 'rollout_reviewer', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Rollout reviewer peer runner for L2 registration' },
+  { id: 'shadow_observation', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Shadow observation registry for passive learning' },
+  { id: 'local_worker_routing', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Local worker routing for task dispatch' },
+  { id: 'central_sync', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Central sync for cross-workspace coordination' },
+  { id: 'message_sanitize', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Message sanitization for LLM output safety' },
+  { id: 'trajectory_collector', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Trajectory collector for session replay' },
+  { id: 'skill_channel', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Skill channel for internalization pipeline' },
+
+  // MVP-Gone — permanently disabled, cannot be re-enabled
+  { id: 'nocturnal', category: 'gone', enabled: false, since: '2026-05-24', description: 'Nocturnal trinity pipeline (retired)' },
+  { id: 'idle_trigger', category: 'gone', enabled: false, since: '2026-05-24', description: 'Idle trigger for background processing (retired)' },
+  { id: 'model_training', category: 'gone', enabled: false, since: '2026-05-24', description: 'Model training channel (retired)' },
+  { id: 'trainer', category: 'gone', enabled: false, since: '2026-05-24', description: 'Trainer peer runner (retired)' },
+];
+
+export function computeEffectiveFlags(
+  userFlags: Record<string, unknown>,
+  defaults: FeatureFlagDefinition[],
+  configPath: string,
+): EffectiveFeatureFlags {
+  const warnings: string[] = [];
+  const flags: Record<string, FeatureFlagDefinition> = {};
+  const hasUserFlags = Object.keys(userFlags).length > 0;
+
+  for (const def of defaults) {
+    const userEntry = userFlags[def.id];
+
+    // No user override → use default as-is
+    if (userEntry === undefined) {
+      flags[def.id] = { ...def };
+      continue;
+    }
+
+    // Validate user override — user config provides {enabled, since}, not full definition
+    const override = userEntry as Record<string, unknown> | null | undefined;
+    const enabledValue = override && typeof override === 'object' && !Array.isArray(override)
+      ? (override).enabled
+      : undefined;
+
+    if (typeof enabledValue !== 'boolean') {
+      flags[def.id] = { ...def };
+      warnings.push(`flag '${def.id}': malformed override kept default (enabled must be boolean)`);
+      continue;
+    }
+
+    // Gone flags can never be re-enabled
+    if (def.category === 'gone') {
+      flags[def.id] = { ...def };
+      if (enabledValue) {
+        warnings.push(`flag '${def.id}': gone flag cannot be re-enabled`);
+      }
+      continue;
+    }
+
+    // Core flags can never be disabled
+    if (def.category === 'core') {
+      flags[def.id] = { ...def };
+      if (!enabledValue) {
+        warnings.push(`flag '${def.id}': core flag cannot be disabled`);
+      }
+      continue;
+    }
+
+    // Quiet flags: accept valid user override
+    flags[def.id] = {
+      ...def,
+      enabled: enabledValue,
+    };
+  }
+
+  // Warn about unknown flags
+  for (const key of Object.keys(userFlags)) {
+    if (!flags[key]) {
+      warnings.push(`flag '${key}': unknown flag ignored`);
+    }
+  }
+
+  return {
+    flags,
+    source: hasUserFlags ? 'workspace_file' : 'defaults',
+    configPath,
+    warnings,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -43,25 +43,30 @@ export function validateFeatureFlagRaw(raw: unknown, source: string): Validation
     return { ok: false, errors: ['input must be a non-null object'], source };
   }
 
-  const obj = raw as Record<string, unknown>;
+  const obj = raw;
 
-  if (typeof obj.id !== 'string' || obj.id.length === 0) {
+  const id = Object.hasOwn(obj, 'id') ? (obj as Record<string, unknown>).id : undefined;
+  if (typeof id !== 'string' || id.length === 0) {
     errors.push('id must be a non-empty string');
   }
 
-  if (!VALID_CATEGORIES.includes(obj.category as FeatureFlagCategory)) {
+  const category = Object.hasOwn(obj, 'category') ? (obj as Record<string, unknown>).category : undefined;
+  if (typeof category !== 'string' || !VALID_CATEGORIES.includes(category as FeatureFlagCategory)) {
     errors.push(`category must be one of: ${VALID_CATEGORIES.join(', ')}`);
   }
 
-  if (typeof obj.enabled !== 'boolean') {
+  const enabled = Object.hasOwn(obj, 'enabled') ? (obj as Record<string, unknown>).enabled : undefined;
+  if (typeof enabled !== 'boolean') {
     errors.push('enabled must be a boolean');
   }
 
-  if (typeof obj.since !== 'string' || obj.since.length === 0) {
+  const since = Object.hasOwn(obj, 'since') ? (obj as Record<string, unknown>).since : undefined;
+  if (typeof since !== 'string' || since.length === 0) {
     errors.push('since must be a non-empty string');
   }
 
-  if (obj.description !== undefined && typeof obj.description !== 'string') {
+  const description = Object.hasOwn(obj, 'description') ? (obj as Record<string, unknown>).description : undefined;
+  if (description !== undefined && typeof description !== 'string') {
     errors.push('description must be a string when present');
   }
 
@@ -70,14 +75,14 @@ export function validateFeatureFlagRaw(raw: unknown, source: string): Validation
   }
 
   const value: FeatureFlagDefinition = {
-    id: obj.id as string,
-    category: obj.category as FeatureFlagCategory,
-    enabled: obj.enabled as boolean,
-    since: obj.since as string,
+    id: id as string,
+    category: category as FeatureFlagCategory,
+    enabled: enabled as boolean,
+    since: since as string,
   };
 
-  if (obj.description !== undefined) {
-    value.description = obj.description as string;
+  if (description !== undefined) {
+    value.description = description as string;
   }
 
   return { ok: true, value };
@@ -130,9 +135,10 @@ export function computeEffectiveFlags(
     }
 
     // Validate user override — user config provides {enabled, since}, not full definition
-    const override = userEntry as Record<string, unknown> | null | undefined;
-    const enabledValue = override && typeof override === 'object' && !Array.isArray(override)
-      ? (override).enabled
+    const override = userEntry;
+    const isPlainObj = override !== null && override !== undefined && typeof override === 'object' && !Array.isArray(override);
+    const enabledValue = isPlainObj && Object.hasOwn(override, 'enabled')
+      ? (override as Record<string, unknown>).enabled
       : undefined;
 
     if (typeof enabledValue !== 'boolean') {
@@ -168,7 +174,7 @@ export function computeEffectiveFlags(
 
   // Warn about unknown flags
   for (const key of Object.keys(userFlags)) {
-    if (!flags[key]) {
+    if (!Object.hasOwn(flags, key)) {
       warnings.push(`flag '${key}': unknown flag ignored`);
     }
   }

--- a/packages/principles-core/src/runtime-v2/feature-flags/index.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/index.ts
@@ -1,0 +1,15 @@
+export {
+  VALID_CATEGORIES,
+  validateFeatureFlagRaw,
+  computeEffectiveFlags,
+  DEFAULT_FEATURE_FLAGS,
+} from './feature-flag-contract.js';
+
+export type {
+  FeatureFlagCategory,
+  FeatureFlagDefinition,
+  EffectiveFeatureFlags,
+  ValidationResult,
+  ValidationResultOk,
+  ValidationResultErr,
+} from './feature-flag-contract.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -292,6 +292,24 @@ export type { OperatorHealthSnapshot, OperatorHealthReadModelOptions, OverallHea
 export { computeOverallStatus, boundedEvidence, safeStringify, truncateReason, makeDeterministicDiagnosticianOutput, recommendNextIssue } from './synthetic-baseline.js';
 export type { SyntheticBaselineSummary, SyntheticBaselineStage, SyntheticBaselineStageName, SyntheticBaselineFailStage, SyntheticBaselineOptions } from './synthetic-baseline.js';
 
+// Feature Flag Registry (PRI-239) — MVP-Quiet loadable feature flags
+
+export {
+  VALID_CATEGORIES,
+  validateFeatureFlagRaw,
+  computeEffectiveFlags,
+  DEFAULT_FEATURE_FLAGS,
+} from './feature-flags/index.js';
+
+export type {
+  FeatureFlagCategory,
+  FeatureFlagDefinition,
+  EffectiveFeatureFlags,
+  ValidationResult as FeatureFlagValidationResult,
+  ValidationResultOk as FeatureFlagValidationResultOk,
+  ValidationResultErr as FeatureFlagValidationResultErr,
+} from './feature-flags/index.js';
+
 // Proven channel baseline (PRI-240) — MVP activation continuity fixtures
 export {
   runPromptFixture,

--- a/packages/principles-core/vitest.config.ts
+++ b/packages/principles-core/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/**/*.test.ts', 'src/prompt-builder/__tests__/**/*.test.ts', 'src/runtime-v2/store/**/*.test.ts', 'src/runtime-v2/runner/**/*.test.ts', 'src/runtime-v2/utils/**/*.test.ts', 'src/runtime-v2/adapter/**/*.test.ts', 'src/runtime-v2/diagnostician/**/*.test.ts', 'src/runtime-v2/__tests__/**/*.test.ts', 'src/runtime-v2/gfi/__tests__/**/*.test.ts', 'src/runtime-v2/idle-trigger/__tests__/**/*.test.ts', 'src/runtime-v2/activation/__tests__/**/*.test.ts', 'src/runtime-v2/activation/writers/__tests__/**/*.test.ts', 'src/runtime-v2/internalization/__tests__/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/prompt-builder/__tests__/**/*.test.ts', 'src/runtime-v2/store/**/*.test.ts', 'src/runtime-v2/runner/**/*.test.ts', 'src/runtime-v2/utils/**/*.test.ts', 'src/runtime-v2/adapter/**/*.test.ts', 'src/runtime-v2/diagnostician/**/*.test.ts', 'src/runtime-v2/__tests__/**/*.test.ts', 'src/runtime-v2/gfi/__tests__/**/*.test.ts', 'src/runtime-v2/idle-trigger/__tests__/**/*.test.ts', 'src/runtime-v2/activation/__tests__/**/*.test.ts', 'src/runtime-v2/activation/writers/__tests__/**/*.test.ts', 'src/runtime-v2/internalization/__tests__/**/*.test.ts', 'src/runtime-v2/feature-flags/__tests__/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Implements PRI-239: A loadable feature flag registry for the MVP-First strategy (ADR-0014).

### Core (`@principles/core/runtime-v2/feature-flags/`)
- **Feature flag contract** with 4 categories: `core`, `quiet`, `gone`, `legacy_retire`
- `validateFeatureFlagRaw()` — discriminated-union validator for raw flag input
- `computeEffectiveFlags()` — safe merge of user overrides with defaults:
  - Core flags can **never** be disabled
  - Gone flags can **never** be re-enabled
  - Quiet flags default off, opt-in via workspace config
  - Malformed overrides fail-closed to defaults with warnings
- **20 feature flags**: 3 core, 13 quiet, 4 gone

### CLI (`packages/pd-cli/`)
- **YAML loader** (`feature-flag-loader.ts`) with `yaml.JSON_SCHEMA` safety
- **`pd runtime features --workspace --json`** observability command
- **GFI canary check** gated by feature flag (consumption point wiring)

### Architecture regression guards
- 6 new boundary tests: CORE_NO_NODE_IO, CORE_NO_RUNTIME_CLASSES, IO_LOADER_OUTSIDE_CORE, CLI_COMMAND_OUTSIDE_CORE, FROZEN_LEGACY_UNTOUCHED, CONSUMPTION_WIRED

## Test plan
- [x] 35 contract tests pass (validateFeatureFlagRaw + computeEffectiveFlags + DEFAULT_FEATURE_FLAGS)
- [x] 450 architecture regression tests pass (including 6 new PRI-239 guards)
- [x] 10 canary tests pass (GFI feature flag gate verified)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] ESLint passes (0 errors)
- [x] `pd runtime features --workspace <ws> --json` verified with temp workspace
- [x] `pd runtime features` with GFI enabled via YAML config verified
- [x] Proven-channel baseline verified: `pd runtime synthetic proven-channel --json` → `"status": "passed"`

## ERR checklist
- ERR-001 (type cast on untrusted JSON): All parsed YAML treated as `unknown`, validated before use, no `as` cast bypass
- ERR-005 (array element type validation): `computeEffectiveFlags` checks `typeof enabled === 'boolean'` on each user override
- ERR-009 (required fields fail loud): Missing `enabled` in user config → warning + default preserved
- ERR-013 (Object.hasOwn for untrusted keys): Used `Object.keys()` iteration over known defaults, `userFlags[def.id]` for lookup

## Remaining risk
- Pre-existing pd-cli test failures (10 tests in runtime-activation, candidate-audit-repair, candidate-intake-e2e, runtime probe) — unrelated to this PR
- Pre-existing core failures (9 tests) — real-LLM E2E tests requiring MINIMAX_API_KEY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增特性开关系统，允许通过工作区配置管理运行时特性并查看其启用状态。
  * 新增 runtime features CLI 子命令，支持文本与 JSON 输出特性开关状态（可指定工作区）。
  * 运行时健康检查现会基于特性开关有条件地跳过或执行相关检查。

* **依赖更新**
  * 添加 js-yaml 用于读取/解析特性开关配置。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->