### PR TITLE
refactor(openclaw-plugin): reconcile correction observer ownership for MVP

### DIFF
--- a/docs/adr/0014-mvp-first-strategy-and-product-pivot.md
+++ b/docs/adr/0014-mvp-first-strategy-and-product-pivot.md
@@ -232,8 +232,8 @@ During real-world execution testing of MVP Story A', it was observed that **dete
 To resolve this bottleneck, we have promoted the **Empathy Observer** (previously classified as MVP-Quiet) and **Correction Observer** (previously part of the retired nocturnal pipeline, now re-designed as an active SDK-level periodic optimizer) to **MVP-Core**.
 
 - **Empathy Observer**: Uses LLM semantic analysis in the background of conversational prompts to extract high-quality emotional friction and frustration keywords from user messages. This reactively captures frustration patterns that traditional programmatic error-catchers miss completely.
-- **Correction Observer**: Periodically reviews SQLite trajectory history on worker heartbeat to automatically adjust keyword weights and decay false positives, ensuring trigger accuracy continuously remains self-correcting.
+- **Correction Observer**: Periodically reviews SQLite trajectory history to automatically adjust keyword weights and decay false positives, ensuring trigger accuracy continuously remains self-correcting. Now runs as an **independent service** (not on evolution heartbeat) per PRI-293.
 
 ### Reclassified Items
 1. **Empathy Observer**: Reclassified from **MVP-Quiet** to **MVP-Core** (wired asynchronously in the prompt build hook).
-2. **Correction Observer**: Reclassified from **MVP-Gone** (as nocturnal workflow) to **MVP-Core** (as a lightweight SDK-level observer triggered on evolution heartbeat).
+2. **Correction Observer**: Reclassified from **MVP-Gone** (as nocturnal workflow) to **MVP-Core**. Originally triggered on evolution heartbeat; extracted to an independent service with its own feature flag (`correction_observer`, core, default on) per PRI-293, so it no longer depends on the default-off EvolutionWorker.

--- a/docs/adr/0014-mvp-first-strategy-and-product-pivot.md
+++ b/docs/adr/0014-mvp-first-strategy-and-product-pivot.md
@@ -236,4 +236,4 @@ To resolve this bottleneck, we have promoted the **Empathy Observer** (previousl
 
 ### Reclassified Items
 1. **Empathy Observer**: Reclassified from **MVP-Quiet** to **MVP-Core** (wired asynchronously in the prompt build hook).
-2. **Correction Observer**: Reclassified from **MVP-Gone** (as nocturnal workflow) to **MVP-Core**. Originally triggered on evolution heartbeat; extracted to an independent service with its own feature flag (`correction_observer`, core, default on) per PRI-293, so it no longer depends on the default-off EvolutionWorker.
+2. **Correction Observer**: Reclassified from **MVP-Gone** (as nocturnal workflow) to **MVP-Core**. Originally triggered on evolution heartbeat; extracted to an independent service with its own feature flag (`correction_observer`, quiet category with enabled=true default, to allow runtime disabling) per PRI-293, so it no longer depends on the default-off EvolutionWorker. Surface registry entries remain `core` for triage; feature flag is `quiet` to preserve the runtime kill switch.

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -49,6 +49,7 @@ import { handleExportCommand } from './commands/export.js';
 import { handleSamplesCommand } from './commands/samples.js';
 import { handleWorkflowDebugCommand } from './commands/workflow-debug.js';
 import { EvolutionWorkerService } from './service/evolution-worker.js';
+import { CorrectionObserverService } from './service/correction-observer-service.js';
 import { TrajectoryService } from './service/trajectory-service.js';
 import { PDTaskService } from './core/pd-task-service.js';
 import { CentralSyncService } from './service/central-sync-service.js';
@@ -168,6 +169,30 @@ export function shouldStartEvolutionWorker(
   return { shouldStart: false, flagSource: flag.source, disabledInfo };
 }
 
+export interface CorrectionObserverGateResult {
+  shouldStart: boolean;
+  flagSource: string;
+  disabledInfo: string | null;
+}
+
+export function shouldStartCorrectionObserver(
+  workspaceDir: string,
+  logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+): CorrectionObserverGateResult {
+  const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'correction_observer', logger);
+  if (flag.enabled) {
+    return { shouldStart: true, flagSource: flag.source, disabledInfo: null };
+  }
+  const disabledInfo = JSON.stringify({
+    reason: 'correction_observer_disabled',
+    nextAction: 'set correction_observer.enabled=true in .pd/feature-flags.yaml to enable',
+    featureFlag: 'correction_observer',
+    boundedContext: 'correction_observer_service',
+    flagSource: flag.source,
+  });
+  return { shouldStart: false, flagSource: flag.source, disabledInfo };
+}
+
 const plugin = {
   name: "Principles Disciple",
   description: "Evolutionary programming agent framework with strategic guardrails and reflection loops.",
@@ -245,6 +270,22 @@ const plugin = {
               // Structured observability per ERR-002: no silent skip
               api.logger.info(`[PD] EvolutionWorker NOT started for workspace: ${workspaceDir}. ${gate.disabledInfo}`);
               SystemLogger.log(workspaceDir, 'EVOLUTION_WORKER_DISABLED', gate.disabledInfo ?? '');
+            }
+
+            // ── Start CorrectionObserver for THIS workspace ──
+            // MVP-Core per ADR-0014 amendment, independently owned (PRI-293).
+            const corrGate = shouldStartCorrectionObserver(workspaceDir, api.logger);
+            if (corrGate.shouldStart) {
+              CorrectionObserverService.start({
+                config: api.config,
+                workspaceDir,
+                stateDir: path.join(workspaceDir, '.state'),
+                logger: api.logger,
+              });
+              api.logger.info(`[PD] CorrectionObserver started for workspace: ${workspaceDir} (flag source: ${corrGate.flagSource})`);
+            } else {
+              api.logger.info(`[PD] CorrectionObserver NOT started for workspace: ${workspaceDir}. ${corrGate.disabledInfo}`);
+              SystemLogger.log(workspaceDir, 'CORRECTION_OBSERVER_DISABLED', corrGate.disabledInfo ?? '');
             }
           }
 
@@ -527,6 +568,8 @@ const plugin = {
       EvolutionWorkerService.api = api;
       const guardedEvolutionWorker = guardService('service:evolution-worker', EvolutionWorkerService, api.logger);
       if (guardedEvolutionWorker) api.registerService(guardedEvolutionWorker);
+      const guardedCorrectionObserver = guardService('service:correction-observer', CorrectionObserverService, api.logger);
+      if (guardedCorrectionObserver) api.registerService(guardedCorrectionObserver);
       const guardedTrajectory = guardService('service:trajectory', TrajectoryService, api.logger);
       if (guardedTrajectory) api.registerService(guardedTrajectory);
       const guardedPdTask = guardService('service:pd-task', PDTaskService, api.logger);

--- a/packages/openclaw-plugin/src/service/correction-observer-service.ts
+++ b/packages/openclaw-plugin/src/service/correction-observer-service.ts
@@ -19,6 +19,7 @@ export interface CorrectionObserverServiceShape {
 
 let correctionObserverTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let correctionObserverStopped = false;
+const startedWorkspaces = new Set<string>();
 
 const CORRECTION_OBSERVER_INTERVAL_MS = 15 * 60 * 1000;
 const CORRECTION_OBSERVER_INITIAL_DELAY_MS = 10_000;
@@ -158,6 +159,12 @@ export const CorrectionObserverService: CorrectionObserverServiceShape = {
             return;
         }
 
+        if (startedWorkspaces.has(workspaceDir)) {
+            if (logger) logger.info(`[PD:CorrectionObserver] Already started for workspace: ${workspaceDir}. Skipping duplicate start.`);
+            return;
+        }
+        startedWorkspaces.add(workspaceDir);
+
         correctionObserverStopped = false;
 
         const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });
@@ -186,6 +193,7 @@ export const CorrectionObserverService: CorrectionObserverServiceShape = {
 
     stop(_ctx: OpenClawPluginServiceContext): void {
         correctionObserverStopped = true;
+        startedWorkspaces.clear();
         if (correctionObserverTimeoutId) clearTimeout(correctionObserverTimeoutId);
         correctionObserverTimeoutId = null;
     },

--- a/packages/openclaw-plugin/src/service/correction-observer-service.ts
+++ b/packages/openclaw-plugin/src/service/correction-observer-service.ts
@@ -18,6 +18,7 @@ export interface CorrectionObserverServiceShape {
 }
 
 let correctionObserverTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let correctionObserverStopped = false;
 
 const CORRECTION_OBSERVER_INTERVAL_MS = 15 * 60 * 1000;
 const CORRECTION_OBSERVER_INITIAL_DELAY_MS = 10_000;
@@ -157,13 +158,17 @@ export const CorrectionObserverService: CorrectionObserverServiceShape = {
             return;
         }
 
+        correctionObserverStopped = false;
+
         const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });
         if (logger) logger.info(`[PD:CorrectionObserver] Starting with workspaceDir=${wctx.workspaceDir}, stateDir=${wctx.stateDir}`);
 
         const interval = CORRECTION_OBSERVER_INTERVAL_MS;
 
         async function runCycle(): Promise<void> {
+            if (correctionObserverStopped) return;
             await runCorrectionObserverCycle(wctx, logger);
+            if (correctionObserverStopped) return;
             correctionObserverTimeoutId = setTimeout(runCycle, interval);
             correctionObserverTimeoutId.unref();
         }
@@ -171,6 +176,7 @@ export const CorrectionObserverService: CorrectionObserverServiceShape = {
         correctionObserverTimeoutId = setTimeout(() => {
             void runCycle().catch((err) => {
                 if (logger) logger.error(`[PD:CorrectionObserver] Startup cycle failed: ${String(err)}`);
+                if (correctionObserverStopped) return;
                 correctionObserverTimeoutId = setTimeout(runCycle, interval);
                 correctionObserverTimeoutId.unref();
             });
@@ -179,6 +185,7 @@ export const CorrectionObserverService: CorrectionObserverServiceShape = {
     },
 
     stop(_ctx: OpenClawPluginServiceContext): void {
+        correctionObserverStopped = true;
         if (correctionObserverTimeoutId) clearTimeout(correctionObserverTimeoutId);
         correctionObserverTimeoutId = null;
     },

--- a/packages/openclaw-plugin/src/service/correction-observer-service.ts
+++ b/packages/openclaw-plugin/src/service/correction-observer-service.ts
@@ -1,0 +1,185 @@
+import type { OpenClawPluginServiceContext, PluginLogger } from '../openclaw-sdk.js';
+import { WorkspaceContext } from '../core/workspace-context.js';
+import { TrajectoryRegistry } from '../core/trajectory.js';
+import { CorrectionCueLearner } from '../core/correction-cue-learner.js';
+import {
+    WorkflowFunnelLoader,
+    PiAiRuntimeAdapter,
+    CorrectionObserver,
+    AgentScheduler,
+} from '@principles/core/runtime-v2';
+import { KeywordOptimizationService } from './keyword-optimization-service.js';
+import { SystemLogger } from '../core/system-logger.js';
+
+export interface CorrectionObserverServiceShape {
+    id: string;
+    start: (ctx: OpenClawPluginServiceContext) => void;
+    stop?: (ctx: OpenClawPluginServiceContext) => void;
+}
+
+let correctionObserverTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+const CORRECTION_OBSERVER_INTERVAL_MS = 15 * 60 * 1000;
+const CORRECTION_OBSERVER_INITIAL_DELAY_MS = 10_000;
+const CORRECTION_OBSERVER_MAX_RECENT_SESSIONS = 20;
+const CORRECTION_OBSERVER_MAX_PAYLOAD_SESSIONS = 5;
+
+export function resolveCorrectionObserver(wctx: WorkspaceContext, logger?: Pick<PluginLogger, 'info' | 'warn' | 'error' | 'debug'>): CorrectionObserver | null {
+    try {
+        const loader = new WorkflowFunnelLoader(wctx.stateDir);
+        const funnel = loader.getFunnel('pd-correction-observer');
+        const policy = funnel?.policy;
+        if (!policy || policy.runtimeKind !== 'pi-ai') {
+            logger?.debug?.('[PD:CorrectionObserver] workflows.yaml pd-correction-observer policy not found. Falling back to environment variables.');
+            const provider = process.env.PD_CORRECTION_PROVIDER || 'anthropic';
+            const model = process.env.PD_CORRECTION_MODEL || 'anthropic/claude-3-5-sonnet';
+            const apiKeyEnv = process.env.PD_CORRECTION_API_KEY_ENV || 'ANTHROPIC_API_KEY';
+            const baseUrl = process.env.PD_CORRECTION_BASE_URL;
+
+            if (!process.env[apiKeyEnv]) {
+                logger?.debug?.(`[PD:CorrectionObserver] API key env ${apiKeyEnv} is not set. Periodic optimization disabled.`);
+                return null;
+            }
+
+            const adapter = new PiAiRuntimeAdapter({
+                provider,
+                model,
+                apiKeyEnv,
+                baseUrl,
+                workspace: wctx.workspaceDir,
+            });
+            return new CorrectionObserver({ runtimeAdapter: adapter });
+        }
+
+        const adapter = new PiAiRuntimeAdapter({
+            provider: String(policy.provider),
+            model: String(policy.model),
+            apiKeyEnv: String(policy.apiKeyEnv),
+            maxRetries: policy.maxRetries,
+            timeoutMs: policy.timeoutMs ?? 30_000,
+            baseUrl: policy.baseUrl,
+            workspace: wctx.workspaceDir,
+        });
+        return new CorrectionObserver({ runtimeAdapter: adapter }, { timeoutMs: policy.timeoutMs });
+    } catch (err) {
+        logger?.warn?.(`[PD:CorrectionObserver] Failed to resolve CorrectionObserver: ${String(err)}`);
+        return null;
+    }
+}
+
+export async function runCorrectionObserverCycle(wctx: WorkspaceContext, logger: PluginLogger): Promise<void> {
+    try {
+        const observer = resolveCorrectionObserver(wctx, logger);
+        if (!observer) {
+            logger?.info?.('[PD:CorrectionObserver] Observer not resolved (no API key or config). Skipping cycle.');
+            return;
+        }
+
+        logger?.info?.('[PD:CorrectionObserver] Observer resolved. Initiating periodic optimization...');
+
+        const db = TrajectoryRegistry.get(wctx.workspaceDir);
+        const recentSessions = db.listRecentSessions({ limit: CORRECTION_OBSERVER_MAX_RECENT_SESSIONS });
+        const recentSessionIds = recentSessions.map(s => s.sessionId);
+
+        if (recentSessionIds.length === 0) {
+            logger?.info?.('[PD:CorrectionObserver] No recent sessions found. Skipping correction optimization.');
+            return;
+        }
+
+        const recentMessages: string[] = [];
+        for (const sId of recentSessionIds.slice(0, CORRECTION_OBSERVER_MAX_PAYLOAD_SESSIONS)) {
+            try {
+                const turns = db.listUserTurnsForSession(sId);
+                for (const t of turns) {
+                    if (t.rawExcerpt) {
+                        recentMessages.push(t.rawExcerpt);
+                    }
+                }
+            } catch (turnErr) {
+                logger?.warn?.(`[PD:CorrectionObserver] Failed to load user turns for session ${sId}: ${String(turnErr)}`);
+            }
+        }
+
+        const learner = CorrectionCueLearner.get(wctx.stateDir);
+        const keywords = learner.getStore().keywords;
+        const keywordStoreSummary = {
+            totalKeywords: keywords.length,
+            terms: keywords.map(k => ({
+                term: k.term,
+                weight: k.weight,
+                hitCount: k.hitCount ?? 0,
+                truePositiveCount: k.truePositiveCount ?? 0,
+                falsePositiveCount: k.falsePositiveCount ?? 0,
+            })),
+        };
+
+        const optimizationService = KeywordOptimizationService.get(wctx.stateDir, wctx.workspaceDir, logger);
+        const trajectoryHistory = await optimizationService.buildTrajectoryHistory(recentSessionIds);
+
+        const payload = {
+            parentSessionId: 'correction-observer-service',
+            workspaceDir: wctx.workspaceDir,
+            keywordStoreSummary,
+            recentMessages,
+            trajectoryHistory,
+        };
+
+        const scheduler = new AgentScheduler();
+        scheduler.register({
+            agentId: 'correction-observer',
+            mode: 'realtime',
+            runner: observer,
+        });
+
+        logger?.info?.(`[PD:CorrectionObserver] Dispatching with ${trajectoryHistory.length} trajectory events, ${recentMessages.length} recent messages.`);
+        const result = await scheduler.dispatch('correction-observer', payload);
+        logger?.info?.(`[PD:CorrectionObserver] Completed: updated=${result.updated}, summary="${result.summary}"`);
+
+        if (result.updated) {
+            optimizationService.applyResult(result);
+        }
+    } catch (err) {
+        const errMsg = `Correction observer cycle failed: ${String(err)}`;
+        logger?.warn?.(`[PD:CorrectionObserver] ${errMsg}`);
+        SystemLogger.log(wctx.workspaceDir, 'CORRECTION_OBSERVER_CYCLE_FAILED', errMsg);
+    }
+}
+
+export const CorrectionObserverService: CorrectionObserverServiceShape = {
+    id: 'principles-correction-observer',
+
+    start(ctx: OpenClawPluginServiceContext): void {
+        const workspaceDir = ctx?.workspaceDir;
+        const logger = ctx?.logger || console;
+
+        if (!workspaceDir) {
+            if (logger) logger.warn('[PD:CorrectionObserver] workspaceDir not found in service config. Correction observer disabled.');
+            return;
+        }
+
+        const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });
+        if (logger) logger.info(`[PD:CorrectionObserver] Starting with workspaceDir=${wctx.workspaceDir}, stateDir=${wctx.stateDir}`);
+
+        const interval = CORRECTION_OBSERVER_INTERVAL_MS;
+
+        async function runCycle(): Promise<void> {
+            await runCorrectionObserverCycle(wctx, logger);
+            correctionObserverTimeoutId = setTimeout(runCycle, interval);
+            correctionObserverTimeoutId.unref();
+        }
+
+        correctionObserverTimeoutId = setTimeout(() => {
+            void runCycle().catch((err) => {
+                if (logger) logger.error(`[PD:CorrectionObserver] Startup cycle failed: ${String(err)}`);
+                correctionObserverTimeoutId = setTimeout(runCycle, interval);
+                correctionObserverTimeoutId.unref();
+            });
+        }, CORRECTION_OBSERVER_INITIAL_DELAY_MS);
+        correctionObserverTimeoutId.unref();
+    },
+
+    stop(_ctx: OpenClawPluginServiceContext): void {
+        if (correctionObserverTimeoutId) clearTimeout(correctionObserverTimeoutId);
+        correctionObserverTimeoutId = null;
+    },
+};

--- a/packages/openclaw-plugin/src/service/evolution-worker.ts
+++ b/packages/openclaw-plugin/src/service/evolution-worker.ts
@@ -22,14 +22,7 @@ export { loadEvolutionQueue, saveEvolutionQueue, withQueueLock, acquireQueueLock
 export { EVOLUTION_QUEUE_LOCK_SUFFIX, LOCK_MAX_RETRIES, LOCK_RETRY_DELAY_MS, LOCK_STALE_MS } from './queue-io.js';
 import { saveEvolutionQueue, requireQueueLock } from './queue-io.js';
 import { WorkflowStore } from './subagent-workflow/workflow-store.js';
-import {
-    WorkflowFunnelLoader,
-    PiAiRuntimeAdapter,
-    CorrectionObserver,
-    AgentScheduler,
-} from '@principles/core/runtime-v2';
-import { KeywordOptimizationService } from './keyword-optimization-service.js';
-import { CorrectionCueLearner } from '../core/correction-cue-learner.js';
+
 
 import { PrincipleCompiler } from '../core/principle-compiler/index.js';
 import { loadLedger, updatePrinciple } from '../core/principle-tree-ledger.js';
@@ -632,49 +625,6 @@ async function processEvolutionQueueWithResult(
     return { queue: queueResult, errors };
 }
 
-function resolveCorrectionObserver(wctx: WorkspaceContext, logger?: Pick<PluginLogger, 'info' | 'warn' | 'error' | 'debug'>): CorrectionObserver | null {
-  try {
-    const loader = new WorkflowFunnelLoader(wctx.stateDir);
-    const funnel = loader.getFunnel('pd-correction-observer');
-    const policy = funnel?.policy;
-    if (!policy || policy.runtimeKind !== 'pi-ai') {
-      logger?.debug?.('[PD:Correction] workflows.yaml pd-correction-observer policy not found. Falling back to environment variables.');
-      const provider = process.env.PD_CORRECTION_PROVIDER || 'anthropic';
-      const model = process.env.PD_CORRECTION_MODEL || 'anthropic/claude-3-5-sonnet';
-      const apiKeyEnv = process.env.PD_CORRECTION_API_KEY_ENV || 'ANTHROPIC_API_KEY';
-      const baseUrl = process.env.PD_CORRECTION_BASE_URL;
-
-      if (!process.env[apiKeyEnv]) {
-        logger?.debug?.(`[PD:Correction] Correction observer API key env ${apiKeyEnv} is not set. Periodic optimization disabled.`);
-        return null;
-      }
-
-      const adapter = new PiAiRuntimeAdapter({
-        provider,
-        model,
-        apiKeyEnv,
-        baseUrl,
-        workspace: wctx.workspaceDir,
-      });
-      return new CorrectionObserver({ runtimeAdapter: adapter });
-    }
-
-    const adapter = new PiAiRuntimeAdapter({
-      provider: String(policy.provider),
-      model: String(policy.model),
-      apiKeyEnv: String(policy.apiKeyEnv),
-      maxRetries: policy.maxRetries,
-      timeoutMs: policy.timeoutMs ?? 30_000,
-      baseUrl: policy.baseUrl,
-      workspace: wctx.workspaceDir,
-    });
-    return new CorrectionObserver({ runtimeAdapter: adapter }, { timeoutMs: policy.timeoutMs });
-  } catch (err) {
-    logger?.warn?.(`[PD:Correction] Failed to resolve CorrectionObserver: ${String(err)}`);
-    return null;
-  }
-}
-
 export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
     id: 'principles-evolution-worker',
     api: null,
@@ -759,78 +709,7 @@ export const EvolutionWorkerService: ExtendedEvolutionWorkerService = {
                     await processDetectionQueue(wctx, api, eventLog);
                 }
                 // processPromotion removed (D-06) — promotion via PAIN_CANDIDATES no longer needed
-
-                // ── Correction Observer: periodic keyword optimization (D-40-08 / H-1) ──
-                try {
-                    const observer = resolveCorrectionObserver(wctx, logger);
-                    if (observer) {
-                        logger?.info?.('[PD:EvolutionWorker] Correction Observer resolved. Initiating periodic optimization...');
-                        const db = TrajectoryRegistry.get(wctx.workspaceDir);
-                        const recentSessions = db.listRecentSessions({ limit: 20 });
-                        const recentSessionIds = recentSessions.map(s => s.sessionId);
-
-                        if (recentSessionIds.length > 0) {
-                            const recentMessages: string[] = [];
-                            for (const sId of recentSessionIds.slice(0, 5)) {
-                                try {
-                                    const turns = db.listUserTurnsForSession(sId);
-                                    for (const t of turns) {
-                                        if (t.rawExcerpt) {
-                                            recentMessages.push(t.rawExcerpt);
-                                        }
-                                    }
-                                } catch (turnErr) {
-                                    logger?.warn?.(`[PD:EvolutionWorker] Failed to load user turns for session ${sId}: ${String(turnErr)}`);
-                                }
-                            }
-
-                            const learner = CorrectionCueLearner.get(wctx.stateDir);
-                            const keywords = learner.getStore().keywords;
-                            const keywordStoreSummary = {
-                                totalKeywords: keywords.length,
-                                terms: keywords.map(k => ({
-                                    term: k.term,
-                                    weight: k.weight,
-                                    hitCount: k.hitCount ?? 0,
-                                    truePositiveCount: k.truePositiveCount ?? 0,
-                                    falsePositiveCount: k.falsePositiveCount ?? 0,
-                                })),
-                            };
-
-                            const optimizationService = KeywordOptimizationService.get(wctx.stateDir, wctx.workspaceDir, logger);
-                            const trajectoryHistory = await optimizationService.buildTrajectoryHistory(recentSessionIds);
-
-                            const payload = {
-                                parentSessionId: 'evolution-worker',
-                                workspaceDir: wctx.workspaceDir,
-                                keywordStoreSummary,
-                                recentMessages,
-                                trajectoryHistory,
-                            };
-
-                            const scheduler = new AgentScheduler();
-                            scheduler.register({
-                                agentId: 'correction-observer',
-                                mode: 'realtime',
-                                runner: observer,
-                            });
-
-                            logger?.info?.(`[PD:EvolutionWorker] Dispatching correction-observer with ${trajectoryHistory.length} trajectory events, ${recentMessages.length} recent messages.`);
-                            const result = await scheduler.dispatch('correction-observer', payload);
-                            logger?.info?.(`[PD:EvolutionWorker] Correction-observer completed: updated=${result.updated}, summary="${result.summary}"`);
-                            
-                            if (result.updated) {
-                                optimizationService.applyResult(result);
-                            }
-                        } else {
-                            logger?.info?.('[PD:EvolutionWorker] No recent sessions found. Skipping correction optimization.');
-                        }
-                    }
-                } catch (corrErr) {
-                    const corrErrMsg = `Correction observer execution failed: ${String(corrErr)}`;
-                    cycleResult.errors.push(corrErrMsg);
-                    logger?.warn?.(`[PD:EvolutionWorker] ${corrErrMsg}`);
-                }
+                // Correction Observer extracted to independent service (PRI-293) — no longer runs on EvolutionWorker heartbeat
 
                 try {
                     const subagentRuntime = api?.runtime?.subagent;

--- a/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
@@ -149,6 +149,42 @@ describe('CorrectionObserverService — Independent Service (PRI-293)', () => {
     }
   });
 
+  it('does not reschedule after stop during active cycle (P2 fix)', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-obs-race-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    let cycleResolve: () => void;
+    const cyclePromise = new Promise<void>(r => { cycleResolve = r; });
+    mockDispatch.mockImplementationOnce(async () => {
+      cycleResolve!();
+      return { updated: false, summary: 'in-flight' };
+    });
+
+    try {
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger,
+        config: { get: () => undefined },
+      } as any);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await cyclePromise;
+
+      CorrectionObserverService.stop?.({} as any);
+
+      vi.advanceTimersByTime(15 * 60 * 1000 * 2);
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    } finally {
+      CorrectionObserverService.stop?.({} as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+
   it('logs structured reason when workspaceDir is missing (ERR-002)', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 

--- a/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
@@ -198,6 +198,89 @@ describe('CorrectionObserverService — Independent Service (PRI-293)', () => {
       expect.stringContaining('workspaceDir not found')
     );
   });
+
+  it('double start same workspace only dispatches one loop (P1 fix)', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-dbl-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const logger1 = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const logger2 = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    try {
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger: logger1,
+        config: { get: () => undefined },
+      } as any);
+
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger: logger2,
+        config: { get: () => undefined },
+      } as any);
+
+      expect(logger2.info).toHaveBeenCalledWith(
+        expect.stringContaining('Already started')
+      );
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+      }
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    } finally {
+      CorrectionObserverService.stop?.({} as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  it('stop after double start cancels all timers and allows clean restart', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-stopdbl-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    try {
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger,
+        config: { get: () => undefined },
+      } as any);
+
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger,
+        config: { get: () => undefined },
+      } as any);
+
+      CorrectionObserverService.stop?.({} as any);
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger,
+        config: { get: () => undefined },
+      } as any);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('[PD:CorrectionObserver] Starting')
+      );
+    } finally {
+      CorrectionObserverService.stop?.({} as any);
+      safeRmDir(workspaceDir);
+    }
+  });
 });
 
 describe('runCorrectionObserverCycle — Independent Execution', () => {

--- a/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { WorkspaceContext } from '../../src/core/workspace-context.js';
+
+const mockLearner = {
+  getStore: vi.fn(() => ({ keywords: [{ term: 'wrong', weight: 0.5, hitCount: 3, truePositiveCount: 1, falsePositiveCount: 2 }] })),
+};
+
+const mockDb = {
+  listRecentSessions: vi.fn(() => [{ sessionId: 'session-1' }]),
+  listUserTurnsForSession: vi.fn(() => [{ rawExcerpt: 'User said wrong input', correctionDetected: true, correctionCue: 'wrong' }]),
+};
+
+const mockOptimizationService = {
+  buildTrajectoryHistory: vi.fn(async () => [
+    { sessionId: 'session-1', timestamp: 'now', term: 'wrong', userMessage: '' }
+  ]),
+  applyResult: vi.fn(),
+};
+
+vi.mock('../../src/core/correction-cue-learner.js', () => ({
+  CorrectionCueLearner: { get: vi.fn(() => mockLearner) },
+}));
+
+vi.mock('../../src/core/trajectory.js', () => ({
+  TrajectoryRegistry: {
+    get: vi.fn(() => mockDb),
+    clear: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/service/keyword-optimization-service.js', () => ({
+  KeywordOptimizationService: { get: vi.fn(() => mockOptimizationService) },
+}));
+
+const mockDispatch = vi.fn().mockResolvedValue({
+  updated: true,
+  summary: 'Keyword store optimized',
+  updates: { wrong: { action: 'update', weight: 0.4, reasoning: 'slightly high FP' } }
+});
+
+const mockRegister = vi.fn();
+
+vi.mock('@principles/core/runtime-v2', () => {
+  return {
+    WorkflowFunnelLoader: class {
+      getFunnel = vi.fn(() => ({
+        policy: {
+          runtimeKind: 'pi-ai',
+          provider: 'anthropic',
+          model: 'anthropic/claude-3-5-sonnet',
+          apiKeyEnv: 'ANTHROPIC_API_KEY',
+          timeoutMs: 30000,
+        }
+      }));
+    },
+    PiAiRuntimeAdapter: class {},
+    CorrectionObserver: class {},
+    AgentScheduler: class {
+      register = mockRegister;
+      dispatch = mockDispatch;
+    }
+  };
+});
+
+import { CorrectionObserverService, runCorrectionObserverCycle } from '../../src/service/correction-observer-service.js';
+import { safeRmDir } from '../test-utils.js';
+
+describe('CorrectionObserverService — Independent Service (PRI-293)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    CorrectionObserverService.stop?.({} as any);
+  });
+
+  it('has correct service id', () => {
+    expect(CorrectionObserverService.id).toBe('principles-correction-observer');
+  });
+
+  it('starts and schedules periodic cycles', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-obs-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    try {
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger,
+        config: { get: () => undefined },
+      } as any);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('[PD:CorrectionObserver] Starting')
+      );
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+      }
+
+      expect(mockRegister).toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith('correction-observer', expect.objectContaining({
+        parentSessionId: 'correction-observer-service',
+        workspaceDir,
+        recentMessages: ['User said wrong input'],
+      }));
+
+      expect(mockOptimizationService.applyResult).toHaveBeenCalledWith(expect.objectContaining({
+        updated: true,
+        summary: 'Keyword store optimized',
+      }));
+    } finally {
+      CorrectionObserverService.stop?.({} as any);
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  it('stops cleanly and cancels pending timer', () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-obs-stop-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    try {
+      CorrectionObserverService.start({
+        workspaceDir,
+        stateDir,
+        logger,
+        config: { get: () => undefined },
+      } as any);
+
+      CorrectionObserverService.stop?.({} as any);
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    } finally {
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  it('logs structured reason when workspaceDir is missing (ERR-002)', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    CorrectionObserverService.start({
+      workspaceDir: undefined as any,
+      logger,
+      config: { get: () => undefined },
+    } as any);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('workspaceDir not found')
+    );
+  });
+});
+
+describe('runCorrectionObserverCycle — Independent Execution', () => {
+  it('skips cycle when no recent sessions exist', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-cycle-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const wctx = WorkspaceContext.fromHookContext({ workspaceDir });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    mockDb.listRecentSessions.mockReturnValueOnce([]);
+
+    try {
+      await runCorrectionObserverCycle(wctx, logger as any);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('No recent sessions found')
+      );
+      expect(mockDispatch).not.toHaveBeenCalled();
+    } finally {
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  it('logs structured error on cycle failure (ERR-002)', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-err-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const wctx = WorkspaceContext.fromHookContext({ workspaceDir });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    mockDb.listRecentSessions.mockImplementationOnce(() => {
+      throw new Error('DB connection failed');
+    });
+
+    try {
+      await runCorrectionObserverCycle(wctx, logger as any);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Correction observer cycle failed')
+      );
+    } finally {
+      safeRmDir(workspaceDir);
+    }
+  });
+});

--- a/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
@@ -1,173 +1,40 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { WorkspaceContext } from '../../src/core/workspace-context.js';
-import { ConfigService } from '../../src/core/config-service.js';
+import { describe, expect, it } from 'vitest';
+import { PLUGIN_SURFACE_REGISTRY } from '@principles/core/runtime-v2';
+import { DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
 
-// Shared mocks
-const mockLearner = {
-  getStore: vi.fn(() => ({ keywords: [{ term: 'wrong', weight: 0.5 }] })),
-};
-
-const mockDb = {
-  listRecentSessions: vi.fn(() => [{ sessionId: 'session-1' }]),
-  listUserTurnsForSession: vi.fn(() => [{ rawExcerpt: 'User said wrong input', correctionDetected: true, correctionCue: 'wrong' }]),
-};
-
-const mockOptimizationService = {
-  buildTrajectoryHistory: vi.fn(async () => [
-    { sessionId: 'session-1', timestamp: 'now', term: 'wrong', userMessage: '' }
-  ]),
-  applyResult: vi.fn(),
-};
-
-// Mock dependencies
-vi.mock('../../src/core/correction-cue-learner.js', () => ({
-  CorrectionCueLearner: { get: vi.fn(() => mockLearner) },
-}));
-
-vi.mock('../../src/core/trajectory.js', () => ({
-  TrajectoryRegistry: {
-    get: vi.fn(() => mockDb),
-    clear: vi.fn(),
-  },
-}));
-
-vi.mock('../../src/service/keyword-optimization-service.js', () => ({
-  KeywordOptimizationService: { get: vi.fn(() => mockOptimizationService) },
-}));
-
-// Mock principles-core runtime-v2 observer/scheduler classes
-const mockDispatch = vi.fn().mockResolvedValue({
-  updated: true,
-  summary: 'Keyword store optimized',
-  updates: { wrong: { action: 'update', weight: 0.4, reasoning: 'slightly high FP' } }
-});
-
-const mockRegister = vi.fn();
-
-vi.mock('@principles/core/runtime-v2', () => {
-  return {
-    WorkflowFunnelLoader: class {
-      getFunnel = vi.fn(() => ({
-        policy: {
-          runtimeKind: 'pi-ai',
-          provider: 'anthropic',
-          model: 'anthropic/claude-3-5-sonnet',
-          apiKeyEnv: 'ANTHROPIC_API_KEY',
-          timeoutMs: 30000,
-        }
-      }));
-    },
-    PiAiRuntimeAdapter: class {},
-    CorrectionObserver: class {},
-    AgentScheduler: class {
-      register = mockRegister;
-      dispatch = mockDispatch;
-    }
-  };
-});
-
-// Import EvolutionWorkerService
-import { EvolutionWorkerService } from '../../src/service/evolution-worker.js';
-import { safeRmDir } from '../test-utils.js';
-
-function createMockApi() {
-  return {
-    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-    runtime: {
-      agent: { runEmbeddedPiAgent: vi.fn() },
-      system: {
-        requestHeartbeatNow: vi.fn(),
-        runHeartbeatOnce: vi.fn(),
-      },
-    },
-  } as any;
-}
-
-const fastPollConfig = { get: (k: string) => k === 'intervals.worker_poll_ms' ? 1000 : undefined };
-
-describe('EvolutionWorkerService Correction Observer Integration', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.clearAllMocks();
-    EvolutionWorkerService.api = null;
+describe('Correction Observer Ownership — Feature Flag & Surface Registry Consistency (PRI-293, ERR-027)', () => {
+  it('correction_observer feature flag is registered as core with enabled:true', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'correction_observer');
+    expect(flag).toBeDefined();
+    expect(flag!.category).toBe('core');
+    expect(flag!.enabled).toBe(true);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-    EvolutionWorkerService.api = null;
+  it('service:correction-observer surface is registered as core with enabledByDefault:true', () => {
+    const surface = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'service:correction-observer');
+    expect(surface).toBeDefined();
+    expect(surface!.category).toBe('core');
+    expect(surface!.enabledByDefault).toBe(true);
   });
 
-  it('runs Correction Observer on heartbeat and applies updates when configured', async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-worker-corr-'));
-    const stateDir = path.join(workspaceDir, '.state');
-    fs.mkdirSync(stateDir, { recursive: true });
+  it('startup:correction-observer surface is registered as core with enabledByDefault:true', () => {
+    const surface = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'startup:correction-observer');
+    expect(surface).toBeDefined();
+    expect(surface!.category).toBe('core');
+    expect(surface!.enabledByDefault).toBe(true);
+  });
 
-    // Initialize an empty queue to avoid processing actual queue items
-    fs.writeFileSync(
-      path.join(stateDir, 'evolution_queue.json'),
-      JSON.stringify([], null, 2),
-      'utf8'
-    );
+  it('evolution_worker feature flag remains quiet with enabled:false', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'evolution_worker');
+    expect(flag).toBeDefined();
+    expect(flag!.category).toBe('quiet');
+    expect(flag!.enabled).toBe(false);
+  });
 
-    // Initialize pain settings with fast poll interval
-    fs.writeFileSync(
-      path.join(stateDir, 'pain_settings.json'),
-      JSON.stringify({
-        intervals: {
-          worker_poll_ms: 1000
-        }
-      }, null, 2),
-      'utf8'
-    );
-
-    // Invalidate workspace cache to load the newly written settings
-    WorkspaceContext.clearCache();
-    ConfigService.reset();
-
-    const mockApi = createMockApi();
-    EvolutionWorkerService.api = mockApi;
-
-    try {
-      EvolutionWorkerService.start({
-        workspaceDir,
-        stateDir,
-        logger: mockApi.logger,
-        config: fastPollConfig,
-        api: mockApi,
-      } as any);
-
-      // 1. Advance to startup timer (5000ms) and wait for microtasks to settle
-      await vi.advanceTimersByTimeAsync(5000);
-      for (let i = 0; i < 20; i++) {
-        await Promise.resolve();
-      }
-
-      // 2. Advance past the poll interval (1000ms) to trigger runCycle
-      await vi.advanceTimersByTimeAsync(1050);
-      for (let i = 0; i < 20; i++) {
-        await Promise.resolve();
-      }
-
-      // Verify that the scheduler dispatch was called with correct payload
-      expect(mockRegister).toHaveBeenCalled();
-      expect(mockDispatch).toHaveBeenCalledWith('correction-observer', expect.objectContaining({
-        parentSessionId: 'evolution-worker',
-        workspaceDir,
-        recentMessages: ['User said wrong input'],
-      }));
-
-      // Verify updates were applied using KeywordOptimizationService
-      expect(mockOptimizationService.applyResult).toHaveBeenCalledWith(expect.objectContaining({
-        updated: true,
-        summary: 'Keyword store optimized',
-      }));
-
-    } finally {
-      EvolutionWorkerService.stop!({ workspaceDir, stateDir, logger: console } as any);
-      safeRmDir(workspaceDir);
-    }
+  it('service:evolution-worker surface remains quiet with enabledByDefault:false', () => {
+    const surface = PLUGIN_SURFACE_REGISTRY.find(s => s.id === 'service:evolution-worker');
+    expect(surface).toBeDefined();
+    expect(surface!.category).toBe('quiet');
+    expect(surface!.enabledByDefault).toBe(false);
   });
 });

--- a/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { PLUGIN_SURFACE_REGISTRY } from '@principles/core/runtime-v2';
-import { DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
+import { DEFAULT_FEATURE_FLAGS, computeEffectiveFlags } from '@principles/core/runtime-v2';
 
 describe('Correction Observer Ownership — Feature Flag & Surface Registry Consistency (PRI-293, ERR-027)', () => {
-  it('correction_observer feature flag is registered as core with enabled:true', () => {
+  it('correction_observer feature flag is registered as quiet with enabled:true (disableable runtime kill switch)', () => {
     const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'correction_observer');
     expect(flag).toBeDefined();
-    expect(flag!.category).toBe('core');
+    expect(flag!.category).toBe('quiet');
     expect(flag!.enabled).toBe(true);
+  });
+
+  it('correction_observer can be disabled via workspace config (P1 fix — runtime kill switch)', () => {
+    const result = computeEffectiveFlags(
+      { correction_observer: { enabled: false } },
+      DEFAULT_FEATURE_FLAGS,
+      '.pd/feature-flags.yaml',
+    );
+    expect(result.flags['correction_observer'].enabled).toBe(false);
+    expect(result.warnings).not.toContain(expect.stringContaining('core flag cannot be disabled'));
   });
 
   it('service:correction-observer surface is registered as core with enabledByDefault:true', () => {

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
@@ -210,6 +210,7 @@ describe('computeEffectiveFlags', () => {
     for (const flag of quietFlags) {
       // feedback_channel is a quiet flag that defaults on (MVP seed channel)
       if (flag.id === 'feedback_channel') continue;
+      if (flag.id === 'correction_observer') continue;
       expect(flag.enabled, `quiet flag ${flag.id} should default off`).toBe(false);
     }
   });

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -95,7 +95,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'prompt', category: 'core', enabled: true, since: '2026-05-24', description: 'Prompt injection for principle application' },
   { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
-  { id: 'correction_observer', category: 'core', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293)' },
+  { id: 'correction_observer', category: 'quiet', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293; quiet flag to allow runtime disable)' },
 
   // MVP-Quiet — opt-in or opt-out via config; enabled value varies per flag
   // Only flags with real consumption paths are registered (PRI-239 constraint)

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -95,6 +95,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'prompt', category: 'core', enabled: true, since: '2026-05-24', description: 'Prompt injection for principle application' },
   { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
+  { id: 'correction_observer', category: 'core', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293)' },
 
   // MVP-Quiet — opt-in or opt-out via config; enabled value varies per flag
   // Only flags with real consumption paths are registered (PRI-239 constraint)

--- a/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
@@ -126,6 +126,14 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
     disabledReason: 'MVP-Quiet: evolution worker gated behind evolution_worker feature flag (PRI-288); default off per ADR-0014 §2.5',
   },
   {
+    id: 'service:correction-observer',
+    kind: 'service',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-06-02',
+    description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293)',
+  },
+  {
     id: 'service:trajectory',
     kind: 'service',
     category: 'quiet',
@@ -168,6 +176,14 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
     since: '2026-06-01',
     description: 'Evolution worker start on first prompt per workspace (MVP-Quiet per PRI-288/ADR-0014)',
     disabledReason: 'MVP-Quiet: evolution worker startup gated behind evolution_worker feature flag (PRI-288); default off per ADR-0014 §2.5',
+  },
+  {
+    id: 'startup:correction-observer',
+    kind: 'startup',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-06-02',
+    description: 'Correction observer start on first prompt per workspace (MVP-Core per ADR-0014 amendment, PRI-293)',
   },
 ];
 


### PR DESCRIPTION
## Path A: Extract Correction Observer from EvolutionWorker

**Closes:** PRI-293

### Decision: Path A (Extract)

**Why Path A over Path B:**
1. ADR-0014 amendment was a deliberate decision based on real MVP Story A' execution testing — programmatic pain signals are extremely hard to trigger and Correction Observer's keyword self-correction is needed to maintain trigger accuracy.
2. The extraction scope is small and well-defined — a single code block (~70 lines) in evolution-worker.ts.
3. Path B would be make docs match broken code rather than fix code to match correct docs.

### Changes

| File | Change |
|------|--------|
| \correction-observer-service.ts\ | **New** — independent periodic service with own heartbeat, feature flag, and disable path |
| \eature-flag-contract.ts\ | Add \correction_observer\ flag: category=core, enabled=true |
| \plugin-surface-registry.ts\ | Add \service:correction-observer\ and \startup:correction-observer\ as core surfaces |
| \index.ts\ | Wire CorrectionObserverService with \shouldStartCorrectionObserver\ gate |
| \volution-worker.ts\ | Remove Correction Observer block and unused imports |
| \correction-observer-service.test.ts\ | **New** — tests proving independent ownership path |
| \volution-worker.correction-observer.test.ts\ | Replaced with feature flag/surface registry consistency test |
| \