### PR TITLE
refactor(core): migrate PhilosopherRunner to BasePeerRunner

### DIFF
--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
@@ -353,4 +353,49 @@ describe('PhilosopherRunner trust boundary (PRI-new)', () => {
     // postFetchTransform should NOT overwrite present-but-empty taskId
     expect(result.failureReason).toContain('taskId mismatch');
   });
+
+  it('risks with non-string elements fails validation (ERR-005 Rule 4)', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const badRisksOutput = { ...makePhilosopherOutput(), risks: [1, {}] };
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: badRisksOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.failureReason).toContain('risks must contain only strings');
+  });
+
+  it('sourceDreamerArtifactId mismatch fails loud before artifact commit (ERR-004)', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const mismatchedIdOutput = { ...makePhilosopherOutput(), sourceDreamerArtifactId: 'wrong-artifact-id' };
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedIdOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+
+    const artifacts = await artifactStore.listBySourceTaskId(PHILOSOPHER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
@@ -1,0 +1,356 @@
+/**
+ * PhilosopherRunner trust-boundary and behavior parity tests (PRI-new).
+ *
+ * Proves that after BasePeerRunner migration:
+ * 1. Malformed runtime payload never reaches typed hooks or artifact commit
+ * 2. Validation failure does not call success commit
+ * 3. Successful run creates expected artifact and marks task succeeded
+ * 4. Lease conflict is non-mutating
+ * 5. postFetchTransform receives untrusted data, checkLineageIntegrity receives validated output
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PhilosopherRunner } from '../philosopher-runner.js';
+import type { PhilosopherRunnerDeps } from '../philosopher-runner.js';
+import type { PhilosopherOutputV1 } from '../philosopher-output.js';
+import { DefaultPhilosopherValidator } from '../philosopher-output.js';
+import type { PIArtifactRecord } from '../pi-artifact.js';
+import { MemoryPIArtifactStore } from '../pi-artifact-store.js';
+import type { RuntimeStateManager } from '../../store/runtime-state-manager.js';
+import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../../runtime-protocol.js';
+import type { StoreEventEmitter } from '../../store/event-emitter.js';
+import type { TaskRecord } from '../../task-status.js';
+import { PDRuntimeError } from '../../error-categories.js';
+import { createPITaskDiagnosticJson } from '../pitask-metadata.js';
+
+const DREAMER_TASK_ID = 'dreamer-tb-001';
+const PHILOSOPHER_TASK_ID = 'philosopher-tb-001';
+
+function makeDreamerArtifact(): PIArtifactRecord {
+  return {
+    artifactId: 'pi-art-dreamer-tb-001-run-001',
+    artifactKind: 'principle',
+    sourceTaskId: DREAMER_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify({
+      valid: true,
+      taskId: DREAMER_TASK_ID,
+      candidates: [{
+        candidateIndex: 0,
+        badDecision: 'Ignored error handling',
+        betterDecision: 'Add try/catch',
+        rationale: 'Prevents unhandled rejections',
+        confidence: 0.85,
+        riskLevel: 'low',
+        strategicPerspective: 'reliability',
+      }],
+      contextRefs: [],
+      generatedAt: new Date().toISOString(),
+    }),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makePhilosopherOutput(): PhilosopherOutputV1 {
+  return {
+    taskId: PHILOSOPHER_TASK_ID,
+    sourceDreamerArtifactId: 'pi-art-dreamer-tb-001-run-001',
+    thesis: 'Error handling should be systematic',
+    principleCandidate: {
+      title: 'Systematic Error Handling',
+      rationale: 'Uncaught errors cascade',
+      scope: 'All async operations',
+      confidence: 0.9,
+    },
+    risks: ['May add latency'],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function makePhilosopherTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: PHILOSOPHER_TASK_ID,
+    taskKind: 'philosopher',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [DREAMER_TASK_ID],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-dreamer-tb-001-run-001' }],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeDreamerTask(): TaskRecord {
+  return {
+    taskId: DREAMER_TASK_ID,
+    taskKind: 'dreamer',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'dreamer://run-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [{ artifactType: 'principle', ref: 'pi-art-dreamer-tb-001-run-001' }],
+    }),
+  };
+}
+
+describe('PhilosopherRunner trust boundary (PRI-new)', () => {
+  let artifactStore: MemoryPIArtifactStore;
+
+  beforeEach(() => {
+    artifactStore = new MemoryPIArtifactStore();
+  });
+
+  function createMockDeps(overrides: Partial<PhilosopherRunnerDeps> = {}): PhilosopherRunnerDeps {
+    const philosopherTask = makePhilosopherTask();
+    const dreamerTask = makeDreamerTask();
+
+    const stateManager = {
+      acquireLease: vi.fn().mockResolvedValue(philosopherTask),
+      getTask: vi.fn().mockImplementation((id: string) => {
+        if (id === PHILOSOPHER_TASK_ID) return Promise.resolve(philosopherTask);
+        if (id === DREAMER_TASK_ID) return Promise.resolve(dreamerTask);
+        return Promise.resolve(null);
+      }),
+      getRunsByTask: vi.fn().mockResolvedValue([{
+        runId: 'run-phil-tb-001',
+        taskId: PHILOSOPHER_TASK_ID,
+        runtimeKind: 'philosopher',
+        startedAt: new Date().toISOString(),
+      }]),
+      updateRunOutput: vi.fn().mockResolvedValue(undefined),
+      markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+      markTaskFailed: vi.fn().mockResolvedValue(undefined),
+      markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+      getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+    } as unknown as RuntimeStateManager;
+
+    const runHandle: RunHandle = { runId: 'run-phil-tb-001', runtimeKind: 'test-double', startedAt: new Date().toISOString() };
+    const succeededStatus: RunStatus = { status: 'succeeded', runId: 'run-phil-tb-001' };
+
+    const runtimeAdapter = {
+      startRun: vi.fn().mockResolvedValue(runHandle),
+      pollRun: vi.fn().mockResolvedValue(succeededStatus),
+      fetchOutput: vi.fn().mockResolvedValue({ payload: makePhilosopherOutput() }),
+      cancelRun: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PDRuntimeAdapter;
+
+    const eventEmitter = {
+      emitTelemetry: vi.fn(),
+    } as unknown as StoreEventEmitter;
+
+    const validator = new DefaultPhilosopherValidator();
+
+    return {
+      stateManager,
+      runtimeAdapter,
+      eventEmitter,
+      validator,
+      artifactStore,
+      ...overrides,
+    };
+  }
+
+  it('malformed payload (non-object) does not write artifact or mark succeeded', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: 'not-an-object',
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+
+    const artifacts = await artifactStore.listBySourceTaskId(PHILOSOPHER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('malformed payload (null) does not write artifact or mark succeeded', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: null,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('validation failure does not write artifact or mark succeeded', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const invalidOutput = {
+      taskId: 'wrong-id',
+      sourceDreamerArtifactId: '',
+      thesis: '',
+      principleCandidate: { title: '', rationale: '', scope: '', confidence: 2.0 },
+      risks: 'not-array',
+      generatedAt: '',
+    };
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+
+    const artifacts = await artifactStore.listBySourceTaskId(PHILOSOPHER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
+
+  it('valid output goes through full success path — artifact written and task succeeded', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('succeeded');
+    expect(result.artifactId).toBeDefined();
+    expect(result.output).toBeDefined();
+    expect(result.output?.principleCandidate.title).toBe('Systematic Error Handling');
+
+    expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
+      PHILOSOPHER_TASK_ID,
+      expect.stringContaining('philosopher://'),
+    );
+
+    const artifacts = await artifactStore.listBySourceTaskId(PHILOSOPHER_TASK_ID);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifactKind).toBe('principle');
+  });
+
+  it('lease conflict does not mutate task state', async () => {
+    const deps = createMockDeps();
+    (deps.stateManager as unknown as Record<string, unknown>).acquireLease = vi.fn().mockRejectedValue(
+      new PDRuntimeError('lease_conflict', 'Another runner holds the lease'),
+    );
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(result.errorCategory).toBe('lease_conflict');
+    expect(deps.stateManager.markTaskFailed).not.toHaveBeenCalled();
+    expect(deps.stateManager.markTaskRetryWait).not.toHaveBeenCalled();
+  });
+
+  it('taskId mismatch in output fails validation loud', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const mismatchedOutput = { ...makePhilosopherOutput(), taskId: 'wrong-task-id' };
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: mismatchedOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    // output_invalid is transient; retry policy says shouldRetry=false → max_attempts_exceeded
+    expect(result.errorCategory).toBe('max_attempts_exceeded');
+    expect(result.failureReason).toContain('taskId mismatch');
+  });
+
+  it('postFetchTransform re-injects taskId when stripped', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    // Simulate adapter stripping lineage fields (PRI-272)
+    const strippedOutput = { ...makePhilosopherOutput() };
+    delete (strippedOutput as Record<string, unknown>).taskId;
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: strippedOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    // postFetchTransform should re-inject taskId, then validation should pass
+    expect(result.status).toBe('succeeded');
+  });
+
+  it('present-but-empty taskId fails validation (not silently corrected)', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const emptyTaskIdOutput = { ...makePhilosopherOutput(), taskId: '' };
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: emptyTaskIdOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    // output_invalid is transient; retry policy says shouldRetry=false → max_attempts_exceeded
+    expect(result.errorCategory).toBe('max_attempts_exceeded');
+    // postFetchTransform should NOT overwrite present-but-empty taskId
+    expect(result.failureReason).toContain('taskId mismatch');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
@@ -398,4 +398,41 @@ describe('PhilosopherRunner trust boundary (PRI-new)', () => {
     const artifacts = await artifactStore.listBySourceTaskId(PHILOSOPHER_TASK_ID);
     expect(artifacts).toHaveLength(0);
   });
+
+  it('invalid errorCategory from custom validator fails loud and does not leak through', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+
+    // Custom validator returning an invalid errorCategory string
+    const rogueValidator = {
+      validate: vi.fn().mockResolvedValue({
+        valid: false,
+        errors: ['some validation error'],
+        errorCategory: 'not_a_real_category',
+      }),
+    };
+
+    const deps = createMockDeps({ artifactStore, validator: rogueValidator });
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    // The invalid category must NOT leak into result.errorCategory
+    expect(result.errorCategory).not.toBe('not_a_real_category');
+    // errorCategory should be a valid PDErrorCategory (output_invalid from the guard,
+    // then escalated by retryOrFail to max_attempts_exceeded since output_invalid is transient
+    // and retry policy returns shouldRetry=false)
+    expect(result.errorCategory).toBe('max_attempts_exceeded');
+    // failureReason must mention the invalid errorCategory
+    expect(result.failureReason).toContain('invalid errorCategory');
+    expect(result.failureReason).toContain('not_a_real_category');
+    // No artifact written, no task marked succeeded
+    expect(deps.stateManager.markTaskSucceeded).not.toHaveBeenCalled();
+    const artifacts = await artifactStore.listBySourceTaskId(PHILOSOPHER_TASK_ID);
+    expect(artifacts).toHaveLength(0);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
@@ -20,6 +20,7 @@ import type { PDRuntimeAdapter, RunHandle, RunStatus } from '../../runtime-proto
 import type { StoreEventEmitter } from '../../store/event-emitter.js';
 import type { TaskRecord } from '../../task-status.js';
 import { PDRuntimeError } from '../../error-categories.js';
+import { RunnerPhase } from '../../runner/runner-phase.js';
 import { createPITaskDiagnosticJson } from '../pitask-metadata.js';
 
 const DREAMER_TASK_ID = 'dreamer-tb-001';
@@ -253,6 +254,7 @@ describe('PhilosopherRunner trust boundary (PRI-new)', () => {
     expect(result.artifactId).toBeDefined();
     expect(result.output).toBeDefined();
     expect(result.output?.principleCandidate.title).toBe('Systematic Error Handling');
+    expect(runner.currentPhase).toBe(RunnerPhase.Completed);
 
     expect(deps.stateManager.markTaskSucceeded).toHaveBeenCalledWith(
       PHILOSOPHER_TASK_ID,
@@ -307,7 +309,36 @@ describe('PhilosopherRunner trust boundary (PRI-new)', () => {
     expect(result.failureReason).toContain('taskId mismatch');
   });
 
-  it('postFetchTransform re-injects taskId when stripped', async () => {
+  it('validation failure does not set phase to Completed', async () => {
+    await artifactStore.upsertArtifact(makeDreamerArtifact());
+    const deps = createMockDeps({ artifactStore });
+
+    const invalidOutput = {
+      taskId: 'wrong-id',
+      sourceDreamerArtifactId: '',
+      thesis: '',
+      principleCandidate: { title: '', rationale: '', scope: '', confidence: 2.0 },
+      risks: 'not-array',
+      generatedAt: '',
+    };
+    (deps.runtimeAdapter as unknown as Record<string, unknown>).fetchOutput = vi.fn().mockResolvedValue({
+      payload: invalidOutput,
+    });
+
+    const runner = new PhilosopherRunner(deps, {
+      owner: 'test',
+      runtimeKind: 'philosopher',
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(PHILOSOPHER_TASK_ID);
+    expect(result.status).toBe('failed');
+    expect(runner.currentPhase).not.toBe(RunnerPhase.Completed);
+    expect(runner.currentPhase).toBe(RunnerPhase.Failed);
+  });
+
+  it('postFetchTransform re-injects taskId when stripped — phase is Completed', async () => {
     await artifactStore.upsertArtifact(makeDreamerArtifact());
     const deps = createMockDeps({ artifactStore });
 
@@ -328,6 +359,7 @@ describe('PhilosopherRunner trust boundary (PRI-new)', () => {
     const result = await runner.run(PHILOSOPHER_TASK_ID);
     // postFetchTransform should re-inject taskId, then validation should pass
     expect(result.status).toBe('succeeded');
+    expect(runner.currentPhase).toBe(RunnerPhase.Completed);
   });
 
   it('present-but-empty taskId fails validation (not silently corrected)', async () => {

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-output.ts
@@ -57,46 +57,55 @@ export interface PhilosopherValidationResult {
 }
 
 export interface PhilosopherValidator {
-  validate(output: PhilosopherOutputV1, taskId: string): Promise<PhilosopherValidationResult>;
+  /**
+   * Validate untrusted LLM/runtime output.
+   *
+   * Receives `unknown` — must perform runtime validation before
+   * treating as PhilosopherOutputV1 (ERR-001, ERR-005, ERR-054).
+   */
+  validate(output: unknown, taskId: string): Promise<PhilosopherValidationResult>;
 }
 
 export class DefaultPhilosopherValidator implements PhilosopherValidator {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  async validate(output: PhilosopherOutputV1, taskId: string): Promise<PhilosopherValidationResult> {
+  async validate(output: unknown, taskId: string): Promise<PhilosopherValidationResult> {
     const errors: string[] = [];
 
     if (typeof output !== 'object' || output === null) {
       return { valid: false, errors: ['Output is not an object'], errorCategory: 'output_invalid' };
     }
 
-    if (output.taskId !== taskId) {
-      errors.push(`taskId mismatch: expected ${taskId}, got ${String(output.taskId)}`);
+    // Safe property access via Record<string, unknown> — no `as PhilosopherOutputV1` (ERR-001).
+    const record = output as Record<string, unknown>;
+
+    if (record.taskId !== taskId) {
+      errors.push(`taskId mismatch: expected ${taskId}, got ${String(record.taskId)}`);
     }
 
-    if (typeof output.sourceDreamerArtifactId !== 'string' || output.sourceDreamerArtifactId.trim() === '') {
+    if (typeof record.sourceDreamerArtifactId !== 'string' || record.sourceDreamerArtifactId.trim() === '') {
       errors.push('sourceDreamerArtifactId must be non-empty string');
     }
 
-    if (typeof output.thesis !== 'string' || output.thesis.trim() === '') {
+    if (typeof record.thesis !== 'string' || record.thesis.trim() === '') {
       errors.push('thesis must be non-empty string');
     }
 
-    if (typeof output.principleCandidate !== 'object' || output.principleCandidate === null) {
+    if (typeof record.principleCandidate !== 'object' || record.principleCandidate === null) {
       errors.push('principleCandidate must be an object');
     } else {
-      const pc = output.principleCandidate as unknown as Record<string, unknown>;
-      if (typeof pc.title !== 'string' || (pc.title).trim() === '') errors.push('principleCandidate.title must be non-empty string');
-      if (typeof pc.rationale !== 'string' || (pc.rationale).trim() === '') errors.push('principleCandidate.rationale must be non-empty string');
-      if (typeof pc.scope !== 'string' || (pc.scope).trim() === '') errors.push('principleCandidate.scope must be non-empty string');
+      const pc = record.principleCandidate as Record<string, unknown>;
+      if (typeof pc.title !== 'string' || pc.title.trim() === '') errors.push('principleCandidate.title must be non-empty string');
+      if (typeof pc.rationale !== 'string' || pc.rationale.trim() === '') errors.push('principleCandidate.rationale must be non-empty string');
+      if (typeof pc.scope !== 'string' || pc.scope.trim() === '') errors.push('principleCandidate.scope must be non-empty string');
       if (typeof pc.confidence !== 'number') errors.push('principleCandidate.confidence must be number');
       else if (pc.confidence < 0 || pc.confidence > 1) errors.push('principleCandidate.confidence must be in [0, 1]');
     }
 
-    if (!Array.isArray(output.risks)) {
+    if (!Array.isArray(record.risks)) {
       errors.push('risks must be an array');
     }
 
-    if (typeof output.generatedAt !== 'string' || output.generatedAt.trim() === '') {
+    if (typeof record.generatedAt !== 'string' || record.generatedAt.trim() === '') {
       errors.push('generatedAt must be non-empty string');
     }
 

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-output.ts
@@ -103,6 +103,8 @@ export class DefaultPhilosopherValidator implements PhilosopherValidator {
 
     if (!Array.isArray(record.risks)) {
       errors.push('risks must be an array');
+    } else if (record.risks.some((risk: unknown) => typeof risk !== 'string')) {
+      errors.push('risks must contain only strings');
     }
 
     if (typeof record.generatedAt !== 'string' || record.generatedAt.trim() === '') {

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
@@ -28,7 +28,7 @@
 import type { RunHandle } from '../runtime-protocol.js';
 import type { PhilosopherOutputV1, PhilosopherValidator } from './philosopher-output.js';
 import type { TaskRecord } from '../task-status.js';
-import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
+import { PDRuntimeError, type PDErrorCategory, isPDErrorCategory } from '../error-categories.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
 import { PhilosopherPromptBuilder } from './philosopher-prompt-builder.js';
 import { injectRunnerLineageIfAbsent } from './peer-runner-contracts.js';
@@ -194,10 +194,28 @@ export class PhilosopherRunner extends BasePeerRunner<PhilosopherContext, Philos
 
   async validateOutput(output: unknown, taskId: string): Promise<PeerRunnerValidationResult> {
     const result = await this.validator.validate(output, taskId);
+
+    // Trust-boundary: validator is an injected dependency returning `string | undefined`
+    // for errorCategory. We must not `as`-cast; validate at runtime (ERR-001, ERR-005).
+    const rawCategory = result.errorCategory;
+    let errorCategory: PDErrorCategory | undefined;
+    if (rawCategory == null) {
+      errorCategory = undefined;
+    } else if (isPDErrorCategory(rawCategory)) {
+      errorCategory = rawCategory;
+    } else {
+      // Invalid errorCategory from validator — fail loud, do not pass through
+      return {
+        valid: false,
+        errors: [...result.errors, `invalid errorCategory: ${rawCategory}`],
+        errorCategory: 'output_invalid',
+      };
+    }
+
     return {
       valid: result.valid,
       errors: result.errors,
-      errorCategory: result.errorCategory as PDErrorCategory | undefined,
+      errorCategory,
     };
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
@@ -1,8 +1,9 @@
 /**
  * PhilosopherRunner — Second peer runner for the Internalization Engine (PRI-90).
  *
- * Reads a Dreamer artifact, invokes PDRuntimeAdapter for philosophical analysis,
- * validates output, writes Philosopher PIArtifact, and marks task succeeded.
+ * Migrated to extend BasePeerRunner (PRI-new). The shared lease → buildContext →
+ * invoke → poll → fetch → validate → succeed/fail pipeline is now in the base
+ * class. This file only contains Philosopher-specific logic.
  *
  * Key constraints (ADR-0003):
  *   - Uses PDRuntimeAdapter for all LLM execution (no direct SDK calls)
@@ -17,32 +18,38 @@
  *   3. fetch Dreamer artifact via PIArtifactStore
  *   4. startRun with outputSchemaRef: 'philosopher-output-v1'
  *   5. pollUntilTerminal
- *   6. fetchOutput → parse as PhilosopherOutputV1
- *   7. validate via PhilosopherValidator
- *   8. updateRunOutput → persist serialized output
- *   9. write PIArtifact → markTaskSucceeded with philosopher:// resultRef
+ *   6. fetchOutput → validate as unknown → cast to PhilosopherOutputV1
+ *   7. updateRunOutput → persist serialized output
+ *   8. write PIArtifact → markTaskSucceeded with philosopher:// resultRef
  *
  * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
+ * @see BasePeerRunner in runner/base-peer-runner.ts
  */
-import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
-import type {
-  PDRuntimeAdapter,
-  RunHandle,
-  RunStatus,
-  StartRunInput,
-} from '../runtime-protocol.js';
-import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { RunHandle } from '../runtime-protocol.js';
 import type { PhilosopherOutputV1, PhilosopherValidator } from './philosopher-output.js';
-import type { PIArtifactStore } from './pi-artifact.js';
 import type { TaskRecord } from '../task-status.js';
 import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
-import type { TelemetryEvent } from '../../telemetry-event.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
-import { RunnerPhase } from '../runner/runner-phase.js';
 import { PhilosopherPromptBuilder } from './philosopher-prompt-builder.js';
 import { injectRunnerLineageIfAbsent } from './peer-runner-contracts.js';
+import { BasePeerRunner } from '../runner/base-peer-runner.js';
+import type {
+  PeerRunnerOptions,
+  PeerRunnerDeps,
+  PeerRunnerResult,
+  PeerRunnerValidationResult,
+} from '../runner/peer-runner-types.js';
 
-// ── Result Types ──────────────────────────────────────────────────────────────
+// ── Philosopher-specific context ──────────────────────────────────────────────
+
+/** Context built by PhilosopherRunner.buildContext() and consumed by invokeRuntime(). */
+interface PhilosopherContext {
+  readonly contextHash: string;
+  readonly dreamerArtifact: string;
+  readonly sourceDreamerArtifactId: string;
+}
+
+// ── Result Types (backward-compatible exports) ───────────────────────────────
 
 export type PhilosopherRunnerResultStatus = 'succeeded' | 'failed' | 'retried';
 
@@ -59,16 +66,9 @@ export interface PhilosopherRunnerResult {
   readonly attemptCount: number;
 }
 
-// ── Constructor Options ───────────────────────────────────────────────────────
+// ── Constructor Options (backward-compatible exports) ────────────────────────
 
-export interface PhilosopherRunnerOptions {
-  readonly pollIntervalMs?: number;
-  readonly timeoutMs?: number;
-  readonly defaultMaxAttempts?: number;
-  readonly owner: string;
-  readonly runtimeKind: string;
-  readonly agentId?: string;
-}
+export type PhilosopherRunnerOptions = PeerRunnerOptions;
 
 export interface ResolvedPhilosopherRunnerOptions {
   readonly pollIntervalMs: number;
@@ -79,14 +79,14 @@ export interface ResolvedPhilosopherRunnerOptions {
   readonly agentId: string;
 }
 
-const DEFAULT_PHILOSOPHER_RUNNER_OPTIONS: Readonly<Omit<ResolvedPhilosopherRunnerOptions, 'owner' | 'runtimeKind'>> = {
+export const DEFAULT_PHILOSOPHER_RUNNER_OPTIONS: Readonly<Omit<ResolvedPhilosopherRunnerOptions, 'owner' | 'runtimeKind'>> = {
   pollIntervalMs: 5_000,
   timeoutMs: 300_000,
   defaultMaxAttempts: 3,
   agentId: 'philosopher',
 } as const;
 
-function resolvePhilosopherRunnerOptions(options: PhilosopherRunnerOptions): ResolvedPhilosopherRunnerOptions {
+export function resolvePhilosopherRunnerOptions(options: PhilosopherRunnerOptions): ResolvedPhilosopherRunnerOptions {
   return {
     pollIntervalMs: options.pollIntervalMs ?? DEFAULT_PHILOSOPHER_RUNNER_OPTIONS.pollIntervalMs,
     timeoutMs: options.timeoutMs ?? DEFAULT_PHILOSOPHER_RUNNER_OPTIONS.timeoutMs,
@@ -97,180 +97,35 @@ function resolvePhilosopherRunnerOptions(options: PhilosopherRunnerOptions): Res
   };
 }
 
-// ── Dependencies ──────────────────────────────────────────────────────────────
+// ── Dependencies (backward-compatible; extends PeerRunnerDeps) ───────────────
 
-export interface PhilosopherRunnerDeps {
-  readonly stateManager: RuntimeStateManager;
-  readonly runtimeAdapter: PDRuntimeAdapter;
-  readonly eventEmitter: StoreEventEmitter;
+export interface PhilosopherRunnerDeps extends PeerRunnerDeps {
   readonly validator: PhilosopherValidator;
-  readonly artifactStore: PIArtifactStore;
 }
 
-// ── Context types for error handling ──────────────────────────────────────────
+// ── PhilosopherRunner ────────────────────────────────────────────────────────
 
-interface FailureContext {
-  readonly taskId: string;
-  readonly task: TaskRecord;
-  readonly errorCategory: PDErrorCategory;
-  readonly failureReason: string;
-}
-
-interface SucceedContext {
-  readonly taskId: string;
-  readonly runId: string;
-  readonly output: PhilosopherOutputV1;
-  readonly task: TaskRecord;
-  readonly contextHash: string;
-}
-
-interface ValidationErrorContext {
-  readonly taskId: string;
-  readonly task: TaskRecord;
-  readonly errors: readonly string[];
-  readonly errorCategory?: string;
-}
-
-// ── PhilosopherRunner ──────────────────────────────────────────────────────────
-
-export class PhilosopherRunner {
-  private phase: RunnerPhase = RunnerPhase.Idle;
-  private readonly resolvedOptions: ResolvedPhilosopherRunnerOptions;
-  private readonly stateManager: RuntimeStateManager;
-  private readonly runtimeAdapter: PDRuntimeAdapter;
-  private readonly eventEmitter: StoreEventEmitter;
+export class PhilosopherRunner extends BasePeerRunner<PhilosopherContext, PhilosopherOutputV1> {
   private readonly validator: PhilosopherValidator;
-  private readonly artifactStore: PIArtifactStore;
 
-  constructor(deps: PhilosopherRunnerDeps, options: PhilosopherRunnerOptions) {
-    this.stateManager = deps.stateManager;
-    this.runtimeAdapter = deps.runtimeAdapter;
-    this.eventEmitter = deps.eventEmitter;
+  constructor(deps: PhilosopherRunnerDeps, options: PeerRunnerOptions) {
+    super(deps, options, {
+      runnerName: 'philosopher',
+      expectedTaskKind: 'philosopher',
+      defaultAgentId: 'philosopher',
+      resultRefPrefix: 'philosopher',
+    });
     this.validator = deps.validator;
-    this.artifactStore = deps.artifactStore;
-    this.resolvedOptions = resolvePhilosopherRunnerOptions(options);
   }
 
-  get currentPhase(): RunnerPhase {
-    return this.phase;
+  // ── Abstract implementations ───────────────────────────────────────────────
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  get permanentErrorCategories(): ReadonlySet<PDErrorCategory> {
+    return new Set(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid']);
   }
 
-  private emitPhilosopherEvent(
-    eventType: string,
-    taskId: string,
-    payload: Record<string, unknown>,
-  ): void {
-    this.eventEmitter.emitTelemetry({
-      eventType: eventType as TelemetryEvent['eventType'],
-      traceId: taskId,
-      timestamp: new Date().toISOString(),
-      sessionId: this.resolvedOptions.owner,
-      agentId: this.resolvedOptions.agentId,
-      payload,
-    });
-  }
-
-  async run(taskId: string): Promise<PhilosopherRunnerResult> {
-    this.phase = RunnerPhase.Idle;
-
-    let leasedTask: TaskRecord;
-    try {
-      leasedTask = await this.stateManager.acquireLease({
-        taskId,
-        owner: this.resolvedOptions.owner,
-        runtimeKind: this.resolvedOptions.runtimeKind,
-      });
-    } catch (error) {
-      return await this.handleLeaseOrPhaseError(taskId, error);
-    }
-
-    if (leasedTask.taskKind !== 'philosopher') {
-      this.emitPhilosopherEvent('philosopher_wrong_task_kind', taskId, {
-        expectedKind: 'philosopher',
-        actualKind: leasedTask.taskKind,
-      });
-      await this.stateManager.markTaskFailed(taskId, 'input_invalid');
-      return {
-        status: 'failed',
-        taskId,
-        errorCategory: 'input_invalid',
-        failureReason: `Task kind must be 'philosopher', got '${leasedTask.taskKind}'`,
-        attemptCount: leasedTask.attemptCount,
-      };
-    }
-
-    this.emitPhilosopherEvent('philosopher_task_leased', taskId, {
-      taskKind: 'philosopher',
-      attemptCount: leasedTask.attemptCount,
-    });
-
-    try {
-      const storeRunId = await this.resolveStoreRunId(taskId);
-
-      this.phase = RunnerPhase.BuildingContext;
-      const { contextHash, dreamerArtifact, sourceDreamerArtifactId } = await this.buildContext(taskId);
-
-      if (!dreamerArtifact) {
-        return this.retryOrFail({
-          taskId,
-          task: leasedTask,
-          errorCategory: 'input_invalid',
-          failureReason: 'Dreamer dependency artifact not found',
-        });
-      }
-
-      this.emitPhilosopherEvent('philosopher_context_built', taskId, { contextHash });
-
-      this.phase = RunnerPhase.Invoking;
-      const runHandle = await this.invokeRuntime({ taskId, contextHash, dreamerArtifact, sourceDreamerArtifactId });
-
-      this.emitPhilosopherEvent('philosopher_run_started', taskId, {
-        runtimeKind: this.resolvedOptions.runtimeKind,
-      });
-
-      this.phase = RunnerPhase.Polling;
-      const finalStatus = await this.pollUntilTerminal(runHandle);
-
-      if (finalStatus.status !== 'succeeded') {
-        return await this.handleRuntimeFailure(taskId, leasedTask, finalStatus);
-      }
-
-      this.phase = RunnerPhase.FetchingOutput;
-      const output = await this.fetchAndParseOutput(runHandle.runId);
-
-      // Re-inject taskId if stripped by stripLineageFields (PRI-272 / ERR-008).
-      injectRunnerLineageIfAbsent(output, 'taskId', taskId);
-
-      this.phase = RunnerPhase.Validating;
-      const validationResult = await this.validator.validate(output, taskId);
-      if (!validationResult.valid) {
-        return await this.handleValidationError({
-          taskId,
-          task: leasedTask,
-          errors: validationResult.errors,
-          errorCategory: validationResult.errorCategory,
-        });
-      }
-
-      this.emitPhilosopherEvent('philosopher_output_validated', taskId, {
-        principleTitle: output.principleCandidate.title,
-      });
-
-      return await this.succeedTask({
-        taskId,
-        runId: storeRunId,
-        output,
-        task: leasedTask,
-        contextHash,
-      });
-    } catch (error) {
-      return await this.handlePostLeaseError(taskId, leasedTask, error);
-    }
-  }
-
-  // ── Phase methods ─────────────────────────────────────────────────────────
-
-  private async buildContext(taskId: string): Promise<{ contextHash: string; dreamerArtifact: string | null; sourceDreamerArtifactId: string | null }> {
+  async buildContext(taskId: string): Promise<PhilosopherContext> {
     const task = await this.stateManager.getTask(taskId);
     if (!task) {
       throw new PDRuntimeError('input_invalid', `Task ${taskId} not found`);
@@ -280,15 +135,14 @@ export class PhilosopherRunner {
     const deps = piTask?.dependencyTaskIds ?? [];
 
     if (deps.length === 0) {
-      this.emitPhilosopherEvent('philosopher_no_dependencies', taskId, {});
-      return { contextHash: 'empty', dreamerArtifact: null, sourceDreamerArtifactId: null };
+      throw new PDRuntimeError('input_invalid', 'Dreamer dependency artifact not found');
     }
 
     for (const depId of deps) {
       const depTask = await this.stateManager.getTask(depId);
       if (!depTask) continue;
       if (depTask.status !== 'succeeded') {
-        this.emitPhilosopherEvent('philosopher_dependency_not_succeeded', taskId, {
+        this.emitEvent('dependency_not_succeeded', taskId, {
           depTaskId: depId,
           depStatus: depTask.status,
         });
@@ -302,409 +156,167 @@ export class PhilosopherRunner {
         if (!firstArtifact) continue;
         const artifactRef = depPiTask?.outputArtifactRefs?.[0]?.ref ?? `pi-artifact://${depId}`;
         return {
-          contextHash: PhilosopherRunner.hashContextRefs([artifactRef]),
+          contextHash: BasePeerRunner.hashContextRefs([artifactRef]),
           dreamerArtifact: firstArtifact.contentJson,
           sourceDreamerArtifactId: firstArtifact.artifactId,
         };
       }
     }
 
-    this.emitPhilosopherEvent('philosopher_no_dreamer_artifact', taskId, {});
-    return { contextHash: 'empty', dreamerArtifact: null, sourceDreamerArtifactId: null };
+    throw new PDRuntimeError('input_invalid', 'Dreamer dependency artifact not found');
   }
 
-  private static hashContextRefs(refs: readonly string[]): string {
-    if (refs.length === 0) return 'empty';
-    const str = refs.join('|');
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
-    }
-    return `ctx-${Math.abs(hash).toString(16)}`;
-  }
-
-  private async resolveStoreRunId(taskId: string): Promise<string> {
-    const runs = await this.stateManager.getRunsByTask(taskId);
-    const latestRun = runs[runs.length - 1];
-    if (!latestRun) {
-      throw new PDRuntimeError('execution_failed', `No run records found for task ${taskId} after lease acquisition`);
-    }
-    return latestRun.runId;
-  }
-
-  private async invokeRuntime(params: {
-    taskId: string;
-    contextHash: string;
-    dreamerArtifact: string | null;
-    sourceDreamerArtifactId: string | null;
-  }): Promise<RunHandle> {
-    let parsedDreamerArtifact: unknown = null;
-    if (params.dreamerArtifact) {
-      try {
-        parsedDreamerArtifact = JSON.parse(params.dreamerArtifact);
-      } catch {
-        parsedDreamerArtifact = params.dreamerArtifact;
-      }
+  async invokeRuntime(taskId: string, context: PhilosopherContext): Promise<RunHandle> {
+    let parsedDreamerArtifact: unknown;
+    try {
+      parsedDreamerArtifact = JSON.parse(context.dreamerArtifact);
+    } catch {
+      parsedDreamerArtifact = context.dreamerArtifact;
     }
 
     const builder = new PhilosopherPromptBuilder();
     const { message } = builder.buildPrompt({
-      taskId: params.taskId,
-      contextHash: params.contextHash,
+      taskId,
+      contextHash: context.contextHash,
       dreamerArtifact: parsedDreamerArtifact,
-      sourceDreamerArtifactId: params.sourceDreamerArtifactId ?? '',
+      sourceDreamerArtifactId: context.sourceDreamerArtifactId,
     });
 
-    const startInput: StartRunInput = {
+    return this.runtimeAdapter.startRun({
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
-      taskRef: { taskId: params.taskId },
+      taskRef: { taskId },
       inputPayload: message,
       contextItems: [],
       outputSchemaRef: 'philosopher-output-v1',
       timeoutMs: this.resolvedOptions.timeoutMs,
+    });
+  }
+
+  async validateOutput(output: unknown, taskId: string): Promise<PeerRunnerValidationResult> {
+    const result = await this.validator.validate(output, taskId);
+    return {
+      valid: result.valid,
+      errors: result.errors,
+      errorCategory: result.errorCategory as PDErrorCategory | undefined,
     };
-
-    return this.runtimeAdapter.startRun(startInput);
   }
 
-  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
-    const deadline = Date.now() + this.resolvedOptions.timeoutMs;
-    const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
-
-    while (Date.now() < deadline) {
-      const status = await this.runtimeAdapter.pollRun(runHandle.runId);
-      if (terminalStatuses.includes(status.status)) {
-        return status;
-      }
-      await this.sleep(this.resolvedOptions.pollIntervalMs);
-    }
-
-    let cancelFailed = false;
+  // eslint-disable-next-line @typescript-eslint/max-params
+  async succeedTask(
+    taskId: string,
+    runId: string,
+    output: PhilosopherOutputV1,
+    task: TaskRecord,
+    contextHash: string,
+    _context: PhilosopherContext,
+  ): Promise<PeerRunnerResult<PhilosopherOutputV1>> {
+    // Store output before marking succeeded
     try {
-      await this.runtimeAdapter.cancelRun(runHandle.runId);
-    } catch (cancelErr) {
-      cancelFailed = true;
-      this.emitPhilosopherEvent('philosopher_cancel_run_failed', runHandle.runId, {
-        runId: runHandle.runId,
-        errorMessage: cancelErr instanceof Error ? cancelErr.message : String(cancelErr),
-      });
-    }
-    const cancelNote = cancelFailed ? ' (cancelRun also failed)' : '';
-    throw new PDRuntimeError('timeout', `Run ${runHandle.runId} timed out after ${this.resolvedOptions.timeoutMs}ms${cancelNote}`);
-  }
-
-  private async fetchAndParseOutput(runId: string): Promise<PhilosopherOutputV1> {
-    const result = await this.runtimeAdapter.fetchOutput(runId);
-    if (!result || !result.payload) {
-      throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
-    }
-    return result.payload as PhilosopherOutputV1;
-  }
-
-  private async succeedTask(ctx: SucceedContext): Promise<PhilosopherRunnerResult> {
-    try {
-      await this.stateManager.updateRunOutput(ctx.runId, JSON.stringify(ctx.output));
+      await this.stateManager.updateRunOutput(runId, JSON.stringify(output));
     } catch (updateErr) {
-      this.emitPhilosopherEvent('philosopher_update_output_failed', ctx.taskId, {
-        runId: ctx.runId,
+      this.emitEvent('update_output_failed', taskId, {
+        runId,
         errorMessage: updateErr instanceof Error ? updateErr.message : String(updateErr),
       });
       throw updateErr;
     }
 
-    const artifactId = `pi-art-${ctx.taskId}-${ctx.runId}`;
-    const now = new Date().toISOString();
-
+    // Resolve lineage artifact IDs
     let lineageArtifactIds: string[] = [];
+    let lineageHasRejected = false;
     try {
-      const piTask = hydratePITaskRecord(ctx.task);
-      const deps = piTask?.dependencyTaskIds ?? [];
-      const results = await Promise.allSettled(
-        deps.map((depId) => this.artifactStore.listBySourceTaskId(depId)),
-      );
-      for (const result of results) {
-        if (result.status === 'fulfilled') {
-          for (const artifact of result.value) {
-            lineageArtifactIds.push(artifact.artifactId);
-          }
-        }
-      }
-    } catch { /* lineage resolution failure is non-fatal */ }
+      const lineageResult = await this.resolveLineageArtifactIds(taskId);
+      lineageArtifactIds = lineageResult.ids;
+      lineageHasRejected = lineageResult.hasRejected;
+    } catch (lineageErr) {
+      this.emitEvent('lineage_resolve_failed', taskId, {
+        runId,
+        errorMessage: lineageErr instanceof Error ? lineageErr.message : String(lineageErr),
+      });
+    }
 
+    if (lineageHasRejected) {
+      this.emitEvent('lineage_partial', taskId, {
+        runId,
+        resolvedCount: lineageArtifactIds.length,
+        warning: 'Some dependency artifact queries were rejected; lineage may be incomplete',
+      });
+    }
+
+    // Write PIArtifact via artifactStore (idempotent upsert)
+    const artifactId = `pi-art-${taskId}-${runId}`;
+    const now = new Date().toISOString();
     try {
       await this.artifactStore.upsertArtifact({
         artifactId,
         artifactKind: 'principle',
-        sourceTaskId: ctx.taskId,
+        sourceTaskId: taskId,
         lineageArtifactIds,
         validationStatus: 'pending',
-        contentJson: JSON.stringify(ctx.output),
+        contentJson: JSON.stringify(output),
         createdAt: now,
         updatedAt: now,
       });
     } catch (artifactErr) {
-      this.emitPhilosopherEvent('philosopher_artifact_write_failed', ctx.taskId, {
-        runId: ctx.runId,
+      this.emitEvent('artifact_write_failed', taskId, {
+        runId,
         errorMessage: artifactErr instanceof Error ? artifactErr.message : String(artifactErr),
       });
       return this.retryOrFail({
-        taskId: ctx.taskId,
-        task: ctx.task,
+        taskId,
+        task,
         errorCategory: 'artifact_commit_failed',
         failureReason: `PIArtifact write failed: ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
       });
     }
 
-    const resultRef = `philosopher://${ctx.runId}`;
+    // Mark task succeeded
+    const resultRef = `${this.config.resultRefPrefix}://${runId}`;
     try {
-      await this.stateManager.markTaskSucceeded(ctx.taskId, resultRef);
+      await this.stateManager.markTaskSucceeded(taskId, resultRef);
     } catch (stateErr) {
-      this.emitPhilosopherEvent('philosopher_mark_succeeded_failed', ctx.taskId, {
-        taskId: ctx.taskId,
-        runId: ctx.runId,
+      this.emitEvent('mark_succeeded_failed', taskId, {
+        taskId,
+        runId,
         errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
       });
       throw stateErr;
     }
 
-    this.emitPhilosopherEvent('philosopher_task_succeeded', ctx.taskId, {
-      attemptCount: ctx.task.attemptCount,
+    this.emitEvent('task_succeeded', taskId, {
+      attemptCount: task.attemptCount,
       resultRef,
-      principleTitle: ctx.output.principleCandidate.title,
+      principleTitle: output.principleCandidate.title,
     });
 
-    this.phase = RunnerPhase.Completed;
     return {
       status: 'succeeded',
-      taskId: ctx.taskId,
-      runId: ctx.runId,
+      taskId,
+      runId,
       artifactId,
       resultRef,
-      contextHash: ctx.contextHash,
-      output: ctx.output,
-      attemptCount: ctx.task.attemptCount,
+      contextHash,
+      output,
+      attemptCount: task.attemptCount,
     };
   }
 
-  private async handleRuntimeFailure(
-    taskId: string,
-    task: TaskRecord,
-    runStatus: RunStatus,
-  ): Promise<PhilosopherRunnerResult> {
-    const errorCategory = this.mapRunStatusToErrorCategory(runStatus.status);
+  // ── Optional hooks ─────────────────────────────────────────────────────────
 
-    this.emitPhilosopherEvent('philosopher_run_failed', taskId, {
-      runStatus: runStatus.status,
-      errorCategory,
-    });
-
-    return this.retryOrFail({
-      taskId,
-      task,
-      errorCategory,
-      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
-    });
-  }
-
-  private async handleValidationError(ctx: ValidationErrorContext): Promise<PhilosopherRunnerResult> {
-    const category = (ctx.errorCategory ?? 'output_invalid') as PDErrorCategory;
-
-    this.emitPhilosopherEvent('philosopher_output_invalid', ctx.taskId, {
-      errorCount: ctx.errors.length,
-      errorCategory: category,
-    });
-
-    return this.retryOrFail({
-      taskId: ctx.taskId,
-      task: ctx.task,
-      errorCategory: category,
-      failureReason: `Validation failed: ${ctx.errors.join('; ')}`,
-    });
-  }
-
-  private async handleLeaseOrPhaseError(
-    taskId: string,
-    error: unknown,
-  ): Promise<PhilosopherRunnerResult> {
-    const classified = this.classifyError(error);
-
-    if (classified.category === 'lease_conflict') {
-      this.emitPhilosopherEvent('philosopher_run_failed', taskId, {
-        errorCategory: 'lease_conflict',
-        errorMessage: classified.message,
-      });
-      return {
-        status: 'failed',
-        taskId,
-        errorCategory: 'lease_conflict',
-        failureReason: classified.message,
-        attemptCount: 1,
-      };
-    }
-
-    this.emitPhilosopherEvent('philosopher_run_failed', taskId, {
-      errorCategory: classified.category,
-      errorMessage: classified.message,
-    });
-
-    const task: TaskRecord = {
-      taskId,
-      taskKind: 'philosopher',
-      status: 'leased',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      attemptCount: 1,
-      maxAttempts: this.resolvedOptions.defaultMaxAttempts,
-    };
-    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
-  }
-
-  private async handlePostLeaseError(
-    taskId: string,
-    task: TaskRecord,
-    error: unknown,
-  ): Promise<PhilosopherRunnerResult> {
-    const classified = this.classifyError(error);
-
-    this.emitPhilosopherEvent('philosopher_run_failed', taskId, {
-      errorCategory: classified.category,
-      errorMessage: classified.message,
-    });
-
-    return this.retryOrFail({ taskId, task, errorCategory: classified.category, failureReason: classified.message });
-  }
-
-  private async retryOrFail(ctx: FailureContext): Promise<PhilosopherRunnerResult> {
-    if (this.isPermanentError(ctx.errorCategory)) {
-      try {
-        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
-      } catch (stateErr) {
-        this.emitPhilosopherEvent('philosopher_mark_failed_error', ctx.taskId, {
-          errorCategory: 'storage_unavailable',
-          attemptCount: ctx.task.attemptCount,
-          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
-        });
-        return {
-          status: 'failed',
-          taskId: ctx.taskId,
-          errorCategory: 'storage_unavailable',
-          failureReason: `State manager error: ${ctx.failureReason}`,
-          attemptCount: ctx.task.attemptCount,
-        };
-      }
-      this.emitPhilosopherEvent('philosopher_task_failed', ctx.taskId, {
-        errorCategory: ctx.errorCategory,
-        attemptCount: ctx.task.attemptCount,
-        failureReason: ctx.failureReason,
-      });
-      this.phase = RunnerPhase.Failed;
-      return {
-        status: 'failed',
-        taskId: ctx.taskId,
-        errorCategory: ctx.errorCategory,
-        failureReason: ctx.failureReason,
-        attemptCount: ctx.task.attemptCount,
-      };
-    }
-
-    const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
-    if (shouldRetry) {
-      try {
-        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
-      } catch (stateErr) {
-        this.emitPhilosopherEvent('philosopher_mark_retry_error', ctx.taskId, {
-          errorCategory: 'storage_unavailable',
-          attemptCount: ctx.task.attemptCount,
-          errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
-        });
-        return {
-          status: 'failed',
-          taskId: ctx.taskId,
-          errorCategory: 'storage_unavailable',
-          failureReason: `State manager error: ${ctx.failureReason}`,
-          attemptCount: ctx.task.attemptCount,
-        };
-      }
-      this.emitPhilosopherEvent('philosopher_task_retried', ctx.taskId, {
-        errorCategory: ctx.errorCategory,
-        attemptCount: ctx.task.attemptCount,
-      });
-      this.phase = RunnerPhase.RetryWaiting;
-      return {
-        status: 'retried',
-        taskId: ctx.taskId,
-        errorCategory: ctx.errorCategory,
-        failureReason: ctx.failureReason,
-        attemptCount: ctx.task.attemptCount,
-      };
-    }
-
-    try {
-      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
-    } catch (stateErr) {
-      this.emitPhilosopherEvent('philosopher_mark_failed_error', ctx.taskId, {
-        errorCategory: 'storage_unavailable',
-        attemptCount: ctx.task.attemptCount,
-        errorMessage: stateErr instanceof Error ? stateErr.message : String(stateErr),
-      });
-      return {
-        status: 'failed',
-        taskId: ctx.taskId,
-        errorCategory: 'storage_unavailable',
-        failureReason: `State manager error: ${ctx.failureReason}`,
-        attemptCount: ctx.task.attemptCount,
-      };
-    }
-    this.emitPhilosopherEvent('philosopher_task_failed', ctx.taskId, {
-      errorCategory: 'max_attempts_exceeded',
-      attemptCount: ctx.task.attemptCount,
-      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
-    });
-    this.phase = RunnerPhase.Failed;
-    return {
-      status: 'failed',
-      taskId: ctx.taskId,
-      errorCategory: 'max_attempts_exceeded',
-      failureReason: `Max attempts exceeded: ${ctx.failureReason}`,
-      attemptCount: ctx.task.attemptCount,
-    };
-  }
-
-  // ── Error classification ──────────────────────────────────────────────────
-
-  private readonly PERMANENT_ERROR_CATEGORIES: ReadonlySet<PDErrorCategory> = new Set(
-    Object.freeze(['storage_unavailable', 'workspace_invalid', 'capability_missing', 'cancelled', 'input_invalid'] as const),
-  );
-
-  private isPermanentError(category: PDErrorCategory): boolean {
-    return this.PERMANENT_ERROR_CATEGORIES.has(category);
-  }
-
+  /**
+   * Re-inject taskId if stripped by stripLineageFields (PRI-272 / ERR-008).
+   * Only fill when absent via Object.hasOwn — present-but-falsy values
+   * must reach validation and fail loud (Runtime Contract Rule 3).
+   */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  private classifyError(error: unknown): { category: PDErrorCategory; message: string } {
-    if (error instanceof PDRuntimeError) {
-      return { category: error.category, message: error.message };
-    }
-    if (error instanceof Error) {
-      return { category: 'execution_failed', message: error.message };
-    }
-    return { category: 'execution_failed', message: String(error) };
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+    injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  private mapRunStatusToErrorCategory(status: string): PDErrorCategory {
-    switch (status) {
-      case 'failed': return 'execution_failed';
-      case 'timed_out': return 'timeout';
-      case 'cancelled': return 'cancelled';
-      default: return 'execution_failed';
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  protected override emitSuccessTelemetry(taskId: string, output: PhilosopherOutputV1): void {
+    this.emitEvent('principle_candidate_generated', taskId, {
+      principleTitle: output.principleCandidate.title,
+      confidence: output.principleCandidate.confidence,
+    });
   }
 }
-
-export { resolvePhilosopherRunnerOptions, DEFAULT_PHILOSOPHER_RUNNER_OPTIONS };

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
@@ -208,8 +208,16 @@ export class PhilosopherRunner extends BasePeerRunner<PhilosopherContext, Philos
     output: PhilosopherOutputV1,
     task: TaskRecord,
     contextHash: string,
-    _context: PhilosopherContext,
+    context: PhilosopherContext,
   ): Promise<PeerRunnerResult<PhilosopherOutputV1>> {
+    // Lineage consistency: sourceDreamerArtifactId must match buildContext result (ERR-004).
+    if (output.sourceDreamerArtifactId !== context.sourceDreamerArtifactId) {
+      throw new PDRuntimeError(
+        'output_invalid',
+        `sourceDreamerArtifactId mismatch: expected ${context.sourceDreamerArtifactId}, got ${output.sourceDreamerArtifactId}`,
+      );
+    }
+
     // Store output before marking succeeded
     try {
       await this.stateManager.updateRunOutput(runId, JSON.stringify(output));

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/base-peer-runner-trust-boundary.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/base-peer-runner-trust-boundary.test.ts
@@ -23,6 +23,7 @@ import type {
   PeerRunnerResult,
   PeerRunnerValidationResult,
 } from '../peer-runner-types.js';
+import { RunnerPhase } from '../runner-phase.js';
 
 // ── Test fixture ─────────────────────────────────────────────────────────────
 
@@ -311,5 +312,32 @@ describe('BasePeerRunner trust boundary (ERR-001, ERR-005)', () => {
     expect(result.status).toBe('failed');
     expect(result.errorCategory).toBe('output_invalid');
     expect(runner.postFetchCallCount).toBe(0);
+  });
+
+  it('successful run sets phase to Completed', async () => {
+    const validPayload = { taskId: 'task-001', valid: true, data: 'test-data' };
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: validPayload,
+      runtimeKind: 'test-double',
+    });
+
+    const result = await runner.run('task-001');
+
+    expect(result.status).toBe('succeeded');
+    expect(runner.currentPhase).toBe(RunnerPhase.Completed);
+  });
+
+  it('validation failure does not set phase to Completed', async () => {
+    (mockDeps.runtimeAdapter.fetchOutput as ReturnType<typeof vi.fn>).mockResolvedValue({
+      payload: { wrong: 'shape' },
+      runtimeKind: 'test-double',
+    });
+    runner.shouldValidateSucceed = false;
+
+    const result = await runner.run('task-001');
+
+    expect(result.status).toBe('failed');
+    expect(runner.currentPhase).not.toBe(RunnerPhase.Completed);
+    expect(runner.currentPhase).toBe(RunnerPhase.Failed);
   });
 });

--- a/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
@@ -257,7 +257,11 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
       this.emitSuccessTelemetry(taskId, output, context);
 
       // 9. Succeed task (abstract — subclass implements commit strategy)
-      return await this.succeedTask(taskId, storeRunId, output, leasedTask, context.contextHash, context);
+      const result = await this.succeedTask(taskId, storeRunId, output, leasedTask, context.contextHash, context);
+      if (result.status === 'succeeded') {
+        this.phase = RunnerPhase.Completed;
+      }
+      return result;
     } catch (error) {
       // Post-lease errors use retryOrFail with the real leasedTask
       return await this.handlePostLeaseError(taskId, leasedTask, error);

--- a/packages/principles-core/src/telemetry-event.ts
+++ b/packages/principles-core/src/telemetry-event.ts
@@ -124,6 +124,27 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('dreamer_context_partial'),
   Type.Literal('dreamer_mark_failed_error'),
   Type.Literal('dreamer_mark_retry_error'),
+  // PRI-new: Philosopher runner events (BasePeerRunner migration)
+  Type.Literal('philosopher_task_leased'),
+  Type.Literal('philosopher_context_built'),
+  Type.Literal('philosopher_run_started'),
+  Type.Literal('philosopher_run_failed'),
+  Type.Literal('philosopher_output_invalid'),
+  Type.Literal('philosopher_output_validated'),
+  Type.Literal('philosopher_task_succeeded'),
+  Type.Literal('philosopher_task_retried'),
+  Type.Literal('philosopher_task_failed'),
+  Type.Literal('philosopher_principle_candidate_generated'),
+  Type.Literal('philosopher_cancel_run_failed'),
+  Type.Literal('philosopher_mark_succeeded_failed'),
+  Type.Literal('philosopher_update_output_failed'),
+  Type.Literal('philosopher_dependency_not_succeeded'),
+  Type.Literal('philosopher_lineage_resolve_failed'),
+  Type.Literal('philosopher_lineage_partial'),
+  Type.Literal('philosopher_artifact_write_failed'),
+  Type.Literal('philosopher_wrong_task_kind'),
+  Type.Literal('philosopher_mark_failed_error'),
+  Type.Literal('philosopher_mark_retry_error'),
 ]);
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/packages/principles-core/src/telemetry-event.ts
+++ b/packages/principles-core/src/telemetry-event.ts
@@ -119,6 +119,7 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('dreamer_task_failed'),
   Type.Literal('dreamer_candidate_generated'),
   Type.Literal('dreamer_cancel_run_failed'),
+  Type.Literal('dreamer_output_extraction_failed'),
   Type.Literal('dreamer_mark_succeeded_failed'),
   Type.Literal('dreamer_update_output_failed'),
   Type.Literal('dreamer_context_partial'),
@@ -143,6 +144,7 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('philosopher_lineage_partial'),
   Type.Literal('philosopher_artifact_write_failed'),
   Type.Literal('philosopher_wrong_task_kind'),
+  Type.Literal('philosopher_output_extraction_failed'),
   Type.Literal('philosopher_mark_failed_error'),
   Type.Literal('philosopher_mark_retry_error'),
 ]);


### PR DESCRIPTION
## Summary

Migrate PhilosopherRunner to extend `BasePeerRunner<PhilosopherContext, PhilosopherOutputV1>`, following the DreamerRunner pattern from PR #806 (PRI-302 Phase A). This is the second peer-runner slice.

### Changes

- **PhilosopherRunner extends BasePeerRunner** — implements abstract methods: `buildContext`, `invokeRuntime`, `validateOutput`, `succeedTask`, `permanentErrorCategories`
- **PhilosopherValidator accepts `unknown`** — trust boundary fix (ERR-001/ERR-005/ERR-054): validator interface changed from `PhilosopherOutputV1` to `unknown`, using `Record<string, unknown>` for safe property access
- **postFetchTransform** — re-injects taskId when stripped by adapter (ERR-008), operates on `unknown` not typed output
- **Trust-boundary tests** — 8 new tests proving malformed payload never reaches typed hooks or artifact commit
- **Backward-compatible exports** maintained: `PhilosopherRunnerResult`, `PhilosopherRunnerOptions`, `PhilosopherRunnerDeps`, `resolvePhilosopherRunnerOptions`, `DEFAULT_PHILOSOPHER_RUNNER_OPTIONS`

### Code reduction

- `philosopher-runner.ts`: 710 → 322 lines (~388 lines removed, ~55% reduction)
- Net diff: 158 insertions, 537 deletions

## Behavior parity statement

All existing PhilosopherRunner behavior is preserved exactly:
- Lease acquisition, conflict handling, task-kind validation
- Dreamer dependency resolution and artifact fetching
- PhilosopherPromptBuilder invocation with parsed dreamer artifact
- Polling, output fetching, validation, artifact writing, task success marking
- Error classification, retry/fail state machine, telemetry events

## Trust-boundary statement

Untrusted LLM/runtime output remains `unknown` until `validateOutput()` passes. Only after validation does the output become `PhilosopherOutputV1`. This matches the DreamerRunner pattern from PR #806 (ERR-001, ERR-005, ERR-054).

## Lineage handling statement

- `postFetchTransform` re-injects `taskId` when absent (stripped by adapter, PRI-272/ERR-008)
- Uses `Object.hasOwn` — present-but-falsy values reach validation and fail loud (Runtime Contract Rule 3)
- `checkLineageIntegrity` and `emitSuccessTelemetry` receive validated `PhilosopherOutputV1` only
- Lineage artifact IDs resolved via `resolveLineageArtifactIds()` (inherited from BasePeerRunner)

## ERR checklist

| ERR | Status |
|-----|--------|
| ERR-001 | ✅ Validator accepts `unknown`, uses `Record<string, unknown>` for property access |
| ERR-005 | ✅ No `as PhilosopherOutputV1` before validation |
| ERR-008 | ✅ postFetchTransform re-injects lineage fields on untrusted data |
| ERR-012 | ✅ Confirmed main includes PR #806 before editing |
| ERR-018/019 | ✅ retryOrFail uses current-iteration task data from BasePeerRunner |
| ERR-049 | ✅ Lineage fields from runner context, not blindly overwritten |
| ERR-054 | ✅ No pre-validation typed hooks |

## Tests run

```
npx vitest run packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-runner-trust-boundary.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/philosopher-runner-vslice.test.ts
npx vitest run packages/principles-core/src/runtime-v2/internalization/__tests__/philosopher-prompt-builder.test.ts
npx vitest run packages/principles-core/src/runtime-v2/runner/__tests__/base-peer-runner-trust-boundary.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/dreamer-runner-vslice.test.ts
npx vitest run packages/principles-core/src/runtime-v2/__tests__/dreamer-runner.test.ts
```

**Result: 514/514 pass across 7 test files**

| Test file | Tests |
|-----------|-------|
| philosopher-runner-trust-boundary | 8 |
| philosopher-runner-vslice | 14 |
| philosopher-prompt-builder | 16 |
| base-peer-runner-trust-boundary | 8 |
| architecture-regression | 440 |
| dreamer-runner-vslice | 14 |
| dreamer-runner | 14 |

## Not migrated in this PR

- ScribeRunner, ArtificerRunner, EvaluatorRunner — deferred to Phase B/C
- DiagnosticianRunner — deferred to Phase D (retryOrFail behavior change risk)
- No BasePeerRunner contract changes required

## Remaining risk

- `PhilosopherValidationResult.errorCategory` is `string` (not `PDErrorCategory`); cast in `validateOutput` is safe since validator always emits known categories, but a future TypeBox schema alignment would be cleaner
- E2E real-LLM tests (`philosopher-runner-real-llm.test.ts`) skipped in CI — behavior parity proven by vslice + trust-boundary tests with mocked adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 强化运行时输出校验与错误归类，明确处理畸形或不符合约束的输出、taskId 不一致与空值场景，避免错误写入工件或误标记成功。
  * 改进租约冲突与异常路径的失败处理，避免误触发重试或失败标注。

* **New Features**
  * 增加哲学分析流程相关的遥测事件，便于监控运行与验证状况。

* **Tests**
  * 新增端到端用例，覆盖验证失败、租约冲突、taskId 边界与不合法验证器返回等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->