### PR TITLE
refactor(runtime-v2): move prompt activation reader contract into core

### DIFF
--- a/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
+++ b/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
@@ -1,23 +1,11 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { SqliteConnection, SqliteActivationStateStore, computeEffectiveFlags, DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
-import type { ActivationStatusRecord, EffectiveFeatureFlags } from '@principles/core/runtime-v2';
+import { SqliteConnection, SqliteActivationStateStore, computeEffectiveFlags, DEFAULT_FEATURE_FLAGS, filterPromptActivations, resolvePrincipleFromArtifact } from '@principles/core/runtime-v2';
+import type { EffectiveFeatureFlags, ActivatedPrinciple, PromptActivationReaderResult } from '@principles/core/runtime-v2';
 
-export const RUNTIME_V2_PRINCIPLE_BUDGET = 2000;
-
-export interface ActivatedPrinciple {
-  principleId: string;
-  text: string;
-  artifactId: string;
-  activationId: string;
-}
-
-export interface PromptActivationReaderResult {
-  principles: ActivatedPrinciple[];
-  warnings: string[];
-  source: 'runtime_v2';
-}
+export { RUNTIME_V2_PRINCIPLE_BUDGET } from '@principles/core/runtime-v2';
+export type { ActivatedPrinciple, PromptActivationReaderResult };
 
 export interface PromptActivationReaderDeps {
   logger?: { warn?: (msg: string) => void; info?: (msg: string) => void; error?: (msg: string) => void };
@@ -54,14 +42,19 @@ export class PromptActivationReader {
       sqliteConn = new SqliteConnection(this.workspaceDir);
       const store = new SqliteActivationStateStore(sqliteConn);
 
-      const activations = await store.listPromptActivations();
+      const allActivations = await store.listPromptActivations();
+      const promptActivations = filterPromptActivations(allActivations);
 
-      for (const activation of activations) {
-        if (activation.channel !== 'prompt' || activation.action !== 'prompt_activate') {
+      for (const activation of promptActivations) {
+        const artifactRow = this.queryArtifactRow(sqliteConn, activation.artifactId);
+        if (artifactRow === null) {
+          const warning = `artifact_not_found: artifactId=${activation.artifactId}; nextAction=check_pi_artifacts_table`;
+          warnings.push(warning);
+          this.deps.logger?.warn?.(`[PD:RuntimeV2] ${warning}`);
           continue;
         }
 
-        const result = this.resolvePrincipleFromActivation(sqliteConn, activation);
+        const result = resolvePrincipleFromArtifact(artifactRow, activation);
         if (result.ok) {
           principles.push(result.principle);
         } else {
@@ -83,6 +76,22 @@ export class PromptActivationReader {
     }
 
     return { principles, warnings, source: 'runtime_v2' };
+  }
+
+  private queryArtifactRow(sqliteConn: SqliteConnection, artifactId: string): unknown | null {
+    try {
+      const db = sqliteConn.getDb();
+      const row = db.prepare(`
+        SELECT artifact_id, artifact_kind, content_json, validation_status
+        FROM pi_artifacts
+        WHERE artifact_id = ?
+      `).get(artifactId);
+      return row ?? null;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.deps.logger?.warn?.(`[PD:RuntimeV2] artifact_query_failed: artifactId=${artifactId} reason=${msg}; nextAction=check_pi_artifacts_table`);
+      return null;
+    }
   }
 
   private loadFeatureFlags(): EffectiveFeatureFlags {
@@ -140,92 +149,5 @@ export class PromptActivationReader {
       }
     }
     return result;
-  }
-
-  private resolvePrincipleFromActivation(
-    sqliteConn: SqliteConnection,
-    activation: ActivationStatusRecord,
-  ): { ok: true; principle: ActivatedPrinciple } | { ok: false; warning: string } {
-    const db = sqliteConn.getDb();
-
-    let contentJson: string;
-
-    try {
-      const row = db.prepare(`
-        SELECT artifact_id, artifact_kind, content_json, validation_status
-        FROM pi_artifacts
-        WHERE artifact_id = ?
-      `).get(activation.artifactId);
-
-      if (!isRecord(row)) {
-        return { ok: false, warning: `artifact_query_unexpected: artifactId=${activation.artifactId}; nextAction=check_pi_artifacts_table` };
-      }
-
-      const artifact_id = Object.hasOwn(row, 'artifact_id') && typeof row.artifact_id === 'string' && row.artifact_id.length > 0 ? row.artifact_id : null;
-      const artifact_kind = Object.hasOwn(row, 'artifact_kind') && typeof row.artifact_kind === 'string' ? row.artifact_kind : null;
-      const raw_content_json = Object.hasOwn(row, 'content_json') && typeof row.content_json === 'string' ? row.content_json : null;
-      const validation_status = Object.hasOwn(row, 'validation_status') && typeof row.validation_status === 'string' ? row.validation_status : null;
-
-      if (!artifact_id) {
-        return { ok: false, warning: `artifact_not_found: artifactId=${activation.artifactId} activationId=${activation.activationId}; nextAction=verify_artifact_exists_or_remove_stale_activation` };
-      }
-
-      if (artifact_kind !== 'principle') {
-        return { ok: false, warning: `artifact_not_principle: artifactId=${artifact_id} kind=${artifact_kind ?? 'missing'}; nextAction=skip_non_principle_activations` };
-      }
-
-      if (validation_status !== 'validated') {
-        return { ok: false, warning: `artifact_not_validated: artifactId=${artifact_id} status=${validation_status ?? 'missing'}; nextAction=skip_unvalidated_artifacts` };
-      }
-
-      if (raw_content_json === null) {
-        return { ok: false, warning: `artifact_missing_content_json: artifactId=${artifact_id}; nextAction=ensure_artifact_has_content_json` };
-      }
-
-      contentJson = raw_content_json;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return { ok: false, warning: `artifact_query_failed: artifactId=${activation.artifactId} reason=${msg}; nextAction=check_pi_artifacts_table` };
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(contentJson);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return { ok: false, warning: `artifact_content_json_parse_error: artifactId=${activation.artifactId} reason=${msg}; nextAction=fix_artifact_content_json` };
-    }
-
-    if (!isRecord(parsed)) {
-      return { ok: false, warning: `artifact_content_malformed: artifactId=${activation.artifactId} reason=parsed_to_non_object; nextAction=fix_artifact_content_json` };
-    }
-
-    const principleId = Object.hasOwn(parsed, 'principleId') && typeof parsed.principleId === 'string' ? parsed.principleId : undefined;
-    const text = Object.hasOwn(parsed, 'text') && typeof parsed.text === 'string' ? parsed.text : undefined;
-
-    const draftObj = Object.hasOwn(parsed, 'principleDraft') && isRecord(parsed.principleDraft) ? parsed.principleDraft : null;
-    const draftTitle = draftObj && Object.hasOwn(draftObj, 'title') && typeof draftObj.title === 'string' ? draftObj.title : undefined;
-    const draftStatement = draftObj && Object.hasOwn(draftObj, 'statement') && typeof draftObj.statement === 'string' ? draftObj.statement : undefined;
-
-    const resolvedPrincipleId = principleId && principleId.length > 0 ? principleId : draftTitle;
-    const resolvedText = text && text.length > 0 ? text : draftStatement;
-
-    if (!resolvedPrincipleId || resolvedPrincipleId.length === 0) {
-      return { ok: false, warning: `artifact_missing_principle_id: artifactId=${activation.artifactId}; nextAction=ensure_artifact_has_principleId_or_principleDraft_title` };
-    }
-
-    if (!resolvedText || resolvedText.length === 0) {
-      return { ok: false, warning: `artifact_missing_text: artifactId=${activation.artifactId} principleId=${resolvedPrincipleId}; nextAction=ensure_artifact_has_text_or_principleDraft_statement` };
-    }
-
-    return {
-      ok: true,
-      principle: {
-        principleId: resolvedPrincipleId,
-        text: resolvedText,
-        artifactId: activation.artifactId,
-        activationId: activation.activationId,
-      },
-    };
   }
 }

--- a/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
+++ b/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
@@ -46,7 +46,17 @@ export class PromptActivationReader {
       const promptActivations = filterPromptActivations(allActivations);
 
       for (const activation of promptActivations) {
-        const artifactRow = this.queryArtifactRow(sqliteConn, activation.artifactId);
+        let artifactRow: unknown | null;
+        try {
+          artifactRow = this.queryArtifactRow(sqliteConn, activation.artifactId);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          const warning = `artifact_query_failed: artifactId=${activation.artifactId} reason=${msg}; nextAction=check_pi_artifacts_table`;
+          warnings.push(warning);
+          this.deps.logger?.warn?.(`[PD:RuntimeV2] ${warning}`);
+          continue;
+        }
+
         if (artifactRow === null) {
           const warning = `artifact_not_found: artifactId=${activation.artifactId}; nextAction=check_pi_artifacts_table`;
           warnings.push(warning);
@@ -89,8 +99,7 @@ export class PromptActivationReader {
       return row ?? null;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      this.deps.logger?.warn?.(`[PD:RuntimeV2] artifact_query_failed: artifactId=${artifactId} reason=${msg}; nextAction=check_pi_artifacts_table`);
-      return null;
+      throw new Error(`artifact_query_failed: artifactId=${artifactId} reason=${msg}; nextAction=check_pi_artifacts_table`);
     }
   }
 

--- a/packages/openclaw-plugin/src/hooks/prompt.ts
+++ b/packages/openclaw-plugin/src/hooks/prompt.ts
@@ -11,9 +11,9 @@ import { classifyTask, type RoutingInput } from '../core/local-worker-routing.js
 import { extractSummary, getHistoryVersions, parseWorkingMemorySection, workingMemoryToInjection, autoCompressFocus, safeReadCurrentFocus } from '../core/focus-history.js';
 import { PathResolver } from '../core/path-resolver.js';
 import { selectPrinciplesForInjection, DEFAULT_PRINCIPLE_BUDGET } from '../core/principle-injection.js';
-import { getCachedMaskedPrincipleSet, WorkflowFunnelLoader, PiAiRuntimeAdapter, EmpathyObserver, AgentScheduler } from '@principles/core/runtime-v2';
+import { getCachedMaskedPrincipleSet, WorkflowFunnelLoader, PiAiRuntimeAdapter, EmpathyObserver, AgentScheduler, RUNTIME_V2_PRINCIPLE_BUDGET, trimToBudget, renderPrinciplesToDirectives } from '@principles/core/runtime-v2';
 import { truncateInjectionToBudget } from '@principles/core/prompt-builder';
-import { PromptActivationReader, RUNTIME_V2_PRINCIPLE_BUDGET } from '../core/runtime-v2-prompt-activation-reader.js';
+import { PromptActivationReader } from '../core/runtime-v2-prompt-activation-reader.js';
 import {
   matchEmpathyKeywords,
   loadKeywordStore,
@@ -899,20 +899,12 @@ ${heartbeatChecklist}
     dedupedV2 = v2Result.principles.filter((p) => !legacyActiveIds.has(p.principleId));
 
     if (dedupedV2.length > 0) {
-      let remaining = RUNTIME_V2_PRINCIPLE_BUDGET;
-      const lines: string[] = [];
-      lines.push('Runtime V2 activated principles (owner-approved):');
-      remaining -= 'Runtime V2 activated principles (owner-approved):'.length;
-
-      for (const p of dedupedV2) {
-        const entry = `- [${escapeXml(p.principleId)}] ${escapeXml(p.text)}`;
-        if (remaining < entry.length + 1) {
-          logger?.info?.(`[PD:RuntimeV2] Principle budget reached (${RUNTIME_V2_PRINCIPLE_BUDGET}c) — truncating after ${lines.length - 1} principles`);
-          break;
-        }
-        lines.push(entry);
-        remaining -= entry.length + 1;
-        runtimeV2PrincipleIds.add(p.principleId);
+      const { lines, injectedIds, truncated } = trimToBudget(dedupedV2, RUNTIME_V2_PRINCIPLE_BUDGET, escapeXml);
+      if (truncated) {
+        logger?.info?.(`[PD:RuntimeV2] Principle budget reached (${RUNTIME_V2_PRINCIPLE_BUDGET}c) — truncating after ${injectedIds.size} principles`);
+      }
+      for (const id of injectedIds) {
+        runtimeV2PrincipleIds.add(id);
       }
       runtimeV2PrinciplesContent = lines.join('\n');
     }
@@ -985,24 +977,8 @@ ${empathySilenceConstraint}
   // PLACED IN prependSystemContext (before gateway system prompt) for highest LLM attention.
   // These are owner-reviewed, validated behavior constraints — not background context.
   if (runtimeV2PrincipleIds.size > 0) {
-    const directiveLines: string[] = [];
-    directiveLines.push('');
-    directiveLines.push('## 【OWNER-APPROVED BEHAVIOR DIRECTIVES】');
-    directiveLines.push('');
-    directiveLines.push('Owner-approved behavior directives are active operating constraints learned from prior owner corrections.');
-    directiveLines.push('These directives are mandatory for this session unless they conflict with safety, security, or higher-priority system policy.');
-    directiveLines.push('For ambiguous coding or file-changing tasks, follow these directives before using mutating tools.');
-    directiveLines.push('');
-    for (const p of dedupedV2) {
-      if (!runtimeV2PrincipleIds.has(p.principleId)) continue;
-      directiveLines.push(`<directive id="${escapeXml(p.principleId)}" source="runtime_v2_activation">`);
-      directiveLines.push(`MANDATORY: ${escapeXml(p.text)}`);
-      directiveLines.push('Apply this as an active behavior constraint. Do not treat this as background context.');
-      directiveLines.push('</directive>');
-      directiveLines.push('');
-    }
-    directiveLines.push('Note: These directives do not override safety, security, or core system policy.');
-    prependSystemContext += directiveLines.join('\n');
+    const directiveText = renderPrinciplesToDirectives(dedupedV2, runtimeV2PrincipleIds, escapeXml);
+    prependSystemContext += directiveText;
   }
 
   // Routing Guidance (section 5 — injected between evolution principles and core principles)

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -145,6 +145,8 @@ const REQUIRED_SOURCE_FILES = [
   // PRI-146
   'activation/writers/rule-host-writer.ts',
   'activation/writers/index.ts',
+  // PRI-295
+  'activation/prompt-activation-reader-contract.ts',
   // PRI-215
   'synthetic-baseline.ts',
   // PRI-239
@@ -403,6 +405,8 @@ const REQUIRED_TEST_FILES = [
   'synthetic-baseline.test.ts',
   // PRI-239
   '../feature-flags/__tests__/feature-flag-contract.test.ts',
+  // PRI-295
+  '../activation/__tests__/prompt-activation-reader-contract.test.ts',
 ];
 
 const REQUIRED_DOC_FILES: string[] = [];
@@ -465,6 +469,11 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     // PRI-239
     'validateFeatureFlagRaw',
     'computeEffectiveFlags',
+    // PRI-295
+    'filterPromptActivations',
+    'resolvePrincipleFromArtifact',
+    'trimToBudget',
+    'renderPrinciplesToDirectives',
   ];
 
   for (const name of REQUIRED_EXPORTS) {

--- a/packages/principles-core/src/runtime-v2/activation/__tests__/prompt-activation-reader-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/__tests__/prompt-activation-reader-contract.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isRecord,
+  filterPromptActivations,
+  resolvePrincipleFromArtifact,
+  trimToBudget,
+  renderPrinciplesToDirectives,
+  RUNTIME_V2_PRINCIPLE_BUDGET,
+} from '../prompt-activation-reader-contract.js';
+import type { ActivationStatusRecord } from '../activation-types.js';
+
+function makeActivation(overrides: Partial<ActivationStatusRecord> = {}): ActivationStatusRecord {
+  return {
+    activationId: 'act-1',
+    idempotencyKey: 'art-1::prompt',
+    artifactId: 'art-1',
+    channel: 'prompt',
+    action: 'prompt_activate',
+    targetRef: 'prependSystemContext',
+    activatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeArtifactRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    artifact_id: 'art-1',
+    artifact_kind: 'principle',
+    content_json: JSON.stringify({ principleId: 'P-001', text: 'Always use typeof checks' }),
+    validation_status: 'validated',
+    ...overrides,
+  };
+}
+
+describe('prompt-activation-reader-contract', () => {
+  describe('isRecord', () => {
+    it('returns true for plain objects', () => {
+      expect(isRecord({})).toBe(true);
+      expect(isRecord({ a: 1 })).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isRecord(null)).toBe(false);
+    });
+
+    it('returns false for arrays', () => {
+      expect(isRecord([])).toBe(false);
+      expect(isRecord([1, 2])).toBe(false);
+    });
+
+    it('returns false for primitives', () => {
+      expect(isRecord('string')).toBe(false);
+      expect(isRecord(42)).toBe(false);
+      expect(isRecord(true)).toBe(false);
+      expect(isRecord(undefined)).toBe(false);
+    });
+  });
+
+  describe('filterPromptActivations', () => {
+    it('keeps only prompt/prompt_activate activations', () => {
+      const activations = [
+        makeActivation({ channel: 'prompt', action: 'prompt_activate' }),
+        makeActivation({ channel: 'code_tool_hook', action: 'activate', activationId: 'act-2', artifactId: 'art-2' }),
+        makeActivation({ channel: 'prompt', action: 'deactivate', activationId: 'act-3', artifactId: 'art-3' }),
+        makeActivation({ channel: 'defer_archive', action: 'prompt_activate', activationId: 'act-4', artifactId: 'art-4' }),
+      ];
+      const result = filterPromptActivations(activations);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.activationId).toBe('act-1');
+    });
+
+    it('returns empty for no matching activations', () => {
+      const activations = [
+        makeActivation({ channel: 'code_tool_hook', action: 'activate' }),
+      ];
+      expect(filterPromptActivations(activations)).toHaveLength(0);
+    });
+
+    it('returns empty for empty input', () => {
+      expect(filterPromptActivations([])).toHaveLength(0);
+    });
+  });
+
+  describe('resolvePrincipleFromArtifact', () => {
+    it('resolves a valid artifact row with principleId and text', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow();
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.principle.principleId).toBe('P-001');
+        expect(result.principle.text).toBe('Always use typeof checks');
+        expect(result.principle.artifactId).toBe('art-1');
+        expect(result.principle.activationId).toBe('act-1');
+      }
+    });
+
+    it('falls back to principleDraft.title and principleDraft.statement', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({
+        content_json: JSON.stringify({
+          principleDraft: { title: 'D-001', statement: 'Draft statement' },
+        }),
+      });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.principle.principleId).toBe('D-001');
+        expect(result.principle.text).toBe('Draft statement');
+      }
+    });
+
+    it('prefers principleId/text over principleDraft', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({
+        content_json: JSON.stringify({
+          principleId: 'P-001',
+          text: 'Primary text',
+          principleDraft: { title: 'D-001', statement: 'Draft text' },
+        }),
+      });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.principle.principleId).toBe('P-001');
+        expect(result.principle.text).toBe('Primary text');
+      }
+    });
+
+    it('rejects non-record artifact row', () => {
+      const activation = makeActivation();
+      const result = resolvePrincipleFromArtifact(null, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_query_unexpected');
+      }
+    });
+
+    it('rejects array artifact row', () => {
+      const activation = makeActivation();
+      const result = resolvePrincipleFromArtifact([1, 2], activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_query_unexpected');
+      }
+    });
+
+    it('rejects artifact with missing artifact_id', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({ artifact_id: '' });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_not_found');
+      }
+    });
+
+    it('rejects artifact with non-principle kind', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({ artifact_kind: 'trace' });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_not_principle');
+      }
+    });
+
+    it('rejects artifact that is not validated', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({ validation_status: 'pending' });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_not_validated');
+      }
+    });
+
+    it('rejects artifact with missing validation_status', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow();
+      delete artifact.validation_status;
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_not_validated');
+      }
+    });
+
+    it('rejects artifact with missing content_json', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow();
+      delete artifact.content_json;
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_missing_content_json');
+      }
+    });
+
+    it('rejects artifact with invalid JSON in content_json', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({ content_json: '{invalid json' });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_content_json_parse_error');
+      }
+    });
+
+    it('rejects artifact where content_json parses to non-object', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({ content_json: '"a string"' });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_content_malformed');
+      }
+    });
+
+    it('rejects artifact with missing principleId and no draft fallback', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({
+        content_json: JSON.stringify({ text: 'Some text' }),
+      });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_missing_principle_id');
+      }
+    });
+
+    it('rejects artifact with missing text and no draft fallback', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({
+        content_json: JSON.stringify({ principleId: 'P-001' }),
+      });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_missing_text');
+      }
+    });
+
+    it('rejects artifact with empty principleId and empty draft title', () => {
+      const activation = makeActivation();
+      const artifact = makeArtifactRow({
+        content_json: JSON.stringify({ principleId: '', text: 'Some text', principleDraft: { title: '', statement: 'Draft' } }),
+      });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('artifact_missing_principle_id');
+      }
+    });
+
+    it('handles artifact with prototype-polluted keys safely', () => {
+      const activation = makeActivation();
+      const artifact = Object.create(null);
+      artifact.__proto__ = { malicious: true };
+      artifact.artifact_id = 'art-1';
+      artifact.artifact_kind = 'principle';
+      artifact.content_json = JSON.stringify({ principleId: 'P-001', text: 'Safe' });
+      artifact.validation_status = 'validated';
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(true);
+    });
+
+    it('handles content_json with inherited properties safely', () => {
+      const activation = makeActivation();
+      const contentObj = Object.create({ toString: 'inherited' });
+      contentObj.principleId = 'P-001';
+      contentObj.text = 'Safe text';
+      const artifact = makeArtifactRow({
+        content_json: JSON.stringify(contentObj),
+      });
+      const result = resolvePrincipleFromArtifact(artifact, activation);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.principle.principleId).toBe('P-001');
+        expect(result.principle.text).toBe('Safe text');
+      }
+    });
+
+    it('includes nextAction in every warning', () => {
+      const activation = makeActivation();
+      const result = resolvePrincipleFromArtifact(null, activation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.warning).toContain('nextAction=');
+      }
+    });
+  });
+
+  describe('trimToBudget', () => {
+    it('includes all principles within budget', () => {
+      const principles = [
+        { principleId: 'P-001', text: 'Short', artifactId: 'a1', activationId: 'act1' },
+      ];
+      const { lines, injectedIds, truncated } = trimToBudget(principles, 2000);
+      expect(lines.length).toBeGreaterThan(1);
+      expect(injectedIds.has('P-001')).toBe(true);
+      expect(truncated).toBe(false);
+    });
+
+    it('truncates when budget is exceeded', () => {
+      const principles = Array.from({ length: 100 }, (_, i) => ({
+        principleId: `P-${String(i).padStart(3, '0')}`,
+        text: 'A'.repeat(100),
+        artifactId: `a${i}`,
+        activationId: `act${i}`,
+      }));
+      const { lines: _lines, injectedIds, truncated } = trimToBudget(principles, 500);
+      expect(truncated).toBe(true);
+      expect(injectedIds.size).toBeLessThan(100);
+    });
+
+    it('returns empty injectedIds for zero principles', () => {
+      const { lines, injectedIds, truncated } = trimToBudget([], 2000);
+      expect(injectedIds.size).toBe(0);
+      expect(truncated).toBe(false);
+      expect(lines).toHaveLength(1);
+    });
+
+    it('uses custom escape function', () => {
+      const principles = [
+        { principleId: 'P<001>', text: 'A&B', artifactId: 'a1', activationId: 'act1' },
+      ];
+      const escapeXml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const { lines } = trimToBudget(principles, 2000, escapeXml);
+      expect(lines[1]).toContain('P&lt;001&gt;');
+      expect(lines[1]).toContain('A&amp;B');
+    });
+  });
+
+  describe('renderPrinciplesToDirectives', () => {
+    it('renders directive XML for injected principles', () => {
+      const principles = [
+        { principleId: 'P-001', text: 'Always use typeof', artifactId: 'a1', activationId: 'act1' },
+        { principleId: 'P-002', text: 'Never use as', artifactId: 'a2', activationId: 'act2' },
+      ];
+      const injectedIds = new Set(['P-001', 'P-002']);
+      const result = renderPrinciplesToDirectives(principles, injectedIds);
+      expect(result).toContain('<directive id="P-001"');
+      expect(result).toContain('MANDATORY: Always use typeof');
+      expect(result).toContain('<directive id="P-002"');
+      expect(result).toContain('MANDATORY: Never use as');
+      expect(result).toContain('OWNER-APPROVED BEHAVIOR DIRECTIVES');
+    });
+
+    it('returns empty string when no principles injected', () => {
+      const principles = [
+        { principleId: 'P-001', text: 'Always use typeof', artifactId: 'a1', activationId: 'act1' },
+      ];
+      const result = renderPrinciplesToDirectives(principles, new Set());
+      expect(result).toBe('');
+    });
+
+    it('skips principles not in injectedIds', () => {
+      const principles = [
+        { principleId: 'P-001', text: 'Included', artifactId: 'a1', activationId: 'act1' },
+        { principleId: 'P-002', text: 'Excluded', artifactId: 'a2', activationId: 'act2' },
+      ];
+      const injectedIds = new Set(['P-001']);
+      const result = renderPrinciplesToDirectives(principles, injectedIds);
+      expect(result).toContain('P-001');
+      expect(result).not.toContain('P-002');
+    });
+
+    it('uses custom escape function', () => {
+      const principles = [
+        { principleId: 'P<001>', text: 'A&B', artifactId: 'a1', activationId: 'act1' },
+      ];
+      const injectedIds = new Set(['P<001>']);
+      const escapeXml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const result = renderPrinciplesToDirectives(principles, injectedIds, escapeXml);
+      expect(result).toContain('P&lt;001&gt;');
+      expect(result).toContain('A&amp;B');
+    });
+  });
+
+  describe('RUNTIME_V2_PRINCIPLE_BUDGET', () => {
+    it('is 2000', () => {
+      expect(RUNTIME_V2_PRINCIPLE_BUDGET).toBe(2000);
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/activation/index.ts
+++ b/packages/principles-core/src/runtime-v2/activation/index.ts
@@ -63,3 +63,17 @@ export { SqliteApprovalQueueStore } from './sqlite-approval-store.js';
 
 export { RuleHostWriter } from './writers/rule-host-writer.js';
 export type { RuleHostWriterConfig } from './writers/rule-host-writer.js';
+
+export {
+  RUNTIME_V2_PRINCIPLE_BUDGET,
+  isRecord as isArtifactRecord,
+  filterPromptActivations,
+  resolvePrincipleFromArtifact,
+  trimToBudget,
+  renderPrinciplesToDirectives,
+} from './prompt-activation-reader-contract.js';
+
+export type {
+  ActivatedPrinciple,
+  PromptActivationReaderResult,
+} from './prompt-activation-reader-contract.js';

--- a/packages/principles-core/src/runtime-v2/activation/prompt-activation-reader-contract.ts
+++ b/packages/principles-core/src/runtime-v2/activation/prompt-activation-reader-contract.ts
@@ -1,0 +1,158 @@
+import type { ActivationStatusRecord } from './activation-types.js';
+
+export const RUNTIME_V2_PRINCIPLE_BUDGET = 2000;
+
+export interface ActivatedPrinciple {
+  principleId: string;
+  text: string;
+  artifactId: string;
+  activationId: string;
+}
+
+export interface PromptActivationReaderResult {
+  principles: ActivatedPrinciple[];
+  warnings: string[];
+  source: 'runtime_v2';
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeJsonParse(input: string): unknown | null {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return null;
+  }
+}
+
+export function filterPromptActivations(
+  activations: ActivationStatusRecord[],
+): ActivationStatusRecord[] {
+  return activations.filter(
+    (a) => a.channel === 'prompt' && a.action === 'prompt_activate',
+  );
+}
+
+export function resolvePrincipleFromArtifact(
+  artifactRow: unknown,
+  activation: ActivationStatusRecord,
+): { ok: true; principle: ActivatedPrinciple } | { ok: false; warning: string } {
+  if (!isRecord(artifactRow)) {
+    return { ok: false, warning: `artifact_query_unexpected: artifactId=${activation.artifactId}; nextAction=check_pi_artifacts_table` };
+  }
+
+  const artifact_id = Object.hasOwn(artifactRow, 'artifact_id') && typeof artifactRow.artifact_id === 'string' && artifactRow.artifact_id.length > 0 ? artifactRow.artifact_id : null;
+  const artifact_kind = Object.hasOwn(artifactRow, 'artifact_kind') && typeof artifactRow.artifact_kind === 'string' ? artifactRow.artifact_kind : null;
+  const raw_content_json = Object.hasOwn(artifactRow, 'content_json') && typeof artifactRow.content_json === 'string' ? artifactRow.content_json : null;
+  const validation_status = Object.hasOwn(artifactRow, 'validation_status') && typeof artifactRow.validation_status === 'string' ? artifactRow.validation_status : null;
+
+  if (!artifact_id) {
+    return { ok: false, warning: `artifact_not_found: artifactId=${activation.artifactId} activationId=${activation.activationId}; nextAction=verify_artifact_exists_or_remove_stale_activation` };
+  }
+
+  if (artifact_kind !== 'principle') {
+    return { ok: false, warning: `artifact_not_principle: artifactId=${artifact_id} kind=${artifact_kind ?? 'missing'}; nextAction=skip_non_principle_activations` };
+  }
+
+  if (validation_status !== 'validated') {
+    return { ok: false, warning: `artifact_not_validated: artifactId=${artifact_id} status=${validation_status ?? 'missing'}; nextAction=skip_unvalidated_artifacts` };
+  }
+
+  if (raw_content_json === null) {
+    return { ok: false, warning: `artifact_missing_content_json: artifactId=${artifact_id}; nextAction=ensure_artifact_has_content_json` };
+  }
+
+  const parsed = safeJsonParse(raw_content_json);
+  if (parsed === null) {
+    return { ok: false, warning: `artifact_content_json_parse_error: artifactId=${activation.artifactId} reason=invalid_json; nextAction=fix_artifact_content_json` };
+  }
+
+  if (!isRecord(parsed)) {
+    return { ok: false, warning: `artifact_content_malformed: artifactId=${activation.artifactId} reason=parsed_to_non_object; nextAction=fix_artifact_content_json` };
+  }
+
+  const principleId = Object.hasOwn(parsed, 'principleId') && typeof parsed.principleId === 'string' ? parsed.principleId : undefined;
+  const text = Object.hasOwn(parsed, 'text') && typeof parsed.text === 'string' ? parsed.text : undefined;
+
+  const draftObj = Object.hasOwn(parsed, 'principleDraft') && isRecord(parsed.principleDraft) ? parsed.principleDraft : null;
+  const draftTitle = draftObj && Object.hasOwn(draftObj, 'title') && typeof draftObj.title === 'string' ? draftObj.title : undefined;
+  const draftStatement = draftObj && Object.hasOwn(draftObj, 'statement') && typeof draftObj.statement === 'string' ? draftObj.statement : undefined;
+
+  const resolvedPrincipleId = principleId && principleId.length > 0 ? principleId : draftTitle;
+  const resolvedText = text && text.length > 0 ? text : draftStatement;
+
+  if (!resolvedPrincipleId || resolvedPrincipleId.length === 0) {
+    return { ok: false, warning: `artifact_missing_principle_id: artifactId=${activation.artifactId}; nextAction=ensure_artifact_has_principleId_or_principleDraft_title` };
+  }
+
+  if (!resolvedText || resolvedText.length === 0) {
+    return { ok: false, warning: `artifact_missing_text: artifactId=${activation.artifactId} principleId=${resolvedPrincipleId}; nextAction=ensure_artifact_has_text_or_principleDraft_statement` };
+  }
+
+  return {
+    ok: true,
+    principle: {
+      principleId: resolvedPrincipleId,
+      text: resolvedText,
+      artifactId: activation.artifactId,
+      activationId: activation.activationId,
+    },
+  };
+}
+
+export function trimToBudget(
+  principles: ActivatedPrinciple[],
+  budget: number,
+  escapeFn: (s: string) => string = (s) => s,
+): { lines: string[]; injectedIds: Set<string>; truncated: boolean } {
+  const lines: string[] = [];
+  const injectedIds = new Set<string>();
+  let remaining = budget;
+  let truncated = false;
+
+  const header = 'Runtime V2 activated principles (owner-approved):';
+  lines.push(header);
+  remaining -= header.length;
+
+  for (const p of principles) {
+    const entry = `- [${escapeFn(p.principleId)}] ${escapeFn(p.text)}`;
+    if (remaining < entry.length + 1) {
+      truncated = true;
+      break;
+    }
+    lines.push(entry);
+    remaining -= entry.length + 1;
+    injectedIds.add(p.principleId);
+  }
+
+  return { lines, injectedIds, truncated };
+}
+
+export function renderPrinciplesToDirectives(
+  principles: { principleId: string; text: string; artifactId: string; activationId: string }[],
+  injectedIds: Set<string>,
+  escapeFn: (s: string) => string = (s) => s,
+): string {
+  if (injectedIds.size === 0) return '';
+
+  const directiveLines: string[] = [];
+  directiveLines.push('');
+  directiveLines.push('## 【OWNER-APPROVED BEHAVIOR DIRECTIVES】');
+  directiveLines.push('');
+  directiveLines.push('Owner-approved behavior directives are active operating constraints learned from prior owner corrections.');
+  directiveLines.push('These directives are mandatory for this session unless they conflict with safety, security, or higher-priority system policy.');
+  directiveLines.push('For ambiguous coding or file-changing tasks, follow these directives before using mutating tools.');
+  directiveLines.push('');
+  for (const p of principles) {
+    if (!injectedIds.has(p.principleId)) continue;
+    directiveLines.push(`<directive id="${escapeFn(p.principleId)}" source="runtime_v2_activation">`);
+    directiveLines.push(`MANDATORY: ${escapeFn(p.text)}`);
+    directiveLines.push('Apply this as an active behavior constraint. Do not treat this as background context.');
+    directiveLines.push('</directive>');
+    directiveLines.push('');
+  }
+  directiveLines.push('Note: These directives do not override safety, security, or core system policy.');
+  return directiveLines.join('\n');
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -961,6 +961,17 @@ export {
   MemoryApprovalQueueStore,
   SqliteApprovalQueueStore,
   mapConfidenceToLabel,
+  RUNTIME_V2_PRINCIPLE_BUDGET,
+  isArtifactRecord,
+  filterPromptActivations,
+  resolvePrincipleFromArtifact,
+  trimToBudget,
+  renderPrinciplesToDirectives,
+} from './activation/index.js';
+
+export type {
+  ActivatedPrinciple,
+  PromptActivationReaderResult,
 } from './activation/index.js';
 
 // ── GFI Core Kernel (PRI-76) ────────────────────────────────────────────────


### PR DESCRIPTION
## PRI-295: Move Runtime V2 prompt activation reader contract into core

### Summary

Moves pure prompt activation filtering/rendering logic from \openclaw-plugin\ into \principles-core\, making the plugin a thin I/O adapter.

### What moved to core (pure logic)

- \ilterPromptActivations()\ — channel/action filtering (\channel === 'prompt' && action === 'prompt_activate'\)
- \esolvePrincipleFromArtifact()\ — artifact row validation + principle extraction
- \	rimToBudget()\ — budget trimming
- \enderPrinciplesToDirectives()\ — directive XML rendering
- \RUNTIME_V2_PRINCIPLE_BUDGET\ constant (2000)
- \isRecord()\ runtime type guard (exported as \isArtifactRecord\)

### What stays in plugin (I/O boundary)

- SQLite store creation + artifact row queries
- Feature flag YAML loading (fs)
- OpenClaw event logging
- Workspace directory binding
- Legacy principle dedup
- \prependSystemContext\ assembly

### Files changed

| File | Change |
|------|--------|
| \packages/principles-core/src/runtime-v2/activation/prompt-activation-reader-contract.ts\ | **NEW** — Pure contract with runtime validation |
| \packages/principles-core/src/runtime-v2/activation/__tests__/prompt-activation-reader-contract.test.ts\ | **NEW** — 34 core tests |
| \packages/principles-core/src/runtime-v2/activation/index.ts\ | Added exports |
| \packages/principles-core/src/runtime-v2/index.ts\ | Added barrel exports |
| \packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts\ | Added PRI-295 entries |
| \packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts\ | Refactored to thin I/O adapter |
| \packages/openclaw-plugin/src/hooks/prompt.ts\ | Import from core |

### ERR Checklist

- **ERR-001 / ERR-005**: No \s\ casts on untrusted data; all DB/artifact input validated via \isRecord()\ + \Object.hasOwn()\ + \	ypeof\
- **ERR-011**: No I/O (fs/db/network/process) in core contract
- **ERR-013**: \Object.hasOwn()\ for all untrusted object key checks
- **ERR-048**: Activation read path remains connected — prompt hook still reads from activations table
- **ERR-025**: Tests cover real production path (34 core + 32 plugin tests)

### Verification

\\\ash
npm run build --workspace=@principles/core          # ✅
npm run build --workspace=@principles/openclaw-plugin # ✅
npx vitest run packages/principles-core/src/runtime-v2/activation/__tests__/prompt-activation-reader-contract.test.ts  # 34 passed
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts  # 440 passed
npx vitest run packages/openclaw-plugin/tests/hooks/runtime-v2-prompt-activation.test.ts  # 32 passed
npm run verify:merge  # ✅
\\\

### Acceptance Criteria

1. ✅ Core owns pure prompt activation filtering/rendering contract
2. ✅ Plugin adapter remains responsible for workspace binding, store creation, and event emission
3. ✅ Runtime V2 prompt activation still injects validated \prompt_activate\ directives into \prependSystemContext\
4. ✅ Tests cover malformed DB/artifact input without \s\ bypass
5. ✅ Architecture guard prevents OpenClaw imports into core