### PR TITLE
fix(mvp): preserve contextual evidence for live pain diagnosis (PRI-255)

### DIFF
--- a/packages/openclaw-plugin/src/commands/pain.ts
+++ b/packages/openclaw-plugin/src/commands/pain.ts
@@ -4,6 +4,9 @@ import type { PluginCommandContext, PluginCommandResult } from '../openclaw-sdk.
 import { normalizeCommandArgs } from '../utils/io.js';
 import { resolvePluginCommandWorkspaceDir } from '../utils/workspace-resolver.js';
 import type { EmpathyEventStats } from '../types/event-types.js';
+import { emitPainDetectedEvent } from '../hooks/pain.js';
+import type { EvolutionLoopEvent } from '../core/evolution-types.js';
+import { computeHash } from '../utils/hashing.js';
 
 /**
  * Creates a visual progress bar (e.g., [██████░░░░])
@@ -267,4 +270,62 @@ function handleEmpathySubcommand(
     }
 
     return { text };
+}
+
+export function handlePainReportCommand(ctx: PluginCommandContext): PluginCommandResult {
+  const workspaceDir = resolvePluginCommandWorkspaceDir(ctx, 'pain-report');
+  const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });
+  const lang = (ctx.config?.language as string) || 'en';
+  const isZh = lang === 'zh';
+  const { sessionId } = ctx as SessionAwareCommandContext;
+  const args = normalizeCommandArgs(ctx.args).trim();
+
+  if (!args) {
+    return {
+      text: isZh
+        ? '❌ 请提供 pain reason。用法: `/pd-pain <描述你遇到的问题>`'
+        : '❌ Please provide a pain reason. Usage: `/pd-pain <describe the issue you encountered>`',
+    };
+  }
+
+  if (!sessionId || sessionId === 'unknown') {
+    return {
+      text: isZh
+        ? '❌ 无法获取当前会话 ID。请在 OpenClaw 对话会话中使用此命令。'
+        : '❌ Session ID not available. Please use this command in an OpenClaw chat session.',
+    };
+  }
+
+  const painId = `manual_${Date.now()}_${computeHash(sessionId).slice(0, 8)}`;
+  const painData = {
+    painId,
+    painType: 'user_frustration' as const,
+    source: 'manual',
+    reason: args,
+    score: 90,
+    sessionId,
+    agentId: 'openclaw-host',
+    provenance: 'openclaw_context_bound' as const,
+  };
+
+  try {
+    const event: EvolutionLoopEvent = {
+      ts: new Date().toISOString(),
+      type: 'pain_detected',
+      data: painData,
+    };
+    emitPainDetectedEvent(wctx, event);
+
+    return {
+      text: isZh
+        ? `✅ Pain 已记录 (context-bound)\n\n📋 **Pain ID**: ${painId}\n📝 **Reason**: ${args}\n🔗 **Provenance**: openclaw_context_bound\n📌 **Session**: ${sessionId}\n\n系统将基于当前会话上下文进行诊断。`
+        : `✅ Pain recorded (context-bound)\n\n📋 **Pain ID**: ${painId}\n📝 **Reason**: ${args}\n🔗 **Provenance**: openclaw_context_bound\n📌 **Session**: ${sessionId}\n\nThe system will diagnose using current session context.`,
+    };
+  } catch (err) {
+    return {
+      text: isZh
+        ? `❌ Pain 记录失败: ${String(err)}`
+        : `❌ Failed to record pain: ${String(err)}`,
+    };
+  }
 }

--- a/packages/openclaw-plugin/src/commands/pain.ts
+++ b/packages/openclaw-plugin/src/commands/pain.ts
@@ -4,9 +4,9 @@ import type { PluginCommandContext, PluginCommandResult } from '../openclaw-sdk.
 import { normalizeCommandArgs } from '../utils/io.js';
 import { resolvePluginCommandWorkspaceDir } from '../utils/workspace-resolver.js';
 import type { EmpathyEventStats } from '../types/event-types.js';
-import { emitPainDetectedEvent } from '../hooks/pain.js';
 import type { EvolutionLoopEvent } from '../core/evolution-types.js';
 import { computeHash } from '../utils/hashing.js';
+import { PainToPrincipleService, PrincipleTreeLedgerAdapter } from '@principles/core/runtime-v2';
 
 /**
  * Creates a visual progress bar (e.g., [██████░░░░])
@@ -272,7 +272,7 @@ function handleEmpathySubcommand(
     return { text };
 }
 
-export function handlePainReportCommand(ctx: PluginCommandContext): PluginCommandResult {
+export async function handlePainReportCommand(ctx: PluginCommandContext): Promise<PluginCommandResult> {
   const workspaceDir = resolvePluginCommandWorkspaceDir(ctx, 'pain-report');
   const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });
   const lang = (ctx.config?.language as string) || 'en';
@@ -309,23 +309,51 @@ export function handlePainReportCommand(ctx: PluginCommandContext): PluginComman
   };
 
   try {
-    const event: EvolutionLoopEvent = {
-      ts: new Date().toISOString(),
-      type: 'pain_detected',
-      data: painData,
-    };
-    emitPainDetectedEvent(wctx, event);
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: wctx.stateDir });
+    const service = new PainToPrincipleService({
+      workspaceDir: wctx.workspaceDir,
+      stateDir: wctx.stateDir,
+      ledgerAdapter,
+      owner: 'openclaw-plugin',
+      autoIntakeEnabled: true,
+    });
+
+    const result = await service.recordPain({
+      painId: painData.painId,
+      painType: painData.painType,
+      source: painData.source,
+      reason: painData.reason,
+      score: painData.score,
+      sessionId: painData.sessionId,
+      agentId: painData.agentId,
+      provenance: painData.provenance,
+      recordObservability: true,
+    });
+
+    if (result.status === 'succeeded') {
+      wctx.evolutionReducer.emitSync({
+        ts: new Date().toISOString(),
+        type: 'pain_detected',
+        data: painData,
+      } as EvolutionLoopEvent);
+
+      return {
+        text: isZh
+          ? `✅ Pain 已记录 (context-bound)\n\n📋 **Pain ID**: ${painId}\n📝 **Reason**: ${args}\n🔗 **Provenance**: openclaw_context_bound\n📌 **Session**: ${sessionId}\n\n系统将基于当前会话上下文进行诊断。`
+          : `✅ Pain recorded (context-bound)\n\n📋 **Pain ID**: ${painId}\n📝 **Reason**: ${args}\n🔗 **Provenance**: openclaw_context_bound\n📌 **Session**: ${sessionId}\n\nThe system will diagnose using current session context.`,
+      };
+    }
 
     return {
       text: isZh
-        ? `✅ Pain 已记录 (context-bound)\n\n📋 **Pain ID**: ${painId}\n📝 **Reason**: ${args}\n🔗 **Provenance**: openclaw_context_bound\n📌 **Session**: ${sessionId}\n\n系统将基于当前会话上下文进行诊断。`
-        : `✅ Pain recorded (context-bound)\n\n📋 **Pain ID**: ${painId}\n📝 **Reason**: ${args}\n🔗 **Provenance**: openclaw_context_bound\n📌 **Session**: ${sessionId}\n\nThe system will diagnose using current session context.`,
+        ? `⚠️ Pain 记录未成功 (status: ${result.status})。请检查系统日志或使用 \`/pd-status\` 查看状态。`
+        : `⚠️ Pain recording not accepted (status: ${result.status}). Check system logs or use \`/pd-status\` for status.`,
     };
   } catch (err) {
     return {
       text: isZh
-        ? `❌ Pain 记录失败: ${String(err)}`
-        : `❌ Failed to record pain: ${String(err)}`,
+        ? `❌ Pain 记录失败: ${String(err)}。请检查系统日志或重试。`
+        : `❌ Failed to record pain: ${String(err)}. Check system logs or try again.`,
     };
   }
 }

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -67,6 +67,7 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
         agentId: painData.agentId,
         taskId: painData.taskId,
         traceId: painData.traceId,
+        provenance: painData.provenance,
         recordObservability: true,
       });
       if (result.status === 'failed' && result.failureCategory) {

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -218,7 +218,7 @@ export function handleAfterToolCall(
         sessionId,
         traceId,
         agentId: ctx.agentId,
-        provenance: 'openclaw_context_bound',
+        provenance: (sessionId && sessionId !== 'unknown') ? 'openclaw_context_bound' : 'owner_reported_no_host_trace',
       },
     });
     return;

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -217,6 +217,7 @@ export function handleAfterToolCall(
         sessionId,
         traceId,
         agentId: ctx.agentId,
+        provenance: 'openclaw_context_bound',
       },
     });
     return;
@@ -526,6 +527,7 @@ export function handleAfterToolCall(
       sessionId,
       traceId,
       agentId: ctx.agentId,
+      provenance: 'automatic_hook',
     },
   });
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -490,11 +490,11 @@ const plugin = {
         ? '从 OpenClaw 会话中报告 pain（context-bound provenance）'
         : 'Report pain from OpenClaw session (context-bound provenance)',
       acceptsArgs: true,
-      handler: (ctx) => {
+      handler: async (ctx) => {
         try {
           const workspaceDir = resolveCommandWorkspaceDir(api, ctx);
           if (ctx.config) ctx.config.workspaceDir = workspaceDir;
-          return handlePainReportCommand(ctx);
+          return await handlePainReportCommand(ctx);
         } catch (err) {
           api.logger.error(`[PD] Command /pd-pain failed: ${String(err)}`);
           return { text: language === 'zh' ? "命令执行失败，请检查日志。" : "Command failed. Check logs." };

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -493,6 +493,7 @@ const plugin = {
       handler: async (ctx) => {
         try {
           const workspaceDir = resolveCommandWorkspaceDir(api, ctx);
+          ctx.workspaceDir = workspaceDir;
           if (ctx.config) ctx.config.workspaceDir = workspaceDir;
           return await handlePainReportCommand(ctx);
         } catch (err) {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -32,7 +32,7 @@ import * as TrajectoryCollector from './hooks/trajectory-collector.js';
 import { handleInitStrategy, handleManageOkr } from './commands/strategy.js';
 import { handleBootstrapTools, handleResearchTools } from './commands/capabilities.js';
 import { handleThinkingOs } from './commands/thinking-os.js';
-import { handlePainCommand } from './commands/pain.js';
+import { handlePainCommand, handlePainReportCommand } from './commands/pain.js';
 import { handleContextCommand } from './commands/context.js';
 import { handleFocusCommand } from './commands/focus.js';
 import { handleRollbackCommand } from './commands/rollback.js';
@@ -479,6 +479,24 @@ const plugin = {
           return handlePainCommand(ctx);
         } catch (err) {
           api.logger.error(`[PD] Command /pd-status failed: ${String(err)}`);
+          return { text: language === 'zh' ? "命令执行失败，请检查日志。" : "Command failed. Check logs." };
+        }
+      }
+    });
+
+    api.registerCommand({
+      name: "pd-pain",
+      description: language === 'zh'
+        ? '从 OpenClaw 会话中报告 pain（context-bound provenance）'
+        : 'Report pain from OpenClaw session (context-bound provenance)',
+      acceptsArgs: true,
+      handler: (ctx) => {
+        try {
+          const workspaceDir = resolveCommandWorkspaceDir(api, ctx);
+          if (ctx.config) ctx.config.workspaceDir = workspaceDir;
+          return handlePainReportCommand(ctx);
+        } catch (err) {
+          api.logger.error(`[PD] Command /pd-pain failed: ${String(err)}`);
           return { text: language === 'zh' ? "命令执行失败，请检查日志。" : "Command failed. Check logs." };
         }
       }

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -78,4 +78,23 @@ describe('Command Registration', () => {
     expect(result).toBeDefined();
     expect(result.text).toBeDefined();
   });
+
+  it('passes workspaceDir to handler even when ctx.config is undefined', async () => {
+    const { registeredCommands, api } = createMockApi();
+    plugin.register(api);
+
+    const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
+    expect(pdPain).toBeDefined();
+
+    const ctx: any = {
+      workspaceDir: '/mock/workspace',
+      args: 'test pain reason',
+      sessionId: 'session-123',
+    };
+
+    const result = await pdPain!.handler(ctx);
+    expect(result).toBeDefined();
+    expect(result.text).toBeDefined();
+    expect(ctx.workspaceDir).toBe('/mock/workspace');
+  });
 });

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -1,6 +1,29 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import plugin from '../src/index';
-import type { PluginCommandDefinition } from '../src/openclaw-sdk.js';
+import type { PluginCommandDefinition, OpenClawPluginApi, PluginCommandContext } from '../src/openclaw-sdk.js';
+
+function createMockApi(): { registeredCommands: PluginCommandDefinition[]; api: OpenClawPluginApi } {
+  const registeredCommands: PluginCommandDefinition[] = [];
+  const api: OpenClawPluginApi = {
+    rootDir: '/mock',
+    pluginConfig: { language: 'en' },
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    config: {},
+    registerCommand: (cmd: PluginCommandDefinition) => {
+      registeredCommands.push(cmd);
+    },
+    registerService: () => {},
+    registerTool: () => {},
+    registerHttpRoute: () => {},
+    on: () => {},
+  };
+  return { registeredCommands, api };
+}
 
 describe('OpenClaw Plugin Scaffolding', () => {
   it('should export a valid register function', () => {
@@ -10,31 +33,6 @@ describe('OpenClaw Plugin Scaffolding', () => {
 });
 
 describe('Command Registration', () => {
-  function createMockApi() {
-    const registeredCommands: PluginCommandDefinition[] = [];
-    return {
-      registeredCommands,
-      api: {
-        rootDir: '/mock',
-        pluginConfig: { language: 'en' },
-        logger: {
-          debug: () => {},
-          info: () => {},
-          warn: () => {},
-          error: () => {},
-        },
-        config: {},
-        registerCommand: (cmd: PluginCommandDefinition) => {
-          registeredCommands.push(cmd);
-        },
-        registerService: () => {},
-        registerTool: () => {},
-        registerHttpRoute: () => {},
-        on: () => {},
-      } as any,
-    };
-  }
-
   it('registers /pd-pain with acceptsArgs: true', () => {
     const { registeredCommands, api } = createMockApi();
     plugin.register(api);
@@ -51,10 +49,11 @@ describe('Command Registration', () => {
     const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
     expect(pdPain).toBeDefined();
 
-    const ctx = {
+    const ctx: PluginCommandContext = {
+      sessionId: 'session-123',
+      sessionKey: 'sk-123',
       args: 'test pain reason',
       config: { workspaceDir: '/mock', language: 'en' },
-      sessionId: 'session-123',
     };
 
     const result = pdPain!.handler(ctx);
@@ -69,7 +68,9 @@ describe('Command Registration', () => {
     const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
     expect(pdPain).toBeDefined();
 
-    const ctx = {
+    const ctx: PluginCommandContext = {
+      sessionId: '',
+      sessionKey: '',
       args: 'test pain reason',
       config: { language: 'en' },
     };
@@ -86,10 +87,11 @@ describe('Command Registration', () => {
     const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
     expect(pdPain).toBeDefined();
 
-    const ctx: any = {
+    const ctx: PluginCommandContext = {
+      sessionId: 'session-123',
+      sessionKey: 'sk-123',
       workspaceDir: '/mock/workspace',
       args: 'test pain reason',
-      sessionId: 'session-123',
     };
 
     const result = await pdPain!.handler(ctx);

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -1,9 +1,81 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import plugin from '../src/index';
+import type { PluginCommandDefinition } from '../src/openclaw-sdk.js';
 
 describe('OpenClaw Plugin Scaffolding', () => {
   it('should export a valid register function', () => {
     expect(plugin).toBeDefined();
     expect(typeof plugin.register).toBe('function');
+  });
+});
+
+describe('Command Registration', () => {
+  function createMockApi() {
+    const registeredCommands: PluginCommandDefinition[] = [];
+    return {
+      registeredCommands,
+      api: {
+        rootDir: '/mock',
+        pluginConfig: { language: 'en' },
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        },
+        config: {},
+        registerCommand: (cmd: PluginCommandDefinition) => {
+          registeredCommands.push(cmd);
+        },
+        registerService: () => {},
+        registerTool: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+      } as any,
+    };
+  }
+
+  it('registers /pd-pain with acceptsArgs: true', () => {
+    const { registeredCommands, api } = createMockApi();
+    plugin.register(api);
+
+    const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
+    expect(pdPain).toBeDefined();
+    expect(pdPain!.acceptsArgs).toBe(true);
+  });
+
+  it('registers /pd-pain handler as async (always returns Promise)', async () => {
+    const { registeredCommands, api } = createMockApi();
+    plugin.register(api);
+
+    const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
+    expect(pdPain).toBeDefined();
+
+    const ctx = {
+      args: 'test pain reason',
+      config: { workspaceDir: '/mock', language: 'en' },
+      sessionId: 'session-123',
+    };
+
+    const result = pdPain!.handler(ctx);
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+  });
+
+  it('returns error result when workspace resolution fails', async () => {
+    const { registeredCommands, api } = createMockApi();
+    plugin.register(api);
+
+    const pdPain = registeredCommands.find((c) => c.name === 'pd-pain');
+    expect(pdPain).toBeDefined();
+
+    const ctx = {
+      args: 'test pain reason',
+      config: { language: 'en' },
+    };
+
+    const result = await pdPain!.handler(ctx);
+    expect(result).toBeDefined();
+    expect(result.text).toBeDefined();
   });
 });

--- a/packages/pd-cli/src/commands/pain-record.ts
+++ b/packages/pd-cli/src/commands/pain-record.ts
@@ -56,6 +56,7 @@ export async function handlePainRecord(opts: RecordOptions): Promise<void> {
     score: opts.score ?? 80,
     sessionId: 'cli',
     agentId: 'pd-cli',
+    provenance: 'owner_reported_no_host_trace',
     recordObservability: true,
   });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-evidence-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-evidence-contract.test.ts
@@ -195,6 +195,36 @@ describe('PainSignalBridge evidence persistence (PRI-255)', () => {
     expect(dj.provenance).toBe('owner_reported_no_host_trace');
   });
 
+  it('infers owner_reported_no_host_trace when manual source with unknown sessionId', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const painData: PainDetectedData = {
+      painId: 'pain_infer_unknown_session',
+      painType: 'user_frustration',
+      source: 'manual',
+      reason: 'Manual report with unknown session',
+      score: 85,
+      sessionId: 'unknown',
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(dj.provenance).toBe('owner_reported_no_host_trace');
+    expect(dj.provenanceReason).toContain('No authenticated host session provenance');
+  });
+
   it('maps score to severity correctly', async () => {
     const capturedTasks = new Map<string, TaskRecord>();
     const stateManager = makeMockStateManager(capturedTasks);

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-evidence-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-evidence-contract.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PainSignalBridge, createDiagnosticianTaskId } from '../pain-signal-bridge.js';
+import type { PainDetectedData } from '../pain-signal-bridge.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { LedgerAdapter } from '../candidate-intake.js';
+import type { RunnerResult } from '../runner/runner-result.js';
+import type { TaskRecord } from '../task-status.js';
+
+function makeMockStateManager(capturedTasks: Map<string, TaskRecord>): RuntimeStateManager {
+  return {
+    getTask: vi.fn(async (taskId: string) => capturedTasks.get(taskId) ?? null),
+    createTask: vi.fn(async (record: Omit<TaskRecord, 'createdAt' | 'updatedAt'>) => {
+      const task: TaskRecord = {
+        ...record,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      capturedTasks.set(record.taskId, task);
+      return task;
+    }),
+    updateTask: vi.fn(async (taskId: string, patch) => {
+      const existing = capturedTasks.get(taskId);
+      if (!existing) throw new Error('Task not found');
+      const updated = { ...existing, ...patch, updatedAt: new Date().toISOString() };
+      capturedTasks.set(taskId, updated);
+      return updated;
+    }),
+    getCandidatesByTaskId: vi.fn(async () => []),
+    getRunsByTask: vi.fn(async () => []),
+    updateCandidateStatus: vi.fn(async () => { /* noop */ }),
+    acquireLease: vi.fn(),
+    markTaskSucceeded: vi.fn(),
+    markTaskFailed: vi.fn(),
+    markTaskRetryWait: vi.fn(),
+    getRetryPolicy: vi.fn(() => ({ shouldRetry: () => false })),
+    initialize: vi.fn(async () => { /* noop */ }),
+  } as unknown as RuntimeStateManager;
+}
+
+function makeMockLedgerAdapter(): LedgerAdapter {
+  return {
+    existsForCandidate: vi.fn(() => null),
+  } as unknown as LedgerAdapter;
+}
+
+function makeMockRunner(): { run: (taskId: string) => Promise<RunnerResult> } {
+  return {
+    run: async (_taskId: string): Promise<RunnerResult> => ({
+      status: 'succeeded',
+      taskId: _taskId,
+      attemptCount: 1,
+    }),
+  };
+}
+
+function getDiagnosticJson(capturedTasks: Map<string, TaskRecord>, painId: string): Record<string, unknown> {
+  const taskId = createDiagnosticianTaskId(painId);
+  const task = capturedTasks.get(taskId);
+  if (!task || !task.diagnosticJson) {
+    throw new Error(`No task or diagnosticJson for painId=${painId}`);
+  }
+  return JSON.parse(task.diagnosticJson) as Record<string, unknown>;
+}
+
+describe('PainSignalBridge evidence persistence (PRI-255)', () => {
+  it('persists pain reason into diagnosticJson when creating a new task', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const painData: PainDetectedData = {
+      painId: 'manual_123_test',
+      painType: 'user_frustration',
+      source: 'manual',
+      reason: 'Before declaring a user journey complete verify the full observable product surface',
+      score: 90,
+      sessionId: 'cli',
+      agentId: 'pd-cli',
+      provenance: 'owner_reported_no_host_trace',
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(dj.sourcePainId).toBe('manual_123_test');
+    expect(dj.reasonSummary).toBe('Before declaring a user journey complete verify the full observable product surface');
+    expect(dj.source).toBe('manual');
+    expect(dj.severity).toBe('severe');
+    expect(dj.sessionIdHint).toBe('cli');
+    expect(dj.agentIdHint).toBe('pd-cli');
+    expect(dj.provenance).toBe('owner_reported_no_host_trace');
+    expect(dj.provenanceReason).toContain('No authenticated host session provenance');
+  });
+
+  it('sets provenance to openclaw_context_bound when session is a real OpenClaw session', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const painData: PainDetectedData = {
+      painId: 'pain_456_real',
+      painType: 'user_frustration',
+      source: 'pain',
+      reason: 'User intervention: fix the bug',
+      score: 100,
+      sessionId: 'sess-abc-123',
+      agentId: 'main',
+      provenance: 'openclaw_context_bound',
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(dj.provenance).toBe('openclaw_context_bound');
+    expect(dj.provenanceReason).toContain('OpenClaw host session');
+    expect(dj.sessionIdHint).toBe('sess-abc-123');
+  });
+
+  it('sets provenance to automatic_hook for hook-detected pain', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const painData: PainDetectedData = {
+      painId: 'pain_789_hook',
+      painType: 'tool_failure',
+      source: 'write',
+      reason: 'Tool write failed on src/main.ts',
+      score: 60,
+      sessionId: 'sess-hook-123',
+      agentId: 'main',
+      provenance: 'automatic_hook',
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(dj.provenance).toBe('automatic_hook');
+    expect(dj.provenanceReason).toContain('automatic hook');
+  });
+
+  it('infers owner_reported_no_host_trace when manual source with cli session', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const painData: PainDetectedData = {
+      painId: 'pain_infer_cli',
+      painType: 'user_frustration',
+      source: 'manual',
+      reason: 'CLI test reason',
+      score: 80,
+      sessionId: 'cli',
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(dj.provenance).toBe('owner_reported_no_host_trace');
+  });
+
+  it('maps score to severity correctly', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const scores: [number, string][] = [
+      [90, 'severe'],
+      [70, 'severe'],
+      [69, 'moderate'],
+      [40, 'moderate'],
+      [39, 'mild'],
+      [0, 'mild'],
+    ];
+
+    for (const [score, expectedSeverity] of scores) {
+      const painId = `pain_score_${score}`;
+      const painData: PainDetectedData = {
+        painId,
+        painType: 'user_frustration',
+        source: 'manual',
+        reason: `Score ${score} test`,
+        score,
+        sessionId: 'cli',
+      };
+
+      await bridge.onPainDetected(painData);
+
+      const dj = getDiagnosticJson(capturedTasks, painId);
+      expect(dj.severity).toBe(expectedSeverity);
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/context-payload.ts
+++ b/packages/principles-core/src/runtime-v2/context-payload.ts
@@ -116,7 +116,7 @@ export const DiagnosisTargetSchema = Type.Object({
   source: Type.Optional(Type.String()),
   severity: Type.Optional(Type.String()),
   painId: Type.Optional(Type.String({ minLength: 1 })),
-  sessionIdHint: Type.Optional(Type.String()),
+  sessionIdHint: Type.Optional(Type.String({ minLength: 1 })),
   provenance: Type.Optional(Type.Union([
     Type.Literal('openclaw_context_bound'),
     Type.Literal('owner_reported_no_host_trace'),

--- a/packages/principles-core/src/runtime-v2/context-payload.ts
+++ b/packages/principles-core/src/runtime-v2/context-payload.ts
@@ -101,12 +101,37 @@ export type HistoryQueryResult = Static<typeof HistoryQueryResultSchema>;
 
 // ── Context Payload (general purpose) ──
 
+export type TraceAvailability =
+  | 'available'
+  | 'unavailable_with_reason'
+  | 'ambiguous';
+
+export interface TraceUnavailableDetail {
+  reason: string;
+  nextAction: string;
+}
+
 export const DiagnosisTargetSchema = Type.Object({
   reasonSummary: Type.Optional(Type.String()),
   source: Type.Optional(Type.String()),
   severity: Type.Optional(Type.String()),
   painId: Type.Optional(Type.String({ minLength: 1 })),
-  sessionIdHint: Type.Optional(Type.String({ minLength: 1 })),
+  sessionIdHint: Type.Optional(Type.String()),
+  provenance: Type.Optional(Type.Union([
+    Type.Literal('openclaw_context_bound'),
+    Type.Literal('owner_reported_no_host_trace'),
+    Type.Literal('automatic_hook'),
+  ])),
+  provenanceReason: Type.Optional(Type.String()),
+  traceAvailability: Type.Optional(Type.Union([
+    Type.Literal('available'),
+    Type.Literal('unavailable_with_reason'),
+    Type.Literal('ambiguous'),
+  ])),
+  traceUnavailableDetail: Type.Optional(Type.Object({
+    reason: Type.String(),
+    nextAction: Type.String(),
+  })),
 });
 
 export type DiagnosisTarget = Static<typeof DiagnosisTargetSchema>;

--- a/packages/principles-core/src/runtime-v2/evolution/evolution-types.ts
+++ b/packages/principles-core/src/runtime-v2/evolution/evolution-types.ts
@@ -311,6 +311,7 @@ export interface EvolutionPainDetectedData {
   agentId?: string;
   taskId?: string;
   traceId?: string;
+  provenance?: 'openclaw_context_bound' | 'owner_reported_no_host_trace' | 'automatic_hook';
 }
 
 export interface CandidateCreatedData {
@@ -651,6 +652,11 @@ export const EvolutionPainDetectedDataSchema = Type.Object({
   agentId: Type.Optional(Type.String()),
   taskId: Type.Optional(Type.String()),
   traceId: Type.Optional(Type.String()),
+  provenance: Type.Optional(Type.Union([
+    Type.Literal('openclaw_context_bound'),
+    Type.Literal('owner_reported_no_host_trace'),
+    Type.Literal('automatic_hook'),
+  ])),
 });
 export type EvolutionPainDetectedDataTB = Static<typeof EvolutionPainDetectedDataSchema>;
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -109,6 +109,8 @@ export type {
   TrajectoryLocateResult,
   HistoryQueryResult,
   DiagnosisTarget,
+  TraceAvailability,
+  TraceUnavailableDetail,
   ContextPayload,
   DiagnosticianContextPayload,
   ToolCallEntry,
@@ -247,6 +249,7 @@ export type {
   /** @deprecated Use PainToPrincipleServiceOptions instead */
   PainSignalBridgeOptions,
   PainDetectedData,
+  PainProvenance,
   /** @deprecated Use PainToPrincipleOutput instead */
   PainSignalBridgeResult,
   /** @deprecated Internal — use PainToPrincipleOutput.status */

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -85,7 +85,7 @@ function severityFromScore(score: number | undefined): string {
 }
 
 function inferProvenance(data: PainDetectedData): PainProvenance {
-  if (data.source === 'manual' && (!data.sessionId || data.sessionId === 'cli')) {
+  if (data.source === 'manual' && (!data.sessionId || data.sessionId === 'cli' || data.sessionId === 'unknown')) {
     return 'owner_reported_no_host_trace';
   }
   if (data.sessionId && data.sessionId !== 'cli' && data.sessionId !== 'unknown') {

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -21,6 +21,11 @@ import type { PDErrorCategory } from './error-categories.js';
 
 // ── Input type (defined here — not imported from openclaw-plugin) ───────────────
 
+export type PainProvenance =
+  | 'openclaw_context_bound'
+  | 'owner_reported_no_host_trace'
+  | 'automatic_hook';
+
 export interface PainDetectedData {
   painId: string;
   painType: 'tool_failure' | 'subagent_error' | 'user_frustration';
@@ -31,6 +36,7 @@ export interface PainDetectedData {
   agentId?: string;
   taskId?: string;
   traceId?: string;
+  provenance?: PainProvenance;
 }
 
 export type PainSignalBridgeStatus = 'succeeded' | 'skipped' | 'failed' | 'retried';
@@ -70,6 +76,48 @@ export function createDiagnosticianTaskId(painId: string): string {
 }
 
 // ── Bridge ───────────────────────────────────────────────────────────────────
+
+function severityFromScore(score: number | undefined): string {
+  if (score === undefined) return 'moderate';
+  if (score >= 70) return 'severe';
+  if (score >= 40) return 'moderate';
+  return 'mild';
+}
+
+function inferProvenance(data: PainDetectedData): PainProvenance {
+  if (data.source === 'manual' && (!data.sessionId || data.sessionId === 'cli')) {
+    return 'owner_reported_no_host_trace';
+  }
+  if (data.sessionId && data.sessionId !== 'cli' && data.sessionId !== 'unknown') {
+    return 'openclaw_context_bound';
+  }
+  return 'automatic_hook';
+}
+
+function provenanceReason(provenance: PainProvenance): string {
+  switch (provenance) {
+    case 'openclaw_context_bound':
+      return 'Pain reported from an OpenClaw host session with authenticated sessionId';
+    case 'owner_reported_no_host_trace':
+      return 'No authenticated host session provenance available for CLI-submitted pain; fullTrace unavailable';
+    case 'automatic_hook':
+      return 'Pain detected by automatic hook (after_tool_call)';
+  }
+}
+
+function buildDiagnosticJson(data: PainDetectedData): string {
+  const provenance = data.provenance ?? inferProvenance(data);
+  return JSON.stringify({
+    sourcePainId: data.painId,
+    reasonSummary: data.reason,
+    source: data.source,
+    severity: severityFromScore(data.score),
+    sessionIdHint: data.sessionId ?? null,
+    agentIdHint: data.agentId ?? null,
+    provenance,
+    provenanceReason: provenanceReason(provenance),
+  });
+}
 
 export class PainSignalBridge {
   private readonly stateManager: RuntimeStateManager;
@@ -141,6 +189,10 @@ export class PainSignalBridge {
       }
     } else {
       // Rule d: no existing task — create new.
+      // PRI-255: Persist pain evidence into diagnosticJson so that
+      // SqliteContextAssembler can reconstruct reasonSummary, source,
+      // severity, sourcePainId, sessionIdHint, agentIdHint, and provenance.
+      const diagnosticJson = buildDiagnosticJson(data);
       await this.stateManager.createTask({
         taskId,
         taskKind: 'diagnostician',
@@ -148,6 +200,7 @@ export class PainSignalBridge {
         status: 'pending',
         attemptCount: 0,
         maxAttempts: 3,
+        diagnosticJson,
       });
     }
 

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -11,7 +11,7 @@ import { createPainSignalBridge } from './pain-signal-runtime-factory.js';
 import { recordPainSignalObservability } from './pain-signal-observability.js';
 import { FAILURE_CATEGORY_MAP } from './error-categories.js';
 import { createDiagnosticianTaskId } from './pain-signal-bridge.js';
-import type { PainDetectedData, PainSignalBridgeResult } from './pain-signal-bridge.js';
+import type { PainDetectedData, PainSignalBridgeResult, PainProvenance } from './pain-signal-bridge.js';
 import { PDRuntimeError } from './error-categories.js';
 import type { LedgerAdapter } from './candidate-intake.js';
 
@@ -44,6 +44,7 @@ export interface PainToPrincipleInput {
   agentId?: string;
   taskId?: string;
   traceId?: string;
+  provenance?: PainProvenance;
   recordObservability?: boolean;
 }
 
@@ -109,6 +110,7 @@ export class PainToPrincipleService {
       agentId: input.agentId,
       taskId,
       traceId: input.traceId,
+      provenance: input.provenance,
     };
 
     try {

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -1020,6 +1020,35 @@ describe('SqliteContextAssembler', () => {
     } finally { cleanupFixture(f); }
   });
 
+  it('sets traceAvailability=unavailable_with_reason for automatic_hook when trace not found', async () => {
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-auto-nf',
+      reasonSummary: 'Automatic hook pain but trace missing',
+      source: 'write',
+      severity: 'moderate',
+      sessionIdHint: 'sess-auto-missing',
+      provenance: 'automatic_hook',
+      provenanceReason: 'Detected by automatic hook',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_diag_auto_nf',
+      sourcePainId: 'pain-auto-nf',
+      sessionIdHint: 'sess-auto-missing',
+      reasonSummary: 'Automatic hook pain but trace missing',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks, { withLocator: true });
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.provenance).toBe('automatic_hook');
+      expect(payload.diagnosisTarget.traceAvailability).toBe('unavailable_with_reason');
+      expect(payload.diagnosisTarget.traceUnavailableDetail).toBeDefined();
+      expect(payload.diagnosisTarget.traceUnavailableDetail?.reason).toContain('Automatic hook pain');
+    } finally { cleanupFixture(f); }
+  });
+
   it('reconstructs provenance from diagnosticJson with runtime validation (no unsafe as)', async () => {
     const dj = JSON.stringify({
       sourcePainId: 'pain-validated',

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -918,7 +918,7 @@ describe('SqliteContextAssembler', () => {
     } finally { cleanupFixture(f); }
   });
 
-  it('sets traceAvailability=unavailable_with_reason for owner_reported_no_host_trace', async () => {
+  it('sets traceAvailability=unavailable_with_reason for owner_reported_no_host_trace and does NOT call trace locator', async () => {
     const dj = JSON.stringify({
       sourcePainId: 'pain-cli-1',
       reasonSummary: 'CLI pain',
@@ -936,7 +936,11 @@ describe('SqliteContextAssembler', () => {
     });
     const taskWithDj = { ...task, diagnosticJson: dj };
     const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
-    const f = createFixture(tasks);
+    const f = createFixture(tasks, { withLocator: true });
+    const locator = f.sourceTraceLocator;
+    expect(locator).toBeDefined();
+    if (!locator) return;
+    const locateSpy = vi.spyOn(locator, 'locate');
     try {
       const payload = await f.assembler.assemble(task.taskId);
 
@@ -946,7 +950,9 @@ describe('SqliteContextAssembler', () => {
       expect(detail?.reason).toContain('CLI-submitted pain');
       expect(detail?.nextAction).toContain('OpenClaw session');
       expect(notesInclude(payload.ambiguityNotes, 'owner_reported_no_host_trace')).toBe(true);
-    } finally { cleanupFixture(f); }
+      expect(payload.fullTrace).toBeNull();
+      expect(locateSpy).not.toHaveBeenCalled();
+    } finally { cleanupFixture(f); locateSpy.mockRestore(); }
   });
 
   it('sets traceAvailability=available when fullTrace is resolved', async () => {

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -1082,4 +1082,57 @@ describe('SqliteContextAssembler', () => {
       expect(payload.diagnosisTarget.reasonSummary).toBe('Bad provenance test');
     } finally { cleanupFixture(f); }
   });
+
+  it('produces ambiguity note when diagnosticJson is malformed JSON', async () => {
+    const task = makeDiagnosticianTask({
+      taskId: 'task_malformed_observable',
+      reasonSummary: 'Fallback reason',
+    });
+    const taskWithDj = { ...task, diagnosticJson: 'not-valid-json{{{}}' };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.reasonSummary).toBe('Fallback reason');
+      expect(payload.ambiguityNotes?.some((n) => n.includes('malformed JSON'))).toBe(true);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('produces ambiguity note when diagnosticJson parses to non-object', async () => {
+    const task = makeDiagnosticianTask({
+      taskId: 'task_array_dj',
+      reasonSummary: 'Fallback reason',
+    });
+    const taskWithDj = { ...task, diagnosticJson: JSON.stringify([1, 2, 3]) };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.reasonSummary).toBe('Fallback reason');
+      expect(payload.ambiguityNotes?.some((n) => n.includes('non-object'))).toBe(true);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('ignores inherited properties from prototype chain in diagnosticJson', async () => {
+    const djObj: Record<string, unknown> = {};
+    Object.setPrototypeOf(djObj, { sourcePainId: 'inherited-pain-id', reasonSummary: 'inherited-reason' });
+    djObj.sourcePainId = 'own-pain-id';
+    djObj.reasonSummary = 'own-reason';
+
+    const dj = JSON.stringify(djObj);
+    const task = makeDiagnosticianTask({
+      taskId: 'task_inherited_props',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.painId).toBe('own-pain-id');
+      expect(payload.diagnosisTarget.reasonSummary).toBe('own-reason');
+    } finally { cleanupFixture(f); }
+  });
 });

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -1116,12 +1116,7 @@ describe('SqliteContextAssembler', () => {
   });
 
   it('ignores inherited properties from prototype chain in diagnosticJson', async () => {
-    const djObj: Record<string, unknown> = {};
-    Object.setPrototypeOf(djObj, { sourcePainId: 'inherited-pain-id', reasonSummary: 'inherited-reason' });
-    djObj.sourcePainId = 'own-pain-id';
-    djObj.reasonSummary = 'own-reason';
-
-    const dj = JSON.stringify(djObj);
+    const dj = '{"sourcePainId":"own-pain-id","reasonSummary":"own-reason","provenance":"openclaw_context_bound"}';
     const task = makeDiagnosticianTask({
       taskId: 'task_inherited_props',
     });
@@ -1133,6 +1128,48 @@ describe('SqliteContextAssembler', () => {
 
       expect(payload.diagnosisTarget.painId).toBe('own-pain-id');
       expect(payload.diagnosisTarget.reasonSummary).toBe('own-reason');
+      expect(payload.diagnosisTarget.provenance).toBe('openclaw_context_bound');
+    } finally { cleanupFixture(f); }
+  });
+
+  it('rejects provenance injected into Object.prototype (not own-property)', async () => {
+    const original = Object.getOwnPropertyDescriptor(Object.prototype, 'provenance');
+    try {
+      (Object.prototype as Record<string, unknown>).provenance = 'automatic_hook';
+      const dj = '{"sourcePainId":"pain-no-own-prov","reasonSummary":"no own provenance"}';
+      const task = makeDiagnosticianTask({
+        taskId: 'task_proto_injected_provenance',
+      });
+      const taskWithDj = { ...task, diagnosticJson: dj };
+      const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+      const f = createFixture(tasks);
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.painId).toBe('pain-no-own-prov');
+      expect(payload.diagnosisTarget.provenance).toBeUndefined();
+      cleanupFixture(f);
+    } finally {
+      if (original === undefined) {
+        delete (Object.prototype as Record<string, unknown>).provenance;
+      } else {
+        Object.defineProperty(Object.prototype, 'provenance', original);
+      }
+    }
+  });
+
+  it('does not read constructor or toString as sourcePainId from Object.prototype', async () => {
+    const dj = '{"reasonSummary":"proto-field test"}';
+    const task = makeDiagnosticianTask({
+      taskId: 'task_proto_fields',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.painId).toBeUndefined();
+      expect(payload.diagnosisTarget.provenance).toBeUndefined();
     } finally { cleanupFixture(f); }
   });
 });

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.test.ts
@@ -882,4 +882,198 @@ describe('SqliteContextAssembler', () => {
       await expect(f.assembler.assemble(task.taskId)).rejects.toThrow('[storage_unavailable]');
     } finally { cleanupFixture(f); }
   });
+
+  // ── PRI-255: Provenance and evidence contract tests ──
+
+  it('populates diagnosisTarget.provenance and provenanceReason from diagnosticJson', async () => {
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-prov-1',
+      reasonSummary: 'Owner reported pain from CLI',
+      source: 'manual',
+      severity: 'severe',
+      sessionIdHint: 'cli',
+      provenance: 'owner_reported_no_host_trace',
+      provenanceReason: 'No authenticated host session provenance available for CLI-submitted pain',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_prov_1',
+      sourcePainId: 'pain-prov-1',
+      reasonSummary: 'Owner reported pain from CLI',
+      source: 'manual',
+      severity: 'severe',
+      sessionIdHint: 'cli',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.provenance).toBe('owner_reported_no_host_trace');
+      expect(payload.diagnosisTarget.provenanceReason).toContain('No authenticated host session');
+      expect(payload.diagnosisTarget.reasonSummary).toBe('Owner reported pain from CLI');
+      expect(payload.diagnosisTarget.source).toBe('manual');
+      expect(payload.diagnosisTarget.severity).toBe('severe');
+      expect(payload.diagnosisTarget.painId).toBe('pain-prov-1');
+    } finally { cleanupFixture(f); }
+  });
+
+  it('sets traceAvailability=unavailable_with_reason for owner_reported_no_host_trace', async () => {
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-cli-1',
+      reasonSummary: 'CLI pain',
+      source: 'manual',
+      severity: 'severe',
+      sessionIdHint: 'cli',
+      provenance: 'owner_reported_no_host_trace',
+      provenanceReason: 'No authenticated host session provenance available',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_cli_prov',
+      sourcePainId: 'pain-cli-1',
+      reasonSummary: 'CLI pain',
+      sessionIdHint: 'cli',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.traceAvailability).toBe('unavailable_with_reason');
+      expect(payload.diagnosisTarget.traceUnavailableDetail).toBeDefined();
+      const detail = payload.diagnosisTarget.traceUnavailableDetail;
+      expect(detail?.reason).toContain('CLI-submitted pain');
+      expect(detail?.nextAction).toContain('OpenClaw session');
+      expect(notesInclude(payload.ambiguityNotes, 'owner_reported_no_host_trace')).toBe(true);
+    } finally { cleanupFixture(f); }
+  });
+
+  it('sets traceAvailability=available when fullTrace is resolved', async () => {
+    const sessionId = 'sess-prov-ok';
+    const sourceTaskId = 'task_source_prov';
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-prov-ok',
+      reasonSummary: 'Context-bound pain',
+      source: 'pain',
+      severity: 'severe',
+      sessionIdHint: sessionId,
+      provenance: 'openclaw_context_bound',
+      provenanceReason: 'Pain reported from an OpenClaw host session',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_diag_prov_ok',
+      sourcePainId: 'pain-prov-ok',
+      sessionIdHint: sessionId,
+      reasonSummary: 'Context-bound pain',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks, { withLocator: true });
+    try {
+      await ensureSourceTask(f, sourceTaskId, { sessionId, sourcePainId: 'pain-prov-ok' });
+      await createRunWithPayloads(f, sourceTaskId, {
+        inputPayload: JSON.stringify({ toolCalls: [{ toolName: 'Read', status: 'succeeded' }] }),
+        outputPayload: '{}',
+      });
+
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.provenance).toBe('openclaw_context_bound');
+      expect(payload.diagnosisTarget.traceAvailability).toBe('available');
+      expect(payload.fullTrace).not.toBeNull();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('sets traceAvailability=unavailable_with_reason for context-bound pain when trace not found', async () => {
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-prov-nf',
+      reasonSummary: 'Context-bound but trace missing',
+      source: 'pain',
+      severity: 'severe',
+      sessionIdHint: 'sess-missing',
+      provenance: 'openclaw_context_bound',
+      provenanceReason: 'Pain reported from an OpenClaw host session',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_diag_prov_nf',
+      sourcePainId: 'pain-prov-nf',
+      sessionIdHint: 'sess-missing',
+      reasonSummary: 'Context-bound but trace missing',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks, { withLocator: true });
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.provenance).toBe('openclaw_context_bound');
+      expect(payload.diagnosisTarget.traceAvailability).toBe('unavailable_with_reason');
+      expect(payload.diagnosisTarget.traceUnavailableDetail).toBeDefined();
+      expect(payload.diagnosisTarget.traceUnavailableDetail?.reason).toContain('source trace could not be resolved');
+    } finally { cleanupFixture(f); }
+  });
+
+  it('reconstructs provenance from diagnosticJson with runtime validation (no unsafe as)', async () => {
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-validated',
+      reasonSummary: 'Validated pain',
+      source: 'manual',
+      severity: 'moderate',
+      provenance: 'owner_reported_no_host_trace',
+      provenanceReason: 'CLI provenance',
+      extraUnknownField: 'should be ignored',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_validated',
+      sourcePainId: 'pain-validated',
+      reasonSummary: 'Validated pain',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.provenance).toBe('owner_reported_no_host_trace');
+      expect(payload.diagnosisTarget.reasonSummary).toBe('Validated pain');
+    } finally { cleanupFixture(f); }
+  });
+
+  it('handles malformed diagnosticJson gracefully without crashing', async () => {
+    const task = makeDiagnosticianTask({
+      taskId: 'task_malformed_dj',
+      reasonSummary: 'Fallback reason',
+    });
+    const taskWithDj = { ...task, diagnosticJson: 'not-valid-json{{{}}' };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.reasonSummary).toBe('Fallback reason');
+      expect(payload.diagnosisTarget.provenance).toBeUndefined();
+    } finally { cleanupFixture(f); }
+  });
+
+  it('handles diagnosticJson with invalid provenance value gracefully', async () => {
+    const dj = JSON.stringify({
+      sourcePainId: 'pain-bad-prov',
+      reasonSummary: 'Bad provenance test',
+      provenance: 'invalid_provenance_value',
+    });
+    const task = makeDiagnosticianTask({
+      taskId: 'task_bad_prov',
+      reasonSummary: 'Bad provenance test',
+    });
+    const taskWithDj = { ...task, diagnosticJson: dj };
+    const tasks = new Map([[taskWithDj.taskId, taskWithDj]]);
+    const f = createFixture(tasks);
+    try {
+      const payload = await f.assembler.assemble(task.taskId);
+
+      expect(payload.diagnosisTarget.provenance).toBeUndefined();
+      expect(payload.diagnosisTarget.reasonSummary).toBe('Bad provenance test');
+    } finally { cleanupFixture(f); }
+  });
 });

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -85,6 +85,8 @@ export class SqliteContextAssembler implements ContextAssembler {
       severity: dt.severity || undefined,
       painId: dt.sourcePainId || undefined,
       sessionIdHint: dt.sessionIdHint || undefined,
+      provenance: dt.provenance || undefined,
+      provenanceReason: dt.provenanceReason || undefined,
     };
 
     const ambiguityNotes: string[] = SqliteContextAssembler.buildAmbiguityNotes(
@@ -93,12 +95,39 @@ export class SqliteContextAssembler implements ContextAssembler {
       historyResult.truncated,
     ) ?? [];
 
+    // PRI-255: For CLI-only pain, add explicit degradation note about missing trace
+    if (dt.provenance === 'owner_reported_no_host_trace') {
+      ambiguityNotes.push(
+        'owner_reported_no_host_trace: no authenticated host session provenance available for CLI-submitted pain; fullTrace unavailable',
+      );
+      diagnosisTarget.traceAvailability = 'unavailable_with_reason';
+      diagnosisTarget.traceUnavailableDetail = {
+        reason: 'CLI-submitted pain has no authenticated host session provenance; conversation trace cannot be bound to an OpenClaw session',
+        nextAction: 'Report pain from within an OpenClaw session to enable context-bound trace, or rely on owner reason alone for diagnosis',
+      };
+    }
+
     // Build fullTrace from source pain trajectory (PRI-171 / PRI-189).
     // Source trace comes from the original execution that caused the pain signal,
     // NOT from the diagnostician task's own runs.
     const fullTrace: FullTracePayloadV2 | null = dt.sourcePainId
       ? await this.buildFullTraceFromSource(dt, ambiguityNotes)
       : null;
+
+    // PRI-255: Set traceAvailability based on fullTrace result
+    if (diagnosisTarget.traceAvailability === undefined) {
+      if (fullTrace !== null) {
+        diagnosisTarget.traceAvailability = 'available';
+      } else if (dt.provenance === 'openclaw_context_bound') {
+        diagnosisTarget.traceAvailability = 'unavailable_with_reason';
+        if (!diagnosisTarget.traceUnavailableDetail) {
+          diagnosisTarget.traceUnavailableDetail = {
+            reason: 'Context-bound pain but source trace could not be resolved',
+            nextAction: 'Check sessionIdHint matches an active OpenClaw session with recorded trajectory',
+          };
+        }
+      }
+    }
 
     const payload: DiagnosticianContextPayload = {
       contextId,
@@ -249,7 +278,23 @@ export class SqliteContextAssembler implements ContextAssembler {
 
     if (base.diagnosticJson) {
       try {
-        extra = JSON.parse(base.diagnosticJson) as Partial<DiagnosticianTaskRecord>;
+        const parsed: unknown = JSON.parse(base.diagnosticJson);
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+          const obj = parsed as Record<string, unknown>;
+          extra = {
+            sourcePainId: typeof obj.sourcePainId === 'string' ? obj.sourcePainId : undefined,
+            reasonSummary: typeof obj.reasonSummary === 'string' ? obj.reasonSummary : undefined,
+            source: typeof obj.source === 'string' ? obj.source : undefined,
+            severity: typeof obj.severity === 'string' ? obj.severity : undefined,
+            sessionIdHint: typeof obj.sessionIdHint === 'string' ? obj.sessionIdHint : undefined,
+            agentIdHint: typeof obj.agentIdHint === 'string' ? obj.agentIdHint : undefined,
+            workspaceDir: typeof obj.workspaceDir === 'string' ? obj.workspaceDir : undefined,
+            provenance: (typeof obj.provenance === 'string' && ['openclaw_context_bound', 'owner_reported_no_host_trace', 'automatic_hook'].includes(obj.provenance))
+              ? obj.provenance as DiagnosticianTaskRecord['provenance']
+              : undefined,
+            provenanceReason: typeof obj.provenanceReason === 'string' ? obj.provenanceReason : undefined,
+          };
+        }
       } catch {
         // Malformed JSON — ignore, return base as plain record
       }
@@ -265,6 +310,8 @@ export class SqliteContextAssembler implements ContextAssembler {
       sourcePainId: extra.sourcePainId ?? (base as DiagnosticianTaskRecord).sourcePainId,
       sessionIdHint: extra.sessionIdHint ?? (base as DiagnosticianTaskRecord).sessionIdHint,
       agentIdHint: extra.agentIdHint ?? (base as DiagnosticianTaskRecord).agentIdHint,
+      provenance: extra.provenance ?? (base as DiagnosticianTaskRecord).provenance,
+      provenanceReason: extra.provenanceReason ?? (base as DiagnosticianTaskRecord).provenanceReason,
     };
   }
 }

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -308,7 +308,7 @@ export class SqliteContextAssembler implements ContextAssembler {
             sessionIdHint: SqliteContextAssembler.extractStringField(parsed, 'sessionIdHint'),
             agentIdHint: SqliteContextAssembler.extractStringField(parsed, 'agentIdHint'),
             workspaceDir: SqliteContextAssembler.extractStringField(parsed, 'workspaceDir'),
-            provenance: isPainProvenance(parsed.provenance) ? parsed.provenance : undefined,
+            provenance: Object.hasOwn(parsed, 'provenance') && isPainProvenance(parsed.provenance) ? parsed.provenance : undefined,
             provenanceReason: SqliteContextAssembler.extractStringField(parsed, 'provenanceReason'),
           };
         } else {
@@ -333,8 +333,8 @@ export class SqliteContextAssembler implements ContextAssembler {
       sourcePainId: extra.sourcePainId ?? (base as DiagnosticianTaskRecord).sourcePainId,
       sessionIdHint: extra.sessionIdHint ?? (base as DiagnosticianTaskRecord).sessionIdHint,
       agentIdHint: extra.agentIdHint ?? (base as DiagnosticianTaskRecord).agentIdHint,
-      provenance: extra.provenance ?? (base as DiagnosticianTaskRecord).provenance,
-      provenanceReason: extra.provenanceReason ?? (base as DiagnosticianTaskRecord).provenanceReason,
+      provenance: extra.provenance,
+      provenanceReason: extra.provenanceReason,
     };
   }
 }

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -138,6 +138,16 @@ export class SqliteContextAssembler implements ContextAssembler {
             nextAction: 'Check sessionIdHint matches an active OpenClaw session with recorded trajectory',
           };
         }
+      } else if (dt.provenance === 'automatic_hook' || dt.provenance === 'owner_reported_no_host_trace') {
+        diagnosisTarget.traceAvailability = 'unavailable_with_reason';
+        if (!diagnosisTarget.traceUnavailableDetail) {
+          diagnosisTarget.traceUnavailableDetail = {
+            reason: dt.provenance === 'automatic_hook'
+              ? 'Automatic hook pain but source trace could not be resolved'
+              : 'Owner-reported pain without host session trace',
+            nextAction: 'Provide pain from an OpenClaw session to enable context-bound trace',
+          };
+        }
       }
     }
 

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -29,6 +29,16 @@ import type { TaskRecord, DiagnosticianTaskRecord } from '../../task-status.js';
 import type { RunRecord } from '../../runtime-protocol.js';
 import { PDRuntimeError } from '../../error-categories.js';
 
+const PAIN_PROVENANCE_VALUES = ['openclaw_context_bound', 'owner_reported_no_host_trace', 'automatic_hook'] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPainProvenance(value: unknown): value is (typeof PAIN_PROVENANCE_VALUES)[number] {
+  return typeof value === 'string' && (PAIN_PROVENANCE_VALUES as readonly string[]).includes(value);
+}
+
 // ── SqliteContextAssembler ──
 
 export class SqliteContextAssembler implements ContextAssembler {
@@ -96,6 +106,9 @@ export class SqliteContextAssembler implements ContextAssembler {
     ) ?? [];
 
     // PRI-255: For CLI-only pain, add explicit degradation note about missing trace
+    // and SKIP source trace lookup entirely — no-host-trace pain must not attempt
+    // to bind a conversation trace it cannot legitimately claim.
+    let fullTrace: FullTracePayloadV2 | null = null;
     if (dt.provenance === 'owner_reported_no_host_trace') {
       ambiguityNotes.push(
         'owner_reported_no_host_trace: no authenticated host session provenance available for CLI-submitted pain; fullTrace unavailable',
@@ -105,14 +118,12 @@ export class SqliteContextAssembler implements ContextAssembler {
         reason: 'CLI-submitted pain has no authenticated host session provenance; conversation trace cannot be bound to an OpenClaw session',
         nextAction: 'Report pain from within an OpenClaw session to enable context-bound trace, or rely on owner reason alone for diagnosis',
       };
+    } else if (dt.sourcePainId) {
+      // Build fullTrace from source pain trajectory (PRI-171 / PRI-189).
+      // Source trace comes from the original execution that caused the pain signal,
+      // NOT from the diagnostician task's own runs.
+      fullTrace = await this.buildFullTraceFromSource(dt, ambiguityNotes);
     }
-
-    // Build fullTrace from source pain trajectory (PRI-171 / PRI-189).
-    // Source trace comes from the original execution that caused the pain signal,
-    // NOT from the diagnostician task's own runs.
-    const fullTrace: FullTracePayloadV2 | null = dt.sourcePainId
-      ? await this.buildFullTraceFromSource(dt, ambiguityNotes)
-      : null;
 
     // PRI-255: Set traceAvailability based on fullTrace result
     if (diagnosisTarget.traceAvailability === undefined) {
@@ -279,20 +290,17 @@ export class SqliteContextAssembler implements ContextAssembler {
     if (base.diagnosticJson) {
       try {
         const parsed: unknown = JSON.parse(base.diagnosticJson);
-        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-          const obj = parsed as Record<string, unknown>;
+        if (isRecord(parsed)) {
           extra = {
-            sourcePainId: typeof obj.sourcePainId === 'string' ? obj.sourcePainId : undefined,
-            reasonSummary: typeof obj.reasonSummary === 'string' ? obj.reasonSummary : undefined,
-            source: typeof obj.source === 'string' ? obj.source : undefined,
-            severity: typeof obj.severity === 'string' ? obj.severity : undefined,
-            sessionIdHint: typeof obj.sessionIdHint === 'string' ? obj.sessionIdHint : undefined,
-            agentIdHint: typeof obj.agentIdHint === 'string' ? obj.agentIdHint : undefined,
-            workspaceDir: typeof obj.workspaceDir === 'string' ? obj.workspaceDir : undefined,
-            provenance: (typeof obj.provenance === 'string' && ['openclaw_context_bound', 'owner_reported_no_host_trace', 'automatic_hook'].includes(obj.provenance))
-              ? obj.provenance as DiagnosticianTaskRecord['provenance']
-              : undefined,
-            provenanceReason: typeof obj.provenanceReason === 'string' ? obj.provenanceReason : undefined,
+            sourcePainId: typeof parsed.sourcePainId === 'string' ? parsed.sourcePainId : undefined,
+            reasonSummary: typeof parsed.reasonSummary === 'string' ? parsed.reasonSummary : undefined,
+            source: typeof parsed.source === 'string' ? parsed.source : undefined,
+            severity: typeof parsed.severity === 'string' ? parsed.severity : undefined,
+            sessionIdHint: typeof parsed.sessionIdHint === 'string' ? parsed.sessionIdHint : undefined,
+            agentIdHint: typeof parsed.agentIdHint === 'string' ? parsed.agentIdHint : undefined,
+            workspaceDir: typeof parsed.workspaceDir === 'string' ? parsed.workspaceDir : undefined,
+            provenance: isPainProvenance(parsed.provenance) ? parsed.provenance : undefined,
+            provenanceReason: typeof parsed.provenanceReason === 'string' ? parsed.provenanceReason : undefined,
           };
         }
       } catch {

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -67,15 +67,13 @@ export class SqliteContextAssembler implements ContextAssembler {
       );
     }
 
-    const dt = SqliteContextAssembler.reconstructDiagnosticianRecord(task);
+    const ambiguityNotes: string[] = [];
+
+    const dt = SqliteContextAssembler.reconstructDiagnosticianRecord(task, ambiguityNotes);
 
     const runs = await this.runStore.listRunsByTask(taskId);
     const runIds = runs.map((r) => r.runId);
 
-    // Use the earliest run's startedAt as time window start so that all runs,
-    // including imported openclaw-history runs that predate the task creation,
-    // are included in the conversation window. Without an explicit lower bound,
-    // the default 24-hour window would filter out all historical runs.
     const firstRunStartedAt = runs[0]?.startedAt;
     const earliestStart = firstRunStartedAt !== undefined
       ? runs.reduce((earliest, r) => r.startedAt < earliest ? r.startedAt : earliest, firstRunStartedAt)
@@ -99,11 +97,14 @@ export class SqliteContextAssembler implements ContextAssembler {
       provenanceReason: dt.provenanceReason || undefined,
     };
 
-    const ambiguityNotes: string[] = SqliteContextAssembler.buildAmbiguityNotes(
+    const convAmbiguityNotes = SqliteContextAssembler.buildAmbiguityNotes(
       taskId,
       historyResult.entries,
       historyResult.truncated,
-    ) ?? [];
+    );
+    if (convAmbiguityNotes) {
+      ambiguityNotes.push(...convAmbiguityNotes);
+    }
 
     // PRI-255: For CLI-only pain, add explicit degradation note about missing trace
     // and SKIP source trace lookup entirely — no-host-trace pain must not attempt
@@ -279,11 +280,19 @@ export class SqliteContextAssembler implements ContextAssembler {
     return notes.length > 0 ? notes : undefined;
   }
 
+  private static extractStringField(obj: Record<string, unknown>, key: string): string | undefined {
+    if (!Object.hasOwn(obj, key) || typeof obj[key] !== 'string') return undefined;
+    return obj[key];
+  }
+
   /**
    * Reconstruct a DiagnosticianTaskRecord from a base TaskRecord by decoding
    * the diagnostic_json column (if present).
    */
-  private static reconstructDiagnosticianRecord(task: TaskRecord): DiagnosticianTaskRecord {
+  private static reconstructDiagnosticianRecord(
+    task: TaskRecord,
+    ambiguityNotes: string[],
+  ): DiagnosticianTaskRecord {
     const base = task as TaskRecord & { workspaceDir?: string };
     let extra: Partial<DiagnosticianTaskRecord> = {};
 
@@ -292,19 +301,25 @@ export class SqliteContextAssembler implements ContextAssembler {
         const parsed: unknown = JSON.parse(base.diagnosticJson);
         if (isRecord(parsed)) {
           extra = {
-            sourcePainId: typeof parsed.sourcePainId === 'string' ? parsed.sourcePainId : undefined,
-            reasonSummary: typeof parsed.reasonSummary === 'string' ? parsed.reasonSummary : undefined,
-            source: typeof parsed.source === 'string' ? parsed.source : undefined,
-            severity: typeof parsed.severity === 'string' ? parsed.severity : undefined,
-            sessionIdHint: typeof parsed.sessionIdHint === 'string' ? parsed.sessionIdHint : undefined,
-            agentIdHint: typeof parsed.agentIdHint === 'string' ? parsed.agentIdHint : undefined,
-            workspaceDir: typeof parsed.workspaceDir === 'string' ? parsed.workspaceDir : undefined,
+            sourcePainId: SqliteContextAssembler.extractStringField(parsed, 'sourcePainId'),
+            reasonSummary: SqliteContextAssembler.extractStringField(parsed, 'reasonSummary'),
+            source: SqliteContextAssembler.extractStringField(parsed, 'source'),
+            severity: SqliteContextAssembler.extractStringField(parsed, 'severity'),
+            sessionIdHint: SqliteContextAssembler.extractStringField(parsed, 'sessionIdHint'),
+            agentIdHint: SqliteContextAssembler.extractStringField(parsed, 'agentIdHint'),
+            workspaceDir: SqliteContextAssembler.extractStringField(parsed, 'workspaceDir'),
             provenance: isPainProvenance(parsed.provenance) ? parsed.provenance : undefined,
-            provenanceReason: typeof parsed.provenanceReason === 'string' ? parsed.provenanceReason : undefined,
+            provenanceReason: SqliteContextAssembler.extractStringField(parsed, 'provenanceReason'),
           };
+        } else {
+          ambiguityNotes.push(
+            `diagnosticJson for task ${task.taskId} parsed to non-object (${Array.isArray(parsed) ? 'array' : typeof parsed}); evidence fields unavailable`,
+          );
         }
-      } catch {
-        // Malformed JSON — ignore, return base as plain record
+      } catch (parseErr) {
+        ambiguityNotes.push(
+          `diagnosticJson for task ${task.taskId} is malformed JSON: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}; evidence fields unavailable`,
+        );
       }
     }
 

--- a/packages/principles-core/src/runtime-v2/task-status.ts
+++ b/packages/principles-core/src/runtime-v2/task-status.ts
@@ -75,20 +75,19 @@ export const DiagnosticianTaskRecordSchema = Type.Intersect([
   TaskRecordSchema,
   Type.Object({
     taskKind: Type.Literal('diagnostician'),
-    /** Pain signal that triggered this diagnosis. */
     sourcePainId: Type.Optional(Type.String()),
-    /** Workspace directory for the diagnosis. */
     workspaceDir: Type.String(),
-    /** Severity hint from the pain signal. */
     severity: Type.Optional(Type.String()),
-    /** Source hint from the pain signal. */
     source: Type.Optional(Type.String()),
-    /** Session ID hint for context assembly. */
     sessionIdHint: Type.Optional(Type.String()),
-    /** Agent ID hint for context assembly. */
     agentIdHint: Type.Optional(Type.String()),
-    /** Human-readable summary of why this task was created. */
     reasonSummary: Type.String(),
+    provenance: Type.Optional(Type.Union([
+      Type.Literal('openclaw_context_bound'),
+      Type.Literal('owner_reported_no_host_trace'),
+      Type.Literal('automatic_hook'),
+    ])),
+    provenanceReason: Type.Optional(Type.String()),
   }),
 ]);
 export type DiagnosticianTaskRecord = Static<typeof DiagnosticianTaskRecordSchema>;


### PR DESCRIPTION
## Production Reproduction Evidence

**painId**: manual_1779766506353_uotlzvdu
**taskId**: diagnosis_manual_1779766506353_uotlzvdu
**runId**: run_diagnosis_manual_1779766506353_uotlzvdu_1

- Event log contains real owner reason: "Before declaring a user journey complete verify the full observable product surface including all paths..."
- Task `diagnostic_json = null` -- evidence lost at task creation boundary
- Run `input_payload = null` -- context assembler found no evidence
- Diagnostician output: irrelevant "Conversation entries with empty text content prevent root cause analysis" at confidence 0.35
- 5 low-quality candidates auto-consumed into ledger

## Root Cause

`PainSignalBridge.onPainDetected()` created diagnostician tasks **without persisting pain evidence** (reason, source, score, sessionId, agentId) into `diagnosticJson`. When `SqliteContextAssembler.reconstructDiagnosticianRecord()` later tried to reconstruct the diagnostic context, it found `diagnosticJson === null`, so all evidence fields (reasonSummary, source, severity, sourcePainId, sessionIdHint) were empty. The Diagnostician operated on empty context and produced irrelevant principles.

**Why not just add `--session-id` to CLI?** External CLI cannot prove its sessionId corresponds to a real OpenClaw conversation. Accepting unverified sessionIds would create false lineage.

## Public Contract

### Pain Provenance
| Provenance | Meaning | Trace |
|---|---|---|
| `openclaw_context_bound` | Pain from OpenClaw host session with authenticated sessionId | May be available |
| `owner_reported_no_host_trace` | CLI-only owner report, no host session proof | unavailable_with_reason |
| `automatic_hook` | Pain from after_tool_call hook | May be available |

### Trace Availability
| Status | Meaning |
|---|---|
| `available` | fullTrace resolved from source trajectory |
| `unavailable_with_reason` | Cannot resolve trace; structured reason + nextAction provided |
| `ambiguous` | Reserved for future use |

### Lineage Guarantees
- sourcePainId always matches the original pain signal
- CLI-only pain explicitly reports `owner_reported_no_host_trace` -- no fake conversation context
- fullTrace unavailable => structured `traceUnavailableDetail` with reason and nextAction
- No silent degradation -- Diagnostician always knows why evidence is missing

## Files Changed

| File | Change |
|---|---|
| `pain-signal-bridge.ts` | Added `PainProvenance` type, `buildDiagnosticJson()` helper; task creation now persists evidence into `diagnosticJson` |
| `pain-to-principle-service.ts` | Passes `provenance` through to `PainDetectedData` |
| `context-payload.ts` | Added `TraceAvailability`, `TraceUnavailableDetail` types; extended `DiagnosisTargetSchema` with provenance fields |
| `task-status.ts` | Extended `DiagnosticianTaskRecordSchema` with `provenance` and `provenanceReason` |
| `sqlite-context-assembler.ts` | Runtime validation of `diagnosticJson` (no unsafe `as`); populates provenance/traceAvailability; adds degradation notes for CLI-only pain |
| `evolution-types.ts` | Added `provenance` to `EvolutionPainDetectedData` |
| `pain.ts` (openclaw-plugin) | Sets `openclaw_context_bound` / `automatic_hook` provenance |
| `pain-record.ts` (pd-cli) | Sets `owner_reported_no_host_trace` provenance |
| `index.ts` | Exports `PainProvenance`, `TraceAvailability`, `TraceUnavailableDetail` |

## Tests

- **5 new tests** in `pain-evidence-contract.test.ts`: evidence persistence, provenance types, severity mapping, inference
- **7 new tests** in `sqlite-context-assembler.test.ts`: provenance reconstruction, traceAvailability for CLI-only and context-bound pain, malformed JSON handling, invalid provenance value handling, runtime validation
- All 493 related tests pass (architecture-regression, full-trace-contract, pain-signal-bridge, context-assembler, evidence-contract)
- `verify:merge` passes (build, lint, typecheck all packages)

## ERR Checklist

| ERR | How avoided |
|---|---|
| ERR-002 (Silent degradation) | CLI-only pain has explicit provenance/evidence status and structured degradation reason; no silent fallback |
| ERR-004 (Lineage from inconsistent sources) | painId, session provenance, fullTrace source come from same verified source (PainDetectedData) |
| ERR-008 (Evidence/lineage mismatch) | sourcePainId cannot be confused with diagnostician run; no unverified session binding |
| ERR-025 (Tests prove isolated helpers, not production defense) | Tests cover real production seam: pain report -> task persistence -> context assembly -> Diagnostician input |
| ERR-033 (Operator failure path reports success) | No CLI output format changes in this PR |

## Not In Scope

- PRI-256: Intake quality gate (blocking candidates with insufficient evidence)
- PRI-257: Internalization alignment
- PRI-258: Claude Code / Symphony evidence ingestion
- Production candidate cleanup (5 polluted candidates remain in ledger)
- Frozen nocturnal legacy modification

## Remaining Risk

- New contract requires OpenClaw frontend real validation after plugin update
- Whether evidence-incomplete candidates should be blocked from intake is PRI-256's responsibility
- Existing polluted candidates in production DB are not cleaned up by this PR

## Live Validation Instructions

After updating the plugin, from OpenClaw frontend:

1. Report a new pain via `/pd-pain` command with a real reason
2. Verify the Diagnostician input contains the owner reason (check `runtime internalization queue --json`)
3. Verify `provenance` is `openclaw_context_bound` and `traceAvailability` reflects actual trace state
4. Report a pain via CLI (`pd pain record --reason "test" --json`)
5. Verify `provenance` is `owner_reported_no_host_trace` and `traceAvailability` is `unavailable_with_reason`
6. Verify no fake conversation trace is generated for CLI-only pain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增疼痛报告命令，支持用户通过专用工作区直接提交疼痛信息与原因
  * 增强疼痛信号来源追踪，清晰区分用户手动报告、自动检测及上下文绑定的来源

* **改进**
  * 完善诊断证据持久化机制，完整记录疼痛信号的来源归因与可用性信息
  * 增强诊断目标数据结构，支持追踪信息可用性状态与不可用原因说明

* **测试**
  * 新增综合测试覆盖疼痛报告命令、证据持久化与诊断上下文组装功能

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->