### PR TITLE
fix(ci): build pd-console before create-principles-disciple

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -189,6 +189,7 @@ jobs:
           elif [ "$PKG_DIR" = "create-principles-disciple" ]; then
             npm run build --workspace=principles-disciple
             npm run build --workspace=@principles/pd-cli
+            npm run build --workspace=@principles/pd-console
             cd packages/create-principles-disciple && npm ci && npm run build
           fi
 

--- a/packages/create-principles-disciple/src/updater.ts
+++ b/packages/create-principles-disciple/src/updater.ts
@@ -1,0 +1,80 @@
+import semver from 'semver';
+
+export interface UpdateCheckResult {
+  hasUpdate: boolean;
+  currentVersion: string;
+  latestVersion?: string;
+  error?: string;
+}
+
+export async function checkForUpdates(currentVersion: string): Promise<UpdateCheckResult> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    let latestVersion = '';
+    try {
+      const response = await fetch('https://registry.npmjs.org/create-principles-disciple/latest', {
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const rawData: unknown = await response.json();
+      if (typeof rawData !== 'object' || rawData === null) {
+        throw new Error('Invalid registry response: not an object');
+      }
+      const data = rawData as Record<string, unknown>;
+      if (typeof data.version !== 'string') {
+        throw new Error('Invalid registry response: missing version');
+      }
+      latestVersion = data.version;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    const hasUpdate = semver.gt(latestVersion, currentVersion);
+
+    return {
+      hasUpdate,
+      currentVersion,
+      latestVersion,
+    };
+  } catch (error) {
+    return {
+      hasUpdate: false,
+      currentVersion,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+export async function fetchChangelog(version: string): Promise<string | undefined> {
+  try {
+    const response = await fetch('https://registry.npmjs.org/create-principles-disciple');
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const rawData: unknown = await response.json();
+    if (typeof rawData !== 'object' || rawData === null) {
+      return undefined;
+    }
+    const data = rawData as Record<string, unknown>;
+    if (typeof data.versions !== 'object' || data.versions === null) {
+      return undefined;
+    }
+    const versions = data.versions as Record<string, unknown>;
+    const versionEntry = versions[version];
+    if (typeof versionEntry !== 'object' || versionEntry === null) {
+      return undefined;
+    }
+    const entry = versionEntry as Record<string, unknown>;
+    if (typeof entry.description !== 'string') {
+      return undefined;
+    }
+    return entry.description;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/create-principles-disciple/tests/updater.test.ts
+++ b/packages/create-principles-disciple/tests/updater.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkForUpdates, fetchChangelog } from '../src/updater.js';
+
+describe('checkForUpdates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should return hasUpdate false when current version is latest', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.73.0' }),
+    }));
+
+    const result = await checkForUpdates('1.73.0');
+    expect(result.hasUpdate).toBe(false);
+    expect(result.currentVersion).toBe('1.73.0');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should return hasUpdate true when newer version exists', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.74.0' }),
+    }));
+
+    const result = await checkForUpdates('1.73.0');
+    expect(result.hasUpdate).toBe(true);
+    expect(result.latestVersion).toBe('1.74.0');
+  });
+
+  it('should handle network errors gracefully', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+    const result = await checkForUpdates('1.73.0');
+    expect(result.hasUpdate).toBe(false);
+    expect(result.error).toBe('Network error');
+  });
+
+  it('should handle HTTP errors gracefully', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+    }));
+    const result = await checkForUpdates('1.73.0');
+    expect(result.hasUpdate).toBe(false);
+    expect(result.error).toContain('HTTP 429');
+  });
+
+  it('should handle invalid registry response gracefully', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'foo' }),
+    }));
+    const result = await checkForUpdates('1.73.0');
+    expect(result.hasUpdate).toBe(false);
+    expect(result.error).toContain('missing version');
+  });
+});
+
+describe('fetchChangelog', () => {
+  it('should fetch changelog for a specific version', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        versions: {
+          '1.74.0': {
+            version: '1.74.0',
+            description: 'Bug fixes and improvements',
+          },
+        },
+      }),
+    }));
+
+    const result = await fetchChangelog('1.74.0');
+    expect(result).toBe('Bug fixes and improvements');
+  });
+
+  it('should handle missing changelog gracefully', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        versions: {
+          '1.74.0': {
+            version: '1.74.0',
+          },
+        },
+      }),
+    }));
+
+    const result = await fetchChangelog('1.74.0');
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The installer bundle script requires packages/pd-console/dist. Added build step for pd-console before building the installer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加自动版本更新检查功能，支持从 npm 源获取最新版本信息
  * 添加更新日志获取功能，显示可用更新的详细说明

* **Tests**
  * 新增单元测试，覆盖更新检查和日志获取功能的多个场景

* **Chores**
  * 优化构建工作流程，添加额外的工作空间构建步骤

<!-- end of auto-generated comment: release notes by coderabbit.ai -->