### PR TITLE
docs: land PRUNING_PIPELINE.md and align cross-references (PRI-183)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,9 +80,12 @@ code-concise/
 .trae
 
 # Docs (removed from git tracking - kept locally only)
-docs/
+docs/*
 # Exception: AI assistant handbook must be committed
 !docs/ERROR_EXPERIENCE_HANDBOOK.md
+# Exception: architecture docs must be committed
+!docs/architecture/
+!docs/architecture/**
 # Exception: website docs must be committed
 !packages/website/docs/
 !packages/website/zh/docs/

--- a/README.md
+++ b/README.md
@@ -232,8 +232,6 @@ Do not use it blindly on critical production workspaces.
 - [ ] Codex / OpenAI-assisted PR review and release workflow experiments
 - [ ] General agent-runtime adapter interface documentation
 
-Detailed planning is tracked in Linear; this README keeps a public roadmap snapshot for reviewers, users, and contributors.
-
 ## Core idea
 
 A coding agent should not only complete tasks.

--- a/README.md
+++ b/README.md
@@ -15,27 +15,25 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/openclaw/openclaw">
-    <img src="https://img.shields.io/badge/OpenClaw-Native%20Plugin-FF6B35" alt="OpenClaw Plugin">
-  </a>
+  <img src="https://img.shields.io/badge/Runtime-OpenClaw%20Adapter-FF6B35" alt="OpenClaw Adapter">
+  <img src="https://img.shields.io/badge/Next-Codex%20CLI-blue" alt="Codex CLI Planned">
   <img src="https://img.shields.io/github/v/release/csuzngjh/principles?style=flat-square&color=5865F2" alt="Release">
-  <img src="https://img.shields.io/npm/dt/principles-disciple?style=flat-square&color=green" alt="Downloads">
 </p>
 
 ---
 
-> Owner-governed behavior internalization for AI agents.
-> Human-supervised. Locally stored. Pain-driven.
+> Principles Disciple (PD) is a local, agent-first governance and feedback layer for AI agents.
+> Its first practical domain is agentic development: coding agents, terminal agents, and project-operation agents.
+> It helps owners, operators, and maintainers turn repeated agent failures, risky actions, user corrections, and workflow mismatches
+> into structured pain signals, reviewed principles, decision logs, and owner-controlled guardrails.
 
-Principles Disciple is an OpenClaw plugin that helps owners turn repeated, meaningful agent behavior evidence into reviewed, reversible principles that can shape future behavior.
-
-**Canonical product definition:** [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md)
-
-> **MVP status (2026-05-24):** the validation path focuses on pain capture, diagnosis, internalization, and three reviewed activation outcomes: prompt guidance, RuleHost enforcement, and defer/archive. Broader learning and agent-lifecycle expansions are deferred until seed-customer evidence exists.
+PD currently ships with an OpenClaw adapter as its first runtime integration. The architecture is designed around a runtime adapter layer so that PD can connect with different agent runtimes and task environments — OpenClaw today, Codex CLI next for agentic development — without being hard-coded to a single agent tool or task domain.
 
 It is built for agents first.
 Agents are the daily users.
 Humans are the operators, supervisors, and risk owners.
+
+**Canonical product definition:** [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md)
 
 [English](README.md) | [中文](README_ZH.md)
 
@@ -79,6 +77,14 @@ Install Principles Disciple if you want to:
 
 ---
 
+## Runtime Adapters: OpenClaw Now, Codex Next
+
+PD is designed with a runtime adapter layer rather than being tied to a single agent runtime or task domain. The first validated domain is agentic development, where agent behavior is observable through tool calls, file edits, command execution, failures, user corrections, and review events. The adapter layer lets PD observe and govern different agent runtimes through a shared local feedback model: pain-signal capture, decision logs, principle review, and maintainer-approved guardrails.
+
+**OpenClaw adapter (implemented).** The first concrete runtime integration, validated through agentic development workflows. PD works as an OpenClaw plugin for capturing agent behavior — tool failures, risky edits, user corrections, blocked operations — and enforcing local development guardrails through prompt guidance, RuleHost enforcement, and defer/archive outcomes.
+
+**Codex CLI adapter (planned).** The next adapter target within the agentic development domain. The goal is to let Codex-style coding agents feed task trajectories, risky edits, repeated failures, and user corrections into PD, so maintainers can review behavior changes before they become durable rules. This would give Codex users the same local-first, maintainer-reviewed governance layer that OpenClaw users have today.
+
 ## What it does
 
 ### 1. Workspace guardrails
@@ -102,7 +108,7 @@ It should:
 4. retry the operation
 ```
 
-### 2. Pain signal capture
+### 2. Pain-signal capture
 
 Tool failures, repeated confusion, user corrections, blocked edits, risky near-misses, and recurring work-style mismatches can be recorded as structured pain signals.
 
@@ -112,15 +118,13 @@ Pain is owner-relevant behavior evidence, not a claim that every task failure sh
 
 The agent uses these signals to understand where its behavior needs to improve.
 
-### 3. Reviewed behavior activation
+### 3. Decision logs and reviewed behavior activation
 
-Reviewed principles can currently result in prompt guidance, RuleHost enforcement, or a deliberate defer/archive outcome. Operators remain responsible for reviewing and enabling behavior changes.
+Every significant agent decision — approvals, blocks, corrections, pain events — is recorded locally as a structured decision log. Reviewed principles can currently result in prompt guidance, RuleHost enforcement, or a deliberate defer/archive outcome. Operators remain responsible for reviewing and enabling behavior changes.
 
 ### 4. Principle internalization
 
-Repeated failures can become candidate principles or rule implementations.
-
-Operators can inspect, evaluate, promote, disable, archive, or roll back these implementations with commands such as:
+Repeated failures can become candidate principles or rule implementations through a replay-based review workflow. Operators can inspect, evaluate, promote, disable, archive, or roll back these implementations with commands such as:
 
 ```text
 /pd-evolution-status
@@ -137,7 +141,11 @@ A principle should not become active just because it sounds good.
 
 It should survive evidence, replay, and operator review.
 
-### 5. Local console
+### 5. Behavior-regression checks
+
+PD includes replay-based validation for rule implementations: before a new principle or rule is activated, it can be tested against recorded agent trajectories to verify that the behavior change actually addresses the pain it was derived from — and doesn't regress other working behavior.
+
+### 6. Local console
 
 Principles Console provides a local web UI for observing agent health and evolution activity.
 
@@ -158,6 +166,19 @@ The console can show:
 
 State is stored locally.
 
+## Using Codex / OpenAI with PD
+
+PD is designed to complement coding agents such as Codex CLI rather than replace them. Future Codex / OpenAI integration will focus on OSS maintainer workflows:
+
+- **Codex-assisted PR review and change summarization** — using Codex to summarize what changed and why, feeding results into PD's decision log.
+- **Issue triage and test generation** — Codex processes issue context, PD records the outcome as structured evidence.
+- **Failure replay from previous agent runs** — replaying past failures through PD's trajectory system to verify that behavior changes actually resolved the original pain.
+- **Behavior-regression checks before activating new principles or guardrails** — validating that candidate rules don't break existing working behavior.
+- **Review of new principle / rule candidates generated from repeated failures** — Codex assists in drafting, PD enforces the review-and-approve workflow.
+- **Release-note generation for maintainer workflows** — summarizing principle activations, guardrail changes, and behavior shifts since the last release.
+
+The long-term goal is to connect powerful coding agents with a local, inspectable, maintainer-reviewed governance layer — so that agent autonomy and human oversight coexist without one blocking the other.
+
 ## What this is not
 
 Principles Disciple is not:
@@ -171,18 +192,18 @@ Principles Disciple is not:
 - a chatbot;
 - a magic self-improvement button.
 
-It is an owner-governed behavior internalization layer for OpenClaw coding agents.
+It is a local-first, owner-governed behavior internalization layer for AI agents, currently validated through agentic development workflows and integrated first with OpenClaw.
 
 ## Current status
 
-Principles Disciple is an early experimental project.
+Principles Disciple is an early-stage, actively maintained project.
 
 Already useful:
 
 - workspace guardrails;
 - agent-first installation flow;
 - reviewed prompt / RuleHost / defer-archive activation paths;
-- pain and friction tracking;
+- pain-signal capture and decision logging;
 - evolution status commands;
 - local console;
 - replay-based review workflow for rule implementations.
@@ -193,11 +214,25 @@ Still evolving:
 - automatic rule generation quality;
 - adaptive thresholds;
 - long-term learning reliability;
-- multi-workspace evolution patterns.
+- multi-workspace evolution patterns;
+- Codex CLI runtime adapter.
 
-Expect bugs.  
-Review promoted behavior carefully.  
+Expect bugs.
+Review promoted behavior carefully.
 Do not use it blindly on critical production workspaces.
+
+## Roadmap
+
+- [x] OpenClaw runtime adapter
+- [x] Local pain-signal capture and decision logging
+- [x] Replay-based review workflow for rule implementations
+- [ ] Codex CLI runtime adapter
+- [ ] Failure replay workflow for agent trajectories
+- [ ] Behavior-regression checks for new principles/rules
+- [ ] Codex / OpenAI-assisted PR review and release workflow experiments
+- [ ] General agent-runtime adapter interface documentation
+
+Detailed planning is tracked in Linear; this README keeps a public roadmap snapshot for reviewers, users, and contributors.
 
 ## Core idea
 

--- a/docs/architecture/CODEX_CLI_ADAPTER_DESIGN.md
+++ b/docs/architecture/CODEX_CLI_ADAPTER_DESIGN.md
@@ -1,0 +1,343 @@
+# Codex CLI Adapter Design
+
+> Status: Draft | Date: 2026-05-31 | Author: AI Assistant | Issue: PRI-278–282
+
+## 1. Overview
+
+This document specifies how Principles Disciple (PD) adapts to [OpenAI Codex CLI](https://github.com/openai/codex) as a new runtime target. Codex CLI is an open-source, locally-running AI coding agent that supports a hook system for lifecycle event interception. PD will use these hooks to capture pain signals, inject principles, and gate tool calls — the same core PD loop already implemented for OpenClaw.
+
+### 1.1 Goals
+
+- Enable PD's core behavior internalization loop on Codex CLI
+- Reuse existing `PDRuntimeAdapter` interface and `@principles/core` logic
+- Provide a seamless installation experience via `create-principles-disciple`
+- Maintain PD's product boundary: owner-reviewed, reversible behavior changes only
+
+### 1.2 Non-Goals
+
+- General task execution or memory management for Codex
+- Replacing or wrapping Codex's own agent loop
+- Supporting Codex Cloud / hosted mode (local-only for MVP)
+
+## 2. Codex CLI Hook System
+
+### 2.1 Architecture
+
+Codex CLI provides 10 lifecycle hook events that external scripts can subscribe to:
+
+| Event | Trigger | Can Block? | Key Capability |
+|-------|---------|-----------|----------------|
+| `SessionStart` | New session begins | No | Initialize state, inject context |
+| `PreToolUse` | Before a tool executes | Yes (deny/ask) | Gate risky operations |
+| `PermissionRequest` | Permission prompt shown | Yes (allow/deny/ask) | Override permission decisions |
+| `PostToolUse` | After a tool executes | Yes (stop) | Capture errors, pain signals |
+| `UserPromptSubmit` | User submits a prompt | Yes (block) | Inject additional context |
+| `PreCompact` | Before context compaction | No | Save critical context |
+| `PostCompact` | After context compaction | No | Restore context markers |
+| `SubagentStart` | Sub-agent spawned | No | Track sub-agent lifecycle |
+| `SubagentStop` | Sub-agent completes | No | Collect sub-agent results |
+| `Stop` | Session ends | No | Final cleanup, telemetry |
+
+### 2.2 Registration Mechanism
+
+Hooks are registered in a global configuration file at `~/.codex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /path/to/pd-codex-hook.js pre-tool-use"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Important limitation**: As of Codex CLI v0.1.x, plugin-local `hooks.json` is not supported ([openai/codex#16430](https://github.com/openai/codex/issues/16430)). All hooks must be registered in the global `~/.codex/hooks.json`. This means the PD installer must merge hooks into the existing global config rather than providing a per-project file.
+
+### 2.3 Execution Model
+
+- Hooks receive input as a single JSON object on **stdin**
+- Hooks produce output as a single JSON object on **stdout**
+- Exit codes: `0` = success, `2` = block (where applicable), other = error
+- Hooks have a **60-second timeout** per execution
+- If a hook times out, Codex proceeds as if the hook was not registered
+
+## 3. Data Contracts
+
+All contracts below are verified against Codex CLI source code (`codex-rs/hooks/src/`).
+
+### 3.1 PreToolUse
+
+**Input (stdin)**:
+```json
+{
+  "session_id": "string",
+  "turn_id": "string",
+  "tool_name": "string",
+  "tool_input": {}
+}
+```
+
+**Output (stdout)** — one of:
+```json
+{"decision": "approve"}
+{"decision": "block", "reason": "string"}
+```
+
+Exit code `2` also blocks the tool call.
+
+### 3.2 PostToolUse
+
+**Input (stdin)**:
+```json
+{
+  "session_id": "string",
+  "turn_id": "string",
+  "tool_name": "string",
+  "tool_input": {},
+  "tool_output": "string"
+}
+```
+
+**Output (stdout)** — one of:
+```json
+{}
+{"decision": "block", "reason": "string"}
+{"decision": "stop", "reason": "string"}
+{"decision": "feedback", "message": "string"}
+```
+
+### 3.3 UserPromptSubmit
+
+**Input (stdin)**:
+```json
+{
+  "session_id": "string",
+  "prompt": "string"
+}
+```
+
+**Output (stdout)** — one of:
+```json
+{}
+{"decision": "block", "reason": "string"}
+{"additionalContext": "string"}
+```
+
+**Key difference from OpenClaw**: `UserPromptSubmit` can only provide `additionalContext`, not rewrite the prompt itself. PD must inject principles as supplementary context rather than prompt modification.
+
+### 3.4 SessionStart
+
+**Input (stdin)**:
+```json
+{
+  "session_id": "string",
+  "source": "string"
+}
+```
+
+**Output (stdout)**:
+```json
+{}
+```
+
+No blocking capability. Used for initialization only.
+
+## 4. PD ↔ Codex Mapping
+
+### 4.1 Hook-to-PD Mapping
+
+| PD Function | Codex Hook | OpenClaw Equivalent |
+|-------------|-----------|-------------------|
+| Principle injection | `UserPromptSubmit` | `before_prompt_build` |
+| Tool call gating | `PreToolUse` | `before_tool_call` |
+| Pain signal capture | `PostToolUse` | `after_tool_call` |
+| Session initialization | `SessionStart` | Plugin `setup()` |
+| Context preservation | `PreCompact` / `PostCompact` | N/A (new) |
+
+### 4.2 Key Differences from OpenClaw
+
+| Aspect | OpenClaw | Codex CLI |
+|--------|----------|-----------|
+| Prompt modification | Full rewrite possible | `additionalContext` only |
+| Tool gating | `approve` / `block` | `approve` / `block` / `ask` |
+| Permission override | N/A | `PermissionRequest` hook |
+| Post-tool blocking | Not supported | `block` / `stop` / `feedback` |
+| Session tracking | Plugin state | `session_id` + `turn_id` |
+| Hook registration | Plugin manifest | Global `~/.codex/hooks.json` |
+| Hook protocol | Direct function call | stdin/stdout JSON + exit codes |
+| Timeout | Configurable | 60s hard limit |
+
+### 4.3 PDRuntimeAdapter Implementation
+
+The existing `PDRuntimeAdapter` interface in `@principles/core` already defines `codex-cli` as a valid `RuntimeKind`. The adapter implementation will:
+
+1. **`kind()`** → returns `'codex-cli'`
+2. **`getCapabilities()`** → returns capabilities reflecting Codex's constraints (e.g., `supportsStructuredJsonOutput: true`, `supportsToolUse: true`)
+3. **`startRun()`** → creates a Codex session context, initializes PD state for the session
+4. **`pollRun()`** → reads session state from the PD state directory
+5. **`appendContext()`** → queues additional context for the next `UserPromptSubmit` hook invocation
+
+## 5. Architecture Design
+
+### 5.1 Package Structure
+
+```
+packages/
+├── principles-core/          # Existing: PDRuntimeAdapter, types, pure logic
+│   └── src/runtime-v2/adapter/
+│       └── codex-cli-runtime-adapter.ts   # NEW: Codex adapter implementation
+├── openclaw-plugin/          # Existing: OpenClaw integration
+├── pd-cli/                   # Existing: CLI tool
+└── codex-hooks/              # NEW: Hook scripts for Codex CLI
+    ├── package.json          # @principles/codex-hooks
+    ├── src/
+    │   ├── index.ts          # Hook entry point (dispatches by event type)
+    │   ├── pre-tool-use.ts   # PreToolUse handler
+    │   ├── post-tool-use.ts  # PostToolUse handler
+    │   ├── user-prompt-submit.ts  # UserPromptSubmit handler
+    │   ├── session-start.ts  # SessionStart handler
+    │   └── lib/
+    │       ├── stdin.ts      # stdin JSON reader
+    │       ├── stdout.ts     # stdout JSON writer
+    │       └── state.ts      # PD state directory access
+    └── tsconfig.json
+```
+
+### 5.2 Hook Script Architecture
+
+Each Codex hook invocation is a separate process. The hook script:
+
+1. Reads JSON input from stdin
+2. Loads PD state from `{workspace}/.principles/` (SQLite)
+3. Delegates to `@principles/core` logic for the relevant operation
+4. Writes JSON output to stdout
+5. Exits with appropriate code (0, 2, or error)
+
+```
+Codex CLI → fork → node pd-codex-hook.js <event>
+                         ↓
+                    read stdin (JSON)
+                         ↓
+                    load PD state (SQLite)
+                         ↓
+                    delegate to @principles/core
+                         ↓
+                    write stdout (JSON)
+                         ↓
+                    exit 0 | 2 | 1
+```
+
+### 5.3 State Management
+
+PD state for Codex sessions is stored in the same per-workspace structure:
+
+```
+{workspace}/
+├── .principles/
+│   ├── principles.db          # SQLite (shared with OpenClaw)
+│   ├── .state/                # Runtime state
+│   │   └── codex-sessions/    # NEW: Codex session tracking
+│   │       └── {session_id}.json
+│   └── ...
+```
+
+The `codex-sessions/` directory tracks:
+- Active session IDs and their start times
+- Pending context injections for the next `UserPromptSubmit`
+- Turn-level pain signal aggregation
+
+### 5.4 Installer Integration
+
+The `create-principles-disciple` installer will be extended to support Codex:
+
+```
+? Which runtime are you installing for?
+  ❯ OpenClaw
+    Codex CLI
+    Both
+```
+
+For Codex CLI installation:
+1. Build and bundle `@principles/codex-hooks` into the installer's `core/` directory
+2. Merge hook entries into `~/.codex/hooks.json` (preserving existing hooks)
+3. Initialize `.principles/` state directory in the workspace
+4. Seed core principles
+
+### 5.5 Principle Injection Strategy
+
+Since Codex's `UserPromptSubmit` only supports `additionalContext` (not prompt rewriting), PD will:
+
+1. **Format principles as structured context comments**:
+   ```
+   <!-- PD Principles Active -->
+   - P-01: Never commit directly to main (enforced)
+   - P-05: Validate all external inputs (enforced)
+   <!-- End PD Principles -->
+   ```
+
+2. **Include pain signal context** when relevant:
+   ```
+   <!-- PD Pain Signal -->
+   Recent pattern: 3x "committed to main" violations in last session
+   <!-- End PD Pain Signal -->
+   ```
+
+3. **Use `PreCompact` to preserve principle markers** so they survive context compaction.
+
+## 6. Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Global hooks.json conflict with other tools | Medium | Medium | Merge strategy: append PD hooks, never remove existing entries |
+| 60s hook timeout insufficient for complex queries | Low | High | Keep hook logic minimal; delegate heavy work to background |
+| Codex hook API changes in future versions | Medium | High | Pin Codex CLI version; add API version check in SessionStart |
+| stdin/stdout protocol fragility | Low | Medium | Strict JSON schema validation; fail-safe defaults |
+| Plugin-local hooks.json not available | High | Low | Document global registration; provide install/uninstall scripts |
+
+## 7. Implementation Phases
+
+### Phase 1: Core Adapter (PRI-278)
+- Implement `CodexCliRuntimeAdapter` in `@principles/core`
+- Add Codex-specific capability definitions
+- Unit tests with test-double runtime
+
+### Phase 2: Hook Scripts (PRI-279)
+- Create `@principles/codex-hooks` package
+- Implement `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart` handlers
+- stdin/stdout protocol layer with schema validation
+
+### Phase 3: Installer Integration (PRI-280)
+- Extend `create-principles-disciple` for Codex CLI
+- Implement `~/.codex/hooks.json` merge logic
+- Add Codex-specific installation flow
+
+### Phase 4: Principle Injection (PRI-281)
+- Implement `additionalContext`-based principle injection
+- `PreCompact`/`PostCompact` context preservation
+- Integration tests with mock Codex sessions
+
+### Phase 5: E2E Validation (PRI-282)
+- Live test against real Codex CLI
+- Pain signal capture → principle internalization loop
+- Documentation and getting-started guide
+
+## 8. Open Questions
+
+1. **Codex CLI version pinning**: Should PD require a minimum Codex CLI version? How to detect and communicate incompatibility?
+2. **Multi-workspace hooks**: Global `hooks.json` means all workspaces share the same hooks. How to disambiguate which workspace a session belongs to?
+3. **Hook script distribution**: Should `@principles/codex-hooks` be published to npm, or bundled into the installer only?
+4. **PermissionRequest hook**: Should PD override Codex's permission prompts? What's the UX for owner review?
+5. **Sub-agent tracking**: Should PD track sub-agent sessions separately, or treat them as part of the parent session?
+
+---
+
+*This design is informed by direct source code analysis of Codex CLI v0.1.x (`codex-rs/hooks/src/`). All data contracts are verified against `schema.rs`, `events/*.rs`, and `engine/output_parser.rs`.*

--- a/docs/architecture/PD_ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/PD_ARCHITECTURE_OVERVIEW.md
@@ -375,7 +375,7 @@ LedgerWriter.deprecate() / archive()
 - `PruningAction` 至今**未实现**，等待独立 issue 推进
 - 任何对 active 原则的状态变更必须可回滚
 
-详见 `PRUNING_PIPELINE.md`（待建）和 `DOMAIN_MODEL.md` §4。
+详见 `PRUNING_PIPELINE.md` 和 `DOMAIN_MODEL.md` §4。
 
 ---
 
@@ -405,7 +405,7 @@ LedgerWriter.deprecate() / archive()
 | Internalization Pipeline | `INTERNALIZATION_PIPELINE.md` §3-4 | ADR-0003, ADR-0005 |
 | Activation Pipeline | `ACTIVATION_CHANNELS.md` | ADR-0006 |
 | Operations Pipeline | `COMPONENTS.md` + 各 ReadModel | ADR-0007 |
-| Pruning Pipeline | `DOMAIN_MODEL.md` §4 | （待建） |
+| Pruning Pipeline | `PRUNING_PIPELINE.md` | — |
 
 ### 5.3 战略层 vs 执行层
 

--- a/docs/architecture/PRUNING_PIPELINE.md
+++ b/docs/architecture/PRUNING_PIPELINE.md
@@ -1,0 +1,408 @@
+# Pruning Pipeline
+
+> **Status**: Active
+> **最后更新**: 2026-05-31
+> **关联**: `PD_ARCHITECTURE_OVERVIEW.md` §4.5, `DATA_ARCHITECTURE.md` §5.5, `INTERNALIZATION_PIPELINE.md` §6, ADR-0012
+
+本文档描述 PD 的修剪（Pruning）流水线：如何检测应被清理的原则、如何记录人工审查决策、以及未来如何执行实际修剪操作。
+
+---
+
+## 1. Purpose
+
+Pruning Pipeline 的职责是**控制 Prompt 上下文压力**，确保活跃原则集合保持在合理规模。具体而言：
+
+- 检测不再产生价值的原则（无痛苦信号、高龄、孤儿引用等）
+- 提供结构化的审查与审计机制
+- 控制实际修剪操作的安全性边界
+
+**核心约束**：PD 不会自动删除或自动归档原则。所有修剪操作都是人在回路（human-in-the-loop）的。
+
+---
+
+## 2. Canonical Terms
+
+### 2.1 Pruning Signal
+
+由 `PruningReadModel` 产出的**只读信号**，描述单个原则的健康状况。每个 Signal 包含：
+
+| 字段 | 含义 |
+|------|------|
+| `principleId` | 原则 ID |
+| `status` | 当前状态（candidate / active / archived / deprecated / probation） |
+| `createdAt` | 原则创建时间（ISO 字符串） |
+| `updatedAt` | 原则最后更新时间（ISO 字符串，缺省时回退到 createdAt） |
+| `derivedCandidateIds` | `derivedFromPainIds` 的完整拷贝（原始候选 ID 列表） |
+| `derivedPainCount` | `derivedFromPainIds` 的长度（派生候选引用数量） |
+| `matchedCandidateCount` | 在 state.db `principle_candidates` 表中匹配到的候选数量 |
+| `recentCandidateCount` | 最近 30 天内创建的 consumed 候选数量 |
+| `orphanCandidateCount` | 孤儿候选数量（存在于 derivedFromPainIds 但不在 state.db 中） |
+| `ageDays` | 原则创建以来的天数 |
+| `riskLevel` | 风险等级（none / watch / review） |
+| `reasons` | 风险分级的具体原因列表 |
+
+**风险分级规则**：
+
+| 条件 | riskLevel |
+|------|-----------|
+| ageDays >= 90 且 derivedPainCount == 0 | `review` |
+| ageDays >= 30 且 derivedPainCount == 0 | `watch` |
+| 其他 | `none` |
+
+**reasons 附加规则**（`buildReasons` 函数）：
+
+除风险分级外，`reasons` 数组还包含以下附加信号：
+
+| 条件 | reason 前缀 |
+|------|------------|
+| `status === 'probation'` | `status:` |
+| `orphanCandidateCount > 0` | `orphan:` |
+| `derivedPainCount > 0 && matchedCandidateCount === 0` | `gap:` |
+| `recentCandidateCount > 0 && derivedPainCount === 0` | `stale:` |
+| `status === 'deprecated' \|\| status === 'archived'` | `status:` |
+
+### 2.2 Pruning Review
+
+人工审查决策，记录到 append-only JSONL 审计日志。决策类型：
+
+| 决策 | 含义 | 是否修改 Ledger |
+|------|------|----------------|
+| `keep` | 保留原则，不做任何操作 | 否 |
+| `defer` | 推迟决策，下次再审查 | 否 |
+| `archive-candidate` | 标记为候选归档，从 Prompt 注入中屏蔽 | 否 |
+
+**重要**：`archive-candidate` 不会修改 Ledger 中的原则状态。它仅将原则 ID 加入 Pruning Mask，在 Prompt 注入时跳过该原则。这是一个**可逆的软操作**，通过 `rollback` 命令即可恢复。
+
+### 2.3 Pruning Action
+
+**未来能力，当前未实现。** 指实际修改 Ledger 中原则状态的操作（如 ``status -> deprecated`` 或 ``status -> archived``）。必须满足：
+
+- 独立 issue 推进
+- dry-run 先行
+- 人工确认
+- 回滚计划
+
+### 2.4 Archive Candidate
+
+当 operator 对某个原则做出 `archive-candidate` 审查决策后，该原则被称为 "Archive Candidate"。此状态**仅存在于 `pruning_reviews.jsonl`** 中，不反映在 Ledger 上。
+
+### 2.5 Orphan Derived Candidate
+
+原则的 `derivedFromPainIds` 中引用的候选 ID 在 `state.db` 的 `principle_candidates` 表中不存在。这通常是因为数据迁移、DB 重建或候选已被清理。当 `state.db` 不可读时，孤儿检测会标记 `dbReadable: false`，此时 `--confirm` 操作会被拒绝。
+
+---
+
+## 3. Pipeline Overview
+
+```mermaid
+flowchart TD
+    subgraph Detection["Signal Detection - Read-Only"]
+        Ledger[(ledger.json)] --> PRM[PruningReadModel]
+        StateDB[(state.db)] --> PRM
+        PRM --> Signals[PruningSignal array]
+        PRM --> Summary[PruningHealthSummary]
+        PRM --> Orphans[OrphanDetectionResult]
+    end
+
+    subgraph Review["Review and Audit - Append-Only"]
+        Signals --> Operator[Operator / pd-cli / pd-console]
+        Operator --> |keep / defer / archive-candidate| ReviewLog[pruning_reviews.jsonl]
+    end
+
+    subgraph Masking["Injection Masking"]
+        ReviewLog --> Mask[buildMaskedPrincipleSet]
+        Mask --> |TTL 60s cache| Prompt[Prompt Injection]
+    end
+
+    subgraph Future["Future: Pruning Action - NOT IMPLEMENTED"]
+        ReviewLog -.-> |requires separate issue| Action[PruningAction]
+        Action -.-> |dry-run + confirm + rollback| LedgerMut[Ledger Mutation]
+    end
+
+    style Future fill:#f0f0f0,stroke-dasharray: 5 5
+    style LedgerMut fill:#f0f0f0,stroke-dasharray: 5 5
+```
+
+**数据流说明**：
+
+1. **Signal Detection**：`PruningReadModel` 读取 Ledger 和 state.db，产出信号。纯只读，无副作用。
+2. **Review and Audit**：Operator 查看信号后做出审查决策，写入 append-only JSONL。
+3. **Injection Masking**：`buildMaskedPrincipleSet` 基于审查日志构建屏蔽集合，在 Prompt 注入时跳过被标记的原则。
+4. **Pruning Action**：实际修改 Ledger 的操作。**未实现**，需要独立 issue 推进。
+
+---
+
+## 4. Current Implementation
+
+### 4.1 Core 模块（`@principles/core/runtime-v2/`）
+
+| 文件 | 职责 | I/O |
+|------|------|-----|
+| `pruning-read-model.ts` | 信号检测、健康摘要、孤儿检测 | 只读：`.state/principle_training_state.json` + `.pd/state.db` |
+| `pruning-review-log.ts` | 审查决策的 append-only JSONL 日志 | 写入：`.state/pruning_reviews.jsonl` |
+| `pruning-mask.ts` | 基于审查日志构建屏蔽集合 + TTL 缓存 | 读：pruning_reviews.jsonl |
+| `l1-hard-cap.ts` | L1 活跃原则数硬上限（默认 12）+ LRU 淘汰计算 | 纯计算，无 I/O |
+
+### 4.2 CLI 命令（`@principles/pd-cli`）
+
+| 命令 | 职责 | 修改数据 |
+|------|------|---------|
+| `pd runtime pruning report` | 健康报告（watch/review 信号总览） | 无 |
+| `pd runtime pruning explain --principle-id <id>` | 单个原则的详细信号解释 | 无 |
+| `pd runtime pruning review --principle-id <id> --decision <decision>` | 记录人工审查决策 | `pruning_reviews.jsonl` |
+| `pd runtime pruning rollback --principle-id <id>` | 撤销 archive-candidate 标记 | `pruning_reviews.jsonl` |
+| `pd runtime pruning orphans` | 检测并可选清理孤儿引用 | 默认 dry-run；`--confirm` 时修改 ledger.json |
+
+### 4.3 L1 Hard Cap
+
+`l1-hard-cap.ts` 提供容量保护机制：
+
+- **默认上限**：12 个活跃原则（`DEFAULT_L1_HARD_CAP`）
+- **最大上限**：不可超过 12（`MAX_L1_HARD_CAP`），配置只能降低不能提高
+- **淘汰策略**：LRU（按 `lastTriggeredAt` 排序，淘汰最久未触发的）
+- **纯计算**：`enforceL1HardCap()` 返回淘汰候选列表，不直接修改 Ledger
+
+### 4.4 Read Model 与 Health Snapshot
+
+`OperatorHealthReadModel` 集成了 pruning 信号，提供整体健康视图。`pd runtime health snapshot` 命令输出的摘要中包含 pruning 相关字段。
+
+---
+
+## 5. Non-Implemented / Future Capabilities
+
+以下能力**当前未实现**，需要独立 issue 推进：
+
+| 能力 | 描述 | 前置条件 |
+|------|------|---------|
+| PruningAction | 实际修改 Ledger 原则状态（deprecate / archive） | 需要 ADR 定义安全边界 |
+| 自动修剪触发 | 定期自动扫描并建议修剪 | PruningAction 实现后 |
+| pd-console Pruning UI | 可视化修剪仪表盘 | PruningAction 实现后 |
+| 批量修剪操作 | 一次审查多个原则 | 需要批量确认机制 |
+| 修剪历史报告 | 基于 pruning_reviews.jsonl 的趋势分析 | 需要聚合查询 |
+| 与 Activation Pipeline 联动 | 修剪后自动调整活跃原则集 | PruningAction 实现后 |
+| 修剪策略配置 | 可配置的 watch/review 阈值 | 当前硬编码 30/90 天 |
+
+---
+
+## 6. Data Model and Stores
+
+### 6.1 Pruning Reviews JSONL
+
+**路径**：`{workspace}/.state/pruning_reviews.jsonl`
+
+每行一条 JSON 记录，格式：
+
+```json
+{
+  "reviewId": "uuid-v4",
+  "principleId": "P_001",
+  "decision": "archive-candidate",
+  "note": "Principle no longer relevant after auth refactor",
+  "reviewer": "operator",
+  "reviewedAt": "2026-05-19T10:30:00.000Z",
+  "signalSnapshot": {
+    "principleId": "P_001",
+    "status": "active",
+    "createdAt": "2026-03-01T00:00:00.000Z",
+    "updatedAt": "2026-05-01T00:00:00.000Z",
+    "derivedCandidateIds": ["C_001"],
+    "derivedPainCount": 1,
+    "matchedCandidateCount": 1,
+    "recentCandidateCount": 0,
+    "orphanCandidateCount": 0,
+    "ageDays": 79,
+    "riskLevel": "watch",
+    "reasons": ["watch: principle older than 30 days with no recent derived pain signals [source: createdAt + derivedFromPainIds]"]
+  }
+}
+```
+
+**特性**：
+- Append-only：不允许 UPDATE / DELETE
+- LWW（Last Write Wins）语义：同一 `principleId` 的多条记录中，只有最新的 `decision` 生效
+- `signalSnapshot` 记录审查时的信号状态，确保审计可追溯
+
+### 6.2 Ledger（读取）
+
+`PruningReadModel` 从 Ledger 读取原则条目（路径：`{workspace}/.state/principle_training_state.json`），关键字段：
+
+- `status`：原则当前状态
+- `derivedFromPainIds`：派生痛苦 ID 列表（用于交叉验证候选）
+- `createdAt` / `updatedAt`：用于计算年龄
+
+### 6.3 state.db（读取）
+
+`PruningReadModel` 从 SQLite 读取 `principle_candidates` 表（路径：`{workspace}/.pd/state.db`），用于：
+
+- 交叉验证 `derivedFromPainIds` 中的候选是否存在
+- 获取候选创建时间（用于计算 recent 候选数）
+
+### 6.4 Pruning Mask（内存缓存）
+
+`pruning-mask.ts` 提供 `getCachedMaskedPrincipleSet()`：
+
+- 输入：pruning_reviews.jsonl 中的所有记录
+- 输出：`Set<string>` — 应从 Prompt 注入中排除的原则 ID 集合
+- 缓存：TTL 60 秒，避免频繁读盘
+- 语义：LWW — `archive-candidate` 的原则被屏蔽；`keep` / `defer` 的不被屏蔽
+
+---
+
+## 7. CLI / Operator Workflows
+
+### 7.1 查看修剪健康状态
+
+```bash
+# 总览报告
+pd runtime pruning report
+
+# 单个原则详细解释
+pd runtime pruning explain --principle-id P_001
+
+# JSON 格式输出（供代理解析）
+pd runtime pruning report --json
+```
+
+### 7.2 审查决策流程
+
+```bash
+# 第 1 步：查看 report，找到 watch/review 标记的原则
+pd runtime pruning report
+
+# 第 2 步：查看具体原因
+pd runtime pruning explain --principle-id P_042
+
+# 第 3 步：做出决策
+pd runtime pruning review --principle-id P_042 --decision archive-candidate --note "Replaced by P_089"
+pd runtime pruning review --principle-id P_043 --decision keep
+pd runtime pruning review --principle-id P_044 --decision defer
+```
+
+### 7.3 撤销审查决策
+
+```bash
+# 如果 archive-candidate 是误判，可以恢复
+pd runtime pruning rollback --principle-id P_042 --note "Restored: false positive"
+```
+
+### 7.4 孤儿引用清理
+
+```bash
+# 第 1 步：dry-run 检查（默认）
+pd runtime pruning orphans
+
+# 第 2 步：确认清理（实际修改 ledger 中的 derivedFromPainIds）
+pd runtime pruning orphans --confirm
+```
+
+**注意**：orphans `--confirm` 是唯一一个直接修改 Ledger 的 pruning 命令。它仅删除 `derivedFromPainIds` 中引用不存在的候选 ID，不修改原则状态。如果 state.db 不可读，`--confirm` 会被拒绝。
+
+### 7.5 Future 命令（未实现）
+
+```bash
+# 以下命令不存在，仅为未来设计参考
+# pd runtime pruning action --principle-id P_042 --dry-run     # Future
+# pd runtime pruning action --principle-id P_042 --confirm     # Future
+# pd runtime pruning batch-review --file decisions.json        # Future
+```
+
+---
+
+## 8. Safety Guardrails
+
+### 8.1 Read-Only Guarantee
+
+`PruningReadModel` 的代码中明确声明：
+
+> Non-goals: No automatic pruning or demotion. No ledger writes. No state changes. No background workers.
+
+所有信号检测方法（`getPrincipleSignals`、`getHealthSummary`、`getOrphanDerivedCandidates`）均为纯只读。
+
+### 8.2 Append-Only Audit
+
+`PruningReviewLog` 是 append-only 的 JSONL 文件。审查决策不会覆盖或删除历史记录。LWW 语义在读取时通过 `buildMaskedPrincipleSet` 计算，不在写入时覆盖。
+
+### 8.3 Archive-Candidate Is Not Mutation
+
+`archive-candidate` 决策的效果**仅限于 Prompt 注入屏蔽**：
+
+1. `buildMaskedPrincipleSet` 将该原则 ID 加入屏蔽集合
+2. Prompt 注入时跳过该原则
+3. Ledger 中原则的 `status` 不变
+4. 通过 `rollback` 命令可立即恢复（追加一条 `keep` 决策）
+
+### 8.4 Orphan Cleanup Guards
+
+`pd runtime pruning orphans --confirm` 的安全保护：
+
+- **默认 dry-run**：不加 `--confirm` 时只显示不修改
+- **DB 不可读时拒绝**：`state.db` 不可读时 `--confirm` 被拒绝，防止误删有效引用
+- **不可变副本**：修改前深拷贝 Ledger（``JSON.parse(JSON.stringify(ledger))``）
+- **原子写入**：通过 `saveLedger` 使用 `atomicWriteFileSync`
+
+### 8.5 Future PruningAction Requirements
+
+实际修改 Ledger 的 PruningAction（未实现）必须满足：
+
+| 要求 | 描述 |
+|------|------|
+| dry-run 先行 | 必须先展示将要修改的内容 |
+| 人工确认 | 必须通过 `--confirm` 或 pd-console 审批 |
+| 回滚计划 | 必须提供回滚命令或步骤 |
+| 审计追踪 | 必须记录操作者、时间、原因 |
+| 无自动执行 | 不允许定时任务或后台 worker 自动触发 |
+
+---
+
+## 9. Relationship to Other Pipelines
+
+### 9.1 Internalization Pipeline
+
+Pruning 和 Internalization 是互补的：
+
+- **Internalization** 负责从痛苦信号产生新原则（增长方向）
+- **Pruning** 负责识别和清理不再有效原则（缩减方向）
+- 两者通过 **Ledger** 共享数据，但操作方向相反
+- Pruning 的 `PruningReadModel` 读取 Internalization 产生的 `principle_candidates` 表来计算信号
+
+### 9.2 Principle Ledger
+
+Pruning 依赖 Ledger 作为主要数据源：
+
+- 读取原则的 `status`、`derivedFromPainIds`、`createdAt`
+- `archive-candidate` 审查决策不修改 Ledger（仅写入 pruning_reviews.jsonl）
+- Orphan cleanup 是唯一修改 Ledger 的操作（清理 `derivedFromPainIds` 中的无效引用）
+
+### 9.3 Activation Pipeline / Approval Queue
+
+当前 Pruning Pipeline 与 Activation Pipeline 之间无直接交互。未来 PruningAction 实现时，可能需要：
+
+- 修剪后触发 ActivationDispatcher 重新评估活跃原则集
+- 高风险修剪操作通过 ApprovalQueue 审批
+
+### 9.4 L1 Hard Cap
+
+`l1-hard-cap.ts` 提供容量保护，与 Pruning 协同工作：
+
+- L1 Hard Cap 限制活跃原则数量（默认 12）
+- 当活跃原则超过上限时，计算 LRU 淘汰候选
+- 淘汰计算本身不修改 Ledger，由调用方决定如何处理
+- Pruning 的 watch/review 信号可以帮助 operator 决定哪些原则应优先淘汰
+
+### 9.5 GoldenTrace / L2
+
+Pruning Pipeline 与 GoldenTrace（L2 replay 验证）目前无直接关系。未来可能利用 GoldenTrace 验证修剪后系统的行为一致性。
+
+---
+
+## 10. Open Questions
+
+| # | 问题 | 状态 |
+|---|------|------|
+| 1 | PruningAction 是否需要独立 ADR？ | Open — 建议实现前创建 ADR |
+| 2 | watch/review 阈值（30/90 天）是否应可配置？ | Open — 当前硬编码在 `PruningReadModel` 构造函数中 |
+| 3 | Pruning Mask 的 TTL（60s）是否合适？ | Open — 当前为模块级缓存，可能需要按 workspace 隔离 |
+| 4 | 孤儿清理是否应自动触发？ | Open — 当前需手动运行 CLI |
+| 5 | PruningAction 的 Ledger mutation 是否应通过 Activation Pipeline？ | Open — 与 ADR-0006 的关系待明确 |
+| 6 | 是否需要 pruning 的定期自动报告（如每日摘要）？ | Open — 当前完全按需查询 |
+| 7 | MAX_L1_HARD_CAP 为何与 DEFAULT_L1_HARD_CAP 相同（12）？ | Design — 防止配置超过测试验证的上限 |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -232,7 +232,7 @@
 | Pain Signal | `DOMAIN_MODEL.md` §4 + `GLOSSARY.md` §1 | LOCKED |
 | Internalization Channel（5 通道）| `DOMAIN_MODEL.md` §3 + `ACTIVATION_CHANNELS.md` §3 | LOCKED |
 | L1 / L2 / L3 | `DOMAIN_MODEL.md` §3 + `PD_System_Dynamics_Model.md` §4 | LOCKED |
-| Pruning Signal | `DOMAIN_MODEL.md` §4 | LOCKED |
+| Pruning Signal | `DOMAIN_MODEL.md` §4 + `PRUNING_PIPELINE.md` §2 | LOCKED |
 | Approval | `DOMAIN_MODEL.md` §5.4 + `ACTIVATION_CHANNELS.md` §2.3 | Active |
 | PIArtifact | `DOMAIN_MODEL.md` §5.5 + `INTERNALIZATION_PIPELINE.md` §3.6 | Active |
 | Peer Runner | `GLOSSARY.md` §2 + `INTERNALIZATION_PIPELINE.md` §3.4 | Active |


### PR DESCRIPTION
## Summary

Land and verify PRUNING_PIPELINE architecture document (PRI-183), plus merge README positioning refinement.

## PRI-183: PRUNING_PIPELINE.md alignment

Review existing pruning design against shipped Runtime V2 code, then commit the document and its cross-links as an authoritative docs-only change.

### Changes to PRUNING_PIPELINE.md

- **Fix S2.1 PruningSignal field table**: add missing `createdAt`, `updatedAt`, `derivedCandidateIds`, `recentCandidateCount`; correct `derivedPainCount` description (is `derivedFromPainIds.length`, not "pain signal count")
- **Add S2.1 reasons附加规则 table**: document all `buildReasons()` reason prefixes (status, orphan, gap, stale)
- **Fix S4.1 I/O paths**: ledger is `.state/principle_training_state.json` (not `ledger.json`); state.db is under `.pd/`
- **Fix S6.2/S6.3**: add explicit file paths for Ledger and state.db
- **Fix S6.1 signalSnapshot**: replace empty `{}` with full example matching `PruningReviewRecord` interface
- **Add S2.5**: note `dbReadable: false` behavior for orphan detection
- **Add ADR-0012** to cross-references
- **Update date** to 2026-05-31

### Cross-reference fixes

- `PD_ARCHITECTURE_OVERVIEW.md`: remove `(待建)` drift, point Pruning Pipeline row to `PRUNING_PIPELINE.md` instead of `DOMAIN_MODEL.md` S4
- `README.md` (architecture index): add `PRUNING_PIPELINE.md` S2 to Pruning Signal canonical ref

### .gitignore fix

- Change `docs/` to `docs/*` so `!docs/architecture/` exception works correctly (git does not traverse ignored directories to check exceptions)

## README positioning refinement (merged from docs/readme-positioning-refinement)

- Refine PD positioning for general AI agents, agentic dev as first domain
- Remove Linear tracking note from roadmap

## ERR Checklist

- ERR-012 (stale main rollback): Branch based on latest `origin/main` with merge from `docs/readme-positioning-refinement`
- This is a docs-only change; no runtime contract rules apply

## Tests run

- `npm run verify:merge` passed (build + lint + typecheck all green)

Closes PRI-183


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档更新**
  * 优化了产品定义与结构说明，明确了核心原理与首个应用方向
  * 新增修剪流水线架构文档，详细说明工作流、决策规则与数据保护机制
  * 完善了架构文档导航与概念索引，改进了相关内容的引用关系

<!-- end of auto-generated comment: release notes by coderabbit.ai -->