### PR TITLE
ci: migrate to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
@@ -188,7 +188,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -92,9 +92,13 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install dependencies (workspace root)
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_READ_TOKEN || secrets.NPM_TOKEN }}
 
       - name: Build core (dependency for plugin/cli)
         if: needs.resolve-package.outputs.pkg_dir != 'create-principles-disciple'
@@ -186,9 +190,12 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install dependencies (workspace root)
         run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_READ_TOKEN || secrets.NPM_TOKEN }}
 
       - name: Build core (dependency for plugin/cli)
         if: needs.resolve-package.outputs.pkg_dir != 'create-principles-disciple'
@@ -338,9 +345,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/${{ needs.resolve-package.outputs.pkg_dir }}
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Create Git tag
         if: needs.resolve-package.outputs.pkg_dir == 'openclaw-plugin' && steps.bump.outputs.type != 'none'

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -14,6 +14,9 @@
   },
   "author": "csuzngjh",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/csuzngjh/principles/issues"
   },

--- a/packages/pd-cli/package.json
+++ b/packages/pd-cli/package.json
@@ -22,5 +22,14 @@
     "@types/node": "^25.6.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/csuzngjh/principles.git",
+    "directory": "packages/pd-cli"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/principles-core/package.json
+++ b/packages/principles-core/package.json
@@ -88,5 +88,13 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/csuzngjh/principles.git",
+    "directory": "packages/principles-core"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary

Migrate npm publishing from long-lived \NPM_TOKEN\ to OIDC-based Trusted Publishing, following npm's security advisory about token rotation.

### Why
npm has rotated all granular access tokens that bypass 2FA (Mini Shai-Hulud attack prevention). The old \NPM_TOKEN\ secret is now invalid. npm recommends using [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) instead.

### Changes

**Workflow (\publish-npm.yml\)**
- Remove \NODE_AUTH_TOKEN\ from \
pm publish\ step — OIDC auto-authenticates
- Remove \--provenance\ flag — auto-generated with Trusted Publishing
- Add \package-manager-cache: false\ to release builds (npm best practice)
- Add \NODE_AUTH_TOKEN\ to \
pm ci\ steps for dependency resolution (read-only token fallback)

**Package metadata**
- Add \epository\ field to \@principles/core\ and \@principles/pd-cli\ (required for Trusted Publishing)
- Add \publishConfig.access: public\ to all publishable packages
- Add \license: MIT\ to \@principles/pd-cli\

### Post-merge steps (user action required)
1. Configure Trusted Publisher on npmjs.com for each package (see instructions in PR comments)
2. Optionally create a read-only \NPM_READ_TOKEN\ for dependency resolution
3. Remove the old \NPM_TOKEN\ secret from GitHub repo settings