### PR TITLE
fix(installer): prevent openclaw.json corruption and unify install paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "principles-disciple-monorepo",
-  "version": "1.10.37",
+  "version": "1.10.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "principles-disciple-monorepo",
-      "version": "1.10.37",
+      "version": "1.10.41",
       "workspaces": [
         "packages/*"
       ],
@@ -1987,7 +1987,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2004,7 +2003,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2021,7 +2019,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2038,7 +2035,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2055,7 +2051,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2072,7 +2067,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2089,7 +2083,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2106,7 +2099,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2123,7 +2115,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2140,7 +2131,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2157,7 +2147,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2174,7 +2163,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2191,7 +2179,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2208,7 +2195,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2225,7 +2211,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2242,7 +2227,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2259,7 +2243,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2276,7 +2259,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2293,7 +2275,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2310,7 +2291,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2327,7 +2307,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2344,7 +2323,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2361,7 +2339,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2378,7 +2355,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2395,7 +2371,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2412,7 +2387,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4899,7 +4873,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4916,7 +4889,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4933,7 +4905,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4950,7 +4921,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4967,7 +4937,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4984,7 +4953,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5001,7 +4969,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5018,7 +4985,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5035,7 +5001,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5052,7 +5017,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5069,7 +5033,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5086,7 +5049,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5100,7 +5062,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -5122,7 +5083,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5139,7 +5099,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18053,7 +18012,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18070,7 +18028,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18087,7 +18044,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18104,7 +18060,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18121,7 +18076,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18138,7 +18092,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18155,7 +18108,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18172,7 +18124,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18189,7 +18140,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18206,7 +18156,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18223,7 +18172,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18240,7 +18188,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18257,7 +18204,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18274,7 +18220,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18291,7 +18236,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18308,7 +18252,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18325,7 +18268,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18342,7 +18284,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18359,7 +18300,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18376,7 +18316,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18393,7 +18332,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18410,7 +18348,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18427,7 +18364,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18444,7 +18380,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18461,7 +18396,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18478,7 +18412,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20027,7 +19960,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "principles-disciple",
-      "version": "1.10.40",
+      "version": "1.10.41",
       "license": "MIT",
       "dependencies": {
         "@principles/core": "^0.1.0",

--- a/packages/create-principles-disciple/src/installer.ts
+++ b/packages/create-principles-disciple/src/installer.ts
@@ -252,7 +252,6 @@ async function installPluginToStaging(pluginDir: string): Promise<void> {
 async function updateOpenClawConfig(): Promise<void> {
   const configDir = getOpenClawDir();
   const configPath = path.join(configDir, 'openclaw.json');
-  const extDir = getPluginExtDir();
 
   if (!existsSync(configPath)) return;
 
@@ -289,23 +288,60 @@ async function updateOpenClawConfig(): Promise<void> {
     throw new Error('openclaw.json plugins.entries is malformed. Fix manually and re-run installer.');
   }
   const entries = { ...(plugins.entries as Record<string, unknown>) };
-  entries['principles-disciple'] = { enabled: true };
+  // Merge with existing config — preserve hooks, config, and other user settings
+  const existingEntry = (typeof entries['principles-disciple'] === 'object' && entries['principles-disciple'] !== null && !Array.isArray(entries['principles-disciple']))
+    ? { ...(entries['principles-disciple'] as Record<string, unknown>) }
+    : {};
+  entries['principles-disciple'] = { ...existingEntry, enabled: true };
   plugins.entries = entries;
 
-  if (!plugins.installs) plugins.installs = {};
-  if (typeof plugins.installs !== 'object' || plugins.installs === null || Array.isArray(plugins.installs)) {
-    throw new Error('openclaw.json plugins.installs is malformed. Fix manually and re-run installer.');
-  }
-  const installs = { ...(plugins.installs as Record<string, unknown>) };
-  installs['principles-disciple'] = {
-    source: 'path',
-    installPath: extDir,
-    installedAt: new Date().toISOString(),
-  };
-  plugins.installs = installs;
+  // Do NOT write plugins.installs — OpenClaw manages install records in
+  // ~/.openclaw/plugins/installs.json and strips plugins.installs from
+  // openclaw.json on every write. Writing it here causes duplicate
+  // registration and config corruption loops.
 
   configObj.plugins = plugins;
   writeFileSync(configPath, JSON.stringify(configObj, null, 2));
+
+  // Write install record to installs.json (the canonical store)
+  const installsDir = path.join(configDir, 'plugins');
+  const installsPath = path.join(installsDir, 'installs.json');
+  try {
+    if (!existsSync(installsDir)) {
+      mkdirSync(installsDir, { recursive: true });
+    }
+    let installs: Record<string, unknown> = { version: 1, installRecords: {} };
+    if (existsSync(installsPath)) {
+      const raw = readFileSync(installsPath, 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        installs = parsed as Record<string, unknown>;
+      }
+    }
+    if (!installs.installRecords || typeof installs.installRecords !== 'object') {
+      installs.installRecords = {};
+    }
+    const extDir = getPluginExtDir();
+    const pkgPath = path.join(extDir, 'package.json');
+    let version: string | undefined = undefined;
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg: unknown = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        if (typeof pkg === 'object' && pkg !== null && 'version' in (pkg as Record<string, unknown>)) {
+          version = (pkg as Record<string, unknown>).version as string;
+        }
+      } catch { /* ignore */ }
+    }
+    (installs.installRecords as Record<string, unknown>)['principles-disciple'] = {
+      source: 'path',
+      installPath: extDir,
+      ...(version ? { version } : {}),
+      installedAt: new Date().toISOString(),
+    };
+    writeFileSync(installsPath, JSON.stringify(installs, null, 2));
+  } catch {
+    // Non-fatal — installs.json is managed by OpenClaw and will self-heal
+  }
 }
 
 async function installPluginDependencies(): Promise<void> {
@@ -522,6 +558,8 @@ async function installConsoleDependencies(): Promise<void> {
   await rebuildNativeModules(consoleDest, 'Console');
 }
 
+const CONSOLE_PORT_MAX_RETRIES = 3;
+
 async function verifyConsole(workspaceDir: string): Promise<{ ok: boolean; url: string; process: ChildProcess | null; reason?: string }> {
   const consoleDest = getInstalledConsoleDir();
   const serverEntry = path.join(consoleDest, 'dist', 'server.js');
@@ -530,82 +568,97 @@ async function verifyConsole(workspaceDir: string): Promise<{ ok: boolean; url: 
     return { ok: false, url: '', process: null, reason: 'Console server entry not found' };
   }
 
-  const port = CONSOLE_PORT_RANGE_MIN + Math.floor(Math.random() * (CONSOLE_PORT_RANGE_MAX - CONSOLE_PORT_RANGE_MIN + 1));
-  const child = spawn(process.execPath, [serverEntry, '--workspace', workspaceDir, '--port', String(port), '--no-auth', '--host', '127.0.0.1'], {
-    stdio: 'pipe',
-    env: { ...process.env },
-    detached: false,
-  });
-
-  let childExited = false;
-  let childExitCode: number | null = null;
-  let childStderr = '';
-  let childStdout = '';
-  child.on('exit', (code) => {
-    childExited = true;
-    childExitCode = code;
-  });
-  child.stderr?.on('data', (chunk: Buffer) => {
-    childStderr += chunk.toString();
-  });
-  child.stdout?.on('data', (chunk: Buffer) => {
-    childStdout += chunk.toString();
-  });
-
-  await new Promise<void>((resolve) => { setTimeout(resolve, CONSOLE_WARMUP_TIME_MS); });
-
-  if (childExited) {
-    const stderrHint = childStderr.slice(0, 500);
-    return { ok: false, url: '', process: null, reason: `Console process exited prematurely with code ${childExitCode}. Stderr: ${stderrHint}` };
+  // Build a shuffled port list to avoid retrying the same port
+  const portRange: number[] = [];
+  for (let p = CONSOLE_PORT_RANGE_MIN; p <= CONSOLE_PORT_RANGE_MAX; p++) portRange.push(p);
+  for (let i = portRange.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [portRange[i], portRange[j]] = [portRange[j], portRange[i]];
   }
+  const portsToTry = portRange.slice(0, CONSOLE_PORT_MAX_RETRIES);
 
-  const url = `http://127.0.0.1:${port}`;
-  let ok = false;
-  let reason = '';
-  try {
-    const result = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
-      const req = http.get(`${url}/api/health`, (res) => {
-        const chunks: Buffer[] = [];
-        res.on('data', (chunk: Buffer) => chunks.push(chunk));
-        res.on('end', () => {
-          resolve({ statusCode: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() });
-        });
-      });
-      req.on('error', reject);
-      req.setTimeout(CONSOLE_HEALTH_CHECK_TIMEOUT_MS, () => { req.destroy(); reject(new Error('health check timeout')); });
+  let lastReason = '';
+
+  for (const port of portsToTry) {
+    const child = spawn(process.execPath, [serverEntry, '--workspace', workspaceDir, '--port', String(port), '--no-auth', '--host', '127.0.0.1'], {
+      stdio: 'pipe',
+      env: { ...process.env },
+      detached: false,
     });
 
-    if (result.statusCode !== 200) {
-      reason = `Console /api/health returned HTTP ${result.statusCode} (expected 200)`;
-    } else if (!result.body || result.body.trim().length === 0) {
-      reason = 'Console /api/health returned empty body';
-    } else {
-      try {
-        const parsed: unknown = JSON.parse(result.body);
-        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-          reason = 'Console /api/health returned non-object JSON';
-        } else {
-          ok = true;
-        }
-      } catch {
-        reason = 'Console /api/health returned malformed JSON';
-      }
+    let childExited = false;
+    let childExitCode: number | null = null;
+    let childStderr = '';
+    let childStdout = '';
+    child.on('exit', (code) => {
+      childExited = true;
+      childExitCode = code;
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      childStderr += chunk.toString();
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      childStdout += chunk.toString();
+    });
+
+    await new Promise<void>((resolve) => { setTimeout(resolve, CONSOLE_WARMUP_TIME_MS); });
+
+    if (childExited) {
+      lastReason = `Console process exited prematurely with code ${childExitCode} on port ${port}. Stderr: ${childStderr.slice(0, 500)}`;
+      continue; // Try next port
     }
-  } catch (e) {
-    reason = `Console health check failed: ${e instanceof Error ? e.message : String(e)}. Stderr: ${childStderr.slice(0, 300)}. Stdout: ${childStdout.slice(0, 300)}`;
-  }
 
-  if (!ok) {
-    try { child.kill('SIGTERM'); } catch { /* ignore */ }
+    const url = `http://127.0.0.1:${port}`;
+    let ok = false;
+    let reason = '';
     try {
-      if (!childExited) {
-        child.kill('SIGKILL');
+      const result = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+        const req = http.get(`${url}/api/health`, (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            resolve({ statusCode: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() });
+          });
+        });
+        req.on('error', reject);
+        req.setTimeout(CONSOLE_HEALTH_CHECK_TIMEOUT_MS, () => { req.destroy(); reject(new Error('health check timeout')); });
+      });
+
+      if (result.statusCode !== 200) {
+        reason = `Console /api/health returned HTTP ${result.statusCode} (expected 200)`;
+      } else if (!result.body || result.body.trim().length === 0) {
+        reason = 'Console /api/health returned empty body';
+      } else {
+        try {
+          const parsed: unknown = JSON.parse(result.body);
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            reason = 'Console /api/health returned non-object JSON';
+          } else {
+            ok = true;
+          }
+        } catch {
+          reason = 'Console /api/health returned malformed JSON';
+        }
       }
-    } catch { /* ignore */ }
-    return { ok: false, url, process: null, reason };
+    } catch (e) {
+      reason = `Console health check failed on port ${port}: ${e instanceof Error ? e.message : String(e)}. Stderr: ${childStderr.slice(0, 300)}. Stdout: ${childStdout.slice(0, 300)}`;
+    }
+
+    if (!ok) {
+      try { child.kill('SIGTERM'); } catch { /* ignore */ }
+      try {
+        if (!childExited) {
+          child.kill('SIGKILL');
+        }
+      } catch { /* ignore */ }
+      lastReason = reason;
+      continue; // Try next port
+    }
+
+    return { ok: true, url, process: child };
   }
 
-  return { ok: true, url, process: child };
+  return { ok: false, url: '', process: null, reason: `All ${CONSOLE_PORT_MAX_RETRIES} port attempts failed. Last: ${lastReason}` };
 }
 
 interface CopyOptions {

--- a/packages/create-principles-disciple/src/uninstaller.ts
+++ b/packages/create-principles-disciple/src/uninstaller.ts
@@ -10,7 +10,7 @@
  *    - State files (.state/ directory)
  *    - Any user data
  */
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import fse from 'fs-extra';
 import * as path from 'path';
 import { confirm } from '@inquirer/prompts';
@@ -150,6 +150,75 @@ function getWorkspacePath(): string | null {
 }
 
 /**
+ * Remove principles-disciple entries from openclaw.json
+ * Cleans plugins.allow, plugins.entries, and plugins.installs
+ */
+function cleanupOpenClawConfig(): { cleaned: boolean; error?: string } {
+  const configDir = getOpenClawConfigDir();
+  const configPath = path.join(configDir, 'openclaw.json');
+
+  if (!existsSync(configPath)) {
+    return { cleaned: false };
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    const config: unknown = JSON.parse(raw);
+
+    if (config === null || typeof config !== 'object' || Array.isArray(config)) {
+      return { cleaned: false, error: 'openclaw.json is not an object' };
+    }
+
+    const configObj = config as Record<string, unknown>;
+    let modified = false;
+
+    // Clean plugins.allow
+    if (Array.isArray(configObj.plugins) || typeof configObj.plugins !== 'object' || configObj.plugins === null) {
+      // plugins is not an object, skip
+    } else {
+      const plugins = configObj.plugins as Record<string, unknown>;
+
+      // Remove from plugins.allow
+      if (Array.isArray(plugins.allow)) {
+        const before = plugins.allow.length;
+        const filtered = (plugins.allow as unknown[]).filter(
+          (a): a is string => typeof a === 'string' && a !== 'principles-disciple'
+        );
+        plugins.allow = filtered;
+        if (filtered.length !== before) modified = true;
+      }
+
+      // Remove from plugins.entries
+      if (typeof plugins.entries === 'object' && plugins.entries !== null && !Array.isArray(plugins.entries)) {
+        const entries = plugins.entries as Record<string, unknown>;
+        if ('principles-disciple' in entries) {
+          delete entries['principles-disciple'];
+          modified = true;
+        }
+      }
+
+      // Remove from plugins.installs (legacy field, but clean it up anyway)
+      if (typeof plugins.installs === 'object' && plugins.installs !== null && !Array.isArray(plugins.installs)) {
+        const installs = plugins.installs as Record<string, unknown>;
+        if ('principles-disciple' in installs) {
+          delete installs['principles-disciple'];
+          modified = true;
+        }
+      }
+    }
+
+    if (modified) {
+      writeFileSync(configPath, JSON.stringify(configObj, null, 2) + '\n');
+      return { cleaned: true };
+    }
+
+    return { cleaned: false };
+  } catch (err) {
+    return { cleaned: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
  * Execute uninstall
  *
  * @param options.force Skip confirmation prompt (dangerous, for scripts only)
@@ -246,6 +315,14 @@ export async function uninstall(
     const { removed, skipped } = await removeGlobalPdShim();
     result.removedGlobalShims = removed;
     result.skippedGlobalShims = skipped;
+
+    // 6.5. Clean up openclaw.json entries
+    const configCleanup = cleanupOpenClawConfig();
+    if (configCleanup.cleaned) {
+      logger.success(t('openclaw_config_cleaned') || 'openclaw.json: removed principles-disciple entries');
+    } else if (configCleanup.error) {
+      logger.warn(`${t('openclaw_config_cleanup_failed') || 'openclaw.json cleanup failed'}: ${configCleanup.error}`);
+    }
 
     // 7. Record preserved paths
     if (workspaceDir) {

--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -551,22 +551,33 @@ function verifyInstalledFingerprint() {
 }
 
 /**
- * Update the plugin version in openclaw.json after successful sync.
- * This ensures the recorded version always matches the installed version.
+ * Update the plugin version in installs.json after successful sync.
+ * OpenClaw manages install records in ~/.openclaw/plugins/installs.json,
+ * NOT in openclaw.json (plugins.installs is a legacy/transient field).
  */
 function updateInstalledPluginVersion(version) {
-    const configPath = join(OPENCLAW_DIR, 'openclaw.json');
+    const installsDir = join(OPENCLAW_DIR, 'plugins');
+    const installsPath = join(installsDir, 'installs.json');
     try {
-        const raw = readFileSync(configPath, 'utf-8');
-        const config = JSON.parse(raw);
-        if (config?.plugins?.installs?.['principles-disciple']) {
-            config.plugins.installs['principles-disciple'].version = version;
-            config.plugins.installs['principles-disciple'].installedAt = new Date().toISOString();
-            writeFileAtomic(configPath, JSON.stringify(config, null, 2) + '\n');
-            console.log(`✅ openclaw.json updated: version=${version}`);
+        if (!existsSync(installsDir)) {
+            mkdirSync(installsDir, { recursive: true });
         }
+        let installs = { version: 1, installRecords: {} };
+        if (existsSync(installsPath)) {
+            const raw = readFileSync(installsPath, 'utf-8');
+            installs = JSON.parse(raw);
+        }
+        if (!installs.installRecords) installs.installRecords = {};
+        installs.installRecords['principles-disciple'] = {
+            source: 'path',
+            installPath: INSTALL_DIR,
+            version: version,
+            installedAt: new Date().toISOString(),
+        };
+        writeFileAtomic(installsPath, JSON.stringify(installs, null, 2) + '\n');
+        console.log(`✅ installs.json updated: version=${version}`);
     } catch (err) {
-        console.warn(`⚠️  Could not update openclaw.json: ${err.message}`);
+        console.warn(`⚠️  Could not update installs.json: ${err.message}`);
     }
 }
 

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -5,7 +5,7 @@
  *
  * Installs the complete Principles Disciple system:
  * - openclaw-plugin to ~/.openclaw/extensions/principles-disciple
- * - pd-console to ~/.openclaw/pd-console/
+ * - pd-console to ~/.openclaw/extensions/principles-disciple/console/
  *
  * Usage:
  *   node scripts/install.mjs [options]
@@ -45,8 +45,9 @@ function getHomeDir() {
 
 const OPENCLAW_DIR = join(getHomeDir(), '.openclaw');
 const INSTALL_PLUGIN_DIR = join(OPENCLAW_DIR, 'extensions', 'principles-disciple');
-const INSTALL_CONSOLE_DIR = join(OPENCLAW_DIR, 'pd-console');
-const INSTALL_BIN_DIR = join(INSTALL_CONSOLE_DIR, 'bin');
+// Console lives INSIDE the plugin extension dir — same location as npm installer
+const INSTALL_CONSOLE_DIR = join(INSTALL_PLUGIN_DIR, 'console');
+const INSTALL_BIN_DIR = join(INSTALL_PLUGIN_DIR, 'bin');
 
 const MIN_NODE_VERSION = '18.0.0';
 
@@ -65,16 +66,16 @@ function copyDir(src, dest) {
   }
 }
 
-function injectCorePackage() {
+function injectCorePackage(targetDir) {
   const monorepoModules = join(ROOT_DIR, 'node_modules', '@principles', 'core');
-  const targetModules = join(INSTALL_CONSOLE_DIR, 'node_modules', '@principles', 'core');
+  const targetModules = join(targetDir, 'node_modules', '@principles', 'core');
 
   if (!existsSync(monorepoModules)) {
-    console.warn('  ⚠️  @principles/core not found in monorepo node_modules — pd-console may fail to start');
+    console.warn('  ⚠️  @principles/core not found in monorepo node_modules');
     return;
   }
 
-  console.log('  📦 Injecting @principles/core into pd-console...');
+  console.log('  📦 Injecting @principles/core...');
   mkdirSync(dirname(targetModules), { recursive: true });
   try {
     execSync(`cp -rL "${monorepoModules}" "${targetModules}"`, { stdio: 'ignore' });
@@ -150,10 +151,10 @@ Options:
   --help, -h         Show this help message
 
 After installation, start the WebUI:
-  node ~/.openclaw/pd-console/dist/server/index.js --workspace <workspace-dir> --port 3100
+  node ~/.openclaw/extensions/principles-disciple/console/dist/server.js --workspace <workspace-dir> --port 3100
 
 Or use the helper script:
-  ~/.openclaw/pd-console/bin/pd-console.ps1 --workspace <workspace-dir>
+  ~/.openclaw/extensions/principles-disciple/bin/pd-console.ps1 --workspace <workspace-dir>
 `);
 }
 
@@ -266,6 +267,60 @@ function installPlugin(args) {
     console.error(`\n❌ Plugin installation script failed: ${error.message}`);
     process.exit(1);
   }
+
+  // Register plugin in openclaw.json (sync-plugin.mjs does not do this)
+  registerPlugin();
+}
+
+/**
+ * Register principles-disciple in openclaw.json.
+ * Merges with existing config — preserves hooks, config, and other user settings.
+ * Does NOT write plugins.installs (OpenClaw manages installs.json).
+ */
+function registerPlugin() {
+  const configPath = join(OPENCLAW_DIR, 'openclaw.json');
+  if (!existsSync(configPath)) {
+    console.warn('  ⚠️  openclaw.json not found — skipping plugin registration');
+    return;
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(raw);
+    if (typeof config !== 'object' || config === null || Array.isArray(config)) return;
+
+    let modified = false;
+
+    // Ensure plugins object exists
+    if (!config.plugins) { config.plugins = {}; modified = true; }
+    const plugins = config.plugins;
+
+    // Add to plugins.allow (idempotent)
+    if (!Array.isArray(plugins.allow)) { plugins.allow = []; modified = true; }
+    if (!plugins.allow.includes('principles-disciple')) {
+      plugins.allow.push('principles-disciple');
+      modified = true;
+    }
+
+    // Merge plugins.entries (preserve existing hooks, config, etc.)
+    if (!plugins.entries) { plugins.entries = {}; modified = true; }
+    const existing = (typeof plugins.entries['principles-disciple'] === 'object' && plugins.entries['principles-disciple'] !== null)
+      ? plugins.entries['principles-disciple']
+      : {};
+    plugins.entries['principles-disciple'] = { ...existing, enabled: true };
+    modified = true;
+
+    if (modified) {
+      const tmp = configPath + '.tmp.' + Date.now();
+      writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+      rmSync(configPath, { force: true });
+      copyFileSync(tmp, configPath);
+      rmSync(tmp, { force: true });
+      console.log('  ✅ Plugin registered in openclaw.json');
+    }
+  } catch (e) {
+    console.warn(`  ⚠️  Could not register plugin in openclaw.json: ${e.message}`);
+  }
 }
 
 // ── pd-console installation ──────────────────────────────────────────────────────────────
@@ -310,8 +365,8 @@ function installPdConsole(args) {
   );
   console.log('  📄 package.json');
 
-  // Inject @principles/core from monorepo (similar to plugin install)
-  injectCorePackage();
+  // Inject @principles/core from monorepo (console lives inside plugin dir)
+  injectCorePackage(INSTALL_CONSOLE_DIR);
 
   // Install production dependencies for pd-console
   console.log('  📦 Installing pd-console dependencies...');
@@ -324,7 +379,7 @@ function installPdConsole(args) {
     console.warn(`  ⚠️  npm install failed for pd-console: ${e.message}`);
   }
 
-  // Create startup scripts
+  // Create startup scripts — console is at extensions/principles-disciple/console/
   if (isWindows()) {
     const psScript = [
       '# PD Console startup script',
@@ -332,7 +387,7 @@ function installPdConsole(args) {
       'if (-not $workspace) { $workspace = "$env:USERPROFILE\\.openclaw\\workspace-main" }',
       '$port = $args[1]',
       'if (-not $port) { $port = 3100 }',
-      '$serverEntry = "$PSScriptRoot\\dist\\server\\index.js"',
+      '$serverEntry = "$PSScriptRoot\\..\\console\\dist\\server.js"',
       'if (-not (Test-Path $serverEntry)) {',
       '  Write-Host "❌ pd-console not installed. Run install.mjs first."',
       '  exit 1',
@@ -349,7 +404,7 @@ function installPdConsole(args) {
       'if "%WORKSPACE%"=="" set WORKSPACE=%USERPROFILE%\\.openclaw\\workspace-main',
       'set PORT=%2',
       'if "%PORT%"=="" set PORT=3100',
-      'node "%~dp0..\\dist\\server\\index.js" --workspace %WORKSPACE% --port %PORT%',
+      'node "%~dp0..\\console\\dist\\server.js" --workspace %WORKSPACE% --port %PORT%',
       '',
     ].join('\r\n');
     writeFileSync(join(INSTALL_BIN_DIR, 'pd-console.cmd'), cmdScript, 'utf-8');
@@ -359,7 +414,7 @@ function installPdConsole(args) {
       '#!/usr/bin/env sh',
       'workspace=${1:-$HOME/.openclaw/workspace-main}',
       'port=${2:-3100}',
-      'server_entry="$(dirname "$0")/../dist/server/index.js"',
+      'server_entry="$(dirname "$0")/../console/dist/server.js"',
       'if [ ! -f "$server_entry" ]; then',
       '  echo "❌ pd-console not installed. Run install.mjs first."',
       '  exit 1',
@@ -372,26 +427,8 @@ function installPdConsole(args) {
     console.log('  📄 bin/pd-console.sh');
   }
 
-  // Update version
   const sourceVersion = getVersion(PD_CONSOLE_SOURCE_DIR);
   if (sourceVersion) {
-    try {
-      const configPath = join(OPENCLAW_DIR, 'openclaw.json');
-      if (existsSync(configPath)) {
-        const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-        if (!config.pdConsole) config.pdConsole = {};
-        config.pdConsole.version = sourceVersion;
-        config.pdConsole.installedAt = new Date().toISOString();
-        const raw = JSON.stringify(config, null, 2) + '\n';
-        const tmp = configPath + '.tmp.' + Date.now();
-        writeFileSync(tmp, raw, 'utf-8');
-        rmSync(configPath, { force: true });
-        copyFileSync(tmp, configPath);
-        rmSync(tmp, { force: true });
-      }
-    } catch (e) {
-      console.warn(`⚠️  Could not update openclaw.json: ${e.message}`);
-    }
     console.log(`✅ pd-console installed: v${sourceVersion}`);
   }
 }
@@ -399,7 +436,7 @@ function installPdConsole(args) {
 // ── Verification ─────────────────────────────────────────────────────────────────────
 
 function verifyPdConsole() {
-  const serverEntry = join(INSTALL_CONSOLE_DIR, 'dist', 'server', 'index.js');
+  const serverEntry = join(INSTALL_CONSOLE_DIR, 'dist', 'server.js');
   if (!existsSync(serverEntry)) {
     console.error('❌ pd-console server entry not found after installation');
     process.exit(1);
@@ -458,12 +495,13 @@ function main() {
 
   if (!args.skipConsole) {
     console.log('\n🌐 To start the PD Console WebUI:');
+    const extDir = join(OPENCLAW_DIR, 'extensions', 'principles-disciple');
     if (isWindows()) {
-      console.log('   .\\bin\\pd-console.ps1 --workspace <path-to-workspace>');
-      console.log('   Or: node ~/.openclaw/pd-console/dist/server/index.js --workspace <path-to-workspace> --port 3100');
+      console.log(`   ${extDir}\\bin\\pd-console.ps1 --workspace <path-to-workspace>`);
+      console.log(`   Or: node ${extDir}\\console\\dist\\server.js --workspace <path-to-workspace> --port 3100`);
     } else {
-      console.log('   ~/.openclaw/pd-console/bin/pd-console.sh <path-to-workspace>');
-      console.log('   Or: node ~/.openclaw/pd-console/dist/server/index.js --workspace <path-to-workspace> --port 3100');
+      console.log(`   ${extDir}/bin/pd-console.sh <path-to-workspace>`);
+      console.log(`   Or: node ${extDir}/console/dist/server.js --workspace <path-to-workspace> --port 3100`);
     }
   }
 }


### PR DESCRIPTION
## Root Cause

Installer wrote `plugins.installs` to `openclaw.json`, but OpenClaw strips this legacy field on every write (migrating to `~/.openclaw/plugins/installs.json`). This caused a config corruption loop:

```
installer writes plugins.installs → OpenClaw strips it → next install writes again → config invalid → doctor --fix → repeat
```

Additionally, `plugins.entries` was unconditionally overwritten with `{ enabled: true }`, losing user-configured `hooks.allowConversationAccess` and other settings.

## Changes

### installer.ts (npm package installer)
- **F1**: Remove `plugins.installs` write — OpenClaw manages `installs.json` as canonical store
- **F2**: Merge `plugins.entries` instead of overwrite — preserve existing `hooks`, `config` settings
- **F6**: Add `~/.openclaw/plugins/installs.json` write with version tracking
- **F7**: Add console health check port retry (3 attempts with shuffled port list)

### uninstaller.ts
- **F3**: Add `cleanupOpenClawConfig()` — removes `principles-disciple` from `plugins.allow`, `plugins.entries`, and `plugins.installs` in `openclaw.json`

### sync-plugin.mjs (developer sync)
- **F4**: Write to `~/.openclaw/plugins/installs.json` instead of `openclaw.json` (was writing to legacy field that OpenClaw strips)

### install.mjs (project-level full installer)
- Fix console install path: `~/.openclaw/pd-console/` → `~/.openclaw/extensions/principles-disciple/console/`
- Fix console entry point: `dist/server/index.js` → `dist/server.js` (matches `package.json` start script)
- Add `registerPlugin()` — writes `plugins.allow` + `plugins.entries` to `openclaw.json` (sync-plugin.mjs does not do this)
- Remove `pdConsole` custom field write from `openclaw.json`

## ERR Handbook

- **ERR-002**: Avoided — all degradation paths have structured reasons
- **ERR-012**: Avoided — branch based on latest main (69974b14)
- **ERR-048**: N/A — not touching activation paths

## Test Plan

- [ ] `cd packages/create-principles-disciple && npm run build` passes
- [ ] `node -c scripts/install.mjs` passes
- [ ] `node -c packages/openclaw-plugin/scripts/sync-plugin.mjs` passes
- [ ] Verify `openclaw.json` no longer has `plugins.installs` after install
- [ ] Verify `~/.openclaw/plugins/installs.json` has correct record after install
- [ ] Verify `hooks.allowConversationAccess` preserved on reinstall
- [ ] Verify uninstaller cleans `openclaw.json` entries
- [ ] Verify console starts from new path: `node ~/.openclaw/extensions/principles-disciple/console/dist/server.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 增强了插件安装验证机制，支持多端口探活与详细的健康检查。

* **改进**
  * 优化了插件配置管理流程，配置信息存储位置调整。
  * 改进了插件卸载时的配置清理逻辑。
  * 更新了扩展安装目录结构。

* **修复**
  * 增强了安装过程中的容错能力与状态追踪。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->