### PR TITLE
fix(gate): reset confirm-first state when activation reader fails (PRI-266)

### DIFF
--- a/packages/openclaw-plugin/src/hooks/prompt.ts
+++ b/packages/openclaw-plugin/src/hooks/prompt.ts
@@ -8,7 +8,7 @@ import { WorkspaceContext } from '../core/workspace-context.js';
 import type { ContextInjectionConfig} from '../types.js';
 import { defaultContextConfig } from '../types.js';
 import { classifyTask, type RoutingInput } from '../core/local-worker-routing.js';
-import { detectApprovalMarker, setConfirmFirstApproval, setConfirmFirstDirective, hydrateFromStore, pruneStoreStaleRows, setConfirmFirstStore } from '../core/confirm-first-gate.js';
+import { detectApprovalMarker, setConfirmFirstApproval, setConfirmFirstDirective, hydrateFromStore, pruneStoreStaleRows, setConfirmFirstStore, resetConfirmFirst } from '../core/confirm-first-gate.js';
 import { extractSummary, getHistoryVersions, parseWorkingMemorySection, workingMemoryToInjection, autoCompressFocus, safeReadCurrentFocus } from '../core/focus-history.js';
 import { PathResolver } from '../core/path-resolver.js';
 import { selectPrinciplesForInjection, DEFAULT_PRINCIPLE_BUDGET } from '../core/principle-injection.js';
@@ -1003,6 +1003,9 @@ ${heartbeatChecklist}
     }
   } catch (e) {
     logger?.warn?.(`[PD:RuntimeV2] Failed to read Runtime V2 prompt activations: ${String(e)}`);
+    if (sessionId) {
+      resetConfirmFirst(sessionId);
+    }
   }
 
   // Build appendSystemContext with recency effect

--- a/packages/openclaw-plugin/tests/hooks/confirm-first-gate.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/confirm-first-gate.test.ts
@@ -286,3 +286,48 @@ describe('Store degradation (ERR-002)', () => {
     expect(evaluateConfirmFirstGateSync('sess-degrade', 'write', {}).action).toBe('allow');
   });
 });
+
+describe('Stale directive cleared on reset (PRI-266)', () => {
+  beforeEach(() => {
+    clearAllConfirmFirstState();
+  });
+
+  it('resetConfirmFirst clears directive and approval from cache and store', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-cf-stale-'));
+    try {
+      const connection = new SqliteConnection(tmpDir);
+      const store = new SqliteConfirmFirstStateStore(connection);
+      setConfirmFirstStore(store);
+
+      setConfirmFirstDirective('sess-stale', true, 'princ-stale');
+      setConfirmFirstApproval('sess-stale');
+
+      expect(hasActiveDirective('sess-stale')).toBe(true);
+      expect(isSessionApproved('sess-stale')).toBe(true);
+
+      resetConfirmFirst('sess-stale');
+
+      expect(hasActiveDirective('sess-stale')).toBe(false);
+      expect(isSessionApproved('sess-stale')).toBe(false);
+      expect(evaluateConfirmFirstGateSync('sess-stale', 'write', {}).action).toBe('skip');
+
+      connection.close();
+    } finally {
+      setConfirmFirstStore(null);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resetConfirmFirst without store clears in-memory cache only', () => {
+    setConfirmFirstDirective('sess-nostore', true, 'princ-nostore');
+    setConfirmFirstApproval('sess-nostore');
+
+    expect(hasActiveDirective('sess-nostore')).toBe(true);
+    expect(isSessionApproved('sess-nostore')).toBe(true);
+
+    resetConfirmFirst('sess-nostore');
+
+    expect(hasActiveDirective('sess-nostore')).toBe(false);
+    expect(isSessionApproved('sess-nostore')).toBe(false);
+  });
+});


### PR DESCRIPTION
## PRI-266: Confirm-first gate — reset stale directive/approval when activation reader fails

### Problem

When the activation reader in `prompt.ts` throws an exception, the catch block only logs a warning but does NOT clear the session's stale directive/approval cache. After PRI-270 merged, stale state now persists across restarts in SQLite, making this worse — the gate continues enforcing based on outdated state indefinitely.

### Fix

Add `resetConfirmFirst(sessionId)` in the catch block, clearing both in-memory cache and SQLite for that session:

```typescript
} catch (e) {
  logger?.warn?.(`[PD:RuntimeV2] Failed to read Runtime V2 prompt activations: ${String(e)}`);
  if (sessionId) {
    resetConfirmFirst(sessionId);
  }
}
```

### Design Decision: Fail-open on reader failure

When the activation reader fails, the gate goes to `skip` (no enforcement) rather than keeping stale enforcement. Rationale:
- The directive was an opt-in safety layer on top of normal tool execution
- Keeping stale block means the operator cannot recover without restarting the gateway
- The `logger.warn` + `resetConfirmFirst` makes the failure observable
- A future successful read will re-instate the directive on the next prompt hook turn

### PRI-268 merged into PRI-266

PRI-268 (stale directive cache cleanup) is the same problem with a different trigger. In normal paths, the directive is already refreshed every prompt hook turn via `setConfirmFirstDirective`. The only scenario where stale state persists is when the reader fails (PRI-266). PRI-268 has been cancelled.

### ERR Checklist

- ERR-002: Reader failure now has observable degradation (warn log + state reset)
- ERR-015/ERR-018/ERR-019: Stale loop state eliminated by resetting on reader failure

### Tests

- 2 new tests: `resetConfirmFirst` with store (cache + SQLite cleared), without store (cache-only cleared)
- All 27 confirm-first-gate tests pass
- `npm run verify:merge` passes

### Validation

```
cd packages/openclaw-plugin && npm run build && npm run test  ✅
npm run lint  ✅
npm run verify:merge  ✅
```
