### PR TITLE
chore: sync package-lock.json with runtime dependency changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20030,8 +20030,10 @@
         "@inquirer/prompts": "^8.4.3",
         "commander": "^14.0.3",
         "fs-extra": "^11.3.5",
+        "js-yaml": "^4.2.0",
         "ora": "^9.4.0",
         "picocolors": "^1.0.0",
+        "semver": "^7.8.1",
         "tar": "^7.5.15"
       },
       "bin": {
@@ -20043,8 +20045,6 @@
         "@types/node": "^25.6.2",
         "@types/semver": "^7.7.0",
         "@types/tar": "^7.0.87",
-        "js-yaml": "^4.2.0",
-        "semver": "^7.8.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
       },
@@ -20104,6 +20104,7 @@
       "license": "MIT",
       "dependencies": {
         "@principles/core": "^1.73.0",
+        "better-sqlite3": "^12.9.0",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1"
       },
@@ -20111,6 +20112,7 @@
         "pd": "dist/index.js"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.2",
         "typescript": "^6.0.3",
@@ -20139,6 +20141,7 @@
         "@tailwindcss/postcss": "^4.3.0",
         "@tailwindcss/vite": "^4.3.0",
         "autoprefixer": "^10.5.0",
+        "better-sqlite3": "^12.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "i18next": "^26.1.0",


### PR DESCRIPTION
Sync package-lock.json with package.json dependency declarations:

- better-sqlite3 declared in pd-cli and pd-console dependencies (used by health.ts, config-doctor.ts, legacy-import.ts, agents.ts)
- js-yaml and semver moved to dependencies in create-principles-disciple (runtime required)