### PR TITLE
test: add test coverage for health and trace commands

### DIFF
--- a/packages/pd-cli/tests/commands/health.test.ts
+++ b/packages/pd-cli/tests/commands/health.test.ts
@@ -1,0 +1,153 @@
+/**
+ * pd health command unit tests.
+ *
+ * Tests the health command's external contract via mocked read models.
+ * Tests JSON/text output formatting, exit code behavior, and error handling.
+ * Note: PainChainReadModel is only created when state.db exists.
+ * These tests focus on the PruningReadModel and auditCandidateLedgerConsistency layer.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockPruningGetHealthSummary, mockAuditCandidateLedgerConsistency } = vi.hoisted(() => {
+  return {
+    mockPruningGetHealthSummary: vi.fn(),
+    mockAuditCandidateLedgerConsistency: vi.fn(),
+  };
+});
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  PruningReadModel: vi.fn().mockImplementation(function () {
+    return { getHealthSummary: mockPruningGetHealthSummary };
+  }),
+  PainChainReadModel: vi.fn().mockImplementation(function () {
+    return { getLastSuccessfulChain: vi.fn().mockResolvedValue(undefined), close: vi.fn() };
+  }),
+  auditCandidateLedgerConsistency: mockAuditCandidateLedgerConsistency,
+  getLedgerFilePathPublic: vi.fn().mockReturnValue('/fake/workspace/.state/principle_training_state.json'),
+}));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+}));
+
+import { handleHealth } from '../../src/commands/health.js';
+
+const WS = '/fake/workspace';
+
+function healthyPruningSummary() {
+  return {
+    totalPrinciples: 5,
+    byStatus: { probation: 3, active: 2 },
+  };
+}
+
+function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+}
+
+describe('handleHealth', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('outputs health report with pruning summary and audit results', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+    await handleHealth({ workspace: WS, json: true });
+
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.generatedAt).toBeDefined();
+    expect(jsonOutput.workspace).toBe(WS);
+    expect(jsonOutput.ledger.totalPrinciples).toBe(5);
+    expect(jsonOutput.ledger.byStatus).toEqual({ probation: 3, active: 2 });
+    expect(jsonOutput.candidateLedgerConsistency.status).toBe('ok');
+    expect(jsonOutput.candidateLedgerConsistency.missing).toBe(0);
+    expect(jsonOutput.pdStateDb.exists).toBe(false);
+  });
+
+  it('outputs readable text format', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+    await handleHealth({ workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain(`workspace: ${WS}`);
+    expect(allOutput).toContain('ledger.totalPrinciples: 5');
+    expect(allOutput).toContain('candidateLedgerConsistency.status: ok');
+    expect(allOutput).toContain('pdStateDb.exists: false');
+  });
+
+  it('reports degraded consistency with exit code 1', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 2 });
+    const exitSpy = mockProcessExit();
+
+    await handleHealth({ workspace: WS, json: false });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('DEGRADED'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+
+  it('outputs degraded consistency JSON with exit code 1', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 2 });
+    const exitSpy = mockProcessExit();
+
+    await handleHealth({ workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.candidateLedgerConsistency.status).toBe('degraded');
+    expect(jsonOutput.candidateLedgerConsistency.missing).toBe(2);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+
+  it('calls PruningReadModel.getHealthSummary', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+    await handleHealth({ workspace: WS, json: true });
+
+    expect(mockPruningGetHealthSummary).toHaveBeenCalled();
+  });
+
+  it('calls auditCandidateLedgerConsistency', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+    await handleHealth({ workspace: WS, json: true });
+
+    expect(mockAuditCandidateLedgerConsistency).toHaveBeenCalled();
+  });
+
+  it('reports zero counts when database does not exist', async () => {
+    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+    await handleHealth({ workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('candidates.total: 0');
+    expect(allOutput).toContain('tasks.total: 0');
+  });
+});

--- a/packages/pd-cli/tests/commands/health.test.ts
+++ b/packages/pd-cli/tests/commands/health.test.ts
@@ -3,15 +3,29 @@
  *
  * Tests the health command's external contract via mocked read models.
  * Tests JSON/text output formatting, exit code behavior, and error handling.
- * Note: PainChainReadModel is only created when state.db exists.
- * These tests focus on the PruningReadModel and auditCandidateLedgerConsistency layer.
+ * Covers both the no-database path and the state.db path (PainChainReadModel).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockPruningGetHealthSummary, mockAuditCandidateLedgerConsistency } = vi.hoisted(() => {
+const {
+  mockPruningGetHealthSummary,
+  mockAuditCandidateLedgerConsistency,
+  mockGetLastSuccessfulChain,
+  mockPainChainClose,
+  mockExistsSync,
+  mockDbPrepare,
+  mockDbAll,
+  mockDbClose,
+} = vi.hoisted(() => {
   return {
     mockPruningGetHealthSummary: vi.fn(),
     mockAuditCandidateLedgerConsistency: vi.fn(),
+    mockGetLastSuccessfulChain: vi.fn(),
+    mockPainChainClose: vi.fn().mockResolvedValue(undefined),
+    mockExistsSync: vi.fn(),
+    mockDbPrepare: vi.fn(),
+    mockDbAll: vi.fn(),
+    mockDbClose: vi.fn(),
   };
 });
 
@@ -20,7 +34,7 @@ vi.mock('@principles/core/runtime-v2', () => ({
     return { getHealthSummary: mockPruningGetHealthSummary };
   }),
   PainChainReadModel: vi.fn().mockImplementation(function () {
-    return { getLastSuccessfulChain: vi.fn().mockResolvedValue(undefined), close: vi.fn() };
+    return { getLastSuccessfulChain: mockGetLastSuccessfulChain, close: mockPainChainClose };
   }),
   auditCandidateLedgerConsistency: mockAuditCandidateLedgerConsistency,
   getLedgerFilePathPublic: vi.fn().mockReturnValue('/fake/workspace/.state/principle_training_state.json'),
@@ -31,8 +45,19 @@ vi.mock('../../src/resolve-workspace.js', () => ({
 }));
 
 vi.mock('fs', () => ({
-  existsSync: vi.fn().mockReturnValue(false),
+  existsSync: mockExistsSync,
 }));
+
+vi.mock('better-sqlite3', () => {
+  return {
+    default: vi.fn().mockImplementation(() => {
+      return {
+        prepare: mockDbPrepare.mockReturnValue({ all: mockDbAll }),
+        close: mockDbClose,
+      };
+    }),
+  };
+});
 
 import { handleHealth } from '../../src/commands/health.js';
 
@@ -42,6 +67,26 @@ function healthyPruningSummary() {
   return {
     totalPrinciples: 5,
     byStatus: { probation: 3, active: 2 },
+  };
+}
+
+function healthyLastChain() {
+  return {
+    painId: 'pain_001',
+    taskId: 'diagnosis_pain_001',
+    runId: 'run_001',
+    artifactId: 'art_001',
+    candidateIds: ['c1'],
+    ledgerEntryIds: ['l1'],
+    status: 'succeeded',
+    latencyMs: {
+      painToTask: 100,
+      taskToRun: 200,
+      runToArtifact: 50,
+    },
+    failureCategory: null,
+    checkedAt: '2026-05-03T12:00:00.000Z',
+    missingLinks: [],
   };
 }
 
@@ -55,8 +100,10 @@ describe('handleHealth', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockExistsSync.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -64,90 +111,220 @@ describe('handleHealth', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('outputs health report with pruning summary and audit results', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+  describe('without state.db', () => {
+    it('outputs health report with pruning summary and audit results', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
 
-    await handleHealth({ workspace: WS, json: true });
+      await handleHealth({ workspace: WS, json: true });
 
-    expect(consoleLogSpy).toHaveBeenCalled();
-    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
-    expect(jsonOutput.generatedAt).toBeDefined();
-    expect(jsonOutput.workspace).toBe(WS);
-    expect(jsonOutput.ledger.totalPrinciples).toBe(5);
-    expect(jsonOutput.ledger.byStatus).toEqual({ probation: 3, active: 2 });
-    expect(jsonOutput.candidateLedgerConsistency.status).toBe('ok');
-    expect(jsonOutput.candidateLedgerConsistency.missing).toBe(0);
-    expect(jsonOutput.pdStateDb.exists).toBe(false);
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.generatedAt).toBeDefined();
+      expect(jsonOutput.workspace).toBe(WS);
+      expect(jsonOutput.ledger.totalPrinciples).toBe(5);
+      expect(jsonOutput.ledger.byStatus).toEqual({ probation: 3, active: 2 });
+      expect(jsonOutput.candidateLedgerConsistency.status).toBe('ok');
+      expect(jsonOutput.candidateLedgerConsistency.missing).toBe(0);
+      expect(jsonOutput.pdStateDb.exists).toBe(false);
+    });
+
+    it('outputs readable text format', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+      await handleHealth({ workspace: WS, json: false });
+
+      const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      expect(allOutput).toContain(`workspace: ${WS}`);
+      expect(allOutput).toContain('ledger.totalPrinciples: 5');
+      expect(allOutput).toContain('candidateLedgerConsistency.status: ok');
+      expect(allOutput).toContain('pdStateDb.exists: false');
+    });
+
+    it('reports zero candidate and task counts', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+      await handleHealth({ workspace: WS, json: false });
+
+      const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      expect(allOutput).toContain('candidates.total: 0');
+      expect(allOutput).toContain('tasks.total: 0');
+    });
+
+    it('reports degraded consistency with exit code 1', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 2 });
+      const exitSpy = mockProcessExit();
+
+      await handleHealth({ workspace: WS, json: false });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('DEGRADED'));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+    });
+
+    it('outputs degraded consistency JSON with exit code 1', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 2 });
+      const exitSpy = mockProcessExit();
+
+      await handleHealth({ workspace: WS, json: true });
+
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.candidateLedgerConsistency.status).toBe('degraded');
+      expect(jsonOutput.candidateLedgerConsistency.missing).toBe(2);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+    });
+
+    it('does not include lastSuccessfulChain when no database exists', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+
+      await handleHealth({ workspace: WS, json: true });
+
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.lastSuccessfulChain).toBeUndefined();
+    });
   });
 
-  it('outputs readable text format', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+  describe('with state.db', () => {
+    beforeEach(() => {
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p.includes('state.db')) return true;
+        return false;
+      });
+      mockDbPrepare.mockReturnValue({ all: mockDbAll });
+      mockDbAll.mockReturnValue([]);
+    });
 
-    await handleHealth({ workspace: WS, json: false });
+    it('reads candidate counts from database', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockDbAll
+        .mockReturnValueOnce([{ total: 3, status: 'consumed' }, { total: 2, status: 'pending' }])
+        .mockReturnValueOnce([]);
 
-    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    expect(allOutput).toContain(`workspace: ${WS}`);
-    expect(allOutput).toContain('ledger.totalPrinciples: 5');
-    expect(allOutput).toContain('candidateLedgerConsistency.status: ok');
-    expect(allOutput).toContain('pdStateDb.exists: false');
-  });
+      await handleHealth({ workspace: WS, json: true });
 
-  it('reports degraded consistency with exit code 1', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 2 });
-    const exitSpy = mockProcessExit();
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.pdStateDb.exists).toBe(true);
+      expect(jsonOutput.candidates.total).toBe(5);
+      expect(jsonOutput.candidates.consumed).toBe(3);
+      expect(jsonOutput.candidates.pending).toBe(2);
+    });
 
-    await handleHealth({ workspace: WS, json: false });
+    it('reads task counts from database', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockDbAll
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([{ total: 4, status: 'succeeded' }, { total: 1, status: 'failed' }]);
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('DEGRADED'));
-    expect(exitSpy).toHaveBeenCalledWith(1);
+      await handleHealth({ workspace: WS, json: true });
 
-    exitSpy.mockRestore();
-  });
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.tasks.total).toBe(5);
+      expect(jsonOutput.tasks.byStatus).toEqual({ succeeded: 4, failed: 1 });
+    });
 
-  it('outputs degraded consistency JSON with exit code 1', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 2 });
-    const exitSpy = mockProcessExit();
+    it('includes lastSuccessfulChain from PainChainReadModel', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockResolvedValue(healthyLastChain());
 
-    await handleHealth({ workspace: WS, json: true });
+      await handleHealth({ workspace: WS, json: true });
 
-    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
-    expect(jsonOutput.candidateLedgerConsistency.status).toBe('degraded');
-    expect(jsonOutput.candidateLedgerConsistency.missing).toBe(2);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.lastSuccessfulChain).toBeDefined();
+      expect(jsonOutput.lastSuccessfulChain.taskId).toBe('diagnosis_pain_001');
+      expect(jsonOutput.lastSuccessfulChain.runId).toBe('run_001');
+      expect(jsonOutput.lastSuccessfulChain.artifactId).toBe('art_001');
+      expect(jsonOutput.lastSuccessfulChain.candidateIds).toEqual(['c1']);
+      expect(jsonOutput.lastSuccessfulChain.ledgerEntryIds).toEqual(['l1']);
+    });
 
-    exitSpy.mockRestore();
-  });
+    it('computes totalMs latency from chain trace', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockResolvedValue(healthyLastChain());
 
-  it('calls PruningReadModel.getHealthSummary', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      await handleHealth({ workspace: WS, json: true });
 
-    await handleHealth({ workspace: WS, json: true });
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.lastSuccessfulChain.latencyMs).toBeDefined();
+      expect(jsonOutput.lastSuccessfulChain.latencyMs.totalMs).toBe(350);
+    });
 
-    expect(mockPruningGetHealthSummary).toHaveBeenCalled();
-  });
+    it('closes PainChainReadModel after use', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockResolvedValue(healthyLastChain());
 
-  it('calls auditCandidateLedgerConsistency', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      await handleHealth({ workspace: WS, json: true });
 
-    await handleHealth({ workspace: WS, json: true });
+      expect(mockPainChainClose).toHaveBeenCalled();
+    });
 
-    expect(mockAuditCandidateLedgerConsistency).toHaveBeenCalled();
-  });
+    it('closes database after use', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockResolvedValue(healthyLastChain());
 
-  it('reports zero counts when database does not exist', async () => {
-    mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
-    mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      await handleHealth({ workspace: WS, json: true });
 
-    await handleHealth({ workspace: WS, json: false });
+      expect(mockDbClose).toHaveBeenCalled();
+    });
 
-    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    expect(allOutput).toContain('candidates.total: 0');
-    expect(allOutput).toContain('tasks.total: 0');
+    it('sets partialHealth when PainChainReadModel throws', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockRejectedValue(new Error('Chain read error'));
+
+      await handleHealth({ workspace: WS, json: true });
+
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.partialHealth).toBe(true);
+      expect(jsonOutput.lastSuccessfulChain).toBeUndefined();
+    });
+
+    it('sets partialHealth when database read throws', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockDbPrepare.mockImplementation(() => { throw new Error('Corrupt DB'); });
+
+      await handleHealth({ workspace: WS, json: true });
+
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.partialHealth).toBe(true);
+    });
+
+    it('handles missing lastSuccessfulChain gracefully', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockResolvedValue(undefined);
+
+      await handleHealth({ workspace: WS, json: true });
+
+      const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+      expect(jsonOutput.lastSuccessfulChain).toBeUndefined();
+    });
+
+    it('includes lastSuccessfulChain in text output', async () => {
+      mockPruningGetHealthSummary.mockReturnValue(healthyPruningSummary());
+      mockAuditCandidateLedgerConsistency.mockResolvedValue({ missingLedgerCount: 0 });
+      mockGetLastSuccessfulChain.mockResolvedValue(healthyLastChain());
+
+      await handleHealth({ workspace: WS, json: false });
+
+      const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+      expect(allOutput).toContain('lastSuccessfulChain:');
+      expect(allOutput).toContain('taskId:');
+      expect(allOutput).toContain('diagnosis_pain_001');
+    });
   });
 });

--- a/packages/pd-cli/tests/commands/trace.test.ts
+++ b/packages/pd-cli/tests/commands/trace.test.ts
@@ -56,6 +56,7 @@ describe('handleTraceShow', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -94,9 +95,49 @@ describe('handleTraceShow', () => {
     expect(allOutput).toContain('Run ID:        run_001');
     expect(allOutput).toContain('Artifact ID:   art_001');
     expect(allOutput).toContain('Candidate IDs:  c1, c2');
+    expect(allOutput).toContain('Ledger Entries: l1');
+    expect(allOutput).toContain('Checked at:    2026-05-03T12:00:00.000Z');
     expect(allOutput).toContain('Latency:');
     expect(allOutput).toContain('pain→task:          100ms');
     expect(allOutput).toContain('task→run:           200ms');
+  });
+
+  it('outputs all latency segments in text mode', async () => {
+    mockTraceByPainId.mockResolvedValue(fullChainTrace());
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('run→artifact:       50ms');
+    expect(allOutput).toContain('artifact→candidate: 30ms');
+    expect(allOutput).toContain('candidate→ledger:   20ms');
+  });
+
+  it('outputs failure category in text mode when present', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      ...fullChainTrace(),
+      status: 'failed',
+      failureCategory: 'runtime_timeout',
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Failure:       runtime_timeout');
+  });
+
+  it('omits candidate/ledger lines when arrays are empty', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      ...fullChainTrace(),
+      candidateIds: [],
+      ledgerEntryIds: [],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).not.toContain('Candidate IDs:');
+    expect(allOutput).not.toContain('Ledger Entries:');
   });
 
   it('handles not_found status with exit code 1', async () => {
@@ -115,7 +156,23 @@ describe('handleTraceShow', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('handles error status with config_missing', async () => {
+  it('handles not_found in text mode with derived taskId and workspace', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      painId: 'pain_001',
+      taskId: 'diagnosis_pain_001',
+      status: 'not_found',
+      failureCategory: 'runtime_unavailable',
+      checkedAt: '2026-05-03T12:00:00.000Z',
+      missingLinks: ['task'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('diagnosis_pain_001'));
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining(WS));
+  });
+
+  it('handles error status with config_missing in JSON mode', async () => {
     mockTraceByPainId.mockResolvedValue({
       painId: 'pain_001',
       taskId: 'diagnosis_pain_001',
@@ -130,6 +187,23 @@ describe('handleTraceShow', () => {
     const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(jsonOutput.status).toBe('error');
     expect(jsonOutput.failureCategory).toBe('config_missing');
+    expect(jsonOutput.message).toContain('Failed to initialize state manager');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('handles error status in text mode', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      painId: 'pain_001',
+      taskId: 'diagnosis_pain_001',
+      status: 'error',
+      failureCategory: 'config_missing',
+      checkedAt: '2026-05-03T12:00:00.000Z',
+      missingLinks: ['state_manager_init'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to open workspace'));
     expect(process.exitCode).toBe(1);
   });
 
@@ -147,17 +221,6 @@ describe('handleTraceShow', () => {
     expect(allOutput).toContain('Missing links');
     expect(allOutput).toContain('candidate:c1 consumed but missing from ledger');
     expect(process.exitCode).toBe(1);
-  });
-
-  it('outputs all latency segments', async () => {
-    mockTraceByPainId.mockResolvedValue(fullChainTrace());
-
-    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
-
-    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    expect(allOutput).toContain('run→artifact:       50ms');
-    expect(allOutput).toContain('artifact→candidate: 30ms');
-    expect(allOutput).toContain('candidate→ledger:   20ms');
   });
 
   it('handles missing painId gracefully', async () => {
@@ -200,6 +263,14 @@ describe('handleTraceShow', () => {
     expect(mockPainChainClose).toHaveBeenCalled();
   });
 
+  it('closes PainChainReadModel even when traceByPainId throws', async () => {
+    mockTraceByPainId.mockRejectedValue(new Error('Database connection failed'));
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    expect(mockPainChainClose).toHaveBeenCalled();
+  });
+
   it('handles traceByPainId throwing an error', async () => {
     mockTraceByPainId.mockRejectedValue(new Error('Database connection failed'));
 
@@ -208,6 +279,7 @@ describe('handleTraceShow', () => {
     const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(jsonOutput.status).toBe('error');
     expect(jsonOutput.failureCategory).toBe('runtime_unavailable');
+    expect(jsonOutput.message).toContain('Database connection failed');
     expect(process.exitCode).toBe(1);
   });
 
@@ -230,5 +302,13 @@ describe('handleTraceShow', () => {
     expect(jsonOutput.message).toContain('No task found');
     expect(jsonOutput.workspace).toBe(WS);
     expect(process.exitCode).toBe(1);
+  });
+
+  it('does not set exit code for succeeded status', async () => {
+    mockTraceByPainId.mockResolvedValue(fullChainTrace());
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    expect(process.exitCode).toBeUndefined();
   });
 });

--- a/packages/pd-cli/tests/commands/trace.test.ts
+++ b/packages/pd-cli/tests/commands/trace.test.ts
@@ -1,0 +1,234 @@
+/**
+ * pd runtime trace show command unit tests.
+ *
+ * Tests the trace command's external contract via mocked PainChainReadModel.
+ * Tests pain-to-ledger chain tracing, latency reporting, consistency checks,
+ * and failure classification output.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockTraceByPainId = vi.fn();
+const mockPainChainClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  PainChainReadModel: vi.fn().mockImplementation(function () {
+    return { traceByPainId: mockTraceByPainId, close: mockPainChainClose };
+  }),
+}));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/fake/workspace'),
+}));
+
+import { handleTraceShow } from '../../src/commands/trace.js';
+
+const WS = '/fake/workspace';
+
+function fullChainTrace() {
+  return {
+    painId: 'pain_001',
+    taskId: 'diagnosis_pain_001',
+    runId: 'run_001',
+    artifactId: 'art_001',
+    candidateIds: ['c1', 'c2'],
+    ledgerEntryIds: ['l1'],
+    status: 'succeeded',
+    latencyMs: {
+      painToTask: 100,
+      taskToRun: 200,
+      runToArtifact: 50,
+      artifactToCandidate: 30,
+      candidateToLedger: 20,
+    },
+    failureCategory: null,
+    checkedAt: '2026-05-03T12:00:00.000Z',
+    missingLinks: [],
+  };
+}
+
+function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+}
+
+describe('handleTraceShow', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('outputs full chain trace with all fields (--json)', async () => {
+    mockTraceByPainId.mockResolvedValue(fullChainTrace());
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.painId).toBe('pain_001');
+    expect(jsonOutput.taskId).toBe('diagnosis_pain_001');
+    expect(jsonOutput.runId).toBe('run_001');
+    expect(jsonOutput.artifactId).toBe('art_001');
+    expect(jsonOutput.candidateIds).toEqual(['c1', 'c2']);
+    expect(jsonOutput.ledgerEntryIds).toEqual(['l1']);
+    expect(jsonOutput.status).toBe('succeeded');
+    expect(jsonOutput.latencyMs).toBeDefined();
+  });
+
+  it('outputs readable text with latency breakdown', async () => {
+    mockTraceByPainId.mockResolvedValue(fullChainTrace());
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Pain ID:       pain_001');
+    expect(allOutput).toContain('Task ID:       diagnosis_pain_001');
+    expect(allOutput).toContain('Status:        succeeded');
+    expect(allOutput).toContain('Run ID:        run_001');
+    expect(allOutput).toContain('Artifact ID:   art_001');
+    expect(allOutput).toContain('Candidate IDs:  c1, c2');
+    expect(allOutput).toContain('Latency:');
+    expect(allOutput).toContain('pain→task:          100ms');
+    expect(allOutput).toContain('task→run:           200ms');
+  });
+
+  it('handles not_found status with exit code 1', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      painId: 'pain_001',
+      taskId: 'diagnosis_pain_001',
+      status: 'not_found',
+      failureCategory: 'runtime_unavailable',
+      checkedAt: '2026-05-03T12:00:00.000Z',
+      missingLinks: ['task'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No task found'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('handles error status with config_missing', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      painId: 'pain_001',
+      taskId: 'diagnosis_pain_001',
+      status: 'error',
+      failureCategory: 'config_missing',
+      checkedAt: '2026-05-03T12:00:00.000Z',
+      missingLinks: ['state_manager_init'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('error');
+    expect(jsonOutput.failureCategory).toBe('config_missing');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports missing links in text output', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      ...fullChainTrace(),
+      status: 'degraded',
+      failureCategory: 'ledger_write_failed',
+      missingLinks: ['candidate:c1 consumed but missing from ledger'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('Missing links');
+    expect(allOutput).toContain('candidate:c1 consumed but missing from ledger');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('outputs all latency segments', async () => {
+    mockTraceByPainId.mockResolvedValue(fullChainTrace());
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allOutput).toContain('run→artifact:       50ms');
+    expect(allOutput).toContain('artifact→candidate: 30ms');
+    expect(allOutput).toContain('candidate→ledger:   20ms');
+  });
+
+  it('handles missing painId gracefully', async () => {
+    await handleTraceShow({ painId: '', workspace: WS, json: false });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('--pain-id'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports failed status with exit code 1', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      ...fullChainTrace(),
+      status: 'failed',
+      failureCategory: 'runtime_timeout',
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports degraded status with exit code 1', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      ...fullChainTrace(),
+      status: 'degraded',
+      failureCategory: 'candidate_missing',
+      missingLinks: ['No candidates generated for succeeded task'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: false });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('closes PainChainReadModel after use', async () => {
+    mockTraceByPainId.mockResolvedValue(fullChainTrace());
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    expect(mockPainChainClose).toHaveBeenCalled();
+  });
+
+  it('handles traceByPainId throwing an error', async () => {
+    mockTraceByPainId.mockRejectedValue(new Error('Database connection failed'));
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.status).toBe('error');
+    expect(jsonOutput.failureCategory).toBe('runtime_unavailable');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('outputs not_found in JSON format with correct fields', async () => {
+    mockTraceByPainId.mockResolvedValue({
+      painId: 'pain_001',
+      taskId: 'diagnosis_pain_001',
+      status: 'not_found',
+      failureCategory: 'runtime_unavailable',
+      checkedAt: '2026-05-03T12:00:00.000Z',
+      missingLinks: ['task'],
+    });
+
+    await handleTraceShow({ painId: 'pain_001', workspace: WS, json: true });
+
+    const jsonOutput = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(jsonOutput.painId).toBe('pain_001');
+    expect(jsonOutput.taskId).toBe('diagnosis_pain_001');
+    expect(jsonOutput.status).toBe('not_found');
+    expect(jsonOutput.message).toContain('No task found');
+    expect(jsonOutput.workspace).toBe(WS);
+    expect(process.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for `pd health` and `pd trace` commands to improve test coverage for recently merged runtime v2 features.

## Motivation

These commands were added in recent merges but lacked test coverage, creating a gap in the regression safety net.

## Changes

### New Test Files

- **packages/pd-cli/tests/commands/health.test.ts** (7 tests)
  - JSON/text output formatting
  - PruningReadModel integration
  - auditCandidateLedgerConsistency integration
  - Degraded consistency detection and exit codes
  - Error handling for missing database

- **packages/pd-cli/tests/commands/trace.test.ts** (12 tests)
  - PainChainReadModel integration
  - Full chain trace output (JSON/text)
  - All latency segment reporting
  - Status handling (succeeded, failed, not_found, error, degraded)
  - Missing link detection
  - Error handling and exit codes

## Testing

All 19 new tests pass:
- tests/commands/health.test.ts (7 tests)
- tests/commands/trace.test.ts (12 tests)

## Risk Assessment

- **Regression Risk**: Low - Tests cover existing behavior
- **Complexity**: Low - Unit tests with mocked dependencies
- **Flakiness**: Low - Deterministic, isolated tests

These tests substantively reduce regression risk by:
1. Verifying health monitoring outputs correct data
2. Testing trace functionality for pain chain analysis
3. Ensuring proper error handling and exit codes