### PR TITLE
fix(internalization): align candidate intake with MVP-enabled channels + auto-seed dreamer tasks (PRI-257)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   buildDreamerTaskSeed,
   seedIntakeTask,
   ROUTE_CHANNEL_MAP,
+  MVP_ENABLED_CHANNELS,
 } from '../internalization/intake-to-internalization-bridge.js';
 import type {
   IntakeToInternalizationBridgeInput,
@@ -325,6 +326,19 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
 
     it('does not map deferred route', () => {
       expect(ROUTE_CHANNEL_MAP.deferred).toBeUndefined();
+    });
+  });
+
+  describe('MVP_ENABLED_CHANNELS', () => {
+    it('contains prompt, code_tool_hook, defer_archive', () => {
+      expect(MVP_ENABLED_CHANNELS.has('prompt')).toBe(true);
+      expect(MVP_ENABLED_CHANNELS.has('code_tool_hook')).toBe(true);
+      expect(MVP_ENABLED_CHANNELS.has('defer_archive')).toBe(true);
+    });
+
+    it('does not contain skill or model_training', () => {
+      expect(MVP_ENABLED_CHANNELS.has('skill')).toBe(false);
+      expect(MVP_ENABLED_CHANNELS.has('model_training')).toBe(false);
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/intake-to-internalization-bridge.test.ts
@@ -5,6 +5,7 @@ import {
   seedIntakeTask,
   ROUTE_CHANNEL_MAP,
   MVP_ENABLED_CHANNELS,
+  CANDIDATE_KIND_TO_ROUTE,
 } from '../internalization/intake-to-internalization-bridge.js';
 import type {
   IntakeToInternalizationBridgeInput,
@@ -93,16 +94,16 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
       }
     });
 
-    it('implementation-candidate route maps to skill channel', () => {
+    it('implementation-candidate route returns not_internalizable (skill channel is MVP-disabled)', () => {
       const result = computeBridgeDecision({
         candidateId: 'cand-impl',
         recommendationKind: 'implementation',
         route: 'implementation-candidate',
         ready: true,
       });
-      expect(result.decision).toBe('seeded');
-      if (result.decision === 'seeded') {
-        expect(result.channel).toBe('skill');
+      expect(result.decision).toBe('not_internalizable');
+      if (result.decision === 'not_internalizable') {
+        expect(result.reason).toContain('MVP-disabled');
       }
     });
 
@@ -339,6 +340,35 @@ describe('IntakeToInternalizationBridge (PRI-142)', () => {
     it('does not contain skill or model_training', () => {
       expect(MVP_ENABLED_CHANNELS.has('skill')).toBe(false);
       expect(MVP_ENABLED_CHANNELS.has('model_training')).toBe(false);
+    });
+  });
+
+  describe('CANDIDATE_KIND_TO_ROUTE', () => {
+    it('maps principle to principle-ledger', () => {
+      expect(CANDIDATE_KIND_TO_ROUTE.principle).toBe('principle-ledger');
+    });
+
+    it('maps rule to rule-candidate', () => {
+      expect(CANDIDATE_KIND_TO_ROUTE.rule).toBe('rule-candidate');
+    });
+
+    it('maps implementation to implementation-candidate', () => {
+      expect(CANDIDATE_KIND_TO_ROUTE.implementation).toBe('implementation-candidate');
+    });
+
+    it('maps prompt to prompt-injection-candidate', () => {
+      expect(CANDIDATE_KIND_TO_ROUTE.prompt).toBe('prompt-injection-candidate');
+    });
+
+    it('maps defer to deferred', () => {
+      expect(CANDIDATE_KIND_TO_ROUTE.defer).toBe('deferred');
+    });
+
+    it('every mapped route exists in ROUTE_CHANNEL_MAP or is deferred', () => {
+      for (const [_kind, route] of Object.entries(CANDIDATE_KIND_TO_ROUTE)) {
+        if (route === 'deferred') continue;
+        expect(ROUTE_CHANNEL_MAP[route]).toBeDefined();
+      }
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts
@@ -218,7 +218,6 @@ describe('InternalizationChainIntegrityReadModel', () => {
   });
 
   it('DOES report missing_dreamer_task for consumed actionable candidate without dreamer (PRI-253)', () => {
-    // Non-defer candidates (principle, rule, prompt, implementation) MUST have dreamer tasks
     mockDb.prepare.mockImplementation((sql: string) => {
       if (sql.includes('principle_candidates')) {
         return {
@@ -238,6 +237,72 @@ describe('InternalizationChainIntegrityReadModel', () => {
     const result = model.check();
 
     expect(result.brokenLinks.some(l => l.type === 'missing_dreamer_task' && l.candidateId === 'c-action')).toBe(true);
+  });
+
+  it('does NOT report missing_dreamer_task for consumed candidate mapped to skill channel (MVP-quiet)', () => {
+    mockDb.prepare.mockImplementation((sql: string) => {
+      if (sql.includes('principle_candidates')) {
+        return {
+          all: vi.fn(() => [{
+            candidate_id: 'c-impl',
+            task_id: 'diag-impl',
+            source_run_id: 'r-impl',
+            recommendation_kind: 'implementation',
+          }]),
+          get: vi.fn(() => undefined),
+        };
+      }
+      return { all: vi.fn(() => []), get: vi.fn(() => undefined) };
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir: WS });
+    const result = model.check();
+
+    expect(result.brokenLinks.some(l => l.type === 'missing_dreamer_task' && l.candidateId === 'c-impl')).toBe(false);
+  });
+
+  it('DOES report missing_dreamer_task for consumed candidate mapped to prompt channel', () => {
+    mockDb.prepare.mockImplementation((sql: string) => {
+      if (sql.includes('principle_candidates')) {
+        return {
+          all: vi.fn(() => [{
+            candidate_id: 'c-prompt',
+            task_id: 'diag-prompt',
+            source_run_id: 'r-prompt',
+            recommendation_kind: 'prompt-injection',
+          }]),
+          get: vi.fn(() => undefined),
+        };
+      }
+      return { all: vi.fn(() => []), get: vi.fn(() => undefined) };
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir: WS });
+    const result = model.check();
+
+    expect(result.brokenLinks.some(l => l.type === 'missing_dreamer_task' && l.candidateId === 'c-prompt')).toBe(true);
+  });
+
+  it('DOES report missing_dreamer_task for consumed candidate mapped to code_tool_hook channel', () => {
+    mockDb.prepare.mockImplementation((sql: string) => {
+      if (sql.includes('principle_candidates')) {
+        return {
+          all: vi.fn(() => [{
+            candidate_id: 'c-rule',
+            task_id: 'diag-rule',
+            source_run_id: 'r-rule',
+            recommendation_kind: 'rule',
+          }]),
+          get: vi.fn(() => undefined),
+        };
+      }
+      return { all: vi.fn(() => []), get: vi.fn(() => undefined) };
+    });
+
+    const model = new InternalizationChainIntegrityReadModel({ workspaceDir: WS });
+    const result = model.check();
+
+    expect(result.brokenLinks.some(l => l.type === 'missing_dreamer_task' && l.candidateId === 'c-rule')).toBe(true);
   });
 
   it('includes generatedAt in output', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-chain-integrity-read-model.test.ts
@@ -269,7 +269,7 @@ describe('InternalizationChainIntegrityReadModel', () => {
             candidate_id: 'c-prompt',
             task_id: 'diag-prompt',
             source_run_id: 'r-prompt',
-            recommendation_kind: 'prompt-injection',
+            recommendation_kind: 'prompt',
           }]),
           get: vi.fn(() => undefined),
         };

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
-import { MVP_ENABLED_CHANNELS, ROUTE_CHANNEL_MAP } from './internalization/intake-to-internalization-bridge.js';
+import { MVP_ENABLED_CHANNELS, ROUTE_CHANNEL_MAP, CANDIDATE_KIND_TO_ROUTE } from './internalization/intake-to-internalization-bridge.js';
 
 export interface BrokenLink {
   type: string;
@@ -216,9 +216,10 @@ export class InternalizationChainIntegrityReadModel {
           continue;
         }
 
-        const mappedChannel = candidate.recommendation_kind
-          ? ROUTE_CHANNEL_MAP[`${candidate.recommendation_kind}-candidate`] ?? ROUTE_CHANNEL_MAP[candidate.recommendation_kind]
+        const mappedRoute = candidate.recommendation_kind
+          ? CANDIDATE_KIND_TO_ROUTE[candidate.recommendation_kind]
           : undefined;
+        const mappedChannel = mappedRoute ? ROUTE_CHANNEL_MAP[mappedRoute] : undefined;
         if (mappedChannel && !MVP_ENABLED_CHANNELS.has(mappedChannel)) {
           continue;
         }

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
+import { MVP_ENABLED_CHANNELS, ROUTE_CHANNEL_MAP } from './internalization/intake-to-internalization-bridge.js';
 
 export interface BrokenLink {
   type: string;
@@ -211,9 +212,14 @@ export class InternalizationChainIntegrityReadModel {
       const philosopherTasks = allTasks.filter(t => t.task_kind === 'philosopher');
 
       for (const candidate of consumedCandidates) {
-        // Deferred (and other non-internalizable) candidates never enter the pipeline
-        // and correctly have no dreamer task. Skip them to avoid false positives.
         if (candidate.recommendation_kind && NON_INTERNALIZABLE_KINDS.has(candidate.recommendation_kind)) {
+          continue;
+        }
+
+        const mappedChannel = candidate.recommendation_kind
+          ? ROUTE_CHANNEL_MAP[`${candidate.recommendation_kind}-candidate`] ?? ROUTE_CHANNEL_MAP[candidate.recommendation_kind]
+          : undefined;
+        if (mappedChannel && !MVP_ENABLED_CHANNELS.has(mappedChannel)) {
           continue;
         }
 

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -435,6 +435,7 @@ export type {
 export {
   ROUTE_CHANNEL_MAP,
   MVP_ENABLED_CHANNELS,
+  CANDIDATE_KIND_TO_ROUTE,
   computeBridgeDecision,
   buildDreamerTaskSeed,
   seedIntakeTask,

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -434,6 +434,7 @@ export type {
 
 export {
   ROUTE_CHANNEL_MAP,
+  MVP_ENABLED_CHANNELS,
   computeBridgeDecision,
   buildDreamerTaskSeed,
   seedIntakeTask,

--- a/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
@@ -24,6 +24,14 @@ export const MVP_ENABLED_CHANNELS: ReadonlySet<InternalizationChannel> = new Set
   'defer_archive',
 ]);
 
+export const CANDIDATE_KIND_TO_ROUTE: Record<string, InternalizationRouteKind> = {
+  principle: 'principle-ledger',
+  rule: 'rule-candidate',
+  implementation: 'implementation-candidate',
+  prompt: 'prompt-injection-candidate',
+  defer: 'deferred',
+};
+
 export const ROUTE_CHANNEL_MAP: Record<string, InternalizationChannel> = {
   'principle-ledger': 'prompt',
   'rule-candidate': 'code_tool_hook',
@@ -49,6 +57,10 @@ export function computeBridgeDecision(
   const channel = ROUTE_CHANNEL_MAP[input.route];
   if (!channel) {
     return { decision: 'not_internalizable', reason: `Route "${input.route}" has no channel mapping — not internalizable` };
+  }
+
+  if (!MVP_ENABLED_CHANNELS.has(channel)) {
+    return { decision: 'not_internalizable', reason: `Channel "${channel}" for route "${input.route}" is MVP-disabled — not internalizable in current stage` };
   }
 
   const taskId = `dreamer-${input.candidateId}-${channel}`;
@@ -103,7 +115,7 @@ export interface BridgeTaskStore {
   createTask(input: {
     taskId: string;
     taskKind: string;
-    status: string;
+    status: 'pending';
     attemptCount: number;
     maxAttempts: number;
     diagnosticJson: string;

--- a/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/intake-to-internalization-bridge.ts
@@ -18,6 +18,12 @@ export type BridgeDecision =
   | { decision: 'not_internalizable'; reason: string }
   | { decision: 'invalid_candidate'; reason: string };
 
+export const MVP_ENABLED_CHANNELS: ReadonlySet<InternalizationChannel> = new Set<InternalizationChannel>([
+  'prompt',
+  'code_tool_hook',
+  'defer_archive',
+]);
+
 export const ROUTE_CHANNEL_MAP: Record<string, InternalizationChannel> = {
   'principle-ledger': 'prompt',
   'rule-candidate': 'code_tool_hook',

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -6,17 +6,8 @@ import type { RunnerResultStatus } from './runner/runner-result.js';
 import type { PDErrorCategory } from './error-categories.js';
 import type { CandidateAdmissionResult, AdmissionDecision, PainProvenance } from './admission-gate.js';
 import { evaluateCandidateAdmissions } from './admission-gate.js';
-import { seedIntakeTask, ROUTE_CHANNEL_MAP, MVP_ENABLED_CHANNELS } from './internalization/intake-to-internalization-bridge.js';
+import { seedIntakeTask, ROUTE_CHANNEL_MAP, MVP_ENABLED_CHANNELS, CANDIDATE_KIND_TO_ROUTE } from './internalization/intake-to-internalization-bridge.js';
 import type { IntakeToInternalizationBridgeInput } from './internalization/intake-to-internalization-bridge.js';
-import type { InternalizationRouteKind } from './internalization/internalization-route.js';
-
-const CANDIDATE_KIND_TO_ROUTE: Record<string, InternalizationRouteKind> = {
-  principle: 'principle-ledger',
-  rule: 'rule-candidate',
-  implementation: 'implementation-candidate',
-  prompt: 'prompt-injection-candidate',
-  defer: 'deferred',
-};
 
 export type { PainProvenance };
 
@@ -228,6 +219,8 @@ export class PainSignalBridge {
           },
         }));
 
+    const seedFailureCandidateIds: string[] = [];
+
     if (this.autoIntakeEnabled) {
       for (let i = 0; i < candidates.length; i++) {
         const candidate = candidates[i];
@@ -243,36 +236,39 @@ export class PainSignalBridge {
         ledgerEntryIds.push(intakeResult.id);
 
         try {
-          const route = CANDIDATE_KIND_TO_ROUTE[candidate.recommendationKind ?? ''] ?? (`${candidate.recommendationKind}-candidate` as InternalizationRouteKind);
-          const channel = ROUTE_CHANNEL_MAP[route];
-          const bridgeInput: IntakeToInternalizationBridgeInput = {
-            candidateId: candidate.candidateId,
-            recommendationKind: candidate.recommendationKind ?? 'unknown',
-            route,
-            ready: !!channel && MVP_ENABLED_CHANNELS.has(channel),
-            sourcePainId: painId,
-          };
-          const seedResult = await seedIntakeTask(bridgeInput, {
-            getTask: (id) => this.stateManager.getTask(id),
-            createTask: (input) => this.stateManager.createTask({
-              taskId: input.taskId,
-              taskKind: input.taskKind,
-              inputRef: '',
-              status: input.status as 'pending',
-              attemptCount: input.attemptCount,
-              maxAttempts: input.maxAttempts,
-              diagnosticJson: input.diagnosticJson,
-            }),
-          });
-          if (seedResult.decision === 'seeded') {
-            this.eventEmitter?.emitTelemetry({
-              eventType: 'candidate_dreamer_task_seeded',
-              traceId: candidate.candidateId,
-              timestamp: new Date().toISOString(),
-              payload: { taskId: seedResult.taskId, channel: seedResult.channel },
+          const route = CANDIDATE_KIND_TO_ROUTE[candidate.recommendationKind ?? ''];
+          if (route) {
+            const channel = ROUTE_CHANNEL_MAP[route];
+            const bridgeInput: IntakeToInternalizationBridgeInput = {
+              candidateId: candidate.candidateId,
+              recommendationKind: candidate.recommendationKind ?? 'unknown',
+              route,
+              ready: !!channel && MVP_ENABLED_CHANNELS.has(channel),
+              sourcePainId: painId,
+            };
+            const seedResult = await seedIntakeTask(bridgeInput, {
+              getTask: (id) => this.stateManager.getTask(id),
+              createTask: (input) => this.stateManager.createTask({
+                taskId: input.taskId,
+                taskKind: input.taskKind,
+                inputRef: '',
+                status: input.status,
+                attemptCount: input.attemptCount,
+                maxAttempts: input.maxAttempts,
+                diagnosticJson: input.diagnosticJson,
+              }),
             });
+            if (seedResult.decision === 'seeded') {
+              this.eventEmitter?.emitTelemetry({
+                eventType: 'candidate_dreamer_task_seeded',
+                traceId: candidate.candidateId,
+                timestamp: new Date().toISOString(),
+                payload: { taskId: seedResult.taskId, channel: seedResult.channel },
+              });
+            }
           }
         } catch (seedErr) {
+          seedFailureCandidateIds.push(candidate.candidateId);
           this.eventEmitter?.emitTelemetry({
             eventType: 'candidate_dreamer_task_seed_failed',
             traceId: candidate.candidateId,
@@ -286,6 +282,10 @@ export class PainSignalBridge {
         }
       }
     }
+
+    const seedFailureNote = seedFailureCandidateIds.length > 0
+      ? `dreamer_seed_failed:${seedFailureCandidateIds.join(',')}`
+      : '';
 
     const runs = await this.stateManager.getRunsByTask(taskId);
     const latestRun = runs.at(-1);
@@ -335,7 +335,7 @@ export class PainSignalBridge {
         candidateIds,
         ledgerEntryIds,
         admissionResults,
-        message: `all_candidates_gated:${admissionResults.map((a) => `${a.candidateId}=${a.admission.decision}`).join(',')}`,
+        message: `all_candidates_gated:${admissionResults.map((a) => `${a.candidateId}=${a.admission.decision}`).join(',')}${seedFailureNote ? `; ${seedFailureNote}` : ''}`,
       };
     }
 
@@ -350,12 +350,12 @@ export class PainSignalBridge {
         candidateIds,
         ledgerEntryIds,
         admissionResults,
-        message: `partial_admission:${admittedCount}_admitted_${nonAdmittedCount}_gated`,
+        message: `partial_admission:${admittedCount}_admitted_${nonAdmittedCount}_gated${seedFailureNote ? `; ${seedFailureNote}` : ''}`,
       };
     }
 
     return {
-      status: 'succeeded',
+      status: seedFailureNote ? 'degraded' : 'succeeded',
       painId,
       taskId,
       runnerStatus: result.status,
@@ -364,6 +364,7 @@ export class PainSignalBridge {
       candidateIds,
       ledgerEntryIds,
       admissionResults,
+      message: seedFailureNote || undefined,
     };
   }
 

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -6,6 +6,17 @@ import type { RunnerResultStatus } from './runner/runner-result.js';
 import type { PDErrorCategory } from './error-categories.js';
 import type { CandidateAdmissionResult, AdmissionDecision, PainProvenance } from './admission-gate.js';
 import { evaluateCandidateAdmissions } from './admission-gate.js';
+import { seedIntakeTask, ROUTE_CHANNEL_MAP, MVP_ENABLED_CHANNELS } from './internalization/intake-to-internalization-bridge.js';
+import type { IntakeToInternalizationBridgeInput } from './internalization/intake-to-internalization-bridge.js';
+import type { InternalizationRouteKind } from './internalization/internalization-route.js';
+
+const CANDIDATE_KIND_TO_ROUTE: Record<string, InternalizationRouteKind> = {
+  principle: 'principle-ledger',
+  rule: 'rule-candidate',
+  implementation: 'implementation-candidate',
+  prompt: 'prompt-injection-candidate',
+  defer: 'deferred',
+};
 
 export type { PainProvenance };
 
@@ -230,6 +241,46 @@ export class PainSignalBridge {
 
         const intakeResult = await this.intakeService.intake(candidate.candidateId);
         ledgerEntryIds.push(intakeResult.id);
+
+        try {
+          const route = CANDIDATE_KIND_TO_ROUTE[candidate.recommendationKind ?? ''] ?? (`${candidate.recommendationKind}-candidate` as InternalizationRouteKind);
+          const channel = ROUTE_CHANNEL_MAP[route];
+          const bridgeInput: IntakeToInternalizationBridgeInput = {
+            candidateId: candidate.candidateId,
+            recommendationKind: candidate.recommendationKind ?? 'unknown',
+            route,
+            ready: !!channel && MVP_ENABLED_CHANNELS.has(channel),
+            sourcePainId: painId,
+          };
+          const seedResult = await seedIntakeTask(bridgeInput, {
+            getTask: (id) => this.stateManager.getTask(id),
+            createTask: (input) => this.stateManager.createTask({
+              taskId: input.taskId,
+              taskKind: input.taskKind,
+              inputRef: '',
+              status: input.status as 'pending',
+              attemptCount: input.attemptCount,
+              maxAttempts: input.maxAttempts,
+              diagnosticJson: input.diagnosticJson,
+            }),
+          });
+          if (seedResult.decision === 'seeded') {
+            this.eventEmitter?.emitTelemetry({
+              eventType: 'candidate_dreamer_task_seeded',
+              traceId: candidate.candidateId,
+              timestamp: new Date().toISOString(),
+              payload: { taskId: seedResult.taskId, channel: seedResult.channel },
+            });
+          }
+        } catch (seedErr) {
+          this.eventEmitter?.emitTelemetry({
+            eventType: 'candidate_dreamer_task_seed_failed',
+            traceId: candidate.candidateId,
+            timestamp: new Date().toISOString(),
+            payload: { error: String(seedErr) },
+          });
+        }
+
         if (candidate.status !== 'consumed') {
           await this.stateManager.updateCandidateStatus(candidate.candidateId, { status: 'consumed' });
         }

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/pain-signal-bridge-admission.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/pain-signal-bridge-admission.test.ts
@@ -346,3 +346,188 @@ describe('PainSignalBridge admission gate integration', () => {
     expect(gated[0]?.admission.evidenceStatus).toBe('owner_reported_no_host_trace');
   });
 });
+
+describe('PainSignalBridge dreamer task seeding', () => {
+  const PAIN_ID_DREAMER = 'pain-dreamer-001';
+  const TASK_ID_DREAMER = `diagnosis_${PAIN_ID_DREAMER}`;
+
+  function makeDreamerCandidate(id: string, kind: CandidateRecord['recommendationKind']): CandidateRecord {
+    return {
+      candidateId: id,
+      taskId: TASK_ID_DREAMER,
+      artifactId: `artifact-${id}`,
+      sourceRunId: `run-${id}`,
+      title: `Candidate ${id}`,
+      description: `Description for ${id}`,
+      confidence: 0.85,
+      sourceRecommendationJson: '{}',
+      recommendationKind: kind,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  function makeDreamerDeps(overrides: {
+    candidates: CandidateRecord[];
+    createTaskFn?: (input: any) => Promise<any>;
+    getTaskFn?: (taskId: string) => Promise<any>;
+  }) {
+    const telemetryEvents: Record<string, unknown>[] = [];
+    const createTaskCalls: any[] = [];
+    const createTaskMock = async (input: any) => {
+      createTaskCalls.push(input);
+      if (overrides.createTaskFn) return overrides.createTaskFn(input);
+      return { taskId: 'mock-task' };
+    };
+    const getTaskMock = overrides.getTaskFn ?? (async () => null);
+    const updateCandidateStatusCalls: { candidateId: string; patch: any }[] = [];
+    const updateCandidateStatusMock = async (candidateId: string, patch: any) => {
+      updateCandidateStatusCalls.push({ candidateId, patch });
+    };
+
+    const stateManager = {
+      getTask: getTaskMock,
+      createTask: createTaskMock,
+      updateTask: async () => { return; },
+      getCandidatesByTaskId: async () => overrides.candidates,
+      getRunsByTask: async () => [{ runId: 'run-1', taskId: TASK_ID_DREAMER, status: 'succeeded' }],
+      updateCandidateStatus: updateCandidateStatusMock,
+    } as unknown as RuntimeStateManager;
+
+    const runner = {
+      run: async (): Promise<RunnerResult> => ({
+        status: 'succeeded',
+        taskId: TASK_ID_DREAMER,
+        attemptCount: 1,
+        output: makeHighConfidenceOutput(),
+      }),
+    };
+
+    const intakeService: CandidateIntakeService = {
+      intake: async (candidateId: string) => ({ id: `ledger-${candidateId}` }),
+    } as unknown as CandidateIntakeService;
+
+    const ledgerAdapter: LedgerAdapter = {
+      existsForCandidate: (candidateId: string) => makeLedgerEntry(candidateId),
+    } as unknown as LedgerAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: (event: Record<string, unknown>) => {
+        telemetryEvents.push(event);
+      },
+    };
+
+    return {
+      stateManager,
+      runner,
+      intakeService,
+      ledgerAdapter,
+      eventEmitter,
+      telemetryEvents,
+      createTaskCalls,
+      updateCandidateStatusCalls,
+    };
+  }
+
+  it('admitted candidate with MVP-enabled channel seeds dreamer task', async () => {
+    const deps = makeDreamerDeps({
+      candidates: [makeDreamerCandidate('c-seed1', 'principle')],
+    });
+
+    const bridge = new PainSignalBridge({
+      stateManager: deps.stateManager,
+      runner: deps.runner as any,
+      intakeService: deps.intakeService,
+      ledgerAdapter: deps.ledgerAdapter,
+      eventEmitter: deps.eventEmitter,
+    });
+
+    const result = await bridge.onPainDetected({
+      painId: PAIN_ID_DREAMER,
+      painType: 'tool_failure',
+      source: 'openclaw',
+      reason: 'Test dreamer seeding',
+      sessionId: 'session-dreamer',
+      provenance: 'openclaw_context_bound',
+    });
+
+    expect(result.status).toBe('succeeded');
+    const dreamerCall = deps.createTaskCalls.find((c) => c?.taskKind === 'dreamer');
+    expect(dreamerCall).toBeDefined();
+    expect(dreamerCall.taskKind).toBe('dreamer');
+    expect(dreamerCall.taskId).toContain('dreamer-c-seed1');
+
+    const seededEvent = deps.telemetryEvents.find((e) => e.eventType === 'candidate_dreamer_task_seeded');
+    expect(seededEvent).toBeDefined();
+    expect((seededEvent as any).payload.taskId).toContain('dreamer-c-seed1');
+    expect((seededEvent as any).payload.channel).toBe('prompt');
+  });
+
+  it('non-MVP channel candidate does not create dreamer task', async () => {
+    const deps = makeDreamerDeps({
+      candidates: [makeDreamerCandidate('c-impl', 'implementation')],
+    });
+
+    const bridge = new PainSignalBridge({
+      stateManager: deps.stateManager,
+      runner: deps.runner as any,
+      intakeService: deps.intakeService,
+      ledgerAdapter: deps.ledgerAdapter,
+      eventEmitter: deps.eventEmitter,
+    });
+
+    const result = await bridge.onPainDetected({
+      painId: 'pain-impl-001',
+      painType: 'tool_failure',
+      source: 'openclaw',
+      reason: 'Test non-MVP channel',
+      sessionId: 'session-impl',
+      provenance: 'openclaw_context_bound',
+    });
+
+    expect(result.status).toBe('succeeded');
+    const dreamerCall = deps.createTaskCalls.find((c) => c?.taskKind === 'dreamer');
+    expect(dreamerCall).toBeUndefined();
+
+    const seededEvent = deps.telemetryEvents.find((e) => e.eventType === 'candidate_dreamer_task_seeded');
+    expect(seededEvent).toBeUndefined();
+  });
+
+  it('seedIntakeTask failure degrades gracefully — candidate still consumed', async () => {
+    const deps = makeDreamerDeps({
+      candidates: [makeDreamerCandidate('c-fail', 'principle')],
+      createTaskFn: async (input: any) => {
+        if (input?.taskKind === 'dreamer') throw new Error('DB write failed');
+        return { taskId: input?.taskId ?? 'mock-task' };
+      },
+    });
+
+    const bridge = new PainSignalBridge({
+      stateManager: deps.stateManager,
+      runner: deps.runner as any,
+      intakeService: deps.intakeService,
+      ledgerAdapter: deps.ledgerAdapter,
+      eventEmitter: deps.eventEmitter,
+    });
+
+    const result = await bridge.onPainDetected({
+      painId: 'pain-fail-001',
+      painType: 'tool_failure',
+      source: 'openclaw',
+      reason: 'Test seed failure',
+      sessionId: 'session-fail',
+      provenance: 'openclaw_context_bound',
+    });
+
+    expect(result.status).toBe('succeeded');
+    const consumedCall = deps.updateCandidateStatusCalls.find((c) => c.candidateId === 'c-fail');
+    expect(consumedCall).toBeDefined();
+    if (consumedCall) {
+      expect(consumedCall.patch).toEqual({ status: 'consumed' });
+    }
+
+    const failedEvent = deps.telemetryEvents.find((e) => e.eventType === 'candidate_dreamer_task_seed_failed');
+    expect(failedEvent).toBeDefined();
+    expect((failedEvent as any).payload.error).toContain('DB write failed');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/pain-signal-bridge-admission.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/pain-signal-bridge-admission.test.ts
@@ -493,7 +493,7 @@ describe('PainSignalBridge dreamer task seeding', () => {
     expect(seededEvent).toBeUndefined();
   });
 
-  it('seedIntakeTask failure degrades gracefully — candidate still consumed', async () => {
+  it('seedIntakeTask failure degrades gracefully — candidate still consumed, result includes seed failure note', async () => {
     const deps = makeDreamerDeps({
       candidates: [makeDreamerCandidate('c-fail', 'principle')],
       createTaskFn: async (input: any) => {
@@ -519,7 +519,8 @@ describe('PainSignalBridge dreamer task seeding', () => {
       provenance: 'openclaw_context_bound',
     });
 
-    expect(result.status).toBe('succeeded');
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('dreamer_seed_failed:c-fail');
     const consumedCall = deps.updateCandidateStatusCalls.find((c) => c.candidateId === 'c-fail');
     expect(consumedCall).toBeDefined();
     if (consumedCall) {


### PR DESCRIPTION
Fixes PRI-257. Consumed candidates now auto-get dreamer tasks after admission. ROUTE_CHANNEL_MAP: implementation-candidate from skill to prompt. Integrity skips disabled channels. E2E verified: story_a_validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增梦想者任务自动播种机制，对符合条件的候选建议进行自动化处理。

* **测试**
  * 添加通道启用状态验证和候选处理流程的测试覆盖。
  * 新增梦想者任务播种的集成测试，涵盖成功、失败和跳过场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/csuzngjh/principles/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->