### PR TITLE
docs(product): reduce mandatory product context load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,16 @@
 
 ## ⚠️ MVP-First Stage — Read First (2026-05-24)
 
-**PD is in MVP-First stage** (ADR-0014). Goal: invite the first real seed customer within 4-6 weeks. **All architectural expansion is paused.** Before starting ANY work:
+**PD is in MVP-First stage** (ADR-0014). Goal: invite the first real seed customer within 4-6 weeks. **All architectural expansion is paused.** Product boundary: **PD owns owner-reviewed, reversible behavior internalization; it does not own general task execution, general memory, generic tool repair, or autonomous value decisions.**
 
-0. Read [`PRODUCT_IDENTITY.md`](PRODUCT_IDENTITY.md) (canonical definition of what PD is and is not)
-1. Read [`docs/adr/0014-mvp-first-strategy-and-product-pivot.md`](docs/adr/0014-mvp-first-strategy-and-product-pivot.md) (MVP-First Strategy)
-2. Read [`docs/plans/2026-05-roadmap/07-mvp-first-pivot.md`](docs/plans/2026-05-roadmap/07-mvp-first-pivot.md) (execution doc)
-3. Read [`docs/plans/post-mvp-conditional-roadmap.md`](docs/plans/post-mvp-conditional-roadmap.md) (deferred work restart conditions)
+Read the strategic documents below before creating or reprioritizing an issue, or changing product scope, architecture, roadmap, ADRs, user journeys, surfaced functionality, activation channels, or public product copy:
+
+0. [`PRODUCT_IDENTITY.md`](PRODUCT_IDENTITY.md) (canonical product boundary)
+1. [`docs/adr/0014-mvp-first-strategy-and-product-pivot.md`](docs/adr/0014-mvp-first-strategy-and-product-pivot.md) (MVP-First Strategy)
+2. [`docs/plans/2026-05-roadmap/07-mvp-first-pivot.md`](docs/plans/2026-05-roadmap/07-mvp-first-pivot.md) (execution doc)
+3. [`docs/plans/post-mvp-conditional-roadmap.md`](docs/plans/post-mvp-conditional-roadmap.md) (deferred work restart conditions)
+
+For a narrowly scoped implementation, bug fix, test fix, or CI fix inside an already approved issue, do not reload all strategic documents unless the change crosses one of those boundaries. The product boundary above still applies.
 
 If a Linear issue or earlier doc instructs you to implement **Attribution Pipeline / WorkspaceLearningSummary / Probation Window / BALM / LRAS / GAP / MissionScheduler / Trainer / model_training channel / pre-existing Phase 1C or Phase 1D work**, **STOP** and verify against post-mvp-conditional-roadmap.md whether the restart conditions are met. They almost certainly are not.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Principles Disciple** is an owner-governed behavior internalization system built as an OpenClaw plugin (Node.js/TypeScript). It captures repeated, owner-relevant behavior evidence ("pain signals"), distills reviewed principles, and applies approved, reversible behavior changes.
 
-Read [`PRODUCT_IDENTITY.md`](PRODUCT_IDENTITY.md) before interpreting product scope. PD does not own general task execution, general memory, tool-call repair, or autonomous value decisions.
+Product boundary: PD does not own general task execution, general memory, tool-call repair, or autonomous value decisions. Read [`PRODUCT_IDENTITY.md`](PRODUCT_IDENTITY.md) when creating or planning issues, or when changing product scope, architecture, roadmaps, user journeys, surfaced functionality, activation channels, or public product copy. A narrow implementation, bug, test, or CI fix inside an approved issue may rely on this summary unless it changes those boundaries.
 
 **Main package:** `packages/openclaw-plugin/`
 **Package manager:** pnpm (monorepo with workspaces)
@@ -78,7 +78,7 @@ docs/                    # Architecture docs, design documents, maps
 
 **Before starting ANY coding task**, you MUST read `docs/ERROR_EXPERIENCE_HANDBOOK.md`. This file records real errors caught in code reviews. Reading it prevents you from repeating mistakes that other AI assistants made on this project.
 
-Before starting product or architecture work, also read `PRODUCT_IDENTITY.md` and reject work that expands PD into task execution, general memory, generic tool repair, or untriggered post-MVP learning infrastructure.
+For work subject to the product-boundary gate above, read `PRODUCT_IDENTITY.md` and reject work that expands PD into task execution, general memory, generic tool repair, or untriggered post-MVP learning infrastructure.
 
 ### Error Handbook Gate
 

--- a/PRODUCT_IDENTITY.md
+++ b/PRODUCT_IDENTITY.md
@@ -1,129 +1,51 @@
 # Principles Disciple Product Identity
 
-> **Status**: Active / canonical product definition
-> **Last updated**: 2026-05-25
-> **Execution boundary**: [ADR-0014](docs/adr/0014-mvp-first-strategy-and-product-pivot.md) and the [MVP execution plan](docs/plans/2026-05-roadmap/07-mvp-first-pivot.md)
+> **Status**: Active canonical product boundary
+> **Read for**: new issues, product or architecture decisions, roadmap changes, user journeys, surfaced functionality, and MVP scope questions
+> **Scope authority**: [ADR-0014](docs/adr/0014-mvp-first-strategy-and-product-pivot.md)
 
-## One-Sentence Definition
+## Definition
 
-**Principles Disciple (PD) is an owner-governed behavior internalization system for AI agents: it turns repeated, owner-relevant behavioral evidence into reviewed, reversible principles that can change future agent behavior.**
+**Principles Disciple (PD) is an owner-governed behavior internalization system for AI agents.** It turns repeated, owner-relevant behavioral evidence into reviewed, reversible principles that can change future behavior.
 
-This definition is the anchor for product decisions, architecture work, issue planning, and user-facing explanation.
+`Pain` is PD's current technical name for incoming behavior evidence. It does not mean every tool failure deserves a principle.
 
-## What PD Owns
+## Boundary
 
-PD owns the layer above individual task execution:
+PD owns:
 
-| Concept | Meaning in PD |
-| --- | --- |
-| **Behavior evidence** | Repeated friction, explicit correction, risky near-miss, or persistent behavior pattern that the owner considers worth improving |
-| **Principle proposal** | A reviewable statement of how the agent should behave differently in similar future situations |
-| **Owner decision** | Human approval, rejection, channel selection, rollback, or defer/archive decision |
-| **Activation** | Applying an approved principle through a reversible behavior channel |
-| **Observed behavior change** | Evidence from a subsequent real or controlled scenario that the activated principle affected agent behavior as intended |
+- behavior evidence the owner considers worth changing;
+- reviewable principle proposals;
+- owner approval, rejection, channel selection, rollback, and archive decisions;
+- reversible activation and later observation of behavior change.
 
-`Pain` is PD's current technical name for incoming behavior evidence. It does **not** mean every tool failure deserves a principle, and it does not limit PD to error handling.
+PD does not own:
 
-## What PD Does Not Own
+- task execution or general agent orchestration;
+- general memory;
+- tool retries or JSON/output-format repair;
+- autonomous value decisions without an owner.
 
-PD is deliberately not:
+PD builds on host/runtime capabilities; it does not duplicate them.
 
-- a task execution engine;
-- a general memory system or external brain;
-- a tool-call retry or JSON-format repair product;
-- a general multi-agent orchestration framework;
-- an autonomous self-improvement system that decides values without an owner.
-
-OpenClaw, Claude Code, and other host/runtime products can become better at execution, memory, tools, and agent coordination. PD should build on those capabilities, not duplicate them. PD's differentiated value is the governed transition from **repeated behavior evidence** to **durable, reviewable behavior policy**.
-
-## The Product Loop
+## MVP Contract
 
 ```text
-Real work evidence
-  -> pattern diagnosis
-  -> principle proposal
-  -> owner review and channel decision
-  -> reversible activation
-  -> observable behavior in a later scenario
+behavior evidence -> diagnosis -> principle proposal -> owner review
+-> reversible activation -> observable later behavior
 ```
 
-The owner is not an exception path in this loop. The owner supplies the value judgment: which behavior matters, which principle is acceptable, how strongly it may be applied, and whether it should remain active.
+Supported MVP activation outcomes are `prompt`, `code_tool_hook` / RuleHost, and `defer_archive`.
 
-## MVP Promise
+MVP success is an owner observing a better-aligned response in a comparable later scenario. It is not statistical attribution, autonomous learning infrastructure, or a new activation channel.
 
-The MVP must demonstrate one simple promise:
+## Decision Gate
 
-> An owner can identify a repeated agent behavior they want changed, review a proposed principle, activate it through a supported channel, and observe a better-aligned response in a comparable later scenario.
+For a new issue, surfaced subsystem, user journey, or product/architecture change, answer:
 
-The supported MVP channels are:
+1. Which step of the owner-governed loop improves?
+2. What owner-visible evidence verifies it?
+3. How is it disabled, rolled back, or deferred?
+4. Does it duplicate a host/runtime capability?
 
-- `prompt`: soft behavioral guidance;
-- `code_tool_hook` / RuleHost: reviewed enforcement for sensitive behavior;
-- `defer_archive`: a deliberate decision not to activate a proposal.
-
-MVP success is **demonstrated behavior change**, not statistical causal attribution.
-
-## Product Horizons
-
-### Short Term: First Seed Customer
-
-Goal: make the owner-governed loop usable and observable.
-
-Must deliver:
-
-- one trustworthy Runtime V2 forward path;
-- a clear Pain / Principle / Approval operator journey;
-- the three supported MVP channels;
-- a reproducible demonstration based on an owner-specified behavior preference;
-- disable, rollback, and failure-diagnosis paths.
-
-Must not expand into:
-
-- new activation channels;
-- autonomous attribution or auto-pruning;
-- general agent lifecycle or mission scheduling;
-- replacement execution, memory, or tool frameworks.
-
-### Medium Term: Evidence of Product Value
-
-Start only after seed customers repeatedly use the MVP loop.
-
-Goal: determine whether activated principles remain useful over time without claiming false causality.
-
-Possible work, only when triggered by observed customer evidence:
-
-- outcome observation and comparison across similar situations;
-- principle usefulness review and assisted archive decisions;
-- cautious attribution experiments with explicit uncertainty;
-- better handling of conflicting or low-quality principles.
-
-The activation of this horizon is governed by the restart conditions in [post-mvp-conditional-roadmap.md](docs/plans/post-mvp-conditional-roadmap.md).
-
-### Long Term: Governed Behavioral Adaptation Layer
-
-Goal: become a portable governance layer for agents running across capable host systems.
-
-PD may eventually help owners understand which behavioral policies work across tasks, tools, agents, and workspaces. It should still remain owner-governed, auditable, and reversible. It should not compete with host runtimes on basic execution, memory, or tool orchestration.
-
-## Decision Filter For Every Issue
-
-Before implementation, ask:
-
-1. Which part of the owner-governed product loop does this improve?
-2. What owner-visible behavior or evidence becomes better?
-3. Can the change be disabled, rolled back, or safely deferred?
-4. Does it duplicate a capability that should belong to the host/runtime instead?
-5. Is it required for the current horizon, or is it an untriggered future idea?
-
-If an issue cannot answer these questions, it should not enter the active MVP queue.
-
-## Document Authority
-
-Use this document for the stable product identity.
-
-- Use `ADR-0014` for current strategic scope and deferred work.
-- Use the MVP execution plan for active sequencing.
-- Use architecture documents for component boundaries and data flow.
-- Use the Owner Reader Companion for longer-term interpretation and systems-thinking context.
-
-If a roadmap or architecture document implies PD owns task execution, general memory, generic tool repair, or unapproved autonomous self-evolution, it conflicts with this product identity and must be corrected before it drives implementation.
+If these cannot be answered, do not add the work to MVP scope. Use ADR-0014 and the post-MVP conditional roadmap for deferred work; use architecture documents only for implementation structure.


### PR DESCRIPTION
## Summary

- compress `PRODUCT_IDENTITY.md` from an explanatory document into a 290-word product boundary card
- keep the owner-governed internalization definition, MVP outcomes, and decision gate intact
- require full strategic-document reading only for issue/product/architecture/scope changes, not narrowly approved bug/test/CI fixes

## Why

PR #710 established the product identity, but its initial reading rule would force agents to load a long strategic document for every narrow implementation task. This follow-up preserves the boundary while reducing repeated context cost and keeping task prompts focused.

## Verification

- `git diff --check`
- `npm run verify:merge`
- pre-push `verify-merge` hook

## Scope

Documentation only. No runtime behavior or feature flag changes.