### PR TITLE
fix(ci): use OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -319,8 +319,6 @@ jobs:
       - name: Publish to npm
         working-directory: packages/${{ matrix.pkg_dir }}
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Git tag and push
         if: matrix.pkg_dir == 'openclaw-plugin'


### PR DESCRIPTION
## Problem

CI 发布失败，报 EOTP 错误（需要一次性密码/2FA）。

原因：npm 在 2025 年 12 月已完全移除 Classic Token（包括 Automation 类型），现在只支持 Granular Access Token，而 Granular Token 的读写权限默认需要 2FA，CI 环境无法完成 2FA 交互。

## Fix

移除 `npm publish` 步骤的 `NODE_AUTH_TOKEN`，让 OIDC Trusted Publishing 接管认证。

- `npm ci`（安装依赖）→ 仍用 `NPM_READ_TOKEN`（只读 granular token）
- `npm publish`（发布）→ 走 OIDC，不需要任何 token

## 前置条件

合并前需要在 npmjs.com 上为每个包配置 Trusted Publisher：

1. 打开包页面 → Settings → Trusted Publisher
2. 选 GitHub Actions
3. 填写：
   - Organization: `csuzngjh`
   - Repository: `principles`
   - Workflow filename: `publish-npm.yml`
   - Allowed actions: 勾选 `npm publish`

需要配置的包：
- `@principles/core`
- `principles-disciple`
- `@principles/pd-cli`
- `create-principles-disciple`
