### PR TITLE
fix(ci): handle first-time package publish in workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -240,19 +240,26 @@ jobs:
           echo "  - npm latest: $NPM_VERSION"
           echo "  - local: $LOCAL_VERSION"
 
-          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
-            echo "Local version ($LOCAL_VERSION) differs from npm ($NPM_VERSION)"
-            echo "Will bump from npm version: $NPM_VERSION"
+          if [ "$NPM_VERSION" = "0.0.0" ]; then
+            echo "Package not yet published on npm — using local version $LOCAL_VERSION"
+            echo "version=$LOCAL_VERSION" >> $GITHUB_OUTPUT
+            echo "old_version=$NPM_VERSION" >> $GITHUB_OUTPUT
+            echo "Bumped: new package at $LOCAL_VERSION"
+          else
+            if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
+              echo "Local version ($LOCAL_VERSION) differs from npm ($NPM_VERSION)"
+              echo "Will bump from npm version: $NPM_VERSION"
+            fi
+
+            npm version $NPM_VERSION --no-git-tag-version
+            npm version $BUMP -m "chore(release): %s [skip ci]"
+
+            NEW_VERSION=$(node -p "require('./package.json').version")
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "old_version=$NPM_VERSION" >> $GITHUB_OUTPUT
+
+            echo "Bumped: $NPM_VERSION -> $NEW_VERSION"
           fi
-
-          npm version $NPM_VERSION --no-git-tag-version
-          npm version $BUMP -m "chore(release): %s [skip ci]"
-
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "old_version=$NPM_VERSION" >> $GITHUB_OUTPUT
-
-          echo "Bumped: $NPM_VERSION -> $NEW_VERSION"
 
       - name: Sync version to all files
         if: needs.resolve-package.outputs.pkg_dir == 'openclaw-plugin' && steps.bump.outputs.type != 'none'


### PR DESCRIPTION
## Problem

The publish workflow fails for packages that have never been published to npm (e.g., \@principles/core\, \@principles/pd-cli\). When \
pm view\ returns 0.0.0 (package not found), the workflow resets the local version to 0.0.0 and bumps to 0.0.1, which:

1. Breaks workspace dependency resolution (\@principles/core@^1.73.0\ not found)
2. Publishes the wrong version (0.0.1 instead of 1.73.0)

## Fix

When npm version is 0.0.0 (package not yet published), skip the version reset and use the local version directly.