### PR TITLE
fix(mvp): close approval-to-activation gap and content_json schema mismatch (PRI-262/263/264/265)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "principles-disciple-monorepo",
-  "version": "1.10.37",
+  "version": "1.10.41",
   "description": "Principles Disciple - OpenClaw Plugin Monorepo",
   "private": true,
   "type": "module",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,9 +2,11 @@
   "id": "principles-disciple",
   "name": "Principles Disciple",
   "description": "Evolutionary programming agent framework with strategic guardrails and reflection loops.",
-  "version": "1.10.37",
+  "version": "1.10.41",
   "activation": {
-    "onCapabilities": ["hook"]
+    "onCapabilities": [
+      "hook"
+    ]
   },
   "skills": [
     "templates/langs/en/skills",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "principles-disciple",
-  "version": "1.10.40",
+  "version": "1.10.41",
   "description": "Native OpenClaw plugin for Principles Disciple",
   "type": "module",
   "main": "./dist/bundle.js",

--- a/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
+++ b/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
@@ -203,19 +203,26 @@ export class PromptActivationReader {
     const principleId = Object.hasOwn(parsed, 'principleId') && typeof parsed.principleId === 'string' ? parsed.principleId : undefined;
     const text = Object.hasOwn(parsed, 'text') && typeof parsed.text === 'string' ? parsed.text : undefined;
 
-    if (!principleId || principleId.length === 0) {
-      return { ok: false, warning: `artifact_missing_principle_id: artifactId=${activation.artifactId}; nextAction=ensure_artifact_has_principleId` };
+    const draftObj = Object.hasOwn(parsed, 'principleDraft') && isRecord(parsed.principleDraft) ? parsed.principleDraft : null;
+    const draftTitle = draftObj && Object.hasOwn(draftObj, 'title') && typeof draftObj.title === 'string' ? draftObj.title : undefined;
+    const draftStatement = draftObj && Object.hasOwn(draftObj, 'statement') && typeof draftObj.statement === 'string' ? draftObj.statement : undefined;
+
+    const resolvedPrincipleId = principleId && principleId.length > 0 ? principleId : draftTitle;
+    const resolvedText = text && text.length > 0 ? text : draftStatement;
+
+    if (!resolvedPrincipleId || resolvedPrincipleId.length === 0) {
+      return { ok: false, warning: `artifact_missing_principle_id: artifactId=${activation.artifactId}; nextAction=ensure_artifact_has_principleId_or_principleDraft_title` };
     }
 
-    if (!text || text.length === 0) {
-      return { ok: false, warning: `artifact_missing_text: artifactId=${activation.artifactId} principleId=${principleId}; nextAction=ensure_artifact_has_text` };
+    if (!resolvedText || resolvedText.length === 0) {
+      return { ok: false, warning: `artifact_missing_text: artifactId=${activation.artifactId} principleId=${resolvedPrincipleId}; nextAction=ensure_artifact_has_text_or_principleDraft_statement` };
     }
 
     return {
       ok: true,
       principle: {
-        principleId,
-        text,
+        principleId: resolvedPrincipleId,
+        text: resolvedText,
         artifactId: activation.artifactId,
         activationId: activation.activationId,
       },

--- a/packages/pd-cli/src/commands/runtime-activation.ts
+++ b/packages/pd-cli/src/commands/runtime-activation.ts
@@ -5,6 +5,7 @@ import {
   PromptWriter,
   DeferArchiveWriter,
   SqliteActivationStateStore,
+  SqliteApprovalQueueStore,
 } from '@principles/core/runtime-v2';
 import type { ActivationDecision, PIArtifactSnapshot, RolloutActivationDecision } from '@principles/core/runtime-v2';
 import type { PIArtifactRecord } from '@principles/core/runtime-v2';
@@ -144,10 +145,11 @@ export async function handleRuntimeActivationDispatch(opts: ActivationDispatchOp
     };
 
     const activationStateStore = new SqliteActivationStateStore(stateManager.connection);
+    const approvalQueueStore = new SqliteApprovalQueueStore(stateManager.connection);
     const dispatcher = new ActivationDispatcher(
       artifactReadModel,
       activationStateStore,
-      { writers: [new PromptWriter(), new DeferArchiveWriter()] },
+      { writers: [new PromptWriter(), new DeferArchiveWriter()], approvalQueueStore },
     );
 
     const result = await dispatcher.dispatch({

--- a/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
+++ b/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
@@ -5,15 +5,21 @@ import type {
   ApprovalListResult,
   ApprovalDecisionResult,
   ApprovalRecord,
+  ApprovalStatus,
 } from '@principles/core/runtime-v2';
 import {
   SqliteConnection,
   SqliteApprovalQueueStore,
+  SqliteActivationStateStore,
+  SqlitePIArtifactStore,
+  ActivationDispatcher,
+  PromptWriter,
+  DeferArchiveWriter,
   ApprovalQueue,
   mapConfidenceToLabel,
   MVP_CHANNELS,
 } from '@principles/core/runtime-v2';
-import type { ApprovalWithContext } from '@principles/core/runtime-v2';
+import type { ApprovalWithContext, ActivationDecision, PIArtifactSnapshot } from '@principles/core/runtime-v2';
 
 const MVP_PROVEN_CHANNELS: ReadonlySet<string> = new Set<string>(MVP_CHANNELS);
 
@@ -26,6 +32,12 @@ function isMissingTableError(err: unknown): boolean {
 
 type UnsupportedChannelResult = { ok: false; error: 'unsupported_channel'; channel: string };
 type ChannelGuardedDecisionResult = ApprovalDecisionResult | UnsupportedChannelResult;
+
+export type ApproveWithActivationResult =
+  | { ok: true; record: ApprovalRecord; activation?: ActivationDecision }
+  | { ok: false; error: 'already_decided'; status: ApprovalStatus }
+  | { ok: false; error: 'not_found' }
+  | { ok: false; error: 'unsupported_channel'; channel: string };
 
 function stateDbExists(workspaceDir: string): boolean {
   return fs.existsSync(path.join(workspaceDir, '.pd', 'state.db'));
@@ -58,6 +70,13 @@ export class ApprovalsConsoleModel {
       this.writeQueue = new ApprovalQueue(store);
     }
     return this.writeQueue;
+  }
+
+  private getWriteConnection(): SqliteConnection {
+    this.getWriteQueue();
+    const conn = this.writeConnection;
+    if (!conn) throw new Error('writeConnection not initialized');
+    return conn;
   }
 
   async listApprovals(filter?: ApprovalListFilter): Promise<ApprovalListResult> {
@@ -104,7 +123,7 @@ export class ApprovalsConsoleModel {
     };
   }
 
-  async approve(approvalId: string, decidedBy: string, note?: string): Promise<ChannelGuardedDecisionResult> {
+  async approve(approvalId: string, decidedBy: string, note?: string): Promise<ApproveWithActivationResult> {
     if (!stateDbExists(this.workspaceDir)) {
       return { ok: false, error: 'not_found' };
     }
@@ -113,7 +132,62 @@ export class ApprovalsConsoleModel {
     if (!MVP_PROVEN_CHANNELS.has(existing.channel)) {
       return { ok: false, error: 'unsupported_channel', channel: existing.channel };
     }
-    return this.getWriteQueue().approve(approvalId, decidedBy, note);
+    const approvalResult = await this.getWriteQueue().approve(approvalId, decidedBy, note);
+    if (!approvalResult.ok) {
+      if (approvalResult.error === 'already_decided') {
+        return { ok: false, error: 'already_decided', status: approvalResult.status };
+      }
+      return { ok: false, error: 'not_found' };
+    }
+
+    const activation = await this.dispatchActivationAfterApproval(existing, decidedBy);
+
+    return { ok: true, record: approvalResult.record, activation };
+  }
+
+  private async dispatchActivationAfterApproval(
+    existing: ApprovalRecord,
+    decidedBy: string,
+  ): Promise<ActivationDecision | undefined> {
+    try {
+      const conn = this.getWriteConnection();
+      const piArtifactStore = new SqlitePIArtifactStore(conn);
+      const artifactReadModel = {
+        getArtifactById: async (id: string): Promise<PIArtifactSnapshot | null> => {
+          const rec = await piArtifactStore.getArtifactById(id);
+          if (!rec) return null;
+          return {
+            artifactId: rec.artifactId,
+            artifactKind: rec.artifactKind,
+            sourceTaskId: rec.sourceTaskId,
+            sourcePrincipleId: rec.sourcePrincipleId,
+            sourceRuleId: rec.sourceRuleId,
+            lineageArtifactIds: rec.lineageArtifactIds,
+            validationStatus: rec.validationStatus,
+            contentJson: rec.contentJson,
+            createdAt: rec.createdAt,
+            updatedAt: rec.updatedAt,
+          };
+        },
+      };
+      const activationStateStore = new SqliteActivationStateStore(conn);
+      const approvalQueueStore = new SqliteApprovalQueueStore(conn);
+      const dispatcher = new ActivationDispatcher(
+        artifactReadModel,
+        activationStateStore,
+        { writers: [new PromptWriter(), new DeferArchiveWriter()], approvalQueueStore },
+      );
+      return await dispatcher.dispatch({
+        artifactId: existing.artifactId,
+        channel: existing.channel,
+        rolloutDecision: 'auto_activate',
+        actor: { kind: 'human', userId: decidedBy },
+        now: new Date().toISOString(),
+        confirm: true,
+      });
+    } catch {
+      return undefined;
+    }
   }
 
   async reject(approvalId: string, decidedBy: string, reason: string): Promise<ChannelGuardedDecisionResult> {

--- a/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
+++ b/packages/pd-console/src/server/models/ApprovalsConsoleModel.ts
@@ -185,8 +185,14 @@ export class ApprovalsConsoleModel {
         now: new Date().toISOString(),
         confirm: true,
       });
-    } catch {
-      return undefined;
+    } catch (dispatchErr) {
+      const dispatchMsg = dispatchErr instanceof Error ? dispatchErr.message : String(dispatchErr);
+      return {
+        decision: 'refused' as const,
+        reason: `activation_dispatch_failed: ${dispatchMsg}`,
+        channel: existing.channel,
+        riskLevel: 'low' as const,
+      };
     }
   }
 

--- a/packages/pd-console/src/server/routes/approvals.ts
+++ b/packages/pd-console/src/server/routes/approvals.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ApprovalStatus, InternalizationChannel } from '@principles/core/runtime-v2';
 import { MVP_CHANNELS } from '@principles/core/runtime-v2';
-import { ApprovalsConsoleModel } from '../models/ApprovalsConsoleModel.js';
+import { ApprovalsConsoleModel, type ApproveWithActivationResult } from '../models/ApprovalsConsoleModel.js';
 import { sendSuccess, sendError, sendNotFound, sendBadRequest } from '../utils/response.js';
 import { parseQuery, readBody } from '../utils/request.js';
 
@@ -121,7 +121,7 @@ export async function handleApprovalsRoute(
       }
 
       const note = typeof parsed.note === 'string' ? parsed.note : undefined;
-      const result = await model.approve(approvalId, 'operator', note);
+      const result: ApproveWithActivationResult = await model.approve(approvalId, 'operator', note);
       if (!result.ok) {
         if (result.error === 'not_found') {
           sendNotFound(res, 'Approval ' + approvalId + ' not found');
@@ -132,7 +132,7 @@ export async function handleApprovalsRoute(
         }
         return;
       }
-      sendSuccess(res, result.record);
+      sendSuccess(res, { record: result.record, activation: result.activation });
     } catch (err: unknown) {
       const message = getErrorMessage(err);
       if (message === 'Request body too large') {

--- a/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
@@ -13,6 +13,7 @@ import type { TaskRecord } from '../task-status.js';
 import { TestDoubleRuntimeAdapter } from '../adapter/test-double-runtime-adapter.js';
 
 const ARTIFICER_TASK_ID = 'artificer-001';
+const SCRIBE_TASK_ID = 'scribe-001';
 const EVALUATOR_TASK_ID = 'evaluator-001';
 
 function makeArtificerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
@@ -56,6 +57,46 @@ function makeEvaluatorTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
   };
 }
 
+function makeScribeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: SCRIBE_TASK_ID,
+    taskKind: 'scribe',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'scribe://run-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-scribe-001' }],
+    }),
+    ...overrides,
+  };
+}
+
+function makeScribeArtifact(): PIArtifactRecord {
+  return {
+    artifactId: 'pi-art-scribe-001',
+    artifactKind: 'principle',
+    sourceTaskId: SCRIBE_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify({
+      principleDraft: {
+        title: 'Always validate async input',
+        statement: 'Every async function must validate its input before processing.',
+      },
+      generatedAt: new Date().toISOString(),
+    }),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
 function makeEvaluatorOutput(): EvaluatorOutputV1 {
   return {
     taskId: EVALUATOR_TASK_ID,
@@ -70,6 +111,7 @@ function makeEvaluatorOutput(): EvaluatorOutputV1 {
     },
     sourceTrace: {
       artificerArtifactId: 'pi-art-artificer-001-run-001',
+      scribeArtifactId: 'pi-art-scribe-001',
     },
     risks: ['May need additional integration tests'],
     generatedAt: new Date().toISOString(),
@@ -111,11 +153,13 @@ describe('EvaluatorRunner (vertical slice)', () => {
     const evaluatorTask = makeEvaluatorTask();
     const artificerTask = makeArtificerTask();
 
+    const scribeTask = makeScribeTask();
     const stateManager = {
       acquireLease: vi.fn().mockResolvedValue(evaluatorTask),
       getTask: vi.fn().mockImplementation((id: string) => {
         if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorTask);
         if (id === ARTIFICER_TASK_ID) return Promise.resolve(artificerTask);
+        if (id === SCRIBE_TASK_ID) return Promise.resolve(scribeTask);
         return Promise.resolve(null);
       }),
       getRunsByTask: vi.fn().mockResolvedValue([{
@@ -247,6 +291,7 @@ describe('EvaluatorRunner (vertical slice)', () => {
   it('valid runtime output writes evaluator PIArtifact', async () => {
     const store = new MemoryPIArtifactStore();
     await store.upsertArtifact(makeArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
     const deps = createMockDeps({ artifactStore: store });
 
     const runner = new EvaluatorRunner(deps, {
@@ -268,6 +313,7 @@ describe('EvaluatorRunner (vertical slice)', () => {
   it('valid runtime output marks task succeeded', async () => {
     const store = new MemoryPIArtifactStore();
     await store.upsertArtifact(makeArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
     const deps = createMockDeps({ artifactStore: store });
 
     const runner = new EvaluatorRunner(deps, {
@@ -330,6 +376,7 @@ describe('EvaluatorRunner (vertical slice)', () => {
     const failingStore = {
       listBySourceTaskId: vi.fn().mockResolvedValue([makeArtificerArtifact()]),
       upsertArtifact: vi.fn().mockRejectedValue(new Error('Disk full')),
+      getArtifactById: vi.fn().mockResolvedValue(null),
     } as unknown as PIArtifactStore;
 
     const deps = createMockDeps({ artifactStore: failingStore });
@@ -344,6 +391,107 @@ describe('EvaluatorRunner (vertical slice)', () => {
     const result = await runner.run(EVALUATOR_TASK_ID);
     expect(result.status).toBe('failed');
     expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('approved evaluator validates scribe principle artifact, not artificer', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+
+    // Scribe artifact should be validated (it carries principleDraft)
+    const scribeArtifact = await store.getArtifactById('pi-art-scribe-001');
+    expect(scribeArtifact).not.toBeNull();
+    expect(scribeArtifact?.validationStatus).toBe('validated');
+
+    // Artificer artifact should remain pending (it's an implementation plan, not principle-bearing)
+    const artificerArtifact = await store.getArtifactById('pi-art-artificer-001-run-001');
+    expect(artificerArtifact).not.toBeNull();
+    expect(artificerArtifact?.validationStatus).toBe('pending');
+  });
+
+  it('missing scribe artifact emits evaluator_no_principle_bearer_found telemetry', async () => {
+    const store = new MemoryPIArtifactStore();
+    // Only artificer artifact — no scribe artifact in store
+    await store.upsertArtifact(makeArtificerArtifact());
+
+    // Output references a scribe artifact that doesn't exist
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = 'pi-art-nonexistent';
+
+    const deps = createMockDeps({ artifactStore: store });
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: output,
+    });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+
+    // Should have emitted telemetry about missing principle bearer
+    const events = (deps.eventEmitter.emitTelemetry as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call: unknown[]) => call[0] as { eventType: string; payload: Record<string, unknown> },
+    );
+    const noBearerEvent = events.find((e) => e.eventType === 'evaluator_no_principle_bearer_found');
+    expect(noBearerEvent).toBeDefined();
+    expect(noBearerEvent?.payload?.scribeArtifactId).toBe('pi-art-nonexistent');
+  });
+
+  it('updateValidationStatus returning false emits evaluator_source_validation_update_not_found', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
+
+    // Wrap store to make updateValidationStatus return false for the scribe artifact
+    const originalUpdate = store.updateValidationStatus.bind(store);
+    const spyStore = {
+      ...store,
+      updateValidationStatus: vi.fn().mockImplementation(async (id: string, status: 'validated' | 'pending') => {
+        if (id === 'pi-art-scribe-001') return false;
+        return originalUpdate(id, status);
+      }),
+      getArtifactById: store.getArtifactById.bind(store),
+      listBySourceTaskId: store.listBySourceTaskId.bind(store),
+      upsertArtifact: store.upsertArtifact.bind(store),
+      createArtifact: store.createArtifact.bind(store),
+      listLineage: store.listLineage.bind(store),
+    } as unknown as PIArtifactStore;
+
+    const deps = createMockDeps({ artifactStore: spyStore });
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+
+    const events = (deps.eventEmitter.emitTelemetry as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call: unknown[]) => call[0] as { eventType: string; payload: Record<string, unknown> },
+    );
+    const notFoundEvent = events.find((e) => e.eventType === 'evaluator_source_validation_update_not_found');
+    expect(notFoundEvent).toBeDefined();
+    expect(notFoundEvent?.payload?.sourceArtifactId).toBe('pi-art-scribe-001');
+    expect(notFoundEvent?.payload?.reason).toBe('principle_artifact_not_found_in_store');
   });
 
   it('mismatched sourceArtificerArtifactId does not write artifact or mark succeeded', async () => {
@@ -606,6 +754,7 @@ describe('EvaluatorRunner integration: test-double captures sourceArtificerArtif
       updatedAt: new Date().toISOString(),
     };
     await artifactStore.upsertArtifact(artificerArtifact);
+    await artifactStore.upsertArtifact(makeScribeArtifact());
 
     const evaluatorTask = makeEvaluatorTask();
 
@@ -642,6 +791,7 @@ describe('EvaluatorRunner integration: test-double captures sourceArtificerArtif
             },
             sourceTrace: {
               artificerArtifactId: capturedSourceArtificerArtifactId ?? ARTIFICER_ART_ID,
+              scribeArtifactId: 'pi-art-scribe-001',
             },
             risks: [],
             generatedAt: new Date().toISOString(),
@@ -654,6 +804,7 @@ describe('EvaluatorRunner integration: test-double captures sourceArtificerArtif
       getTask: vi.fn().mockImplementation((id: string) => {
         if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorTask);
         if (id === ARTIFICER_TASK_ID) return Promise.resolve(makeArtificerTask());
+        if (id === SCRIBE_TASK_ID) return Promise.resolve(makeScribeTask());
         return Promise.resolve(null);
       }),
       getRunsByTask: vi.fn().mockResolvedValue([{
@@ -705,5 +856,15 @@ describe('EvaluatorRunner integration: test-double captures sourceArtificerArtif
     const storedOutput = JSON.parse(storedArtifact.contentJson) as EvaluatorOutputV1;
     expect(storedOutput.sourceArtificerArtifactId).toBe(ARTIFICER_ART_ID);
     expect(storedOutput.sourceTrace.artificerArtifactId).toBe(ARTIFICER_ART_ID);
+
+    // Scribe artifact should be validated (principle bearer)
+    const validatedScribe = await artifactStore.getArtifactById('pi-art-scribe-001');
+    expect(validatedScribe).not.toBeNull();
+    expect(validatedScribe?.validationStatus).toBe('validated');
+
+    // Artificer artifact should remain pending
+    const pendingArtificer = await artifactStore.getArtifactById(ARTIFICER_ART_ID);
+    expect(pendingArtificer).not.toBeNull();
+    expect(pendingArtificer?.validationStatus).toBe('pending');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice.test.ts
@@ -494,6 +494,330 @@ describe('EvaluatorRunner (vertical slice)', () => {
     expect(notFoundEvent?.payload?.reason).toBe('principle_artifact_not_found_in_store');
   });
 
+  it('fallback lineage with 1 principle-bearing artifact validates it', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
+
+    // Output has no scribeArtifactId — forces fallback to lineage search
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = undefined;
+
+    // Evaluator must depend on both artificer and scribe tasks for lineage search
+    const evaluatorBothDeps = makeEvaluatorTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [ARTIFICER_TASK_ID, SCRIBE_TASK_ID],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const artificerTask = makeArtificerTask();
+    const scribeTask = makeScribeTask();
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(evaluatorBothDeps),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorBothDeps);
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(artificerTask);
+        if (id === SCRIBE_TASK_ID) return Promise.resolve(scribeTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-evaluator-001',
+        taskId: EVALUATOR_TASK_ID,
+        runtimeKind: 'evaluator',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = { emitTelemetry: vi.fn() } as unknown as StoreEventEmitter;
+
+    const deps: EvaluatorRunnerDeps = {
+      stateManager,
+      runtimeAdapter: {
+        startRun: vi.fn().mockResolvedValue({ runId: 'run-evaluator-001', runtimeKind: 'evaluator', startedAt: new Date().toISOString() }),
+        pollRun: vi.fn().mockResolvedValue({ status: 'succeeded', runId: 'run-evaluator-001' }),
+        fetchOutput: vi.fn().mockResolvedValue({ payload: output }),
+        cancelRun: vi.fn().mockResolvedValue(undefined),
+      } as unknown as PDRuntimeAdapter,
+      eventEmitter,
+      validator: new DefaultEvaluatorValidator(),
+      artifactStore: store,
+    };
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+
+    // Scribe artifact should be validated via lineage fallback
+    const scribeArtifact = await store.getArtifactById('pi-art-scribe-001');
+    expect(scribeArtifact).not.toBeNull();
+    expect(scribeArtifact?.validationStatus).toBe('validated');
+  });
+
+  it('fallback lineage with 2 principle-bearing artifacts emits ambiguity and validates none', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
+
+    // Add a second principle-bearing artifact from a different task
+    const SECOND_SCRIBE_TASK_ID = 'scribe-002';
+    const secondScribeArtifact: PIArtifactRecord = {
+      artifactId: 'pi-art-scribe-002',
+      artifactKind: 'principle',
+      sourceTaskId: SECOND_SCRIBE_TASK_ID,
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: JSON.stringify({
+        principleDraft: {
+          title: 'Always handle errors',
+          statement: 'Every function must handle errors gracefully.',
+        },
+        generatedAt: new Date().toISOString(),
+      }),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await store.upsertArtifact(secondScribeArtifact);
+
+    // Output has no scribeArtifactId — forces fallback to lineage search
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = undefined;
+
+    // Mock deps: evaluator depends on both artificer and second scribe task
+    const evaluatorTaskBothDeps = makeEvaluatorTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [ARTIFICER_TASK_ID, SCRIBE_TASK_ID, SECOND_SCRIBE_TASK_ID],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const artificerTask = makeArtificerTask();
+    const scribeTask = makeScribeTask();
+    const secondScribeTask: TaskRecord = {
+      taskId: SECOND_SCRIBE_TASK_ID,
+      taskKind: 'scribe',
+      status: 'succeeded',
+      attemptCount: 1,
+      maxAttempts: 3,
+      resultRef: 'scribe://run-002',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-scribe-002' }],
+      }),
+    };
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(evaluatorTaskBothDeps),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(evaluatorTaskBothDeps);
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(artificerTask);
+        if (id === SCRIBE_TASK_ID) return Promise.resolve(scribeTask);
+        if (id === SECOND_SCRIBE_TASK_ID) return Promise.resolve(secondScribeTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-evaluator-001',
+        taskId: EVALUATOR_TASK_ID,
+        runtimeKind: 'evaluator',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = { emitTelemetry: vi.fn() } as unknown as StoreEventEmitter;
+
+    const deps: EvaluatorRunnerDeps = {
+      stateManager,
+      runtimeAdapter: {
+        startRun: vi.fn().mockResolvedValue({ runId: 'run-evaluator-001', runtimeKind: 'evaluator', startedAt: new Date().toISOString() }),
+        pollRun: vi.fn().mockResolvedValue({ status: 'succeeded', runId: 'run-evaluator-001' }),
+        fetchOutput: vi.fn().mockResolvedValue({ payload: output }),
+        cancelRun: vi.fn().mockResolvedValue(undefined),
+      } as unknown as PDRuntimeAdapter,
+      eventEmitter,
+      validator: new DefaultEvaluatorValidator(),
+      artifactStore: store,
+    };
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+
+    // Ambiguity telemetry should be emitted
+    const events = (eventEmitter.emitTelemetry as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call: unknown[]) => call[0] as { eventType: string; payload: Record<string, unknown> },
+    );
+    const ambiguousEvent = events.find((e) => e.eventType === 'evaluator_principle_bearer_ambiguous');
+    expect(ambiguousEvent).toBeDefined();
+    expect(ambiguousEvent?.payload?.candidateArtifactIds).toEqual(
+      expect.arrayContaining(['pi-art-scribe-001', 'pi-art-scribe-002']),
+    );
+    expect(ambiguousEvent?.payload?.reason).toBe('multiple_principle_bearing_artifacts_in_lineage');
+
+    // Neither scribe artifact should be validated
+    const scribe1 = await store.getArtifactById('pi-art-scribe-001');
+    const scribe2 = await store.getArtifactById('pi-art-scribe-002');
+    expect(scribe1?.validationStatus).toBe('pending');
+    expect(scribe2?.validationStatus).toBe('pending');
+  });
+
+  it('hasPrincipleDraftContent rejects malformed JSON, array, null, and inherited properties', async () => {
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeArtificerArtifact());
+
+    // Artificer artifact has implementationPlan, not principleDraft — should NOT be treated as principle bearer
+    const artificerOnly = makeArtificerArtifact();
+    artificerOnly.contentJson = JSON.stringify({ implementationPlan: { summary: 'test' } });
+    await store.upsertArtifact(artificerOnly);
+
+    // Malformed: array
+    const arrayArtifact: PIArtifactRecord = {
+      artifactId: 'pi-art-array',
+      artifactKind: 'principle',
+      sourceTaskId: 'other-task',
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: '[1, 2, 3]',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await store.upsertArtifact(arrayArtifact);
+
+    // Malformed: null
+    const nullArtifact: PIArtifactRecord = {
+      artifactId: 'pi-art-null',
+      artifactKind: 'principle',
+      sourceTaskId: 'other-task-2',
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: 'null',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await store.upsertArtifact(nullArtifact);
+
+    // Malformed: inherited property (toString as principleDraft)
+    const inheritedArtifact: PIArtifactRecord = {
+      artifactId: 'pi-art-inherited',
+      artifactKind: 'principle',
+      sourceTaskId: 'other-task-3',
+      lineageArtifactIds: [],
+      validationStatus: 'pending',
+      contentJson: JSON.stringify({ toString: 'not-a-draft' }),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await store.upsertArtifact(inheritedArtifact);
+
+    // Output has no scribeArtifactId — forces lineage fallback
+    const output = makeEvaluatorOutput();
+    (output.sourceTrace as unknown as Record<string, unknown>).scribeArtifactId = undefined;
+
+    // Evaluator depends on all the tasks above
+    const allDepsTask = makeEvaluatorTask({
+      diagnosticJson: createPITaskDiagnosticJson({
+        dependencyTaskIds: [ARTIFICER_TASK_ID, 'other-task', 'other-task-2', 'other-task-3'],
+        channel: 'prompt',
+        timeoutMs: 300_000,
+        inputArtifactRefs: [],
+        outputArtifactRefs: [],
+      }),
+    });
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(allDepsTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === EVALUATOR_TASK_ID) return Promise.resolve(allDepsTask);
+        if (id === ARTIFICER_TASK_ID) return Promise.resolve(makeArtificerTask());
+        return Promise.resolve(makeScribeTask({ taskId: id }));
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-evaluator-001',
+        taskId: EVALUATOR_TASK_ID,
+        runtimeKind: 'evaluator',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const eventEmitter = { emitTelemetry: vi.fn() } as unknown as StoreEventEmitter;
+
+    const deps: EvaluatorRunnerDeps = {
+      stateManager,
+      runtimeAdapter: {
+        startRun: vi.fn().mockResolvedValue({ runId: 'run-evaluator-001', runtimeKind: 'evaluator', startedAt: new Date().toISOString() }),
+        pollRun: vi.fn().mockResolvedValue({ status: 'succeeded', runId: 'run-evaluator-001' }),
+        fetchOutput: vi.fn().mockResolvedValue({ payload: output }),
+        cancelRun: vi.fn().mockResolvedValue(undefined),
+      } as unknown as PDRuntimeAdapter,
+      eventEmitter,
+      validator: new DefaultEvaluatorValidator(),
+      artifactStore: store,
+    };
+
+    const runner = new EvaluatorRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'evaluator',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(EVALUATOR_TASK_ID);
+    expect(result.status).toBe('succeeded');
+
+    // No artifact should be validated — none have valid principleDraft content
+    const events = (eventEmitter.emitTelemetry as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call: unknown[]) => call[0] as { eventType: string; payload: Record<string, unknown> },
+    );
+    const noBearerEvent = events.find((e) => e.eventType === 'evaluator_no_principle_bearer_found');
+    expect(noBearerEvent).toBeDefined();
+
+    // All artifacts should remain pending
+    const arr = await store.getArtifactById('pi-art-array');
+    const nil = await store.getArtifactById('pi-art-null');
+    const inh = await store.getArtifactById('pi-art-inherited');
+    expect(arr?.validationStatus).toBe('pending');
+    expect(nil?.validationStatus).toBe('pending');
+    expect(inh?.validationStatus).toBe('pending');
+  });
+
   it('mismatched sourceArtificerArtifactId does not write artifact or mark succeeded', async () => {
     const store = new MemoryPIArtifactStore();
     await store.upsertArtifact(makeArtificerArtifact());

--- a/packages/principles-core/src/runtime-v2/activation/low-risk-writers.ts
+++ b/packages/principles-core/src/runtime-v2/activation/low-risk-writers.ts
@@ -10,7 +10,8 @@ function extractPrincipleId(artifact: PIArtifactSnapshot): string | null {
     if (sourceId !== '') return sourceId;
   }
   try {
-    const parsed = JSON.parse(artifact.contentJson) as Record<string, unknown>;
+    const parsed = JSON.parse(artifact.contentJson);
+    if (!isRecord(parsed)) return null;
     if (typeof parsed.principleId === 'string' && parsed.principleId.trim() !== '') {
       return parsed.principleId.trim();
     }

--- a/packages/principles-core/src/runtime-v2/activation/low-risk-writers.ts
+++ b/packages/principles-core/src/runtime-v2/activation/low-risk-writers.ts
@@ -1,5 +1,9 @@
 import type { PIArtifactSnapshot, CanActivateResult, ChannelWriter, WriterInput, WriterResult } from './activation-types.js';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function extractPrincipleId(artifact: PIArtifactSnapshot): string | null {
   if (typeof artifact.sourcePrincipleId === 'string') {
     const sourceId = artifact.sourcePrincipleId.trim();
@@ -12,6 +16,12 @@ function extractPrincipleId(artifact: PIArtifactSnapshot): string | null {
     }
     if (typeof parsed.sourcePrincipleId === 'string' && parsed.sourcePrincipleId.trim() !== '') {
       return parsed.sourcePrincipleId.trim();
+    }
+    if (isRecord(parsed.principleDraft)) {
+      const draft = parsed.principleDraft;
+      if (typeof draft.title === 'string' && draft.title.trim() !== '') {
+        return draft.title.trim();
+      }
     }
   } catch {
     return null;

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -827,6 +827,7 @@ export type {
 
 export type { PIArtifactRecord, PIArtifactStore } from './internalization/pi-artifact.js';
 export { MemoryPIArtifactStore } from './internalization/pi-artifact-store.js';
+export { SqlitePIArtifactStore } from './store/artifact/sqlite-pi-artifact-store.js';
 
 // ── Intake To Internalization Bridge (PRI-142) ────────────────────────────────
 

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/queue-actionability.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/queue-actionability.test.ts
@@ -79,14 +79,12 @@ describe('classifyTaskActionability', () => {
     expect(result.actionable).toBe(true);
   });
 
-  it('suppresses evaluator task with task_kind_not_mvp_actionable reason', () => {
+  it('classifies enabled-channel MVP-Core evaluator as actionable', () => {
     const result = classifyTaskActionability(
       { taskId: 'eval-abc-prompt', taskKind: 'evaluator', channel: 'prompt' },
       defaultPolicy,
     );
-    expect(result.actionable).toBe(false);
-    if (result.actionable) throw new Error('expected not actionable');
-    expect(result.reason).toBe('task_kind_not_mvp_actionable');
+    expect(result.actionable).toBe(true);
   });
 
   it('suppresses trainer task with task_kind_not_mvp_actionable reason', () => {
@@ -124,15 +122,15 @@ describe('classifyTaskActionability', () => {
 });
 
 describe('MVP_CORE_TASK_KINDS constant', () => {
-  it('includes dreamer, philosopher, scribe, artificer', () => {
+  it('includes dreamer, philosopher, scribe, artificer, evaluator', () => {
     expect(MVP_CORE_TASK_KINDS).toContain('dreamer');
     expect(MVP_CORE_TASK_KINDS).toContain('philosopher');
     expect(MVP_CORE_TASK_KINDS).toContain('scribe');
     expect(MVP_CORE_TASK_KINDS).toContain('artificer');
+    expect(MVP_CORE_TASK_KINDS).toContain('evaluator');
   });
 
   it('does not include post-MVP runners', () => {
-    expect(MVP_CORE_TASK_KINDS).not.toContain('evaluator');
     expect(MVP_CORE_TASK_KINDS).not.toContain('rollout_reviewer');
     expect(MVP_CORE_TASK_KINDS).not.toContain('trainer');
   });

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -437,18 +437,29 @@ export class EvaluatorRunner {
 
     const resultRef = `evaluator://${ctx.runId}`;
 
-    if (ctx.output.evaluation.decision === 'approved' && ctx.output.sourceArtificerArtifactId) {
-      try {
-        await this.artifactStore.updateValidationStatus(
-          ctx.output.sourceArtificerArtifactId,
-          'validated',
-        );
-      } catch (updateErr) {
-        this.emitEvaluatorEvent('evaluator_source_validation_update_failed', ctx.taskId, {
-          runId: ctx.runId,
-          sourceArtifactId: ctx.output.sourceArtificerArtifactId,
-          errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
-        });
+    if (ctx.output.evaluation.decision === 'approved') {
+      const principleArtifactId = await this.resolvePrincipleBearerArtifact(ctx.output, ctx.taskId);
+      if (principleArtifactId) {
+        try {
+          const updated = await this.artifactStore.updateValidationStatus(
+            principleArtifactId,
+            'validated',
+          );
+          if (!updated) {
+            this.emitEvaluatorEvent('evaluator_source_validation_update_not_found', ctx.taskId, {
+              runId: ctx.runId,
+              sourceArtifactId: principleArtifactId,
+              reason: 'principle_artifact_not_found_in_store',
+              nextAction: 'verify_artifact_lineage_and_store_consistency',
+            });
+          }
+        } catch (updateErr) {
+          this.emitEvaluatorEvent('evaluator_source_validation_update_failed', ctx.taskId, {
+            runId: ctx.runId,
+            sourceArtifactId: principleArtifactId,
+            errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
+          });
+        }
       }
     }
 
@@ -690,6 +701,97 @@ export class EvaluatorRunner {
       case 'timed_out': return 'timeout';
       case 'cancelled': return 'cancelled';
       default: return 'execution_failed';
+    }
+  }
+
+  private async resolvePrincipleBearerArtifact(
+    output: EvaluatorOutputV1,
+    taskId: string,
+  ): Promise<string | null> {
+    // Strategy 1: Use scribeArtifactId from sourceTrace (the Scribe artifact carries principleDraft)
+    const scribeArtifactId = output.sourceTrace?.scribeArtifactId;
+    if (typeof scribeArtifactId === 'string' && scribeArtifactId.trim() !== '') {
+      const scribeArtifact = await this.artifactStore.getArtifactById(scribeArtifactId);
+      if (scribeArtifact && scribeArtifact.artifactKind === 'principle') {
+        return scribeArtifactId;
+      }
+      // Scribe artifact not found or wrong kind — fall through to lineage search
+      this.emitEvaluatorEvent('evaluator_scribe_artifact_not_principle', taskId, {
+        scribeArtifactId,
+        actualKind: scribeArtifact?.artifactKind ?? 'not_found',
+      });
+    }
+
+    // Strategy 2: Search lineage for a principle-kind artifact with principleDraft content
+    const lineageArtifactIds = await this.resolveLineageArtifactIds(taskId);
+    for (const lineageId of lineageArtifactIds) {
+      const artifact = await this.artifactStore.getArtifactById(lineageId);
+      if (!artifact) continue;
+      if (artifact.artifactKind !== 'principle') continue;
+      if (this.hasPrincipleDraftContent(artifact.contentJson)) {
+        return lineageId;
+      }
+    }
+
+    // Strategy 3: Fallback — no principle-bearing artifact found
+    this.emitEvaluatorEvent('evaluator_no_principle_bearer_found', taskId, {
+      runId: output.taskId,
+      scribeArtifactId: scribeArtifactId ?? 'not_provided',
+      lineageCount: lineageArtifactIds.length,
+      reason: 'no_principle_bearing_artifact_in_lineage',
+      nextAction: 'verify_scribe_artifact_exists_and_has_principle_draft',
+    });
+    return null;
+  }
+
+  private async resolveLineageArtifactIds(taskId: string): Promise<string[]> {
+    try {
+      const task = await this.stateManager.getTask(taskId);
+      if (!task) return [];
+      const piTask = hydratePITaskRecord(task);
+      const deps = piTask?.dependencyTaskIds ?? [];
+      const results = await Promise.allSettled(
+        deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+      );
+      const ids: string[] = [];
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          for (const artifact of result.value) {
+            ids.push(artifact.artifactId);
+          }
+        }
+      }
+      return ids;
+    } catch {
+      return [];
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private hasPrincipleDraftContent(contentJson: string): boolean {
+    try {
+      const parsed: unknown = JSON.parse(contentJson);
+      if (typeof parsed !== 'object' || parsed === null) return false;
+      const record = parsed as Record<string, unknown>;
+      // Check for principleDraft.title + principleDraft.statement
+      if (Object.hasOwn(record, 'principleDraft')) {
+        const draft = record.principleDraft;
+        if (typeof draft === 'object' && draft !== null) {
+          const draftRecord = draft as Record<string, unknown>;
+          if (Object.hasOwn(draftRecord, 'title') && typeof draftRecord.title === 'string' && draftRecord.title.trim() !== ''
+            && Object.hasOwn(draftRecord, 'statement') && typeof draftRecord.statement === 'string' && draftRecord.statement.trim() !== '') {
+            return true;
+          }
+        }
+      }
+      // Check for principleId + text (alternative principle format)
+      if (Object.hasOwn(record, 'principleId') && typeof record.principleId === 'string' && record.principleId.trim() !== ''
+        && Object.hasOwn(record, 'text') && typeof record.text === 'string' && record.text.trim() !== '') {
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -722,15 +722,30 @@ export class EvaluatorRunner {
       });
     }
 
-    // Strategy 2: Search lineage for a principle-kind artifact with principleDraft content
+    // Strategy 2: Search lineage for all principle-kind artifacts with principleDraft content
     const lineageArtifactIds = await this.resolveLineageArtifactIds(taskId);
+    const candidates: string[] = [];
     for (const lineageId of lineageArtifactIds) {
       const artifact = await this.artifactStore.getArtifactById(lineageId);
       if (!artifact) continue;
       if (artifact.artifactKind !== 'principle') continue;
       if (this.hasPrincipleDraftContent(artifact.contentJson)) {
-        return lineageId;
+        candidates.push(lineageId);
       }
+    }
+
+    if (candidates.length === 1) {
+      const [only] = candidates;
+      return only ?? null;
+    }
+
+    if (candidates.length > 1) {
+      this.emitEvaluatorEvent('evaluator_principle_bearer_ambiguous', taskId, {
+        candidateArtifactIds: candidates,
+        reason: 'multiple_principle_bearing_artifacts_in_lineage',
+        nextAction: 'disambiguate_principle_source_or_fix_lineage',
+      });
+      return null;
     }
 
     // Strategy 3: Fallback — no principle-bearing artifact found
@@ -771,28 +786,29 @@ export class EvaluatorRunner {
   private hasPrincipleDraftContent(contentJson: string): boolean {
     try {
       const parsed: unknown = JSON.parse(contentJson);
-      if (typeof parsed !== 'object' || parsed === null) return false;
-      const record = parsed as Record<string, unknown>;
+      if (!EvaluatorRunner.isRecord(parsed)) return false;
       // Check for principleDraft.title + principleDraft.statement
-      if (Object.hasOwn(record, 'principleDraft')) {
-        const draft = record.principleDraft;
-        if (typeof draft === 'object' && draft !== null) {
-          const draftRecord = draft as Record<string, unknown>;
-          if (Object.hasOwn(draftRecord, 'title') && typeof draftRecord.title === 'string' && draftRecord.title.trim() !== ''
-            && Object.hasOwn(draftRecord, 'statement') && typeof draftRecord.statement === 'string' && draftRecord.statement.trim() !== '') {
-            return true;
-          }
+      if (Object.hasOwn(parsed, 'principleDraft')) {
+        const draft = parsed.principleDraft;
+        if (EvaluatorRunner.isRecord(draft)
+          && Object.hasOwn(draft, 'title') && typeof draft.title === 'string' && draft.title.trim() !== ''
+          && Object.hasOwn(draft, 'statement') && typeof draft.statement === 'string' && draft.statement.trim() !== '') {
+          return true;
         }
       }
       // Check for principleId + text (alternative principle format)
-      if (Object.hasOwn(record, 'principleId') && typeof record.principleId === 'string' && record.principleId.trim() !== ''
-        && Object.hasOwn(record, 'text') && typeof record.text === 'string' && record.text.trim() !== '') {
+      if (Object.hasOwn(parsed, 'principleId') && typeof parsed.principleId === 'string' && parsed.principleId.trim() !== ''
+        && Object.hasOwn(parsed, 'text') && typeof parsed.text === 'string' && parsed.text.trim() !== '') {
         return true;
       }
       return false;
     } catch {
       return false;
     }
+  }
+
+  private static isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
   }
 
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -436,6 +436,22 @@ export class EvaluatorRunner {
     }
 
     const resultRef = `evaluator://${ctx.runId}`;
+
+    if (ctx.output.evaluation.decision === 'approved' && ctx.output.sourceArtificerArtifactId) {
+      try {
+        await this.artifactStore.updateValidationStatus(
+          ctx.output.sourceArtificerArtifactId,
+          'validated',
+        );
+      } catch (updateErr) {
+        this.emitEvaluatorEvent('evaluator_source_validation_update_failed', ctx.taskId, {
+          runId: ctx.runId,
+          sourceArtifactId: ctx.output.sourceArtificerArtifactId,
+          errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
+        });
+      }
+    }
+
     try {
       await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
     } catch (stateErr) {

--- a/packages/principles-core/src/runtime-v2/internalization/pi-artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pi-artifact-store.ts
@@ -68,4 +68,11 @@ export class MemoryPIArtifactStore implements PIArtifactStore {
     }
     return results;
   }
+
+  async updateValidationStatus(artifactId: string, validationStatus: PIArtifactRecord['validationStatus']): Promise<boolean> {
+    const existing = this.artifacts.get(artifactId);
+    if (!existing) return false;
+    this.artifacts.set(artifactId, { ...existing, validationStatus, updatedAt: new Date().toISOString() });
+    return true;
+  }
 }

--- a/packages/principles-core/src/runtime-v2/internalization/pi-artifact.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pi-artifact.ts
@@ -21,4 +21,5 @@ export interface PIArtifactStore {
   getArtifactById(artifactId: string): Promise<PIArtifactRecord | null>;
   listBySourceTaskId(sourceTaskId: string): Promise<PIArtifactRecord[]>;
   listLineage(artifactId: string): Promise<PIArtifactRecord[]>;
+  updateValidationStatus(artifactId: string, validationStatus: PIArtifactValidationStatus): Promise<boolean>;
 }

--- a/packages/principles-core/src/runtime-v2/internalization/queue-actionability.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/queue-actionability.ts
@@ -19,6 +19,7 @@ export const MVP_CORE_TASK_KINDS: readonly PeerRunnerKind[] = [
   'philosopher',
   'scribe',
   'artificer',
+  'evaluator',
 ] as const;
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/store/artifact/sqlite-pi-artifact-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/artifact/sqlite-pi-artifact-store.ts
@@ -127,4 +127,14 @@ export class SqlitePIArtifactStore implements PIArtifactStore {
     `).all(...artifact.lineageArtifactIds) as PiArtifactRow[];
     return rows.map(rowToRecord);
   }
+
+  async updateValidationStatus(artifactId: string, validationStatus: PIArtifactRecord['validationStatus']): Promise<boolean> {
+    const db = this.connection.getDb();
+    const now = new Date().toISOString();
+    const result = db.prepare(`
+      UPDATE pi_artifacts SET validation_status = ?, updated_at = ?
+      WHERE artifact_id = ?
+    `).run(validationStatus, now, artifactId);
+    return result.changes > 0;
+  }
 }


### PR DESCRIPTION
## Summary

Fix 4 MVP acceptance issues found during Phase 4 verification that prevented the approval-to-activation-to-prompt-injection pipeline from working end-to-end.

## Issues Fixed

### PRI-262: CLI `pd runtime activation dispatch` returns `refused` for approval-path artifacts
- **Root cause**: `ActivationDispatcher` constructed without `approvalQueueStore`, so `requires_approval` path always returned `refused`
- **Fix**: Added `SqliteApprovalQueueStore` import and construction, passed to dispatcher config
- **File**: `packages/pd-cli/src/commands/runtime-activation.ts`

### PRI-263: Console approve does not auto-dispatch activation
- **Root cause**: `ApprovalsConsoleModel.approve()` only updated approval status, never triggered activation dispatch
- **Fix**: New `dispatchActivationAfterApproval()` private method constructs `ActivationDispatcher` and calls `dispatch()` after approval succeeds. API response now includes `activation` decision.
- **Files**: `packages/pd-console/src/server/models/ApprovalsConsoleModel.ts`, `packages/pd-console/src/server/routes/approvals.ts`

### PRI-264: PromptActivationReader content_json schema mismatch
- **Root cause**: Internalization pipeline produces `principleDraft.title/statement`, but read path expects `principleId/text`
- **Fix**: Added fallback parsing in both `resolvePrincipleFromActivation()` and `extractPrincipleId()` to read from `principleDraft` when top-level fields are absent
- **Files**: `packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts`, `packages/principles-core/src/runtime-v2/activation/low-risk-writers.ts`

### PRI-265: Evaluator suppressed as `task_kind_not_mvp_actionable`
- **Root cause**: `evaluator` not in `MVP_CORE_TASK_KINDS`, so evaluator tasks were suppressed and artifacts stayed at `pending` validation status
- **Fix**: Added `evaluator` to `MVP_CORE_TASK_KINDS`. Added `updateValidationStatus()` to `PIArtifactStore` interface and both implementations. Evaluator runner now updates source artifact to `validated` on approved evaluation decisions.
- **Files**: `queue-actionability.ts`, `evaluator-runner.ts`, `pi-artifact.ts`, `pi-artifact-store.ts`, `sqlite-pi-artifact-store.ts`

## ERR Checklist
- ERR-001: No `as` bypass - all runtime validation uses typeof/Object.hasOwn
- ERR-005: Array element validation - isRecord() type guard used before accessing principleDraft
- ERR-009: Fail loud on missing fields - warning messages include artifactId and nextAction
- ERR-013: Object.hasOwn for untrusted keys - used consistently in resolvePrincipleFromActivation
- ERR-002: Graceful degradation with reason - dispatchActivationAfterApproval catches errors and returns undefined with approval still succeeding

## Tests Run
- `cd packages/principles-core && npm run test` - 161/163 pass (2 Real LLM E2E failures unrelated to this change)
- `cd packages/openclaw-plugin && npm run test` - 138/138 pass
- `npm run lint` - pass
- `npm run verify:merge` - pass (pre-push hook)

## Remaining Risk
- `rollout_reviewer` remains outside MVP_CORE_TASK_KINDS (intentional - post-MVP)
- Console activation dispatch failure is silently swallowed (approval still succeeds) - could add telemetry in follow-up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 审批流程在通过后可触发自动激活调度，API 返回包含激活结果。
  * 评估器任务列为可操作任务，评估通过可触发源工件的验证标记更新。
  * 新增工件验证状态更新能力（可将工件标记为已验证/未验证）。

* **改进**
  * 版本更新至 1.10.41，若激活调度失败会返回明确拒绝原因以便诊断。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->