### PR TITLE
feat(console): restrict approvals to proven MVP channels (PRI-244)

### DIFF
--- a/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
+++ b/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
@@ -18,25 +18,36 @@ type UnsupportedChannelResult = { ok: false; error: 'unsupported_channel'; chann
 type ChannelGuardedDecisionResult = ApprovalDecisionResult | UnsupportedChannelResult;
 
 export class ApprovalsConsoleModel {
-  private connection: SqliteConnection | null = null;
-  private queue: ApprovalQueue | null = null;
+  private readConnection: SqliteConnection | null = null;
+  private readQueue: ApprovalQueue | null = null;
+  private writeConnection: SqliteConnection | null = null;
+  private writeQueue: ApprovalQueue | null = null;
   private readonly workspaceDir: string;
 
   constructor(workspaceDir: string) {
     this.workspaceDir = workspaceDir;
   }
 
-  private getQueue(): ApprovalQueue {
-    if (!this.queue) {
-      this.connection = new SqliteConnection({ workspaceDir: this.workspaceDir });
-      const store = new SqliteApprovalQueueStore(this.connection);
-      this.queue = new ApprovalQueue(store);
+  private getReadQueue(): ApprovalQueue {
+    if (!this.readQueue) {
+      this.readConnection = new SqliteConnection({ workspaceDir: this.workspaceDir, readonly: true });
+      const store = new SqliteApprovalQueueStore(this.readConnection);
+      this.readQueue = new ApprovalQueue(store);
     }
-    return this.queue;
+    return this.readQueue;
+  }
+
+  private getWriteQueue(): ApprovalQueue {
+    if (!this.writeQueue) {
+      this.writeConnection = new SqliteConnection({ workspaceDir: this.workspaceDir });
+      const store = new SqliteApprovalQueueStore(this.writeConnection);
+      this.writeQueue = new ApprovalQueue(store);
+    }
+    return this.writeQueue;
   }
 
   async listApprovals(filter?: ApprovalListFilter): Promise<ApprovalListResult> {
-    const queue = this.getQueue();
+    const queue = this.getReadQueue();
     const allItems = await queue.listAll({ status: filter?.status, channel: filter?.channel });
     const mvpItems = allItems.filter((record) => MVP_PROVEN_CHANNELS.has(record.channel));
     const total = mvpItems.length;
@@ -62,7 +73,7 @@ export class ApprovalsConsoleModel {
   }
 
   async getApprovalDetail(approvalId: string): Promise<(ApprovalWithContext & { isMvpProven: boolean }) | null> {
-    const queue = this.getQueue();
+    const queue = this.getReadQueue();
     const record = await queue.getById(approvalId);
     if (!record) return null;
     return {
@@ -73,30 +84,35 @@ export class ApprovalsConsoleModel {
   }
 
   async approve(approvalId: string, decidedBy: string, note?: string): Promise<ChannelGuardedDecisionResult> {
-    const queue = this.getQueue();
-    const existing = await queue.getById(approvalId);
+    const readQueue = this.getReadQueue();
+    const existing = await readQueue.getById(approvalId);
     if (!existing) return { ok: false, error: 'not_found' };
     if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
       return { ok: false, error: 'unsupported_channel', channel: existing.channel };
     }
-    return queue.approve(approvalId, decidedBy, note);
+    return this.getWriteQueue().approve(approvalId, decidedBy, note);
   }
 
   async reject(approvalId: string, decidedBy: string, reason: string): Promise<ChannelGuardedDecisionResult> {
-    const queue = this.getQueue();
-    const existing = await queue.getById(approvalId);
+    const readQueue = this.getReadQueue();
+    const existing = await readQueue.getById(approvalId);
     if (!existing) return { ok: false, error: 'not_found' };
     if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
       return { ok: false, error: 'unsupported_channel', channel: existing.channel };
     }
-    return queue.reject(approvalId, decidedBy, reason);
+    return this.getWriteQueue().reject(approvalId, decidedBy, reason);
   }
 
   dispose(): void {
-    if (this.connection) {
-      try { this.connection.close(); } catch { /* best-effort */ }
-      this.connection = null;
+    if (this.readConnection) {
+      try { this.readConnection.close(); } catch { /* best-effort */ }
+      this.readConnection = null;
     }
-    this.queue = null;
+    this.readQueue = null;
+    if (this.writeConnection) {
+      try { this.writeConnection.close(); } catch { /* best-effort */ }
+      this.writeConnection = null;
+    }
+    this.writeQueue = null;
   }
 }

--- a/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
+++ b/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type {
   ApprovalListFilter,
   ApprovalListResult,
@@ -14,8 +16,14 @@ import type { ApprovalWithContext } from '@principles/core/runtime-v2';
 
 const MVP_PROVEN_CHANNELS: ReadonlySet<string> = new Set<string>(MVP_CHANNELS);
 
+const EMPTY_STATS = { pending: 0, approved: 0, rejected: 0, cancelled: 0 } as const;
+
 type UnsupportedChannelResult = { ok: false; error: 'unsupported_channel'; channel: string };
 type ChannelGuardedDecisionResult = ApprovalDecisionResult | UnsupportedChannelResult;
+
+function stateDbExists(workspaceDir: string): boolean {
+  return fs.existsSync(path.join(workspaceDir, '.pd', 'state.db'));
+}
 
 export class ApprovalsConsoleModel {
   private readConnection: SqliteConnection | null = null;
@@ -47,6 +55,9 @@ export class ApprovalsConsoleModel {
   }
 
   async listApprovals(filter?: ApprovalListFilter): Promise<ApprovalListResult> {
+    if (!stateDbExists(this.workspaceDir)) {
+      return { items: [], total: 0, stats: { ...EMPTY_STATS } };
+    }
     const queue = this.getReadQueue();
     const allItems = await queue.listAll({ status: filter?.status, channel: filter?.channel });
     const mvpItems = allItems.filter((record) => MVP_PROVEN_CHANNELS.has(record.channel));
@@ -73,6 +84,9 @@ export class ApprovalsConsoleModel {
   }
 
   async getApprovalDetail(approvalId: string): Promise<(ApprovalWithContext & { isMvpProven: boolean }) | null> {
+    if (!stateDbExists(this.workspaceDir)) {
+      return null;
+    }
     const queue = this.getReadQueue();
     const record = await queue.getById(approvalId);
     if (!record) return null;
@@ -84,6 +98,9 @@ export class ApprovalsConsoleModel {
   }
 
   async approve(approvalId: string, decidedBy: string, note?: string): Promise<ChannelGuardedDecisionResult> {
+    if (!stateDbExists(this.workspaceDir)) {
+      return { ok: false, error: 'not_found' };
+    }
     const readQueue = this.getReadQueue();
     const existing = await readQueue.getById(approvalId);
     if (!existing) return { ok: false, error: 'not_found' };
@@ -94,6 +111,9 @@ export class ApprovalsConsoleModel {
   }
 
   async reject(approvalId: string, decidedBy: string, reason: string): Promise<ChannelGuardedDecisionResult> {
+    if (!stateDbExists(this.workspaceDir)) {
+      return { ok: false, error: 'not_found' };
+    }
     const readQueue = this.getReadQueue();
     const existing = await readQueue.getById(approvalId);
     if (!existing) return { ok: false, error: 'not_found' };

--- a/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
+++ b/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
@@ -4,6 +4,7 @@ import type {
   ApprovalListFilter,
   ApprovalListResult,
   ApprovalDecisionResult,
+  ApprovalRecord,
 } from '@principles/core/runtime-v2';
 import {
   SqliteConnection,
@@ -17,6 +18,11 @@ import type { ApprovalWithContext } from '@principles/core/runtime-v2';
 const MVP_PROVEN_CHANNELS: ReadonlySet<string> = new Set<string>(MVP_CHANNELS);
 
 const EMPTY_STATS = { pending: 0, approved: 0, rejected: 0, cancelled: 0 } as const;
+
+function isMissingTableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.includes('no such table');
+}
 
 type UnsupportedChannelResult = { ok: false; error: 'unsupported_channel'; channel: string };
 type ChannelGuardedDecisionResult = ApprovalDecisionResult | UnsupportedChannelResult;
@@ -58,8 +64,10 @@ export class ApprovalsConsoleModel {
     if (!stateDbExists(this.workspaceDir)) {
       return { items: [], total: 0, stats: { ...EMPTY_STATS } };
     }
-    const queue = this.getReadQueue();
-    const allItems = await queue.listAll({ status: filter?.status, channel: filter?.channel });
+    const allItems = await this.readSafeList(filter);
+    if (!allItems) {
+      return { items: [], total: 0, stats: { ...EMPTY_STATS } };
+    }
     const mvpItems = allItems.filter((record) => MVP_PROVEN_CHANNELS.has(record.channel));
     const total = mvpItems.length;
     const page = filter?.page ?? 1;
@@ -87,8 +95,7 @@ export class ApprovalsConsoleModel {
     if (!stateDbExists(this.workspaceDir)) {
       return null;
     }
-    const queue = this.getReadQueue();
-    const record = await queue.getById(approvalId);
+    const record = await this.readSafeGetById(approvalId);
     if (!record) return null;
     return {
       ...record,
@@ -101,8 +108,7 @@ export class ApprovalsConsoleModel {
     if (!stateDbExists(this.workspaceDir)) {
       return { ok: false, error: 'not_found' };
     }
-    const readQueue = this.getReadQueue();
-    const existing = await readQueue.getById(approvalId);
+    const existing = await this.readSafeGetById(approvalId);
     if (!existing) return { ok: false, error: 'not_found' };
     if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
       return { ok: false, error: 'unsupported_channel', channel: existing.channel };
@@ -114,13 +120,34 @@ export class ApprovalsConsoleModel {
     if (!stateDbExists(this.workspaceDir)) {
       return { ok: false, error: 'not_found' };
     }
-    const readQueue = this.getReadQueue();
-    const existing = await readQueue.getById(approvalId);
+    const existing = await this.readSafeGetById(approvalId);
     if (!existing) return { ok: false, error: 'not_found' };
     if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
       return { ok: false, error: 'unsupported_channel', channel: existing.channel };
     }
     return this.getWriteQueue().reject(approvalId, decidedBy, reason);
+  }
+
+  /** Returns null when the approvals table does not exist. */
+  private async readSafeGetById(approvalId: string): Promise<ApprovalRecord | null> {
+    const queue = this.getReadQueue();
+    try {
+      return await queue.getById(approvalId);
+    } catch (err) {
+      if (isMissingTableError(err)) return null;
+      throw err;
+    }
+  }
+
+  /** Returns null when the approvals table does not exist. */
+  private async readSafeList(filter?: ApprovalListFilter): Promise<ApprovalRecord[] | null> {
+    const queue = this.getReadQueue();
+    try {
+      return await queue.listAll({ status: filter?.status, channel: filter?.channel });
+    } catch (err) {
+      if (isMissingTableError(err)) return null;
+      throw err;
+    }
   }
 
   dispose(): void {

--- a/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
+++ b/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
@@ -1,7 +1,6 @@
 import type {
   ApprovalListFilter,
   ApprovalListResult,
-  ApprovalWithContext,
   ApprovalDecisionResult,
 } from '@principles/core/runtime-v2';
 import {
@@ -9,7 +8,14 @@ import {
   SqliteApprovalQueueStore,
   ApprovalQueue,
   mapConfidenceToLabel,
+  MVP_CHANNELS,
 } from '@principles/core/runtime-v2';
+import type { ApprovalWithContext } from '@principles/core/runtime-v2';
+
+const MVP_PROVEN_CHANNELS: ReadonlySet<string> = new Set<string>(MVP_CHANNELS);
+
+type UnsupportedChannelResult = { ok: false; error: 'unsupported_channel'; channel: string };
+type ChannelGuardedDecisionResult = ApprovalDecisionResult | UnsupportedChannelResult;
 
 export class ApprovalsConsoleModel {
   private connection: SqliteConnection | null = null;
@@ -31,42 +37,58 @@ export class ApprovalsConsoleModel {
 
   async listApprovals(filter?: ApprovalListFilter): Promise<ApprovalListResult> {
     const queue = this.getQueue();
-    const [items, stats] = await Promise.all([
-      queue.listAll({ status: filter?.status, channel: filter?.channel }),
-      queue.countByStatus(),
-    ]);
-    const total = items.length;
+    const allItems = await queue.listAll({ status: filter?.status, channel: filter?.channel });
+    const mvpItems = allItems.filter((record) => MVP_PROVEN_CHANNELS.has(record.channel));
+    const total = mvpItems.length;
     const page = filter?.page ?? 1;
     const pageSize = filter?.pageSize ?? 0;
-    const pageItems = pageSize > 0 ? items.slice((page - 1) * pageSize, page * pageSize) : items;
+    const pageItems = pageSize > 0 ? mvpItems.slice((page - 1) * pageSize, page * pageSize) : mvpItems;
     const enriched = pageItems.map((record) => ({
       ...record,
       confidenceLabel: mapConfidenceToLabel(record.confidence),
     }));
+    const mvpStats = { pending: 0, approved: 0, rejected: 0, cancelled: 0 };
+    for (const item of mvpItems) {
+      const key = item.status as keyof typeof mvpStats;
+      if (Object.hasOwn(mvpStats, key)) {
+        mvpStats[key]++;
+      }
+    }
     return {
       items: enriched,
       total,
-      stats,
+      stats: mvpStats,
     };
   }
 
-  async getApprovalDetail(approvalId: string): Promise<ApprovalWithContext | null> {
+  async getApprovalDetail(approvalId: string): Promise<(ApprovalWithContext & { isMvpProven: boolean }) | null> {
     const queue = this.getQueue();
     const record = await queue.getById(approvalId);
     if (!record) return null;
     return {
       ...record,
       confidenceLabel: mapConfidenceToLabel(record.confidence),
+      isMvpProven: MVP_PROVEN_CHANNELS.has(record.channel),
     };
   }
 
-  async approve(approvalId: string, decidedBy: string, note?: string): Promise<ApprovalDecisionResult> {
+  async approve(approvalId: string, decidedBy: string, note?: string): Promise<ChannelGuardedDecisionResult> {
     const queue = this.getQueue();
+    const existing = await queue.getById(approvalId);
+    if (!existing) return { ok: false, error: 'not_found' };
+    if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
+      return { ok: false, error: 'unsupported_channel', channel: existing.channel };
+    }
     return queue.approve(approvalId, decidedBy, note);
   }
 
-  async reject(approvalId: string, decidedBy: string, reason: string): Promise<ApprovalDecisionResult> {
+  async reject(approvalId: string, decidedBy: string, reason: string): Promise<ChannelGuardedDecisionResult> {
     const queue = this.getQueue();
+    const existing = await queue.getById(approvalId);
+    if (!existing) return { ok: false, error: 'not_found' };
+    if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
+      return { ok: false, error: 'unsupported_channel', channel: existing.channel };
+    }
     return queue.reject(approvalId, decidedBy, reason);
   }
 

--- a/packages/pd-console/src/server/routes/approvals.ts
+++ b/packages/pd-console/src/server/routes/approvals.ts
@@ -1,10 +1,15 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ApprovalStatus, InternalizationChannel } from '@principles/core/runtime-v2';
+import { MVP_CHANNELS } from '@principles/core/runtime-v2';
 import { ApprovalsConsoleModel } from '../models/ApprovalsConsoleModel.js';
 import { sendSuccess, sendError, sendNotFound, sendBadRequest } from '../utils/response.js';
 import { parseQuery, readBody } from '../utils/request.js';
 
 const models = new Map<string, ApprovalsConsoleModel>();
+
+const MVP_PROVEN_CHANNELS: ReadonlySet<string> = new Set<string>(MVP_CHANNELS);
+
+const MVP_CHANNEL_LIST = MVP_CHANNELS.join(', ');
 
 function getModel(workspaceDir: string): ApprovalsConsoleModel {
   let model = models.get(workspaceDir);
@@ -19,6 +24,31 @@ function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function tryParseJson(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJsonBody(body: string, res: ServerResponse): Record<string, unknown> | null {
+  const raw = tryParseJson(body);
+  if (raw === undefined) {
+    sendBadRequest(res, 'Invalid JSON body');
+    return null;
+  }
+  if (!isRecord(raw)) {
+    sendBadRequest(res, 'Request body must be a JSON object');
+    return null;
+  }
+  return raw;
+}
+
 /* eslint-disable @typescript-eslint/max-params */
 export async function handleApprovalsRoute(
   req: IncomingMessage,
@@ -28,7 +58,7 @@ export async function handleApprovalsRoute(
 ): Promise<void> {
   const model = getModel(workspaceDir);
 
-  // GET /api/v1/approvals - list all approvals
+  // GET /api/v1/approvals - list all approvals (MVP proven channels only)
   if (req.method === 'GET' && (subPath === '' || subPath === '/')) {
     try {
       const query = parseQuery(req.url ?? '');
@@ -37,15 +67,14 @@ export async function handleApprovalsRoute(
       const page = Number.isNaN(pageRaw) ? 1 : Math.max(1, pageRaw);
       const pageSize = Number.isNaN(pageSizeRaw) ? 0 : Math.min(Math.max(0, pageSizeRaw), 100);
       const ALLOWED_STATUSES = new Set<string>(['pending', 'approved', 'rejected', 'cancelled']);
-      const ALLOWED_CHANNELS = new Set<string>(['code_tool_hook', 'skill', 'model_training', 'prompt', 'defer_archive']);
-      const {status} = query;
+      const { status } = query;
       if (status !== undefined && !ALLOWED_STATUSES.has(status)) {
         sendBadRequest(res, 'Invalid status value');
         return;
       }
-      const {channel} = query;
-      if (channel !== undefined && !ALLOWED_CHANNELS.has(channel)) {
-        sendBadRequest(res, 'Invalid channel value');
+      const { channel } = query;
+      if (channel !== undefined && !MVP_PROVEN_CHANNELS.has(channel)) {
+        sendBadRequest(res, `Unsupported channel: ${channel}. MVP proven channels are: ${MVP_CHANNEL_LIST}`);
         return;
       }
       const result = await model.listApprovals({
@@ -84,21 +113,20 @@ export async function handleApprovalsRoute(
     const approvalId = decodeURIComponent(approveMatch[1]);
     try {
       const body = await readBody(req);
-      let parsed: { note?: string } = {};
-      try {
-        parsed = JSON.parse(body) as { note?: string };
-      } catch {
-        sendBadRequest(res, 'Invalid JSON body');
-        return;
-      }
-      if (parsed.note !== undefined && typeof parsed.note !== 'string') {
+      const parsed = parseJsonBody(body, res);
+      if (!parsed) return;
+      if (Object.hasOwn(parsed, 'note') && typeof parsed.note !== 'string') {
         sendBadRequest(res, 'note must be a string');
         return;
       }
-      const result = await model.approve(approvalId, 'operator', parsed.note);
+
+      const note = typeof parsed.note === 'string' ? parsed.note : undefined;
+      const result = await model.approve(approvalId, 'operator', note);
       if (!result.ok) {
         if (result.error === 'not_found') {
           sendNotFound(res, 'Approval ' + approvalId + ' not found');
+        } else if (result.error === 'unsupported_channel') {
+          sendError(res, 403, 'unsupported_channel', `Cannot approve unsupported channel. Only MVP proven channels (${MVP_CHANNEL_LIST}) can be approved.`);
         } else {
           sendError(res, 409, 'conflict', 'Approval already decided: ' + (result.status ?? 'unknown'));
         }
@@ -122,21 +150,23 @@ export async function handleApprovalsRoute(
     const approvalId = decodeURIComponent(rejectMatch[1]);
     try {
       const body = await readBody(req);
-      let parsed: { reason?: string } = {};
-      try {
-        parsed = JSON.parse(body) as { reason?: string };
-      } catch {
-        sendBadRequest(res, 'Invalid JSON body');
-        return;
-      }
-      if (!parsed.reason || typeof parsed.reason !== 'string') {
+      const parsed = parseJsonBody(body, res);
+      if (!parsed) return;
+      if (!Object.hasOwn(parsed, 'reason') || typeof parsed.reason !== 'string') {
         sendBadRequest(res, 'reason is required and must be a string');
         return;
       }
+      if (parsed.reason === '') {
+        sendBadRequest(res, 'reason must not be empty');
+        return;
+      }
+
       const result = await model.reject(approvalId, 'operator', parsed.reason);
       if (!result.ok) {
         if (result.error === 'not_found') {
           sendNotFound(res, 'Approval ' + approvalId + ' not found');
+        } else if (result.error === 'unsupported_channel') {
+          sendError(res, 403, 'unsupported_channel', `Cannot reject unsupported channel. Only MVP proven channels (${MVP_CHANNEL_LIST}) can be operated on.`);
         } else {
           sendError(res, 409, 'conflict', 'Approval already decided: ' + (result.status ?? 'unknown'));
         }

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -560,6 +560,7 @@ interface ApprovalRecord {
   confidenceExplanation: string | undefined;
   effectDescription: string | undefined;
   rejectionEffect: string | undefined;
+  isMvpProven?: boolean;
 }
 
 interface ApprovalListResult {

--- a/packages/pd-console/src/ui/components/approval-detail-dialog.tsx
+++ b/packages/pd-console/src/ui/components/approval-detail-dialog.tsx
@@ -39,6 +39,7 @@ export function ApprovalDetailDialog({
   if (!approval) return null;
 
   const isPending = approval.status === "pending";
+  const canAct = isPending && approval.isMvpProven !== false;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -101,7 +102,12 @@ export function ApprovalDetailDialog({
           )}
         </div>
 
-        {isPending && (
+        {isPending && approval.isMvpProven === false && (
+          <div className="text-xs text-muted-foreground italic pt-2">
+            {t("components:approvalCard.channel." + approval.channel, approval.channel)} — {t("components:approvalCard.channel.retired", "retired")}
+          </div>
+        )}
+        {canAct && (
           <DialogFooter>
             <Button
               variant="destructive"

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -475,11 +475,11 @@
       },
       "decidedBy": "Decided by {{by}}",
       "channel": {
-        "skill": "Skill Activation",
-        "code_tool_hook": "Code Tool Hook",
+        "code_tool_hook": "RuleHost",
         "defer_archive": "Defer Archive",
-        "model_training": "Model Training",
-        "prompt": "Prompt Injection"
+        "prompt": "Prompt",
+        "skill": "Skill (retired)",
+        "model_training": "Model Training (retired)"
       },
       "riskLevel": "Risk Level"
     },

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -481,6 +481,7 @@
         "skill": "Skill (retired)",
         "model_training": "Model Training (retired)"
       },
+      "retired": "This channel is retired and cannot be actioned",
       "riskLevel": "Risk Level"
     },
     "approvalDetail": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -475,11 +475,11 @@
       },
       "decidedBy": "决定者：{{by}}",
       "channel": {
-        "skill": "技能激活",
-        "code_tool_hook": "代码工具钩子",
+        "code_tool_hook": "RuleHost",
         "defer_archive": "延迟归档",
-        "model_training": "模型训练",
-        "prompt": "提示注入"
+        "prompt": "提示注入",
+        "skill": "技能激活（已停用）",
+        "model_training": "模型训练（已停用）"
       },
       "riskLevel": "风险级别"
     },

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -481,6 +481,7 @@
         "skill": "技能激活（已停用）",
         "model_training": "模型训练（已停用）"
       },
+      "retired": "此通道已停用，无法执行审批操作",
       "riskLevel": "风险级别"
     },
     "approvalDetail": {

--- a/packages/pd-console/tests/integration/approvals-api.test.ts
+++ b/packages/pd-console/tests/integration/approvals-api.test.ts
@@ -493,4 +493,90 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       expect(fs.existsSync(pdDir)).toBe(false);
     });
   });
+
+  // ── 11. Pre-approvals-schema workspace — DB exists but no approvals table ──
+
+  describe('Pre-approvals-schema workspace', () => {
+    let preTmp: string;
+    let prePort: number;
+    let preServer: http.Server;
+
+    beforeAll(async () => {
+      // Create a workspace with .pd/state.db containing only the tasks table
+      // (simulating a DB created before the approvals schema was added)
+      preTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-pre-schema-test-'));
+      const pdDir = path.join(preTmp, '.pd');
+      fs.mkdirSync(pdDir, { recursive: true });
+
+      // Use SqliteConnection in writable mode to create the DB with core tables only,
+      // then manually drop the approvals table to simulate a pre-approvals-era DB.
+      const conn = new SqliteConnection({ workspaceDir: preTmp });
+      const db = conn.getDb();
+      // initSchema() already ran and created all tables including approvals.
+      // Drop approvals to simulate pre-approvals state.
+      db.exec('DROP TABLE IF EXISTS approvals');
+      conn.close();
+
+      preServer = http.createServer((req, res) => {
+        const urlPath = req.url?.split('?')[0] ?? '/';
+        if (!urlPath.startsWith('/api/v1/approvals')) {
+          sendNotFound(res, 'Not found');
+          return;
+        }
+        const subPath = urlPath.slice('/api/v1/approvals'.length);
+        (async () => handleApprovalsRoute(req, res, preTmp, subPath))().catch((err: unknown) => {
+          if (!res.headersSent) {
+            sendJson(res, 500, { success: false, error: err instanceof Error ? err.message : 'Internal error' });
+          }
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        preServer.listen(0, () => {
+          const addr = preServer.address();
+          prePort = addr && typeof addr === 'object' ? addr.port : 0;
+          resolve();
+        });
+      });
+      expect(prePort).toBeGreaterThan(0);
+    });
+
+    afterAll(async () => {
+      disposeApprovalsModels();
+      await new Promise<void>((resolve) => preServer.close(() => resolve()));
+      try { fs.rmSync(preTmp, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('GET list returns 200 with empty items when approvals table missing', async () => {
+      const res = await fetch(`http://127.0.0.1:${prePort}/api/v1/approvals`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const data = getDataObject(body);
+      expect(data).toBeDefined();
+      expect(data?.total).toBe(0);
+      const items = getItemsArray(body);
+      expect(items).toEqual([]);
+    });
+
+    it('GET detail returns 404 when approvals table missing', async () => {
+      const res = await fetch(`http://127.0.0.1:${prePort}/api/v1/approvals/any-id`);
+      expect(res.status).toBe(404);
+    });
+
+    it('GET does not recreate the approvals table', async () => {
+      // Hit the list endpoint first
+      const res = await fetch(`http://127.0.0.1:${prePort}/api/v1/approvals`);
+      expect(res.status).toBe(200);
+
+      // Use a raw readonly connection to check — writable SqliteConnection
+      // would run initSchema() and recreate the table.
+      const dbPath = path.join(preTmp, '.pd', 'state.db');
+      expect(fs.existsSync(dbPath)).toBe(true);
+      const Database = (await import('better-sqlite3')).default;
+      const db = new Database(dbPath, { readonly: true });
+      const table = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='approvals'").get();
+      db.close();
+      expect(table).toBeUndefined();
+    });
+  });
 });

--- a/packages/pd-console/tests/integration/approvals-api.test.ts
+++ b/packages/pd-console/tests/integration/approvals-api.test.ts
@@ -11,6 +11,38 @@ import {
 import { handleApprovalsRoute, disposeApprovalsModels } from '../../src/server/routes/approvals.js';
 import { sendJson, sendNotFound } from '../../src/server/utils/response.js';
 
+// ── Runtime guards (no `as` on untrusted data) ─────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getStringField(obj: unknown, key: string): string | undefined {
+  if (!isRecord(obj)) return undefined;
+  const val = obj[key];
+  return typeof val === 'string' ? val : undefined;
+}
+
+function getBooleanField(obj: unknown, key: string): boolean | undefined {
+  if (!isRecord(obj)) return undefined;
+  const val = obj[key];
+  return typeof val === 'boolean' ? val : undefined;
+}
+
+function getDataObject(body: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(body)) return undefined;
+  const data = body.data;
+  return isRecord(data) ? data : undefined;
+}
+
+function getItemsArray(body: unknown): Array<Record<string, unknown>> | undefined {
+  const data = getDataObject(body);
+  if (!data) return undefined;
+  const items = data.items;
+  if (!Array.isArray(items)) return undefined;
+  return items.filter(isRecord);
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const PROVEN_CHANNELS = ['prompt', 'code_tool_hook', 'defer_archive'] as const;
@@ -58,7 +90,6 @@ function seedApproval(channel: string, status: string = 'pending', extra?: Recor
 
 describe('Approvals API — Proven Channel Restrictions', () => {
   beforeAll(async () => {
-    // Create temp workspace with SqliteConnection for direct seeding
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-approval-test-'));
     const stateDir = path.join(tmpDir, '.state');
     fs.mkdirSync(stateDir, { recursive: true });
@@ -138,11 +169,11 @@ describe('Approvals API — Proven Channel Restrictions', () => {
     it('returns only proven channel records (no skill/model_training)', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals');
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      const items = data.items as Array<Record<string, unknown>>;
-      const channels = items.map((i) => i.channel as string);
-      // No unsupported channels should appear in results
-      for (const ch of channels) {
+      const items = getItemsArray(body);
+      expect(items).toBeDefined();
+      for (const item of items ?? []) {
+        const ch = getStringField(item, 'channel');
+        expect(ch).toBeDefined();
         expect(UNSUPPORTED_CHANNELS).not.toContain(ch);
       }
     });
@@ -154,15 +185,17 @@ describe('Approvals API — Proven Channel Restrictions', () => {
     it('rejects ?channel=skill with bad request', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=skill');
       expect(status).toBe(400);
-      const errBody = body as Record<string, unknown>;
-      expect(errBody.success).toBe(false);
+      if (isRecord(body)) {
+        expect(body.success).toBe(false);
+      }
     });
 
     it('rejects ?channel=model_training with bad request', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=model_training');
       expect(status).toBe(400);
-      const errBody = body as Record<string, unknown>;
-      expect(errBody.success).toBe(false);
+      if (isRecord(body)) {
+        expect(body.success).toBe(false);
+      }
     });
   });
 
@@ -172,30 +205,27 @@ describe('Approvals API — Proven Channel Restrictions', () => {
     it('filters by prompt', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=prompt');
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      const items = data.items as Array<Record<string, unknown>>;
-      for (const item of items) {
-        expect(item.channel).toBe('prompt');
+      const items = getItemsArray(body);
+      for (const item of items ?? []) {
+        expect(getStringField(item, 'channel')).toBe('prompt');
       }
     });
 
     it('filters by code_tool_hook', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=code_tool_hook');
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      const items = data.items as Array<Record<string, unknown>>;
-      for (const item of items) {
-        expect(item.channel).toBe('code_tool_hook');
+      const items = getItemsArray(body);
+      for (const item of items ?? []) {
+        expect(getStringField(item, 'channel')).toBe('code_tool_hook');
       }
     });
 
     it('filters by defer_archive', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=defer_archive');
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      const items = data.items as Array<Record<string, unknown>>;
-      for (const item of items) {
-        expect(item.channel).toBe('defer_archive');
+      const items = getItemsArray(body);
+      for (const item of items ?? []) {
+        expect(getStringField(item, 'channel')).toBe('defer_archive');
       }
     });
   });
@@ -286,39 +316,45 @@ describe('Approvals API — Proven Channel Restrictions', () => {
     let legacyApprovalId: string;
 
     beforeAll(() => {
-      // Get a skill approval ID from the DB
       const db = sqliteConn.getDb();
       const row = db.prepare("SELECT approval_id FROM approvals WHERE channel = 'skill' LIMIT 1").get() as { approval_id: string } | undefined;
       legacyApprovalId = row?.approval_id ?? '';
       expect(legacyApprovalId).toBeTruthy();
     });
 
-    it('detail returns unsupported_channel status for legacy record', async () => {
+    it('detail returns record with isMvpProven=false for legacy record', async () => {
       const { status, body } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}`);
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      // Must indicate this is not an MVP-actionable channel
-      expect(typeof data.channel).toBe('string');
-      expect(UNSUPPORTED_CHANNELS).toContain(data.channel);
+      const data = getDataObject(body);
+      expect(data).toBeDefined();
+      const ch = getStringField(data, 'channel');
+      expect(ch).toBeDefined();
+      expect(UNSUPPORTED_CHANNELS).toContain(ch);
+      expect(getBooleanField(data, 'isMvpProven')).toBe(false);
     });
 
-    it('approve on unsupported channel record returns error', async () => {
-      const { status } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}/approve`, {
+    it('approve on unsupported channel returns 403 unsupported_channel', async () => {
+      const { status, body } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}/approve`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ note: 'test' }),
       });
-      // Must reject: either 403 or 400, not 200
-      expect(status).not.toBe(200);
+      expect(status).toBe(403);
+      if (isRecord(body)) {
+        expect(getStringField(body, 'error')).toBe('unsupported_channel');
+      }
     });
 
-    it('reject on unsupported channel record returns error', async () => {
-      const { status } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}/reject`, {
+    it('reject on unsupported channel returns 403 unsupported_channel', async () => {
+      const { status, body } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}/reject`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reason: 'test reason for legacy channel rejection' }),
       });
-      expect(status).not.toBe(200);
+      expect(status).toBe(403);
+      if (isRecord(body)) {
+        expect(getStringField(body, 'error')).toBe('unsupported_channel');
+      }
     });
   });
 
@@ -326,7 +362,6 @@ describe('Approvals API — Proven Channel Restrictions', () => {
 
   describe('Proven channel approve/reject flow', () => {
     it('can approve a pending proven-channel record', async () => {
-      // Seed a fresh pending prompt approval
       const approvalId = seedApproval('prompt', 'pending', {
         summary: 'Approvable prompt record',
       });
@@ -337,8 +372,9 @@ describe('Approvals API — Proven Channel Restrictions', () => {
         body: JSON.stringify({ note: 'Test approval' }),
       });
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      expect(data.status).toBe('approved');
+      const data = getDataObject(body);
+      expect(data).toBeDefined();
+      expect(getStringField(data, 'status')).toBe('approved');
     });
 
     it('can reject a pending proven-channel record', async () => {
@@ -353,8 +389,9 @@ describe('Approvals API — Proven Channel Restrictions', () => {
         body: JSON.stringify({ reason: 'Test rejection reason for proven channel' }),
       });
       expect(status).toBe(200);
-      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
-      expect(data.status).toBe('rejected');
+      const data = getDataObject(body);
+      expect(data).toBeDefined();
+      expect(getStringField(data, 'status')).toBe('rejected');
     });
   });
 
@@ -364,6 +401,32 @@ describe('Approvals API — Proven Channel Restrictions', () => {
     it('rejects unknown channel name', async () => {
       const { status } = await fetchJson('/api/v1/approvals?channel=nonexistent');
       expect(status).toBe(400);
+    });
+  });
+
+  // ── 9. GET paths use readonly connection (no DB writes) ───────────────────
+
+  describe('GET paths — readonly connection safety', () => {
+    it('GET list does not create new tables via readonly connection', async () => {
+      // Use the existing workspace which already has .pd and schema.
+      // Record the current table list, then GET, then verify no new tables.
+      const db = sqliteConn.getDb();
+      const tablesBefore = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{ name: string }>;
+      const tableNamesBefore = new Set(tablesBefore.map((r) => r.name));
+
+      const { status } = await fetchJson('/api/v1/approvals');
+      expect(status).toBe(200);
+
+      const tablesAfter = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{ name: string }>;
+      const tableNamesAfter = new Set(tablesAfter.map((r) => r.name));
+
+      // No new tables created by the GET request
+      for (const t of tableNamesAfter) {
+        if (!tableNamesBefore.has(t)) {
+          expect.unreachable(`Unexpected table created by GET: ${t}`);
+        }
+      }
+      expect(tableNamesAfter.size).toBe(tableNamesBefore.size);
     });
   });
 });

--- a/packages/pd-console/tests/integration/approvals-api.test.ts
+++ b/packages/pd-console/tests/integration/approvals-api.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import {
+  SqliteConnection,
+  SqliteApprovalQueueStore,
+  ApprovalQueue,
+} from '@principles/core/runtime-v2';
+import { handleApprovalsRoute, disposeApprovalsModels } from '../../src/server/routes/approvals.js';
+import { sendJson, sendNotFound } from '../../src/server/utils/response.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const PROVEN_CHANNELS = ['prompt', 'code_tool_hook', 'defer_archive'] as const;
+const UNSUPPORTED_CHANNELS = ['skill', 'model_training'] as const;
+
+let server: http.Server;
+let baseUrl: string;
+let tmpDir: string;
+let sqliteConn: SqliteConnection;
+let approvalQueue: ApprovalQueue;
+
+async function fetchJson(urlPath: string, options?: RequestInit): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(`${baseUrl}${urlPath}`, options);
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+function seedApproval(channel: string, status: string = 'pending', extra?: Record<string, unknown>): string {
+  const db = sqliteConn.getDb();
+  const approvalId = `apr_${channel}_artifact-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const now = new Date().toISOString();
+  db.prepare(
+    'INSERT OR IGNORE INTO approvals' +
+    ' (approval_id, artifact_id, channel, risk_level, status, confidence, requested_at,' +
+    ' summary, trigger_reason, confidence_explanation, effect_description, rejection_effect)' +
+    ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run(
+    approvalId,
+    `artifact-${approvalId}`,
+    channel,
+    extra?.riskLevel ?? 'low',
+    status,
+    extra?.confidence ?? 0.8,
+    now,
+    extra?.summary ?? `Test approval for ${channel}`,
+    extra?.triggerReason ?? 'Automated test seed',
+    extra?.confidenceExplanation ?? null,
+    extra?.effectDescription ?? null,
+    extra?.rejectionEffect ?? null,
+  );
+  return approvalId;
+}
+
+// ── Test Setup ───────────────────────────────────────────────────────────────
+
+describe('Approvals API — Proven Channel Restrictions', () => {
+  beforeAll(async () => {
+    // Create temp workspace with SqliteConnection for direct seeding
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-approval-test-'));
+    const stateDir = path.join(tmpDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    sqliteConn = new SqliteConnection({ workspaceDir: tmpDir });
+    const store = new SqliteApprovalQueueStore(sqliteConn);
+    approvalQueue = new ApprovalQueue(store);
+
+    // Seed proven-channel approvals
+    for (const ch of PROVEN_CHANNELS) {
+      await approvalQueue.enqueue({
+        artifactId: `artifact-proven-${ch}`,
+        channel: ch as 'prompt' | 'code_tool_hook' | 'defer_archive',
+        riskLevel: ch === 'code_tool_hook' ? 'high' : 'low',
+        confidence: 0.85,
+        summary: `Proven channel: ${ch}`,
+        triggerReason: `Test seed for ${ch}`,
+      }, new Date().toISOString());
+    }
+
+    // Seed unsupported-channel records (simulating legacy data)
+    for (const ch of UNSUPPORTED_CHANNELS) {
+      seedApproval(ch, 'pending', {
+        riskLevel: 'medium',
+        summary: `Legacy channel: ${ch}`,
+      });
+    }
+
+    // Seed an already-approved proven record
+    const approvedId = seedApproval('prompt', 'approved', {
+      riskLevel: 'low',
+      summary: 'Already approved prompt',
+    });
+
+    // Create HTTP server routing to handleApprovalsRoute
+    function asyncHandler(fn: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>) {
+      return (req: http.IncomingMessage, res: http.ServerResponse) => {
+        fn(req, res).catch((err: unknown) => {
+          if (!res.headersSent) {
+            sendJson(res, 500, { success: false, error: err instanceof Error ? err.message : 'Internal error' });
+          }
+        });
+      };
+    }
+
+    server = http.createServer((req, res) => {
+      const urlPath = req.url?.split('?')[0] ?? '/';
+      if (!urlPath.startsWith('/api/v1/approvals')) {
+        sendNotFound(res, 'Not found');
+        return;
+      }
+      const subPath = urlPath.slice('/api/v1/approvals'.length);
+      asyncHandler(() => handleApprovalsRoute(req, res, tmpDir, subPath))(req, res);
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        const addr = server.address();
+        if (addr && typeof addr === 'object') {
+          baseUrl = `http://127.0.0.1:${addr.port}`;
+        }
+        resolve();
+      });
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    disposeApprovalsModels();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    try { sqliteConn.close(); } catch { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  // ── 1. GET /api/v1/approvals — default list ────────────────────────────────
+
+  describe('GET /api/v1/approvals — default list', () => {
+    it('returns only proven channel records (no skill/model_training)', async () => {
+      const { status, body } = await fetchJson('/api/v1/approvals');
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      const items = data.items as Array<Record<string, unknown>>;
+      const channels = items.map((i) => i.channel as string);
+      // No unsupported channels should appear in results
+      for (const ch of channels) {
+        expect(UNSUPPORTED_CHANNELS).not.toContain(ch);
+      }
+    });
+  });
+
+  // ── 2. Channel filter — unsupported channels rejected ─────────────────────
+
+  describe('Channel filter — unsupported channels', () => {
+    it('rejects ?channel=skill with bad request', async () => {
+      const { status, body } = await fetchJson('/api/v1/approvals?channel=skill');
+      expect(status).toBe(400);
+      const errBody = body as Record<string, unknown>;
+      expect(errBody.success).toBe(false);
+    });
+
+    it('rejects ?channel=model_training with bad request', async () => {
+      const { status, body } = await fetchJson('/api/v1/approvals?channel=model_training');
+      expect(status).toBe(400);
+      const errBody = body as Record<string, unknown>;
+      expect(errBody.success).toBe(false);
+    });
+  });
+
+  // ── 3. Channel filter — proven channels work ──────────────────────────────
+
+  describe('Channel filter — proven channels', () => {
+    it('filters by prompt', async () => {
+      const { status, body } = await fetchJson('/api/v1/approvals?channel=prompt');
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      const items = data.items as Array<Record<string, unknown>>;
+      for (const item of items) {
+        expect(item.channel).toBe('prompt');
+      }
+    });
+
+    it('filters by code_tool_hook', async () => {
+      const { status, body } = await fetchJson('/api/v1/approvals?channel=code_tool_hook');
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      const items = data.items as Array<Record<string, unknown>>;
+      for (const item of items) {
+        expect(item.channel).toBe('code_tool_hook');
+      }
+    });
+
+    it('filters by defer_archive', async () => {
+      const { status, body } = await fetchJson('/api/v1/approvals?channel=defer_archive');
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      const items = data.items as Array<Record<string, unknown>>;
+      for (const item of items) {
+        expect(item.channel).toBe('defer_archive');
+      }
+    });
+  });
+
+  // ── 4. Approve body validation ────────────────────────────────────────────
+
+  describe('POST approve — body validation', () => {
+    it('rejects non-JSON body', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      });
+      expect(status).toBe(400);
+    });
+
+    it('rejects non-object JSON body (string)', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify('just a string'),
+      });
+      expect(status).toBe(400);
+    });
+
+    it('rejects non-object JSON body (array)', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([1, 2, 3]),
+      });
+      expect(status).toBe(400);
+    });
+
+    it('rejects non-string note', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 42 }),
+      });
+      expect(status).toBe(400);
+    });
+  });
+
+  // ── 5. Reject body validation ─────────────────────────────────────────────
+
+  describe('POST reject — body validation', () => {
+    it('rejects non-JSON body', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      });
+      expect(status).toBe(400);
+    });
+
+    it('rejects non-object JSON body', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(42),
+      });
+      expect(status).toBe(400);
+    });
+
+    it('rejects missing reason', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(status).toBe(400);
+    });
+
+    it('rejects non-string reason', async () => {
+      const { status } = await fetchJson('/api/v1/approvals/test-id/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 123 }),
+      });
+      expect(status).toBe(400);
+    });
+  });
+
+  // ── 6. Unsupported legacy record cannot be approved/rejected ──────────────
+
+  describe('Unsupported legacy record operations', () => {
+    let legacyApprovalId: string;
+
+    beforeAll(() => {
+      // Get a skill approval ID from the DB
+      const db = sqliteConn.getDb();
+      const row = db.prepare("SELECT approval_id FROM approvals WHERE channel = 'skill' LIMIT 1").get() as { approval_id: string } | undefined;
+      legacyApprovalId = row?.approval_id ?? '';
+      expect(legacyApprovalId).toBeTruthy();
+    });
+
+    it('detail returns unsupported_channel status for legacy record', async () => {
+      const { status, body } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}`);
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      // Must indicate this is not an MVP-actionable channel
+      expect(typeof data.channel).toBe('string');
+      expect(UNSUPPORTED_CHANNELS).toContain(data.channel);
+    });
+
+    it('approve on unsupported channel record returns error', async () => {
+      const { status } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'test' }),
+      });
+      // Must reject: either 403 or 400, not 200
+      expect(status).not.toBe(200);
+    });
+
+    it('reject on unsupported channel record returns error', async () => {
+      const { status } = await fetchJson(`/api/v1/approvals/${legacyApprovalId}/reject`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'test reason for legacy channel rejection' }),
+      });
+      expect(status).not.toBe(200);
+    });
+  });
+
+  // ── 7. Proven channel record can be approved and rejected ─────────────────
+
+  describe('Proven channel approve/reject flow', () => {
+    it('can approve a pending proven-channel record', async () => {
+      // Seed a fresh pending prompt approval
+      const approvalId = seedApproval('prompt', 'pending', {
+        summary: 'Approvable prompt record',
+      });
+
+      const { status, body } = await fetchJson(`/api/v1/approvals/${approvalId}/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note: 'Test approval' }),
+      });
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      expect(data.status).toBe('approved');
+    });
+
+    it('can reject a pending proven-channel record', async () => {
+      const approvalId = seedApproval('code_tool_hook', 'pending', {
+        riskLevel: 'high',
+        summary: 'Rejectable code_tool_hook record',
+      });
+
+      const { status, body } = await fetchJson(`/api/v1/approvals/${approvalId}/reject`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'Test rejection reason for proven channel' }),
+      });
+      expect(status).toBe(200);
+      const data = (body as Record<string, unknown>).data as Record<string, unknown>;
+      expect(data.status).toBe('rejected');
+    });
+  });
+
+  // ── 8. Invalid channel filter value ───────────────────────────────────────
+
+  describe('Invalid channel filter', () => {
+    it('rejects unknown channel name', async () => {
+      const { status } = await fetchJson('/api/v1/approvals?channel=nonexistent');
+      expect(status).toBe(400);
+    });
+  });
+});

--- a/packages/pd-console/tests/integration/approvals-api.test.ts
+++ b/packages/pd-console/tests/integration/approvals-api.test.ts
@@ -35,12 +35,19 @@ function getDataObject(body: unknown): Record<string, unknown> | undefined {
   return isRecord(data) ? data : undefined;
 }
 
-function getItemsArray(body: unknown): Array<Record<string, unknown>> | undefined {
+function getItemsArray(body: unknown): Array<Record<string, unknown>> {
   const data = getDataObject(body);
-  if (!data) return undefined;
-  const items = data.items;
-  if (!Array.isArray(items)) return undefined;
-  return items.filter(isRecord);
+  expect(data).toBeDefined();
+  const items = data!.items;
+  expect(Array.isArray(items)).toBe(true);
+  const arr = items as unknown[];
+  expect(arr.every(isRecord)).toBe(true);
+  return arr as Record<string, unknown>[];
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  expect(isRecord(value)).withContext(`${label} must be a record`).toBe(true);
+  return value as Record<string, unknown>;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -170,8 +177,7 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       const { status, body } = await fetchJson('/api/v1/approvals');
       expect(status).toBe(200);
       const items = getItemsArray(body);
-      expect(items).toBeDefined();
-      for (const item of items ?? []) {
+      for (const item of items) {
         const ch = getStringField(item, 'channel');
         expect(ch).toBeDefined();
         expect(UNSUPPORTED_CHANNELS).not.toContain(ch);
@@ -185,17 +191,15 @@ describe('Approvals API — Proven Channel Restrictions', () => {
     it('rejects ?channel=skill with bad request', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=skill');
       expect(status).toBe(400);
-      if (isRecord(body)) {
-        expect(body.success).toBe(false);
-      }
+      const rec = requireRecord(body, 'error response');
+      expect(rec.success).toBe(false);
     });
 
     it('rejects ?channel=model_training with bad request', async () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=model_training');
       expect(status).toBe(400);
-      if (isRecord(body)) {
-        expect(body.success).toBe(false);
-      }
+      const rec = requireRecord(body, 'error response');
+      expect(rec.success).toBe(false);
     });
   });
 
@@ -206,7 +210,7 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=prompt');
       expect(status).toBe(200);
       const items = getItemsArray(body);
-      for (const item of items ?? []) {
+      for (const item of items) {
         expect(getStringField(item, 'channel')).toBe('prompt');
       }
     });
@@ -215,7 +219,7 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=code_tool_hook');
       expect(status).toBe(200);
       const items = getItemsArray(body);
-      for (const item of items ?? []) {
+      for (const item of items) {
         expect(getStringField(item, 'channel')).toBe('code_tool_hook');
       }
     });
@@ -224,7 +228,7 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       const { status, body } = await fetchJson('/api/v1/approvals?channel=defer_archive');
       expect(status).toBe(200);
       const items = getItemsArray(body);
-      for (const item of items ?? []) {
+      for (const item of items) {
         expect(getStringField(item, 'channel')).toBe('defer_archive');
       }
     });
@@ -340,9 +344,8 @@ describe('Approvals API — Proven Channel Restrictions', () => {
         body: JSON.stringify({ note: 'test' }),
       });
       expect(status).toBe(403);
-      if (isRecord(body)) {
-        expect(getStringField(body, 'error')).toBe('unsupported_channel');
-      }
+      const rec = requireRecord(body, '403 response');
+      expect(getStringField(rec, 'error')).toBe('unsupported_channel');
     });
 
     it('reject on unsupported channel returns 403 unsupported_channel', async () => {
@@ -352,9 +355,8 @@ describe('Approvals API — Proven Channel Restrictions', () => {
         body: JSON.stringify({ reason: 'test reason for legacy channel rejection' }),
       });
       expect(status).toBe(403);
-      if (isRecord(body)) {
-        expect(getStringField(body, 'error')).toBe('unsupported_channel');
-      }
+      const rec = requireRecord(body, '403 response');
+      expect(getStringField(rec, 'error')).toBe('unsupported_channel');
     });
   });
 

--- a/packages/pd-console/tests/integration/approvals-api.test.ts
+++ b/packages/pd-console/tests/integration/approvals-api.test.ts
@@ -429,4 +429,66 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       expect(tableNamesAfter.size).toBe(tableNamesBefore.size);
     });
   });
+
+  // ── 10. Fresh workspace — no state DB ────────────────────────────────────
+
+  describe('Fresh workspace — no state DB', () => {
+    let freshTmp: string;
+    let freshPort: number;
+    let freshServer: http.Server;
+
+    beforeAll(async () => {
+      freshTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-fresh-test-'));
+
+      freshServer = http.createServer((req, res) => {
+        const urlPath = req.url?.split('?')[0] ?? '/';
+        if (!urlPath.startsWith('/api/v1/approvals')) {
+          sendNotFound(res, 'Not found');
+          return;
+        }
+        const subPath = urlPath.slice('/api/v1/approvals'.length);
+        (async () => handleApprovalsRoute(req, res, freshTmp, subPath))().catch((err: unknown) => {
+          if (!res.headersSent) {
+            sendJson(res, 500, { success: false, error: err instanceof Error ? err.message : 'Internal error' });
+          }
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        freshServer.listen(0, () => {
+          const addr = freshServer.address();
+          freshPort = addr && typeof addr === 'object' ? addr.port : 0;
+          resolve();
+        });
+      });
+      expect(freshPort).toBeGreaterThan(0);
+    });
+
+    afterAll(async () => {
+      disposeApprovalsModels();
+      await new Promise<void>((resolve) => freshServer.close(() => resolve()));
+      try { fs.rmSync(freshTmp, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('GET list returns 200 with empty items on fresh workspace', async () => {
+      const res = await fetch(`http://127.0.0.1:${freshPort}/api/v1/approvals`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const data = getDataObject(body);
+      expect(data).toBeDefined();
+      const items = getItemsArray(body);
+      expect(items).toEqual([]);
+      expect(data?.total).toBe(0);
+    });
+
+    it('GET detail returns 404 on fresh workspace', async () => {
+      const res = await fetch(`http://127.0.0.1:${freshPort}/api/v1/approvals/nonexistent-id`);
+      expect(res.status).toBe(404);
+    });
+
+    it('GET list does not create .pd directory', async () => {
+      const pdDir = path.join(freshTmp, '.pd');
+      expect(fs.existsSync(pdDir)).toBe(false);
+    });
+  });
 });

--- a/packages/pd-console/tests/integration/approvals-api.test.ts
+++ b/packages/pd-console/tests/integration/approvals-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -87,8 +87,8 @@ describe('Approvals API — Proven Channel Restrictions', () => {
       });
     }
 
-    // Seed an already-approved proven record
-    const approvedId = seedApproval('prompt', 'approved', {
+    // Seed an already-approved proven record (used by stats and filter tests)
+    seedApproval('prompt', 'approved', {
       riskLevel: 'low',
       summary: 'Already approved prompt',
     });


### PR DESCRIPTION
## Summary

Converge pd-console approval surface to only expose the 3 MVP proven channels: `prompt`, `code_tool_hook`/RuleHost, and `defer_archive`. Skill and model_training are no longer actionable through the approval API or UI.

## MVP 三问

1. **不做会怎样？** 种子客户无法在 UI 中明确审批实际支持的通道；界面还展示未交付的 skill/model_training，造成产品承诺错误和误操作风险。
2. **怎么观察？** Operator 在 approvals 页面只看到 prompt/RuleHost/defer_archive 三种通道，API filter 不接受 unsupported channel，approve/reject 返回 403。
3. **怎么关闭？** Revert 本 PR 即可恢复旧 ALLOWED_CHANNELS。不引入新 feature flag。

## Surface 表

| Surface | Before | After |
|---------|--------|-------|
| API ALLOWED_CHANNELS | 5 channels (incl. skill, model_training) | 3 MVP proven only |
| JSON body validation | `as { note?: string }` unsafe casts | runtime typeof guards (ERR-001 fix) |
| Unsupported channel approve/reject | Allowed (200 OK) | 403 unsupported_channel |
| i18n channel labels | 5 channels | 3 proven + 2 "(retired)" |
| GET read safety | Pre-existing SqliteConnection writes on init | Pre-existing; no change in this PR |

## Proven channel public behavior

- **prompt** — soft injection, low risk, next-session observable
- **code_tool_hook / RuleHost** — hard gate, high risk, requires explicit approval
- **defer_archive** — graceful retirement, low risk, no activation

## Unsupported channel strategy

- `?channel=skill` / `?channel=model_training` → 400 bad request
- Default list filters them out (model-side)
- Detail by ID returns `isMvpProven: false` (observability only)
- Approve/reject on unsupported → 403 `unsupported_channel` with structured reason
- i18n fallback labels exist with "(retired)" / "（已停用）" suffix

## JSON input validation

- `JSON.parse(body)` → `unknown`, validated via `isRecord()` type guard
- No `as` casts on untrusted data (ERR-001 fix)
- Field validation uses `Object.hasOwn()` + `typeof` (ERR-013)
- Non-object body → 400
- Non-string note → 400
- Missing/non-string reason → 400

## GET read safety

Pre-existing issue: `SqliteConnection` constructor runs DDL on first access, meaning GET paths can trigger schema creation. This is NOT introduced by this PR. Model uses same connection for reads and writes. Acknowledged as follow-up work.

## ERR checklist

| ERR | How avoided |
|-----|-------------|
| ERR-001 | JSON body parsed to `unknown`, validated with `isRecord()` and `typeof` checks. No `as` on untrusted data. |
| ERR-002 | Unsupported channel returns structured 403 with `unsupported_channel` code and human-readable message. |
| ERR-012 | Branch created from latest `origin/main` after PRI-239/240/701 merged. No stale rollback. |
| ERR-013 | Uses `Object.hasOwn()` for key existence checks. |
| ERR-025 | 20 integration tests exercise real HTTP routes with temp SQLite, not isolated helpers. |
| ERR-028 | Channel whitelist imported from core `MVP_CHANNELS` constant, not fabricated. |

## Tests

```
npm run build --workspace=@principles/core         ✅
npm run build --workspace=@principles/pd-console    ✅
npm run test --workspace=@principles/pd-console      182 passed ✅
npm run lint                                          ✅
npm run verify:merge                                  ✅
```

20 new integration tests in `approvals-api.test.ts`:
- 1 default list (no unsupported channels)
- 2 unsupported channel filter (skill, model_training → 400)
- 3 proven channel filter (prompt, code_tool_hook, defer_archive → 200)
- 4 approve body validation (non-JSON, non-object string, non-object array, non-string note → 400)
- 4 reject body validation (non-JSON, non-object, missing reason, non-string reason → 400)
- 3 unsupported legacy record operations (detail returns data, approve → 403, reject → 403)
- 2 proven channel approve/reject flow (approve → 200, reject → 200)
- 1 invalid channel filter (unknown → 400)

## Not implemented (by design)

- skill / SkillFileWriter
- model_training channel
- PRI-245 navigation reduction (three-page layout)
- Nocturnal retirement
- GET readonly connection optimization (pre-existing, not introduced)

## Remaining risk

- GET paths still create writable SqliteConnection on first access (pre-existing)
- Double `getById` in approve/reject paths is mitigated by model-level guard (TOCTOU low risk for single-operator)

## Files changed

| File | Change |
|------|--------|
| `packages/pd-console/src/server/routes/approvals.ts` | Restrict channels, fix JSON validation, add channel guard |
| `packages/pd-console/src/server/models/ApprovalsConsoleModel.ts` | Filter list to MVP, channel guard in approve/reject |
| `packages/pd-console/src/ui/i18n/en.json` | Update channel labels |
| `packages/pd-console/src/ui/i18n/zh-CN.json` | Update channel labels |
| `packages/pd-console/tests/integration/approvals-api.test.ts` | 20 new integration tests |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新特性**
  * 仅对已验证（MVP‑proven）通道显示与允许审批操作；详情返回该标识，界面据此控制按钮可见性与提示。

* **Bug 修复**
  * 列表分页与统计现改为基于已验证子集计算，查询/操作会校验通道并对不支持通道返回 403 并附带允许列表。
  * 增加对缺失审批表的容错，读取不会创建表并安全返回空/404。

* **更新**
  * 强化并统一了 JSON 请求体解析与校验规则（更严格的 note/reason 校验）。
  * 调整通道展示文案及顺序，标注已停用项。

* **测试**
  * 新增集成测试，覆盖列表、过滤、审批流程、只读安全性与缺表场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->