### PR TITLE
feat(diagnostician): weak-model robustness — multi-attempt repair + provider-level structured output (PRI-271)

### DIFF
--- a/packages/principles-core/src/prompt-builder/__tests__/empathy-keyword-matching.test.ts
+++ b/packages/principles-core/src/prompt-builder/__tests__/empathy-keyword-matching.test.ts
@@ -394,7 +394,8 @@ describe('Empathy Keyword Matching (core)', () => {
       const term = '垃圾';
       const entry = store.terms[term];
       expect(entry).toBeDefined();
-      const expectedWeight = entry!.weight * (1 - entry!.falsePositiveRate);
+      if (!entry) return;
+      const expectedWeight = entry.weight * (1 - entry.falsePositiveRate);
 
       const result = matchEmpathyKeywords(term, store);
 

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -239,6 +239,7 @@ const KNOWN_PLUGIN_CORE_FILES = new Set([
   'schema/migrations/001-init-trajectory.ts',
 
   // ── I/O Boundary ────────────────────────────────────────────────────────
+  'confirm-first-gate.ts',
   'trajectory.ts',
   'evolution-reducer.ts',
   'promotion-gate.ts',
@@ -332,7 +333,7 @@ describe('PRI-212 plugin core anti-growth guard', () => {
     // Sanity check: if the baseline grows, update this number.
     // Prevents accidental baseline bloat from going unnoticed.
     // See docs/reviews/plugin-core-inventory-2026-05.md §7
-    expect(KNOWN_PLUGIN_CORE_FILES.size).toBe(94);
+    expect(KNOWN_PLUGIN_CORE_FILES.size).toBe(95);
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
@@ -135,7 +135,7 @@ function makeDiagnosticianOutput(overrides?: Partial<DiagnosticianOutputV1>): Di
     summary: 'Attack test diagnosis',
     rootCause: 'Attack test root cause',
     violatedPrinciples: [],
-    evidence: [],
+    evidence: [{ sourceRef: 'test', note: 'Attack test evidence' }],
     recommendations: [
       { kind: 'principle', description: 'Always validate inputs before processing' },
     ],

--- a/packages/principles-core/src/runtime-v2/__tests__/error-categories.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/error-categories.test.ts
@@ -68,7 +68,7 @@ describe('isPDErrorCategory', () => {
 
 describe('FAILURE_CATEGORY_MAP', () => {
   it('maps workspace_dirty to artifact_missing (critical for PRI-137)', () => {
-    expect(FAILURE_CATEGORY_MAP['workspace_dirty']).toBe('artifact_missing');
+    expect(FAILURE_CATEGORY_MAP.workspace_dirty).toBe('artifact_missing');
   });
 
   it('maps all PD_ERROR_CATEGORIES to failure categories', () => {
@@ -79,30 +79,30 @@ describe('FAILURE_CATEGORY_MAP', () => {
   });
 
   it('maps runtime_unavailable errors correctly', () => {
-    expect(FAILURE_CATEGORY_MAP['runtime_unavailable']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['lease_conflict']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['lease_expired']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['execution_failed']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['history_not_found']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['trajectory_ambiguous']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['context_assembly_failed']).toBe('runtime_unavailable');
-    expect(FAILURE_CATEGORY_MAP['query_invalid']).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.runtime_unavailable).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.lease_conflict).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.lease_expired).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.execution_failed).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.history_not_found).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.trajectory_ambiguous).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.context_assembly_failed).toBe('runtime_unavailable');
+    expect(FAILURE_CATEGORY_MAP.query_invalid).toBe('runtime_unavailable');
   });
 
   it('maps timeout errors correctly', () => {
-    expect(FAILURE_CATEGORY_MAP['timeout']).toBe('runtime_timeout');
-    expect(FAILURE_CATEGORY_MAP['cancelled']).toBe('runtime_timeout');
-    expect(FAILURE_CATEGORY_MAP['max_attempts_exceeded']).toBe('runtime_timeout');
+    expect(FAILURE_CATEGORY_MAP.timeout).toBe('runtime_timeout');
+    expect(FAILURE_CATEGORY_MAP.cancelled).toBe('runtime_timeout');
+    expect(FAILURE_CATEGORY_MAP.max_attempts_exceeded).toBe('runtime_timeout');
   });
 
   it('maps config errors correctly', () => {
-    expect(FAILURE_CATEGORY_MAP['capability_missing']).toBe('config_missing');
-    expect(FAILURE_CATEGORY_MAP['input_invalid']).toBe('config_missing');
-    expect(FAILURE_CATEGORY_MAP['workspace_invalid']).toBe('config_missing');
+    expect(FAILURE_CATEGORY_MAP.capability_missing).toBe('config_missing');
+    expect(FAILURE_CATEGORY_MAP.input_invalid).toBe('config_missing');
+    expect(FAILURE_CATEGORY_MAP.workspace_invalid).toBe('config_missing');
   });
 
   it('maps ledger errors correctly', () => {
-    expect(FAILURE_CATEGORY_MAP['storage_unavailable']).toBe('ledger_write_failed');
+    expect(FAILURE_CATEGORY_MAP.storage_unavailable).toBe('ledger_write_failed');
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/activation/__tests__/memory-activation-state-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/__tests__/memory-activation-state-store.test.ts
@@ -16,6 +16,7 @@ function makeActivationRecord(overrides: Partial<ActivationStatusRecord> = {}): 
 }
 
 describe('MemoryActivationStateStore', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let store: MemoryActivationStateStore;
 
   beforeEach(() => {
@@ -133,6 +134,7 @@ describe('MemoryActivationStateStore', () => {
 });
 
 describe('MemoryArtifactReadModel', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let model: MemoryArtifactReadModel;
 
   beforeEach(() => {

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/chaos-json-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/chaos-json-repair.test.ts
@@ -252,6 +252,7 @@ describe('Chaos 8: Schema-invalid JSON that repair still fails', () => {
       { confidence: 'high', summary: 'test' },
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck },
+      { maxRepairAttempts: 1 },
     );
 
     expect(result.repaired).toBe(false);
@@ -270,6 +271,7 @@ describe('Chaos 8: Schema-invalid JSON that repair still fails', () => {
       { confidence: 'high', summary: 'test' },
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck },
+      { maxRepairAttempts: 1 },
     );
 
     expect(result.repaired).toBe(false);
@@ -284,6 +286,7 @@ describe('Chaos 8: Schema-invalid JSON that repair still fails', () => {
       { confidence: 'high' },
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: 1 },
     );
 
     expect(result.repaired).toBe(false);
@@ -552,7 +555,7 @@ describe('Chaos 11: maxRepairAttempts bounded', () => {
   it('11a: normalizeMaxRepairAttempts with absurd values', () => {
     expect(normalizeMaxRepairAttempts(1e10, 1)).toBe(MAX_REPAIR_ATTEMPTS);
     expect(normalizeMaxRepairAttempts(Number.MAX_VALUE, 1)).toBe(MAX_REPAIR_ATTEMPTS); // finite → clamped
-    expect(normalizeMaxRepairAttempts(7.999999999, 1)).toBe(2); // floors to 2, cap at 2
+    expect(normalizeMaxRepairAttempts(7.999999999, 1)).toBe(3); // floors to 7, cap at MAX_REPAIR_ATTEMPTS=3
     expect(normalizeMaxRepairAttempts(-0, 1)).toBe(-0); // -0 is not < 0, so it passes through
   });
 
@@ -586,6 +589,7 @@ describe('Chaos 12: Telemetry and evidence pack completeness', () => {
       { confidence: 'high' },
       [{ path: '/confidence', message: 'Expected number', value: 'high' }],
       { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: 1 },
     );
 
     expect(result.repairAttempts).toHaveLength(1);
@@ -600,7 +604,7 @@ describe('Chaos 12: Telemetry and evidence pack completeness', () => {
       { confidence: 'high' },
       [{ path: '/confidence', message: 'Expected number', value: 'high' }],
       { llmCaller, schemaCheck: () => false },
-      { schemaRef: 'chaos-test-output-v1' },
+      { schemaRef: 'chaos-test-output-v1', maxRepairAttempts: 1 },
     );
 
     expect(result.repairAttempts).toHaveLength(1);
@@ -645,6 +649,7 @@ describe('Chaos 12: Telemetry and evidence pack completeness', () => {
       { confidence: 'high' },
       [{ path: '/confidence', message: 'Expected number', value: 'high' }],
       { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: 1 },
     );
 
     expect(result.repairAttempts).toHaveLength(1);

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
@@ -94,6 +94,7 @@ function makeAdapter(overrides: Record<string, unknown> = {}) {
     model: 'anthropic/claude-sonnet-4',
     apiKeyEnv: 'TEST_API_KEY',
     _testBackoffDelayMs: 0,
+    outputPathStrategy: 'free_form_only', // Default to free_form for existing tests
     ...overrides,
   });
 }
@@ -520,6 +521,8 @@ describe('PiAiRuntimeAdapter', () => {
       mockComplete.mockReset();
       mockComplete
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify({ valid: true })))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify({ valid: true })))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify({ valid: true })))
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify({ valid: true })));
 
       const adapter = makeAdapter({ maxRetries: 3 });
@@ -527,8 +530,8 @@ describe('PiAiRuntimeAdapter', () => {
       await expect(adapter.startRun(makeStartRunInput({
         outputSchemaRef: 'diagnostician-output-v1',
       }))).rejects.toThrow(PDRuntimeError);
-      // 1 original + 1 repair attempt = 2 calls (not 3+ retries)
-      expect(mockComplete).toHaveBeenCalledTimes(2);
+      // 1 original + 3 repair attempts = 4 calls (not infinite retries)
+      expect(mockComplete).toHaveBeenCalledTimes(4);
     });
 
     it('does not retry on PDRuntimeError (runtime_unavailable)', async () => {
@@ -789,13 +792,16 @@ describe('PiAiRuntimeAdapter', () => {
     it('repair fails — still throws output_invalid after repair attempt', async () => {
       mockComplete
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)));
 
       const adapter = makeAdapter();
       await expect(adapter.startRun(makeDiagnosticianInput())).rejects.toMatchObject({
         category: 'output_invalid',
       });
-      expect(mockComplete).toHaveBeenCalledTimes(2);
+      // 1 original + 3 repair attempts = 4 calls
+      expect(mockComplete).toHaveBeenCalledTimes(4);
     });
 
     it('skips repair for unknown outputSchemaRef (not in registry)', async () => {
@@ -854,6 +860,8 @@ describe('PiAiRuntimeAdapter', () => {
     it('emits output_repair_attempted with repaired=false on failure', async () => {
       mockComplete
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)));
 
       const adapter = makeAdapter();
@@ -895,8 +903,10 @@ describe('PiAiRuntimeAdapter', () => {
       expect(repairMessage).toContain('confidence');
     });
 
-    it('repair budget exhausted — maxRepairAttempts=1, no infinite loop', async () => {
+    it('repair budget exhausted — default maxRepairAttempts=3, no infinite loop', async () => {
       mockComplete
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
+        .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)))
         .mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(INVALID_DIAGNOSIS)));
 
@@ -904,8 +914,8 @@ describe('PiAiRuntimeAdapter', () => {
       await expect(adapter.startRun(makeDiagnosticianInput())).rejects.toMatchObject({
         category: 'output_invalid',
       });
-      // 1 original + 1 repair = 2 calls total (not infinite)
-      expect(mockComplete).toHaveBeenCalledTimes(2);
+      // 1 original + 3 repair attempts = 4 calls total (not infinite)
+      expect(mockComplete).toHaveBeenCalledTimes(4);
     });
 
     it('repairs evaluator-output-v1 with prose-wrapped JSON', async () => {
@@ -1229,8 +1239,8 @@ describe('PiAiRuntimeAdapter', () => {
         category: 'output_invalid',
       });
 
-      // 1 original + 1 repair (default maxRepairAttempts=1) = 2 calls total
-      expect(mockComplete).toHaveBeenCalledTimes(2);
+      // 1 original + 3 repair (default maxRepairAttempts=3) = 4 calls total
+      expect(mockComplete).toHaveBeenCalledTimes(4);
     });
 
     it('7. repair prompt includes schemaRef and error paths', async () => {

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts
@@ -135,6 +135,7 @@ describe('attemptStructuredOutputRepair', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck },
+      { maxRepairAttempts: 1, _testJitterMs: 0 },
     );
 
     expect(result.repaired).toBe(false);
@@ -149,6 +150,7 @@ describe('attemptStructuredOutputRepair', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => true },
+      { maxRepairAttempts: 1, _testJitterMs: 0 },
     );
 
     expect(result.repaired).toBe(false);
@@ -185,7 +187,7 @@ describe('attemptStructuredOutputRepair', () => {
     expect(callerInvoked).toBe(false);
   });
 
-  it('uses default maxRepairAttempts=1 (single attempt)', async () => {
+  it('uses default maxRepairAttempts=3 (three attempts)', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => { callCount++; return JSON.stringify(SAMPLE_INVALID_JSON); };
 
@@ -193,9 +195,10 @@ describe('attemptStructuredOutputRepair', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => false },
+      { _testJitterMs: 0 },
     );
 
-    expect(callCount).toBe(1);
+    expect(callCount).toBe(3);
   });
 
   it('repairSummary contains bounded error information', async () => {
@@ -295,7 +298,7 @@ describe('attemptStructuredOutputRepair', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck },
-      { schemaRef: 'diagnostician-output-v1' },
+      { schemaRef: 'diagnostician-output-v1', maxRepairAttempts: 1, _testJitterMs: 0 },
     );
 
     expect(result.repairAttempts).toHaveLength(1);
@@ -309,6 +312,7 @@ describe('attemptStructuredOutputRepair', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => false },
+      { maxRepairAttempts: 1, _testJitterMs: 0 },
     );
 
     expect(result.repairAttempts).toHaveLength(1);
@@ -599,7 +603,7 @@ describe('attemptStructuredOutputRepair', () => {
 
 describe('DEFAULT_REPAIR_CONFIG', () => {
   it('has sensible defaults', () => {
-    expect(DEFAULT_REPAIR_CONFIG.maxRepairAttempts).toBe(1);
+    expect(DEFAULT_REPAIR_CONFIG.maxRepairAttempts).toBe(3);
     expect(DEFAULT_REPAIR_CONFIG.maxErrorsInPrompt).toBe(10);
     expect(DEFAULT_REPAIR_CONFIG.maxErrorChars).toBe(200);
     expect(DEFAULT_REPAIR_CONFIG.maxRawOutputChars).toBe(2000);
@@ -609,7 +613,7 @@ describe('DEFAULT_REPAIR_CONFIG', () => {
 // ── PRI-200 Finding 1: Bounded repair attempts ──
 
 describe('PRI-200 Finding 1: maxRepairAttempts hard cap', () => {
-  it('maxRepairAttempts: 999 only calls llmCaller 2 times (clamped to MAX_REPAIR_ATTEMPTS)', async () => {
+  it('maxRepairAttempts: 999 only calls llmCaller 3 times (clamped to MAX_REPAIR_ATTEMPTS)', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -620,15 +624,15 @@ describe('PRI-200 Finding 1: maxRepairAttempts hard cap', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => false },
-      { maxRepairAttempts: 999 },
+      { maxRepairAttempts: 999, _testJitterMs: 0 },
     );
 
     expect(result.repaired).toBe(false);
-    expect(callCount).toBe(2);
-    expect(result.attemptsUsed).toBe(2);
+    expect(callCount).toBe(3);
+    expect(result.attemptsUsed).toBe(3);
   });
 
-  it('maxRepairAttempts: Infinity falls back to default (1)', async () => {
+  it('maxRepairAttempts: Infinity falls back to default (3)', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -639,15 +643,15 @@ describe('PRI-200 Finding 1: maxRepairAttempts hard cap', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => false },
-      { maxRepairAttempts: Infinity },
+      { maxRepairAttempts: Infinity, _testJitterMs: 0 },
     );
 
     expect(result.repaired).toBe(false);
-    expect(callCount).toBe(1);
-    expect(result.attemptsUsed).toBe(1);
+    expect(callCount).toBe(3);
+    expect(result.attemptsUsed).toBe(3);
   });
 
-  it('maxRepairAttempts: NaN falls back to default (1)', async () => {
+  it('maxRepairAttempts: NaN falls back to default (3)', async () => {
     let callCount = 0;
     const llmCaller: RepairLLMCaller = async () => {
       callCount++;
@@ -658,12 +662,12 @@ describe('PRI-200 Finding 1: maxRepairAttempts hard cap', () => {
       SAMPLE_INVALID_JSON,
       SAMPLE_ERRORS,
       { llmCaller, schemaCheck: () => false },
-      { maxRepairAttempts: NaN },
+      { maxRepairAttempts: NaN, _testJitterMs: 0 },
     );
 
     expect(result.repaired).toBe(false);
-    expect(callCount).toBe(1);
-    expect(result.attemptsUsed).toBe(1);
+    expect(callCount).toBe(3);
+    expect(result.attemptsUsed).toBe(3);
   });
 
   it('maxRepairAttempts: -1 skips repair entirely', async () => {
@@ -715,6 +719,7 @@ describe('PRI-200 Finding 2: safe preview serialization in repair loop', () => {
       circular,
       [{ path: '/confidence', message: 'Expected number', value: '85%' }],
       { llmCaller, schemaCheck: () => false },
+      { _testJitterMs: 0 },
     );
 
     expect(result.repaired).toBe(false);

--- a/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
@@ -110,6 +110,16 @@ export function preserveLineageFields(
   return result;
 }
 
+export function stripLineageFields(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...obj };
+  for (const field of LINEAGE_FIELDS) {
+    delete result[field];
+  }
+  return result;
+}
+
 export function formatValidationErrorEntry(
   path: string,
   message: string,

--- a/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/output-repair-contract.ts
@@ -46,7 +46,7 @@ export interface OutputEvidencePack {
 
 export const REPAIR_PROMPT_VERSION = '1';
 
-export const MAX_REPAIR_ATTEMPTS = 2;
+export const MAX_REPAIR_ATTEMPTS = 3;
 
 export function normalizeMaxRepairAttempts(raw: number | undefined, defaultVal: number): number {
   if (raw === undefined) return defaultVal;

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -30,9 +30,10 @@ import { RolloutReviewerOutputV1Schema } from '../internalization/rollout-review
 import { TrainerOutputV1Schema } from '../internalization/trainer-output.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
-import { attemptStructuredOutputRepair } from './structured-output-repair.js';
+import { attemptStructuredOutputRepair, deriveSchemaSummary } from './structured-output-repair.js';
 import type { OutputEvidencePack, OutputValidationErrorEntry } from './output-repair-contract.js';
 import { formatValidationErrorEntry, safeStringifyPreview } from './output-repair-contract.js';
+import { RECORD_DIAGNOSIS_V1_TOOL } from './tools/diagnostician-tool.js';
 import type {
   PDRuntimeAdapter,
   RuntimeKind,
@@ -44,6 +45,12 @@ import type {
   StructuredRunOutput,
   RuntimeArtifactRef,
 } from '../runtime-protocol.js';
+
+/** Output path strategy for structured output (PRI-271 B3). */
+export type OutputPathStrategy = 'tool_call_first' | 'json_mode_first' | 'free_form_only';
+
+/** Result of a specific output path attempt (PRI-271 B3). */
+export type OutputPathLabel = 'tool_call' | 'json_object_mode' | 'free_form_with_repair';
 
 /**
  * Configuration for PiAiRuntimeAdapter.
@@ -70,6 +77,15 @@ export interface PiAiRuntimeAdapterConfig {
   eventEmitter?: StoreEventEmitter;
   /** Reasoning/thinking level. Set to false to disable thinking for models that enable it by default. Default: undefined (use model default). */
   reasoning?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | false;
+  /**
+   * Output path strategy for structured output (PRI-271 B3).
+   * - 'tool_call_first': Try tool calling → JSON mode → free-form + repair (default)
+   * - 'json_mode_first': Try JSON mode → free-form + repair (skip tool calling)
+   * - 'free_form_only': Only use current free-form + repair path
+   */
+  outputPathStrategy?: OutputPathStrategy;
+  /** Maximum repair attempts for structured output repair loop (PRI-271 A1). Default: 3. */
+  maxRepairAttempts?: number;
   /** Internal override for the retry delay backoff, primarily for fast unit testing. */
   _testBackoffDelayMs?: number;
 }
@@ -479,123 +495,74 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
     });
 
     try {
-      // Call LLM with retry — pass effectiveTimeoutMs so provider request uses runner timeout
-      const response = await this.completeWithRetry(model, context, { signal, apiKey, effectiveTimeoutMs, timeoutSource, input, runId });
-
-      // extractAssistantTextOrThrow normalizes resolved-error responses
-      // (e.g., stopReason:'error' + errorMessage:'401 Unauthorized')
-      // into proper PDRuntimeError — prevents misclassifying API errors as output_invalid
-      const text = extractAssistantTextOrThrow(response, signal);
-
-      // Parse response — handles prose-wrapped and code-fenced JSON
-      let validatedOutput: unknown = extractJsonObject(text);
-      if (!validatedOutput) {
-        this.eventEmitter.emitTelemetry({
-          eventType: 'output_extraction_failed',
-          traceId: input.taskRef?.taskId ?? runId,
-          timestamp: new Date().toISOString(),
-          sessionId: 'pi-ai-adapter',
-          agentId: 'pi-ai-adapter',
-          payload: {
-            runId,
-            runtimeKind: 'pi-ai',
-            provider: this.config.provider,
-            model: this.config.model,
-            outputSchemaRef: input.outputSchemaRef ?? 'unknown',
-            rawOutputPreview: text.slice(0, 500),
-          },
-        });
-        throw new PDRuntimeError('output_invalid', 'No valid JSON found in LLM response');
-      }
-
+      // PRI-271 B3: Three-path fallback chain for structured output
       const schemaRef = input.outputSchemaRef;
       const schema = schemaRef ? OUTPUT_SCHEMA_REGISTRY.get(schemaRef) : undefined;
+      const strategy = this.config.outputPathStrategy ?? 'tool_call_first';
 
-      if (schema && !Value.Check(schema, validatedOutput)) {
-        const schemaErrors = [...Value.Errors(schema, validatedOutput)]
-          .map(e => ({ path: e.path, message: e.message, value: e.value }));
+      let validatedOutput: unknown = undefined;
+      const schemaSummary = (schema && schemaRef) ? deriveSchemaSummary(schema) : undefined;
 
-        if (schemaErrors.length === 0) {
-          throw new PDRuntimeError(
-            'output_invalid',
-            `LLM output does not match ${schemaRef ?? 'unknown'} schema (no specific errors enumerated)`,
-          );
+      // ── Path 1: Tool calling (PRI-271 B2) ──
+      if (strategy === 'tool_call_first' && schema && schemaRef) {
+        const toolResult = await this.tryToolCallPath({ model, baseContext: context, schemaRef, schema, signal, apiKey, effectiveTimeoutMs, input, runId });
+        if (toolResult.success && toolResult.output !== undefined) {
+          validatedOutput = toolResult.output;
+          this.emitOutputPathTelemetry({ runId, input, path: 'tool_call', fallbackReason: null });
+        } else {
+          this.emitOutputPathTelemetry({ runId, input, path: null, fallbackReason: toolResult.fallbackReason ?? 'provider_no_tool_use' });
+        }
+      }
+
+      // ── Path 2: JSON mode (PRI-271 B1) ──
+      if (!validatedOutput && (strategy === 'tool_call_first' || strategy === 'json_mode_first') && schema && schemaRef) {
+        const jsonResult = await this.tryJsonModePath({ model, baseContext: context, schemaRef, schema, signal, apiKey, effectiveTimeoutMs, input, runId });
+        if (jsonResult.success && jsonResult.output !== undefined) {
+          validatedOutput = jsonResult.output;
+          this.emitOutputPathTelemetry({ runId, input, path: 'json_object_mode', fallbackReason: null });
+        } else {
+          this.emitOutputPathTelemetry({ runId, input, path: null, fallbackReason: jsonResult.fallbackReason ?? 'json_parse_failed' });
+        }
+      }
+
+      // ── Path 3: Free-form + repair (current behavior, enhanced) ──
+      if (!validatedOutput) {
+        const response = await this.completeWithRetry(model, context, { signal, apiKey, effectiveTimeoutMs, timeoutSource, input, runId });
+        const text = extractAssistantTextOrThrow(response, signal);
+        let parsedOutput = extractJsonObject(text);
+
+        if (!parsedOutput) {
+          this.eventEmitter.emitTelemetry({
+            eventType: 'output_extraction_failed',
+            traceId: input.taskRef?.taskId ?? runId,
+            timestamp: new Date().toISOString(),
+            sessionId: 'pi-ai-adapter',
+            agentId: 'pi-ai-adapter',
+            payload: {
+              runId,
+              runtimeKind: 'pi-ai',
+              provider: this.config.provider,
+              model: this.config.model,
+              outputSchemaRef: input.outputSchemaRef ?? 'unknown',
+              rawOutputPreview: text.slice(0, 500),
+            },
+          });
+          throw new PDRuntimeError('output_invalid', 'No valid JSON found in LLM response');
         }
 
-        const validationErrorEntries: OutputValidationErrorEntry[] = schemaErrors
-          .slice(0, 10)
-          .map(e => formatValidationErrorEntry(e.path, e.message, e.value));
+        if (schema && !Value.Check(schema, parsedOutput)) {
+          // Schema validation failed — attempt repair with enhanced config (PRI-271 A1/A2/A3)
+          const schemaErrors = [...Value.Errors(schema, parsedOutput)]
+            .map(e => ({ path: e.path, message: e.message, value: e.value }));
 
-        const rawOutputPreview = safeStringifyPreview(validatedOutput);
+          const validationErrorEntries: OutputValidationErrorEntry[] = schemaErrors
+            .slice(0, 10)
+            .map(e => formatValidationErrorEntry(e.path, e.message, e.value));
 
-        this.eventEmitter.emitTelemetry({
-          eventType: 'output_schema_invalid',
-          traceId: input.taskRef?.taskId ?? runId,
-          timestamp: new Date().toISOString(),
-          sessionId: 'pi-ai-adapter',
-          agentId: 'pi-ai-adapter',
-          payload: {
-            runId,
-            runtimeKind: 'pi-ai',
-            outputSchemaRef: schemaRef ?? 'unknown',
-            provider: this.config.provider,
-            model: this.config.model,
-            rawOutputPreview,
-            validationErrors: validationErrorEntries,
-          },
-        });
-
-        const originalOutput = typeof validatedOutput === 'object' && validatedOutput !== null
-          ? validatedOutput as Record<string, unknown>
-          : undefined;
-
-        const repairResult = await attemptStructuredOutputRepair<Record<string, unknown>>(
-          validatedOutput,
-          schemaErrors,
-          {
-            llmCaller: (prompt: string) => this.repairLLMCall(model, prompt, { signal, apiKey }),
-            schemaCheck: (value: unknown) => Value.Check(schema, value),
-            schemaErrors: (value: unknown) =>
-              [...Value.Errors(schema, value)].map(e => ({ path: e.path, message: e.message, value: e.value })),
-          },
-          {
-            schemaRef: schemaRef ?? 'unknown',
-            originalOutput,
-          },
-        );
-
-        this.eventEmitter.emitTelemetry({
-          eventType: 'output_repair_attempted',
-          traceId: input.taskRef?.taskId ?? runId,
-          timestamp: new Date().toISOString(),
-          sessionId: 'pi-ai-adapter',
-          agentId: 'pi-ai-adapter',
-          payload: {
-            runId,
-            runtimeKind: 'pi-ai',
-            outputSchemaRef: schemaRef ?? 'unknown',
-            repaired: repairResult.repaired,
-            attemptsUsed: repairResult.attemptsUsed,
-            repairSummary: repairResult.repairSummary,
-            repairAttempts: repairResult.repairAttempts,
-          },
-        });
-
-        if (repairResult.repaired && repairResult.output) {
-          validatedOutput = repairResult.output;
-        } else {
-          const evidencePack: OutputEvidencePack = {
-            schemaRef: schemaRef ?? 'unknown',
-            provider: this.config.provider,
-            model: this.config.model,
-            rawOutputPreview,
-            validationErrors: validationErrorEntries,
-            repairAttempts: repairResult.repairAttempts,
-            finalFailureReason: 'repair_exhausted',
-          };
+          const rawOutputPreview = safeStringifyPreview(parsedOutput);
 
           this.eventEmitter.emitTelemetry({
-            eventType: 'output_repair_exhausted',
+            eventType: 'output_schema_invalid',
             traceId: input.taskRef?.taskId ?? runId,
             timestamp: new Date().toISOString(),
             sessionId: 'pi-ai-adapter',
@@ -608,17 +575,90 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
               model: this.config.model,
               rawOutputPreview,
               validationErrors: validationErrorEntries,
-              repairAttempts: evidencePack.repairAttempts,
-              finalFailureReason: evidencePack.finalFailureReason,
             },
           });
 
-          throw new PDRuntimeError(
-            'output_invalid',
-            `LLM output does not match ${schemaRef ?? 'unknown'} schema`,
-            { evidencePack },
+          const originalOutput = typeof parsedOutput === 'object' && parsedOutput !== null
+            ? parsedOutput as Record<string, unknown>
+            : undefined;
+
+          const repairResult = await attemptStructuredOutputRepair<Record<string, unknown>>(
+            parsedOutput,
+            schemaErrors,
+            {
+              llmCaller: (prompt: string) => this.repairLLMCall(model, prompt, { signal, apiKey }),
+              schemaCheck: (value: unknown) => Value.Check(schema, value),
+              schemaErrors: (value: unknown) =>
+                [...Value.Errors(schema, value)].map(e => ({ path: e.path, message: e.message, value: e.value })),
+            },
+            {
+              schemaRef: schemaRef ?? 'unknown',
+              originalOutput,
+              schemaSummary,
+              maxRepairAttempts: this.config.maxRepairAttempts,
+            },
           );
+
+          this.eventEmitter.emitTelemetry({
+            eventType: 'output_repair_attempted',
+            traceId: input.taskRef?.taskId ?? runId,
+            timestamp: new Date().toISOString(),
+            sessionId: 'pi-ai-adapter',
+            agentId: 'pi-ai-adapter',
+            payload: {
+              runId,
+              runtimeKind: 'pi-ai',
+              outputSchemaRef: schemaRef ?? 'unknown',
+              repaired: repairResult.repaired,
+              attemptsUsed: repairResult.attemptsUsed,
+              repairSummary: repairResult.repairSummary,
+              repairAttempts: repairResult.repairAttempts,
+              outputPath: 'free_form_with_repair',
+            },
+          });
+
+          if (repairResult.repaired && repairResult.output) {
+            parsedOutput = repairResult.output;
+          } else {
+            const evidencePack: OutputEvidencePack = {
+              schemaRef: schemaRef ?? 'unknown',
+              provider: this.config.provider,
+              model: this.config.model,
+              rawOutputPreview,
+              validationErrors: validationErrorEntries,
+              repairAttempts: repairResult.repairAttempts,
+              finalFailureReason: 'repair_exhausted',
+            };
+
+            this.eventEmitter.emitTelemetry({
+              eventType: 'output_repair_exhausted',
+              traceId: input.taskRef?.taskId ?? runId,
+              timestamp: new Date().toISOString(),
+              sessionId: 'pi-ai-adapter',
+              agentId: 'pi-ai-adapter',
+              payload: {
+                runId,
+                runtimeKind: 'pi-ai',
+                outputSchemaRef: schemaRef ?? 'unknown',
+                provider: this.config.provider,
+                model: this.config.model,
+                rawOutputPreview,
+                validationErrors: validationErrorEntries,
+                repairAttempts: evidencePack.repairAttempts,
+                finalFailureReason: evidencePack.finalFailureReason,
+              },
+            });
+
+            throw new PDRuntimeError(
+              'output_invalid',
+              `LLM output does not match ${schemaRef ?? 'unknown'} schema`,
+              { evidencePack },
+            );
+          }
         }
+
+        validatedOutput = parsedOutput;
+        this.emitOutputPathTelemetry({ runId, input, path: 'free_form_with_repair', fallbackReason: null });
       }
 
       // Update run state to succeeded
@@ -780,6 +820,168 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
   }
 
   // ── Private helpers ──
+
+  // ── PRI-271: Three-path output extraction ──
+
+  /**
+   * Path 1: Tool calling (PRI-271 B2).
+   *
+   * Passes `RECORD_DIAGNOSIS_V1_TOOL` via context.tools and injects
+   * `tool_choice: 'required'` via onPayload. If the provider supports tool
+   * calling, the response contains ToolCall content blocks with pre-parsed
+   * arguments that we validate against the schema.
+   */
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- stateless helper; kept as private method for cohesion
+  private async tryToolCallPath(
+    params: {
+      model: ReturnType<typeof resolveModel>;
+      baseContext: Context;
+      schemaRef: string;
+      schema: TSchema;
+      signal: AbortSignal;
+      apiKey: string;
+      effectiveTimeoutMs: number;
+      input: StartRunInput;
+      runId: string;
+    },
+  ): Promise<{ success: boolean; output?: unknown; fallbackReason?: string }> {
+    try {
+      const toolContext: Context = {
+        ...params.baseContext,
+        tools: [RECORD_DIAGNOSIS_V1_TOOL],
+      };
+
+      const completeOptions: SimpleStreamOptions = {
+        signal: params.signal,
+        apiKey: params.apiKey,
+        timeoutMs: params.effectiveTimeoutMs,
+        maxRetries: 0,
+        onPayload: (payload: unknown) => {
+          if (typeof payload === 'object' && payload !== null) {
+            const p = payload as Record<string, unknown>;
+            p.tool_choice = 'required';
+          }
+          return payload;
+        },
+      };
+
+      const response = await completeSimple(params.model, toolContext, completeOptions);
+
+      if (response.stopReason !== 'toolUse') {
+        return { success: false, fallbackReason: 'provider_no_tool_use' };
+      }
+
+      const toolCallBlock = response.content.find(
+        (block): block is { type: 'toolCall'; id: string; name: string; arguments: Record<string, unknown> } =>
+          typeof block === 'object' && block !== null && 'type' in block && block.type === 'toolCall',
+      );
+
+      if (!toolCallBlock) {
+        return { success: false, fallbackReason: 'tool_call_extraction_failed' };
+      }
+
+      const toolArgs = toolCallBlock.arguments;
+
+      if (!Value.Check(params.schema, toolArgs)) {
+        return { success: false, fallbackReason: 'tool_call_schema_invalid' };
+      }
+
+      return { success: true, output: toolArgs };
+    } catch (err) {
+      const reason = err instanceof PDRuntimeError && err.category === 'output_invalid'
+        ? 'tool_call_extraction_failed'
+        : 'provider_no_tool_use';
+      return { success: false, fallbackReason: reason };
+    }
+  }
+
+  /**
+   * Path 2: JSON mode (PRI-271 B1).
+   *
+   * Injects `response_format: { type: 'json_object' }` via onPayload
+   * to force the provider to output valid JSON. Then parses and validates.
+   */
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- stateless helper; kept as private method for cohesion
+  private async tryJsonModePath(
+    params: {
+      model: ReturnType<typeof resolveModel>;
+      baseContext: Context;
+      schemaRef: string;
+      schema: TSchema;
+      signal: AbortSignal;
+      apiKey: string;
+      effectiveTimeoutMs: number;
+      input: StartRunInput;
+      runId: string;
+    },
+  ): Promise<{ success: boolean; output?: unknown; fallbackReason?: string }> {
+    try {
+      const completeOptions: SimpleStreamOptions = {
+        signal: params.signal,
+        apiKey: params.apiKey,
+        timeoutMs: params.effectiveTimeoutMs,
+        maxRetries: 0,
+        onPayload: (payload: unknown) => {
+          if (typeof payload === 'object' && payload !== null) {
+            const p = payload as Record<string, unknown>;
+            p.response_format = { type: 'json_object' };
+          }
+          return payload;
+        },
+      };
+
+      const response = await completeSimple(params.model, params.baseContext, completeOptions);
+      const text = extractAssistantTextOrThrow(response, params.signal);
+
+      const parsed = extractJsonObject(text);
+      if (!parsed) {
+        return { success: false, fallbackReason: 'json_parse_failed' };
+      }
+
+      if (!Value.Check(params.schema, parsed)) {
+        return { success: false, fallbackReason: 'json_schema_invalid' };
+      }
+
+      return { success: true, output: parsed };
+    } catch (err) {
+      if (err instanceof PDRuntimeError && err.category === 'output_invalid') {
+        return { success: false, fallbackReason: 'json_parse_failed' };
+      }
+      return { success: false, fallbackReason: 'provider_no_json_mode' };
+    }
+  }
+
+  /**
+   * Emit output_path_chosen telemetry (PRI-271 B3).
+   *
+   * Every path selection and fallback emits structured telemetry.
+   * `path` is set when a path succeeds; null when recording a fallback reason.
+   */
+  private emitOutputPathTelemetry(
+    params: {
+      runId: string;
+      input: StartRunInput;
+      path: OutputPathLabel | null;
+      fallbackReason: string | null;
+    },
+  ): void {
+    this.eventEmitter.emitTelemetry({
+      eventType: params.path ? 'output_path_chosen' : 'output_path_fallback',
+      traceId: params.input.taskRef?.taskId ?? params.runId,
+      timestamp: new Date().toISOString(),
+      sessionId: 'pi-ai-adapter',
+      agentId: 'pi-ai-adapter',
+      payload: {
+        runId: params.runId,
+        runtimeKind: 'pi-ai',
+        provider: this.config.provider,
+        model: this.config.model,
+        outputSchemaRef: params.input.outputSchemaRef ?? 'unknown',
+        outputPath: params.path,
+        fallbackReason: params.fallbackReason,
+      },
+    });
+  }
 
   /**
    * Make a single LLM call for output repair (PRI-71).

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -32,7 +32,7 @@ import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair, deriveSchemaSummary } from './structured-output-repair.js';
 import type { OutputEvidencePack, OutputValidationErrorEntry } from './output-repair-contract.js';
-import { formatValidationErrorEntry, safeStringifyPreview } from './output-repair-contract.js';
+import { formatValidationErrorEntry, safeStringifyPreview, stripLineageFields } from './output-repair-contract.js';
 import { RECORD_DIAGNOSIS_V1_TOOL } from './tools/diagnostician-tool.js';
 import type {
   PDRuntimeAdapter,
@@ -886,8 +886,15 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
         return { success: false, fallbackReason: 'tool_call_schema_invalid' };
       }
 
-      return { success: true, output: toolArgs };
+      const protectedArgs = typeof toolArgs === 'object' && toolArgs !== null
+        ? stripLineageFields(toolArgs)
+        : toolArgs;
+
+      return { success: true, output: protectedArgs };
     } catch (err) {
+      if (err instanceof PDRuntimeError && (err.category === 'timeout' || err.category === 'runtime_unavailable')) {
+        throw err;
+      }
       const reason = err instanceof PDRuntimeError && err.category === 'output_invalid'
         ? 'tool_call_extraction_failed'
         : 'provider_no_tool_use';
@@ -942,8 +949,15 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
         return { success: false, fallbackReason: 'json_schema_invalid' };
       }
 
-      return { success: true, output: parsed };
+      const protectedParsed = typeof parsed === 'object' && parsed !== null
+        ? stripLineageFields(parsed)
+        : parsed;
+
+      return { success: true, output: protectedParsed };
     } catch (err) {
+      if (err instanceof PDRuntimeError && (err.category === 'timeout' || err.category === 'runtime_unavailable')) {
+        throw err;
+      }
       if (err instanceof PDRuntimeError && err.category === 'output_invalid') {
         return { success: false, fallbackReason: 'json_parse_failed' };
       }

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -886,6 +886,12 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
         return { success: false, fallbackReason: 'tool_call_schema_invalid' };
       }
 
+      // Lineage fields (taskId/sourcePainId/sourceTaskId/etc.) are
+      // intentionally stripped from LLM output. Downstream consumers
+      // (DiagnosticianRunner, committer) MUST get these values from
+      // RunnerContext / TaskRecord, never from validated output.
+      // This prevents LLM-supplied lineage from poisoning downstream
+      // commits (ERR-008 family). See PRI-271 D4 in PR description.
       const protectedArgs = typeof toolArgs === 'object' && toolArgs !== null
         ? stripLineageFields(toolArgs)
         : toolArgs;
@@ -949,6 +955,12 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
         return { success: false, fallbackReason: 'json_schema_invalid' };
       }
 
+      // Lineage fields (taskId/sourcePainId/sourceTaskId/etc.) are
+      // intentionally stripped from LLM output. Downstream consumers
+      // (DiagnosticianRunner, committer) MUST get these values from
+      // RunnerContext / TaskRecord, never from validated output.
+      // This prevents LLM-supplied lineage from poisoning downstream
+      // commits (ERR-008 family). See PRI-271 D4 in PR description.
       const protectedParsed = typeof parsed === 'object' && parsed !== null
         ? stripLineageFields(parsed)
         : parsed;

--- a/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/structured-output-repair.ts
@@ -29,7 +29,7 @@ export interface SchemaValidationError {
 
 /** Configuration for the repair loop. */
 export interface RepairConfig {
-  /** Maximum repair attempts. Default: 1. */
+  /** Maximum repair attempts. Default: 3. */
   readonly maxRepairAttempts?: number;
   /** Maximum number of errors to include in repair prompt. Default: 10. */
   readonly maxErrorsInPrompt?: number;
@@ -41,11 +41,15 @@ export interface RepairConfig {
   readonly schemaRef?: string;
   /** Original output with lineage fields to preserve during repair (PRI-200). */
   readonly originalOutput?: Record<string, unknown>;
+  /** Human-readable schema summary to include in repair prompt (PRI-271 A2). */
+  readonly schemaSummary?: string;
+  /** Internal override for jitter between repair attempts (PRI-271 A3). Set to 0 to disable. */
+  readonly _testJitterMs?: number;
 }
 
 /** Sensible defaults for repair configuration. */
-export const DEFAULT_REPAIR_CONFIG: Required<Omit<RepairConfig, 'schemaRef' | 'originalOutput'>> = {
-  maxRepairAttempts: 1,
+export const DEFAULT_REPAIR_CONFIG: Required<Omit<RepairConfig, 'schemaRef' | 'originalOutput' | 'schemaSummary' | '_testJitterMs'>> = {
+  maxRepairAttempts: 3,
   maxErrorsInPrompt: 10,
   maxErrorChars: 200,
   maxRawOutputChars: 2000,
@@ -79,6 +83,65 @@ export interface RepairCallbacks {
 // Re-export from json-extractor so callers can use a single import path
 export { extractJsonObject } from './json-extractor.js';
 import { extractJsonObject } from './json-extractor.js';
+import type { TSchema } from '@sinclair/typebox';
+
+/**
+ * Derive a human-readable schema summary from a TypeBox schema (PRI-271 A2).
+ *
+ * Produces a compact text description of field names, types, required status,
+ * and enum values — suitable for inclusion in repair prompts so the LLM knows
+ * the target schema structure without needing the full JSON Schema.
+ */
+export function deriveSchemaSummary(schema: TSchema): string {
+  if (!schema || typeof schema !== 'object') return '(unknown schema)';
+
+  // Handle Object schemas
+  if (schema.type === 'object' && schema.properties) {
+    const required = Array.isArray(schema.required) ? new Set(schema.required as string[]) : new Set<string>();
+    const lines: string[] = [];
+    const props = schema.properties as Record<string, TSchema>;
+
+    for (const [key, propSchema] of Object.entries(props)) {
+      if (typeof propSchema !== 'object' || propSchema === null) continue;
+      const isReq = required.has(key);
+      const reqMark = isReq ? ' (required)' : ' (optional)';
+
+      if (propSchema.type === 'array') {
+        const items = propSchema.items as TSchema | undefined;
+        const itemType = items?.type ?? 'unknown';
+        lines.push(`  ${key}: ${itemType}[]${reqMark}`);
+      } else if (propSchema.enum) {
+        const values = (propSchema.enum as unknown[]).map(String).join(' | ');
+        lines.push(`  ${key}: enum(${values})${reqMark}`);
+      } else if (propSchema.type) {
+        const typeStr = typeof propSchema.type === 'string' ? propSchema.type : 'unknown';
+        const constraints: string[] = [];
+        if (typeof propSchema.minimum === 'number') constraints.push(`min: ${propSchema.minimum}`);
+        if (typeof propSchema.maximum === 'number') constraints.push(`max: ${propSchema.maximum}`);
+        if (typeof propSchema.minLength === 'number') constraints.push(`minLength: ${propSchema.minLength}`);
+        const constraintStr = constraints.length > 0 ? ` {${constraints.join(', ')}}` : '';
+        lines.push(`  ${key}: ${typeStr}${constraintStr}${reqMark}`);
+      } else if (propSchema.anyOf || propSchema.allOf || propSchema.oneOf) {
+        lines.push(`  ${key}: union${reqMark}`);
+      }
+    }
+    return lines.join('\n');
+  }
+
+  // Fallback for non-object schemas
+  if (schema.type) return `type: ${schema.type}`;
+  return '(complex schema)';
+}
+
+/**
+ * Compute jitter delay for repair attempt backoff (PRI-271 A3).
+ * Returns delay in milliseconds: 200-500ms random jitter.
+ * Overridable via config._testJitterMs for deterministic tests.
+ */
+function computeJitterDelay(config: RepairConfig): number {
+  if (config._testJitterMs !== undefined) return config._testJitterMs;
+  return 200 + Math.random() * 300;
+}
 
 /**
  * Format TypeBox schema errors into a bounded, human-readable repair prompt.
@@ -113,10 +176,15 @@ export function formatRepairPrompt(
     ? [`SCHEMA REF: ${cfg.schemaRef}`, '']
     : [];
 
+  const schemaSummaryBlock = cfg.schemaSummary
+    ? ['EXPECTED SCHEMA:', cfg.schemaSummary, '']
+    : [];
+
   return [
     'This is a schema validation repair loop. Your previous JSON output still has errors. Fix ALL remaining errors and return the complete corrected JSON object.',
     '',
     ...schemaRefLine,
+    ...schemaSummaryBlock,
     'PREVIOUS OUTPUT:',
     rawJson,
     '',
@@ -139,7 +207,7 @@ function buildValidationErrorEntries(
  * the LLM with specific validation errors.
  *
  * Returns RepairResult<T> — either repaired+validated output or null.
- * Bounded by maxRepairAttempts (default 1).
+ * Bounded by maxRepairAttempts (default 3).
  *
  * PRI-200: Returns repairAttempts[] for evidence pack, protects lineage fields.
  */
@@ -257,6 +325,12 @@ export async function attemptStructuredOutputRepair<T>(
 
     invalidOutput = candidateWithLineage;
     currentErrors = nextErrors;
+
+    // PRI-271 A3: Jitter between repair attempts to avoid provider rate limits
+    if (attempt < cfg.maxRepairAttempts - 1) {
+      const jitterMs = computeJitterDelay(cfg);
+      await new Promise(r => setTimeout(r, jitterMs));
+    }
   }
 
   return {

--- a/packages/principles-core/src/runtime-v2/adapter/tools/diagnostician-tool.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/tools/diagnostician-tool.ts
@@ -1,0 +1,34 @@
+/**
+ * Diagnostician tool definition for provider-level structured output (PRI-271 B2).
+ *
+ * Defines `record_diagnosis_v1` tool whose parameters schema is derived from
+ * `DiagnosticianOutputV1Schema`. When a provider supports tool calling, the
+ * adapter passes this tool via `context.tools` and extracts the structured
+ * arguments from the `ToolCall` response — bypassing JSON extraction entirely.
+ *
+ * Design decisions (PRI-271):
+ *   D2: Tool definition in dedicated file, shared TypeBox schema source
+ *   D4: Lineage fields protected via preserveLineageFields() after extraction
+ */
+import type { Tool } from '@mariozechner/pi-ai';
+import { DiagnosticianOutputV1Schema } from '../../diagnostician-output.js';
+
+/**
+ * Tool definition for diagnostician structured output via function calling.
+ *
+ * The `parameters` field uses the canonical TypeBox schema so the provider
+ * receives the same schema that PD validates against — single source of truth.
+ */
+export const RECORD_DIAGNOSIS_V1_TOOL: Tool = {
+  name: 'record_diagnosis_v1',
+  description:
+    'Record a root cause analysis diagnosis result. ' +
+    'Call this tool with the complete diagnosis output including: ' +
+    'summary, rootCause (with category prefix like "Design:" or "People:"), ' +
+    'violatedPrinciples, evidence (with sourceRef and note), ' +
+    'recommendations (kind must be one of: principle, rule, implementation, prompt, defer), ' +
+    'and confidence (0.0-1.0). ' +
+    'All recommendations of kind "principle" must include abstractedPrinciple. ' +
+    'All recommendations of kind "rule" must include triggerPattern and action.',
+  parameters: DiagnosticianOutputV1Schema,
+};

--- a/packages/principles-core/src/runtime-v2/idle-trigger/__tests__/idle-trigger-edge-cases.test.ts
+++ b/packages/principles-core/src/runtime-v2/idle-trigger/__tests__/idle-trigger-edge-cases.test.ts
@@ -71,7 +71,7 @@ describe('evaluateIdleTrigger edge cases', () => {
 
   describe('idle duration edge cases', () => {
     it('idleForMs exactly at idleThresholdMs boundary triggers', () => {
-      const idleThresholdMs = DEFAULT_IDLE_TRIGGER_CONFIG.idleThresholdMs;
+      const { idleThresholdMs } = DEFAULT_IDLE_TRIGGER_CONFIG;
       const input = makeInput({
         lastActivityAt: new Date(NOW_MS - idleThresholdMs).toISOString(),
         queue: { readyCount: 1, pendingCount: 0, retryWaitCount: 0 },
@@ -81,7 +81,7 @@ describe('evaluateIdleTrigger edge cases', () => {
     });
 
     it('idleForMs just below idleThresholdMs returns skip not_idle_enough', () => {
-      const idleThresholdMs = DEFAULT_IDLE_TRIGGER_CONFIG.idleThresholdMs;
+      const { idleThresholdMs } = DEFAULT_IDLE_TRIGGER_CONFIG;
       const input = makeInput({
         lastActivityAt: new Date(NOW_MS - idleThresholdMs + 1).toISOString(),
         queue: { readyCount: 1, pendingCount: 0, retryWaitCount: 0 },
@@ -114,7 +114,7 @@ describe('evaluateIdleTrigger edge cases', () => {
 
   describe('activityCooldown boundary conditions', () => {
     it('idleForMs exactly at activityCooldownMs returns skip not_idle_enough', () => {
-      const activityCooldownMs = DEFAULT_IDLE_TRIGGER_CONFIG.activityCooldownMs;
+      const { activityCooldownMs } = DEFAULT_IDLE_TRIGGER_CONFIG;
       const input = makeInput({
         config: { ...DEFAULT_IDLE_TRIGGER_CONFIG },
         lastActivityAt: new Date(NOW_MS - activityCooldownMs).toISOString(),

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/diagnostician-telemetry.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/diagnostician-telemetry.test.ts
@@ -72,14 +72,13 @@ function makeDiagnosticianOutput(): DiagnosticianOutputV1 {
   return {
     valid: true,
     diagnosisId: 'diag-telem-001',
-    taskId: TASK_ID,
     summary: 'Test diagnosis summary',
     rootCause: 'Test root cause',
     violatedPrinciples: [],
     evidence: [],
     recommendations: [],
     confidence: 0.9,
-  };
+  } as unknown as DiagnosticianOutputV1;
 }
 
 // ── Mock factory ───────────────────────────────────────────────────────────────
@@ -331,5 +330,35 @@ describe('DiagnosticianRunner telemetry emission', () => {
     expect(lastCall).toBeDefined();
     const lastEvent = (lastCall as unknown[])[0] as { eventType: string; payload: { errorCategory: string } };
     expect(lastEvent.payload.errorCategory).toBe('workspace_invalid');
+  });
+
+  it('emits lineage_strip_contract_violation when output contains taskId after adapter strip', async () => {
+    const mocks = createMocks();
+    const outputWithTaskId: DiagnosticianOutputV1 = {
+      valid: true,
+      diagnosisId: 'diag-lineage-001',
+      taskId: 'LLM-FABRICATED-TASK-ID',
+      summary: 'Test diagnosis with unstripped taskId',
+      rootCause: 'Test root cause',
+      violatedPrinciples: [],
+      evidence: [],
+      recommendations: [],
+      confidence: 0.9,
+    };
+    mocks._runtimeAdapter.fetchOutput.mockResolvedValue({ runId: RUN_ID, payload: outputWithTaskId });
+
+    const runner = createRunner(mocks);
+    const result = await runner.run(TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+    const eventTypes = extractEventTypes(mocks._eventEmitter.emitTelemetry);
+    expect(eventTypes).toContain('lineage_strip_contract_violation');
+    const violationCall = mocks._eventEmitter.emitTelemetry.mock.calls.find(
+      (call: unknown[]) => (call[0] as { eventType: string }).eventType === 'lineage_strip_contract_violation',
+    );
+    expect(violationCall).toBeDefined();
+    const violationEvent = (violationCall as unknown[])[0] as { payload: { reason: string; expectedAdapter: string } };
+    expect(violationEvent.payload.reason).toBe('output_contained_taskId_after_strip');
+    expect(violationEvent.payload.expectedAdapter).toBe('pi-ai-runtime-adapter');
   });
 });

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/m8-02-e2e.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/m8-02-e2e.test.ts
@@ -202,7 +202,7 @@ function makeDiagnosticianOutputWithCandidates(taskId: string): DiagnosticianOut
     summary: 'E2E m8-02 test diagnosis summary',
     rootCause: 'E2E m8-02 root cause — missing validation before tool call',
     violatedPrinciples: [],
-    evidence: [],
+    evidence: [{ sourceRef: 'test', note: 'E2E test evidence' }],
     recommendations: [
       {
         kind: 'principle',

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/m9-adapter-integration.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/m9-adapter-integration.test.ts
@@ -61,7 +61,7 @@ function makeDiagnosticianOutputWithCandidates(taskId: string): DiagnosticianOut
     summary: 'E2E m9-04 adapter integration test diagnosis summary',
     rootCause: 'E2E m9-04 root cause — adapter integration test',
     violatedPrinciples: [],
-    evidence: [],
+    evidence: [{ sourceRef: 'test', note: 'E2E test evidence' }],
     recommendations: [
       { kind: 'principle', description: 'Always validate tool arguments before execution to prevent silent failures' },
       { kind: 'principle', description: 'Log all tool invocations with argument summaries for traceability' },
@@ -78,7 +78,7 @@ const VALID_DIAGNOSIS = {
   summary: 'Adapter integration test summary',
   rootCause: 'Adapter integration root cause',
   violatedPrinciples: [],
-  evidence: [],
+  evidence: [{ sourceRef: 'test', note: 'E2E test evidence' }],
   recommendations: [],
   confidence: 0.9,
 };
@@ -177,6 +177,7 @@ describe('E2E m9-adapter-integration — PiAiRuntimeAdapter + DiagnosticianRunne
       apiKeyEnv: 'TEST_API_KEY',
       maxRetries: 0,
       timeoutMs: 60_000,
+      outputPathStrategy: 'free_form_only',
     });
 
     const runner = createRunner(adapter);

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/m9-e2e.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/m9-e2e.test.ts
@@ -71,7 +71,7 @@ function makeDiagnosticianOutputWithCandidates(taskId: string): DiagnosticianOut
     summary: 'E2E m9-04 full chain test diagnosis summary',
     rootCause: 'E2E m9-04 full chain root cause — missing validation before tool call',
     violatedPrinciples: [],
-    evidence: [],
+    evidence: [{ sourceRef: 'test', note: 'E2E test evidence' }],
     recommendations: [
       { kind: 'principle', description: 'Always validate tool arguments before execution to prevent silent failures' },
       { kind: 'principle', description: 'Log all tool invocations with argument summaries for traceability' },
@@ -132,7 +132,7 @@ describe('E2E m9 — PainSignalBridge + PiAiRuntimeAdapter full chain', () => {
   }
 
   function makePiAiAdapter(): PiAiRuntimeAdapter {
-    return new PiAiRuntimeAdapter({ provider: 'openrouter', model: 'anthropic/claude-sonnet-4', apiKeyEnv: 'TEST_API_KEY', maxRetries: 0, timeoutMs: 60_000 });
+    return new PiAiRuntimeAdapter({ provider: 'openrouter', model: 'anthropic/claude-sonnet-4', apiKeyEnv: 'TEST_API_KEY', maxRetries: 0, timeoutMs: 60_000, outputPathStrategy: 'free_form_only' });
   }
 
   // TEST 1: Full chain

--- a/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
@@ -301,6 +301,18 @@ export class DiagnosticianRunner {
   }
 
   private async succeedTask(ctx: SucceedContext): Promise<RunnerResult> {
+    // Lineage strip contract invariant: adapter should have stripped lineage
+    // fields (taskId, sourcePainId, etc.) from LLM output. If they survive,
+    // the adapter violated its contract — emit telemetry but don't crash.
+    const outputRecord = ctx.output as unknown as Record<string, unknown>;
+    if (typeof outputRecord === 'object' && outputRecord !== null &&
+        Object.hasOwn(outputRecord, 'taskId')) {
+      this.emitDiagnosticianEvent('lineage_strip_contract_violation', ctx.taskId, {
+        reason: 'output_contained_taskId_after_strip',
+        expectedAdapter: 'pi-ai-runtime-adapter',
+      });
+    }
+
     // Store output before commit so run record reflects output on disk
     try {
       await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));

--- a/packages/principles-core/src/runtime-v2/store/concurrent-lease.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/concurrent-lease.test.ts
@@ -8,10 +8,15 @@ import { SqliteRunStore } from './run/sqlite-run-store.js';
 import { DefaultLeaseManager } from './lifecycle/lease-manager.js';
 
 describe('ConcurrentLeaseConflict', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let tmpdir: string;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let connection: SqliteConnection;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let taskStore: SqliteTaskStore;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let runStore: SqliteRunStore;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let leaseManager: DefaultLeaseManager;
 
   beforeEach(() => {
@@ -110,7 +115,7 @@ describe('ConcurrentLeaseConflict', () => {
 
     const renewed = await leaseManager.renewLease('task-4', 'runtime-A', 120_000);
     expect(renewed.leaseExpiresAt).not.toBe(original.leaseExpiresAt);
-    expect(new Date(renewed.leaseExpiresAt!) > new Date(original.leaseExpiresAt!)).toBe(true);
+    expect(renewed.leaseExpiresAt && original.leaseExpiresAt && new Date(renewed.leaseExpiresAt) > new Date(original.leaseExpiresAt)).toBe(true);
   });
 
   it('concurrent acquireLease from two runtimes — only one succeeds', async () => {

--- a/packages/principles-core/src/runtime-v2/store/idempotent-transitions.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/idempotent-transitions.test.ts
@@ -7,12 +7,19 @@ import { SqliteTaskStore } from './task/sqlite-task-store.js';
 import { SqliteRunStore } from './run/sqlite-run-store.js';
 import { DefaultRecoverySweep } from './lifecycle/recovery-sweep.js';
 import { DefaultRetryPolicy } from './lifecycle/retry-policy.js';
+import type { TaskRecord } from '../task-status.js';
+import type { LeaseManager } from './lifecycle/lease-manager.js';
 
 describe('IdempotentStateTransitions', () => {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let tmpdir: string;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let connection: SqliteConnection;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let taskStore: SqliteTaskStore;
-  let runStore: SqliteRunStore;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let _runStore: SqliteRunStore;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let retryPolicy: DefaultRetryPolicy;
 
   beforeEach(() => {
@@ -20,7 +27,7 @@ describe('IdempotentStateTransitions', () => {
     fs.mkdirSync(tmpdir, { recursive: true });
     connection = new SqliteConnection(tmpdir);
     taskStore = new SqliteTaskStore(connection);
-    runStore = new SqliteRunStore(connection);
+    _runStore = new SqliteRunStore(connection);
     retryPolicy = new DefaultRetryPolicy();
   });
 
@@ -31,8 +38,8 @@ describe('IdempotentStateTransitions', () => {
 
   async function createLeasedTask(taskId: string, expired = false) {
     const expiresAt = expired
-      ? new Date(Date.now() - 60_000).toISOString() // expired 1 min ago
-      : new Date(Date.now() + 300_000).toISOString(); // expires in 5 min
+      ? new Date(Date.now() - 60_000).toISOString()
+      : new Date(Date.now() + 300_000).toISOString();
     await taskStore.createTask({
       taskId,
       taskKind: 'test',
@@ -55,7 +62,7 @@ describe('IdempotentStateTransitions', () => {
 
     const sweep = new DefaultRecoverySweep(taskStore, {
       isLeaseExpired: () => false,
-    } as any, retryPolicy, connection);
+    } as unknown as LeaseManager, retryPolicy, connection);
 
     const result = await sweep.recoverTask('task-pending');
     expect(result).toBeNull();
@@ -66,7 +73,7 @@ describe('IdempotentStateTransitions', () => {
 
     const sweep = new DefaultRecoverySweep(taskStore, {
       isLeaseExpired: () => false,
-    } as any, retryPolicy, connection);
+    } as unknown as LeaseManager, retryPolicy, connection);
 
     const result = await sweep.recoverTask('task-not-expired');
     expect(result).toBeNull();
@@ -76,13 +83,15 @@ describe('IdempotentStateTransitions', () => {
     await createLeasedTask('task-expired', true);
 
     const sweep = new DefaultRecoverySweep(taskStore, {
-      isLeaseExpired: (task: any) => task.taskId === 'task-expired',
-    } as any, retryPolicy, connection);
+      isLeaseExpired: (task: TaskRecord) => task.taskId === 'task-expired',
+    } as unknown as LeaseManager, retryPolicy, connection);
 
     const result = await sweep.recoverTask('task-expired');
     expect(result).not.toBeNull();
-    expect(result!.newStatus).toBe('retry_wait');
-    expect(result!.previousStatus).toBe('leased');
+    if (result) {
+      expect(result.newStatus).toBe('retry_wait');
+      expect(result.previousStatus).toBe('leased');
+    }
   });
 
   it('recoverTask on expired lease with maxAttempts reached transitions to failed', async () => {
@@ -91,45 +100,44 @@ describe('IdempotentStateTransitions', () => {
       taskKind: 'test',
       status: 'leased',
       attemptCount: 3,
-      maxAttempts: 3, // already at max
+      maxAttempts: 3,
       leaseOwner: 'test-owner',
       leaseExpiresAt: new Date(Date.now() - 60_000).toISOString(),
     });
 
     const sweep = new DefaultRecoverySweep(taskStore, {
-      isLeaseExpired: (task: any) => true,
-    } as any, retryPolicy, connection);
+      isLeaseExpired: (_task: TaskRecord) => true,
+    } as unknown as LeaseManager, retryPolicy, connection);
 
     const result = await sweep.recoverTask('task-max-attempts');
     expect(result).not.toBeNull();
-    expect(result!.newStatus).toBe('failed');
-    expect(result!.wasLeaseExpired).toBe(true);
+    if (result) {
+      expect(result.newStatus).toBe('failed');
+      expect(result.wasLeaseExpired).toBe(true);
+    }
   });
 
   it('recoverTask can be called multiple times safely (idempotent)', async () => {
     await createLeasedTask('task-idempotent', true);
 
     const sweep = new DefaultRecoverySweep(taskStore, {
-      // Only expired for tasks in 'leased' status (matches real LeaseManager.isLeaseExpired)
-      isLeaseExpired: (task: any) => task.status === 'leased' && task.taskId === 'task-idempotent',
-    } as any, retryPolicy, connection);
+      isLeaseExpired: (task: TaskRecord) => task.status === 'leased' && task.taskId === 'task-idempotent',
+    } as unknown as LeaseManager, retryPolicy, connection);
 
-    // First call: transitions to retry_wait
     const first = await sweep.recoverTask('task-idempotent');
     expect(first).not.toBeNull();
-    expect(first!.newStatus).toBe('retry_wait');
+    if (first) {
+      expect(first.newStatus).toBe('retry_wait');
+    }
 
-    // Second call: task is now retry_wait (status !== 'leased'), so returns null
     const second = await sweep.recoverTask('task-idempotent');
     expect(second).toBeNull();
 
-    // Third call: still null
     const third = await sweep.recoverTask('task-idempotent');
     expect(third).toBeNull();
   });
 
   it('recoverAll skips already-recovered tasks without error', async () => {
-    // Set up two expired tasks
     await taskStore.createTask({
       taskId: 'task-a',
       taskKind: 'test',
@@ -150,22 +158,19 @@ describe('IdempotentStateTransitions', () => {
     });
 
     const sweep = new DefaultRecoverySweep(taskStore, {
-      isLeaseExpired: (task: any) => true,
-    } as any, retryPolicy, connection);
+      isLeaseExpired: (_task: TaskRecord) => true,
+    } as unknown as LeaseManager, retryPolicy, connection);
 
-    // First recoverAll: recovers both
     const firstRun = await sweep.recoverAll();
     expect(firstRun.recovered).toBe(2);
     expect(firstRun.errors).toHaveLength(0);
 
-    // Second recoverAll: no tasks to recover (both are retry_wait now)
     const secondRun = await sweep.recoverAll();
     expect(secondRun.recovered).toBe(0);
     expect(secondRun.errors).toHaveLength(0);
   });
 
   it('transition from retry_wait back to leased preserves attemptCount', async () => {
-    // Create a task in retry_wait (recovered from expired lease)
     await taskStore.createTask({
       taskId: 'task-retry',
       taskKind: 'test',
@@ -173,10 +178,9 @@ describe('IdempotentStateTransitions', () => {
       attemptCount: 1,
       maxAttempts: 3,
       lastError: 'lease_expired',
-      leaseExpiresAt: new Date(Date.now() + 30_000).toISOString(), // retry_wait has backoff expiry
+      leaseExpiresAt: new Date(Date.now() + 30_000).toISOString(),
     });
 
-    // Simulate re-acquiring lease (treat as new attempt)
     await taskStore.updateTask('task-retry', {
       status: 'leased',
       leaseOwner: 'runtime-A',
@@ -184,8 +188,10 @@ describe('IdempotentStateTransitions', () => {
     });
 
     const task = await taskStore.getTask('task-retry');
-    expect(task!.status).toBe('leased');
-    expect(task!.leaseOwner).toBe('runtime-A');
-    // attemptCount stays at 1 (will be incremented when Run is created)
+    expect(task).not.toBeNull();
+    if (task) {
+      expect(task.status).toBe('leased');
+      expect(task.leaseOwner).toBe('runtime-A');
+    }
   });
 });

--- a/packages/principles-core/src/runtime-v2/store/lifecycle/lease-manager.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/lifecycle/lease-manager.test.ts
@@ -26,10 +26,12 @@ function makeTaskInput(taskId: string, overrides: Partial<Omit<TaskRecord, 'crea
 
 describe('DefaultLeaseManager', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-test-${process.pid}-${Date.now()}`);
+  /* eslint-disable @typescript-eslint/init-declarations */
   let conn: SqliteConnection;
   let taskStore: SqliteTaskStore;
   let runStore: SqliteRunStore;
   let leaseManager: DefaultLeaseManager;
+  /* eslint-enable @typescript-eslint/init-declarations */
 
   beforeEach(() => {
     const testDir = path.join(tmpDir, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -126,8 +128,10 @@ describe('DefaultLeaseManager', () => {
       });
       const runs = await runStore.listRunsByTask('lease-with-run');
       expect(runs).toHaveLength(1);
-      expect(runs[0]!.executionStatus).toBe('running');
-      expect(runs[0]!.attemptNumber).toBe(1);
+      const [run0] = runs;
+      if (!run0) return;
+      expect(run0.executionStatus).toBe('running');
+      expect(run0.attemptNumber).toBe(1);
     });
 
     it('increments attempt number on re-lease', async () => {
@@ -148,7 +152,9 @@ describe('DefaultLeaseManager', () => {
       });
       const runs = await runStore.listRunsByTask('lease-retry-count');
       expect(runs).toHaveLength(2);
-      expect(runs[1]!.attemptNumber).toBe(2);
+      const [, run1] = runs;
+      if (!run1) return;
+      expect(run1.attemptNumber).toBe(2);
     });
   });
 
@@ -198,8 +204,9 @@ describe('DefaultLeaseManager', () => {
       });
       const result = await leaseManager.renewLease('renew-task-1', 'agent-renew', 120_000);
       expect(result.leaseExpiresAt).toBeTruthy();
-      // New expiry should be approximately 120s from now
-      const expiry = new Date(result.leaseExpiresAt!).getTime();
+      const { leaseExpiresAt } = result;
+      if (!leaseExpiresAt) return;
+      const expiry = new Date(leaseExpiresAt).getTime();
       const now = Date.now();
       expect(expiry - now).toBeGreaterThan(100_000);
     });

--- a/packages/principles-core/src/runtime-v2/store/lifecycle/recovery-sweep.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/lifecycle/recovery-sweep.test.ts
@@ -27,11 +27,13 @@ function makeTaskInput(taskId: string, overrides: Partial<Omit<TaskRecord, 'crea
 
 describe('DefaultRecoverySweep', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-test-${process.pid}-${Date.now()}`);
+  /* eslint-disable @typescript-eslint/init-declarations */
   let conn: SqliteConnection;
   let taskStore: SqliteTaskStore;
   let leaseManager: DefaultLeaseManager;
   let retryPolicy: DefaultRetryPolicy;
   let recoverySweep: DefaultRecoverySweep;
+  /* eslint-enable @typescript-eslint/init-declarations */
 
   beforeEach(() => {
     const testDir = path.join(tmpDir, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -45,6 +47,7 @@ describe('DefaultRecoverySweep', () => {
       updateRun: async () => { throw new Error('not implemented'); },
       listRunsByTask: async () => [],
       deleteRun: async () => false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     leaseManager = new DefaultLeaseManager(taskStore, runStore, conn);
     retryPolicy = new DefaultRetryPolicy({
@@ -137,11 +140,12 @@ describe('DefaultRecoverySweep', () => {
       });
       const result = await recoverySweep.recoverTask('retry-task');
       expect(result).not.toBeNull();
-      expect(result!.newStatus).toBe('retry_wait');
-      expect(result!.wasLeaseExpired).toBe(true);
-      // Verify task was actually updated
+      if (!result) return;
+      expect(result.newStatus).toBe('retry_wait');
+      expect(result.wasLeaseExpired).toBe(true);
       const updated = await taskStore.getTask('retry-task');
-      expect(updated!.status).toBe('retry_wait');
+      if (!updated) return;
+      expect(updated.status).toBe('retry_wait');
     });
 
     it('recovers to failed when maxAttempts exceeded', async () => {
@@ -153,8 +157,9 @@ describe('DefaultRecoverySweep', () => {
       });
       const result = await recoverySweep.recoverTask('fail-task');
       expect(result).not.toBeNull();
-      expect(result!.newStatus).toBe('failed');
-      expect(result!.wasLeaseExpired).toBe(true);
+      if (!result) return;
+      expect(result.newStatus).toBe('failed');
+      expect(result.wasLeaseExpired).toBe(true);
     });
 
     it('clears leaseOwner and sets retry_wait expiry on recovery', async () => {
@@ -166,10 +171,10 @@ describe('DefaultRecoverySweep', () => {
       });
       await recoverySweep.recoverTask('clear-lease-task');
       const updated = await taskStore.getTask('clear-lease-task');
-      expect(updated!.leaseOwner).toBeUndefined();
-      // retry_wait state has a backoff expiry, not undefined
-      expect(updated!.leaseExpiresAt).toBeTruthy();
-      expect(updated!.status).toBe('retry_wait');
+      if (!updated) return;
+      expect(updated.leaseOwner).toBeUndefined();
+      expect(updated.leaseExpiresAt).toBeTruthy();
+      expect(updated.status).toBe('retry_wait');
     });
   });
 
@@ -249,14 +254,15 @@ describe('DefaultRecoverySweep', () => {
       const result = await recoverySweep.recoverTask('dirty-stalled-task');
 
       expect(result).not.toBeNull();
-      expect(result!.newStatus).toBe('needs_human_review');
-      expect(result!.wasLeaseExpired).toBe(true);
+      if (!result) return;
+      expect(result.newStatus).toBe('needs_human_review');
+      expect(result.wasLeaseExpired).toBe(true);
 
-      // Verify task was updated to needs_human_review
       const updated = await taskStore.getTask('dirty-stalled-task');
-      expect(updated!.status).toBe('needs_human_review');
-      expect(updated!.leaseOwner).toBeUndefined();
-      expect(updated!.leaseExpiresAt).toBeUndefined();
+      if (!updated) return;
+      expect(updated.status).toBe('needs_human_review');
+      expect(updated.leaseOwner).toBeUndefined();
+      expect(updated.leaseExpiresAt).toBeUndefined();
     });
 
     it('clean stalled attempt (no workspace_dirty) -> follows existing retry behavior', async () => {
@@ -276,9 +282,11 @@ describe('DefaultRecoverySweep', () => {
       const result = await recoverySweep.recoverTask('clean-stalled-task');
 
       expect(result).not.toBeNull();
-      expect(result!.newStatus).toBe('retry_wait');
+      if (!result) return;
+      expect(result.newStatus).toBe('retry_wait');
       const updated = await taskStore.getTask('clean-stalled-task');
-      expect(updated!.status).toBe('retry_wait');
+      if (!updated) return;
+      expect(updated.status).toBe('retry_wait');
     });
 
     it('dirty workspace with maxAttempts exceeded -> goes to failed not retry_wait', async () => {
@@ -299,9 +307,9 @@ describe('DefaultRecoverySweep', () => {
 
       const result = await recoverySweep.recoverTask('dirty-max-task');
 
-      // Even with workspace_dirty, if max attempts exceeded -> failed
       expect(result).not.toBeNull();
-      expect(result!.newStatus).toBe('failed');
+      if (!result) return;
+      expect(result.newStatus).toBe('failed');
     });
 
     it('needs_human_review task is not recovered by recoverAll (idempotent)', async () => {
@@ -324,7 +332,8 @@ describe('DefaultRecoverySweep', () => {
 
       // Task should remain in needs_human_review
       const updated = await taskStore.getTask('already-review-task');
-      expect(updated!.status).toBe('needs_human_review');
+      if (!updated) return;
+      expect(updated.status).toBe('needs_human_review');
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/store/lifecycle/retry-policy.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/lifecycle/retry-policy.test.ts
@@ -73,6 +73,7 @@ describe('DefaultRetryPolicy', () => {
       // NaN is not a valid number, but shouldRetry safely returns true (allow retry)
       // JavaScript: typeof NaN === 'number' is true, but NaN comparisons are all false
       // so task.attemptCount < NaN is false... but our guard handles this
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const nanTask = { ...makeTask(0, 1), maxAttempts: NaN as any };
       expect(policy.shouldRetry(nanTask)).toBe(true);
     });

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.integration.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.integration.test.ts
@@ -27,6 +27,7 @@ function makeTaskInput(taskId: string, overrides: Partial<Omit<TaskRecord, 'crea
 
 describe('RuntimeStateManager task/run truth alignment', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-rsm-test-${process.pid}-${Date.now()}`);
+  // eslint-disable-next-line @typescript-eslint/init-declarations
   let mgr: RuntimeStateManager;
 
   beforeEach(async () => {
@@ -53,28 +54,35 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     expect(leased.attemptCount).toBe(1);
     const runs = await mgr.getRunsByTask('task-attempt-1');
     expect(runs).toHaveLength(1);
-    expect(runs[0]!.attemptNumber).toBe(1);
-    expect(runs[0]!.executionStatus).toBe('running');
-    expect(runs[0]!.endedAt).toBeUndefined();
+    const [run0] = runs;
+    if (!run0) return;
+    expect(run0.attemptNumber).toBe(1);
+    expect(run0.executionStatus).toBe('running');
+    expect(run0.endedAt).toBeUndefined();
   });
 
   it('second acquireLease (after expired lease) sets task.attemptCount=2 and run.attemptNumber=2', async () => {
     await mgr.createTask(makeTaskInput('task-attempt-2'));
     await mgr.acquireLease({ taskId: 'task-attempt-2', owner: 'agent-1', runtimeKind: 'openclaw' });
-    expect((await mgr.getTask('task-attempt-2'))!.attemptCount).toBe(1);
-    // Simulate worker crash: directly expire the lease (past date) so recovery picks it up
+    const taskAfter1 = await mgr.getTask('task-attempt-2');
+    if (!taskAfter1) return;
+    expect(taskAfter1.attemptCount).toBe(1);
     await mgr.updateTask('task-attempt-2', { leaseExpiresAt: new Date(Date.now() - 60_000).toISOString() });
     const sweep = await mgr.runRecoverySweep();
     expect(sweep.recovered).toBe(1);
-    expect((await mgr.getTask('task-attempt-2'))!.status).toBe('retry_wait');
+    const taskAfterSweep = await mgr.getTask('task-attempt-2');
+    if (!taskAfterSweep) return;
+    expect(taskAfterSweep.status).toBe('retry_wait');
 
     const second = await mgr.acquireLease({ taskId: 'task-attempt-2', owner: 'agent-2', runtimeKind: 'openclaw' });
     expect(second.attemptCount).toBe(2);
     const runs = await mgr.getRunsByTask('task-attempt-2');
     expect(runs).toHaveLength(2);
-    expect(runs[0]!.attemptNumber).toBe(1);
-    expect(runs[1]!.attemptNumber).toBe(2);
-    expect(runs[1]!.executionStatus).toBe('running');
+    const [r0, r1] = runs;
+    if (!r0 || !r1) return;
+    expect(r0.attemptNumber).toBe(1);
+    expect(r1.attemptNumber).toBe(2);
+    expect(r1.executionStatus).toBe('running');
   });
 
   // ── markTaskSucceeded updates run to terminal state ──────────────────────────
@@ -85,13 +93,16 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     await mgr.markTaskSucceeded('task-succeeded', 'output-ref-abc');
     const runs = await mgr.getRunsByTask('task-succeeded');
     expect(runs).toHaveLength(1);
-    expect(runs[0]!.executionStatus).toBe('succeeded');
-    expect(runs[0]!.endedAt).toBeTruthy();
-    expect(runs[0]!.reason).toBe('task_completed');
-    expect(runs[0]!.outputRef).toBe('output-ref-abc');
+    const [run0] = runs;
+    if (!run0) return;
+    expect(run0.executionStatus).toBe('succeeded');
+    expect(run0.endedAt).toBeTruthy();
+    expect(run0.reason).toBe('task_completed');
+    expect(run0.outputRef).toBe('output-ref-abc');
     const task = await mgr.getTask('task-succeeded');
-    expect(task!.status).toBe('succeeded');
-    expect(task!.resultRef).toBe('output-ref-abc');
+    if (!task) return;
+    expect(task.status).toBe('succeeded');
+    expect(task.resultRef).toBe('output-ref-abc');
   });
 
   // ── markTaskFailed updates run to terminal state ─────────────────────────────
@@ -102,13 +113,16 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     await mgr.markTaskFailed('task-failed', 'lease_conflict');
     const runs = await mgr.getRunsByTask('task-failed');
     expect(runs).toHaveLength(1);
-    expect(runs[0]!.executionStatus).toBe('failed');
-    expect(runs[0]!.endedAt).toBeTruthy();
-    expect(runs[0]!.reason).toBe('task_failed');
-    expect(runs[0]!.errorCategory).toBe('lease_conflict');
+    const [run0] = runs;
+    if (!run0) return;
+    expect(run0.executionStatus).toBe('failed');
+    expect(run0.endedAt).toBeTruthy();
+    expect(run0.reason).toBe('task_failed');
+    expect(run0.errorCategory).toBe('lease_conflict');
     const task = await mgr.getTask('task-failed');
-    expect(task!.status).toBe('failed');
-    expect(task!.lastError).toBe('lease_conflict');
+    if (!task) return;
+    expect(task.status).toBe('failed');
+    expect(task.lastError).toBe('lease_conflict');
   });
 
   // ── attemptCount + maxAttempts enforcement ───────────────────────────────────
@@ -117,33 +131,40 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     // maxAttempts=3: after 3 lease expirations, recovery moves to failed
     await mgr.createTask(makeTaskInput('task-max-attempts', { attemptCount: 0, maxAttempts: 3 }));
 
-    // Attempt 1: acquire → expire lease → recovery → retry_wait
     await mgr.acquireLease({ taskId: 'task-max-attempts', owner: 'agent-1', runtimeKind: 'openclaw' });
-    expect((await mgr.getTask('task-max-attempts'))!.attemptCount).toBe(1);
+    let task = await mgr.getTask('task-max-attempts');
+    if (!task) return;
+    expect(task.attemptCount).toBe(1);
     await mgr.updateTask('task-max-attempts', { leaseExpiresAt: new Date(Date.now() - 60_000).toISOString() });
     let sweep = await mgr.runRecoverySweep();
     expect(sweep.recovered).toBe(1);
-    expect((await mgr.getTask('task-max-attempts'))!.status).toBe('retry_wait');
+    task = await mgr.getTask('task-max-attempts');
+    if (!task) return;
+    expect(task.status).toBe('retry_wait');
 
-    // Attempt 2: re-acquire → expire lease → recovery → retry_wait
     await mgr.acquireLease({ taskId: 'task-max-attempts', owner: 'agent-2', runtimeKind: 'openclaw' });
-    expect((await mgr.getTask('task-max-attempts'))!.attemptCount).toBe(2);
+    task = await mgr.getTask('task-max-attempts');
+    if (!task) return;
+    expect(task.attemptCount).toBe(2);
     await mgr.updateTask('task-max-attempts', { leaseExpiresAt: new Date(Date.now() - 60_000).toISOString() });
     sweep = await mgr.runRecoverySweep();
     expect(sweep.recovered).toBe(1);
-    expect((await mgr.getTask('task-max-attempts'))!.status).toBe('retry_wait');
+    task = await mgr.getTask('task-max-attempts');
+    if (!task) return;
+    expect(task.status).toBe('retry_wait');
 
-    // Attempt 3: re-acquire → expire lease → recovery → FAILED (maxAttempts reached)
     await mgr.acquireLease({ taskId: 'task-max-attempts', owner: 'agent-3', runtimeKind: 'openclaw' });
-    expect((await mgr.getTask('task-max-attempts'))!.attemptCount).toBe(3);
+    task = await mgr.getTask('task-max-attempts');
+    if (!task) return;
+    expect(task.attemptCount).toBe(3);
     await mgr.updateTask('task-max-attempts', { leaseExpiresAt: new Date(Date.now() - 60_000).toISOString() });
     sweep = await mgr.runRecoverySweep();
     expect(sweep.recovered).toBe(1);
 
-    // task.attemptCount=3, maxAttempts=3 → shouldRetry=false → task goes to failed
-    const task = await mgr.getTask('task-max-attempts');
-    expect(task!.status).toBe('failed');
-    expect(task!.lastError).toBe('max_attempts_exceeded');
+    task = await mgr.getTask('task-max-attempts');
+    if (!task) return;
+    expect(task.status).toBe('failed');
+    expect(task.lastError).toBe('max_attempts_exceeded');
     const runs = await mgr.getRunsByTask('task-max-attempts');
     expect(runs).toHaveLength(3);
   });
@@ -158,13 +179,14 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     await mgr.runRecoverySweep();
 
     let task = await mgr.getTask('task-retry-preserve');
-    expect(task!.status).toBe('retry_wait');
-    expect(task!.attemptCount).toBe(1);
+    if (!task) return;
+    expect(task.status).toBe('retry_wait');
+    expect(task.attemptCount).toBe(1);
 
-    // Acquire again — attemptCount should become 2
     await mgr.acquireLease({ taskId: 'task-retry-preserve', owner: 'agent-2', runtimeKind: 'openclaw' });
     task = await mgr.getTask('task-retry-preserve');
-    expect(task!.attemptCount).toBe(2);
-    expect(task!.status).toBe('leased');
+    if (!task) return;
+    expect(task.attemptCount).toBe(2);
+    expect(task.status).toBe('leased');
   });
 });

--- a/packages/principles-core/src/runtime-v2/store/sqlite-run-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-run-store.test.ts
@@ -39,9 +39,11 @@ function makeRunInput(taskId: string, attemptNumber = 1): Omit<RunRecord, 'creat
 
 describe('SqliteRunStore', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-test-${process.pid}-${Date.now()}`);
+  /* eslint-disable @typescript-eslint/init-declarations */
   let conn: SqliteConnection;
   let taskStore: SqliteTaskStore;
   let runStore: SqliteRunStore;
+  /* eslint-enable @typescript-eslint/init-declarations */
 
   beforeEach(() => {
     const testDir = path.join(tmpDir, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);

--- a/packages/principles-core/src/runtime-v2/store/sqlite-task-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-task-store.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { SqliteConnection } from './sqlite-connection.js';
 import { SqliteTaskStore } from './task/sqlite-task-store.js';
-import type { TaskRecord, PDTaskStatus } from '../task-status.js';
+import type { TaskRecord } from '../task-status.js';
 
 function makeTaskInput(overrides: Partial<Omit<TaskRecord, 'createdAt' | 'updatedAt'>> = {}): Omit<TaskRecord, 'createdAt' | 'updatedAt'> {
   return {
@@ -29,8 +29,10 @@ function makeTaskInput(overrides: Partial<Omit<TaskRecord, 'createdAt' | 'update
 
 describe('SqliteTaskStore', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-test-${process.pid}-${Date.now()}`);
+  /* eslint-disable @typescript-eslint/init-declarations */
   let connection: SqliteConnection;
   let store: SqliteTaskStore;
+  /* eslint-enable @typescript-eslint/init-declarations */
 
   beforeEach(() => {
     const testDir = path.join(tmpDir, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -161,7 +163,10 @@ describe('SqliteTaskStore', () => {
       const page2 = await store.listTasks({ limit: 2, offset: 2 });
       expect(page1.length).toBe(2);
       expect(page2.length).toBe(2);
-      expect(page1[0]!.taskId).not.toBe(page2[0]!.taskId);
+      const [p1] = page1;
+      const [p2] = page2;
+      if (!p1 || !p2) return;
+      expect(p1.taskId).not.toBe(p2.taskId);
     });
   });
 

--- a/packages/principles-core/src/telemetry-event.ts
+++ b/packages/principles-core/src/telemetry-event.ts
@@ -104,6 +104,9 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('output_extraction_failed'),
   Type.Literal('output_schema_invalid'),
   Type.Literal('output_repair_exhausted'),
+  // PRI-271: Weak-model output path events
+  Type.Literal('output_path_chosen'),
+  Type.Literal('output_path_fallback'),
   // PRI-67: Dreamer runner events
   Type.Literal('dreamer_task_leased'),
   Type.Literal('dreamer_context_built'),

--- a/packages/principles-core/src/workflow-funnel-loader.ts
+++ b/packages/principles-core/src/workflow-funnel-loader.ts
@@ -74,6 +74,10 @@ export interface FunnelPolicy {
   maxRetries?: number;
   /** Custom base URL for OpenAI-compatible providers not in pi-ai's built-in registry. */
   baseUrl?: string;
+  /** Maximum repair attempts for structured output repair loop (PRI-271 A1). Default: 3. */
+  maxRepairAttempts?: number;
+  /** Output path strategy for structured output (PRI-271 B3). Default: 'tool_call_first'. */
+  outputPathStrategy?: 'tool_call_first' | 'json_mode_first' | 'free_form_only';
 }
 
 /**


### PR DESCRIPTION
﻿<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Lineage Contract

**Stripped fields**: `taskId`, `sourcePainId`, `sourceTaskId`, `sourceRunIds`, `contextHash` — all fields listed in `LINEAGE_FIELDS` constant in `output-repair-contract.ts`.

**Why strip, not preserve**: PD does not accept LLM-carried lineage. These fields represent ground-truth identity and provenance that must come from `RunnerContext` / `TaskRecord`, never from LLM output. If the LLM fabricates or mutates a `taskId`, downstream commits would be poisoned (ERR-008 family). The `preserveLineageFields()` function used in the free-form+repair path copies original values over repaired ones; `stripLineageFields()` used in tool_call/json_mode paths removes them entirely since there is no "original" to preserve from — the only source of truth is the runner context.

**Verification**: `DiagnosticianRunner.succeedTask()` checks for `taskId` in output at runtime. If found (adapter contract violation), it emits `lineage_strip_contract_violation` telemetry with `reason: output_contained_taskId_after_strip` — observable but non-blocking. This invariant is tested in `diagnostician-telemetry.test.ts`.
