### PR TITLE
test(plugin): guard MVP hook and service surface

### DIFF
--- a/packages/openclaw-plugin/src/core/surface-guard.ts
+++ b/packages/openclaw-plugin/src/core/surface-guard.ts
@@ -1,0 +1,97 @@
+import {
+  PLUGIN_SURFACE_REGISTRY,
+  validateSurfaceRegistry,
+  getSurfacesByCategory,
+  type PluginSurfaceEntry,
+  type MvpCategory,
+} from '@principles/core/runtime-v2';
+
+export interface SurfaceGuardResult {
+  passed: boolean;
+  enabledCoreSurfaces: string[];
+  disabledNonCoreSurfaces: string[];
+  violations: string[];
+  warnings: string[];
+}
+
+export function checkSurfaceGuard(): SurfaceGuardResult {
+  const validation = validateSurfaceRegistry(PLUGIN_SURFACE_REGISTRY);
+  const violations: string[] = [];
+  const warnings: string[] = [...validation.warnings];
+
+  const coreSurfaces = getSurfacesByCategory(PLUGIN_SURFACE_REGISTRY, 'core');
+  const enabledCore = coreSurfaces.filter(s => s.enabledByDefault);
+  const nonCoreEnabled = PLUGIN_SURFACE_REGISTRY.filter(
+    s => s.category !== 'core' && s.enabledByDefault,
+  );
+
+  if (nonCoreEnabled.length > 0) {
+    for (const surface of nonCoreEnabled) {
+      violations.push(
+        `non-core surface '${surface.id}' (${surface.category}) is enabledByDefault=true — must be false per ADR-0014`,
+      );
+    }
+  }
+
+  if (!validation.valid) {
+    violations.push(...validation.errors);
+  }
+
+  return {
+    passed: violations.length === 0,
+    enabledCoreSurfaces: enabledCore.map(s => s.id),
+    disabledNonCoreSurfaces: PLUGIN_SURFACE_REGISTRY
+      .filter(s => s.category !== 'core' && !s.enabledByDefault)
+      .map(s => s.id),
+    violations,
+    warnings,
+  };
+}
+
+export function getSurfaceIdForHook(hookEvent: string, label?: string): string {
+  if (label) {
+    return `hook:${hookEvent}.${label}`;
+  }
+  return `hook:${hookEvent}`;
+}
+
+export function getSurfaceIdForService(serviceName: string): string {
+  return `service:${serviceName}`;
+}
+
+export function isSurfaceEnabled(
+  surfaceId: string,
+  overrides: Record<string, boolean> = {},
+): { enabled: boolean; reason?: string } {
+  const entry = PLUGIN_SURFACE_REGISTRY.find(s => s.id === surfaceId);
+
+  if (!entry) {
+    return {
+      enabled: false,
+      reason: `surface '${surfaceId}' not found in registry — classify before enabling (PRI-289)`,
+    };
+  }
+
+  if (Object.hasOwn(overrides, surfaceId)) {
+    const override = overrides[surfaceId];
+    if (typeof override !== 'boolean') {
+      return { enabled: entry.enabledByDefault, reason: `override for '${surfaceId}' is not boolean, using default` };
+    }
+    if (entry.category === 'gone') {
+      return { enabled: false, reason: `surface '${surfaceId}' is gone and cannot be re-enabled` };
+    }
+    if (entry.category === 'core' && !override) {
+      return { enabled: true, reason: `surface '${surfaceId}' is core and cannot be disabled` };
+    }
+    return { enabled: override };
+  }
+
+  if (!entry.enabledByDefault && entry.disabledReason) {
+    return { enabled: false, reason: entry.disabledReason };
+  }
+
+  return { enabled: entry.enabledByDefault };
+}
+
+export { PLUGIN_SURFACE_REGISTRY, validateSurfaceRegistry, getSurfacesByCategory };
+export type { PluginSurfaceEntry, MvpCategory };

--- a/packages/openclaw-plugin/src/core/surface-guard.ts
+++ b/packages/openclaw-plugin/src/core/surface-guard.ts
@@ -106,7 +106,7 @@ export function guardHook<E, C, R>(
     return handler;
   }
   const reason = check.reason ?? 'surface not enabled';
-  return (event: E, ctx: C): R | Promise<R> => {
+  return (_event: E, _ctx: C): R | Promise<R> => {
     logger?.debug?.(`[PD:surface-guard] SKIP ${surfaceId}: ${reason}`);
     return undefined as R;
   };

--- a/packages/openclaw-plugin/src/core/surface-guard.ts
+++ b/packages/openclaw-plugin/src/core/surface-guard.ts
@@ -98,8 +98,8 @@ export type HookHandler<E, C, R> = (event: E, ctx: C) => R | Promise<R>;
 
 export function guardHook<E, C, R>(
   surfaceId: string,
+  logger: { info?: (msg: string) => void; debug?: (msg: string) => void } | undefined,
   handler: HookHandler<E, C, R>,
-  logger?: { info?: (msg: string) => void; debug?: (msg: string) => void },
 ): HookHandler<E, C, R> {
   const check = isSurfaceEnabled(surfaceId);
   if (check.enabled) {
@@ -107,7 +107,7 @@ export function guardHook<E, C, R>(
   }
   const reason = check.reason ?? 'surface not enabled';
   return (_event: E, _ctx: C): R | Promise<R> => {
-    logger?.debug?.(`[PD:surface-guard] SKIP ${surfaceId}: ${reason}`);
+    logger?.info?.(`[PD:surface-guard] SKIP ${surfaceId}: ${reason}`);
     return undefined as R;
   };
 }

--- a/packages/openclaw-plugin/src/core/surface-guard.ts
+++ b/packages/openclaw-plugin/src/core/surface-guard.ts
@@ -5,6 +5,7 @@ import {
   type PluginSurfaceEntry,
   type MvpCategory,
 } from '@principles/core/runtime-v2';
+import type { OpenClawPluginService } from '../openclaw-sdk.js';
 
 export interface SurfaceGuardResult {
   passed: boolean;
@@ -91,6 +92,38 @@ export function isSurfaceEnabled(
   }
 
   return { enabled: entry.enabledByDefault };
+}
+
+export type HookHandler<E, C, R> = (event: E, ctx: C) => R | Promise<R>;
+
+export function guardHook<E, C, R>(
+  surfaceId: string,
+  handler: HookHandler<E, C, R>,
+  logger?: { info?: (msg: string) => void; debug?: (msg: string) => void },
+): HookHandler<E, C, R> {
+  const check = isSurfaceEnabled(surfaceId);
+  if (check.enabled) {
+    return handler;
+  }
+  const reason = check.reason ?? 'surface not enabled';
+  return (event: E, ctx: C): R | Promise<R> => {
+    logger?.debug?.(`[PD:surface-guard] SKIP ${surfaceId}: ${reason}`);
+    return undefined as R;
+  };
+}
+
+export function guardService<T extends OpenClawPluginService>(
+  surfaceId: string,
+  service: T,
+  logger?: { info?: (msg: string) => void; debug?: (msg: string) => void },
+): T | null {
+  const check = isSurfaceEnabled(surfaceId);
+  if (check.enabled) {
+    return service;
+  }
+  const reason = check.reason ?? 'surface not enabled';
+  logger?.info?.(`[PD:surface-guard] SKIP service ${surfaceId}: ${reason}`);
+  return null;
 }
 
 export { PLUGIN_SURFACE_REGISTRY, validateSurfaceRegistry, getSurfacesByCategory };

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -62,7 +62,7 @@ import { computeRuntimeShadowTaskFingerprint, PD_LOCAL_PROFILES } from './utils/
 import type { WorkerProfile } from './core/model-deployment-registry.js';
 import { validateWorkspaceDir } from './core/workspace-dir-validation.js';
 import { resolveWorkspaceDirFromApi } from './core/path-resolver.js';
-import { checkSurfaceGuard } from './core/surface-guard.js';
+import { checkSurfaceGuard, guardHook, guardService, getSurfaceIdForHook, getSurfaceIdForService } from './core/surface-guard.js';
 
 // Track started workspaces — one-time init + evolution worker per workspace
 const startedWorkspaces = new Set<string>();
@@ -209,7 +209,7 @@ const plugin = {
     // ── Hook: Prompt Building ──
     api.on(
       'before_prompt_build',
-      async (event: PluginHookBeforePromptBuildEvent, ctx: PluginHookAgentContext): Promise<PluginHookBeforePromptBuildResult | void> => {
+      guardHook('hook:before_prompt_build', async (event: PluginHookBeforePromptBuildEvent, ctx: PluginHookAgentContext): Promise<PluginHookBeforePromptBuildResult | void> => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_prompt_build');
         if (!workspaceDir) {
           api.logger.error(
@@ -265,13 +265,13 @@ const plugin = {
           });
           api.logger.error(`[PD] Error in before_prompt_build: ${String(err)}`);
         }
-      }
+      })
     );
 
     // ── Hook: Security Gate ──
     api.on(
       'before_tool_call',
-      (event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext): PluginHookBeforeToolCallResult | void => {
+      guardHook('hook:before_tool_call', (event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext): PluginHookBeforeToolCallResult | void => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_tool_call');
         if (!workspaceDir) {
           api.logger.error(
@@ -300,13 +300,13 @@ const plugin = {
           }, { flushImmediately: true });
           api.logger.error(`[PD] Error in before_tool_call: ${String(err)}`);
         }
-      }
+      })
     );
 
     // ── Hook: Pain & Trust ──
     api.on(
       'after_tool_call',
-      (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
+      guardHook('hook:after_tool_call', (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'after_tool_call');
         if (!workspaceDir) {
           api.logger.error(
@@ -333,13 +333,13 @@ const plugin = {
           }, { flushImmediately: true });
           api.logger.error(`[PD:EmpathyObserver] Error in after_tool_call: ${String(err)}`);
         }
-      }
+      })
     );
 
     // ── Hook: LLM Analysis ──
     api.on(
       'llm_output',
-      (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
+      guardHook('hook:llm_output', (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'llm_output');
         if (!workspaceDir) {
           api.logger.error(
@@ -366,14 +366,14 @@ const plugin = {
           });
           api.logger.error(`[PD] Error in llm_output: ${String(err)}`);
         }
-      }
+      })
     );
 
     // ── Hook: Trajectory Collection (Behavior Evolution Phase 0) ──
     // Note: after_tool_call and llm_output are safe to collect
     api.on(
       'after_tool_call',
-      (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
+      guardHook('hook:after_tool_call.trajectory', (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
         try {
           const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'trajectory.after_tool_call');
           if (!workspaceDir) return;
@@ -382,12 +382,12 @@ const plugin = {
         } catch (_err) {
           // Non-critical: don't log, just skip
         }
-      }
+      })
     );
 
     api.on(
       'llm_output',
-      (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
+      guardHook('hook:llm_output.trajectory', (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
         try {
           const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'trajectory.llm_output');
           if (!workspaceDir) return;
@@ -396,14 +396,14 @@ const plugin = {
         } catch (_err) {
           // Non-critical: don't log, just skip
         }
-      }
+      })
     );
 
     // ── Hook: Subagent Loop Closure ──
     api.on(
       'subagent_spawning',
        
-      (event: PluginHookSubagentSpawningEvent, _ctx: PluginHookSubagentContext): void | PluginHookSubagentSpawningResult => {
+      guardHook('hook:subagent_spawning', (event: PluginHookSubagentSpawningEvent, _ctx: PluginHookSubagentContext): void | PluginHookSubagentSpawningResult => {
         try {
           // FIX (B): Never fall back to '.' — fail-fast with ERROR log if workspaceDir cannot be resolved.
           // For subagent hooks, we use event.agentId as the target agent for workspace resolution.
@@ -442,12 +442,12 @@ const plugin = {
           api.logger.error(`[PD] Error in subagent_spawning shadow routing: ${String(err)}`);
           return { status: 'ok' }; // Don't block spawn on shadow observation errors
         }
-      }
+      })
     );
 
     api.on(
       'subagent_ended',
-      (event: PluginHookSubagentEndedEvent, ctx: PluginHookSubagentContext): void => {
+      guardHook('hook:subagent_ended', (event: PluginHookSubagentEndedEvent, ctx: PluginHookSubagentContext): void => {
         try {
           // FIX (B): Never fall back to '.' — fail-fast with ERROR log if workspaceDir cannot be resolved.
           const workspaceDir = resolveWorkspaceDirFromApi(api, undefined);
@@ -479,11 +479,11 @@ const plugin = {
         } catch (err) {
           api.logger.error(`[PD] Error in subagent_ended: ${String(err)}`);
         }
-      }
+      })
     );
 
     // ── Hook: Lifecycle ──
-    api.on('before_reset', (event: PluginHookBeforeResetEvent, ctx: PluginHookAgentContext) => {
+    api.on('before_reset', guardHook('hook:before_reset', (event: PluginHookBeforeResetEvent, ctx: PluginHookAgentContext) => {
       const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_reset');
       if (!workspaceDir) {
         api.logger.error(
@@ -494,9 +494,9 @@ const plugin = {
         return;
       }
       return handleBeforeReset(event, { ...ctx, workspaceDir });
-    });
+    }));
     
-    api.on('before_compaction', (event: PluginHookBeforeCompactionEvent, ctx: PluginHookAgentContext) => {
+    api.on('before_compaction', guardHook('hook:before_compaction', (event: PluginHookBeforeCompactionEvent, ctx: PluginHookAgentContext) => {
       const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_compaction');
       if (!workspaceDir) {
         api.logger.error(
@@ -507,9 +507,9 @@ const plugin = {
         return;
       }
       return handleBeforeCompaction(event, { ...ctx, workspaceDir });
-    });
+    }));
     
-    api.on('after_compaction', (event: PluginHookAfterCompactionEvent, ctx: PluginHookAgentContext) => {
+    api.on('after_compaction', guardHook('hook:after_compaction', (event: PluginHookAfterCompactionEvent, ctx: PluginHookAgentContext) => {
       const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'after_compaction');
       if (!workspaceDir) {
         api.logger.error(
@@ -520,17 +520,21 @@ const plugin = {
         return;
       }
       return handleAfterCompaction(event, { ...ctx, workspaceDir });
-    });
+    }));
 
     // ── Service: Background Evolution Worker ──
     try {
       EvolutionWorkerService.api = api;
-      api.registerService(EvolutionWorkerService);
-      api.registerService(TrajectoryService);
-      api.registerService(PDTaskService);
-      api.registerService(CentralSyncService);
+      const guardedEvolutionWorker = guardService('service:evolution-worker', EvolutionWorkerService, api.logger);
+      if (guardedEvolutionWorker) api.registerService(guardedEvolutionWorker);
+      const guardedTrajectory = guardService('service:trajectory', TrajectoryService, api.logger);
+      if (guardedTrajectory) api.registerService(guardedTrajectory);
+      const guardedPdTask = guardService('service:pd-task', PDTaskService, api.logger);
+      if (guardedPdTask) api.registerService(guardedPdTask);
+      const guardedCentralSync = guardService('service:central-sync', CentralSyncService, api.logger);
+      if (guardedCentralSync) api.registerService(guardedCentralSync);
     } catch (err) {
-      api.logger.error(`[PD] Failed to register EvolutionWorkerService: ${String(err)}`);
+      api.logger.error(`[PD] Failed to register services: ${String(err)}`);
     }
 
     // ── Slash Commands ──

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -18,6 +18,9 @@ import type {
   PluginHookSubagentContext,
 } from './openclaw-sdk.js';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { computeEffectiveFlags, DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
 import { classifyTask } from './core/local-worker-routing.js';
 import { completeShadowObservation, recordShadowRouting } from './core/shadow-observation-registry.js';
 import { getCommandDescription } from './i18n/commands.js';
@@ -71,6 +74,65 @@ const HOOK_WORKSPACE_RESOLUTION_NEXT_ACTION =
 // Used to complete shadow observations when subagent ends
 const pendingShadowObservations = new Map<string, string>();
 
+// ── Feature Flag Loader (plugin I/O boundary) ─────────────────────────────
+// Reads workspace feature-flags.yaml and checks a specific flag.
+// Returns the flag definition with effective enabled state.
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function loadFeatureFlagFromWorkspace(
+  workspaceDir: string,
+  flagId: string,
+  logger?: { warn?: (msg: string) => void; info?: (msg: string) => void },
+): { enabled: boolean; source: string } {
+  const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+
+  if (!fs.existsSync(configPath)) {
+    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
+    const flag = flags.flags[flagId];
+    return { enabled: flag?.enabled ?? false, source: 'defaults' };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger?.warn?.(`[PD:FeatureFlags] Feature flags unreadable: ${msg} — using defaults`);
+    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
+    const flag = flags.flags[flagId];
+    return { enabled: flag?.enabled ?? false, source: 'defaults' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+  } catch {
+    logger?.warn?.(`[PD:FeatureFlags] Feature flags YAML parse error — using defaults`);
+    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
+    const flag = flags.flags[flagId];
+    return { enabled: flag?.enabled ?? false, source: 'defaults' };
+  }
+
+  if (parsed === null || parsed === undefined || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    logger?.warn?.(`[PD:FeatureFlags] Feature flags not a mapping — using defaults`);
+    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
+    const flag = flags.flags[flagId];
+    return { enabled: flag?.enabled ?? false, source: 'defaults' };
+  }
+
+  const parsedRecord: Record<string, unknown> = Object.create(null);
+  for (const key of Object.keys(parsed as Record<string, unknown>)) {
+    if (DANGEROUS_KEYS.has(key)) continue;
+    if (Object.hasOwn(parsed as Record<string, unknown>, key)) {
+      parsedRecord[key] = (parsed as Record<string, unknown>)[key];
+    }
+  }
+
+  const flags = computeEffectiveFlags(parsedRecord, DEFAULT_FEATURE_FLAGS, configPath);
+  const flag = flags.flags[flagId];
+  return { enabled: flag?.enabled ?? false, source: flags.source };
+}
+
 const plugin = {
   name: "Principles Disciple",
   description: "Evolutionary programming agent framework with strategic guardrails and reflection loops.",
@@ -120,16 +182,29 @@ const plugin = {
             SystemLogger.log(workspaceDir, 'SYSTEM_BOOT', `Principles Disciple online. Language: ${language}`);
 
             // ── Start EvolutionWorker for THIS workspace ──
-            // One EvolutionWorker per workspace so each agent's pain signals
-            // are processed independently.
-            EvolutionWorkerService.api = api;
-            EvolutionWorkerService.start({
-              config: api.config,
-              workspaceDir,
-              stateDir: path.join(workspaceDir, '.state'),
-              logger: api.logger,
-            });
-            api.logger.info(`[PD] EvolutionWorker started for workspace: ${workspaceDir}`);
+            // Gated behind evolution_worker feature flag (MVP-Quiet, default OFF per ADR-0014).
+            const evoFlag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', api.logger);
+            if (evoFlag.enabled) {
+              EvolutionWorkerService.api = api;
+              EvolutionWorkerService.start({
+                config: api.config,
+                workspaceDir,
+                stateDir: path.join(workspaceDir, '.state'),
+                logger: api.logger,
+              });
+              api.logger.info(`[PD] EvolutionWorker started for workspace: ${workspaceDir} (flag source: ${evoFlag.source})`);
+            } else {
+              // Structured observability per ERR-002: no silent skip
+              const disabledInfo = JSON.stringify({
+                reason: 'mvp_quiet_per_adr0014',
+                nextAction: 'set evolution_worker.enabled=true in .pd/feature-flags.yaml to enable',
+                featureFlag: 'evolution_worker',
+                boundedContext: 'legacy_evolution_worker',
+                flagSource: evoFlag.source,
+              });
+              api.logger.info(`[PD] EvolutionWorker NOT started for workspace: ${workspaceDir}. ${disabledInfo}`);
+              SystemLogger.log(workspaceDir, 'EVOLUTION_WORKER_DISABLED', disabledInfo);
+            }
           }
 
           const result = await handleBeforePromptBuild(event, { ...ctx, api: api as Parameters<typeof handleBeforePromptBuild>[1]['api'], workspaceDir });
@@ -758,5 +833,7 @@ const plugin = {
 };
 
 export { PrincipleTreeLedgerAdapter } from './core/principle-tree-ledger-adapter.js';
+/* istanbul ignore next — test export for loadFeatureFlagFromWorkspace */
+export { loadFeatureFlagFromWorkspace };
 
 export default plugin;

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -62,6 +62,7 @@ import { computeRuntimeShadowTaskFingerprint, PD_LOCAL_PROFILES } from './utils/
 import type { WorkerProfile } from './core/model-deployment-registry.js';
 import { validateWorkspaceDir } from './core/workspace-dir-validation.js';
 import { resolveWorkspaceDirFromApi } from './core/path-resolver.js';
+import { checkSurfaceGuard } from './core/surface-guard.js';
 
 // Track started workspaces — one-time init + evolution worker per workspace
 const startedWorkspaces = new Set<string>();
@@ -189,6 +190,19 @@ const plugin = {
       }
     }, 1000);
     healthCheckTimer.unref(); // Don't keep process alive for health check
+
+    // ── MVP Surface Guard (PRI-289): Verify surface classification ──
+    const surfaceGuard = checkSurfaceGuard();
+    if (!surfaceGuard.passed) {
+      for (const violation of surfaceGuard.violations) {
+        api.logger.error(`[PD:surface-guard] VIOLATION: ${violation}`);
+      }
+    }
+    api.logger.info(`[PD:surface-guard] Core surfaces: ${surfaceGuard.enabledCoreSurfaces.join(', ')}`);
+    api.logger.info(`[PD:surface-guard] Disabled non-core surfaces: ${surfaceGuard.disabledNonCoreSurfaces.length}`);
+    for (const warning of surfaceGuard.warnings) {
+      api.logger.warn(`[PD:surface-guard] ${warning}`);
+    }
 
     const language = (api.pluginConfig?.language as string) || 'en';
 

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -209,7 +209,7 @@ const plugin = {
     // ── Hook: Prompt Building ──
     api.on(
       'before_prompt_build',
-      guardHook('hook:before_prompt_build', async (event: PluginHookBeforePromptBuildEvent, ctx: PluginHookAgentContext): Promise<PluginHookBeforePromptBuildResult | void> => {
+      guardHook('hook:before_prompt_build', api.logger, async (event: PluginHookBeforePromptBuildEvent, ctx: PluginHookAgentContext): Promise<PluginHookBeforePromptBuildResult | void> => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_prompt_build');
         if (!workspaceDir) {
           api.logger.error(
@@ -271,7 +271,7 @@ const plugin = {
     // ── Hook: Security Gate ──
     api.on(
       'before_tool_call',
-      guardHook('hook:before_tool_call', (event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext): PluginHookBeforeToolCallResult | void => {
+      guardHook('hook:before_tool_call', api.logger, (event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext): PluginHookBeforeToolCallResult | void => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_tool_call');
         if (!workspaceDir) {
           api.logger.error(
@@ -306,7 +306,7 @@ const plugin = {
     // ── Hook: Pain & Trust ──
     api.on(
       'after_tool_call',
-      guardHook('hook:after_tool_call', (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
+      guardHook('hook:after_tool_call', api.logger, (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'after_tool_call');
         if (!workspaceDir) {
           api.logger.error(
@@ -339,7 +339,7 @@ const plugin = {
     // ── Hook: LLM Analysis ──
     api.on(
       'llm_output',
-      guardHook('hook:llm_output', (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
+      guardHook('hook:llm_output', api.logger, (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
         const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'llm_output');
         if (!workspaceDir) {
           api.logger.error(
@@ -373,7 +373,7 @@ const plugin = {
     // Note: after_tool_call and llm_output are safe to collect
     api.on(
       'after_tool_call',
-      guardHook('hook:after_tool_call.trajectory', (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
+      guardHook('hook:after_tool_call.trajectory', api.logger, (event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void => {
         try {
           const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'trajectory.after_tool_call');
           if (!workspaceDir) return;
@@ -387,7 +387,7 @@ const plugin = {
 
     api.on(
       'llm_output',
-      guardHook('hook:llm_output.trajectory', (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
+      guardHook('hook:llm_output.trajectory', api.logger, (event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext): void => {
         try {
           const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'trajectory.llm_output');
           if (!workspaceDir) return;
@@ -403,7 +403,7 @@ const plugin = {
     api.on(
       'subagent_spawning',
        
-      guardHook('hook:subagent_spawning', (event: PluginHookSubagentSpawningEvent, _ctx: PluginHookSubagentContext): void | PluginHookSubagentSpawningResult => {
+      guardHook('hook:subagent_spawning', api.logger, (event: PluginHookSubagentSpawningEvent, _ctx: PluginHookSubagentContext): void | PluginHookSubagentSpawningResult => {
         try {
           // FIX (B): Never fall back to '.' — fail-fast with ERROR log if workspaceDir cannot be resolved.
           // For subagent hooks, we use event.agentId as the target agent for workspace resolution.
@@ -447,7 +447,7 @@ const plugin = {
 
     api.on(
       'subagent_ended',
-      guardHook('hook:subagent_ended', (event: PluginHookSubagentEndedEvent, ctx: PluginHookSubagentContext): void => {
+      guardHook('hook:subagent_ended', api.logger, (event: PluginHookSubagentEndedEvent, ctx: PluginHookSubagentContext): void => {
         try {
           // FIX (B): Never fall back to '.' — fail-fast with ERROR log if workspaceDir cannot be resolved.
           const workspaceDir = resolveWorkspaceDirFromApi(api, undefined);
@@ -483,7 +483,7 @@ const plugin = {
     );
 
     // ── Hook: Lifecycle ──
-    api.on('before_reset', guardHook('hook:before_reset', (event: PluginHookBeforeResetEvent, ctx: PluginHookAgentContext) => {
+    api.on('before_reset', guardHook('hook:before_reset', api.logger, (event: PluginHookBeforeResetEvent, ctx: PluginHookAgentContext) => {
       const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_reset');
       if (!workspaceDir) {
         api.logger.error(
@@ -496,7 +496,7 @@ const plugin = {
       return handleBeforeReset(event, { ...ctx, workspaceDir });
     }));
     
-    api.on('before_compaction', guardHook('hook:before_compaction', (event: PluginHookBeforeCompactionEvent, ctx: PluginHookAgentContext) => {
+    api.on('before_compaction', guardHook('hook:before_compaction', api.logger, (event: PluginHookBeforeCompactionEvent, ctx: PluginHookAgentContext) => {
       const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'before_compaction');
       if (!workspaceDir) {
         api.logger.error(
@@ -509,7 +509,7 @@ const plugin = {
       return handleBeforeCompaction(event, { ...ctx, workspaceDir });
     }));
     
-    api.on('after_compaction', guardHook('hook:after_compaction', (event: PluginHookAfterCompactionEvent, ctx: PluginHookAgentContext) => {
+    api.on('after_compaction', guardHook('hook:after_compaction', api.logger, (event: PluginHookAfterCompactionEvent, ctx: PluginHookAgentContext) => {
       const workspaceDir = resolveToolHookWorkspaceDirSafe(ctx, api, 'after_compaction');
       if (!workspaceDir) {
         api.logger.error(

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -79,6 +79,10 @@ const pendingShadowObservations = new Map<string, string>();
 // Returns the flag definition with effective enabled state.
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function loadFeatureFlagFromWorkspace(
   workspaceDir: string,
   flagId: string,
@@ -106,31 +110,61 @@ function loadFeatureFlagFromWorkspace(
   let parsed: unknown;
   try {
     parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
-  } catch {
-    logger?.warn?.(`[PD:FeatureFlags] Feature flags YAML parse error — using defaults`);
+  } catch (e) {
+    const parseMsg = e instanceof Error ? e.message : String(e);
+    logger?.warn?.(`[PD:FeatureFlags] Feature flags YAML parse error: ${parseMsg} — using defaults`);
     const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
     const flag = flags.flags[flagId];
     return { enabled: flag?.enabled ?? false, source: 'defaults' };
   }
 
-  if (parsed === null || parsed === undefined || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     logger?.warn?.(`[PD:FeatureFlags] Feature flags not a mapping — using defaults`);
     const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
     const flag = flags.flags[flagId];
     return { enabled: flag?.enabled ?? false, source: 'defaults' };
   }
 
+  // parsed is now narrowed to Record<string, unknown> by isRecord guard
   const parsedRecord: Record<string, unknown> = Object.create(null);
-  for (const key of Object.keys(parsed as Record<string, unknown>)) {
+  for (const key of Object.keys(parsed)) {
     if (DANGEROUS_KEYS.has(key)) continue;
-    if (Object.hasOwn(parsed as Record<string, unknown>, key)) {
-      parsedRecord[key] = (parsed as Record<string, unknown>)[key];
+    if (Object.hasOwn(parsed, key)) {
+      parsedRecord[key] = parsed[key];
     }
   }
 
   const flags = computeEffectiveFlags(parsedRecord, DEFAULT_FEATURE_FLAGS, configPath);
   const flag = flags.flags[flagId];
   return { enabled: flag?.enabled ?? false, source: flags.source };
+}
+
+// ── Evolution Worker Startup Gate (shared between index.ts and tests) ───────
+// Determines whether the legacy evolution worker should start and produces
+// structured observability when disabled (ERR-002).
+
+export interface EvolutionWorkerGateResult {
+  shouldStart: boolean;
+  flagSource: string;
+  disabledInfo: string | null;
+}
+
+export function shouldStartEvolutionWorker(
+  workspaceDir: string,
+  logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+): EvolutionWorkerGateResult {
+  const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+  if (flag.enabled) {
+    return { shouldStart: true, flagSource: flag.source, disabledInfo: null };
+  }
+  const disabledInfo = JSON.stringify({
+    reason: 'mvp_quiet_per_adr0014',
+    nextAction: 'set evolution_worker.enabled=true in .pd/feature-flags.yaml to enable',
+    featureFlag: 'evolution_worker',
+    boundedContext: 'legacy_evolution_worker',
+    flagSource: flag.source,
+  });
+  return { shouldStart: false, flagSource: flag.source, disabledInfo };
 }
 
 const plugin = {
@@ -183,8 +217,8 @@ const plugin = {
 
             // ── Start EvolutionWorker for THIS workspace ──
             // Gated behind evolution_worker feature flag (MVP-Quiet, default OFF per ADR-0014).
-            const evoFlag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', api.logger);
-            if (evoFlag.enabled) {
+            const gate = shouldStartEvolutionWorker(workspaceDir, api.logger);
+            if (gate.shouldStart) {
               EvolutionWorkerService.api = api;
               EvolutionWorkerService.start({
                 config: api.config,
@@ -192,18 +226,11 @@ const plugin = {
                 stateDir: path.join(workspaceDir, '.state'),
                 logger: api.logger,
               });
-              api.logger.info(`[PD] EvolutionWorker started for workspace: ${workspaceDir} (flag source: ${evoFlag.source})`);
+              api.logger.info(`[PD] EvolutionWorker started for workspace: ${workspaceDir} (flag source: ${gate.flagSource})`);
             } else {
               // Structured observability per ERR-002: no silent skip
-              const disabledInfo = JSON.stringify({
-                reason: 'mvp_quiet_per_adr0014',
-                nextAction: 'set evolution_worker.enabled=true in .pd/feature-flags.yaml to enable',
-                featureFlag: 'evolution_worker',
-                boundedContext: 'legacy_evolution_worker',
-                flagSource: evoFlag.source,
-              });
-              api.logger.info(`[PD] EvolutionWorker NOT started for workspace: ${workspaceDir}. ${disabledInfo}`);
-              SystemLogger.log(workspaceDir, 'EVOLUTION_WORKER_DISABLED', disabledInfo);
+              api.logger.info(`[PD] EvolutionWorker NOT started for workspace: ${workspaceDir}. ${gate.disabledInfo}`);
+              SystemLogger.log(workspaceDir, 'EVOLUTION_WORKER_DISABLED', gate.disabledInfo ?? '');
             }
           }
 
@@ -833,7 +860,7 @@ const plugin = {
 };
 
 export { PrincipleTreeLedgerAdapter } from './core/principle-tree-ledger-adapter.js';
-/* istanbul ignore next — test export for loadFeatureFlagFromWorkspace */
-export { loadFeatureFlagFromWorkspace };
+/* istanbul ignore next — test exports for evolution worker gate */
+export { loadFeatureFlagFromWorkspace, isRecord };
 
 export default plugin;

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -62,7 +62,7 @@ import { computeRuntimeShadowTaskFingerprint, PD_LOCAL_PROFILES } from './utils/
 import type { WorkerProfile } from './core/model-deployment-registry.js';
 import { validateWorkspaceDir } from './core/workspace-dir-validation.js';
 import { resolveWorkspaceDirFromApi } from './core/path-resolver.js';
-import { checkSurfaceGuard, guardHook, guardService, getSurfaceIdForHook, getSurfaceIdForService } from './core/surface-guard.js';
+import { checkSurfaceGuard, guardHook, guardService } from './core/surface-guard.js';
 
 // Track started workspaces — one-time init + evolution worker per workspace
 const startedWorkspaces = new Set<string>();

--- a/packages/openclaw-plugin/tests/core-anti-growth.test.ts
+++ b/packages/openclaw-plugin/tests/core-anti-growth.test.ts
@@ -123,6 +123,7 @@ describe('PRI-212 plugin core anti-growth guard', () => {
     'evolution-engine.ts',
     'runtime-v2-prompt-activation-reader.ts',
     'workspace-guidance-migrator.ts',
+    'surface-guard.ts',
   ] as const;
 
   // Category 6: Test files

--- a/packages/openclaw-plugin/tests/evolution-worker-quarantine.test.ts
+++ b/packages/openclaw-plugin/tests/evolution-worker-quarantine.test.ts
@@ -4,12 +4,11 @@
  * Tests prove:
  * 1. Default config (no feature-flags.yaml) → EvolutionWorkerService does NOT start.
  * 2. Explicit enable in feature-flags.yaml → EvolutionWorkerService starts.
- * 3. Disabled state has structured observability (reason, nextAction, featureFlag, boundedContext).
+ * 3. Disabled state has structured observability from real helper, not hand-written JSON.
  * 4. api.registerService still works regardless of flag state.
  *
- * ERR-002: disabled startup must be observable — verified via SystemLogger + api.logger.
- * ERR-025: tests cover the real plugin startup path (loadFeatureFlagFromWorkspace + gate logic),
- *          not just isolated helpers.
+ * ERR-002: disabled startup must be observable — verified via real shouldStartEvolutionWorker output.
+ * ERR-025: tests cover the real gate helper + loadFeatureFlagFromWorkspace, not hand-coded JSON.
  * ERR-027: DEFAULT_FEATURE_FLAGS declaration matches runtime behavior.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -47,8 +46,8 @@ vi.mock('../src/core/workspace-context.js', () => {
   };
 });
 
-// Import after mocks
-import { loadFeatureFlagFromWorkspace } from '../src/index.js';
+// Import after mocks — real helpers, not re-implemented logic
+import { loadFeatureFlagFromWorkspace, shouldStartEvolutionWorker, isRecord } from '../src/index.js';
 import { EvolutionWorkerService } from '../src/service/evolution-worker.js';
 import { computeEffectiveFlags, DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
 
@@ -137,13 +136,18 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
       expect(result.source).toBe('workspace_file');
     });
 
-    it('returns enabled=false when YAML is malformed', () => {
+    it('returns enabled=false when YAML is malformed and warning includes error detail', () => {
       const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
       fs.writeFileSync(configPath, '  bad: [yaml: content', 'utf8');
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
       expect(result.enabled).toBe(false);
-      expect(logger.warn).toHaveBeenCalled();
+      // YAML parse warning must include error detail (fix #6)
+      const warnCalls = logger.warn.mock.calls.map((c: unknown[]) => c[0] as string);
+      const parseWarn = warnCalls.find((m: string) => m.includes('YAML parse error'));
+      expect(parseWarn).toBeDefined();
+      // Error detail must contain something beyond "using defaults"
+      expect(parseWarn!.length).toBeGreaterThan('YAML parse error — using defaults'.length);
     });
 
     it('returns defaults when file is unreadable', () => {
@@ -156,7 +160,8 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
       expect(logger.warn).toHaveBeenCalled();
     });
 
-    it('rejects dangerous keys', () => {
+    it('rejects dangerous keys (__proto__) and does not enable via prototype pollution', () => {
+      // Write raw YAML with __proto__ to test dangerous key rejection on raw parsed output
       writeFeatureFlags(workspaceDir, {
         __proto__: { enabled: true },
         evolution_worker: { enabled: false },
@@ -167,44 +172,34 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
     });
   });
 
-  // ── 3. EvolutionWorkerService does NOT start by default ──
+  // ── 3. shouldStartEvolutionWorker — real helper, real output ──
 
-  describe('default config: worker does not start', () => {
-    it('EvolutionWorkerService.start is NOT called when flag is disabled', async () => {
-      // No feature-flags.yaml → flag defaults to false
-      const startSpy = vi.spyOn(EvolutionWorkerService, 'start');
-
-      const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', createMockLogger());
-      expect(flag.enabled).toBe(false);
-
-      // Verify the worker is not in _startedWorkspaces
-      expect(EvolutionWorkerService._startedWorkspaces.has(workspaceDir)).toBe(false);
-      expect(startSpy).not.toHaveBeenCalled();
-
-      startSpy.mockRestore();
+  describe('shouldStartEvolutionWorker gate helper', () => {
+    it('returns shouldStart=false by default (no feature-flags.yaml)', () => {
+      const logger = createMockLogger();
+      const gate = shouldStartEvolutionWorker(workspaceDir, logger);
+      expect(gate.shouldStart).toBe(false);
+      expect(gate.flagSource).toBe('defaults');
+      expect(gate.disabledInfo).not.toBeNull();
     });
 
-    it('disabled state produces structured observability', () => {
+    it('returns shouldStart=true when explicitly enabled', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: true },
+      });
       const logger = createMockLogger();
-      const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      const gate = shouldStartEvolutionWorker(workspaceDir, logger);
+      expect(gate.shouldStart).toBe(true);
+      expect(gate.flagSource).toBe('workspace_file');
+      expect(gate.disabledInfo).toBeNull();
+    });
 
-      // Simulate the logging path from index.ts
-      if (!flag.enabled) {
-        const disabledInfo = JSON.stringify({
-          reason: 'mvp_quiet_per_adr0014',
-          nextAction: 'set evolution_worker.enabled=true in .pd/feature-flags.yaml to enable',
-          featureFlag: 'evolution_worker',
-          boundedContext: 'legacy_evolution_worker',
-          flagSource: flag.source,
-        });
-        logger.info(`[PD] EvolutionWorker NOT started. ${disabledInfo}`);
-      }
-
-      expect(logger.info).toHaveBeenCalledTimes(1);
-      const loggedMsg = logger.info.mock.calls[0][0] as string;
-      expect(loggedMsg).toContain('EvolutionWorker NOT started');
-      // Verify structured fields present in the JSON payload
-      const parsed = JSON.parse(loggedMsg.substring(loggedMsg.indexOf('{')));
+    it('disabledInfo is valid JSON with required structured fields', () => {
+      const logger = createMockLogger();
+      const gate = shouldStartEvolutionWorker(workspaceDir, logger);
+      expect(gate.disabledInfo).not.toBeNull();
+      // Parse the real output — not hand-written JSON
+      const parsed = JSON.parse(gate.disabledInfo!);
       expect(parsed.reason).toBe('mvp_quiet_per_adr0014');
       expect(parsed.nextAction).toContain('evolution_worker.enabled=true');
       expect(parsed.featureFlag).toBe('evolution_worker');
@@ -213,43 +208,82 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
     });
   });
 
-  // ── 4. Explicit enable: worker starts ──
+  // ── 4. EvolutionWorkerService does NOT start by default ──
 
-  describe('explicit enable: worker starts', () => {
-    it('EvolutionWorkerService.start is called when flag is enabled', () => {
-      writeFeatureFlags(workspaceDir, {
-        evolution_worker: { enabled: true },
-      });
+  describe('default config: worker does not start', () => {
+    it('EvolutionWorkerService.start is NOT called when gate returns shouldStart=false', () => {
+      const startSpy = vi.spyOn(EvolutionWorkerService, 'start');
+      const logger = createMockLogger();
+      const gate = shouldStartEvolutionWorker(workspaceDir, logger);
 
-      const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', createMockLogger());
-      expect(flag.enabled).toBe(true);
-      expect(flag.source).toBe('workspace_file');
+      expect(gate.shouldStart).toBe(false);
+      expect(EvolutionWorkerService._startedWorkspaces.has(workspaceDir)).toBe(false);
+      expect(startSpy).not.toHaveBeenCalled();
+
+      startSpy.mockRestore();
     });
 
-    it('can start EvolutionWorkerService when flag is enabled', () => {
+    it('disabled observability comes from real helper — logger receives structured output', () => {
+      const logger = createMockLogger();
+      const gate = shouldStartEvolutionWorker(workspaceDir, logger);
+
+      // Simulate what index.ts does with the gate result
+      if (!gate.shouldStart && gate.disabledInfo) {
+        logger.info(`[PD] EvolutionWorker NOT started for workspace: ${workspaceDir}. ${gate.disabledInfo}`);
+      }
+
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      const loggedMsg = logger.info.mock.calls[0][0] as string;
+      expect(loggedMsg).toContain('EvolutionWorker NOT started');
+      // Parse the JSON from the real helper output embedded in the log message
+      const jsonStart = loggedMsg.indexOf('{');
+      expect(jsonStart).toBeGreaterThan(0);
+      const parsed = JSON.parse(loggedMsg.substring(jsonStart));
+      expect(parsed.reason).toBe('mvp_quiet_per_adr0014');
+      expect(parsed.featureFlag).toBe('evolution_worker');
+    });
+  });
+
+  // ── 5. Explicit enable: worker starts ──
+
+  describe('explicit enable: worker starts', () => {
+    it('shouldStartEvolutionWorker returns true when enabled in config', () => {
       writeFeatureFlags(workspaceDir, {
         evolution_worker: { enabled: true },
       });
 
-      const mockApi = {
-        logger: createMockLogger(),
-        config: { get: vi.fn((k: string) => k === 'intervals.worker_poll_ms' ? 60000 : undefined) },
-        runtime: { subagent: {} },
-      } as any;
+      const logger = createMockLogger();
+      const gate = shouldStartEvolutionWorker(workspaceDir, logger);
+      expect(gate.shouldStart).toBe(true);
+      expect(gate.flagSource).toBe('workspace_file');
+    });
 
-      EvolutionWorkerService.api = mockApi;
+    it('EvolutionWorkerService.start actually runs when gate is true', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: true },
+      });
+
+      const mockLogger = createMockLogger();
+      const mockConfig = { get: (k: string) => k === 'intervals.worker_poll_ms' ? 60000 : undefined };
+      const mockApi = {
+        logger: mockLogger,
+        config: mockConfig,
+        runtime: { subagent: {} },
+      };
+
+      EvolutionWorkerService.api = mockApi as typeof EvolutionWorkerService.api;
       EvolutionWorkerService.start({
-        config: mockApi.config,
+        config: mockConfig,
         workspaceDir,
         stateDir: path.join(workspaceDir, '.state'),
-        logger: mockApi.logger,
+        logger: mockLogger,
       });
 
       expect(EvolutionWorkerService._startedWorkspaces.has(workspaceDir)).toBe(true);
     });
   });
 
-  // ── 5. core flags remain functional ──
+  // ── 6. Core flags remain functional ──
 
   describe('MVP-Core flags unaffected', () => {
     it('prompt, code_tool_hook, defer_archive remain core+enabled', () => {
@@ -264,9 +298,11 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
 
       const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
       const raw = fs.readFileSync(configPath, 'utf8');
-      const parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
+      const parsed: unknown = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
 
-      const flags = computeEffectiveFlags(parsed, DEFAULT_FEATURE_FLAGS, configPath);
+      // Use isRecord type guard instead of `as`
+      expect(isRecord(parsed)).toBe(true);
+      const flags = computeEffectiveFlags(parsed as Record<string, unknown>, DEFAULT_FEATURE_FLAGS, configPath);
       expect(flags.flags['prompt']?.enabled).toBe(true);
       expect(flags.flags['code_tool_hook']?.enabled).toBe(true);
       expect(flags.flags['defer_archive']?.enabled).toBe(true);
@@ -281,16 +317,17 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
 
       const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
       const raw = fs.readFileSync(configPath, 'utf8');
-      const parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
+      const parsed: unknown = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
 
-      const flags = computeEffectiveFlags(parsed, DEFAULT_FEATURE_FLAGS, configPath);
+      expect(isRecord(parsed)).toBe(true);
+      const flags = computeEffectiveFlags(parsed as Record<string, unknown>, DEFAULT_FEATURE_FLAGS, configPath);
       expect(flags.flags['prompt']?.enabled).toBe(true); // core cannot be disabled
       expect(flags.flags['code_tool_hook']?.enabled).toBe(true); // core cannot be disabled
       expect(flags.warnings.length).toBeGreaterThan(0); // warnings about core override attempt
     });
   });
 
-  // ── 6. No PLAN.md / confirm-first gate regression ──
+  // ── 7. No PLAN.md / confirm-first gate regression ──
 
   describe('no confirm-first gate regression', () => {
     it('no PLAN.md or confirm-first files are created in workspace', () => {
@@ -298,7 +335,6 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
         evolution_worker: { enabled: false },
       });
 
-      // Simulate checking workspace for forbidden files
       const planMd = path.join(workspaceDir, 'PLAN.md');
       expect(fs.existsSync(planMd)).toBe(false);
     });

--- a/packages/openclaw-plugin/tests/evolution-worker-quarantine.test.ts
+++ b/packages/openclaw-plugin/tests/evolution-worker-quarantine.test.ts
@@ -1,0 +1,306 @@
+/**
+ * PRI-288: Quarantine EvolutionWorkerService default startup behind MVP feature flag.
+ *
+ * Tests prove:
+ * 1. Default config (no feature-flags.yaml) → EvolutionWorkerService does NOT start.
+ * 2. Explicit enable in feature-flags.yaml → EvolutionWorkerService starts.
+ * 3. Disabled state has structured observability (reason, nextAction, featureFlag, boundedContext).
+ * 4. api.registerService still works regardless of flag state.
+ *
+ * ERR-002: disabled startup must be observable — verified via SystemLogger + api.logger.
+ * ERR-025: tests cover the real plugin startup path (loadFeatureFlagFromWorkspace + gate logic),
+ *          not just isolated helpers.
+ * ERR-027: DEFAULT_FEATURE_FLAGS declaration matches runtime behavior.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as yaml from 'js-yaml';
+
+// ── Mock dependencies that would trigger side effects ──
+vi.mock('../src/core/dictionary-service.js', () => ({
+  DictionaryService: { get: vi.fn(() => ({ flush: vi.fn() })) },
+}));
+
+vi.mock('../src/core/session-tracker.js', () => ({
+  initPersistence: vi.fn(),
+  flushAllSessions: vi.fn(),
+  listSessions: vi.fn(() => []),
+}));
+
+vi.mock('../src/core/workspace-context.js', () => {
+  const mockCtx = {
+    stateDir: '',
+    workspaceDir: '',
+    config: { get: vi.fn() },
+    eventLog: { recordHookExecution: vi.fn() },
+    dictionary: { flush: vi.fn() },
+    resolve: vi.fn((key: string) => `/mock/${key}`),
+    trajectory: null,
+  };
+  return {
+    WorkspaceContext: {
+      fromHookContext: vi.fn(() => mockCtx),
+      clearCache: vi.fn(),
+    },
+  };
+});
+
+// Import after mocks
+import { loadFeatureFlagFromWorkspace } from '../src/index.js';
+import { EvolutionWorkerService } from '../src/service/evolution-worker.js';
+import { computeEffectiveFlags, DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
+
+// ── Helpers ──
+
+function createTempWorkspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-quarantine-'));
+  fs.mkdirSync(path.join(dir, '.pd'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.state'), { recursive: true });
+  return dir;
+}
+
+function writeFeatureFlags(workspaceDir: string, flags: Record<string, unknown>): void {
+  const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+  const content = yaml.dump(flags, { schema: yaml.JSON_SCHEMA });
+  fs.writeFileSync(configPath, content, 'utf8');
+}
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+// ── Tests ──
+
+describe('PRI-288: EvolutionWorkerService quarantine', () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = createTempWorkspace();
+    EvolutionWorkerService.api = null;
+    EvolutionWorkerService._startedWorkspaces.clear();
+  });
+
+  afterEach(() => {
+    EvolutionWorkerService.api = null;
+    EvolutionWorkerService._startedWorkspaces.clear();
+    // Clean up temp dir
+    try {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  // ── 1. Feature flag registry ──
+
+  describe('DEFAULT_FEATURE_FLAGS includes evolution_worker', () => {
+    it('has evolution_worker flag with quiet category and enabled=false', () => {
+      const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'evolution_worker');
+      expect(flag).toBeDefined();
+      expect(flag!.category).toBe('quiet');
+      expect(flag!.enabled).toBe(false);
+      expect(flag!.since).toBe('2026-06-01');
+    });
+  });
+
+  // ── 2. loadFeatureFlagFromWorkspace ──
+
+  describe('loadFeatureFlagFromWorkspace', () => {
+    it('returns enabled=false when no feature-flags.yaml exists', () => {
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      expect(result.enabled).toBe(false);
+      expect(result.source).toBe('defaults');
+    });
+
+    it('returns enabled=false when feature-flags.yaml has no evolution_worker entry', () => {
+      writeFeatureFlags(workspaceDir, { prompt: { enabled: true } });
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      expect(result.enabled).toBe(false);
+    });
+
+    it('returns enabled=true when feature-flags.yaml explicitly enables evolution_worker', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: true },
+      });
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      expect(result.enabled).toBe(true);
+      expect(result.source).toBe('workspace_file');
+    });
+
+    it('returns enabled=false when YAML is malformed', () => {
+      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      fs.writeFileSync(configPath, '  bad: [yaml: content', 'utf8');
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      expect(result.enabled).toBe(false);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('returns defaults when file is unreadable', () => {
+      // Create a directory where a file should be — causes read error
+      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      fs.mkdirSync(configPath, { recursive: true });
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      expect(result.enabled).toBe(false);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('rejects dangerous keys', () => {
+      writeFeatureFlags(workspaceDir, {
+        __proto__: { enabled: true },
+        evolution_worker: { enabled: false },
+      });
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+      expect(result.enabled).toBe(false);
+    });
+  });
+
+  // ── 3. EvolutionWorkerService does NOT start by default ──
+
+  describe('default config: worker does not start', () => {
+    it('EvolutionWorkerService.start is NOT called when flag is disabled', async () => {
+      // No feature-flags.yaml → flag defaults to false
+      const startSpy = vi.spyOn(EvolutionWorkerService, 'start');
+
+      const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', createMockLogger());
+      expect(flag.enabled).toBe(false);
+
+      // Verify the worker is not in _startedWorkspaces
+      expect(EvolutionWorkerService._startedWorkspaces.has(workspaceDir)).toBe(false);
+      expect(startSpy).not.toHaveBeenCalled();
+
+      startSpy.mockRestore();
+    });
+
+    it('disabled state produces structured observability', () => {
+      const logger = createMockLogger();
+      const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
+
+      // Simulate the logging path from index.ts
+      if (!flag.enabled) {
+        const disabledInfo = JSON.stringify({
+          reason: 'mvp_quiet_per_adr0014',
+          nextAction: 'set evolution_worker.enabled=true in .pd/feature-flags.yaml to enable',
+          featureFlag: 'evolution_worker',
+          boundedContext: 'legacy_evolution_worker',
+          flagSource: flag.source,
+        });
+        logger.info(`[PD] EvolutionWorker NOT started. ${disabledInfo}`);
+      }
+
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      const loggedMsg = logger.info.mock.calls[0][0] as string;
+      expect(loggedMsg).toContain('EvolutionWorker NOT started');
+      // Verify structured fields present in the JSON payload
+      const parsed = JSON.parse(loggedMsg.substring(loggedMsg.indexOf('{')));
+      expect(parsed.reason).toBe('mvp_quiet_per_adr0014');
+      expect(parsed.nextAction).toContain('evolution_worker.enabled=true');
+      expect(parsed.featureFlag).toBe('evolution_worker');
+      expect(parsed.boundedContext).toBe('legacy_evolution_worker');
+      expect(parsed.flagSource).toBe('defaults');
+    });
+  });
+
+  // ── 4. Explicit enable: worker starts ──
+
+  describe('explicit enable: worker starts', () => {
+    it('EvolutionWorkerService.start is called when flag is enabled', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: true },
+      });
+
+      const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', createMockLogger());
+      expect(flag.enabled).toBe(true);
+      expect(flag.source).toBe('workspace_file');
+    });
+
+    it('can start EvolutionWorkerService when flag is enabled', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: true },
+      });
+
+      const mockApi = {
+        logger: createMockLogger(),
+        config: { get: vi.fn((k: string) => k === 'intervals.worker_poll_ms' ? 60000 : undefined) },
+        runtime: { subagent: {} },
+      } as any;
+
+      EvolutionWorkerService.api = mockApi;
+      EvolutionWorkerService.start({
+        config: mockApi.config,
+        workspaceDir,
+        stateDir: path.join(workspaceDir, '.state'),
+        logger: mockApi.logger,
+      });
+
+      expect(EvolutionWorkerService._startedWorkspaces.has(workspaceDir)).toBe(true);
+    });
+  });
+
+  // ── 5. core flags remain functional ──
+
+  describe('MVP-Core flags unaffected', () => {
+    it('prompt, code_tool_hook, defer_archive remain core+enabled', () => {
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'prompt', createMockLogger());
+      expect(result.enabled).toBe(true);
+    });
+
+    it('computeEffectiveFlags preserves core flags even with evolution_worker override', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: true },
+      });
+
+      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      const raw = fs.readFileSync(configPath, 'utf8');
+      const parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
+
+      const flags = computeEffectiveFlags(parsed, DEFAULT_FEATURE_FLAGS, configPath);
+      expect(flags.flags['prompt']?.enabled).toBe(true);
+      expect(flags.flags['code_tool_hook']?.enabled).toBe(true);
+      expect(flags.flags['defer_archive']?.enabled).toBe(true);
+      expect(flags.flags['evolution_worker']?.enabled).toBe(true);
+    });
+
+    it('core flags cannot be disabled by user override', () => {
+      writeFeatureFlags(workspaceDir, {
+        prompt: { enabled: false },
+        code_tool_hook: { enabled: false },
+      });
+
+      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      const raw = fs.readFileSync(configPath, 'utf8');
+      const parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
+
+      const flags = computeEffectiveFlags(parsed, DEFAULT_FEATURE_FLAGS, configPath);
+      expect(flags.flags['prompt']?.enabled).toBe(true); // core cannot be disabled
+      expect(flags.flags['code_tool_hook']?.enabled).toBe(true); // core cannot be disabled
+      expect(flags.warnings.length).toBeGreaterThan(0); // warnings about core override attempt
+    });
+  });
+
+  // ── 6. No PLAN.md / confirm-first gate regression ──
+
+  describe('no confirm-first gate regression', () => {
+    it('no PLAN.md or confirm-first files are created in workspace', () => {
+      writeFeatureFlags(workspaceDir, {
+        evolution_worker: { enabled: false },
+      });
+
+      // Simulate checking workspace for forbidden files
+      const planMd = path.join(workspaceDir, 'PLAN.md');
+      expect(fs.existsSync(planMd)).toBe(false);
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  PLUGIN_SURFACE_REGISTRY,
+  validateSurfaceRegistry,
+  findUnclassifiedSurfaces,
+  getSurfacesByCategory,
+  getSurfacesByKind,
+  type PluginSurfaceEntry,
+} from '@principles/core/runtime-v2';
+
+function findRepoRoot(cwd: string): string {
+  let dir = cwd;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return cwd;
+}
+
+const repoRoot = findRepoRoot(process.cwd());
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function extractHookRegistrations(source: string): string[] {
+  const hooks: string[] = [];
+  const hookPattern = /api\.on\s*\(\s*['"]([^'"]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = hookPattern.exec(source)) !== null) {
+    hooks.push(match[1]);
+  }
+  return hooks;
+}
+
+function extractServiceRegistrations(source: string): string[] {
+  const services: string[] = [];
+  const servicePattern = /api\.registerService\s*\(\s*(\w+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = servicePattern.exec(source)) !== null) {
+    services.push(match[1]);
+  }
+  return services;
+}
+
+const SERVICE_NAME_MAP: Record<string, string> = {
+  EvolutionWorkerService: 'service:evolution-worker',
+  TrajectoryService: 'service:trajectory',
+  PDTaskService: 'service:pd-task',
+  CentralSyncService: 'service:central-sync',
+};
+
+const HOOK_LABEL_MAP: Record<string, string[]> = {
+  before_prompt_build: ['hook:before_prompt_build'],
+  before_tool_call: ['hook:before_tool_call'],
+  after_tool_call: ['hook:after_tool_call', 'hook:after_tool_call.trajectory'],
+  llm_output: ['hook:llm_output', 'hook:llm_output.trajectory'],
+  subagent_spawning: ['hook:subagent_spawning'],
+  subagent_ended: ['hook:subagent_ended'],
+  before_reset: ['hook:before_reset'],
+  before_compaction: ['hook:before_compaction'],
+  after_compaction: ['hook:after_compaction'],
+};
+
+describe('MVP Surface Registry Guard (PRI-289)', () => {
+  describe('registry self-validation', () => {
+    it('PLUGIN_SURFACE_REGISTRY passes validateSurfaceRegistry', () => {
+      const result = validateSurfaceRegistry(PLUGIN_SURFACE_REGISTRY);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('has no duplicate surface ids', () => {
+      const ids = PLUGIN_SURFACE_REGISTRY.map(s => s.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('core surfaces are all enabledByDefault', () => {
+      const coreSurfaces = getSurfacesByCategory(PLUGIN_SURFACE_REGISTRY, 'core');
+      for (const surface of coreSurfaces) {
+        expect(surface.enabledByDefault).toBe(true);
+      }
+    });
+
+    it('non-core surfaces are not enabledByDefault', () => {
+      const nonCore = PLUGIN_SURFACE_REGISTRY.filter(s => s.category !== 'core');
+      for (const surface of nonCore) {
+        expect(surface.enabledByDefault).toBe(false);
+      }
+    });
+
+    it('quiet/gone/legacy_retire surfaces have disabledReason', () => {
+      const disabled = PLUGIN_SURFACE_REGISTRY.filter(
+        s => s.category === 'quiet' || s.category === 'gone' || s.category === 'legacy_retire',
+      );
+      for (const surface of disabled) {
+        expect(surface.disabledReason).toBeDefined();
+        expect(typeof surface.disabledReason).toBe('string');
+        expect(surface.disabledReason!.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('hook registration coverage', () => {
+    it('every api.on() hook event in index.ts is classified in the registry', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const hookEvents = extractHookRegistrations(source);
+      const uniqueHookEvents = [...new Set(hookEvents)];
+
+      const registeredHookIds = new Set(
+        PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').map(s => s.id),
+      );
+
+      const unclassified: string[] = [];
+      for (const event of uniqueHookEvents) {
+        const expectedIds = HOOK_LABEL_MAP[event];
+        if (!expectedIds) {
+          unclassified.push(event);
+          continue;
+        }
+        for (const expectedId of expectedIds) {
+          if (!registeredHookIds.has(expectedId)) {
+            unclassified.push(expectedId);
+          }
+        }
+      }
+
+      expect(unclassified).toEqual([]);
+    });
+
+    it('every api.registerService() in index.ts is classified in the registry', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const serviceNames = extractServiceRegistrations(source);
+
+      const registeredServiceIds = new Set(
+        PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'service').map(s => s.id),
+      );
+
+      const unclassified: string[] = [];
+      for (const name of serviceNames) {
+        const expectedId = SERVICE_NAME_MAP[name];
+        if (!expectedId) {
+          unclassified.push(name);
+          continue;
+        }
+        if (!registeredServiceIds.has(expectedId)) {
+          unclassified.push(expectedId);
+        }
+      }
+
+      expect(unclassified).toEqual([]);
+    });
+
+    it('findUnclassifiedSurfaces detects new unregistered surfaces', () => {
+      const registeredIds = PLUGIN_SURFACE_REGISTRY.map(s => s.id);
+      const actualIds = ['hook:before_prompt_build', 'hook:new_unregistered_hook'];
+      const unclassified = findUnclassifiedSurfaces(registeredIds, actualIds);
+      expect(unclassified).toEqual(['hook:new_unregistered_hook']);
+    });
+  });
+
+  describe('ADR-0014 compliance', () => {
+    it('only MVP-Core surfaces are enabledByDefault', () => {
+      const enabledByDefault = PLUGIN_SURFACE_REGISTRY.filter(s => s.enabledByDefault);
+      for (const surface of enabledByDefault) {
+        expect(surface.category).toBe('core');
+      }
+    });
+
+    it('core hooks match ADR-0014 MVP-Core activation paths', () => {
+      const coreHooks = getSurfacesByKind(PLUGIN_SURFACE_REGISTRY, 'hook')
+        .filter(s => s.category === 'core')
+        .map(s => s.id);
+
+      expect(coreHooks).toContain('hook:before_prompt_build');
+      expect(coreHooks).toContain('hook:before_tool_call');
+      expect(coreHooks).toContain('hook:after_tool_call');
+      expect(coreHooks).toContain('hook:llm_output');
+    });
+
+    it('trajectory hooks are MVP-Quiet (ADR-0014 §2.5)', () => {
+      const trajectoryHooks = PLUGIN_SURFACE_REGISTRY.filter(
+        s => s.kind === 'hook' && s.id.includes('trajectory'),
+      );
+      for (const hook of trajectoryHooks) {
+        expect(hook.category).toBe('quiet');
+        expect(hook.enabledByDefault).toBe(false);
+      }
+    });
+
+    it('subagent/shadow hooks are MVP-Quiet (ADR-0014 §2.5)', () => {
+      const shadowHooks = PLUGIN_SURFACE_REGISTRY.filter(
+        s => s.kind === 'hook' && (s.id.includes('subagent') || s.id.includes('shadow')),
+      );
+      for (const hook of shadowHooks) {
+        expect(hook.category).toBe('quiet');
+        expect(hook.enabledByDefault).toBe(false);
+      }
+    });
+
+    it('lifecycle hooks are MVP-Quiet (ADR-0014 §2.5)', () => {
+      const lifecycleHooks = PLUGIN_SURFACE_REGISTRY.filter(
+        s => s.kind === 'hook' && (s.id.includes('reset') || s.id.includes('compaction')),
+      );
+      for (const hook of lifecycleHooks) {
+        expect(hook.category).toBe('quiet');
+        expect(hook.enabledByDefault).toBe(false);
+      }
+    });
+
+    it('central-sync service is MVP-Quiet (ADR-0014 §2.5: single workspace)', () => {
+      const centralSync = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'service:central-sync');
+      expect(centralSync).toBeDefined();
+      expect(centralSync!.category).toBe('quiet');
+      expect(centralSync!.enabledByDefault).toBe(false);
+    });
+
+    it('message_sanitize is MVP-Gone (ADR-0014 §2.5: COMPONENTS.md self-tagged)', () => {
+      const sanitize = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'prompt_section:message_sanitize');
+      expect(sanitize).toBeDefined();
+      expect(sanitize!.category).toBe('gone');
+      expect(sanitize!.enabledByDefault).toBe(false);
+    });
+  });
+
+  describe('surface guard runtime', () => {
+    it('checkSurfaceGuard passes with current registry', async () => {
+      const { checkSurfaceGuard } = await import('../../src/core/surface-guard.js');
+      const result = checkSurfaceGuard();
+      expect(result.passed).toBe(true);
+      expect(result.violations).toEqual([]);
+    });
+
+    it('isSurfaceEnabled returns false for unknown surface with reason', async () => {
+      const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
+      const result = isSurfaceEnabled('hook:unknown_new_hook');
+      expect(result.enabled).toBe(false);
+      expect(result.reason).toContain('not found in registry');
+    });
+
+    it('isSurfaceEnabled returns true for core surfaces', async () => {
+      const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
+      const result = isSurfaceEnabled('hook:before_prompt_build');
+      expect(result.enabled).toBe(true);
+    });
+
+    it('isSurfaceEnabled returns false for gone surfaces even with override', async () => {
+      const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
+      const result = isSurfaceEnabled('prompt_section:message_sanitize', { 'prompt_section:message_sanitize': true });
+      expect(result.enabled).toBe(false);
+      expect(result.reason).toContain('gone');
+    });
+
+    it('isSurfaceEnabled returns true for core surfaces even with false override', async () => {
+      const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
+      const result = isSurfaceEnabled('hook:before_prompt_build', { 'hook:before_prompt_build': false });
+      expect(result.enabled).toBe(true);
+      expect(result.reason).toContain('core');
+    });
+
+    it('isSurfaceEnabled returns false for quiet surfaces by default', async () => {
+      const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
+      const result = isSurfaceEnabled('hook:after_tool_call.trajectory');
+      expect(result.enabled).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+
+    it('isSurfaceEnabled allows quiet surfaces with explicit override', async () => {
+      const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
+      const result = isSurfaceEnabled('hook:after_tool_call.trajectory', { 'hook:after_tool_call.trajectory': true });
+      expect(result.enabled).toBe(true);
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
@@ -26,22 +26,27 @@ function read(relativePath: string): string {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
 
-interface HookRegistration {
+interface ApiOnRegistration {
   event: string;
-  surfaceId: string;
+  surfaceId: string | null;
+  rawLine: string;
   index: number;
 }
 
-function extractHookRegistrations(source: string): HookRegistration[] {
-  const registrations: HookRegistration[] = [];
-  const hookPattern = /guardHook\s*\(\s*['"]([^'"]+)['"]\s*,/g;
+function extractApiOnRegistrations(source: string): ApiOnRegistration[] {
+  const registrations: ApiOnRegistration[] = [];
+  const apiOnPattern = /api\.on\s*\(\s*['"]([^'"]+)['"]\s*,\s*/g;
   let match: RegExpExecArray | null;
-  let hookIndex = 0;
-  while ((match = hookPattern.exec(source)) !== null) {
+  let regIndex = 0;
+  while ((match = apiOnPattern.exec(source)) !== null) {
+    const event = match[1];
+    const afterMatch = source.slice(match.index + match[0].length);
+    const guardHookMatch = afterMatch.match(/^guardHook\s*\(\s*['"]([^'"]+)['"]\s*,/);
     registrations.push({
-      surfaceId: match[1],
-      event: match[1].replace(/^hook:/, '').replace(/\..+$/, ''),
-      index: hookIndex++,
+      event,
+      surfaceId: guardHookMatch ? guardHookMatch[1] : null,
+      rawLine: match[0],
+      index: regIndex++,
     });
   }
   return registrations;
@@ -106,66 +111,71 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
     });
   });
 
-  describe('hook registration coverage — per-registration, not deduplicated', () => {
-    it('every guardHook() call in index.ts has a classified surface id', () => {
-      const source = read('packages/openclaw-plugin/src/index.ts');
-      const registrations = extractHookRegistrations(source);
+  describe('api.on() registration coverage — every hook must be guarded', () => {
+    const source = read('packages/openclaw-plugin/src/index.ts');
+    const registrations = extractApiOnRegistrations(source);
 
+    it('has at least one api.on registration', () => {
       expect(registrations.length).toBeGreaterThan(0);
+    });
 
-      const registeredIds = new Set(
-        PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').map(s => s.id),
-      );
+    it('every api.on() handler is wrapped with guardHook()', () => {
+      const unguarded = registrations.filter(r => r.surfaceId === null);
+      if (unguarded.length > 0) {
+        const details = unguarded.map(r => `api.on('${r.event}', ...) #${r.index} — NOT wrapped with guardHook`);
+        throw new Error(
+          `Found ${unguarded.length} unguarded api.on() registration(s):\n${details.join('\n')}\n` +
+          `Every api.on() handler MUST be wrapped with guardHook('<surfaceId>', api.logger, ...) per PRI-289.`,
+        );
+      }
+    });
 
+    it('every guardHook surface id exists in PLUGIN_SURFACE_REGISTRY', () => {
+      const guarded = registrations.filter(r => r.surfaceId !== null);
+      const registeredIds = new Set(PLUGIN_SURFACE_REGISTRY.map(s => s.id));
       const unclassified: string[] = [];
-      for (const reg of registrations) {
-        if (!registeredIds.has(reg.surfaceId)) {
-          unclassified.push(reg.surfaceId);
+      for (const reg of guarded) {
+        if (!registeredIds.has(reg.surfaceId!)) {
+          unclassified.push(reg.surfaceId!);
         }
       }
-
       expect(unclassified).toEqual([]);
     });
 
-    it('each individual hook registration is covered (no dedup by event name)', () => {
-      const source = read('packages/openclaw-plugin/src/index.ts');
-      const registrations = extractHookRegistrations(source);
-
-      const registeredIds = new Set(
-        PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').map(s => s.id),
-      );
-
-      for (const reg of registrations) {
-        expect(registeredIds.has(reg.surfaceId)).toBe(true);
+    it('each individual api.on registration is covered (no dedup by event name)', () => {
+      const guarded = registrations.filter(r => r.surfaceId !== null);
+      const registeredIds = new Set(PLUGIN_SURFACE_REGISTRY.map(s => s.id));
+      for (const reg of guarded) {
+        expect(registeredIds.has(reg.surfaceId!)).toBe(true);
       }
     });
 
     it('after_tool_call has two registrations: core + trajectory', () => {
-      const source = read('packages/openclaw-plugin/src/index.ts');
-      const registrations = extractHookRegistrations(source);
-
-      const afterToolCallRegs = registrations.filter(r => r.surfaceId.startsWith('hook:after_tool_call'));
+      const afterToolCallRegs = registrations.filter(r => r.event === 'after_tool_call');
       expect(afterToolCallRegs.length).toBe(2);
       expect(afterToolCallRegs[0].surfaceId).toBe('hook:after_tool_call');
       expect(afterToolCallRegs[1].surfaceId).toBe('hook:after_tool_call.trajectory');
     });
 
     it('llm_output has two registrations: core + trajectory', () => {
-      const source = read('packages/openclaw-plugin/src/index.ts');
-      const registrations = extractHookRegistrations(source);
-
-      const llmOutputRegs = registrations.filter(r => r.surfaceId.startsWith('hook:llm_output'));
+      const llmOutputRegs = registrations.filter(r => r.event === 'llm_output');
       expect(llmOutputRegs.length).toBe(2);
       expect(llmOutputRegs[0].surfaceId).toBe('hook:llm_output');
       expect(llmOutputRegs[1].surfaceId).toBe('hook:llm_output.trajectory');
     });
 
-    it('total hook registrations match expected count', () => {
-      const source = read('packages/openclaw-plugin/src/index.ts');
-      const registrations = extractHookRegistrations(source);
-
+    it('total api.on registrations with guardHook match registry hook count', () => {
+      const guarded = registrations.filter(r => r.surfaceId !== null);
       const registryHookCount = PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').length;
-      expect(registrations.length).toBe(registryHookCount);
+      expect(guarded.length).toBe(registryHookCount);
+    });
+
+    it('all guardHook calls pass api.logger as second argument', () => {
+      const guardHookWithLogger = /guardHook\s*\(\s*['"][^'"]+['"]\s*,\s*api\.logger\s*,/g;
+      const guardHookTotal = /guardHook\s*\(\s*['"][^'"]+['"]\s*,/g;
+      const withLoggerCount = (source.match(guardHookWithLogger) ?? []).length;
+      const totalCount = (source.match(guardHookTotal) ?? []).length;
+      expect(withLoggerCount).toBe(totalCount);
     });
   });
 
@@ -330,14 +340,14 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
     it('guardHook returns original handler for core surfaces', async () => {
       const { guardHook } = await import('../../src/core/surface-guard.js');
       const handler = () => 'result';
-      const guarded = guardHook('hook:before_prompt_build', handler);
+      const guarded = guardHook('hook:before_prompt_build', undefined, handler);
       expect(guarded).toBe(handler);
     });
 
     it('guardHook returns no-op handler for quiet surfaces', async () => {
       const { guardHook } = await import('../../src/core/surface-guard.js');
       const handler = () => 'result';
-      const guarded = guardHook('hook:after_tool_call.trajectory', handler);
+      const guarded = guardHook('hook:after_tool_call.trajectory', undefined, handler);
       expect(guarded).not.toBe(handler);
       expect(guarded({} as never, {} as never)).toBeUndefined();
     });
@@ -345,8 +355,30 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
     it('guardHook returns no-op handler for gone surfaces', async () => {
       const { guardHook } = await import('../../src/core/surface-guard.js');
       const handler = () => 'result';
-      const guarded = guardHook('prompt_section:message_sanitize', handler);
+      const guarded = guardHook('prompt_section:message_sanitize', undefined, handler);
       expect(guarded).not.toBe(handler);
+    });
+
+    it('guardHook logs disabled reason via logger for quiet surfaces', async () => {
+      const { guardHook } = await import('../../src/core/surface-guard.js');
+      const logs: string[] = [];
+      const logger = { info: (msg: string) => { logs.push(msg); } };
+      const handler = () => 'result';
+      const guarded = guardHook('hook:after_tool_call.trajectory', logger, handler);
+      guarded({} as never, {} as never);
+      expect(logs.length).toBe(1);
+      expect(logs[0]).toContain('[PD:surface-guard] SKIP');
+      expect(logs[0]).toContain('hook:after_tool_call.trajectory');
+    });
+
+    it('guardHook does not log for enabled surfaces', async () => {
+      const { guardHook } = await import('../../src/core/surface-guard.js');
+      const logs: string[] = [];
+      const logger = { info: (msg: string) => { logs.push(msg); } };
+      const handler = () => 'result';
+      const guarded = guardHook('hook:before_prompt_build', logger, handler);
+      guarded({} as never, {} as never);
+      expect(logs.length).toBe(0);
     });
 
     it('guardService returns null for evolution-worker (quiet, default off)', async () => {

--- a/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
@@ -280,13 +280,6 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       expect(centralSync!.category).toBe('quiet');
       expect(centralSync!.enabledByDefault).toBe(false);
     });
-
-    it('message_sanitize is MVP-Gone (ADR-0014 §2.5: COMPONENTS.md self-tagged)', () => {
-      const sanitize = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'prompt_section:message_sanitize');
-      expect(sanitize).toBeDefined();
-      expect(sanitize!.category).toBe('gone');
-      expect(sanitize!.enabledByDefault).toBe(false);
-    });
   });
 
   describe('surface guard runtime', () => {
@@ -310,11 +303,11 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       expect(result.enabled).toBe(true);
     });
 
-    it('isSurfaceEnabled returns false for gone surfaces even with override', async () => {
+    it('isSurfaceEnabled returns false for unknown surfaces even with override', async () => {
       const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
-      const result = isSurfaceEnabled('prompt_section:message_sanitize', { 'prompt_section:message_sanitize': true });
+      const result = isSurfaceEnabled('hook:nonexistent_gone', { 'hook:nonexistent_gone': true });
       expect(result.enabled).toBe(false);
-      expect(result.reason).toContain('gone');
+      expect(result.reason).toContain('not found in registry');
     });
 
     it('isSurfaceEnabled returns true for core surfaces even with false override', async () => {
@@ -352,10 +345,10 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       expect(guarded({} as never, {} as never)).toBeUndefined();
     });
 
-    it('guardHook returns no-op handler for gone surfaces', async () => {
+    it('guardHook returns no-op handler for unregistered surfaces', async () => {
       const { guardHook } = await import('../../src/core/surface-guard.js');
       const handler = () => 'result';
-      const guarded = guardHook('prompt_section:message_sanitize', undefined, handler);
+      const guarded = guardHook('hook:nonexistent_hook', undefined, handler);
       expect(guarded).not.toBe(handler);
     });
 
@@ -395,10 +388,10 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       expect(guarded).toBeNull();
     });
 
-    it('guardService returns null for gone surfaces even with override', async () => {
+    it('guardService returns null for unregistered surfaces', async () => {
       const { guardService } = await import('../../src/core/surface-guard.js');
       const service = { api: null, start: () => {} };
-      const guarded = guardService('prompt_section:message_sanitize', service);
+      const guarded = guardService('service:nonexistent_service', service);
       expect(guarded).toBeNull();
     });
   });

--- a/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
@@ -7,7 +7,6 @@ import {
   findUnclassifiedSurfaces,
   getSurfacesByCategory,
   getSurfacesByKind,
-  type PluginSurfaceEntry,
 } from '@principles/core/runtime-v2';
 
 function findRepoRoot(cwd: string): string {
@@ -27,44 +26,45 @@ function read(relativePath: string): string {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
 
-function extractHookRegistrations(source: string): string[] {
-  const hooks: string[] = [];
-  const hookPattern = /api\.on\s*\(\s*['"]([^'"]+)['"]/g;
+interface HookRegistration {
+  event: string;
+  surfaceId: string;
+  index: number;
+}
+
+function extractHookRegistrations(source: string): HookRegistration[] {
+  const registrations: HookRegistration[] = [];
+  const hookPattern = /guardHook\s*\(\s*['"]([^'"]+)['"]\s*,/g;
   let match: RegExpExecArray | null;
+  let hookIndex = 0;
   while ((match = hookPattern.exec(source)) !== null) {
-    hooks.push(match[1]);
+    registrations.push({
+      surfaceId: match[1],
+      event: match[1].replace(/^hook:/, '').replace(/\..+$/, ''),
+      index: hookIndex++,
+    });
   }
-  return hooks;
+  return registrations;
 }
 
-function extractServiceRegistrations(source: string): string[] {
-  const services: string[] = [];
-  const servicePattern = /api\.registerService\s*\(\s*(\w+)/g;
+interface ServiceRegistration {
+  surfaceId: string;
+  index: number;
+}
+
+function extractServiceRegistrations(source: string): ServiceRegistration[] {
+  const registrations: ServiceRegistration[] = [];
+  const servicePattern = /guardService\s*\(\s*['"]([^'"]+)['"]\s*,/g;
   let match: RegExpExecArray | null;
+  let serviceIndex = 0;
   while ((match = servicePattern.exec(source)) !== null) {
-    services.push(match[1]);
+    registrations.push({
+      surfaceId: match[1],
+      index: serviceIndex++,
+    });
   }
-  return services;
+  return registrations;
 }
-
-const SERVICE_NAME_MAP: Record<string, string> = {
-  EvolutionWorkerService: 'service:evolution-worker',
-  TrajectoryService: 'service:trajectory',
-  PDTaskService: 'service:pd-task',
-  CentralSyncService: 'service:central-sync',
-};
-
-const HOOK_LABEL_MAP: Record<string, string[]> = {
-  before_prompt_build: ['hook:before_prompt_build'],
-  before_tool_call: ['hook:before_tool_call'],
-  after_tool_call: ['hook:after_tool_call', 'hook:after_tool_call.trajectory'],
-  llm_output: ['hook:llm_output', 'hook:llm_output.trajectory'],
-  subagent_spawning: ['hook:subagent_spawning'],
-  subagent_ended: ['hook:subagent_ended'],
-  before_reset: ['hook:before_reset'],
-  before_compaction: ['hook:before_compaction'],
-  after_compaction: ['hook:after_compaction'],
-};
 
 describe('MVP Surface Registry Guard (PRI-289)', () => {
   describe('registry self-validation', () => {
@@ -106,61 +106,96 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
     });
   });
 
-  describe('hook registration coverage', () => {
-    it('every api.on() hook event in index.ts is classified in the registry', () => {
+  describe('hook registration coverage — per-registration, not deduplicated', () => {
+    it('every guardHook() call in index.ts has a classified surface id', () => {
       const source = read('packages/openclaw-plugin/src/index.ts');
-      const hookEvents = extractHookRegistrations(source);
-      const uniqueHookEvents = [...new Set(hookEvents)];
+      const registrations = extractHookRegistrations(source);
 
-      const registeredHookIds = new Set(
+      expect(registrations.length).toBeGreaterThan(0);
+
+      const registeredIds = new Set(
         PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').map(s => s.id),
       );
 
       const unclassified: string[] = [];
-      for (const event of uniqueHookEvents) {
-        const expectedIds = HOOK_LABEL_MAP[event];
-        if (!expectedIds) {
-          unclassified.push(event);
-          continue;
-        }
-        for (const expectedId of expectedIds) {
-          if (!registeredHookIds.has(expectedId)) {
-            unclassified.push(expectedId);
-          }
+      for (const reg of registrations) {
+        if (!registeredIds.has(reg.surfaceId)) {
+          unclassified.push(reg.surfaceId);
         }
       }
 
       expect(unclassified).toEqual([]);
     });
 
-    it('every api.registerService() in index.ts is classified in the registry', () => {
+    it('each individual hook registration is covered (no dedup by event name)', () => {
       const source = read('packages/openclaw-plugin/src/index.ts');
-      const serviceNames = extractServiceRegistrations(source);
+      const registrations = extractHookRegistrations(source);
 
-      const registeredServiceIds = new Set(
+      const registeredIds = new Set(
+        PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').map(s => s.id),
+      );
+
+      for (const reg of registrations) {
+        expect(registeredIds.has(reg.surfaceId)).toBe(true);
+      }
+    });
+
+    it('after_tool_call has two registrations: core + trajectory', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const registrations = extractHookRegistrations(source);
+
+      const afterToolCallRegs = registrations.filter(r => r.surfaceId.startsWith('hook:after_tool_call'));
+      expect(afterToolCallRegs.length).toBe(2);
+      expect(afterToolCallRegs[0].surfaceId).toBe('hook:after_tool_call');
+      expect(afterToolCallRegs[1].surfaceId).toBe('hook:after_tool_call.trajectory');
+    });
+
+    it('llm_output has two registrations: core + trajectory', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const registrations = extractHookRegistrations(source);
+
+      const llmOutputRegs = registrations.filter(r => r.surfaceId.startsWith('hook:llm_output'));
+      expect(llmOutputRegs.length).toBe(2);
+      expect(llmOutputRegs[0].surfaceId).toBe('hook:llm_output');
+      expect(llmOutputRegs[1].surfaceId).toBe('hook:llm_output.trajectory');
+    });
+
+    it('total hook registrations match expected count', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const registrations = extractHookRegistrations(source);
+
+      const registryHookCount = PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'hook').length;
+      expect(registrations.length).toBe(registryHookCount);
+    });
+  });
+
+  describe('service registration coverage — per-registration', () => {
+    it('every guardService() call in index.ts has a classified surface id', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const registrations = extractServiceRegistrations(source);
+
+      expect(registrations.length).toBeGreaterThan(0);
+
+      const registeredIds = new Set(
         PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'service').map(s => s.id),
       );
 
       const unclassified: string[] = [];
-      for (const name of serviceNames) {
-        const expectedId = SERVICE_NAME_MAP[name];
-        if (!expectedId) {
-          unclassified.push(name);
-          continue;
-        }
-        if (!registeredServiceIds.has(expectedId)) {
-          unclassified.push(expectedId);
+      for (const reg of registrations) {
+        if (!registeredIds.has(reg.surfaceId)) {
+          unclassified.push(reg.surfaceId);
         }
       }
 
       expect(unclassified).toEqual([]);
     });
 
-    it('findUnclassifiedSurfaces detects new unregistered surfaces', () => {
-      const registeredIds = PLUGIN_SURFACE_REGISTRY.map(s => s.id);
-      const actualIds = ['hook:before_prompt_build', 'hook:new_unregistered_hook'];
-      const unclassified = findUnclassifiedSurfaces(registeredIds, actualIds);
-      expect(unclassified).toEqual(['hook:new_unregistered_hook']);
+    it('total service registrations match expected count', () => {
+      const source = read('packages/openclaw-plugin/src/index.ts');
+      const registrations = extractServiceRegistrations(source);
+
+      const registryServiceCount = PLUGIN_SURFACE_REGISTRY.filter(s => s.kind === 'service').length;
+      expect(registrations.length).toBe(registryServiceCount);
     });
   });
 
@@ -181,6 +216,22 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       expect(coreHooks).toContain('hook:before_tool_call');
       expect(coreHooks).toContain('hook:after_tool_call');
       expect(coreHooks).toContain('hook:llm_output');
+    });
+
+    it('evolution-worker service is MVP-Quiet (PRI-288/ADR-0014 alignment)', () => {
+      const ew = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'service:evolution-worker');
+      expect(ew).toBeDefined();
+      expect(ew!.category).toBe('quiet');
+      expect(ew!.enabledByDefault).toBe(false);
+      expect(ew!.disabledReason).toContain('PRI-288');
+    });
+
+    it('evolution-worker startup is MVP-Quiet (PRI-288/ADR-0014 alignment)', () => {
+      const ew = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'startup:evolution-worker');
+      expect(ew).toBeDefined();
+      expect(ew!.category).toBe('quiet');
+      expect(ew!.enabledByDefault).toBe(false);
+      expect(ew!.disabledReason).toContain('PRI-288');
     });
 
     it('trajectory hooks are MVP-Quiet (ADR-0014 §2.5)', () => {
@@ -274,6 +325,49 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       const { isSurfaceEnabled } = await import('../../src/core/surface-guard.js');
       const result = isSurfaceEnabled('hook:after_tool_call.trajectory', { 'hook:after_tool_call.trajectory': true });
       expect(result.enabled).toBe(true);
+    });
+
+    it('guardHook returns original handler for core surfaces', async () => {
+      const { guardHook } = await import('../../src/core/surface-guard.js');
+      const handler = () => 'result';
+      const guarded = guardHook('hook:before_prompt_build', handler);
+      expect(guarded).toBe(handler);
+    });
+
+    it('guardHook returns no-op handler for quiet surfaces', async () => {
+      const { guardHook } = await import('../../src/core/surface-guard.js');
+      const handler = () => 'result';
+      const guarded = guardHook('hook:after_tool_call.trajectory', handler);
+      expect(guarded).not.toBe(handler);
+      expect(guarded({} as never, {} as never)).toBeUndefined();
+    });
+
+    it('guardHook returns no-op handler for gone surfaces', async () => {
+      const { guardHook } = await import('../../src/core/surface-guard.js');
+      const handler = () => 'result';
+      const guarded = guardHook('prompt_section:message_sanitize', handler);
+      expect(guarded).not.toBe(handler);
+    });
+
+    it('guardService returns null for evolution-worker (quiet, default off)', async () => {
+      const { guardService } = await import('../../src/core/surface-guard.js');
+      const service = { api: null, start: () => {} };
+      const guarded = guardService('service:evolution-worker', service);
+      expect(guarded).toBeNull();
+    });
+
+    it('guardService returns null for quiet surfaces', async () => {
+      const { guardService } = await import('../../src/core/surface-guard.js');
+      const service = { api: null, start: () => {} };
+      const guarded = guardService('service:trajectory', service);
+      expect(guarded).toBeNull();
+    });
+
+    it('guardService returns null for gone surfaces even with override', async () => {
+      const { guardService } = await import('../../src/core/surface-guard.js');
+      const service = { api: null, start: () => {} };
+      const guarded = guardService('prompt_section:message_sanitize', service);
+      expect(guarded).toBeNull();
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -282,6 +282,7 @@ const KNOWN_PLUGIN_CORE_FILES = new Set([
   // ── Runtime V2 ──────────────────────────────────────────────────────────
   'runtime-v2-prompt-activation-reader.ts',
   'workspace-guidance-migrator.ts',
+  'surface-guard.ts',
 
   // ── Test Files ──────────────────────────────────────────────────────────
   '__tests__/focus-history.test.ts',
@@ -335,7 +336,7 @@ describe('PRI-212 plugin core anti-growth guard', () => {
     // Prevents accidental baseline bloat from going unnoticed.
     // See docs/reviews/plugin-core-inventory-2026-05.md §7
     // PRI-286: Removed confirm-first-gate.ts (95 → 94)
-    expect(KNOWN_PLUGIN_CORE_FILES.size).toBe(95);
+    expect(KNOWN_PLUGIN_CORE_FILES.size).toBe(96);
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/plugin-surface-registry.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/plugin-surface-registry.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PLUGIN_SURFACE_REGISTRY,
+  validateSurfaceRegistry,
+  getEnabledSurfaces,
+  getSurfacesByCategory,
+  getSurfacesByKind,
+  findUnclassifiedSurfaces,
+  VALID_SURFACE_KINDS,
+  VALID_MVP_CATEGORIES,
+  type PluginSurfaceEntry,
+} from '../plugin-surface-registry.js';
+
+describe('plugin-surface-registry', () => {
+  describe('validateSurfaceRegistry', () => {
+    it('validates the default registry without errors', () => {
+      const result = validateSurfaceRegistry(PLUGIN_SURFACE_REGISTRY);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('rejects duplicate ids', () => {
+      const registry: PluginSurfaceEntry[] = [
+        { id: 'hook:test', kind: 'hook', category: 'core', enabledByDefault: true, since: '2026-01-01', description: 'test' },
+        { id: 'hook:test', kind: 'hook', category: 'core', enabledByDefault: true, since: '2026-01-01', description: 'test2' },
+      ];
+      const result = validateSurfaceRegistry(registry);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("duplicate surface id: 'hook:test'");
+    });
+
+    it('rejects core surface with enabledByDefault=false', () => {
+      const registry: PluginSurfaceEntry[] = [
+        { id: 'hook:test', kind: 'hook', category: 'core', enabledByDefault: false, since: '2026-01-01', description: 'test' },
+      ];
+      const result = validateSurfaceRegistry(registry);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('core surface must be enabledByDefault=true'))).toBe(true);
+    });
+
+    it('rejects non-core surface with enabledByDefault=true', () => {
+      const registry: PluginSurfaceEntry[] = [
+        { id: 'hook:test', kind: 'hook', category: 'quiet', enabledByDefault: true, since: '2026-01-01', description: 'test' },
+      ];
+      const result = validateSurfaceRegistry(registry);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('non-core surface') && e.includes('must not be enabledByDefault=true'))).toBe(true);
+    });
+
+    it('rejects invalid kind', () => {
+      const registry = [
+        { id: 'test', kind: 'invalid', category: 'core', enabledByDefault: true, since: '2026-01-01', description: 'test' },
+      ] as unknown as PluginSurfaceEntry[];
+      const result = validateSurfaceRegistry(registry);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes("invalid kind 'invalid'"))).toBe(true);
+    });
+
+    it('rejects invalid category', () => {
+      const registry = [
+        { id: 'test', kind: 'hook', category: 'invalid', enabledByDefault: true, since: '2026-01-01', description: 'test' },
+      ] as unknown as PluginSurfaceEntry[];
+      const result = validateSurfaceRegistry(registry);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes("invalid category 'invalid'"))).toBe(true);
+    });
+
+    it('warns when quiet/gone/legacy_retire surface has no disabledReason', () => {
+      const registry: PluginSurfaceEntry[] = [
+        { id: 'hook:test', kind: 'hook', category: 'quiet', enabledByDefault: false, since: '2026-01-01', description: 'test' },
+      ];
+      const result = validateSurfaceRegistry(registry);
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.includes('no disabledReason'))).toBe(true);
+    });
+  });
+
+  describe('getEnabledSurfaces', () => {
+    it('returns only core surfaces by default', () => {
+      const enabled = getEnabledSurfaces(PLUGIN_SURFACE_REGISTRY);
+      for (const surface of enabled) {
+        expect(surface.category).toBe('core');
+        expect(surface.enabledByDefault).toBe(true);
+      }
+    });
+
+    it('allows quiet surface override', () => {
+      const enabled = getEnabledSurfaces(PLUGIN_SURFACE_REGISTRY, {
+        'hook:after_tool_call.trajectory': true,
+      });
+      const trajectoryHook = enabled.find(s => s.id === 'hook:after_tool_call.trajectory');
+      expect(trajectoryHook).toBeDefined();
+    });
+
+    it('ignores gone surface override', () => {
+      const enabled = getEnabledSurfaces(PLUGIN_SURFACE_REGISTRY, {
+        'prompt_section:message_sanitize': true,
+      });
+      const sanitize = enabled.find(s => s.id === 'prompt_section:message_sanitize');
+      expect(sanitize).toBeUndefined();
+    });
+
+    it('ignores core surface disable override', () => {
+      const enabled = getEnabledSurfaces(PLUGIN_SURFACE_REGISTRY, {
+        'hook:before_prompt_build': false,
+      });
+      const promptHook = enabled.find(s => s.id === 'hook:before_prompt_build');
+      expect(promptHook).toBeDefined();
+    });
+  });
+
+  describe('getSurfacesByCategory', () => {
+    it('returns only core surfaces', () => {
+      const core = getSurfacesByCategory(PLUGIN_SURFACE_REGISTRY, 'core');
+      expect(core.length).toBeGreaterThan(0);
+      for (const s of core) {
+        expect(s.category).toBe('core');
+      }
+    });
+
+    it('returns only quiet surfaces', () => {
+      const quiet = getSurfacesByCategory(PLUGIN_SURFACE_REGISTRY, 'quiet');
+      expect(quiet.length).toBeGreaterThan(0);
+      for (const s of quiet) {
+        expect(s.category).toBe('quiet');
+      }
+    });
+  });
+
+  describe('getSurfacesByKind', () => {
+    it('returns only hook surfaces', () => {
+      const hooks = getSurfacesByKind(PLUGIN_SURFACE_REGISTRY, 'hook');
+      expect(hooks.length).toBeGreaterThan(0);
+      for (const s of hooks) {
+        expect(s.kind).toBe('hook');
+      }
+    });
+  });
+
+  describe('findUnclassifiedSurfaces', () => {
+    it('returns empty when all actual surfaces are registered', () => {
+      const registryIds = PLUGIN_SURFACE_REGISTRY.map(s => s.id);
+      const result = findUnclassifiedSurfaces(registryIds, registryIds);
+      expect(result).toEqual([]);
+    });
+
+    it('returns unregistered surface ids', () => {
+      const registryIds = PLUGIN_SURFACE_REGISTRY.map(s => s.id);
+      const actualIds = [...registryIds, 'hook:brand_new_hook'];
+      const result = findUnclassifiedSurfaces(registryIds, actualIds);
+      expect(result).toEqual(['hook:brand_new_hook']);
+    });
+  });
+
+  describe('constant integrity', () => {
+    it('VALID_SURFACE_KINDS contains expected kinds', () => {
+      expect(VALID_SURFACE_KINDS).toEqual(['hook', 'service', 'startup', 'prompt_section']);
+    });
+
+    it('VALID_MVP_CATEGORIES contains expected categories', () => {
+      expect(VALID_MVP_CATEGORIES).toEqual(['core', 'quiet', 'gone', 'legacy_retire']);
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/plugin-surface-registry.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/plugin-surface-registry.test.ts
@@ -93,11 +93,15 @@ describe('plugin-surface-registry', () => {
     });
 
     it('ignores gone surface override', () => {
-      const enabled = getEnabledSurfaces(PLUGIN_SURFACE_REGISTRY, {
-        'prompt_section:message_sanitize': true,
+      const goneEntry: PluginSurfaceEntry = {
+        id: 'hook:gone_test', kind: 'hook', category: 'gone', enabledByDefault: false,
+        since: '2026-01-01', description: 'test gone', disabledReason: 'test',
+      };
+      const enabled = getEnabledSurfaces([...PLUGIN_SURFACE_REGISTRY, goneEntry], {
+        'hook:gone_test': true,
       });
-      const sanitize = enabled.find(s => s.id === 'prompt_section:message_sanitize');
-      expect(sanitize).toBeUndefined();
+      const gone = enabled.find(s => s.id === 'hook:gone_test');
+      expect(gone).toBeUndefined();
     });
 
     it('ignores core surface disable override', () => {
@@ -154,7 +158,7 @@ describe('plugin-surface-registry', () => {
 
   describe('constant integrity', () => {
     it('VALID_SURFACE_KINDS contains expected kinds', () => {
-      expect(VALID_SURFACE_KINDS).toEqual(['hook', 'service', 'startup', 'prompt_section']);
+      expect(VALID_SURFACE_KINDS).toEqual(['hook', 'service', 'startup']);
     });
 
     it('VALID_MVP_CATEGORIES contains expected categories', () => {

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -100,6 +100,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   // Only flags with real consumption paths are registered (PRI-239 constraint)
   { id: 'feedback_channel', category: 'quiet', enabled: true, since: '2026-06-01', description: 'MVP seed feedback channel — privacy-preserving report drafts' },
   { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Global Friction Index session scoring' },
+  { id: 'evolution_worker', category: 'quiet', enabled: false, since: '2026-06-01', description: 'Legacy evolution worker heartbeat (MVP-Quiet per ADR-0014 §2.5)' },
 
   // MVP-Gone — permanently disabled, cannot be re-enabled
   { id: 'nocturnal', category: 'gone', enabled: false, since: '2026-05-24', description: 'Nocturnal trinity pipeline (retired)' },

--- a/packages/principles-core/src/runtime-v2/feature-flags/index.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/index.ts
@@ -13,3 +13,21 @@ export type {
   ValidationResultOk,
   ValidationResultErr,
 } from './feature-flag-contract.js';
+
+export {
+  VALID_SURFACE_KINDS,
+  VALID_MVP_CATEGORIES,
+  PLUGIN_SURFACE_REGISTRY,
+  validateSurfaceRegistry,
+  getEnabledSurfaces,
+  getSurfacesByCategory,
+  getSurfacesByKind,
+  findUnclassifiedSurfaces,
+} from './plugin-surface-registry.js';
+
+export type {
+  SurfaceKind,
+  MvpCategory,
+  PluginSurfaceEntry,
+  SurfaceRegistryValidationResult,
+} from './plugin-surface-registry.js';

--- a/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
@@ -119,10 +119,11 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
   {
     id: 'service:evolution-worker',
     kind: 'service',
-    category: 'core',
-    enabledByDefault: true,
-    since: '2026-05-24',
-    description: 'Background evolution worker for pain processing',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-06-01',
+    description: 'Background evolution worker for pain processing (MVP-Quiet per PRI-288/ADR-0014)',
+    disabledReason: 'MVP-Quiet: evolution worker gated behind evolution_worker feature flag (PRI-288); default off per ADR-0014 §2.5',
   },
   {
     id: 'service:trajectory',
@@ -162,10 +163,11 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
   {
     id: 'startup:evolution-worker',
     kind: 'startup',
-    category: 'core',
-    enabledByDefault: true,
-    since: '2026-05-24',
-    description: 'Evolution worker start on first prompt per workspace',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-06-01',
+    description: 'Evolution worker start on first prompt per workspace (MVP-Quiet per PRI-288/ADR-0014)',
+    disabledReason: 'MVP-Quiet: evolution worker startup gated behind evolution_worker feature flag (PRI-288); default off per ADR-0014 §2.5',
   },
   {
     id: 'prompt_section:principles',

--- a/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
@@ -1,0 +1,320 @@
+export type SurfaceKind = 'hook' | 'service' | 'startup' | 'prompt_section';
+export type MvpCategory = 'core' | 'quiet' | 'gone' | 'legacy_retire';
+
+export const VALID_SURFACE_KINDS: readonly SurfaceKind[] = ['hook', 'service', 'startup', 'prompt_section'];
+export const VALID_MVP_CATEGORIES: readonly MvpCategory[] = ['core', 'quiet', 'gone', 'legacy_retire'];
+
+export interface PluginSurfaceEntry {
+  id: string;
+  kind: SurfaceKind;
+  category: MvpCategory;
+  enabledByDefault: boolean;
+  since: string;
+  description: string;
+  disabledReason?: string;
+}
+
+export interface SurfaceRegistryValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
+  {
+    id: 'hook:before_prompt_build',
+    kind: 'hook',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Principle injection + workspace init on prompt build',
+  },
+  {
+    id: 'hook:before_tool_call',
+    kind: 'hook',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Security gate for tool calls (risk assessment, plan approval)',
+  },
+  {
+    id: 'hook:after_tool_call',
+    kind: 'hook',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Pain detection + empathy observer on tool call result',
+  },
+  {
+    id: 'hook:llm_output',
+    kind: 'hook',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'LLM output analysis for pain signal extraction',
+  },
+  {
+    id: 'hook:after_tool_call.trajectory',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Trajectory collector for after_tool_call events',
+    disabledReason: 'MVP-Quiet: trajectory collection not required for Story A\'',
+  },
+  {
+    id: 'hook:llm_output.trajectory',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Trajectory collector for llm_output events',
+    disabledReason: 'MVP-Quiet: trajectory collection not required for Story A\'',
+  },
+  {
+    id: 'hook:subagent_spawning',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Shadow routing observation on subagent spawn',
+    disabledReason: 'MVP-Quiet: shadow observation not required for Story A\'',
+  },
+  {
+    id: 'hook:subagent_ended',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Shadow observation completion on subagent end',
+    disabledReason: 'MVP-Quiet: shadow observation not required for Story A\'',
+  },
+  {
+    id: 'hook:before_reset',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Lifecycle hook for context reset',
+    disabledReason: 'MVP-Quiet: lifecycle hooks not required for Story A\'',
+  },
+  {
+    id: 'hook:before_compaction',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Lifecycle hook for before compaction',
+    disabledReason: 'MVP-Quiet: lifecycle hooks not required for Story A\'',
+  },
+  {
+    id: 'hook:after_compaction',
+    kind: 'hook',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Lifecycle hook for after compaction',
+    disabledReason: 'MVP-Quiet: lifecycle hooks not required for Story A\'',
+  },
+  {
+    id: 'service:evolution-worker',
+    kind: 'service',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Background evolution worker for pain processing',
+  },
+  {
+    id: 'service:trajectory',
+    kind: 'service',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Trajectory collection service',
+    disabledReason: 'MVP-Quiet: trajectory not required for Story A\'',
+  },
+  {
+    id: 'service:pd-task',
+    kind: 'service',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'PD task management service',
+    disabledReason: 'MVP-Quiet: task service not required for Story A\'',
+  },
+  {
+    id: 'service:central-sync',
+    kind: 'service',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Cross-workspace central sync service',
+    disabledReason: 'MVP-Quiet: central sync not required for single-workspace MVP',
+  },
+  {
+    id: 'startup:workspace-init',
+    kind: 'startup',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Workspace migration + template setup on first prompt',
+  },
+  {
+    id: 'startup:evolution-worker',
+    kind: 'startup',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Evolution worker start on first prompt per workspace',
+  },
+  {
+    id: 'prompt_section:principles',
+    kind: 'prompt_section',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-24',
+    description: 'Active principles injection into agent prompt',
+  },
+  {
+    id: 'prompt_section:empathy_observer',
+    kind: 'prompt_section',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-05-30',
+    description: 'Empathy observer for frustration/friction detection (ADR-0014 amendment)',
+  },
+  {
+    id: 'prompt_section:thinking_os',
+    kind: 'prompt_section',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Thinking OS mental model injection',
+    disabledReason: 'MVP-Quiet: makes prompt less interpretable; ADR-0014 §2.5',
+  },
+  {
+    id: 'prompt_section:gfi',
+    kind: 'prompt_section',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Global Friction Index session scoring injection',
+    disabledReason: 'MVP-Quiet: internal metric, not user-visible; ADR-0014 §2.5',
+  },
+  {
+    id: 'prompt_section:focus_history',
+    kind: 'prompt_section',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Focus history detailed injection',
+    disabledReason: 'MVP-Quiet: less interpretable; ADR-0014 §2.5',
+  },
+  {
+    id: 'prompt_section:routing_guidance',
+    kind: 'prompt_section',
+    category: 'quiet',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Routing guidance for local worker dispatch',
+    disabledReason: 'MVP-Quiet: shadow/local-worker routing not in Story A\'',
+  },
+  {
+    id: 'prompt_section:message_sanitize',
+    kind: 'prompt_section',
+    category: 'gone',
+    enabledByDefault: false,
+    since: '2026-05-24',
+    description: 'Message sanitization hook (retired)',
+    disabledReason: 'MVP-Gone: COMPONENTS.md self-tagged for deletion',
+  },
+];
+
+export function validateSurfaceRegistry(registry: readonly PluginSurfaceEntry[]): SurfaceRegistryValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entry of registry) {
+    if (seenIds.has(entry.id)) {
+      errors.push(`duplicate surface id: '${entry.id}'`);
+    }
+    seenIds.add(entry.id);
+
+    if (typeof entry.id !== 'string' || entry.id.length === 0) {
+      errors.push(`surface entry has invalid id: '${String(entry.id)}'`);
+    }
+
+    if (!VALID_SURFACE_KINDS.includes(entry.kind)) {
+      errors.push(`surface '${entry.id}': invalid kind '${entry.kind}'`);
+    }
+
+    if (!VALID_MVP_CATEGORIES.includes(entry.category)) {
+      errors.push(`surface '${entry.id}': invalid category '${entry.category}'`);
+    }
+
+    if (typeof entry.enabledByDefault !== 'boolean') {
+      errors.push(`surface '${entry.id}': enabledByDefault must be boolean`);
+    }
+
+    if (typeof entry.since !== 'string' || entry.since.length === 0) {
+      errors.push(`surface '${entry.id}': since must be a non-empty string`);
+    }
+
+    if (typeof entry.description !== 'string' || entry.description.length === 0) {
+      errors.push(`surface '${entry.id}': description must be a non-empty string`);
+    }
+
+    if (entry.category === 'core' && !entry.enabledByDefault) {
+      errors.push(`surface '${entry.id}': core surface must be enabledByDefault=true`);
+    }
+
+    if (entry.category !== 'core' && entry.enabledByDefault) {
+      errors.push(`surface '${entry.id}': non-core surface (${entry.category}) must not be enabledByDefault=true`);
+    }
+
+    if ((entry.category === 'quiet' || entry.category === 'gone' || entry.category === 'legacy_retire') && !entry.disabledReason) {
+      warnings.push(`surface '${entry.id}': ${entry.category} surface has no disabledReason — observability gap (ERR-002)`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+export function getEnabledSurfaces(
+  registry: readonly PluginSurfaceEntry[],
+  overrides: Record<string, boolean> = {},
+): PluginSurfaceEntry[] {
+  return registry.filter(entry => {
+    if (Object.hasOwn(overrides, entry.id)) {
+      const override = overrides[entry.id];
+      if (typeof override !== 'boolean') return entry.enabledByDefault;
+      if (entry.category === 'gone') return false;
+      if (entry.category === 'core' && !override) return true;
+      return override;
+    }
+    return entry.enabledByDefault;
+  });
+}
+
+export function getSurfacesByCategory(
+  registry: readonly PluginSurfaceEntry[],
+  category: MvpCategory,
+): PluginSurfaceEntry[] {
+  return registry.filter(entry => entry.category === category);
+}
+
+export function getSurfacesByKind(
+  registry: readonly PluginSurfaceEntry[],
+  kind: SurfaceKind,
+): PluginSurfaceEntry[] {
+  return registry.filter(entry => entry.kind === kind);
+}
+
+export function findUnclassifiedSurfaces(
+  registryIds: readonly string[],
+  actualSurfaceIds: readonly string[],
+): string[] {
+  const registered = new Set<string>(registryIds);
+  return actualSurfaceIds.filter(id => !registered.has(id));
+}

--- a/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
@@ -1,7 +1,7 @@
-export type SurfaceKind = 'hook' | 'service' | 'startup' | 'prompt_section';
+export type SurfaceKind = 'hook' | 'service' | 'startup';
 export type MvpCategory = 'core' | 'quiet' | 'gone' | 'legacy_retire';
 
-export const VALID_SURFACE_KINDS: readonly SurfaceKind[] = ['hook', 'service', 'startup', 'prompt_section'];
+export const VALID_SURFACE_KINDS: readonly SurfaceKind[] = ['hook', 'service', 'startup'];
 export const VALID_MVP_CATEGORIES: readonly MvpCategory[] = ['core', 'quiet', 'gone', 'legacy_retire'];
 
 export interface PluginSurfaceEntry {
@@ -168,67 +168,6 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
     since: '2026-06-01',
     description: 'Evolution worker start on first prompt per workspace (MVP-Quiet per PRI-288/ADR-0014)',
     disabledReason: 'MVP-Quiet: evolution worker startup gated behind evolution_worker feature flag (PRI-288); default off per ADR-0014 §2.5',
-  },
-  {
-    id: 'prompt_section:principles',
-    kind: 'prompt_section',
-    category: 'core',
-    enabledByDefault: true,
-    since: '2026-05-24',
-    description: 'Active principles injection into agent prompt',
-  },
-  {
-    id: 'prompt_section:empathy_observer',
-    kind: 'prompt_section',
-    category: 'core',
-    enabledByDefault: true,
-    since: '2026-05-30',
-    description: 'Empathy observer for frustration/friction detection (ADR-0014 amendment)',
-  },
-  {
-    id: 'prompt_section:thinking_os',
-    kind: 'prompt_section',
-    category: 'quiet',
-    enabledByDefault: false,
-    since: '2026-05-24',
-    description: 'Thinking OS mental model injection',
-    disabledReason: 'MVP-Quiet: makes prompt less interpretable; ADR-0014 §2.5',
-  },
-  {
-    id: 'prompt_section:gfi',
-    kind: 'prompt_section',
-    category: 'quiet',
-    enabledByDefault: false,
-    since: '2026-05-24',
-    description: 'Global Friction Index session scoring injection',
-    disabledReason: 'MVP-Quiet: internal metric, not user-visible; ADR-0014 §2.5',
-  },
-  {
-    id: 'prompt_section:focus_history',
-    kind: 'prompt_section',
-    category: 'quiet',
-    enabledByDefault: false,
-    since: '2026-05-24',
-    description: 'Focus history detailed injection',
-    disabledReason: 'MVP-Quiet: less interpretable; ADR-0014 §2.5',
-  },
-  {
-    id: 'prompt_section:routing_guidance',
-    kind: 'prompt_section',
-    category: 'quiet',
-    enabledByDefault: false,
-    since: '2026-05-24',
-    description: 'Routing guidance for local worker dispatch',
-    disabledReason: 'MVP-Quiet: shadow/local-worker routing not in Story A\'',
-  },
-  {
-    id: 'prompt_section:message_sanitize',
-    kind: 'prompt_section',
-    category: 'gone',
-    enabledByDefault: false,
-    since: '2026-05-24',
-    description: 'Message sanitization hook (retired)',
-    disabledReason: 'MVP-Gone: COMPONENTS.md self-tagged for deletion',
   },
 ];
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -322,6 +322,26 @@ export type {
   ValidationResultErr as FeatureFlagValidationResultErr,
 } from './feature-flags/index.js';
 
+// Plugin Surface Registry (PRI-289) — MVP hook/service/startup surface guard
+
+export {
+  VALID_SURFACE_KINDS,
+  VALID_MVP_CATEGORIES,
+  PLUGIN_SURFACE_REGISTRY,
+  validateSurfaceRegistry,
+  getEnabledSurfaces,
+  getSurfacesByCategory,
+  getSurfacesByKind,
+  findUnclassifiedSurfaces,
+} from './feature-flags/index.js';
+
+export type {
+  SurfaceKind,
+  MvpCategory,
+  PluginSurfaceEntry,
+  SurfaceRegistryValidationResult,
+} from './feature-flags/index.js';
+
 // Proven channel baseline (PRI-240) — MVP activation continuity fixtures
 export {
   runPromptFixture,


### PR DESCRIPTION
## PRI-289: Add MVP Surface Registry Guard for Plugin Hooks and Services

### Summary
Static registry + runtime guard that makes the OpenClaw plugin's default hook/service surface explicit and prevents MVP-Quiet/Gone components from being default-enabled without maintainer approval.

**Scope: hook/service/startup only.** `prompt_section` surfaces are deferred to PRI-291 because enforcing them requires prompt diet changes (modifying `prompt.ts` / `defaultContextConfig` / Thinking OS injection logic), which is out of scope for this PR.

### Changes

**principles-core** (pure logic):
- `plugin-surface-registry.ts`: 17 surface entries (10 hooks, 4 services, 2 startups, 1 gone placeholder) classified as core/quiet/gone/legacy_retire with validation
- Exports: `PLUGIN_SURFACE_REGISTRY`, `validateSurfaceRegistry`, `getSurfacesByCategory`, `getSurfacesByKind`, `findUnclassifiedSurfaces`, `getEnabledSurfaces`

**openclaw-plugin** (I/O boundary):
- `surface-guard.ts`: Runtime guard with `guardHook(surfaceId, logger, handler)` and `guardService(surfaceId, service, logger)`
  - `guardHook`: Returns original handler for core surfaces; returns no-op handler for quiet/gone/legacy_retire
  - `guardService`: Returns original service for core; returns null for quiet/gone/legacy_retire
  - Both log disabled reason via logger (ERR-002 compliance — no silent skip)
- `index.ts`: Every `api.on()` handler wrapped with `guardHook('<surfaceId>', api.logger, ...)`; every `api.registerService()` wrapped with `guardService()`

### ADR-0014 Alignment
- Evolution-worker service/startup: `category: 'quiet'`, `enabledByDefault: false` (aligned with PRI-288)
- Only 4 hooks are MVP-Core: before_prompt_build, before_tool_call, after_tool_call, llm_output
- All other hooks (trajectory, subagent, lifecycle) are MVP-Quiet
- prompt_section surfaces deferred to PRI-291

### Review Comment Classification (Round 3)

| # | Finding | Severity | Status |
|---|---------|----------|--------|
| 1 | guardHook calls missing api.logger — quiet/gone hooks skip silently | P2 | **Fixed**: guardHook signature changed to (surfaceId, logger, handler); all calls pass api.logger |
| 2 | Test only scans guardHook() patterns, not api.on() registrations — unguarded api.on() would pass | P2 | **Fixed**: Test now extracts each api.on() and asserts handler is wrapped with guardHook |
| 3 | prompt_section surfaces in registry but not enforced — scope creep beyond hook/service guard | P2 | **Fixed**: Removed all prompt_section entries; deferred to PRI-291 |

### ERR Checklist
- ERR-001/ERR-005: No `as` casts on untrusted data; runtime validation via isSurfaceEnabled
- ERR-002: No silent fallback — guardHook logs disabled reason via logger.info; guardService logs via logger.info
- ERR-009/ERR-010: Missing surface id fails loud with `not found in registry` reason
- ERR-013: Uses Object.hasOwn() for override checks

### Tests
- `plugin-surface-registry.test.ts`: 18 unit tests (registry validation, category filtering, override behavior)
- `mvp-surface-registry-guard.test.ts`: 38 integration tests (api.on guard coverage, service coverage, ADR-0014 compliance, runtime guard behavior, logger observability)

### Verification
```
npm run build — ✅
npx vitest run packages/principles-core/src/runtime-v2/feature-flags/__tests__/plugin-surface-registry.test.ts — 18/18 ✅
npx vitest run packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts — 38/38 ✅
npm run verify:merge — ✅
```
