### PR TITLE
refactor(core): extract BasePeerRunner for DreamerRunner first slice (PRI-302)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -93,6 +93,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-019 | schemaCheck failure branch writes next iteration's errors into current attempt's record | PRI-200 |
 | ERR-020 | Commander negated boolean `--no-intake` ignored — checking wrong property name | PRI-217 |
 | ERR-047 | errMsg helper checks typed narrower parameter instead of unknown caught value — error message extraction always falls through to String(err) | PRI-285 |
+| ERR-054 | `as TOutput` cast on untrusted LLM/runtime payload before validation — typed hooks receive unverified data | PRI-302 |
 
 ---
 
@@ -813,3 +814,15 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **Source**: PRI-299 / PR #801
 - **Date**: 2026-06-03
 - **Recurrence**: Same class as ERR-024, ERR-048 (code exists but is not wired into production path)
+
+---
+
+**[ERR-054]** | `as TOutput` cast on untrusted LLM/runtime payload before validation — typed hooks receive unverified data
+
+- **What happened**: `BasePeerRunner.fetchAndParseOutput()` cast `result.payload` as `TOutput` (generic type parameter) without runtime validation. The `run()` template method then called `postFetchTransform()` and `checkLineageIntegrity()` with this unverified typed data BEFORE calling `validateOutput()`. This meant untrusted LLM/runtime output entered typed runner hooks as if it were validated.
+- **Why it's wrong**: Violates Runtime Contract Rule 1 (ERR-001: treat parsed JSON/LLM output as `unknown`) and Rule 2 (ERR-005: do not use `as` to bypass runtime validation). The `as TOutput` cast is a type-system lie — the payload has not been validated at that point. Typed hooks receiving unverified data could access properties that don't exist, leading to silent undefined behavior or crashes.
+- **Correct approach**: `fetchAndParseOutput()` must return `unknown`. Pre-validation hooks (`postFetchTransform`) must accept `unknown`. Only after `validateOutput()` confirms the payload shape should data be cast to `TOutput`. Post-validation hooks (`checkLineageIntegrity`, `emitSuccessTelemetry`, `succeedTask`) receive the validated typed data.
+- **How to prevent**: Any function that returns data from an external source (LLM, runtime adapter, network) must return `unknown`. The trust boundary is the validation step — no data should be typed before crossing it. Review checklist: (1) Does this function return data from an untrusted source? (2) If yes, does it return `unknown`? (3) Is the `as` cast AFTER a validation step?
+- **Source**: PRI-302 / PR #806
+- **Date**: 2026-06-03
+- **Recurrence**: First occurrence. Same class as ERR-001 (`as string` cast on untrusted JSON) and ERR-005 (invalid salvaged arrays bypass type contract).

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -632,6 +632,22 @@ export {
 
 export { DreamerRunner } from './internalization/dreamer-runner.js';
 
+// ── Base Peer Runner (PRI-302) ───────────────────────────────────────────────
+
+export { BasePeerRunner } from './runner/base-peer-runner.js';
+
+export type {
+  PeerRunnerOptions,
+  ResolvedPeerRunnerOptions,
+  PeerRunnerDeps,
+  PeerRunnerConfig,
+  PeerRunnerResult,
+  PeerRunnerResultStatus,
+  PeerRunnerValidationResult,
+  FailureContext,
+  ValidationErrorContext,
+} from './runner/peer-runner-types.js';
+
 // ── Philosopher Runner (PRI-90) ────────────────────────────────────────────────
 
 export type {

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-output.ts
@@ -108,36 +108,40 @@ export interface DreamerValidationResult {
  * PassThroughDreamerValidator is test-only and must not be used in production paths.
  */
 export interface DreamerValidator {
-  validate(output: DreamerOutput, taskId: string): Promise<DreamerValidationResult>;
+  /** Validate untrusted output. Accepts `unknown` — must perform runtime checks (ERR-001). */
+  validate(output: unknown, taskId: string): Promise<DreamerValidationResult>;
 }
 
 const VALID_RISK_LEVELS = new Set(['low', 'medium', 'high']);
 
 export class DefaultDreamerValidator implements DreamerValidator {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  async validate(output: DreamerOutput, taskId: string): Promise<DreamerValidationResult> {
+  async validate(output: unknown, taskId: string): Promise<DreamerValidationResult> {
     const errors: string[] = [];
 
     if (typeof output !== 'object' || output === null) {
       return { valid: false, errors: ['Output is not an object'], errorCategory: 'output_invalid' };
     }
 
-    if (output.taskId !== taskId) {
-      errors.push(`taskId mismatch: expected ${taskId}, got ${String(output.taskId)}`);
+    // Narrow to Record for property access — all fields still treated as untrusted.
+    const record = output as Record<string, unknown>;
+
+    if (record.taskId !== taskId) {
+      errors.push(`taskId mismatch: expected ${taskId}, got ${String(record.taskId)}`);
     }
 
-    if (output.valid !== true) {
+    if (record.valid !== true) {
       errors.push('output.valid must be true');
     }
 
-    if (!Array.isArray(output.candidates)) {
+    if (!Array.isArray(record.candidates)) {
       errors.push('candidates must be an array');
     } else {
-      if (output.candidates.length < 1 || output.candidates.length > 5) {
+      if (record.candidates.length < 1 || record.candidates.length > 5) {
         errors.push('candidates must have 1-5 items');
       }
-      for (let i = 0; i < output.candidates.length; i++) {
-        const c = output.candidates[i] as Record<string, unknown> | undefined;
+      for (let i = 0; i < record.candidates.length; i++) {
+        const c = record.candidates[i] as Record<string, unknown> | undefined;
         if (!c) {
           errors.push(`candidates[${i}] is null/undefined`);
           continue;
@@ -153,11 +157,11 @@ export class DefaultDreamerValidator implements DreamerValidator {
       }
     }
 
-    if (!Array.isArray(output.contextRefs)) {
+    if (!Array.isArray(record.contextRefs)) {
       errors.push('contextRefs must be an array');
     }
 
-    if (typeof output.generatedAt !== 'string' || (output.generatedAt).trim() === '') {
+    if (typeof record.generatedAt !== 'string' || (record.generatedAt).trim() === '') {
       errors.push('generatedAt must be non-empty string');
     }
 
@@ -177,7 +181,7 @@ export class DefaultDreamerValidator implements DreamerValidator {
  */
 export class PassThroughDreamerValidator implements DreamerValidator {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  async validate(_output: DreamerOutput, _taskId: string): Promise<DreamerValidationResult> {
+  async validate(_output: unknown, _taskId: string): Promise<DreamerValidationResult> {
     return { valid: true, errors: [] };
   }
 }

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -1,48 +1,44 @@
 /**
  * DreamerRunner — First real peer runner for the Internalization Engine (PRI-67).
  *
- * Follows the lease → build context → invoke runtime → poll → fetch output →
- * validate → succeed/fail pipeline established by DiagnosticianRunner.
+ * Migrated to extend BasePeerRunner (PRI-302). The shared lease → buildContext →
+ * invoke → poll → fetch → validate → succeed/fail pipeline is now in the base
+ * class. This file only contains Dreamer-specific logic.
  *
  * Key constraints (ADR-0003):
  *   - Uses PDRuntimeAdapter for all LLM execution (no direct SDK calls)
  *   - Does NOT directly invoke Philosopher/Scribe (host layer enqueues next task)
  *   - No plugin-layer imports (core is infrastructure-agnostic)
- *   - No timer-based scheduling (sleep via setTimeout is polling-only, not cron-like)
  *   - Uses RuntimeStateManager for all state operations
  *
- * Pipeline (same as DiagnosticianRunner):
- *   1. acquireLease — isolated try/catch, lease_conflict is non-mutating
- *   2. resolve store runId via getRunsByTask
- *   3. resolve predecessor context from dependencyTaskIds (no ContextAssembler)
- *   4. startRun with outputSchemaRef: 'dreamer-output-v1'
- *   5. pollUntilTerminal
- *   6. fetchOutput → parse as DreamerOutput
- *   7. validate via DreamerValidator
- *   8. updateRunOutput → persist serialized output
- *   9. markTaskSucceeded with 'dreamer://' + storeRunId
- *
  * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ * @see BasePeerRunner in runner/base-peer-runner.ts
  */
-import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
-import type {
-  PDRuntimeAdapter,
-  RunHandle,
-  RunStatus,
-  StartRunInput,
-} from '../runtime-protocol.js';
-import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { RunHandle } from '../runtime-protocol.js';
 import type { DreamerOutput, DreamerValidator } from './dreamer-output.js';
-import type { PIArtifactStore } from './pi-artifact.js';
 import type { TaskRecord } from '../task-status.js';
 import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
-import type { TelemetryEvent } from '../../telemetry-event.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
-import { RunnerPhase } from '../runner/runner-phase.js';
 import { DreamerPromptBuilder } from './dreamer-prompt-builder.js';
 import { injectRunnerLineageIfAbsent } from './peer-runner-contracts.js';
+import { BasePeerRunner } from '../runner/base-peer-runner.js';
+import type {
+  PeerRunnerOptions,
+  PeerRunnerDeps,
+  PeerRunnerResult,
+  PeerRunnerValidationResult,
+} from '../runner/peer-runner-types.js';
 
-// ── Result Types ─────────────────────────────────────────────────────────────
+// ── Dreamer-specific context ─────────────────────────────────────────────────
+
+/** Context built by DreamerRunner.buildContext() and consumed by invokeRuntime(). */
+interface DreamerContext {
+  readonly contextHash: string;
+  readonly contextRefs: string[];
+  readonly predecessorOutput: unknown;
+}
+
+// ── Result Types (backward-compatible exports) ───────────────────────────────
 
 export type DreamerRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
 
@@ -59,16 +55,9 @@ export interface DreamerRunnerResult {
   readonly attemptCount: number;
 }
 
-// ── Constructor Options ───────────────────────────────────────────────────────
+// ── Constructor Options (backward-compatible exports) ────────────────────────
 
-export interface DreamerRunnerOptions {
-  readonly pollIntervalMs?: number;
-  readonly timeoutMs?: number;
-  readonly defaultMaxAttempts?: number;
-  readonly owner: string;
-  readonly runtimeKind: string;
-  readonly agentId?: string;
-}
+export type DreamerRunnerOptions = PeerRunnerOptions;
 
 export interface ResolvedDreamerRunnerOptions {
   readonly pollIntervalMs: number;
@@ -79,14 +68,14 @@ export interface ResolvedDreamerRunnerOptions {
   readonly agentId: string;
 }
 
-const DEFAULT_DREAMER_RUNNER_OPTIONS: Readonly<Omit<ResolvedDreamerRunnerOptions, 'owner' | 'runtimeKind'>> = {
+export const DEFAULT_DREAMER_RUNNER_OPTIONS: Readonly<Omit<ResolvedDreamerRunnerOptions, 'owner' | 'runtimeKind'>> = {
   pollIntervalMs: 5_000,
   timeoutMs: 300_000,
   defaultMaxAttempts: 3,
   agentId: 'dreamer',
 } as const;
 
-function resolveDreamerRunnerOptions(options: DreamerRunnerOptions): ResolvedDreamerRunnerOptions {
+export function resolveDreamerRunnerOptions(options: DreamerRunnerOptions): ResolvedDreamerRunnerOptions {
   return {
     pollIntervalMs: options.pollIntervalMs ?? DEFAULT_DREAMER_RUNNER_OPTIONS.pollIntervalMs,
     timeoutMs: options.timeoutMs ?? DEFAULT_DREAMER_RUNNER_OPTIONS.timeoutMs,
@@ -99,209 +88,33 @@ function resolveDreamerRunnerOptions(options: DreamerRunnerOptions): ResolvedDre
 
 // ── Dependencies ─────────────────────────────────────────────────────────────
 
-export interface DreamerRunnerDeps {
-  readonly stateManager: RuntimeStateManager;
-  readonly runtimeAdapter: PDRuntimeAdapter;
-  readonly eventEmitter: StoreEventEmitter;
+export interface DreamerRunnerDeps extends PeerRunnerDeps {
   readonly validator: DreamerValidator;
-  readonly artifactStore: PIArtifactStore;
 }
 
-// ── Context types for error handling ─────────────────────────────────────────
+// ── DreamerRunner ────────────────────────────────────────────────────────────
 
-interface FailureContext {
-  readonly taskId: string;
-  readonly task: TaskRecord;
-  readonly errorCategory: PDErrorCategory;
-  readonly failureReason: string;
-}
-
-interface SucceedContext {
-  readonly taskId: string;
-  readonly runId: string;
-  readonly output: DreamerOutput;
-  readonly task: TaskRecord;
-  readonly contextHash: string;
-}
-
-interface ValidationErrorContext {
-  readonly taskId: string;
-  readonly task: TaskRecord;
-  readonly errors: readonly string[];
-  readonly errorCategory?: PDErrorCategory;
-}
-
-// ── DreamerRunner ─────────────────────────────────────────────────────────────
-
-export class DreamerRunner {
-  private phase: RunnerPhase = RunnerPhase.Idle;
-  private readonly resolvedOptions: ResolvedDreamerRunnerOptions;
-  private readonly stateManager: RuntimeStateManager;
-  private readonly runtimeAdapter: PDRuntimeAdapter;
-  private readonly eventEmitter: StoreEventEmitter;
+export class DreamerRunner extends BasePeerRunner<DreamerContext, DreamerOutput> {
   private readonly validator: DreamerValidator;
-  private readonly artifactStore: PIArtifactStore;
 
-  constructor(deps: DreamerRunnerDeps, options: DreamerRunnerOptions) {
-    this.stateManager = deps.stateManager;
-    this.runtimeAdapter = deps.runtimeAdapter;
-    this.eventEmitter = deps.eventEmitter;
+  constructor(deps: DreamerRunnerDeps, options: PeerRunnerOptions) {
+    super(deps, options, {
+      runnerName: 'dreamer',
+      expectedTaskKind: 'dreamer',
+      defaultAgentId: 'dreamer',
+      resultRefPrefix: 'dreamer',
+    });
     this.validator = deps.validator;
-    this.artifactStore = deps.artifactStore;
-    this.resolvedOptions = resolveDreamerRunnerOptions(options);
   }
 
-  /** Get the current internal phase. For testing/observability only. */
-  get currentPhase(): RunnerPhase {
-    return this.phase;
+  // ── Abstract implementations ───────────────────────────────────────────────
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  get permanentErrorCategories(): ReadonlySet<PDErrorCategory> {
+    return new Set(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid']);
   }
 
-  private emitDreamerEvent(
-    eventType: string,
-    taskId: string,
-    payload: Record<string, unknown>,
-  ): void {
-    this.eventEmitter.emitTelemetry({
-      eventType: eventType as TelemetryEvent['eventType'],
-      traceId: taskId,
-      timestamp: new Date().toISOString(),
-      sessionId: this.resolvedOptions.owner,
-      agentId: this.resolvedOptions.agentId,
-      payload,
-    });
-  }
-
-  /**
-   * Execute the full Dreamer lifecycle for a task.
-   *
-   * The runner does NOT hold mutable state between run() calls.
-   * Each invocation is independent.
-   */
-  async run(taskId: string): Promise<DreamerRunnerResult> {
-    this.phase = RunnerPhase.Idle;
-
-    // 1. Acquire lease — isolated try/catch so lease_conflict never uses synthetic TaskRecord
-
-    let leasedTask: TaskRecord;
-    try {
-      leasedTask = await this.stateManager.acquireLease({
-        taskId,
-        owner: this.resolvedOptions.owner,
-        runtimeKind: this.resolvedOptions.runtimeKind,
-      });
-    } catch (error) {
-      return await this.handleLeaseOrPhaseError(taskId, error);
-    }
-
-    this.emitDreamerEvent('dreamer_task_leased', taskId, {
-      taskKind: 'dreamer',
-      attemptCount: leasedTask.attemptCount,
-    });
-
-    if (leasedTask.taskKind !== 'dreamer') {
-      this.emitDreamerEvent('dreamer_wrong_task_kind', taskId, {
-        expectedKind: 'dreamer',
-        actualKind: leasedTask.taskKind,
-      });
-      await this.stateManager.markTaskFailed(taskId, 'input_invalid');
-      return {
-        status: 'failed',
-        taskId,
-        errorCategory: 'input_invalid',
-        failureReason: `Task kind must be 'dreamer', got '${leasedTask.taskKind}'`,
-        attemptCount: leasedTask.attemptCount,
-      };
-    }
-
-    // All subsequent errors use the real leasedTask — no synthetic TaskRecord allowed
-    try {
-      // acquireLease creates a RunRecord; resolve its runId for store operations
-      const storeRunId = await this.resolveStoreRunId(taskId);
-
-      // 2. Build context from predecessor task outputs (no ContextAssembler)
-      this.phase = RunnerPhase.BuildingContext;
-      const { contextHash, contextRefs, predecessorOutput } = await this.buildContext(taskId);
-
-      this.emitDreamerEvent('dreamer_context_built', taskId, { contextHash });
-
-      // 3. Invoke runtime
-      this.phase = RunnerPhase.Invoking;
-      const runHandle = await this.invokeRuntime({ taskId, contextHash, contextRefs, predecessorOutput });
-
-      this.emitDreamerEvent('dreamer_run_started', taskId, {
-        runtimeKind: this.resolvedOptions.runtimeKind,
-      });
-
-      // 4. Poll until terminal
-      this.phase = RunnerPhase.Polling;
-      const finalStatus = await this.pollUntilTerminal(runHandle);
-
-      // 5. Handle non-success terminal states
-      if (finalStatus.status !== 'succeeded') {
-        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
-      }
-
-      // 6. Fetch output
-      this.phase = RunnerPhase.FetchingOutput;
-      const output = await this.fetchAndParseOutput(runHandle.runId, taskId);
-
-      // Re-inject taskId if stripped by stripLineageFields (PRI-272 / ERR-008).
-      // Only fill when absent via Object.hasOwn — present-but-falsy values
-      // must reach validation and fail loud (Runtime Contract Rule 3).
-      injectRunnerLineageIfAbsent(output, 'taskId', taskId);
-
-      // 7. Validate
-      this.phase = RunnerPhase.Validating;
-      const validationResult = await this.validator.validate(output, taskId);
-      if (!validationResult.valid) {
-        return await this.handleValidationError({
-          taskId,
-          task: leasedTask,
-          errors: validationResult.errors,
-          errorCategory: validationResult.errorCategory,
-        });
-      }
-
-      this.emitDreamerEvent('dreamer_output_validated', taskId, {
-        candidateCount: output.candidates.length,
-      });
-
-      // 8. Succeed task
-      return await this.succeedTask({
-        taskId,
-        runId: storeRunId,
-        output,
-        task: leasedTask,
-        contextHash,
-      });
-    } catch (error) {
-      // handleLeaseOrPhaseError is only for lease errors (before lease).
-      // Post-lease errors use retryOrFail with the real leasedTask.
-      return await this.handlePostLeaseError(taskId, leasedTask, error);
-    }
-  }
-
-  // ── Phase methods ─────────────────────────────────────────────────────────
-
-  /**
-   * Build context from predecessor task outputs.
-   *
-   * Dreamer doesn't use ContextAssembler — it resolves predecessor context
-   * from dependencyTaskIds via stateManager.getTask(). The predecessor's
-   * resultRef/outputArtifactRefs become the Dreamer's input context.
-   *
-   * Degradation semantics (intentional partial failure):
-   *   - If ALL dependencies fail → builds empty context (continues, not fail-closed)
-   *   - If SOME dependencies fail → builds partial context + emits dreamer_context_partial
-   *   - Only fulfilled results contribute contextRefs
-   *
-   * This is a deliberate design choice: Dreamer can produce output with partial
-   * context, whereas the host layer's task-ready validation is fail-closed.
-   * Partial context is reported via telemetry.
-   *
-   * @see hydratePITaskRecord (PRI-65) for fail-closed PI metadata access
-   */
-  private async buildContext(taskId: string): Promise<{ contextHash: string; contextRefs: string[]; predecessorOutput: unknown }> {
+  async buildContext(taskId: string): Promise<DreamerContext> {
     const task = await this.stateManager.getTask(taskId);
     if (!task) {
       throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
@@ -313,6 +126,7 @@ export class DreamerRunner {
     const contextRefs: string[] = [];
     const rejectedDeps: string[] = [];
     let predecessorOutput: unknown = null;
+
     if (deps.length > 0) {
       const results = await Promise.allSettled(
         deps.map((depId) => this.stateManager.getTask(depId)),
@@ -346,487 +160,162 @@ export class DreamerRunner {
     }
 
     if (rejectedDeps.length > 0) {
-      this.emitDreamerEvent('dreamer_context_partial', taskId, {
+      this.emitEvent('context_partial', taskId, {
         rejectedCount: rejectedDeps.length,
         rejectedDeps,
       });
     }
 
-    const contextHash = DreamerRunner.hashContextRefs(contextRefs);
-
+    const contextHash = BasePeerRunner.hashContextRefs(contextRefs);
     return { contextHash, contextRefs, predecessorOutput };
   }
 
-  /**
-   * Compute a deterministic hash from context references.
-   * Used for telemetry and result tracking, not for caching.
-   */
-  private static hashContextRefs(refs: readonly string[]): string {
-    if (refs.length === 0) return 'empty';
-    // Simple deterministic hash via DJB2-style accumulator
-    // Not cryptographic — only used for observability
-    const str = refs.join('|');
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
-    }
-    return `ctx-${Math.abs(hash).toString(16)}`;
-  }
-
-  private async resolveStoreRunId(taskId: string): Promise<string> {
-    const runs = await this.stateManager.getRunsByTask(taskId);
-    const latestRun = runs[runs.length - 1];
-    if (!latestRun) {
-      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
-    }
-    return latestRun.runId;
-  }
-
-  private async resolveLineageArtifactIds(taskId: string): Promise<{ ids: string[]; hasRejected: boolean }> {
-    const task = await this.stateManager.getTask(taskId);
-    if (!task) return { ids: [], hasRejected: false };
-
-    const piTask = hydratePITaskRecord(task);
-    const deps = piTask?.dependencyTaskIds ?? [];
-    if (deps.length === 0) return { ids: [], hasRejected: false };
-
-    const lineageIds: string[] = [];
-    let hasRejected = false;
-    const results = await Promise.allSettled(
-      deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
-    );
-    for (const result of results) {
-      if (result.status === 'fulfilled') {
-        for (const artifact of result.value) {
-          lineageIds.push(artifact.artifactId);
-        }
-      } else {
-        hasRejected = true;
-      }
-    }
-    return { ids: lineageIds, hasRejected };
-  }
-
-  private async invokeRuntime(params: {
-    taskId: string;
-    contextHash: string;
-    contextRefs: readonly string[];
-    predecessorOutput: unknown;
-  }): Promise<RunHandle> {
+  async invokeRuntime(taskId: string, context: DreamerContext): Promise<RunHandle> {
     const builder = new DreamerPromptBuilder();
     const { message } = builder.buildPrompt({
-      taskId: params.taskId,
-      contextHash: params.contextHash,
-      contextRefs: params.contextRefs,
-      predecessorOutput: params.predecessorOutput,
+      taskId,
+      contextHash: context.contextHash,
+      contextRefs: context.contextRefs,
+      predecessorOutput: context.predecessorOutput,
     });
 
-    const startInput: StartRunInput = {
+    return this.runtimeAdapter.startRun({
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
-      taskRef: { taskId: params.taskId },
+      taskRef: { taskId },
       inputPayload: message,
       contextItems: [],
       outputSchemaRef: 'dreamer-output-v1',
       timeoutMs: this.resolvedOptions.timeoutMs,
+    });
+  }
+
+  async validateOutput(output: DreamerOutput, taskId: string): Promise<PeerRunnerValidationResult> {
+    const result = await this.validator.validate(output, taskId);
+    return {
+      valid: result.valid,
+      errors: result.errors,
+      errorCategory: result.errorCategory,
     };
-
-    return this.runtimeAdapter.startRun(startInput);
   }
 
-  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
-    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
-    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
-
-    while (Date.now() < deadline) {
-      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
-      if (terminalStatuses.includes(status.status)) {
-        return status;
-      }
-      await this.sleep(this.resolvedOptions.pollIntervalMs);
-    }
-
-    // Timeout — cancel gracefully, preserve timeout error with cancel status
-    let cancelFailed = false;
+  // eslint-disable-next-line @typescript-eslint/max-params
+  async succeedTask(
+    taskId: string,
+    runId: string,
+    output: DreamerOutput,
+    task: TaskRecord,
+    contextHash: string,
+    _context: DreamerContext,
+  ): Promise<PeerRunnerResult<DreamerOutput>> {
+    // Store output before marking succeeded
     try {
-      await this.runtimeAdapter.cancelRun(runHandle.runId);
-    } catch (cancelErr) {
-      cancelFailed = true;
-      this.emitDreamerEvent('dreamer_cancel_run_failed', runHandle.runId, {
-        runId: runHandle.runId,
-        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
-      });
-    }
-    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
-    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
-  }
-
-  private async fetchAndParseOutput(runId: string, taskId: string): Promise<DreamerOutput> {
-    const result = await this.fetchOutputWithTelemetry(runId, taskId);
-    if (!result || !result.payload) {
-      this.emitDreamerEvent('dreamer_output_extraction_failed', taskId, {
-        runId,
-        stage: 'payload_missing',
-        errorMessage: `No output available for run ${runId}`,
-      });
-      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
-    }
-    const payload = result.payload as Record<string, unknown>;
-    if (typeof payload !== 'object' || payload === null) {
-      this.emitDreamerEvent('dreamer_output_extraction_failed', taskId, {
-        runId,
-        stage: 'payload_not_object',
-        errorMessage: `Output payload is not an object for run ${runId}`,
-      });
-      throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
-    }
-    return result.payload as DreamerOutput;
-  }
-
-  private async fetchOutputWithTelemetry(runId: string, taskId: string): Promise<Awaited<ReturnType<PDRuntimeAdapter['fetchOutput']>>> {
-    try {
-      return await this.runtimeAdapter.fetchOutput(runId);
-    } catch (fetchErr) {
-      this.emitDreamerEvent('dreamer_output_extraction_failed', taskId, {
-        runId,
-        stage: 'fetchOutput',
-        errorMessage: fetchErr instanceof Error ? fetchErr.message : String(fetchErr),
-      });
-      throw fetchErr;
-    }
-  }
-
-  private async succeedTask(ctx: SucceedContext): Promise<DreamerRunnerResult> {
-    // Store output before marking succeeded so run record reflects output
-    try {
-      await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));
+      await this.stateManager.updateRunOutput(runId, JSON.stringify(output));
     } catch (updateErr) {
-      this.emitDreamerEvent('dreamer_update_output_failed', ctx.taskId, {
-        runId: ctx.runId,
+      this.emitEvent('update_output_failed', taskId, {
+        runId,
         errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
       });
       throw updateErr;
     }
 
-    // Emit per-candidate telemetry
-    for (const candidate of ctx.output.candidates) {
-      this.emitDreamerEvent('dreamer_candidate_generated', ctx.taskId, {
-        candidateIndex: candidate.candidateIndex,
-        confidence: candidate.confidence,
-        riskLevel: candidate.riskLevel,
-      });
-    }
-
     // Write PIArtifact via artifactStore (idempotent upsert)
-    // PIArtifact is the core durable output of DreamerRunner.
-    // If artifact write fails, the task must NOT be marked succeeded —
-    // downstream runners (Philosopher/Scribe) require durable artifact input.
     let lineageArtifactIds: string[] = [];
     let lineageHasRejected = false;
     try {
-      const lineageResult = await this.resolveLineageArtifactIds(ctx.taskId);
+      const lineageResult = await this.resolveLineageArtifactIds(taskId);
       lineageArtifactIds = lineageResult.ids;
       lineageHasRejected = lineageResult.hasRejected;
     } catch (lineageErr) {
-      this.emitDreamerEvent('dreamer_lineage_resolve_failed', ctx.taskId, {
-        runId: ctx.runId,
+      this.emitEvent('lineage_resolve_failed', taskId, {
+        runId,
         errorMessage: lineageErr instanceof Error ? lineageErr.message : String(lineageErr),
       });
     }
 
     if (lineageHasRejected) {
-      this.emitDreamerEvent('dreamer_lineage_partial', ctx.taskId, {
-        runId: ctx.runId,
+      this.emitEvent('lineage_partial', taskId, {
+        runId,
         resolvedCount: lineageArtifactIds.length,
         warning: 'Some dependency artifact queries were rejected; lineage may be incomplete',
       });
     }
 
-    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
+    const artifactId = `pi-art-${taskId}-${runId}`;
     const now = new Date().toISOString();
     try {
       await this.artifactStore.upsertArtifact({
         artifactId,
         artifactKind: 'principle',
-        sourceTaskId: ctx.taskId,
+        sourceTaskId: taskId,
         lineageArtifactIds,
         validationStatus: 'pending',
-        contentJson: JSON.stringify(ctx.output),
+        contentJson: JSON.stringify(output),
         createdAt: now,
         updatedAt: now,
       });
     } catch (artifactErr) {
-      this.emitDreamerEvent('dreamer_artifact_write_failed', ctx.taskId, {
-        runId: ctx.runId,
+      this.emitEvent('artifact_write_failed', taskId, {
+        runId,
         errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
       });
       return this.retryOrFail({
-        taskId: ctx.taskId,
-        task: ctx.task,
+        taskId,
+        task,
         errorCategory: 'artifact_commit_failed',
         failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
       });
     }
 
-    // Mark task succeeded with dreamer:// resultRef
-    const resultRef = `dreamer://${ctx.runId}`;
+    // Mark task succeeded
+    const resultRef = `${this.config.resultRefPrefix}://${runId}`;
     try {
-      await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
+      await this.stateManager.markTaskSucceeded(taskId, resultRef);
     } catch (stateErr) {
-      this.emitDreamerEvent('dreamer_mark_succeeded_failed', ctx.taskId, {
-        taskId: ctx.taskId,
-        runId: ctx.runId,
+      this.emitEvent('mark_succeeded_failed', taskId, {
+        taskId,
+        runId,
         errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
       });
       throw stateErr;
     }
 
-    this.emitDreamerEvent('dreamer_task_succeeded', ctx.taskId, {
-      attemptCount: ctx.task.attemptCount,
+    this.emitEvent('task_succeeded', taskId, {
+      attemptCount: task.attemptCount,
       resultRef,
-      candidateCount: ctx.output.candidates.length,
+      candidateCount: output.candidates.length,
     });
 
-    this.phase = RunnerPhase.Completed;
     return {
       status: 'succeeded',
-      taskId: ctx.taskId,
-      runId: ctx.runId,
+      taskId,
+      runId,
       artifactId,
       resultRef,
-      contextHash: ctx.contextHash,
-      output: ctx.output,
-      attemptCount: ctx.task.attemptCount,
+      contextHash,
+      output,
+      attemptCount: task.attemptCount,
     };
   }
 
-  private async handleRuntimeFailure(
-    taskId: string,
-    task: TaskRecord,
-    runStatus: RunStatus,
-  ): Promise<DreamerRunnerResult> {
-    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status, runStatus.reason);
+  // ── Optional hooks ─────────────────────────────────────────────────────────
 
-    this.emitDreamerEvent('dreamer_run_failed', taskId, {
-      runStatus: runStatus.status,
-      errorCategory,
-    });
-
-    return this.retryOrFail({
-      taskId,
-      task,
-      errorCategory,
-      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
-    });
-  }
-
-  private async handleValidationError(ctx: ValidationErrorContext): Promise<DreamerRunnerResult> {
-    const category = ctx.errorCategory ?? 'output_invalid';
-
-    this.emitDreamerEvent('dreamer_output_invalid', ctx.taskId, {
-      errorCount: ctx.errors.length,
-      errorCategory: category,
-    });
-
-    return this.retryOrFail({
-      taskId: ctx.taskId,
-      task: ctx.task,
-      errorCategory: category,
-      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
-    });
-  }
-
-  private async handleLeaseOrPhaseError(
-    taskId: string,
-    error: unknown,
-  ): Promise<DreamerRunnerResult> {
-    const classified = this.classifyError(error);
-
-    // lease_conflict is concurrent-access conflict, not a state change.
-    // No mutation methods (markTaskFailed/markTaskRetryWait) are called.
-    if (classified.category === 'lease_conflict') {
-      this.emitDreamerEvent('dreamer_run_failed', taskId, {
-        errorCategory: 'lease_conflict',
-        errorMessage: classified.message,
-      });
-      return {
-        status: 'failed',
-        taskId,
-        errorCategory: 'lease_conflict',
-        failureReason: classified.message,
-        attemptCount: 1,
-      };
-    }
-
-    // Non-lease errors (e.g., storage_unavailable before lease) must not
-    // use synthetic TaskRecord. Build one with real defaults from options.
-    this.emitDreamerEvent('dreamer_run_failed', taskId, {
-      errorCategory: classified.category,
-      errorMessage: classified.message,
-    });
-
-    const task: TaskRecord = {
-      taskId,
-      taskKind: 'dreamer',
-      status: 'leased',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      attemptCount: 1,
-      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
-    };
-    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
-  }
-
-  private async handlePostLeaseError(
-    taskId: string,
-    task: TaskRecord,
-    error: unknown,
-  ): Promise<DreamerRunnerResult> {
-    const classified = this.classifyError(error);
-
-    this.emitDreamerEvent('dreamer_run_failed', taskId, {
-      errorCategory: classified.category,
-      errorMessage: classified.message,
-    });
-
-    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
-  }
-
-  private async retryOrFail(ctx: FailureContext): Promise<DreamerRunnerResult> {
-    // Check if error is permanent (never retry)
-    if (this.isPermanentError(ctx.errorCategory)) {
-      try {
-        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
-      } catch (stateErr) {
-        this.emitDreamerEvent('dreamer_mark_failed_error', ctx.taskId, {
-          errorCategory: 'storage_unavailable',
-          attemptCount: ctx.task.attemptCount,
-          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
-        });
-        return {
-          status: 'failed',
-          taskId: ctx.taskId,
-          errorCategory: 'storage_unavailable',
-          failureReason: `State manager error: ${ctx.failureReason}`,
-          attemptCount: ctx.task.attemptCount,
-        };
-      }
-      this.emitDreamerEvent('dreamer_task_failed', ctx.taskId, {
-        errorCategory: ctx.errorCategory,
-        attemptCount: ctx.task.attemptCount,
-        failureReason: ctx.failureReason,
-      });
-      this.phase = RunnerPhase.Failed;
-      return {
-        status: 'failed',
-        taskId: ctx.taskId,
-        errorCategory: ctx.errorCategory,
-        failureReason: ctx.failureReason,
-        attemptCount: ctx.task.attemptCount,
-      };
-    }
-
-    // Check retry policy
-    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
-    if (shouldRetry) {
-      try {
-        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
-      } catch (stateErr) {
-        this.emitDreamerEvent('dreamer_mark_retry_error', ctx.taskId, {
-          errorCategory: 'storage_unavailable',
-          attemptCount: ctx.task.attemptCount,
-          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
-        });
-        return {
-          status: 'failed',
-          taskId: ctx.taskId,
-          errorCategory: 'storage_unavailable',
-          failureReason: `State manager error: ${ctx.failureReason}`,
-          attemptCount: ctx.task.attemptCount,
-        };
-      }
-      this.emitDreamerEvent('dreamer_task_retried', ctx.taskId, {
-        errorCategory: ctx.errorCategory,
-        attemptCount: ctx.task.attemptCount,
-      });
-      this.phase = RunnerPhase.RetryWaiting;
-      return {
-        status: 'retried',
-        taskId: ctx.taskId,
-        errorCategory: ctx.errorCategory,
-        failureReason: ctx.failureReason,
-        attemptCount: ctx.task.attemptCount,
-      };
-    }
-
-    // Max attempts exceeded
-    try {
-      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
-    } catch (stateErr) {
-      this.emitDreamerEvent('dreamer_mark_failed_error', ctx.taskId, {
-        errorCategory: 'storage_unavailable',
-        attemptCount: ctx.task.attemptCount,
-        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
-      });
-      return {
-        status: 'failed',
-        taskId: ctx.taskId,
-        errorCategory: 'storage_unavailable',
-        failureReason: `State manager error: ${ctx.failureReason}`,
-        attemptCount: ctx.task.attemptCount,
-      };
-    }
-    this.emitDreamerEvent('dreamer_task_failed', ctx.taskId, {
-      errorCategory: 'max_attempts_exceeded',
-      attemptCount: ctx.task.attemptCount,
-      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
-    });
-    this.phase = RunnerPhase.Failed;
-    return {
-      status: 'failed',
-      taskId: ctx.taskId,
-      errorCategory: 'max_attempts_exceeded',
-      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
-      attemptCount: ctx.task.attemptCount,
-    };
-  }
-
-  // ── Error classification ──────────────────────────────────────────────────
-
-  private readonly PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set(
-    Object.freeze(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid'] as const),
-  );
-
-  private isPermanentError(category: PDErrorCategory): boolean {
-    return this.PERMANENT_ERROR_CATEGORIES.has(category);
-  }
-
+  /**
+   * Re-inject taskId if stripped by stripLineageFields (PRI-272 / ERR-008).
+   * Only fill when absent via Object.hasOwn — present-but-falsy values
+   * must reach validation and fail loud (Runtime Contract Rule 3).
+   */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
-    if (error instanceof PDRuntimeError) {
-      return { category: error.category, message: error.message };
-    }
-    if (error instanceof Error) {
-      return { category: 'execution_failed', message: error.message };
-    }
-    return { category: 'execution_failed', message: String(error) };
+  protected override postFetchTransform(taskId: string, output: DreamerOutput): void {
+    injectRunnerLineageIfAbsent(output as unknown, 'taskId', taskId);
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  private mapRunStatusToErrorCategory(status: string, _reason?: string): PDErrorCategory {
-    switch (status) {
-      case 'failed': return 'execution_failed';
-      case 'timed_out': return 'timeout';
-      case 'cancelled': return 'cancelled';
-      default: return 'execution_failed';
+  protected override emitSuccessTelemetry(taskId: string, output: DreamerOutput): void {
+    for (const candidate of output.candidates) {
+      this.emitEvent('candidate_generated', taskId, {
+        candidateIndex: candidate.candidateIndex,
+        confidence: candidate.confidence,
+        riskLevel: candidate.riskLevel,
+      });
     }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
-
-// ── Exports ───────────────────────────────────────────────────────────────────
-
-export { resolveDreamerRunnerOptions, DEFAULT_DREAMER_RUNNER_OPTIONS };

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -189,7 +189,7 @@ export class DreamerRunner extends BasePeerRunner<DreamerContext, DreamerOutput>
     });
   }
 
-  async validateOutput(output: DreamerOutput, taskId: string): Promise<PeerRunnerValidationResult> {
+  async validateOutput(output: unknown, taskId: string): Promise<PeerRunnerValidationResult> {
     const result = await this.validator.validate(output, taskId);
     return {
       valid: result.valid,
@@ -305,8 +305,8 @@ export class DreamerRunner extends BasePeerRunner<DreamerContext, DreamerOutput>
    * must reach validation and fail loud (Runtime Contract Rule 3).
    */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected override postFetchTransform(taskId: string, output: DreamerOutput): void {
-    injectRunnerLineageIfAbsent(output as unknown, 'taskId', taskId);
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+    injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
   }
 
   protected override emitSuccessTelemetry(taskId: string, output: DreamerOutput): void {

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/base-peer-runner-trust-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/base-peer-runner-trust-boundary.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Regression tests for BasePeerRunner trust boundary (ERR-001, ERR-005).
+ *
+ * Verifies that untrusted LLM/runtime payloads do NOT enter typed hooks
+ * before validation. Malformed payloads must be rejected at the
+ * validateOutput boundary — postFetchTransform and checkLineageIntegrity
+ * must never receive unvalidated data as TOutput.
+ *
+ * @see ERR-001: Treat parsed JSON / LLM output as unknown
+ * @see ERR-005: Do not use `as` to bypass runtime validation
+ * @see PRI-302 trust boundary fix
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BasePeerRunner } from '../base-peer-runner.js';
+import type { RuntimeStateManager } from '../../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../../runtime-protocol.js';
+import type { StoreEventEmitter } from '../../store/event-emitter.js';
+import type { PIArtifactStore } from '../../internalization/pi-artifact.js';
+import type { TaskRecord } from '../../task-status.js';
+import type { PDErrorCategory } from '../../error-categories.js';
+import type {
+  PeerRunnerDeps,
+  PeerRunnerResult,
+  PeerRunnerValidationResult,
+} from '../peer-runner-types.js';
+
+// ── Test fixture ─────────────────────────────────────────────────────────────
+
+interface TestContext {
+  contextHash: string;
+}
+
+interface TestOutput {
+  taskId: string;
+  valid: boolean;
+  data: string;
+}
+
+class TestPeerRunner extends BasePeerRunner<TestContext, TestOutput> {
+  public postFetchCallCount = 0;
+  public postFetchReceivedUnknown = true;
+  public checkLineageCallCount = 0;
+  public checkLineageReceivedUnknown = true;
+  public validateCallCount = 0;
+  public succeedCallCount = 0;
+  public shouldValidateSucceed = true;
+
+  constructor(deps: PeerRunnerDeps) {
+    super(
+      deps,
+      { owner: 'test', runtimeKind: 'test-double' },
+      {
+        runnerName: 'test',
+        expectedTaskKind: 'dreamer',
+        defaultAgentId: 'test',
+        resultRefPrefix: 'test',
+      },
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  get permanentErrorCategories(): ReadonlySet<PDErrorCategory> {
+    return new Set(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid', 'output_invalid']);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async buildContext(_taskId: string): Promise<TestContext> {
+    return { contextHash: 'test-hash' };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async invokeRuntime(_taskId: string, _context: TestContext): Promise<RunHandle> {
+    return {
+      runId: 'run-001',
+      runtimeKind: 'test-double',
+      startedAt: new Date().toISOString(),
+    };
+  }
+
+  async validateOutput(output: unknown, _taskId: string): Promise<PeerRunnerValidationResult> {
+    this.validateCallCount++;
+    // Verify that output is unknown (not pre-cast to TOutput)
+    this.postFetchReceivedUnknown = typeof output !== 'object' || output === null
+      ? true
+      : !(('data' in (output as Record<string, unknown>)) && typeof (output as Record<string, unknown>).data === 'string');
+
+    if (!this.shouldValidateSucceed) {
+      return { valid: false, errors: ['intentional validation failure'], errorCategory: 'output_invalid' };
+    }
+
+    // Simulate runtime validation: check shape
+    if (typeof output !== 'object' || output === null) {
+      return { valid: false, errors: ['not an object'], errorCategory: 'output_invalid' };
+    }
+    const record = output as Record<string, unknown>;
+    if (typeof record.data !== 'string') {
+      return { valid: false, errors: ['missing data field'], errorCategory: 'output_invalid' };
+    }
+
+    return { valid: true, errors: [] };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/max-params
+  async succeedTask(
+    taskId: string,
+    runId: string,
+    output: TestOutput,
+    task: TaskRecord,
+    _contextHash: string,
+    _context: TestContext,
+  ): Promise<PeerRunnerResult<TestOutput>> {
+    this.succeedCallCount++;
+    return {
+      status: 'succeeded',
+      taskId,
+      runId,
+      output,
+      attemptCount: task.attemptCount,
+    };
+  }
+
+  protected override postFetchTransform(_taskId: string, untrustedOutput: unknown): void {
+    this.postFetchCallCount++;
+    // Verify the output is NOT typed as TestOutput
+    this.postFetchReceivedUnknown = typeof untrustedOutput !== 'object' || untrustedOutput === null
+      ? true
+      : !('data' in (untrustedOutput as Record<string, unknown>));
+  }
+
+  protected override checkLineageIntegrity(_taskId: string, output: TestOutput): void {
+    this.checkLineageCallCount++;
+    // At this point, output SHOULD be typed (validation passed)
+    this.checkLineageReceivedUnknown = typeof output !== 'object' || output === null;
+  }
+}
+
+function createMockDeps(overrides?: Partial<PeerRunnerDeps>): PeerRunnerDeps {
+  return {
+    stateManager: {
+      acquireLease: vi.fn().mockResolvedValue({
+        taskId: 'task-001',
+        taskKind: 'dreamer',
+        status: 'leased',
+        attemptCount: 1,
+        maxAttempts: 3,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } satisfies TaskRecord),
+      getTask: vi.fn().mockResolvedValue(null),
+      getRunsByTask: vi.fn().mockResolvedValue([{ runId: 'run-001' }]),
+      getRetryPolicy: vi.fn().mockReturnValue({
+        shouldRetry: vi.fn().mockReturnValue(false),
+      }),
+      markTaskSucceeded: vi.fn().mockResolvedValue({}),
+      markTaskFailed: vi.fn().mockResolvedValue({}),
+      markTaskRetryWait: vi.fn().mockResolvedValue({}),
+      updateRunOutput: vi.fn().mockResolvedValue({}),
+    } as unknown as RuntimeStateManager,
+    runtimeAdapter: {
+      startRun: vi.fn().mockResolvedValue({
+        runId: 'run-001',
+        runtimeKind: 'test-double',
+        startedAt: new Date().toISOString(),
+      } satisfies RunHandle),
+      pollRun: vi.fn().mockResolvedValue({
+        status: 'succeeded',
+        runId: 'run-001',
+      } satisfies RunStatus),
+      fetchOutput: vi.fn(),
+      cancelRun: vi.fn(),
+    } as unknown as PDRuntimeAdapter,
+    eventEmitter: {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter,
+    artifactStore: {
+      upsertArtifact: vi.fn(),
+      listBySourceTaskId: vi.fn().mockResolvedValue([]),
+    } as unknown as PIArtifactStore,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('BasePeerRunner trust boundary (ERR-001, ERR-005)', () => {
+  let runner: TestPeerRunner;
+  let mockDeps: PeerRunnerDeps;
+
+  beforeEach(() => {
+    mockDeps = createMockDeps();
+    runner = new TestPeerRunner(mockDeps);
+  });
+
+  it('malformed payload (non-object) does NOT enter postFetchTransform', async () => {
+    // fetchOutput returns a non-object payload (e.g., string)
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: 'not-an-object',
+      runtimeKind: 'test-double',
+    });
+
+    const result = await runner.run('task-001');
+
+    // Should fail with output_invalid (payload_not_object stage in fetchAndParseOutput)
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    // postFetchTransform must NOT have been called
+    expect(runner.postFetchCallCount).toBe(0);
+  });
+
+  it('malformed payload (null) does NOT enter postFetchTransform', async () => {
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: null,
+      runtimeKind: 'test-double',
+    });
+
+    const result = await runner.run('task-001');
+
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+    expect(runner.postFetchCallCount).toBe(0);
+  });
+
+  it('malformed payload does NOT enter checkLineageIntegrity', async () => {
+    // fetchOutput returns a valid object, but validation fails
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: { wrong: 'shape' },
+      runtimeKind: 'test-double',
+    });
+    runner.shouldValidateSucceed = false;
+
+    const result = await runner.run('task-001');
+
+    // Should fail validation
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+
+    // postFetchTransform WAS called (it operates on untrusted data — this is OK)
+    expect(runner.postFetchCallCount).toBe(1);
+
+    // checkLineageIntegrity must NOT have been called (validation failed)
+    expect(runner.checkLineageCallCount).toBe(0);
+  });
+
+  it('valid output goes through full success path: fetch → postFetch → validate → checkLineage → succeed', async () => {
+    const validPayload = { taskId: 'task-001', valid: true, data: 'test-data' };
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: validPayload,
+      runtimeKind: 'test-double',
+    });
+
+    const result = await runner.run('task-001');
+
+    expect(result.status).toBe('succeeded');
+    expect(result.output).toEqual(validPayload);
+
+    // All hooks were called
+    expect(runner.postFetchCallCount).toBe(1);
+    expect(runner.validateCallCount).toBe(1);
+    expect(runner.checkLineageCallCount).toBe(1);
+    expect(runner.succeedCallCount).toBe(1);
+  });
+
+  it('postFetchTransform receives untrusted data (unknown), not typed TOutput', async () => {
+    const validPayload = { taskId: 'task-001', valid: true, data: 'test-data' };
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: validPayload,
+      runtimeKind: 'test-double',
+    });
+
+    await runner.run('task-001');
+
+    // postFetchTransform should have received the raw payload
+    // The "receivedUnknown" check verifies the data wasn't pre-typed
+    expect(runner.postFetchCallCount).toBe(1);
+  });
+
+  it('checkLineageIntegrity receives validated output (typed TOutput)', async () => {
+    const validPayload = { taskId: 'task-001', valid: true, data: 'test-data' };
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: validPayload,
+      runtimeKind: 'test-double',
+    });
+
+    await runner.run('task-001');
+
+    // checkLineageIntegrity should have been called with validated output
+    expect(runner.checkLineageCallCount).toBe(1);
+    // The output should be typed (not unknown)
+    expect(runner.checkLineageReceivedUnknown).toBe(false);
+  });
+
+  it('fetchOutput returning undefined triggers output_invalid', async () => {
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const result = await runner.run('task-001');
+
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+    expect(runner.postFetchCallCount).toBe(0);
+  });
+
+  it('fetchOutput returning payload with no payload field triggers output_invalid', async () => {
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      runtimeKind: 'test-double',
+      // no payload field
+    });
+
+    const result = await runner.run('task-001');
+
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('output_invalid');
+    expect(runner.postFetchCallCount).toBe(0);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
@@ -113,8 +113,8 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
   /** Invoke the runtime with runner-specific prompt builder. */
   abstract invokeRuntime(taskId: string, context: TContext): Promise<RunHandle>;
 
-  /** Validate the LLM output. */
-  abstract validateOutput(output: TOutput, taskId: string, context: TContext): Promise<PeerRunnerValidationResult>;
+  /** Validate the LLM output. Receives untrusted data — must perform runtime validation. */
+  abstract validateOutput(output: unknown, taskId: string, context: TContext): Promise<PeerRunnerValidationResult>;
 
   /** Commit artifact + mark task succeeded. Runner-specific commit strategy. */
   abstract succeedTask(
@@ -134,7 +134,10 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
     // default no-op
   }
 
-  /** Check lineage strip contract. Called after fetchAndParseOutput. */
+  /**
+   * Check lineage strip contract. Called AFTER validation passes.
+   * Receives validated output — safe to treat as TOutput.
+   */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   protected checkLineageIntegrity(_taskId: string, _output: TOutput): void {
     // default no-op
@@ -143,10 +146,10 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
   /**
    * Transform output after fetch, before validation.
    * Used by runners that need to re-inject lineage fields stripped by the adapter.
-   * Called after fetchAndParseOutput, before validateOutput.
+   * Receives untrusted data — must NOT assume TOutput shape.
    */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected postFetchTransform(_taskId: string, _output: TOutput): void {
+  protected postFetchTransform(_taskId: string, _untrustedOutput: unknown): void {
     // default no-op
   }
 
@@ -222,19 +225,17 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
         return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
       }
 
-      // 7. Fetch output
+      // 7. Fetch output (returns unknown — untrusted LLM/runtime payload)
       this.phase = RunnerPhase.FetchingOutput;
-      const output = await this.fetchAndParseOutput(runHandle.runId, taskId);
+      const untrustedOutput = await this.fetchAndParseOutput(runHandle.runId, taskId);
 
-      // 7b. Post-fetch transform (re-inject lineage fields, etc.)
-      this.postFetchTransform(taskId, output);
+      // 7b. Post-fetch transform on untrusted data (e.g., re-inject lineage fields).
+      // Operates on `unknown` — must NOT assume TOutput shape (ERR-001).
+      this.postFetchTransform(taskId, untrustedOutput);
 
-      // 7c. Check lineage integrity (optional hook)
-      this.checkLineageIntegrity(taskId, output);
-
-      // 8. Validate
+      // 8. Validate — the trust boundary. Only validated output becomes TOutput.
       this.phase = RunnerPhase.Validating;
-      const validationResult = await this.validateOutput(output, taskId, context);
+      const validationResult = await this.validateOutput(untrustedOutput, taskId, context);
       if (!validationResult.valid) {
         return await this.handleValidationError({
           taskId,
@@ -244,9 +245,15 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
         });
       }
 
+      // Validation passed — safe to treat as TOutput.
+      const output: TOutput = untrustedOutput as TOutput;
+
       this.emitEvent('output_validated', taskId, {});
 
-      // 8b. Emit success telemetry (optional hook)
+      // 8b. Check lineage integrity (receives validated output)
+      this.checkLineageIntegrity(taskId, output);
+
+      // 8c. Emit success telemetry (receives validated output)
       this.emitSuccessTelemetry(taskId, output, context);
 
       // 9. Succeed task (abstract — subclass implements commit strategy)
@@ -309,7 +316,13 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
 
   // ── Output fetching ────────────────────────────────────────────────────────
 
-  private async fetchAndParseOutput(runId: string, taskId: string): Promise<TOutput> {
+  /**
+   * Fetch raw output from the runtime adapter.
+   *
+   * Returns `unknown` — the payload is untrusted LLM/runtime output.
+   * Callers MUST validate before treating as TOutput (ERR-001, ERR-005).
+   */
+  private async fetchAndParseOutput(runId: string, taskId: string): Promise<unknown> {
     let result: Awaited<ReturnType<PDRuntimeAdapter['fetchOutput']>>;
     try {
       result = await this.runtimeAdapter.fetchOutput(runId);
@@ -331,7 +344,9 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
       throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
     }
 
-    const payload = result.payload as Record<string, unknown>;
+    // Structural check: payload must be a non-null object.
+    // This is NOT a type assertion — we still return `unknown`.
+    const { payload } = result;
     if (typeof payload !== 'object' || payload === null) {
       this.emitEvent('output_extraction_failed', taskId, {
         runId,
@@ -341,7 +356,7 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
       throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
     }
 
-    return result.payload as TOutput;
+    return payload;
   }
 
   // ── Lineage resolution ─────────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
@@ -1,0 +1,632 @@
+/**
+ * BasePeerRunner — Abstract base class for all peer runners (PRI-302).
+ *
+ * Extracts the shared lease → buildContext → invoke → poll → fetch →
+ * validate → succeed/fail pipeline from 8 duplicated runner implementations.
+ *
+ * Subclasses implement:
+ *   - permanentErrorCategories (abstract getter)
+ *   - buildContext() — runner-specific context assembly
+ *   - invokeRuntime() — runner-specific LLM invocation
+ *   - validateOutput() — runner-specific output validation
+ *   - succeedTask() — runner-specific artifact commit + task success
+ *
+ * Optional hooks:
+ *   - emitSuccessTelemetry() — runner-specific success telemetry (default: no-op)
+ *   - checkLineageIntegrity() — lineage strip contract check (default: no-op)
+ *
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ * @see Linear PRI-302
+ */
+
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type {
+  PDRuntimeAdapter,
+  RunHandle,
+  RunStatus,
+} from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { PIArtifactStore } from '../internalization/pi-artifact.js';
+import type { TaskRecord } from '../task-status.js';
+import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
+import type { TelemetryEvent } from '../../telemetry-event.js';
+import { RunnerPhase } from './runner-phase.js';
+import type {
+  PeerRunnerOptions,
+  ResolvedPeerRunnerOptions,
+  PeerRunnerDeps,
+  PeerRunnerConfig,
+  PeerRunnerResult,
+  PeerRunnerValidationResult,
+  FailureContext,
+} from './peer-runner-types.js';
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_PEER_RUNNER_OPTIONS: Readonly<Omit<ResolvedPeerRunnerOptions, 'owner' | 'runtimeKind'>> = {
+  pollIntervalMs: 5_000,
+  timeoutMs: 300_000,
+  defaultMaxAttempts: 3,
+  agentId: 'peer-runner',
+} as const;
+
+function resolvePeerRunnerOptions(
+  options: PeerRunnerOptions,
+  defaultAgentId: string,
+): ResolvedPeerRunnerOptions {
+  return {
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_PEER_RUNNER_OPTIONS.pollIntervalMs,
+    timeoutMs: options.timeoutMs ?? DEFAULT_PEER_RUNNER_OPTIONS.timeoutMs,
+    defaultMaxAttempts: options.defaultMaxAttempts ?? DEFAULT_PEER_RUNNER_OPTIONS.defaultMaxAttempts,
+    owner: options.owner,
+    runtimeKind: options.runtimeKind,
+    agentId: options.agentId ?? defaultAgentId,
+  };
+}
+
+// ── BasePeerRunner ───────────────────────────────────────────────────────────
+
+/**
+ * Abstract base class for peer runners.
+ *
+ * TContext — the type returned by buildContext(). Must include contextHash.
+ * TOutput — the type of the validated LLM output.
+ */
+export abstract class BasePeerRunner<TContext extends { contextHash: string }, TOutput> {
+  // ── Shared dependencies (protected for subclass access) ──
+  protected readonly stateManager: RuntimeStateManager;
+  protected readonly runtimeAdapter: PDRuntimeAdapter;
+  protected readonly eventEmitter: StoreEventEmitter;
+  protected readonly artifactStore: PIArtifactStore;
+  protected readonly resolvedOptions: ResolvedPeerRunnerOptions;
+  protected readonly config: PeerRunnerConfig;
+  private phase: RunnerPhase = RunnerPhase.Idle;
+
+  constructor(
+    deps: PeerRunnerDeps,
+    options: PeerRunnerOptions,
+    config: PeerRunnerConfig,
+  ) {
+    this.stateManager = deps.stateManager;
+    this.runtimeAdapter = deps.runtimeAdapter;
+    this.eventEmitter = deps.eventEmitter;
+    this.artifactStore = deps.artifactStore;
+    this.config = config;
+    this.resolvedOptions = resolvePeerRunnerOptions(options, config.defaultAgentId);
+  }
+
+  // ── Observability ──────────────────────────────────────────────────────────
+
+  /** Current internal phase. For testing/observability only. */
+  get currentPhase(): RunnerPhase {
+    return this.phase;
+  }
+
+  // ── Abstract: subclass must implement ───────────────────────────────────────
+
+  /** Permanent error categories — runner's inherent property. */
+  abstract get permanentErrorCategories(): ReadonlySet<PDErrorCategory>;
+
+  /** Build runner-specific context from task and predecessor outputs. */
+  abstract buildContext(taskId: string): Promise<TContext>;
+
+  /** Invoke the runtime with runner-specific prompt builder. */
+  abstract invokeRuntime(taskId: string, context: TContext): Promise<RunHandle>;
+
+  /** Validate the LLM output. */
+  abstract validateOutput(output: TOutput, taskId: string, context: TContext): Promise<PeerRunnerValidationResult>;
+
+  /** Commit artifact + mark task succeeded. Runner-specific commit strategy. */
+  abstract succeedTask(
+    taskId: string,
+    runId: string,
+    output: TOutput,
+    task: TaskRecord,
+    contextHash: string,
+    context: TContext,
+  ): Promise<PeerRunnerResult<TOutput>>;
+
+  // ── Optional hooks (default no-op) ─────────────────────────────────────────
+
+  /** Emit runner-specific success telemetry. Called after validation passes. */
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  protected emitSuccessTelemetry(_taskId: string, _output: TOutput, _context: TContext): void {
+    // default no-op
+  }
+
+  /** Check lineage strip contract. Called after fetchAndParseOutput. */
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  protected checkLineageIntegrity(_taskId: string, _output: TOutput): void {
+    // default no-op
+  }
+
+  /**
+   * Transform output after fetch, before validation.
+   * Used by runners that need to re-inject lineage fields stripped by the adapter.
+   * Called after fetchAndParseOutput, before validateOutput.
+   */
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  protected postFetchTransform(_taskId: string, _output: TOutput): void {
+    // default no-op
+  }
+
+  // ── Template method: full pipeline ─────────────────────────────────────────
+
+  /**
+   * Execute the full peer runner lifecycle for a task.
+   *
+   * Pipeline: lease → resolveRunId → buildContext → invoke → poll →
+   *           fetch → validate → succeedTask (abstract)
+   *
+   * Each invocation is independent — no mutable state between run() calls.
+   */
+  async run(taskId: string): Promise<PeerRunnerResult<TOutput>> {
+    this.phase = RunnerPhase.Idle;
+
+    // 1. Acquire lease — isolated try/catch so lease_conflict never uses synthetic TaskRecord
+    let leasedTask: TaskRecord;
+    try {
+      leasedTask = await this.stateManager.acquireLease({
+        taskId,
+        owner: this.resolvedOptions.owner,
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+    } catch (error) {
+      return await this.handleLeaseOrPhaseError(taskId, error);
+    }
+
+    // 1b. Validate task kind
+    if (leasedTask.taskKind !== this.config.expectedTaskKind) {
+      this.emitEvent('wrong_task_kind', taskId, {
+        expectedKind: this.config.expectedTaskKind,
+        actualKind: leasedTask.taskKind,
+      });
+      await this.stateManager.markTaskFailed(taskId, 'input_invalid');
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'input_invalid',
+        failureReason: `Task kind must be '${this.config.expectedTaskKind}', got '${leasedTask.taskKind}'`,
+        attemptCount: leasedTask.attemptCount,
+      };
+    }
+
+    this.emitEvent('task_leased', taskId, {
+      taskKind: this.config.expectedTaskKind,
+      attemptCount: leasedTask.attemptCount,
+    });
+
+    // All subsequent errors use the real leasedTask — no synthetic TaskRecord allowed
+    try {
+      // 2. Resolve store runId
+      const storeRunId = await this.resolveStoreRunId(taskId);
+
+      // 3. Build context
+      this.phase = RunnerPhase.BuildingContext;
+      const context = await this.buildContext(taskId);
+      this.emitEvent('context_built', taskId, { contextHash: context.contextHash });
+
+      // 4. Invoke runtime
+      this.phase = RunnerPhase.Invoking;
+      const runHandle = await this.invokeRuntime(taskId, context);
+      this.emitEvent('run_started', taskId, {
+        runtimeKind: this.resolvedOptions.runtimeKind,
+      });
+
+      // 5. Poll until terminal
+      this.phase = RunnerPhase.Polling;
+      const finalStatus = await this.pollUntilTerminal(runHandle);
+
+      // 6. Handle non-success terminal states
+      if (finalStatus.status !== 'succeeded') {
+        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
+      }
+
+      // 7. Fetch output
+      this.phase = RunnerPhase.FetchingOutput;
+      const output = await this.fetchAndParseOutput(runHandle.runId, taskId);
+
+      // 7b. Post-fetch transform (re-inject lineage fields, etc.)
+      this.postFetchTransform(taskId, output);
+
+      // 7c. Check lineage integrity (optional hook)
+      this.checkLineageIntegrity(taskId, output);
+
+      // 8. Validate
+      this.phase = RunnerPhase.Validating;
+      const validationResult = await this.validateOutput(output, taskId, context);
+      if (!validationResult.valid) {
+        return await this.handleValidationError({
+          taskId,
+          task: leasedTask,
+          errors: validationResult.errors,
+          errorCategory: validationResult.errorCategory,
+        });
+      }
+
+      this.emitEvent('output_validated', taskId, {});
+
+      // 8b. Emit success telemetry (optional hook)
+      this.emitSuccessTelemetry(taskId, output, context);
+
+      // 9. Succeed task (abstract — subclass implements commit strategy)
+      return await this.succeedTask(taskId, storeRunId, output, leasedTask, context.contextHash, context);
+    } catch (error) {
+      // Post-lease errors use retryOrFail with the real leasedTask
+      return await this.handlePostLeaseError(taskId, leasedTask, error);
+    }
+  }
+
+  // ── Telemetry ──────────────────────────────────────────────────────────────
+
+  /**
+   * Emit a telemetry event with the runner's name prefix.
+   * Event type: `{runnerName}_{eventType}`
+   */
+  protected emitEvent(
+    eventType: string,
+    taskId: string,
+    payload: Record<string, unknown>,
+  ): void {
+    this.eventEmitter.emitTelemetry({
+      eventType: `${this.config.runnerName}_${eventType}` as TelemetryEvent['eventType'],
+      traceId: taskId,
+      timestamp: new Date().toISOString(),
+      sessionId: this.resolvedOptions.owner,
+      agentId: this.resolvedOptions.agentId,
+      payload,
+    });
+  }
+
+  // ── Polling ────────────────────────────────────────────────────────────────
+
+  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
+    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
+
+    while (Date.now() < deadline) {
+      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
+      if (terminalStatuses.includes(status.status)) {
+        return status;
+      }
+      await this.sleep(this.resolvedOptions.pollIntervalMs);
+    }
+
+    // Timeout — cancel gracefully
+    let cancelFailed = false;
+    try {
+      await this.runtimeAdapter.cancelRun(runHandle.runId);
+    } catch (cancelErr) {
+      cancelFailed = true;
+      this.emitEvent('cancel_run_failed', runHandle.runId, {
+        runId: runHandle.runId,
+        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
+      });
+    }
+    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
+    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
+  }
+
+  // ── Output fetching ────────────────────────────────────────────────────────
+
+  private async fetchAndParseOutput(runId: string, taskId: string): Promise<TOutput> {
+    let result: Awaited<ReturnType<PDRuntimeAdapter['fetchOutput']>>;
+    try {
+      result = await this.runtimeAdapter.fetchOutput(runId);
+    } catch (fetchErr) {
+      this.emitEvent('output_extraction_failed', taskId, {
+        runId,
+        stage: 'fetchOutput',
+        errorMessage: fetchErr instanceof Error ? fetchErr.message : String(fetchErr),
+      });
+      throw fetchErr;
+    }
+
+    if (!result || !result.payload) {
+      this.emitEvent('output_extraction_failed', taskId, {
+        runId,
+        stage: 'payload_missing',
+        errorMessage: `No output available for run ${runId}`,
+      });
+      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
+    }
+
+    const payload = result.payload as Record<string, unknown>;
+    if (typeof payload !== 'object' || payload === null) {
+      this.emitEvent('output_extraction_failed', taskId, {
+        runId,
+        stage: 'payload_not_object',
+        errorMessage: `Output payload is not an object for run ${runId}`,
+      });
+      throw new PDRuntimeError('output_invalid', `Output payload is not an object for run ${runId}`);
+    }
+
+    return result.payload as TOutput;
+  }
+
+  // ── Lineage resolution ─────────────────────────────────────────────────────
+
+  /** Resolve artifact IDs from predecessor tasks for lineage tracking. */
+  protected async resolveLineageArtifactIds(taskId: string): Promise<{ ids: string[]; hasRejected: boolean }> {
+    const { hydratePITaskRecord } = await import('../internalization/pitask-metadata.js');
+    const task = await this.stateManager.getTask(taskId);
+    if (!task) return { ids: [], hasRejected: false };
+
+    const piTask = hydratePITaskRecord(task);
+    const deps = piTask?.dependencyTaskIds ?? [];
+    if (deps.length === 0) return { ids: [], hasRejected: false };
+
+    const lineageIds: string[] = [];
+    let hasRejected = false;
+    const results = await Promise.allSettled(
+      deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
+    );
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        for (const artifact of result.value) {
+          lineageIds.push(artifact.artifactId);
+        }
+      } else {
+        hasRejected = true;
+      }
+    }
+    return { ids: lineageIds, hasRejected };
+  }
+
+  // ── Store helpers ──────────────────────────────────────────────────────────
+
+  private async resolveStoreRunId(taskId: string): Promise<string> {
+    const runs = await this.stateManager.getRunsByTask(taskId);
+    const latestRun = runs[runs.length - 1];
+    if (!latestRun) {
+      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
+    }
+    return latestRun.runId;
+  }
+
+  /** Compute a deterministic hash from context references (observability only). */
+  protected static hashContextRefs(refs: readonly string[]): string {
+    if (refs.length === 0) return 'empty';
+    const str = refs.join('|');
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+    }
+    return `ctx-${Math.abs(hash).toString(16)}`;
+  }
+
+  // ── Error handling ─────────────────────────────────────────────────────────
+
+  private async handleLeaseOrPhaseError(
+    taskId: string,
+    error: unknown,
+  ): Promise<PeerRunnerResult<TOutput>> {
+    const classified = this.classifyError(error);
+
+    // lease_conflict is concurrent-access conflict, not a state change.
+    // No mutation methods (markTaskFailed/markTaskRetryWait) are called.
+    if (classified.category === 'lease_conflict') {
+      this.emitEvent('run_failed', taskId, {
+        errorCategory: 'lease_conflict',
+        errorMessage: classified.message,
+      });
+      return {
+        status: 'failed',
+        taskId,
+        errorCategory: 'lease_conflict',
+        failureReason: classified.message,
+        attemptCount: 1,
+      };
+    }
+
+    // Non-lease errors (e.g., storage_unavailable before lease) must not
+    // use synthetic TaskRecord. Build one with real defaults from options.
+    this.emitEvent('run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    const task: TaskRecord = {
+      taskId,
+      taskKind: this.config.expectedTaskKind,
+      status: 'leased',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      attemptCount: 1,
+      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
+    };
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async handlePostLeaseError(
+    taskId: string,
+    task: TaskRecord,
+    error: unknown,
+  ): Promise<PeerRunnerResult<TOutput>> {
+    const classified = this.classifyError(error);
+
+    this.emitEvent('run_failed', taskId, {
+      errorCategory: classified.category,
+      errorMessage: classified.message,
+    });
+
+    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
+  }
+
+  private async handleRuntimeFailure(
+    taskId: string,
+    task: TaskRecord,
+    runStatus: RunStatus,
+  ): Promise<PeerRunnerResult<TOutput>> {
+    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status, runStatus.reason);
+
+    this.emitEvent('run_failed', taskId, {
+      runStatus: runStatus.status,
+      errorCategory,
+    });
+
+    return this.retryOrFail({
+      taskId,
+      task,
+      errorCategory,
+      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
+    });
+  }
+
+  protected async handleValidationError(ctx: {
+    taskId: string;
+    task: TaskRecord;
+    errors: readonly string[];
+    errorCategory?: PDErrorCategory;
+  }): Promise<PeerRunnerResult<TOutput>> {
+    const category = ctx.errorCategory ?? 'output_invalid';
+
+    this.emitEvent('output_invalid', ctx.taskId, {
+      errorCount: ctx.errors.length,
+      errorCategory: category,
+    });
+
+    return this.retryOrFail({
+      taskId: ctx.taskId,
+      task: ctx.task,
+      errorCategory: category,
+      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
+    });
+  }
+
+  // ── Retry/fail state machine ───────────────────────────────────────────────
+
+  /**
+   * Core retry-or-fail decision.
+   *
+   * Uses try/catch around markTaskFailed/markTaskRetryWait for robustness.
+   * If state manager operations fail, returns storage_unavailable instead of
+   * propagating the exception (ERR-002: graceful degradation with reason).
+   */
+  protected async retryOrFail(ctx: FailureContext): Promise<PeerRunnerResult<TOutput>> {
+    // Permanent errors — never retry
+    if (this.permanentErrorCategories.has(ctx.errorCategory)) {
+      try {
+        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitEvent('mark_failed_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitEvent('task_failed', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+        failureReason: ctx.failureReason,
+      });
+      this.phase = RunnerPhase.Failed;
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    // Retry policy check
+    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
+    if (shouldRetry) {
+      try {
+        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
+      } catch (stateErr) {
+        this.emitEvent('mark_retry_error', ctx.taskId, {
+          errorCategory: 'storage_unavailable',
+          attemptCount: ctx.task.attemptCount,
+          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        });
+        return {
+          status: 'failed',
+          taskId: ctx.taskId,
+          errorCategory: 'storage_unavailable',
+          failureReason: `State manager error: ${ctx.failureReason}`,
+          attemptCount: ctx.task.attemptCount,
+        };
+      }
+      this.emitEvent('task_retried', ctx.taskId, {
+        errorCategory: ctx.errorCategory,
+        attemptCount: ctx.task.attemptCount,
+      });
+      this.phase = RunnerPhase.RetryWaiting;
+      return {
+        status: 'retried',
+        taskId: ctx.taskId,
+        errorCategory: ctx.errorCategory,
+        failureReason: ctx.failureReason,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+
+    // Max attempts exceeded
+    try {
+      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
+    } catch (stateErr) {
+      this.emitEvent('mark_failed_error', ctx.taskId, {
+        errorCategory: 'storage_unavailable',
+        attemptCount: ctx.task.attemptCount,
+        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
+      });
+      return {
+        status: 'failed',
+        taskId: ctx.taskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `State manager error: ${ctx.failureReason}`,
+        attemptCount: ctx.task.attemptCount,
+      };
+    }
+    this.emitEvent('task_failed', ctx.taskId, {
+      errorCategory: 'max_attempts_exceeded',
+      attemptCount: ctx.task.attemptCount,
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+    });
+    this.phase = RunnerPhase.Failed;
+    return {
+      status: 'failed',
+      taskId: ctx.taskId,
+      errorCategory: 'max_attempts_exceeded',
+      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
+      attemptCount: ctx.task.attemptCount,
+    };
+  }
+
+  // ── Error classification ──────────────────────────────────────────────────
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
+    if (error instanceof PDRuntimeError) {
+      return { category: error.category, message: error.message };
+    }
+    if (error instanceof Error) {
+      return { category: 'execution_failed', message: error.message };
+    }
+    return { category: 'execution_failed', message: String(error) };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private mapRunStatusToErrorCategory(status: string, _reason?: string): PDErrorCategory {
+    switch (status) {
+      case 'failed': return 'execution_failed';
+      case 'timed_out': return 'timeout';
+      case 'cancelled': return 'cancelled';
+      default: return 'execution_failed';
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/principles-core/src/runtime-v2/runner/peer-runner-types.ts
+++ b/packages/principles-core/src/runtime-v2/runner/peer-runner-types.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared types for the BasePeerRunner abstract class (PRI-302).
+ *
+ * These types replace the per-runner duplicated interfaces:
+ *   - DreamerRunnerOptions / ScribeRunnerOptions / ...
+ *   - DreamerRunnerDeps / ScribeRunnerDeps / ...
+ *   - DreamerRunnerResult / ScribeRunnerResult / ...
+ *   - FailureContext / SucceedContext / ValidationErrorContext
+ *
+ * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ */
+
+import type { PDErrorCategory } from '../error-categories.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter } from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { PIArtifactStore } from '../internalization/pi-artifact.js';
+import type { PeerRunnerKind } from '../internalization/peer-runner-contracts.js';
+import type { TaskRecord } from '../task-status.js';
+
+// ── Options ──────────────────────────────────────────────────────────────────
+
+/** Shared runner options. All peer runners accept this shape. */
+export interface PeerRunnerOptions {
+  readonly pollIntervalMs?: number;
+  readonly timeoutMs?: number;
+  readonly defaultMaxAttempts?: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId?: string;
+}
+
+/** Resolved options with defaults applied. */
+export interface ResolvedPeerRunnerOptions {
+  readonly pollIntervalMs: number;
+  readonly timeoutMs: number;
+  readonly defaultMaxAttempts: number;
+  readonly owner: string;
+  readonly runtimeKind: string;
+  readonly agentId: string;
+}
+
+// ── Dependencies ─────────────────────────────────────────────────────────────
+
+/**
+ * Shared dependencies injected into all peer runners.
+ *
+ * Runners with additional dependencies (e.g. DiagnosticianRunner needs
+ * ContextAssembler + DiagnosticianCommitter) should extend this interface.
+ */
+export interface PeerRunnerDeps {
+  readonly stateManager: RuntimeStateManager;
+  readonly runtimeAdapter: PDRuntimeAdapter;
+  readonly eventEmitter: StoreEventEmitter;
+  readonly artifactStore: PIArtifactStore;
+}
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+/**
+ * Runner-specific configuration passed to the BasePeerRunner constructor.
+ * Each subclass provides its own config instance.
+ */
+export interface PeerRunnerConfig {
+  /** Runner name for telemetry event prefix (e.g. 'dreamer', 'scribe'). */
+  readonly runnerName: string;
+  /** Expected taskKind for lease validation (e.g. 'dreamer'). */
+  readonly expectedTaskKind: PeerRunnerKind;
+  /** Default agentId if not provided in options. */
+  readonly defaultAgentId: string;
+  /** ResultRef prefix (e.g. 'dreamer' → 'dreamer://runId'). */
+  readonly resultRefPrefix: string;
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+/** Status values shared by all peer runner results. */
+export type PeerRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
+
+/**
+ * Generic result type for all peer runners.
+ * Replaces the per-runner result interfaces (DreamerRunnerResult, etc.).
+ */
+export interface PeerRunnerResult<TOutput> {
+  readonly status: PeerRunnerResultStatus;
+  readonly taskId: string;
+  readonly runId?: string;
+  readonly artifactId?: string;
+  readonly resultRef?: string;
+  readonly contextHash?: string;
+  readonly output?: TOutput;
+  readonly errorCategory?: PDErrorCategory;
+  readonly failureReason?: string;
+  readonly attemptCount: number;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+/**
+ * Validation result returned by the abstract validateOutput() method.
+ * Replaces the per-runner validation result interfaces.
+ *
+ * Note: named PeerRunnerValidationResult to avoid collision with
+ * ValidationResult from rule-code-validator.ts.
+ */
+export interface PeerRunnerValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+  readonly errorCategory?: PDErrorCategory;
+}
+
+// ── Internal context types (used by base class) ──────────────────────────────
+
+/** Context for the retryOrFail decision. */
+export interface FailureContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errorCategory: PDErrorCategory;
+  readonly failureReason: string;
+}
+
+/** Context for validation error handling. */
+export interface ValidationErrorContext {
+  readonly taskId: string;
+  readonly task: TaskRecord;
+  readonly errors: readonly string[];
+  readonly errorCategory?: PDErrorCategory;
+}


### PR DESCRIPTION
## Summary

Extracts `BasePeerRunner<TContext, TOutput>` abstract class from duplicated peer runner pipeline code. Migrates DreamerRunner as proof of concept.

## Changes

### New files
- `runner/base-peer-runner.ts` — abstract base class with shared `lease → buildContext → invoke → poll → fetch → validate → succeed/fail` pipeline
- `runner/peer-runner-types.ts` — shared types (`PeerRunnerOptions`, `PeerRunnerDeps`, `PeerRunnerConfig`, `PeerRunnerResult`, `PeerRunnerValidationResult`)

### Modified
- `dreamer-runner.ts` — extends `BasePeerRunner`, only Dreamer-specific logic remains (~200 lines vs ~830 lines original)
- `index.ts` — exports new base class and shared types

## Design Decisions (confirmed via grilling + review)

| Decision | Choice | Rationale |
|----------|--------|-----------|
| `succeedTask()` | Abstract | DiagnosticianCommitter vs PIArtifactStore — fundamentally different commit contracts |
| `validateOutput()` | Abstract | Delegates to injected validator in subclass |
| `retryOrFail()` | Base class | Adopts robust Internalization pattern (try/catch with storage_unavailable fallback) |
| `postFetchTransform()` | Optional hook | DreamerRunner uses it to re-inject lineage fields |
| `checkLineageIntegrity()` | Optional hook | DiagnosticianRunner will override for lineage strip contract |
| `PeerRunnerConfig` | Constructor param | runnerName, expectedTaskKind, defaultAgentId, resultRefPrefix |

## Scope — Phase A Only

**This PR:** BasePeerRunner + DreamerRunner only.
**Follow-up PRs:** Remaining 6 internalization runners + DiagnosticianRunner.

## Verification

- [x] `npm run build --workspace=@principles/core` — PASS
- [x] 744 tests (16 files) — PASS
- [x] `architecture-regression.test.ts` (440 tests) — PASS
- [x] DiagnosticianRunner tests (34 tests) — PASS (untouched)
- [x] `npm run build --workspace=openclaw-plugin` — PASS
- [x] lint — PASS

## Relevant ERR Entries

- ERR-001: `unknown` for untrusted data (LLM output)
- ERR-009: Required fields fail loud
- ERR-015/018/019: Retry/repair loops distinguish current/next/recorded state
- ERR-002: Graceful degradation with structured reason (try/catch pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **基础设施改进**
  * 优化内部运行器架构，提升代码可维护性和一致性。
  * 新增共享类型定义，为后续扩展奠定基础。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->