### PR TITLE
docs(website): add missing documentation pages for MVP features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ code-concise/
 docs/
 # Exception: AI assistant handbook must be committed
 !docs/ERROR_EXPERIENCE_HANDBOOK.md
+# Exception: website docs must be committed
+!packages/website/docs/
+!packages/website/zh/docs/
 
 # Interactive Conversation Test Output
 packages/openclaw-plugin/tests/interactive-conversation/output/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1987,6 +1987,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2003,6 +2004,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2019,6 +2021,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2035,6 +2038,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2051,6 +2055,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2067,6 +2072,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2083,6 +2089,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2099,6 +2106,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2115,6 +2123,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2131,6 +2140,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2147,6 +2157,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2163,6 +2174,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2179,6 +2191,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2195,6 +2208,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2211,6 +2225,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2227,6 +2242,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2243,6 +2259,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2259,6 +2276,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2275,6 +2293,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2291,6 +2310,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2307,6 +2327,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2323,6 +2344,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2339,6 +2361,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2355,6 +2378,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2371,6 +2395,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2387,6 +2412,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4873,6 +4899,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4889,6 +4916,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4905,6 +4933,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4921,6 +4950,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4937,6 +4967,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4953,6 +4984,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4969,6 +5001,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4985,6 +5018,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5001,6 +5035,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5017,6 +5052,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5033,6 +5069,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5049,6 +5086,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5062,6 +5100,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -5083,6 +5122,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5099,6 +5139,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18012,6 +18053,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18028,6 +18070,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18044,6 +18087,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18060,6 +18104,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18076,6 +18121,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18092,6 +18138,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18108,6 +18155,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18124,6 +18172,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18140,6 +18189,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18156,6 +18206,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18172,6 +18223,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18188,6 +18240,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18204,6 +18257,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18220,6 +18274,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18236,6 +18291,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18252,6 +18308,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18268,6 +18325,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18284,6 +18342,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18300,6 +18359,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18316,6 +18376,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18332,6 +18393,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18348,6 +18410,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18364,6 +18427,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18380,6 +18444,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18396,6 +18461,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18412,6 +18478,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/packages/website/docs/development.md
+++ b/packages/website/docs/development.md
@@ -1,0 +1,227 @@
+---
+title: Development Guide
+description: Contribute to Principles Disciple — architecture, coding conventions, and workflow.
+---
+
+# Development Guide
+
+Want to contribute to Principles Disciple? This guide covers the architecture, coding conventions, and development workflow you need to know.
+
+## Project Structure
+
+```
+principles/
+├── packages/
+│   ├── principles-core/     # Pure domain logic, state machines
+│   ├── openclaw-plugin/     # OpenClaw hooks and event formatting
+│   ├── pd-cli/              # Command-line tool
+│   ├── create-principles-disciple/  # Installer
+│   └── website/             # Documentation site (VitePress)
+├── docs/
+│   ├── architecture/        # Architecture decision records & models
+│   └── adr/                 # Architecture Decision Records
+├── PRODUCT_IDENTITY.md      # Canonical product boundary
+└── CONTRIBUTING.md          # Contribution guidelines
+```
+
+## Architecture Overview
+
+PD follows a strict layered architecture with three tiers:
+
+### Core Layer (`@principles/core`)
+
+**Location**: `packages/principles-core/`
+
+This is the pure domain logic layer. It contains:
+- State machines for Principle, Rule, and Implementation lifecycles
+- The internalization pipeline (4 active MVP runners: Dreamer, Scribe, Artificer, Bridge)
+- The activation pipeline (3 MVP channels: prompt, code_tool_hook, defer_archive)
+- Pain signal processing and diagnosis
+- Read models and evolution store
+
+**Hard rule**: This layer MUST NOT import from `openclaw-plugin`, `pd-cli`, or any host layer. It depends only on its own contracts and types.
+
+### Host Layer (`openclaw-plugin`)
+
+**Location**: `packages/openclaw-plugin/`
+
+This is the integration layer. It contains:
+- OpenClaw hooks that intercept agent operations
+- Event payload extraction and delegation to core
+- RuleHost code execution
+- Slash command handlers
+
+**Hard rule**: This layer MUST NOT contain complex business logic or diagnosis algorithms. It extracts event payloads and delegates to `@principles/core`.
+
+### CLI Layer (`pd-cli`)
+
+**Location**: `packages/pd-cli/`
+
+The command-line interface for operators. It provides:
+- Pain signal recording
+- Runtime health checks (canary)
+- Internalization queue inspection
+- Console server
+
+## Core Domain Model
+
+PD's knowledge evolves through a fixed three-layer structure:
+
+```
+Principle  →  Rule  →  Implementation
+(Why/What)    (When/Where/How)   (Concrete executable)
+```
+
+### Principle
+
+A highly abstract, cross-scenario guideline. It explains *why* the agent should behave differently.
+
+- **Type hierarchy**: Core Principle → Domain Principle → Scenario Principle
+- **Lifecycle**: `candidate → probation → active → archived → deprecated`
+- **Key rule**: Never assign status directly. Use `taskStateMachine.transition(task, 'succeed')`.
+
+### Rule
+
+A hard, testable contract derived from a Principle. It specifies *when* and *how* the agent should respond.
+
+- Must answer: Which Principle? What scenario? What problem? How to test?
+- **Enforcement types**: `block | warn | log | requireApproval | propose_correction`
+
+### Implementation
+
+The concrete code or prompt that carries out a Rule.
+
+- **MVP types**: `code` (RuleHost hook), `prompt` (context injection)
+- **Future types**: `skill`, `lora`, `test` (not active in MVP)
+- **Lifecycle**: `candidate → active → disabled → archived`
+- Same Rule can have multiple Implementation candidates, but only one `active` at a time
+
+## Activation Channels (MVP)
+
+Three channels are currently active in the MVP:
+
+| Channel | Level | Carrier | Approval Required |
+|---------|-------|---------|-------------------|
+| `prompt` | L1 (soft) | System prompt injection | No |
+| `defer_archive` | n/a | Ledger state change | No |
+| `code_tool_hook` | L2 (hard) | RuleHost JS code | Yes |
+
+Two additional channels exist in the architecture but are **not active** in the MVP:
+- `skill` (L1.5) — stretch goal, not yet implemented
+- `model_training` (L3) — retired, feature flag set to `gone`
+
+## Development Workflow
+
+### Branch Naming
+
+| Type | Format | Example |
+|------|--------|---------|
+| Feature | `feature/<name>` | `feature/evolution-points` |
+| Fix | `fix/<issue-id>-<name>` | `fix/18-trust-engine` |
+| Docs | `docs/<name>` | `docs/readme-update` |
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+### PR Requirements
+
+- All PRs must have at least 1 reviewer
+- CI tests must pass
+- Lint checks must pass (`npm run lint` in `packages/openclaw-plugin/`)
+
+### Decision Matrix
+
+| Decision | Made By |
+|----------|---------|
+| Code implementation | AI contributors |
+| Test verification | AI contributors |
+| PR merge | Human maintainer |
+| Strategic direction | Human maintainer |
+
+## Coding Conventions
+
+### No Direct State Assignment
+
+```typescript
+// ❌ Wrong
+task.status = 'succeeded'
+
+// ✅ Correct
+taskStateMachine.transition(task, 'succeed')
+```
+
+### Contract Centralization
+
+All core entity schemas are defined centrally. Import them, don't redefine:
+
+```typescript
+// ❌ Wrong — ad-hoc interface
+interface TemporaryTask { ... }
+
+// ✅ Correct — import from contracts
+import { type PDTask, PDTaskSchema } from '../contracts/task-schema'
+```
+
+### Respect Layer Boundaries
+
+```typescript
+// ❌ Wrong — core importing from host
+import { something } from 'openclaw-plugin'
+
+// ✅ Correct — core importing from its own contracts
+import { something } from '../contracts/...'
+```
+
+### Lint Rules
+
+- `no-empty`: error
+- `no-console`: warn
+- `complexity`: max 10
+- `@typescript-eslint/no-explicit-any`: warn
+- `@typescript-eslint/no-unused-vars`: warn (underscore-prefixed params excluded)
+
+Run before committing:
+```bash
+cd packages/openclaw-plugin && npm run lint
+```
+
+## MVP Three Questions
+
+Every new issue must answer these before implementation:
+
+1. **What happens if we don't do this?** — Will someone still care in 30 days? If you can't answer, the issue is rejected.
+2. **How do we observe it?** — How does the user verify it works? UI? CLI? Logs? No observability = rejected.
+3. **How do we turn it off?** — Feature flag? PR revert? If only revert, the flag must come with the PR.
+
+## Key Architecture Documents
+
+Before making architectural changes, read these:
+
+| Document | Purpose |
+|----------|---------|
+| `docs/architecture/DOMAIN_MODEL.md` | Core ontology — Principle, Rule, Implementation |
+| `docs/architecture/PD_SYSTEM_ARCHITECTURE.md` | System architecture overview |
+| `docs/architecture/ACTIVATION_CHANNELS.md` | 5-channel activation design |
+| `docs/architecture/INTERNALIZATION_PIPELINE.md` | Internalization pipeline design |
+| `docs/architecture/SECURITY_ARCHITECTURE.md` | Security model |
+| `PRODUCT_IDENTITY.md` | Canonical product boundary and MVP contract |
+| `docs/adr/0014-mvp-first-strategy-and-product-pivot.md` | MVP strategy and scope |
+
+## Reporting Issues
+
+When reporting bugs, include:
+
+- **Problem**: What happened
+- **Steps to reproduce**: 1, 2, 3...
+- **Expected behavior**: What should have happened
+- **Actual behavior**: What actually happened
+- **Environment**: Node.js version, OS, OpenClaw version
+
+Issue tracker: [github.com/csuzngjh/principles/issues](https://github.com/csuzngjh/principles/issues)

--- a/packages/website/docs/getting-started.md
+++ b/packages/website/docs/getting-started.md
@@ -1,0 +1,81 @@
+---
+title: Getting Started
+description: Install Principles Disciple in 2 minutes and let your AI agent learn from its mistakes.
+---
+
+# Getting Started
+
+## 30 Seconds: What PD Does
+
+Your AI agent keeps making the same mistakes? PD captures those mistakes, finds the pattern, and lets you turn them into **reviewed, reversible rules** — so the agent doesn't repeat them.
+
+```
+Agent repeats a mistake → PD spots the pattern → You review → Agent improves
+```
+
+You're always in control. Nothing activates without your approval.
+
+## 2 Minutes: Install & Go
+
+**Prerequisites**: Node.js ≥ 18 | OpenClaw CLI installed
+
+### 1. Install
+
+```bash
+npx create-principles-disciple --yes
+openclaw gateway --force
+```
+
+### 2. Verify
+
+```bash
+pd runtime canary --workspace "<your-workspace-path>"
+```
+
+See `healthy`? You're good.
+
+### 3. Open the Console
+
+```bash
+pd console --workspace "<your-workspace-path>" --no-auth
+```
+
+Then open **http://127.0.0.1:3100** — this is where you review and approve principle proposals.
+
+### 4. Let It Run
+
+Use your AI agent as usual. When it makes repeated mistakes, PD will:
+
+1. **Capture** the pain signal automatically
+2. **Diagnose** whether it's a one-off or a pattern
+3. **Propose** a principle candidate
+
+You'll see the proposal in the console. Choose one of three actions:
+
+| Action | What Happens | When to Use |
+|--------|-------------|-------------|
+| **Prompt** | Soft reminder injected into agent context | Default choice — low risk |
+| **RuleHost** | Hard rule that blocks violating actions | When soft reminders aren't enough |
+| **Defer** | Skip and archive | When it's not worth acting on |
+
+### 5. Roll Back If Needed
+
+Changed your mind? Undo anytime:
+
+```
+/pd-rollback-impl <id>
+```
+
+## That's It
+
+PD is now watching for repeated mistakes and waiting for your review. No configuration needed — it just works.
+
+---
+
+**Stuck?**
+
+- AI won't edit files? → Check `PLAN.md` needs `STATUS: READY`
+- Plugin won't load? → `cd ~/.openclaw/extensions/principles-disciple && npm install micromatch@^4.0.8 @sinclair/typebox@^0.34.48`
+- Check health anytime → `/pd-status`
+
+**Want more?** → [User Guide](/docs/user-guide) | [Development Guide](/docs/development)

--- a/packages/website/docs/user-guide.md
+++ b/packages/website/docs/user-guide.md
@@ -1,0 +1,321 @@
+---
+title: User Guide
+description: Complete reference for Principles Disciple's MVP features, commands, and workflows.
+---
+
+# User Guide
+
+This guide covers everything you need to use Principles Disciple (PD) effectively. PD is an owner-governed behavior internalization system for AI agents — it helps your agent learn from repeated mistakes and turn those lessons into reviewed, reversible principles.
+
+## How PD Works
+
+PD follows a simple loop:
+
+```
+Agent makes mistakes (Pain)
+       ↓
+PD diagnoses the pattern (Diagnosis)
+       ↓
+PD proposes a principle (Candidate)
+       ↓
+You review and decide (Review)
+       ↓
+PD activates the principle (Activation)
+       ↓
+Agent behaves better next time (Observation)
+```
+
+You are always in control. No principle becomes active without your review.
+
+## Core Concepts
+
+### Pain Signal
+
+A **pain signal** is structured evidence that something went wrong. It's not punishment — it's data. Pain signals come from:
+
+- Tool failures (e.g., a command that keeps failing)
+- User corrections (e.g., "don't do it that way")
+- Blocked edits (e.g., workspace guardrails intercepted a risky change)
+- Risky near-misses (e.g., almost overwrote an important file)
+
+### Principle
+
+A **principle** is a soft, highly abstract guideline. It answers "Why should the agent behave differently?" and "What direction should it follow?"
+
+Principles go through a lifecycle:
+
+| Status | Meaning |
+|--------|---------|
+| `candidate` | Newly proposed, not yet reviewed |
+| `probation` | Under trial / shadow mode |
+| `active` | Officially in effect |
+| `archived` | Kept for history, not active |
+
+### Rule
+
+A **rule** is a hard, testable contract derived from a principle. It answers "When does this apply?" and "How should the agent respond?"
+
+### Implementation
+
+An **implementation** is the concrete code or prompt that carries out a rule. This is what actually changes agent behavior.
+
+### Activation Channels
+
+When you approve a principle, you choose how it takes effect:
+
+| Channel | Strength | What Happens | Needs Your Approval? |
+|---------|----------|-------------|---------------------|
+| **Prompt** | Soft | A reminder is injected into the agent's context | No (automatic) |
+| **RuleHost** | Hard | A code hook blocks or warns on violating actions | Yes (required) |
+| **Defer / Archive** | None | The candidate is deliberately skipped | No (automatic) |
+
+The general strategy: **start soft, escalate if needed.**
+
+## Workspace Guardrails
+
+PD can block risky edits until the agent has a clear plan. This protects important files like:
+
+- Agent identity files (`SOUL.md`, `AGENTS.md`)
+- Memory files (`memory/`)
+- Strategy and plan files (`PLAN.md`)
+- Custom high-risk paths you configure
+
+### How It Works
+
+When the agent tries to edit a protected file, PD checks `PLAN.md`:
+
+```
+STATUS: READY    → Edit allowed
+STATUS: DRAFT    → Edit blocked
+No PLAN.md       → Edit blocked
+```
+
+### What the Agent Should Do When Blocked
+
+1. Update `PLAN.md` with an explanation
+2. Describe the risk and why the edit is needed
+3. Set `STATUS: READY`
+4. Retry the operation
+
+### Configuring Risk Paths
+
+Edit your workspace's `docs/PROFILE.json`:
+
+```json
+{
+  "progressive_gate": {
+    "enabled": true,
+    "plan_approvals": {
+      "enabled": true,
+      "allowed_patterns": ["docs/**", "skills/**"],
+      "allowed_operations": ["write", "edit"]
+    }
+  }
+}
+```
+
+## Slash Commands
+
+PD integrates with OpenClaw through slash commands. Here are the MVP commands:
+
+### Setup
+
+| Command | Short | Description |
+|---------|-------|-------------|
+| `/pd-init` | `/pdi` | Initialize workspace |
+| `/pd-bootstrap` | `/pdb` | Scan environment tools |
+| `/pd-research` | `/pdr` | Research tools and capabilities |
+| `/pd-help` | `/pdh` | Show command reference |
+
+### Pain & Monitoring
+
+| Command | Description |
+|---------|-------------|
+| `/pd-pain` | Report a pain signal from the current session |
+| `/pd-status` | View system health, hook status, and error rate |
+| `/pd-evolution-status` | View principle evolution state |
+
+### Principle Management
+
+| Command | Description |
+|---------|-------------|
+| `/pd-promote-impl list` | List all implementation candidates |
+| `/pd-promote-impl eval <id>` | Evaluate a specific candidate |
+| `/pd-promote-impl show <id>` | Show candidate details |
+| `/pd-promote-impl <id>` | Promote a candidate to active |
+| `/pd-disable-impl <id>` | Disable an active implementation |
+| `/pd-rollback-impl <id>` | Roll back to previous state |
+| `/pd-archive-impl <id>` | Archive an implementation |
+| `/pd-principle-rollback` | Roll back a principle to probation |
+
+## The PD CLI
+
+The `pd` command-line tool provides additional capabilities outside of OpenClaw sessions.
+
+### Record a Pain Signal
+
+```bash
+pd pain record --reason "edited file without reading first" --score 75
+```
+
+Options:
+- `--reason, -r` — Why the pain occurred (required)
+- `--score, -s` — Pain severity, 0–100 (default: 80)
+- `--session-id` — Session ID (default: auto-generated)
+
+### Health Check (Canary)
+
+```bash
+pd runtime canary --workspace "<path>" --json
+```
+
+The canary runs 7 checks and reports one of three statuses:
+
+| Status | Meaning |
+|--------|---------|
+| `healthy` | All checks pass |
+| `degraded` | Non-critical issues found (orphan candidates, queue blockers) |
+| `error` | Schema failure or exception — investigate before proceeding |
+
+### Start the Console
+
+```bash
+pd console --workspace "<path>" --no-auth
+```
+
+Opens the local web UI at [http://127.0.0.1:3100](http://127.0.0.1:3100).
+
+::: warning
+The console binds to `127.0.0.1` (loopback only) by default. It is not accessible from other machines. If you need network access, use `--host <ip>` with `--token <secret>`.
+:::
+
+## The Review Console
+
+The local console is your primary window into PD's activity.
+
+### What You Can See
+
+- **Pain trends** — How often is the agent encountering problems?
+- **Principle candidates** — What new principles have been proposed?
+- **Active principles** — What's currently guiding or constraining the agent?
+- **Approval queue** — What's waiting for your decision?
+- **Evolution events** — Timeline of all principle lifecycle changes
+
+### Reviewing a Principle Candidate
+
+1. Open the console
+2. Navigate to the **Principles** page
+3. Select a candidate to review
+4. Read the pain evidence and proposed principle text
+5. Choose an activation channel:
+   - **Prompt** — Soft guidance, good for first attempts
+   - **RuleHost** — Hard enforcement, use when soft guidance isn't enough
+   - **Defer / Archive** — Skip this candidate for now
+
+### Rolling Back
+
+If an activated principle causes problems:
+
+```bash
+/pd-rollback-impl <id>
+```
+
+This restores the previous state. You can also disable without rolling back:
+
+```bash
+/pd-disable-impl <id>
+```
+
+## Configuration
+
+### Workspace Configuration
+
+PD needs to know where your agent's workspace is. This is usually set during installation, but you can configure it manually.
+
+**Option 1: Configuration file** (recommended)
+
+Create `~/.openclaw/principles-disciple.json`:
+
+```json
+{
+  "workspace": "/path/to/your/workspace",
+  "state": "/path/to/your/workspace/.state",
+  "debug": false
+}
+```
+
+**Option 2: Environment variables**
+
+```bash
+export PD_WORKSPACE_DIR=/path/to/your/workspace
+export PD_STATE_DIR=/path/to/your/workspace/.state
+```
+
+**Configuration priority** (highest to lowest):
+
+1. Environment variables (`PD_WORKSPACE_DIR`, `PD_STATE_DIR`)
+2. Configuration file (`~/.openclaw/principles-disciple.json`)
+3. OpenClaw environment (`OPENCLAW_WORKSPACE`)
+4. Default (`~/.openclaw/workspace`)
+
+### Plugin Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `language` | `zh` | Interaction language (`en` or `zh`) |
+| `auditLevel` | `medium` | Security guardrail level (`low`, `medium`, `high`) |
+| `riskPaths` | `[]` | High-risk directories requiring explicit authorization |
+
+## Troubleshooting
+
+### Plugin fails to load
+
+**Error**: `Cannot find module 'micromatch'`
+
+**Fix**:
+```bash
+cd ~/.openclaw/extensions/principles-disciple
+npm install micromatch@^4.0.8 @sinclair/typebox@^0.34.48
+```
+
+### Plugin shows old version after update
+
+**Fix**:
+```bash
+rm -rf ~/.openclaw/extensions/principles-disciple
+cd /path/to/principles
+./packages/openclaw-plugin/scripts/install.sh
+```
+
+### Configuration errors
+
+**Error**: `Invalid config: plugin not found: principles-disciple`
+
+**Fix**:
+```bash
+openclaw doctor --fix
+./packages/openclaw-plugin/scripts/install.sh
+```
+
+### Where to find logs
+
+Default location: `~/.openclaw/workspace/memory/.state/logs/`
+
+| File | Contents |
+|------|----------|
+| `events.jsonl` | Structured event log (tool calls, pain signals, gate blocks, evolution tasks) |
+| `plugin.log` | Runtime plugin logs |
+| `daily-stats.json` | Daily statistics summary |
+
+## What PD Is Not
+
+To set expectations clearly:
+
+- PD is **not** a task execution engine
+- PD is **not** a general memory system or external brain
+- PD is **not** a generic tool-call or output-format repair product
+- PD is **not** a LangChain-style app builder
+- PD is **not** a SaaS product or chatbot
+- PD is **not** a magic self-improvement button
+
+PD is an **owner-governed behavior internalization layer** for OpenClaw coding agents. It helps your agent learn from pain — with you in the loop.

--- a/packages/website/zh/docs/user-guide.md
+++ b/packages/website/zh/docs/user-guide.md
@@ -1,0 +1,321 @@
+---
+title: 用户指南
+description: Principles Disciple MVP 功能、命令和工作流的完整参考。
+---
+
+# 用户指南
+
+本指南涵盖使用 Principles Disciple（PD）所需的一切。PD 是一个面向 AI 智能体的行为内化系统——它帮助你的智能体从反复犯的错误中学习，把这些教训转化为经过审核、可回滚的行为原则。
+
+## PD 是怎么工作的
+
+PD 遵循一个简单的闭环：
+
+```
+智能体犯错（痛觉信号）
+       ↓
+PD 诊断出行为模式（诊断）
+       ↓
+PD 提出原则候选（候选）
+       ↓
+你审核并决定（审核）
+       ↓
+PD 激活原则（激活）
+       ↓
+智能体下次表现更好（观察）
+```
+
+你始终掌控全局。没有你的审核，任何原则都不会生效。
+
+## 核心概念
+
+### 痛觉信号（Pain Signal）
+
+**痛觉信号**是"出了问题"的结构化证据。它不是惩罚——它是数据。痛觉信号来自：
+
+- 工具失败（例如，一个命令反复报错）
+- 用户纠正（例如，"不要这样做"）
+- 编辑被拦截（例如，工作区门禁阻止了一次危险修改）
+- 危险接近（例如，差点覆盖了重要文件）
+
+### 原则（Principle）
+
+**原则**是一条高度抽象、跨场景的指导方针。它回答"智能体为什么要改变行为？"和"应该朝什么方向改变？"
+
+原则的生命周期：
+
+| 状态 | 含义 |
+|------|------|
+| `candidate` | 新提出，尚未审核 |
+| `probation` | 试用中 / 影子模式 |
+| `active` | 正式生效 |
+| `archived` | 保留历史记录，不再生效 |
+
+### 规则（Rule）
+
+**规则**是从原则推导出的硬性、可测试的契约。它回答"什么时候适用？"和"智能体应该怎么响应？"
+
+### 实现（Implementation）
+
+**实现**是承载规则的具体代码或提示词。它是真正改变智能体行为的东西。
+
+### 激活通道
+
+当你批准一个原则时，你需要选择它如何生效：
+
+| 通道 | 强度 | 会发生什么 | 需要你审批吗？ |
+|------|------|-----------|--------------|
+| **Prompt** | 软 | 在智能体的上下文中注入一段提醒 | 不需要（自动） |
+| **RuleHost** | 硬 | 代码钩子会阻止或警告违规操作 | 需要（必须审批） |
+| **Defer / Archive** | 无 | 刻意跳过激活，归档候选 | 不需要（自动） |
+
+通用策略：**先软后硬，逐步升级。**
+
+## 工作区安全门禁
+
+PD 可以在智能体修改高风险文件前进行拦截。这保护了重要文件，例如：
+
+- 智能体身份文件（`SOUL.md`、`AGENTS.md`）
+- 记忆文件（`memory/`）
+- 战略和计划文件（`PLAN.md`）
+- 你自定义的高风险路径
+
+### 工作原理
+
+当智能体尝试编辑受保护的文件时，PD 会检查 `PLAN.md`：
+
+```
+STATUS: READY    → 允许编辑
+STATUS: DRAFT    → 拦截编辑
+没有 PLAN.md     → 拦截编辑
+```
+
+### 被拦截后智能体应该怎么做
+
+1. 更新 `PLAN.md`，说明为什么要编辑
+2. 描述风险和必要性
+3. 设置 `STATUS: READY`
+4. 重试操作
+
+### 配置风险路径
+
+编辑工作区的 `docs/PROFILE.json`：
+
+```json
+{
+  "progressive_gate": {
+    "enabled": true,
+    "plan_approvals": {
+      "enabled": true,
+      "allowed_patterns": ["docs/**", "skills/**"],
+      "allowed_operations": ["write", "edit"]
+    }
+  }
+}
+```
+
+## 斜杠命令
+
+PD 通过斜杠命令与 OpenClaw 集成。以下是 MVP 命令：
+
+### 初始化
+
+| 命令 | 缩写 | 说明 |
+|------|------|------|
+| `/pd-init` | `/pdi` | 初始化工作区 |
+| `/pd-bootstrap` | `/pdb` | 扫描环境工具 |
+| `/pd-research` | `/pdr` | 研究工具和能力 |
+| `/pd-help` | `/pdh` | 显示命令参考 |
+
+### 痛觉与监控
+
+| 命令 | 说明 |
+|------|------|
+| `/pd-pain` | 从当前会话报告痛觉信号 |
+| `/pd-status` | 查看系统健康状态、钩子状态和错误率 |
+| `/pd-evolution-status` | 查看原则演化状态 |
+
+### 原则管理
+
+| 命令 | 说明 |
+|------|------|
+| `/pd-promote-impl list` | 列出所有实现候选 |
+| `/pd-promote-impl eval <id>` | 评估指定候选 |
+| `/pd-promote-impl show <id>` | 查看候选详情 |
+| `/pd-promote-impl <id>` | 将候选晋升为激活状态 |
+| `/pd-disable-impl <id>` | 禁用一个激活的实现 |
+| `/pd-rollback-impl <id>` | 回滚到之前的状态 |
+| `/pd-archive-impl <id>` | 归档一个实现 |
+| `/pd-principle-rollback` | 将原则回滚到试用状态 |
+
+## PD 命令行工具
+
+`pd` 命令行工具提供了 OpenClaw 会话之外的额外功能。
+
+### 记录痛觉信号
+
+```bash
+pd pain record --reason "编辑文件前没有先阅读" --score 75
+```
+
+选项：
+- `--reason, -r` — 痛觉原因（必填）
+- `--score, -s` — 痛觉严重程度，0–100（默认：80）
+- `--session-id` — 会话 ID（默认：自动生成）
+
+### 健康检查（Canary）
+
+```bash
+pd runtime canary --workspace "<路径>" --json
+```
+
+Canary 运行 7 项检查，报告三种状态之一：
+
+| 状态 | 含义 |
+|------|------|
+| `healthy` | 所有检查通过 |
+| `degraded` | 发现非关键问题（孤立候选、队列阻塞等） |
+| `error` | Schema 失败或异常——需要调查后再继续 |
+
+### 启动控制台
+
+```bash
+pd console --workspace "<路径>" --no-auth
+```
+
+在浏览器中打开 [http://127.0.0.1:3100](http://127.0.0.1:3100)。
+
+::: warning
+控制台默认绑定到 `127.0.0.1`（仅本机回环），其他机器无法访问。如果需要网络访问，请使用 `--host <ip>` 配合 `--token <密钥>`。
+:::
+
+## 审核控制台
+
+本地控制台是你观察 PD 活动的主要窗口。
+
+### 你能看到什么
+
+- **痛觉趋势** — 智能体遇到问题的频率如何？
+- **原则候选** — 有哪些新原则被提出？
+- **激活的原则** — 当前有什么在指导或约束智能体？
+- **审批队列** — 有什么在等待你的决定？
+- **演化事件** — 所有原则生命周期变更的时间线
+
+### 审核原则候选
+
+1. 打开控制台
+2. 进入 **原则** 页面
+3. 选择一个候选进行审核
+4. 阅读痛觉证据和提议的原则文本
+5. 选择激活通道：
+   - **Prompt** — 软性引导，适合首次尝试
+   - **RuleHost** — 硬性拦截，软引导不够时使用
+   - **Defer / Archive** — 暂时跳过这个候选
+
+### 回滚
+
+如果激活的原则导致了问题：
+
+```bash
+/pd-rollback-impl <id>
+```
+
+这会恢复到之前的状态。你也可以只禁用而不回滚：
+
+```bash
+/pd-disable-impl <id>
+```
+
+## 配置
+
+### 工作区配置
+
+PD 需要知道你的智能体工作区在哪里。这通常在安装时设置，但你也可以手动配置。
+
+**方式一：配置文件**（推荐）
+
+创建 `~/.openclaw/principles-disciple.json`：
+
+```json
+{
+  "workspace": "/path/to/your/workspace",
+  "state": "/path/to/your/workspace/.state",
+  "debug": false
+}
+```
+
+**方式二：环境变量**
+
+```bash
+export PD_WORKSPACE_DIR=/path/to/your/workspace
+export PD_STATE_DIR=/path/to/your/workspace/.state
+```
+
+**配置优先级**（从高到低）：
+
+1. 环境变量（`PD_WORKSPACE_DIR`、`PD_STATE_DIR`）
+2. 配置文件（`~/.openclaw/principles-disciple.json`）
+3. OpenClaw 环境（`OPENCLAW_WORKSPACE`）
+4. 默认值（`~/.openclaw/workspace`）
+
+### 插件配置
+
+| 选项 | 默认值 | 说明 |
+|------|--------|------|
+| `language` | `zh` | 交互语言（`en` 或 `zh`） |
+| `auditLevel` | `medium` | 安全门禁级别（`low`、`medium`、`high`） |
+| `riskPaths` | `[]` | 需要显式授权的高风险目录 |
+
+## 常见问题
+
+### 插件加载失败
+
+**错误**：`Cannot find module 'micromatch'`
+
+**解决**：
+```bash
+cd ~/.openclaw/extensions/principles-disciple
+npm install micromatch@^4.0.8 @sinclair/typebox@^0.34.48
+```
+
+### 更新后插件仍显示旧版本
+
+**解决**：
+```bash
+rm -rf ~/.openclaw/extensions/principles-disciple
+cd /path/to/principles
+./packages/openclaw-plugin/scripts/install.sh
+```
+
+### 配置错误
+
+**错误**：`Invalid config: plugin not found: principles-disciple`
+
+**解决**：
+```bash
+openclaw doctor --fix
+./packages/openclaw-plugin/scripts/install.sh
+```
+
+### 日志在哪里
+
+默认位置：`~/.openclaw/workspace/memory/.state/logs/`
+
+| 文件 | 内容 |
+|------|------|
+| `events.jsonl` | 结构化事件日志（工具调用、痛觉信号、门禁拦截、演化任务） |
+| `plugin.log` | 运行时插件日志 |
+| `daily-stats.json` | 每日统计汇总 |
+
+## PD 不是什么
+
+为了明确期望：
+
+- PD **不是**任务执行引擎
+- PD **不是**通用记忆系统或外接大脑
+- PD **不是**通用工具调用或输出格式修复工具
+- PD **不是** LangChain 式应用构建器
+- PD **不是** SaaS 产品或聊天机器人
+- PD **不是**一键自动变强的魔法按钮
+
+PD 是 OpenClaw 编程智能体的**行为内化层**。它帮助你的智能体从痛觉中学习——而你始终在环。


### PR DESCRIPTION
## Problem

The VitePress config referenced 4 documentation routes that did not exist, causing 404 errors on the deployed site:
- `/docs/getting-started`
- `/docs/user-guide`
- `/docs/development`
- `/zh/docs/user-guide`

## Changes

### New files (4)
- `packages/website/docs/getting-started.md` — 2-minute quick start guide
- `packages/website/docs/user-guide.md` — Complete MVP feature reference (English)
- `packages/website/docs/development.md` — Architecture and contribution guide
- `packages/website/zh/docs/user-guide.md` — Complete MVP feature reference (Chinese)

### Modified files (1)
- `.gitignore` — Added exceptions for `packages/website/docs/` and `packages/website/zh/docs/` which were blocked by the root `docs/` ignore rule

## Content scope

All documentation is scoped to **MVP-Core features only** (per ADR-0014):
- Pain capture, diagnosis, principle internalization
- 3 activation channels (prompt, RuleHost, defer/archive)
- Workspace guardrails, review console, CLI tools
- 15 MVP slash commands

Non-MVP commands excluded: `/pd-thinking`, `/pd-focus`, `/pd-context`, `/pd-daily`, `/pd-grooming`, `/pd-export`, `/pd-samples`, `/pd-workflow-debug`

## Verification
- [x] `npm run docs:build` passes
- [x] All 4 HTML pages generated correctly
- [x] All commands and features verified against source code
- [x] Non-existent/retired commands removed
- [x] Command names corrected (`/pd-rollback` → `/pd-principle-rollback`)