### PR TITLE
fix: pd-cli version from package.json + installer gateway detection and npm auto-upgrade

### DIFF
--- a/packages/create-principles-disciple/core/package.json
+++ b/packages/create-principles-disciple/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@principles/core",
-  "version": "0.1.0",
+  "version": "1.73.0",
   "description": "Universal Evolution SDK - framework-agnostic pain signal capture and principle injection",
   "type": "module",
   "main": "./dist/index.js",
@@ -88,5 +88,13 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/csuzngjh/principles.git",
+    "directory": "packages/principles-core"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/create-principles-disciple/pd-cli/package.json
+++ b/packages/create-principles-disciple/pd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@principles/pd-cli",
-  "version": "0.1.0",
+  "version": "1.73.0",
   "description": "PD CLI — Pain recording, sample management, and evolution tasks",
   "type": "module",
   "bin": {
@@ -22,5 +22,14 @@
     "@types/node": "^25.6.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/csuzngjh/principles.git",
+    "directory": "packages/pd-cli"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-principles-disciple/src/installer.ts
+++ b/packages/create-principles-disciple/src/installer.ts
@@ -6,6 +6,7 @@ import { execSync, execFileSync, spawn, type ChildProcess } from 'child_process'
 import type { ExecSyncOptions } from 'child_process';
 import ora, { type Ora } from 'ora';
 import { logger } from './utils/logger.js';
+import { checkOpenClawGateway } from './utils/env.js';
 import type { InstallOptions } from './prompts.js';
 import {
   generateFeatureFlagsYamlContent,
@@ -424,6 +425,69 @@ function installGlobalPdShim(): boolean {
   }
 }
 
+function tryUpgradePdCliFromNpm(installedPdCliDir: string): void {
+  try {
+    const npmVersion = execSync('npm view @principles/pd-cli version', {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    if (!npmVersion || !/^\d+\.\d+\.\d+/.test(npmVersion)) return;
+
+    const localPkgPath = path.join(installedPdCliDir, 'package.json');
+    const localPkg = JSON.parse(readFileSync(localPkgPath, 'utf-8')) as { version: string };
+    const localVersion = localPkg.version;
+
+    if (npmVersion === localVersion) return;
+
+    logger.info(`Upgrading pd-cli from bundled v${localVersion} to npm v${npmVersion}...`);
+
+    const tmpDir = path.join(installedPdCliDir, '__npm_upgrade_tmp');
+    try {
+      mkdirSync(tmpDir, { recursive: true });
+      execSync(`npm pack @principles/pd-cli@${npmVersion} --pack-destination "${tmpDir}"`, {
+        encoding: 'utf-8',
+        timeout: 30_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const tgzFiles = readdirSync(tmpDir).filter(f => f.endsWith('.tgz'));
+      if (tgzFiles.length === 0) {
+        logger.info('No npm tarball found, keeping bundled version.');
+        return;
+      }
+
+      const extractDir = path.join(tmpDir, 'extracted');
+      mkdirSync(extractDir, { recursive: true });
+      execSync(`tar -xzf "${path.join(tmpDir, tgzFiles[0])}" -C "${extractDir}"`, {
+        encoding: 'utf-8',
+        timeout: 15_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const packageDir = path.join(extractDir, 'package');
+      if (!existsSync(path.join(packageDir, 'dist', 'index.js'))) {
+        logger.info('Npm package structure unexpected, keeping bundled version.');
+        return;
+      }
+
+      rmSync(path.join(installedPdCliDir, 'dist'), { recursive: true, force: true });
+      cpSync(path.join(packageDir, 'dist'), path.join(installedPdCliDir, 'dist'), { recursive: true });
+      if (existsSync(path.join(packageDir, 'package.json'))) {
+        copyFileSync(path.join(packageDir, 'package.json'), localPkgPath);
+      }
+
+      logger.success(`pd-cli upgraded to v${npmVersion}`);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.info(`pd-cli npm upgrade skipped (${msg}). Bundled version is functional.`);
+  }
+}
+
 function syncPdCli(pluginDir: string): boolean {
   const pdCliSourceDir = path.join(pluginDir, 'pd-cli');
   const distDir = path.join(pdCliSourceDir, 'dist');
@@ -437,6 +501,8 @@ function syncPdCli(pluginDir: string): boolean {
   mkdirSync(installedPdCliDir, { recursive: true });
   cpSync(distDir, path.join(installedPdCliDir, 'dist'), { recursive: true });
   copyFileSync(path.join(pdCliSourceDir, 'package.json'), path.join(installedPdCliDir, 'package.json'));
+
+  tryUpgradePdCliFromNpm(installedPdCliDir);
 
   const installedBinDir = getInstalledBinDir();
   mkdirSync(installedBinDir, { recursive: true });
@@ -796,6 +862,16 @@ export interface InstallResult {
 }
 
 export async function install(options: InstallOptions, pluginDir: string, quiet = false): Promise<InstallResult> {
+  const gatewayStatus = await checkOpenClawGateway();
+  if (gatewayStatus.isRunning) {
+    const portInfo = gatewayStatus.port ? ` (port ${gatewayStatus.port})` : '';
+    const pidInfo = gatewayStatus.pid ? `, PID ${gatewayStatus.pid}` : '';
+    logger.warn(`OpenClaw gateway is running${portInfo}${pidInfo}.`);
+    logger.warn('This may cause file lock issues during installation (EPERM on native modules).');
+    logger.warn('Recommendation: stop OpenClaw first with "openclaw gateway stop", then re-run the installer.');
+    logger.warn('Proceeding anyway — if installation fails, stop OpenClaw and retry.\n');
+  }
+
   const spinner = quiet ? null : ora('Installing...').start();
   let backupDir: string | null = null;
   const components: ComponentStatus = { plugin: 'skipped', cli: 'skipped', console: 'skipped' };

--- a/packages/create-principles-disciple/src/uninstaller.ts
+++ b/packages/create-principles-disciple/src/uninstaller.ts
@@ -15,7 +15,7 @@ import fse from 'fs-extra';
 import * as path from 'path';
 import { confirm } from '@inquirer/prompts';
 import { logger } from './utils/logger.js';
-import { getOpenClawConfigDir, getPluginExtDir } from './utils/env.js';
+import { getOpenClawConfigDir, getPluginExtDir, checkOpenClawGateway } from './utils/env.js';
 import { getGlobalShimPaths, getInstalledBinDir, isWindows } from './mvp-config.js';
 import { setLanguage, t, getLanguage } from './i18n.js';
 
@@ -223,6 +223,23 @@ function cleanupOpenClawConfig(): { cleaned: boolean; error?: string } {
  *
  * @param options.force Skip confirmation prompt (dangerous, for scripts only)
  */
+const REMOVE_RETRY_ATTEMPTS = 3;
+const REMOVE_RETRY_DELAY_MS = 1000;
+
+async function removeWithRetry(targetPath: string, _type: 'dir' | 'file'): Promise<void> {
+  for (let attempt = 1; attempt <= REMOVE_RETRY_ATTEMPTS; attempt++) {
+    try {
+      await fse.remove(targetPath);
+      return;
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      const isLockError = errMsg.includes('EPERM') || errMsg.includes('EBUSY') || errMsg.includes('permission');
+      if (!isLockError || attempt === REMOVE_RETRY_ATTEMPTS) throw error;
+      await new Promise(r => setTimeout(r, REMOVE_RETRY_DELAY_MS * attempt));
+    }
+  }
+}
+
 export async function uninstall(
   options: {
     force?: boolean;
@@ -240,6 +257,17 @@ export async function uninstall(
   };
 
   try {
+    const gatewayStatus = await checkOpenClawGateway();
+    if (gatewayStatus.isRunning) {
+      const portInfo = gatewayStatus.port ? ` (port ${gatewayStatus.port})` : '';
+      const pidInfo = gatewayStatus.pid ? `, PID ${gatewayStatus.pid}` : '';
+      logger.warn(`OpenClaw gateway is running${portInfo}${pidInfo}.`);
+      logger.warn(isWindows()
+        ? '文件可能被占用导致删除失败。建议先关闭 OpenClaw（openclaw gateway stop），然后重新运行卸载。'
+        : 'Files may be locked. Stop OpenClaw first (openclaw gateway stop), then re-run uninstall.');
+      console.log('');
+    }
+
     // 1. Check install status
     const status = checkInstallStatus();
 
@@ -291,21 +319,30 @@ export async function uninstall(
     }
 
     // 5. Execute deletion (only plugin system files)
+    const deleteErrors: { name: string; error: string }[] = [];
     for (const p of status.paths) {
       if (!p.exists) continue;
 
       try {
+        await removeWithRetry(p.path, p.type);
         if (p.type === 'dir') {
-          await fse.remove(p.path);
           result.removedDirs.push(p.path);
-          logger.success(`${t('deleted')}: ${p.name}`);
         } else {
-          await fse.remove(p.path);
           result.removedFiles.push(p.path);
-          logger.success(`${t('deleted')}: ${p.name}`);
         }
+        logger.success(`${t('deleted')}: ${p.name}`);
       } catch (error) {
-        logger.error(`${t('delete_failed')}: ${p.name} - ${error instanceof Error ? error.message : String(error)}`);
+        const errMsg = error instanceof Error ? error.message : String(error);
+        const isPermError = errMsg.includes('EPERM') || errMsg.includes('permission') || errMsg.includes('access denied') || errMsg.includes('EBUSY');
+        if (isPermError) {
+          logger.error(`${t('delete_failed')}: ${p.name} - ${errMsg}`);
+          logger.warn(isWindows()
+            ? '文件被占用，请先关闭 OpenClaw（openclaw gateway stop），然后手动删除目录或重新运行卸载。'
+            : 'File is locked. Stop OpenClaw first (openclaw gateway stop), then re-run uninstall or delete manually.');
+        } else {
+          logger.error(`${t('delete_failed')}: ${p.name} - ${errMsg}`);
+        }
+        deleteErrors.push({ name: p.name, error: errMsg });
       }
     }
 
@@ -335,10 +372,17 @@ export async function uninstall(
       }
     }
 
-    result.success = true;
+    result.success = deleteErrors.length === 0;
+    if (deleteErrors.length > 0) {
+      result.error = deleteErrors.map(e => `${e.name}: ${e.error}`).join('; ');
+    }
 
     console.log('\n');
-    logger.success(t('uninstall_complete'));
+    if (deleteErrors.length > 0) {
+      logger.warn(t('uninstall_partial') || '卸载部分完成 — 部分文件未能删除，请按上方提示处理。');
+    } else {
+      logger.success(t('uninstall_complete'));
+    }
     console.log('\n');
 
     if (result.preservedPaths.length > 0) {

--- a/packages/create-principles-disciple/src/utils/env.ts
+++ b/packages/create-principles-disciple/src/utils/env.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import * as net from 'net';
 
 export interface EnvCheckResult {
   hasOpenClaw: boolean;
@@ -151,4 +152,63 @@ export function getOpenClawConfigDir(): string {
  */
 export function getPluginExtDir(): string {
   return path.join(getOpenClawConfigDir(), 'extensions', 'principles-disciple');
+}
+
+export interface OpenClawGatewayStatus {
+  isRunning: boolean;
+  port?: number;
+  pid?: number;
+}
+
+function readOpenClawPort(): number | null {
+  const configPath = path.join(getOpenClawConfigDir(), 'openclaw.json');
+  if (!fs.existsSync(configPath)) return null;
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const config: unknown = JSON.parse(raw);
+    if (config && typeof config === 'object' && !Array.isArray(config)) {
+      const { gateway } = config as Record<string, unknown>;
+      if (gateway && typeof gateway === 'object' && !Array.isArray(gateway)) {
+        const { port } = gateway as Record<string, unknown>;
+        if (typeof port === 'number' && port > 0 && port < 65536) return port;
+      }
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function checkPortListening(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const timeout = 2000;
+    socket.setTimeout(timeout);
+    socket.on('connect', () => { socket.destroy(); resolve(true); });
+    socket.on('error', () => { socket.destroy(); resolve(false); });
+    socket.on('timeout', () => { socket.destroy(); resolve(false); });
+    socket.connect(port, '127.0.0.1');
+  });
+}
+
+export async function checkOpenClawGateway(): Promise<OpenClawGatewayStatus> {
+  const port = readOpenClawPort();
+  if (!port) return { isRunning: false };
+
+  const listening = await checkPortListening(port);
+  if (!listening) return { isRunning: false };
+
+  let pid: number | undefined = undefined;
+  try {
+    if (process.platform === 'win32') {
+      const output = execSync(
+        `powershell -NoProfile -Command "(Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue).OwningProcess"`,
+        { encoding: 'utf-8', timeout: 5000 }
+      ).trim();
+      if (output) pid = parseInt(output.split('\n')[0].trim(), 10);
+    } else {
+      const output = execSync(`lsof -i :${port} -t -sTCP:LISTEN 2>/dev/null`, { encoding: 'utf-8', timeout: 5000 }).trim();
+      if (output) pid = parseInt(output.split('\n')[0].trim(), 10);
+    }
+  } catch { /* ignore */ }
+
+  return { isRunning: true, port, pid };
 }

--- a/packages/pd-cli/package.json
+++ b/packages/pd-cli/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@principles/pd-cli",
-  "version": "1.73.0",
+  "version": "1.73.1",
   "description": "PD CLI — Pain recording, sample management, and evolution tasks",
   "type": "module",
   "bin": {
-    "pd": "./dist/index.js"
+    "pd": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -47,12 +47,16 @@ import { handleProvenChannelBaseline } from './commands/proven-channel-baseline.
 import { handleDemoStoryA } from './commands/demo-story-a.js';
 import { handleRuntimeFeaturesStatus } from './commands/runtime-features.js';
 
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
+
 const program = new Command();
 
 program
   .name('pd')
   .description('PD CLI — Pain recording, sample management, and evolution tasks')
-  .version('0.1.0');
+  .version(pkg.version);
 
 const painCmd = program
   .command('pain')


### PR DESCRIPTION
## Summary

Fixes discovered during end-to-end install testing (simulating a new user experience).

### P1 Fixes
- **pd-cli version hardcoded as 0.1.0**: Changed from `.version('0.1.0')` to dynamically reading from package.json via `createRequire`

### Installer Improvements
- **OpenClaw gateway detection**: Before install/uninstall, check if gateway is running (port probe + PID lookup) and warn user about potential file lock issues
- **npm auto-upgrade for pd-cli**: After installing bundled pd-cli, attempt to upgrade from npm if a newer version exists (`tryUpgradePdCliFromNpm`). Falls back gracefully to bundled version on failure.
- **mkdirSync before npm pack**: Fixed missing directory creation that caused silent upgrade failure

### Uninstaller Improvements
- **OpenClaw gateway detection**: Warn before uninstall if gateway is running
- **EPERM/EBUSY retry**: Added `removeWithRetry()` with 3 retries and progressive delay for file lock errors
- **Proper error reporting**: Set `result.error` from deleteErrors when partial deletion fails (was showing `undefined`)
- **Partial vs complete status**: Distinguish partial uninstall from complete success

### Files Changed
- `packages/pd-cli/src/index.ts` — Dynamic version from package.json
- `packages/pd-cli/package.json` — Version bump to 1.73.2
- `packages/create-principles-disciple/src/utils/env.ts` — New `checkOpenClawGateway()` function
- `packages/create-principles-disciple/src/installer.ts` — Gateway detection + npm auto-upgrade
- `packages/create-principles-disciple/src/uninstaller.ts` — Gateway detection + EPERM retry + error reporting
- `packages/create-principles-disciple/core/package.json` — Version sync
- `packages/create-principles-disciple/pd-cli/package.json` — Version sync

### Testing
- Full uninstall + reinstall cycle completed successfully
- `pd runtime canary` returns healthy
- npm auto-upgrade verified: `Upgrading pd-cli from bundled v1.73.0 to npm v1.73.1...` / `pd-cli upgraded to v1.73.1`
- EPERM handling verified: shows Chinese warning when OpenClaw gateway is running

### Post-Merge Actions Required
After merging, publish to npm:
1. `@principles/pd-cli@1.73.2` — includes version fix
2. `create-principles-disciple@1.73.1` — includes all installer/uninstaller improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 安装/卸载流程新增对本地网关运行状态检测并在运行时给出警告。
  * 安装流程尝试从远端包源安全升级已捆绑的 CLI（失败则跳过继续安装）。

* **Bug Fixes**
  * 卸载删除操作增加重试与容错，支持汇总失败项并报告“部分完成”。

* **Chores**
  * 包版本号与发布元信息更新（多包）。
  * 优化 CLI 入口与命令行版本展示方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->