### PR TITLE
test: add coverage for MVP active-path modules (feature-flag-loader, json-extractor)

### DIFF
--- a/packages/pd-cli/tests/services/feature-flag-loader.test.ts
+++ b/packages/pd-cli/tests/services/feature-flag-loader.test.ts
@@ -88,6 +88,7 @@ describe('feature-flag-loader', () => {
       try {
         const result = loadEffectiveFeatureFlags(tmpDir);
         expect(result.source).toBe('defaults');
+        expect(result.warnings.some(w => w.includes('expected a mapping'))).toBe(true);
       } finally {
         cleanup(tmpDir);
       }
@@ -121,6 +122,7 @@ describe('feature-flag-loader', () => {
       try {
         const result = loadEffectiveFeatureFlags(tmpDir);
         expect(result.warnings.some(w => w.includes("dangerous key '__proto__' rejected"))).toBe(true);
+        expect(Object.hasOwn(result.flags, '__proto__')).toBe(false);
       } finally {
         cleanup(tmpDir);
       }
@@ -132,6 +134,7 @@ describe('feature-flag-loader', () => {
       try {
         const result = loadEffectiveFeatureFlags(tmpDir);
         expect(result.warnings.some(w => w.includes("dangerous key 'constructor' rejected"))).toBe(true);
+        expect(Object.hasOwn(result.flags, 'constructor')).toBe(false);
       } finally {
         cleanup(tmpDir);
       }
@@ -143,6 +146,7 @@ describe('feature-flag-loader', () => {
       try {
         const result = loadEffectiveFeatureFlags(tmpDir);
         expect(result.warnings.some(w => w.includes("dangerous key 'prototype' rejected"))).toBe(true);
+        expect(Object.hasOwn(result.flags, 'prototype')).toBe(false);
       } finally {
         cleanup(tmpDir);
       }

--- a/packages/pd-cli/tests/services/feature-flag-loader.test.ts
+++ b/packages/pd-cli/tests/services/feature-flag-loader.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  loadEffectiveFeatureFlags,
+  getFeatureFlagsConfigPath,
+  FEATURE_FLAGS_CONFIG_FILENAME,
+  FEATURE_FLAGS_CONFIG_DIR,
+} from '../../src/services/feature-flag-loader.js';
+
+function createTempWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-ffl-test-'));
+}
+
+function writeConfig(tmpDir: string, content: string): void {
+  const configDir = path.join(tmpDir, FEATURE_FLAGS_CONFIG_DIR);
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, FEATURE_FLAGS_CONFIG_FILENAME), content, 'utf8');
+}
+
+function cleanup(tmpDir: string): void {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+describe('feature-flag-loader', () => {
+  describe('getFeatureFlagsConfigPath', () => {
+    it('should return path under .pd/feature-flags.yaml', () => {
+      const result = getFeatureFlagsConfigPath('/workspace/project');
+      expect(result).toBe(path.join('/workspace/project', '.pd', 'feature-flags.yaml'));
+    });
+
+    it('should use FEATURE_FLAGS_CONFIG_DIR and FEATURE_FLAGS_CONFIG_FILENAME constants', () => {
+      const result = getFeatureFlagsConfigPath('/root');
+      expect(result).toContain(FEATURE_FLAGS_CONFIG_DIR);
+      expect(result).toContain(FEATURE_FLAGS_CONFIG_FILENAME);
+    });
+  });
+
+  describe('loadEffectiveFeatureFlags', () => {
+    it('should return defaults when config file does not exist', () => {
+      const tmpDir = createTempWorkspace();
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.source).toBe('defaults');
+        expect(result.warnings).toEqual([]);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should return defaults with YAML parse error warning for malformed YAML', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, 'gfi: [unterminated');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes('YAML parse error'))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should return defaults with mapping warning when YAML contains an array', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, '- item1\n- item2\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes('expected a mapping'))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should return defaults with mapping warning when YAML contains null', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, '---\nnull\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes('expected a mapping'))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should return defaults with mapping warning when YAML is undefined after parse', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, '---\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.source).toBe('defaults');
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should return defaults with mapping warning when YAML contains a scalar string', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, 'just a string\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes('expected a mapping'))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should return defaults with mapping warning when YAML contains a number', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, '42\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes('expected a mapping'))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should reject __proto__ dangerous key', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, '"__proto__":\n  enabled: true\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes("dangerous key '__proto__' rejected"))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should reject constructor dangerous key', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, 'constructor:\n  enabled: true\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes("dangerous key 'constructor' rejected"))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should reject prototype dangerous key', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, 'prototype:\n  enabled: true\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes("dangerous key 'prototype' rejected"))).toBe(true);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should allow valid keys while rejecting dangerous ones', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, 'gfi:\n  enabled: true\nprototype:\n  enabled: true\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.warnings.some(w => w.includes("dangerous key 'prototype' rejected"))).toBe(true);
+        expect(result.flags.gfi).toBeDefined();
+        if (result.flags.gfi) {
+          expect(result.flags.gfi.enabled).toBe(true);
+        }
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should parse valid YAML config and set source to workspace_file', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, 'gfi:\n  enabled: true\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.source).toBe('workspace_file');
+        expect(result.flags.gfi).toBeDefined();
+        if (result.flags.gfi) {
+          expect(result.flags.gfi.enabled).toBe(true);
+        }
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should handle empty YAML mapping with defaults source', () => {
+      const tmpDir = createTempWorkspace();
+      writeConfig(tmpDir, '{}\n');
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.source).toBe('defaults');
+        expect(result.warnings).toEqual([]);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+
+    it('should include configPath in result', () => {
+      const tmpDir = createTempWorkspace();
+      try {
+        const result = loadEffectiveFeatureFlags(tmpDir);
+        expect(result.configPath).toContain(FEATURE_FLAGS_CONFIG_FILENAME);
+      } finally {
+        cleanup(tmpDir);
+      }
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
@@ -143,7 +143,7 @@ describe('extractJsonObject', () => {
     expect(result).toBeNull();
   });
 
-  it('parses JSON object after array-like prefix that contains an object', () => {
+  it('parses JSON object after prose prefix', () => {
     const input = 'Result: {"found":true}';
     const result = extractJsonObject(input);
     expect(result).toEqual({ found: true });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
@@ -94,4 +94,82 @@ describe('extractJsonObject', () => {
     const result = extractJsonObject(input);
     expect(result).toEqual({ taskId: 't1', summary: 'Use {braces} for objects', score: 0.5 });
   });
+
+  it('parses JSON with escaped quotes inside string values', () => {
+    const input = '{"taskId":"t1","message":"He said \\"hello\\""}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', message: 'He said "hello"' });
+  });
+
+  it('parses JSON with null values', () => {
+    const input = '{"taskId":"t1","optional":null}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', optional: null });
+  });
+
+  it('parses JSON with boolean and number values', () => {
+    const input = '{"active":true,"count":42,"ratio":3.14,"negative":-1}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ active: true, count: 42, ratio: 3.14, negative: -1 });
+  });
+
+  it('returns null for array containing objects at top level', () => {
+    const input = '[{"a":1},{"b":2}]';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('parses JSON with Unicode characters', () => {
+    const input = '{"taskId":"t1","label":"\\u4f60\\u597d"}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1', label: '\u4f60\u597d' });
+  });
+
+  it('parses JSON with escaped backslash in string', () => {
+    const input = '{"path":"C:\\\\Users\\\\test"}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ path: 'C:\\Users\\test' });
+  });
+
+  it('parses deeply nested JSON object', () => {
+    const input = '{"a":{"b":{"c":{"d":"deep"}}}}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ a: { b: { c: { d: 'deep' } } } });
+  });
+
+  it('returns null for string with unmatched opening brace', () => {
+    const input = 'some text { "key": "value" no close';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('parses JSON object after array-like prefix that contains an object', () => {
+    const input = 'Result: {"found":true}';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ found: true });
+  });
+
+  it('handles code fence with extra whitespace', () => {
+    const input = '```  json  \n  {"taskId":"t1"}  \n```';
+    const result = extractJsonObject(input);
+    expect(result).toEqual({ taskId: 't1' });
+  });
+
+  it('returns null for bracket-scanned array starting with [ that contains an object with escaped quotes', () => {
+    const input = '[{"msg":"He said \\"hello\\""}]';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for bracket-scanned array with escaped backslash inside string', () => {
+    const input = '[{"path":"C:\\\\Users"}]';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for bracket-scanned array with nested braces inside strings', () => {
+    const input = '[{"template":"Use {braces} here"}]';
+    const result = extractJsonObject(input);
+    expect(result).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for two MVP active-path modules only.

### feature-flag-loader.test.ts (16 tests)
Covers the YAML config loading path in `pd-cli`, including:
- Config path resolution
- Missing config file → defaults fallback
- YAML parse error handling
- Non-mapping type rejection (array, null, undefined, scalar string, number)
- Dangerous key rejection (`__proto__`, `constructor`, `prototype`)
- Valid key + dangerous key coexistence
- Valid YAML config parsing
- Empty YAML mapping → defaults source

### json-extractor.test.ts (+13 boundary tests)
Extends existing 15-test suite with boundary cases for the LLM output JSON extraction state machine:
- Escaped quotes in string values
- `null`, boolean, and number value types
- Array-of-objects rejection at top level
- Unicode escape sequences
- Escaped backslashes in strings
- Deeply nested objects
- Unmatched opening braces
- Prose-prefixed objects
- Code fence with extra whitespace
- Bracket-scan path with escaped quotes, backslashes, and braces inside strings

## Scope Decision

Per PR #723 review feedback:
- **Removed**: `evolution-dedup.test.ts` — covers legacy evolution paths being retired per MVP-First strategy
- **Removed**: `package-lock.json` churn — unrelated to test coverage goal
- **Kept**: Only MVP active-path test files

## Test Results

```
✓ json-extractor.test.ts (28 tests) 16ms
✓ feature-flag-loader.test.ts (16 tests) 15ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 增强了特性标志加载器的测试覆盖，包括配置路径验证、默认值处理和异常情况。
  * 扩展了JSON提取器的测试用例，涵盖更多解析边界场景和错误情况，确保数据解析的可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->