### PR TITLE
feat(console): bundle pd-console before packaging and add approvals smoke test

### DIFF
--- a/packages/create-principles-disciple/scripts/bundle-plugin.mjs
+++ b/packages/create-principles-disciple/scripts/bundle-plugin.mjs
@@ -3,6 +3,7 @@
 import { existsSync, mkdirSync, rmSync, cpSync, copyFileSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,6 +17,25 @@ const CONSOLE_SRC = join(ROOT_DIR, 'packages', 'pd-console');
 const CONSOLE_DEST = join(__dirname, '..', 'console');
 const CORE_SRC = join(ROOT_DIR, 'packages', 'principles-core');
 const CORE_DEST = join(__dirname, '..', 'core');
+
+function buildConsole() {
+  const serverJs = join(CONSOLE_SRC, 'dist', 'server.js');
+  const webIndex = join(CONSOLE_SRC, 'dist', 'web', 'index.html');
+
+  console.log('  🔨 Building pd-console (always rebuild before bundling)...');
+  try {
+    execSync('npm run build', { cwd: CONSOLE_SRC, stdio: 'inherit', timeout: 120_000 });
+  } catch (e) {
+    console.error('❌ Failed to build pd-console. Cannot bundle without it.');
+    process.exit(1);
+  }
+
+  if (!existsSync(serverJs) || !existsSync(webIndex)) {
+    console.error('❌ pd-console build completed but dist artifacts still missing.');
+    process.exit(1);
+  }
+  console.log('  ✅ pd-console build succeeded');
+}
 
 const PLUGIN_REQUIRED = [
   'dist',
@@ -50,6 +70,9 @@ const CORE_REQUIRED = [
 ];
 
 console.log('📦 Bundling plugin + pd-cli for npm publish...\n');
+
+console.log('🔍 Building pd-console before bundling...');
+buildConsole();
 
 for (const item of PLUGIN_REQUIRED) {
   const src = join(PLUGIN_SRC, item);

--- a/packages/create-principles-disciple/tests/smoke-packaged-install.test.ts
+++ b/packages/create-principles-disciple/tests/smoke-packaged-install.test.ts
@@ -220,6 +220,96 @@ describe('Real packaged install smoke test', () => {
     expect(healthOk).toBe(true);
   }, 60_000);
 
+  it('/api/v1/approvals returns valid contract (non-404)', async () => {
+    const installedConsoleDir = getInstalledConsoleDir(tempHomeDir);
+    const serverEntry = path.join(installedConsoleDir, 'dist', 'server.js');
+    if (!fs.existsSync(serverEntry)) {
+      throw new Error('Console server entry not found at installed location');
+    }
+
+    const port = 3400 + Math.floor(Math.random() * 100);
+    const child = spawn(process.execPath, [
+      serverEntry,
+      '--workspace', tempWorkspaceDir,
+      '--port', String(port),
+      '--host', '127.0.0.1',
+      '--no-auth',
+    ], {
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        HOME: tempHomeDir,
+        USERPROFILE: tempHomeDir,
+      },
+    });
+
+    let childStderr = '';
+    child.stderr?.on('data', (chunk: Buffer) => { childStderr += chunk.toString(); });
+
+    await new Promise<void>((resolve) => { setTimeout(resolve, 6000); });
+
+    let approvalsOk = false;
+    let approvalsReason = '';
+    try {
+      const result = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+        const req = http.get(`http://127.0.0.1:${port}/api/v1/approvals`, (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            resolve({ statusCode: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() });
+          });
+        });
+        req.on('error', reject);
+        req.setTimeout(8000, () => { req.destroy(); reject(new Error('timeout')); });
+      });
+
+      if (result.statusCode === 404) {
+        approvalsReason = `Got 404 — approvals route not registered`;
+      } else if (result.statusCode !== 200) {
+        approvalsReason = `Got HTTP ${result.statusCode} (expected 200)`;
+      } else {
+        const parsed: unknown = JSON.parse(result.body);
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+          approvalsReason = 'Response body is not a JSON object';
+        } else {
+          const entries = Object.entries(parsed);
+          const itemsEntry = entries.find(([k]) => k === 'items');
+          const totalEntry = entries.find(([k]) => k === 'total');
+          const statsEntry = entries.find(([k]) => k === 'stats');
+          if (itemsEntry === undefined) {
+            approvalsReason = 'Response missing "items" field';
+          } else if (totalEntry === undefined) {
+            approvalsReason = 'Response missing "total" field';
+          } else if (statsEntry === undefined) {
+            approvalsReason = 'Response missing "stats" field';
+          } else {
+            const items = itemsEntry[1];
+            const total = totalEntry[1];
+            const stats = statsEntry[1];
+            if (!Array.isArray(items)) {
+              approvalsReason = 'Response "items" is not an array';
+            } else if (typeof total !== 'number') {
+              approvalsReason = 'Response "total" is not a number';
+            } else if (typeof stats !== 'object' || stats === null || Array.isArray(stats)) {
+              approvalsReason = 'Response "stats" is not an object';
+            } else {
+              approvalsOk = true;
+            }
+          }
+        }
+      }
+    } catch (e) {
+      approvalsReason = `${e}. Stderr: ${childStderr.slice(0, 500)}`;
+    } finally {
+      try { child.kill('SIGTERM'); } catch { /* ignore */ }
+      try { child.kill('SIGKILL'); } catch { /* ignore */ }
+    }
+
+    if (!approvalsOk) {
+      throw new Error(`/api/v1/approvals contract check failed: ${approvalsReason}`);
+    }
+  }, 60_000);
+
   it('console refuses --no-auth with non-loopback host', () => {
     const installedConsoleDir = getInstalledConsoleDir(tempHomeDir);
     const serverEntry = path.join(installedConsoleDir, 'dist', 'server.js');


### PR DESCRIPTION
## Summary

Ensure the packaged console always includes a fresh pd-console build and that the /api/v1/approvals endpoint returns a valid contract response on clean tarball install.

## Changes

### 1. bundle-plugin.mjs - Always rebuild pd-console before bundling
- Replaced conditional ensureConsoleBuilt() with unconditional buildConsole()
- Always runs npm run build in pd-console before copying dist
- Prevents stale dist (missing new routes like /api/v1/approvals) from being packaged
- Exits with error if build fails or artifacts are missing after build

### 2. smoke-packaged-install.test.ts - Approvals endpoint contract test
- New test case: /api/v1/approvals returns valid contract (non-404)
- Starts the packaged console server on a random port
- Requests GET /api/v1/approvals
- Verifies response is not 404 (route is registered)
- Verifies response is HTTP 200 with valid JSON
- Validates contract shape: items (array), total (number), stats (object)
- Uses Object.entries + find for field extraction - no as assertions (Runtime Contract Rule 2)
- Treats response body as unknown with full runtime validation (Runtime Contract Rule 1)

## Review Findings Addressed

| Finding | Severity | Resolution |
|---------|----------|------------|
| --force-approve mixed into PR | P0 | Removed: runtime-activation.ts and index.ts reverted to main |
| tmp-query.cjs with hardcoded production DB path | P0 | Deleted from branch |
| Stale dist skip logic in bundle-plugin.mjs | P1 | Fixed: always rebuild pd-console before bundling |
| as Record bypass in smoke test | P2 | Fixed: replaced with Object.entries + find, zero as assertions |

## ERR Checklist

| ERR | How avoided |
|-----|-------------|
| ERR-040 | Bundle script always rebuilds pd-console, never packages stale dist |
| ERR-041 | Smoke test verifies /api/v1/approvals returns valid contract, not just server startup |
| ERR-025 | Smoke test exercises real production endpoint on packaged console |
| ERR-038 | Approvals model already has stateDbExists() guard; smoke test verifies it works with fresh workspace |
| ERR-001 | No as bypasses; all untrusted data validated via typeof/Array.isArray/Object.entries |

## Tests Run

- cd packages/create-principles-disciple && npx tsc --noEmit - pass
- cd packages/create-principles-disciple && npx vitest run tests/mvp-config.test.ts - 195 tests pass
- cd packages/pd-console && npx vitest run tests/integration/approvals-api.test.ts - 27 tests pass
- Pre-push verify:merge gate - pass

## Remaining Risk

- The smoke test for /api/v1/approvals is in the smoke-packaged-install test suite which requires a full tarball build to run; it is not executed in regular CI. Manual verification was done via pd-console integration tests.