### PR TITLE
fix(pain): enrich GFI-triggered pain with owner message + agent trajectory evidence (PRI-277)

### DIFF
--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -861,12 +861,13 @@ export class TrajectoryDatabase {
   listUserTurnsForSession(sessionId: string): {
     id: number;
     turnIndex: number;
+    rawExcerpt: string;
     correctionDetected: boolean;
     correctionCue: string | null;
     createdAt: string;
   }[] {
     const rows = this.db.prepare(`
-      SELECT id, turn_index, correction_detected, correction_cue, created_at
+      SELECT id, turn_index, raw_excerpt, correction_detected, correction_cue, created_at
       FROM user_turns
       WHERE session_id = ?
       ORDER BY turn_index ASC
@@ -875,6 +876,7 @@ export class TrajectoryDatabase {
     return rows.map((row) => ({
       id: Number(row.id),
       turnIndex: Number(row.turn_index),
+      rawExcerpt: String(row.raw_excerpt ?? ''),
       correctionDetected: Boolean(row.correction_detected),
       correctionCue: row.correction_cue ? String(row.correction_cue) : null,
       createdAt: String(row.created_at),

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -11,8 +11,9 @@ import { recordEvolutionSuccess, recordEvolutionFailure } from '../core/evolutio
 import type { EvolutionLoopEvent } from '../core/evolution-types.js';
 import type { PluginHookAfterToolCallEvent, PluginHookToolContext, OpenClawPluginApi } from '../openclaw-sdk.js';
 import { resolveWorkspaceDirForRuntimeV2 } from '../utils/workspace-resolver.js';
-import { PainToPrincipleService, PrincipleTreeLedgerAdapter, type PainDetectedData } from '@principles/core/runtime-v2';
+import { PainToPrincipleService, PrincipleTreeLedgerAdapter, type PainDetectedData, type PainEvidenceEntry, MAX_EVIDENCE_ENTRIES, MAX_EVIDENCE_NOTE_CHARS } from '@principles/core/runtime-v2';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
+import { sanitizeAssistantText } from './message-sanitize.js';
 
 /**
  * Interface for tool parameters to avoid 'any'
@@ -42,6 +43,53 @@ function createPainToPrincipleService(wctx: WorkspaceContext): PainToPrincipleSe
   });
 }
 
+function buildTrajectoryEvidence(wctx: WorkspaceContext, sessionId: string): PainEvidenceEntry[] {
+  const evidence: PainEvidenceEntry[] = [];
+
+  try {
+    const userTurns = wctx.trajectory?.listUserTurnsForSession?.(sessionId) ?? [];
+    const lastCorrectionTurn = [...userTurns].reverse().find(t => t.correctionDetected);
+    if (lastCorrectionTurn) {
+      const sanitizedOwnerMessage = sanitizeAssistantText(
+        (lastCorrectionTurn.rawExcerpt ?? '').slice(0, MAX_EVIDENCE_NOTE_CHARS)
+      );
+      evidence.push({
+        sourceRef: `owner_message:${lastCorrectionTurn.createdAt}`,
+        note: sanitizedOwnerMessage,
+      });
+    }
+  } catch (e) {
+    evidence.push({
+      sourceRef: 'owner_message:unavailable',
+      note: `trajectory_user_turns_unavailable: ${String(e).slice(0, 100)}`,
+    });
+  }
+
+  try {
+    const assistantTurns = wctx.trajectory?.listAssistantTurns?.(sessionId) ?? [];
+    const recentAssistant = assistantTurns.slice(-3);
+    for (const turn of recentAssistant) {
+      if (evidence.length >= MAX_EVIDENCE_ENTRIES) break;
+      const sanitizedNote = sanitizeAssistantText(
+        (turn.sanitizedText ?? '').slice(0, MAX_EVIDENCE_NOTE_CHARS)
+      );
+      evidence.push({
+        sourceRef: `agent_turn:${turn.createdAt}`,
+        note: sanitizedNote,
+      });
+    }
+  } catch (e) {
+    if (evidence.length < MAX_EVIDENCE_ENTRIES) {
+      evidence.push({
+        sourceRef: 'agent_turn:unavailable',
+        note: `trajectory_assistant_turns_unavailable: ${String(e).slice(0, 100)}`,
+      });
+    }
+  }
+
+  return evidence.slice(0, MAX_EVIDENCE_ENTRIES);
+}
+
 function shouldAttributePrincipleToTool(principle: { contextTags: string[]; trigger: string; }, toolName: string): boolean {
   return principle.contextTags.includes(toolName) || principle.trigger.includes(toolName);
 }
@@ -68,6 +116,7 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
         taskId: painData.taskId,
         traceId: painData.traceId,
         provenance: painData.provenance,
+        evidence: painData.evidence,
         recordObservability: true,
       });
       if (result.status === 'failed' && result.failureCategory) {
@@ -219,6 +268,7 @@ export function handleAfterToolCall(
         traceId,
         agentId: ctx.agentId,
         provenance: (sessionId && sessionId !== 'unknown') ? 'openclaw_context_bound' : 'owner_reported_no_host_trace',
+        evidence: buildTrajectoryEvidence(wctx, sessionId),
       },
     });
     return;
@@ -529,6 +579,7 @@ export function handleAfterToolCall(
       traceId,
       agentId: ctx.agentId,
       provenance: 'automatic_hook',
+      evidence: buildTrajectoryEvidence(wctx, sessionId),
     },
   });
 }

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -46,8 +46,16 @@ function createPainToPrincipleService(wctx: WorkspaceContext): PainToPrincipleSe
 function buildTrajectoryEvidence(wctx: WorkspaceContext, sessionId: string): PainEvidenceEntry[] {
   const evidence: PainEvidenceEntry[] = [];
 
+  if (!wctx.trajectory || sessionId === 'unknown') {
+    evidence.push({
+      sourceRef: 'owner_message:unavailable',
+      note: `trajectory_unavailable: ${!wctx.trajectory ? 'no_trajectory_db' : 'unknown_session'}`,
+    });
+    return evidence.slice(0, MAX_EVIDENCE_ENTRIES);
+  }
+
   try {
-    const userTurns = wctx.trajectory?.listUserTurnsForSession?.(sessionId) ?? [];
+    const userTurns = wctx.trajectory.listUserTurnsForSession(sessionId) ?? [];
     const lastCorrectionTurn = [...userTurns].reverse().find(t => t.correctionDetected);
     if (lastCorrectionTurn) {
       const sanitizedOwnerMessage = sanitizeAssistantText(
@@ -66,7 +74,7 @@ function buildTrajectoryEvidence(wctx: WorkspaceContext, sessionId: string): Pai
   }
 
   try {
-    const assistantTurns = wctx.trajectory?.listAssistantTurns?.(sessionId) ?? [];
+    const assistantTurns = wctx.trajectory.listAssistantTurns(sessionId) ?? [];
     const recentAssistant = assistantTurns.slice(-3);
     for (const turn of recentAssistant) {
       if (evidence.length >= MAX_EVIDENCE_ENTRIES) break;

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-evidence-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-evidence-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { PainSignalBridge, createDiagnosticianTaskId } from '../pain-signal-bridge.js';
-import type { PainDetectedData } from '../pain-signal-bridge.js';
+import { PainSignalBridge, createDiagnosticianTaskId, MAX_EVIDENCE_ENTRIES, MAX_EVIDENCE_NOTE_CHARS } from '../pain-signal-bridge.js';
+import type { PainDetectedData, PainEvidenceEntry } from '../pain-signal-bridge.js';
 import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
 import type { LedgerAdapter } from '../candidate-intake.js';
 import type { RunnerResult } from '../runner/runner-result.js';
@@ -264,5 +264,122 @@ describe('PainSignalBridge evidence persistence (PRI-255)', () => {
       const dj = getDiagnosticJson(capturedTasks, painId);
       expect(dj.severity).toBe(expectedSeverity);
     }
+  });
+});
+
+describe('PainSignalBridge evidence field (PRI-277)', () => {
+  it('persists evidence entries into diagnosticJson', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const evidence: PainEvidenceEntry[] = [
+      { sourceRef: 'owner_message:2026-05-30T12:00:00Z', note: '错了，重写' },
+      { sourceRef: 'agent_turn:2026-05-30T12:00:05Z', note: 'I will modify the config file' },
+    ];
+
+    const painData: PainDetectedData = {
+      painId: 'pain_evidence_test',
+      painType: 'tool_failure',
+      source: 'write',
+      reason: 'Tool write failed on config.ts',
+      score: 60,
+      sessionId: 'sess-evidence',
+      provenance: 'automatic_hook',
+      evidence,
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(Array.isArray(dj.evidence)).toBe(true);
+    const ev = dj.evidence as PainEvidenceEntry[];
+    expect(ev).toHaveLength(2);
+    expect(ev[0]?.sourceRef).toBe('owner_message:2026-05-30T12:00:00Z');
+    expect(ev[0]?.note).toBe('错了，重写');
+    expect(ev[1]?.sourceRef).toBe('agent_turn:2026-05-30T12:00:05Z');
+  });
+
+  it('defaults evidence to empty array when not provided', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const painData: PainDetectedData = {
+      painId: 'pain_no_evidence',
+      painType: 'tool_failure',
+      source: 'write',
+      reason: 'No evidence test',
+      score: 40,
+      sessionId: 'sess-noev',
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    expect(Array.isArray(dj.evidence)).toBe(true);
+    expect((dj.evidence as unknown[]).length).toBe(0);
+  });
+
+  it('respects MAX_EVIDENCE_ENTRIES constant', () => {
+    expect(MAX_EVIDENCE_ENTRIES).toBe(4);
+  });
+
+  it('respects MAX_EVIDENCE_NOTE_CHARS constant', () => {
+    expect(MAX_EVIDENCE_NOTE_CHARS).toBe(200);
+  });
+
+  it('evidence entries have correct shape', async () => {
+    const capturedTasks = new Map<string, TaskRecord>();
+    const stateManager = makeMockStateManager(capturedTasks);
+    const ledgerAdapter = makeMockLedgerAdapter();
+    const runner = makeMockRunner();
+
+    const bridge = new PainSignalBridge({
+      stateManager,
+      runner: runner as never,
+      intakeService: undefined as never,
+      ledgerAdapter,
+      autoIntakeEnabled: false,
+    });
+
+    const longNote = 'A'.repeat(300);
+    const evidence: PainEvidenceEntry[] = [
+      { sourceRef: 'owner_message:2026-05-30T12:00:00Z', note: longNote },
+    ];
+
+    const painData: PainDetectedData = {
+      painId: 'pain_long_note',
+      painType: 'user_frustration',
+      source: 'manual',
+      reason: 'Long note test',
+      score: 80,
+      sessionId: 'sess-long',
+      evidence,
+    };
+
+    await bridge.onPainDetected(painData);
+
+    const dj = getDiagnosticJson(capturedTasks, painData.painId);
+    const ev = dj.evidence as PainEvidenceEntry[];
+    expect(ev[0]?.note).toBe(longNote);
   });
 });

--- a/packages/principles-core/src/runtime-v2/context-payload.ts
+++ b/packages/principles-core/src/runtime-v2/context-payload.ts
@@ -111,6 +111,13 @@ export interface TraceUnavailableDetail {
   nextAction: string;
 }
 
+export const PainEvidenceEntrySchema = Type.Object({
+  sourceRef: Type.String({ minLength: 1 }),
+  note: Type.String({ minLength: 1, maxLength: 200 }),
+});
+
+export type PainEvidenceEntry = Static<typeof PainEvidenceEntrySchema>;
+
 export const DiagnosisTargetSchema = Type.Object({
   reasonSummary: Type.Optional(Type.String()),
   source: Type.Optional(Type.String()),
@@ -132,6 +139,7 @@ export const DiagnosisTargetSchema = Type.Object({
     reason: Type.String(),
     nextAction: Type.String(),
   })),
+  evidence: Type.Optional(Type.Array(PainEvidenceEntrySchema)),
 });
 
 export type DiagnosisTarget = Static<typeof DiagnosisTargetSchema>;

--- a/packages/principles-core/src/runtime-v2/evolution/evolution-types.ts
+++ b/packages/principles-core/src/runtime-v2/evolution/evolution-types.ts
@@ -8,6 +8,7 @@
  * - 5级成长路径：Seed → Forest
  */
 import { Type, type Static } from '@sinclair/typebox';
+import type { PainEvidenceEntry } from '../pain-signal-bridge.js';
 
 // ===== 等级定义 =====
 
@@ -312,6 +313,7 @@ export interface EvolutionPainDetectedData {
   taskId?: string;
   traceId?: string;
   provenance?: 'openclaw_context_bound' | 'owner_reported_no_host_trace' | 'automatic_hook';
+  evidence?: PainEvidenceEntry[];
 }
 
 export interface CandidateCreatedData {

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -249,11 +249,13 @@ export type {
   /** @deprecated Use PainToPrincipleServiceOptions instead */
   PainSignalBridgeOptions,
   PainDetectedData,
+  PainEvidenceEntry,
   /** @deprecated Use PainToPrincipleOutput instead */
   PainSignalBridgeResult,
   /** @deprecated Internal — use PainToPrincipleOutput.status */
   PainSignalBridgeStatus,
 } from './pain-signal-bridge.js';
+export { MAX_EVIDENCE_ENTRIES, MAX_EVIDENCE_NOTE_CHARS } from './pain-signal-bridge.js';
 /** @deprecated Internal implementation detail — observability is handled by PainToPrincipleService */
 export { recordPainSignalObservability } from './pain-signal-observability.js';
 export type { PainSignalObservabilityResult, RecordPainSignalObservabilityOptions } from './pain-signal-observability.js';

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -9,6 +9,14 @@ import { evaluateCandidateAdmissions } from './admission-gate.js';
 
 export type { PainProvenance };
 
+export const MAX_EVIDENCE_ENTRIES = 4;
+export const MAX_EVIDENCE_NOTE_CHARS = 200;
+
+export interface PainEvidenceEntry {
+  sourceRef: string;
+  note: string;
+}
+
 export interface PainDetectedData {
   painId: string;
   painType: 'tool_failure' | 'subagent_error' | 'user_frustration';
@@ -20,6 +28,7 @@ export interface PainDetectedData {
   taskId?: string;
   traceId?: string;
   provenance?: PainProvenance;
+  evidence?: PainEvidenceEntry[];
 }
 
 export type PainSignalBridgeStatus = 'succeeded' | 'skipped' | 'failed' | 'retried' | 'degraded';
@@ -93,6 +102,7 @@ function buildDiagnosticJson(data: PainDetectedData): string {
     agentIdHint: data.agentId ?? null,
     provenance,
     provenanceReason: provenanceReason(provenance),
+    evidence: data.evidence ?? [],
   });
 }
 

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -11,7 +11,7 @@ import { createPainSignalBridge } from './pain-signal-runtime-factory.js';
 import { recordPainSignalObservability } from './pain-signal-observability.js';
 import { FAILURE_CATEGORY_MAP } from './error-categories.js';
 import { createDiagnosticianTaskId } from './pain-signal-bridge.js';
-import type { PainDetectedData, PainSignalBridgeResult, PainProvenance } from './pain-signal-bridge.js';
+import type { PainDetectedData, PainSignalBridgeResult, PainProvenance, PainEvidenceEntry } from './pain-signal-bridge.js';
 import { PDRuntimeError } from './error-categories.js';
 import type { LedgerAdapter } from './candidate-intake.js';
 
@@ -45,6 +45,7 @@ export interface PainToPrincipleInput {
   taskId?: string;
   traceId?: string;
   provenance?: PainProvenance;
+  evidence?: PainEvidenceEntry[];
   recordObservability?: boolean;
 }
 
@@ -116,6 +117,7 @@ export class PainToPrincipleService {
       taskId,
       traceId: input.traceId,
       provenance: input.provenance,
+      evidence: input.evidence,
     };
 
     try {

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -29,7 +29,7 @@ import {
 import type { TaskRecord, DiagnosticianTaskRecord } from '../../task-status.js';
 import type { RunRecord } from '../../runtime-protocol.js';
 import { PDRuntimeError } from '../../error-categories.js';
-import { MAX_EVIDENCE_ENTRIES } from '../../pain-signal-bridge.js';
+import { MAX_EVIDENCE_ENTRIES, MAX_EVIDENCE_NOTE_CHARS } from '../../pain-signal-bridge.js';
 
 const PAIN_PROVENANCE_VALUES = ['openclaw_context_bound', 'owner_reported_no_host_trace', 'automatic_hook'] as const;
 
@@ -308,6 +308,10 @@ export class SqliteContextAssembler implements ContextAssembler {
         typeof (e as Record<string, unknown>).sourceRef === 'string' &&
         typeof (e as Record<string, unknown>).note === 'string'
       )
+      .map((e) => ({
+        sourceRef: e.sourceRef,
+        note: e.note.slice(0, MAX_EVIDENCE_NOTE_CHARS),
+      }))
       .slice(0, MAX_EVIDENCE_ENTRIES);
   }
 

--- a/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
+++ b/packages/principles-core/src/runtime-v2/store/context/sqlite-context-assembler.ts
@@ -19,6 +19,7 @@ import {
   type DiagnosticianContextPayload,
   type DiagnosisTarget,
   type FullTracePayloadV2,
+  type PainEvidenceEntry,
   DiagnosticianContextPayloadSchema,
   validateFullTracePayload,
   sanitizeFullTracePayload,
@@ -28,6 +29,7 @@ import {
 import type { TaskRecord, DiagnosticianTaskRecord } from '../../task-status.js';
 import type { RunRecord } from '../../runtime-protocol.js';
 import { PDRuntimeError } from '../../error-categories.js';
+import { MAX_EVIDENCE_ENTRIES } from '../../pain-signal-bridge.js';
 
 const PAIN_PROVENANCE_VALUES = ['openclaw_context_bound', 'owner_reported_no_host_trace', 'automatic_hook'] as const;
 
@@ -95,6 +97,7 @@ export class SqliteContextAssembler implements ContextAssembler {
       sessionIdHint: dt.sessionIdHint || undefined,
       provenance: dt.provenance || undefined,
       provenanceReason: dt.provenanceReason || undefined,
+      evidence: dt.evidence,
     };
 
     const convAmbiguityNotes = SqliteContextAssembler.buildAmbiguityNotes(
@@ -151,12 +154,14 @@ export class SqliteContextAssembler implements ContextAssembler {
       }
     }
 
+    const evidenceSourceRefs = dt.evidence?.map(e => e.sourceRef) ?? [];
+
     const payload: DiagnosticianContextPayload = {
       contextId,
       contextHash,
       taskId,
       workspaceDir: dt.workspaceDir,
-      sourceRefs: [taskId, ...runIds],
+      sourceRefs: [taskId, ...runIds, ...evidenceSourceRefs],
       diagnosisTarget,
       conversationWindow: historyResult.entries,
       ambiguityNotes: ambiguityNotes.length > 0 ? ambiguityNotes : undefined,
@@ -295,6 +300,17 @@ export class SqliteContextAssembler implements ContextAssembler {
     return obj[key];
   }
 
+  private static extractEvidence(parsed: Record<string, unknown>): PainEvidenceEntry[] | undefined {
+    if (!Object.hasOwn(parsed, 'evidence') || !Array.isArray(parsed.evidence)) return undefined;
+    return (parsed.evidence as unknown[])
+      .filter((e: unknown): e is PainEvidenceEntry =>
+        typeof e === 'object' && e !== null &&
+        typeof (e as Record<string, unknown>).sourceRef === 'string' &&
+        typeof (e as Record<string, unknown>).note === 'string'
+      )
+      .slice(0, MAX_EVIDENCE_ENTRIES);
+  }
+
   /**
    * Reconstruct a DiagnosticianTaskRecord from a base TaskRecord by decoding
    * the diagnostic_json column (if present).
@@ -320,6 +336,7 @@ export class SqliteContextAssembler implements ContextAssembler {
             workspaceDir: SqliteContextAssembler.extractStringField(parsed, 'workspaceDir'),
             provenance: Object.hasOwn(parsed, 'provenance') && isPainProvenance(parsed.provenance) ? parsed.provenance : undefined,
             provenanceReason: SqliteContextAssembler.extractStringField(parsed, 'provenanceReason'),
+            evidence: SqliteContextAssembler.extractEvidence(parsed),
           };
         } else {
           ambiguityNotes.push(
@@ -345,6 +362,7 @@ export class SqliteContextAssembler implements ContextAssembler {
       agentIdHint: extra.agentIdHint ?? (base as DiagnosticianTaskRecord).agentIdHint,
       provenance: extra.provenance,
       provenanceReason: extra.provenanceReason,
+      evidence: extra.evidence,
     };
   }
 }

--- a/packages/principles-core/src/runtime-v2/task-status.ts
+++ b/packages/principles-core/src/runtime-v2/task-status.ts
@@ -88,6 +88,10 @@ export const DiagnosticianTaskRecordSchema = Type.Intersect([
       Type.Literal('automatic_hook'),
     ])),
     provenanceReason: Type.Optional(Type.String()),
+    evidence: Type.Optional(Type.Array(Type.Object({
+      sourceRef: Type.String({ minLength: 1 }),
+      note: Type.String({ minLength: 1, maxLength: 200 }),
+    }))),
   }),
 ]);
 export type DiagnosticianTaskRecord = Static<typeof DiagnosticianTaskRecordSchema>;


### PR DESCRIPTION
## Summary (PRI-277)

Root cause: Empathy keyword matches trigger GFI accumulation, but the resulting pain signals only contain internal mechanism descriptions like `Accumulated GFI crossed threshold`. The diagnostician has no owner verbatim or agent behavior context, so it produces self-referential principles about PD internals instead of actionable agent behavior principles.

## Changes

### principles-core (7 files)
- **pain-signal-bridge.ts**: Add `PainEvidenceEntry` type, `MAX_EVIDENCE_ENTRIES` (4) and `MAX_EVIDENCE_NOTE_CHARS` (200) constants, `evidence` field on `PainDetectedData`, serialize evidence in `buildDiagnosticJson()`
- **pain-to-principle-service.ts**: Add `evidence` to `PainToPrincipleInput`, pass through to `PainDetectedData`
- **context-payload.ts**: Add `PainEvidenceEntrySchema` TypeBox schema, `evidence` on `DiagnosisTargetSchema`
- **task-status.ts**: Add `evidence` to `DiagnosticianTaskRecordSchema`
- **sqlite-context-assembler.ts**: Add `extractEvidence()` static method with runtime validation, propagate evidence to `diagnosisTarget` and `sourceRefs`
- **evolution-types.ts**: Add `evidence` to `EvolutionPainDetectedData`
- **index.ts**: Export `PainEvidenceEntry`, `MAX_EVIDENCE_ENTRIES`, `MAX_EVIDENCE_NOTE_CHARS`

### openclaw-plugin (2 files)
- **trajectory.ts**: Add `rawExcerpt` to `listUserTurnsForSession()` return type and SQL query
- **pain.ts**: Add `buildTrajectoryEvidence()` helper that pulls owner verbatim (correction-detected user turn) + last 3 assistant turns from trajectory; wire into both pain emission paths (manual + GFI-triggered)

### Tests (1 file)
- **pain-evidence-contract.test.ts**: 5 new test cases covering evidence persistence, default empty array, constants, and entry shape

## ERR Checklist

| ERR | How Avoided |
|-----|-------------|
| ERR-002 | Graceful degrade with reason string when trajectory unavailable (not silent skip) |
| ERR-005/007 | `extractEvidence()` validates array element types with typeof checks |
| ERR-008 | Deterministic sourceRef format (`owner_message:<ts>`, `agent_turn:<ts>`) |
| ERR-014/016/017 | All text sanitized via `sanitizeAssistantText()`, note length bounded at 200, array bounded at 4 |

## Acceptance Criteria

- [x] Diagnostician receives owner verbatim + agent behavior context via evidence
- [x] `diagnostic_json.evidence` array contains at least one owner_message sourceRef
- [x] All evidence notes sanitized and length-bounded
- [x] Trajectory unavailable -> graceful degrade with reason (no crash)
- [x] Full verification passed: build + test + lint + verify:merge

## Scope Boundaries

- No restart of empathy subagent
- No change to admission gate contract
- No change to diagnostician-output schema
- No frozen legacy file modifications
- No mutation of D:\.openclaw\workspace
- No `gh pr merge`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 诊断系统现已支持记录和跟踪痛点证据。每条证据包含来源引用和详细说明信息，最多保留4条证据记录，单条说明限制200字符。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->