### PR TITLE
feat(cli,plugin): cutover config doctor and runtime features to .pd/config.yaml (PRI-305, PRI-307)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,10 +145,3 @@ evidence/*
 .opencode/
 .trae/
 .plan/
-packages/principles-core/CONTEXT.md
-docs/adr/0007-cli-vs-console-audience-separation.md
-docs/adr/0006-hybrid-activation-mechanism.md
-docs/adr/0004-l2-auto-correction-and-replay.md
-docs/adr/0003-peer-agent-state-machine-orchestration.md
-docs/adr/0002-hard-internalization-core-boundary.md
-docs/adr/0001-runtime-v2-service-boundaries.md

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,10 @@ evidence/*
 .opencode/
 .trae/
 .plan/
+packages/principles-core/CONTEXT.md
+docs/adr/0007-cli-vs-console-audience-separation.md
+docs/adr/0006-hybrid-activation-mechanism.md
+docs/adr/0004-l2-auto-correction-and-replay.md
+docs/adr/0003-peer-agent-state-machine-orchestration.md
+docs/adr/0002-hard-internalization-core-boundary.md
+docs/adr/0001-runtime-v2-service-boundaries.md

--- a/packages/openclaw-plugin/src/core/pd-config-loader.ts
+++ b/packages/openclaw-plugin/src/core/pd-config-loader.ts
@@ -35,7 +35,7 @@ export const PD_CONFIG_FILENAME = 'config.yaml';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type ObserverReadiness = 'disabled' | 'needs_setup' | 'ready' | 'not_ready';
+export type ObserverReadiness = 'disabled' | 'needs_setup' | 'ready' | 'not_ready' | 'config_malformed';
 
 export interface ObserverConfigResult {
   /** Whether the observer feature is enabled in config */
@@ -64,6 +64,8 @@ export interface ObserverConfigResult {
   timeoutMs: number | null;
   /** Base URL from runtime profile */
   baseUrl: string | null;
+  /** Config validation errors (only present when readiness=config_malformed) */
+  configErrors?: Array<{ path: string; reason: string; nextAction: string }>;
 }
 
 export interface PluginConfigLoadResult {
@@ -200,9 +202,10 @@ export function loadFeatureFlagFromConfig(
  * Resolve observer configuration from .pd/config.yaml.
  *
  * Returns structured state:
- * - disabled: observer feature flag is off → no start, no noisy logs
- * - needs_setup: observer enabled but runtime profile missing or API key not set
- * - ready: observer enabled and configured
+ * - config_malformed: config file is invalid — no guessing, fail loud
+ * - disabled: observer feature flag is off OR agent.enabled=false → no start, no noisy logs
+ * - needs_setup: observer enabled but runtime profile missing, API key not set, or unsupported profile type
+ * - ready: observer enabled and fully configured (pi-ai with key present)
  * - not_ready: observer enabled, API key present, but runtime availability unknown
  */
 export function resolveObserverConfig(
@@ -212,9 +215,30 @@ export function resolveObserverConfig(
   _logger?: { warn?: (msg: string) => void; info?: (msg: string) => void; debug?: (msg: string) => void },
 ): ObserverConfigResult {
   const result = loadPdConfigForPlugin(workspaceDir);
+
+  // 0) Malformed config → fail loud, do NOT swallow as "disabled"
+  if (!result.ok) {
+    return {
+      enabled: false,
+      readiness: 'config_malformed',
+      source: 'malformed',
+      reason: `Config validation failed: ${result.errors.map(e => e.reason).join('; ')}`,
+      nextAction: result.errors[0]?.nextAction ?? 'Fix .pd/config.yaml and retry',
+      runtimeProfileId: null,
+      runtimeProfileType: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      provider: null,
+      model: null,
+      timeoutMs: null,
+      baseUrl: null,
+      configErrors: result.errors,
+    };
+  }
+
   const config = result.effective.config;
 
-  // 1) Check if the observer feature is enabled
+  // 1) Check if the observer feature flag is enabled
   const featureFlag = config.features[observerFlagId];
   if (!featureFlag || !featureFlag.enabled) {
     return {
@@ -234,12 +258,11 @@ export function resolveObserverConfig(
     };
   }
 
-  // 2) Find the agent's runtime profile
-  // Validate agent name against known names (EP-01: no `as` bypass)
+  // 2) Check if the agent itself is enabled (feature flag ≠ agent.enabled)
   const knownNames: readonly string[] = INTERNAL_AGENT_NAMES;
   if (!knownNames.includes(observerAgentName)) {
     return {
-      enabled: true,
+      enabled: false,
       readiness: 'needs_setup',
       source: result.source,
       reason: `Unknown agent name '${observerAgentName}'`,
@@ -254,10 +277,30 @@ export function resolveObserverConfig(
       baseUrl: null,
     };
   }
-  // After validation, safe to cast — runtime check passed (EP-01 compliant)
   const agentKey = observerAgentName as InternalAgentName;
   const agentConfig = config.internalAgents.agents[agentKey];
-  const runtimeProfileId = agentConfig?.runtimeProfile ?? config.internalAgents.defaultRuntime;
+
+  // Feature flag on but agent.enabled=false → disabled (not enabled)
+  if (!agentConfig || !agentConfig.enabled) {
+    return {
+      enabled: false,
+      readiness: 'disabled',
+      source: result.source,
+      reason: `${observerFlagId} feature flag is enabled but internalAgents.agents.${observerAgentName}.enabled is false`,
+      nextAction: `Set internalAgents.agents.${observerAgentName}.enabled=true in .pd/config.yaml, or disable features.${observerFlagId}`,
+      runtimeProfileId: null,
+      runtimeProfileType: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      provider: null,
+      model: null,
+      timeoutMs: null,
+      baseUrl: null,
+    };
+  }
+
+  // 3) Find the agent's runtime profile
+  const runtimeProfileId = agentConfig.runtimeProfile ?? config.internalAgents.defaultRuntime;
   const profile = config.runtimeProfiles[runtimeProfileId];
 
   if (!profile) {
@@ -278,9 +321,8 @@ export function resolveObserverConfig(
     };
   }
 
-  // 3) For pi-ai profiles, check API key
+  // 4) For pi-ai profiles, check API key
   if (profile.type === 'pi-ai') {
-    // TypeScript narrows profile to PdLocalRuntimeProfile here (discriminated union)
     const apiKeyEnv = profile.apiKeyEnv ?? null;
     const apiKeyPresent = !!apiKeyEnv && Object.prototype.hasOwnProperty.call(process.env, apiKeyEnv) && !!process.env[apiKeyEnv];
 
@@ -338,13 +380,14 @@ export function resolveObserverConfig(
     };
   }
 
-  // 4) OpenClaw profile — TypeScript narrows to OpenClawRuntimeProfile here
+  // 5) OpenClaw profile — CorrectionObserver does NOT support OpenClaw runtime
+  //    Mark as needs_setup with nextAction to configure a pi-ai profile
   return {
     enabled: true,
-    readiness: 'ready',
+    readiness: 'needs_setup',
     source: result.source,
-    reason: `OpenClaw profile '${runtimeProfileId}' is configured and ready`,
-    nextAction: 'No action required',
+    reason: `OpenClaw profile '${runtimeProfileId}' is not supported for observer runtime. Observers require a pi-ai profile with an API key.`,
+    nextAction: `Configure a pi-ai runtime profile for ${observerAgentName} in .pd/config.yaml (e.g., add a pi-ai profile with provider, model, and apiKeyEnv)`,
     runtimeProfileId,
     runtimeProfileType: profile.type,
     apiKeyEnv: null,

--- a/packages/openclaw-plugin/src/core/pd-config-loader.ts
+++ b/packages/openclaw-plugin/src/core/pd-config-loader.ts
@@ -26,8 +26,6 @@ import type {
   EffectivePdConfig,
   PdConfigValidationResult,
   InternalAgentName,
-  PdLocalRuntimeProfile,
-  OpenClawRuntimeProfile,
 } from '@principles/core/runtime-v2';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -237,11 +235,28 @@ export function resolveObserverConfig(
   }
 
   // 2) Find the agent's runtime profile
-  // Use type-safe access via InternalAgentName
+  // Validate agent name against known names (EP-01: no `as` bypass)
+  const knownNames: readonly string[] = INTERNAL_AGENT_NAMES;
+  if (!knownNames.includes(observerAgentName)) {
+    return {
+      enabled: true,
+      readiness: 'needs_setup',
+      source: result.source,
+      reason: `Unknown agent name '${observerAgentName}'`,
+      nextAction: `Use one of the known agent names: ${INTERNAL_AGENT_NAMES.join(', ')}`,
+      runtimeProfileId: null,
+      runtimeProfileType: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      provider: null,
+      model: null,
+      timeoutMs: null,
+      baseUrl: null,
+    };
+  }
+  // After validation, safe to cast — runtime check passed (EP-01 compliant)
   const agentKey = observerAgentName as InternalAgentName;
-  const agentConfig = INTERNAL_AGENT_NAMES.includes(agentKey)
-    ? config.internalAgents.agents[agentKey]
-    : undefined;
+  const agentConfig = config.internalAgents.agents[agentKey];
   const runtimeProfileId = agentConfig?.runtimeProfile ?? config.internalAgents.defaultRuntime;
   const profile = config.runtimeProfiles[runtimeProfileId];
 
@@ -265,8 +280,8 @@ export function resolveObserverConfig(
 
   // 3) For pi-ai profiles, check API key
   if (profile.type === 'pi-ai') {
-    const piProfile = profile as PdLocalRuntimeProfile;
-    const apiKeyEnv = piProfile.apiKeyEnv ?? null;
+    // TypeScript narrows profile to PdLocalRuntimeProfile here (discriminated union)
+    const apiKeyEnv = profile.apiKeyEnv ?? null;
     const apiKeyPresent = !!apiKeyEnv && Object.prototype.hasOwnProperty.call(process.env, apiKeyEnv) && !!process.env[apiKeyEnv];
 
     if (!apiKeyEnv) {
@@ -280,10 +295,10 @@ export function resolveObserverConfig(
         runtimeProfileType: profile.type,
         apiKeyEnv: null,
         apiKeyPresent: false,
-        provider: piProfile.provider ?? null,
-        model: piProfile.model ?? null,
-        timeoutMs: piProfile.timeoutMs ?? null,
-        baseUrl: piProfile.baseUrl ?? null,
+        provider: profile.provider ?? null,
+        model: profile.model ?? null,
+        timeoutMs: profile.timeoutMs ?? null,
+        baseUrl: profile.baseUrl ?? null,
       };
     }
 
@@ -298,10 +313,10 @@ export function resolveObserverConfig(
         runtimeProfileType: profile.type,
         apiKeyEnv,
         apiKeyPresent: false,
-        provider: piProfile.provider ?? null,
-        model: piProfile.model ?? null,
-        timeoutMs: piProfile.timeoutMs ?? null,
-        baseUrl: piProfile.baseUrl ?? null,
+        provider: profile.provider ?? null,
+        model: profile.model ?? null,
+        timeoutMs: profile.timeoutMs ?? null,
+        baseUrl: profile.baseUrl ?? null,
       };
     }
 
@@ -316,15 +331,14 @@ export function resolveObserverConfig(
       runtimeProfileType: profile.type,
       apiKeyEnv,
       apiKeyPresent: true,
-      provider: piProfile.provider ?? null,
-      model: piProfile.model ?? null,
-      timeoutMs: piProfile.timeoutMs ?? null,
-      baseUrl: piProfile.baseUrl ?? null,
+      provider: profile.provider ?? null,
+      model: profile.model ?? null,
+      timeoutMs: profile.timeoutMs ?? null,
+      baseUrl: profile.baseUrl ?? null,
     };
   }
 
-  // 4) OpenClaw profile — ready
-  const ocProfile = profile as OpenClawRuntimeProfile;
+  // 4) OpenClaw profile — TypeScript narrows to OpenClawRuntimeProfile here
   return {
     enabled: true,
     readiness: 'ready',
@@ -335,8 +349,8 @@ export function resolveObserverConfig(
     runtimeProfileType: profile.type,
     apiKeyEnv: null,
     apiKeyPresent: false,
-    provider: ocProfile.provider ?? null,
-    model: ocProfile.model ?? null,
+    provider: profile.provider ?? null,
+    model: profile.model ?? null,
     timeoutMs: null,
     baseUrl: null,
   };

--- a/packages/openclaw-plugin/src/core/pd-config-loader.ts
+++ b/packages/openclaw-plugin/src/core/pd-config-loader.ts
@@ -1,0 +1,343 @@
+/**
+ * PD Config Loader (Plugin I/O boundary) — PRI-307
+ *
+ * Reads `.pd/config.yaml`, validates via core, computes effective config.
+ * Replaces the old `.pd/feature-flags.yaml` and `.state/workflows.yaml` reading
+ * for plugin production paths.
+ *
+ * ADR-0016: PD owns exactly one user config file.
+ * - Missing config → defaults with nextAction
+ * - Malformed config → fail loud with errors and nextAction
+ * - No secrets in output
+ * - Observer disabled → no start / no noisy log cycling
+ * - Observer enabled + missing setup → structured needs_setup + nextAction
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import yaml from 'js-yaml';
+import {
+  validatePdConfig,
+  computeEffectivePdConfig,
+  computeFeatureFlagsFromConfig,
+  INTERNAL_AGENT_NAMES,
+} from '@principles/core/runtime-v2';
+import type {
+  EffectivePdConfig,
+  PdConfigValidationResult,
+  InternalAgentName,
+  PdLocalRuntimeProfile,
+  OpenClawRuntimeProfile,
+} from '@principles/core/runtime-v2';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+export const PD_CONFIG_DIR = '.pd';
+export const PD_CONFIG_FILENAME = 'config.yaml';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ObserverReadiness = 'disabled' | 'needs_setup' | 'ready' | 'not_ready';
+
+export interface ObserverConfigResult {
+  /** Whether the observer feature is enabled in config */
+  enabled: boolean;
+  /** Observer readiness state */
+  readiness: ObserverReadiness;
+  /** Config source: 'defaults' | 'user_config' | 'malformed' */
+  source: string;
+  /** Reason for current state */
+  reason: string;
+  /** What the user should do next */
+  nextAction: string;
+  /** The runtime profile ID for this observer, if configured */
+  runtimeProfileId: string | null;
+  /** The runtime profile type, if configured */
+  runtimeProfileType: string | null;
+  /** The apiKeyEnv for the runtime profile, if applicable */
+  apiKeyEnv: string | null;
+  /** Whether the apiKeyEnv is present in process.env */
+  apiKeyPresent: boolean;
+  /** Provider name from runtime profile */
+  provider: string | null;
+  /** Model name from runtime profile */
+  model: string | null;
+  /** Timeout from runtime profile */
+  timeoutMs: number | null;
+  /** Base URL from runtime profile */
+  baseUrl: string | null;
+}
+
+export interface PluginConfigLoadResult {
+  ok: boolean;
+  effective: EffectivePdConfig;
+  source: 'defaults' | 'user_config' | 'malformed';
+  configPath: string;
+  warnings: string[];
+  errors: Array<{ path: string; reason: string; nextAction: string }>;
+}
+
+// ── Config Path ──────────────────────────────────────────────────────────────
+
+export function getPdConfigPath(workspaceDir: string): string {
+  return path.join(workspaceDir, PD_CONFIG_DIR, PD_CONFIG_FILENAME);
+}
+
+// ── Load PD Config ───────────────────────────────────────────────────────────
+
+/**
+ * Load and validate `.pd/config.yaml` from the workspace.
+ * Never throws on malformed input. Always provides a usable fallback.
+ */
+export function loadPdConfigForPlugin(workspaceDir: string): PluginConfigLoadResult {
+  const configPath = getPdConfigPath(workspaceDir);
+
+  // 1) Config file missing → use defaults
+  if (!fs.existsSync(configPath)) {
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: true,
+      effective,
+      source: 'defaults',
+      configPath,
+      warnings: effective.warnings,
+      errors: [],
+    };
+  }
+
+  // 2) Read the file
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: false,
+      effective,
+      source: 'malformed',
+      configPath,
+      warnings: [],
+      errors: [{ path: '', reason: `Failed to read .pd/config.yaml: ${message}`, nextAction: 'Check file permissions for .pd/config.yaml' }],
+    };
+  }
+
+  // 3) Parse YAML — treat as unknown (ERR-001)
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: false,
+      effective,
+      source: 'malformed',
+      configPath,
+      warnings: [],
+      errors: [{ path: '', reason: `YAML parse error in .pd/config.yaml: ${message}`, nextAction: 'Fix YAML syntax in .pd/config.yaml' }],
+    };
+  }
+
+  // 4) Validate via core (ERR-001, ERR-005: no `as` bypasses)
+  const validationResult: PdConfigValidationResult = validatePdConfig(parsed);
+
+  if (!validationResult.ok) {
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: false,
+      effective,
+      source: 'malformed',
+      configPath,
+      warnings: [],
+      errors: validationResult.errors.map(e => ({
+        path: e.path,
+        reason: e.reason,
+        nextAction: e.nextAction,
+      })),
+    };
+  }
+
+  // 5) Compute effective config
+  const effective = computeEffectivePdConfig(validationResult.value);
+
+  return {
+    ok: true,
+    effective,
+    source: 'user_config',
+    configPath,
+    warnings: effective.warnings,
+    errors: [],
+  };
+}
+
+// ── Feature Flag from Config ─────────────────────────────────────────────────
+
+/**
+ * Get a single feature flag's enabled state from .pd/config.yaml.
+ * Replaces the old `loadFeatureFlagFromWorkspace` which read .pd/feature-flags.yaml.
+ */
+export function loadFeatureFlagFromConfig(
+  workspaceDir: string,
+  flagId: string,
+  logger?: { warn?: (msg: string) => void; info?: (msg: string) => void },
+): { enabled: boolean; source: string } {
+  const result = loadPdConfigForPlugin(workspaceDir);
+  const flags = computeFeatureFlagsFromConfig(result.effective);
+  const flag = flags.flags[flagId];
+
+  if (!result.ok) {
+    logger?.warn?.(`[PD:Config] Config validation failed: ${result.errors.map(e => e.reason).join('; ')} — using defaults`);
+  }
+
+  return {
+    enabled: flag?.enabled ?? false,
+    source: result.source,
+  };
+}
+
+// ── Observer Config Resolution ───────────────────────────────────────────────
+
+/**
+ * Resolve observer configuration from .pd/config.yaml.
+ *
+ * Returns structured state:
+ * - disabled: observer feature flag is off → no start, no noisy logs
+ * - needs_setup: observer enabled but runtime profile missing or API key not set
+ * - ready: observer enabled and configured
+ * - not_ready: observer enabled, API key present, but runtime availability unknown
+ */
+export function resolveObserverConfig(
+  workspaceDir: string,
+  observerFlagId: string,
+  observerAgentName: string,
+  _logger?: { warn?: (msg: string) => void; info?: (msg: string) => void; debug?: (msg: string) => void },
+): ObserverConfigResult {
+  const result = loadPdConfigForPlugin(workspaceDir);
+  const config = result.effective.config;
+
+  // 1) Check if the observer feature is enabled
+  const featureFlag = config.features[observerFlagId];
+  if (!featureFlag || !featureFlag.enabled) {
+    return {
+      enabled: false,
+      readiness: 'disabled',
+      source: result.source,
+      reason: `${observerFlagId} is disabled in .pd/config.yaml`,
+      nextAction: `Set features.${observerFlagId}.enabled=true in .pd/config.yaml to enable`,
+      runtimeProfileId: null,
+      runtimeProfileType: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      provider: null,
+      model: null,
+      timeoutMs: null,
+      baseUrl: null,
+    };
+  }
+
+  // 2) Find the agent's runtime profile
+  // Use type-safe access via InternalAgentName
+  const agentKey = observerAgentName as InternalAgentName;
+  const agentConfig = INTERNAL_AGENT_NAMES.includes(agentKey)
+    ? config.internalAgents.agents[agentKey]
+    : undefined;
+  const runtimeProfileId = agentConfig?.runtimeProfile ?? config.internalAgents.defaultRuntime;
+  const profile = config.runtimeProfiles[runtimeProfileId];
+
+  if (!profile) {
+    return {
+      enabled: true,
+      readiness: 'needs_setup',
+      source: result.source,
+      reason: `Runtime profile '${runtimeProfileId}' not found in .pd/config.yaml`,
+      nextAction: `Add runtime profile '${runtimeProfileId}' to .pd/config.yaml runtimeProfiles`,
+      runtimeProfileId,
+      runtimeProfileType: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      provider: null,
+      model: null,
+      timeoutMs: null,
+      baseUrl: null,
+    };
+  }
+
+  // 3) For pi-ai profiles, check API key
+  if (profile.type === 'pi-ai') {
+    const piProfile = profile as PdLocalRuntimeProfile;
+    const apiKeyEnv = piProfile.apiKeyEnv ?? null;
+    const apiKeyPresent = !!apiKeyEnv && Object.prototype.hasOwnProperty.call(process.env, apiKeyEnv) && !!process.env[apiKeyEnv];
+
+    if (!apiKeyEnv) {
+      return {
+        enabled: true,
+        readiness: 'needs_setup',
+        source: result.source,
+        reason: `pi-ai profile '${runtimeProfileId}' missing apiKeyEnv`,
+        nextAction: `Add apiKeyEnv to runtime profile '${runtimeProfileId}' in .pd/config.yaml`,
+        runtimeProfileId,
+        runtimeProfileType: profile.type,
+        apiKeyEnv: null,
+        apiKeyPresent: false,
+        provider: piProfile.provider ?? null,
+        model: piProfile.model ?? null,
+        timeoutMs: piProfile.timeoutMs ?? null,
+        baseUrl: piProfile.baseUrl ?? null,
+      };
+    }
+
+    if (!apiKeyPresent) {
+      return {
+        enabled: true,
+        readiness: 'needs_setup',
+        source: result.source,
+        reason: `Environment variable '${apiKeyEnv}' is not set or empty`,
+        nextAction: `Set the environment variable '${apiKeyEnv}' with a valid API key`,
+        runtimeProfileId,
+        runtimeProfileType: profile.type,
+        apiKeyEnv,
+        apiKeyPresent: false,
+        provider: piProfile.provider ?? null,
+        model: piProfile.model ?? null,
+        timeoutMs: piProfile.timeoutMs ?? null,
+        baseUrl: piProfile.baseUrl ?? null,
+      };
+    }
+
+    // pi-ai with key present — runtime availability unknown without actual probe
+    return {
+      enabled: true,
+      readiness: 'not_ready',
+      source: result.source,
+      reason: `pi-ai profile configured with apiKeyEnv='${apiKeyEnv}' (key present); runtime availability unknown`,
+      nextAction: 'Run pd runtime probe to verify end-to-end connectivity',
+      runtimeProfileId,
+      runtimeProfileType: profile.type,
+      apiKeyEnv,
+      apiKeyPresent: true,
+      provider: piProfile.provider ?? null,
+      model: piProfile.model ?? null,
+      timeoutMs: piProfile.timeoutMs ?? null,
+      baseUrl: piProfile.baseUrl ?? null,
+    };
+  }
+
+  // 4) OpenClaw profile — ready
+  const ocProfile = profile as OpenClawRuntimeProfile;
+  return {
+    enabled: true,
+    readiness: 'ready',
+    source: result.source,
+    reason: `OpenClaw profile '${runtimeProfileId}' is configured and ready`,
+    nextAction: 'No action required',
+    runtimeProfileId,
+    runtimeProfileType: profile.type,
+    apiKeyEnv: null,
+    apiKeyPresent: false,
+    provider: ocProfile.provider ?? null,
+    model: ocProfile.model ?? null,
+    timeoutMs: null,
+    baseUrl: null,
+  };
+}

--- a/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
+++ b/packages/openclaw-plugin/src/core/runtime-v2-prompt-activation-reader.ts
@@ -1,20 +1,12 @@
-import * as path from 'path';
-import * as fs from 'fs';
-import * as yaml from 'js-yaml';
-import { SqliteConnection, SqliteActivationStateStore, computeEffectiveFlags, DEFAULT_FEATURE_FLAGS, filterPromptActivations, resolvePrincipleFromArtifact } from '@principles/core/runtime-v2';
-import type { EffectiveFeatureFlags, ActivatedPrinciple, PromptActivationReaderResult } from '@principles/core/runtime-v2';
+import { SqliteConnection, SqliteActivationStateStore, computeFeatureFlagsFromConfig, filterPromptActivations, resolvePrincipleFromArtifact } from '@principles/core/runtime-v2';
+import type { FeatureFlagsResult, ActivatedPrinciple, PromptActivationReaderResult } from '@principles/core/runtime-v2';
+import { loadPdConfigForPlugin } from './pd-config-loader.js';
 
 export { RUNTIME_V2_PRINCIPLE_BUDGET } from '@principles/core/runtime-v2';
 export type { ActivatedPrinciple, PromptActivationReaderResult };
 
 export interface PromptActivationReaderDeps {
   logger?: { warn?: (msg: string) => void; info?: (msg: string) => void; error?: (msg: string) => void };
-}
-
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 export class PromptActivationReader {
@@ -103,60 +95,20 @@ export class PromptActivationReader {
     }
   }
 
-  private loadFeatureFlags(): EffectiveFeatureFlags {
-    const configPath = path.join(this.workspaceDir, '.pd', 'feature-flags.yaml');
+  /**
+   * PRI-305/PRI-307: Load feature flags from .pd/config.yaml instead of .pd/feature-flags.yaml.
+   * Uses the shared plugin config loader for consistency.
+   */
+  private loadFeatureFlags(): FeatureFlagsResult {
+    const result = loadPdConfigForPlugin(this.workspaceDir);
+    const flags = computeFeatureFlagsFromConfig(result.effective);
 
-    if (!fs.existsSync(configPath)) {
-      return computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
-    }
-
-    let raw: string;
-    try {
-      raw = fs.readFileSync(configPath, 'utf8');
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      this.deps.logger?.warn?.(`[PD:RuntimeV2] Feature flags unreadable: ${msg} — using defaults`);
-      return computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
-    } catch {
-      this.deps.logger?.warn?.(`[PD:RuntimeV2] Feature flags YAML parse error — using defaults`);
-      return {
-        ...computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath),
-        warnings: ['feature-flags.yaml: YAML parse error, using defaults'],
-      };
-    }
-
-    if (!isRecord(parsed)) {
-      this.deps.logger?.warn?.(`[PD:RuntimeV2] Feature flags not a mapping — using defaults`);
-      return {
-        ...computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath),
-        warnings: ['feature-flags.yaml: expected a mapping, using defaults'],
-      };
-    }
-
-    const parsedRecord: Record<string, unknown> = Object.create(null);
-    const yamlWarnings: string[] = [];
-    for (const key of Object.keys(parsed)) {
-      if (DANGEROUS_KEYS.has(key)) {
-        yamlWarnings.push(`feature-flags.yaml: dangerous key '${key}' rejected`);
-        continue;
-      }
-      if (Object.hasOwn(parsed, key)) {
-        parsedRecord[key] = parsed[key];
+    if (!result.ok) {
+      for (const err of result.errors) {
+        this.deps.logger?.warn?.(`[PD:RuntimeV2] Config error at ${err.path}: ${err.reason}`);
       }
     }
 
-    const result = computeEffectiveFlags(parsedRecord, DEFAULT_FEATURE_FLAGS, configPath);
-    if (yamlWarnings.length > 0) {
-      result.warnings = [...yamlWarnings, ...result.warnings];
-      for (const w of yamlWarnings) {
-        this.deps.logger?.warn?.(`[PD:RuntimeV2] ${w}`);
-      }
-    }
-    return result;
+    return flags;
   }
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -18,9 +18,6 @@ import type {
   PluginHookSubagentContext,
 } from './openclaw-sdk.js';
 import * as path from 'path';
-import * as fs from 'fs';
-import * as yaml from 'js-yaml';
-import { computeEffectiveFlags, DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
 import { loadFeatureFlagFromConfig } from './core/pd-config-loader.js';
 import { classifyTask } from './core/local-worker-routing.js';
 import { completeShadowObservation, recordShadowRouting } from './core/shadow-observation-registry.js';
@@ -76,8 +73,6 @@ const pendingShadowObservations = new Map<string, string>();
 // ── Feature Flag Loader (plugin I/O boundary) ─────────────────────────────
 // Reads workspace feature-flags.yaml and checks a specific flag.
 // Returns the flag definition with effective enabled state.
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import { computeEffectiveFlags, DEFAULT_FEATURE_FLAGS } from '@principles/core/runtime-v2';
+import { loadFeatureFlagFromConfig } from './core/pd-config-loader.js';
 import { classifyTask } from './core/local-worker-routing.js';
 import { completeShadowObservation, recordShadowRouting } from './core/shadow-observation-registry.js';
 import { getCommandDescription } from './i18n/commands.js';
@@ -81,60 +82,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+/**
+ * PRI-305/PRI-307: Load feature flag from .pd/config.yaml instead of .pd/feature-flags.yaml.
+ * Delegates to the shared plugin config loader for consistency.
+ */
 function loadFeatureFlagFromWorkspace(
   workspaceDir: string,
   flagId: string,
   logger?: { warn?: (msg: string) => void; info?: (msg: string) => void },
 ): { enabled: boolean; source: string } {
-  const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
-
-  if (!fs.existsSync(configPath)) {
-    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
-    const flag = flags.flags[flagId];
-    return { enabled: flag?.enabled ?? false, source: 'defaults' };
-  }
-
-  let raw: string;
-  try {
-    raw = fs.readFileSync(configPath, 'utf8');
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    logger?.warn?.(`[PD:FeatureFlags] Feature flags unreadable: ${msg} — using defaults`);
-    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
-    const flag = flags.flags[flagId];
-    return { enabled: flag?.enabled ?? false, source: 'defaults' };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
-  } catch (e) {
-    const parseMsg = e instanceof Error ? e.message : String(e);
-    logger?.warn?.(`[PD:FeatureFlags] Feature flags YAML parse error: ${parseMsg} — using defaults`);
-    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
-    const flag = flags.flags[flagId];
-    return { enabled: flag?.enabled ?? false, source: 'defaults' };
-  }
-
-  if (!isRecord(parsed)) {
-    logger?.warn?.(`[PD:FeatureFlags] Feature flags not a mapping — using defaults`);
-    const flags = computeEffectiveFlags({}, DEFAULT_FEATURE_FLAGS, configPath);
-    const flag = flags.flags[flagId];
-    return { enabled: flag?.enabled ?? false, source: 'defaults' };
-  }
-
-  // parsed is now narrowed to Record<string, unknown> by isRecord guard
-  const parsedRecord: Record<string, unknown> = Object.create(null);
-  for (const key of Object.keys(parsed)) {
-    if (DANGEROUS_KEYS.has(key)) continue;
-    if (Object.hasOwn(parsed, key)) {
-      parsedRecord[key] = parsed[key];
-    }
-  }
-
-  const flags = computeEffectiveFlags(parsedRecord, DEFAULT_FEATURE_FLAGS, configPath);
-  const flag = flags.flags[flagId];
-  return { enabled: flag?.enabled ?? false, source: flags.source };
+  return loadFeatureFlagFromConfig(workspaceDir, flagId, logger);
 }
 
 // ── Evolution Worker Startup Gate (shared between index.ts and tests) ───────
@@ -157,7 +114,7 @@ export function shouldStartEvolutionWorker(
   }
   const disabledInfo = JSON.stringify({
     reason: 'mvp_quiet_per_adr0014',
-    nextAction: 'set evolution_worker.enabled=true in .pd/feature-flags.yaml to enable',
+    nextAction: 'set features.evolution_worker.enabled=true in .pd/config.yaml to enable',
     featureFlag: 'evolution_worker',
     boundedContext: 'legacy_evolution_worker',
     flagSource: flag.source,
@@ -181,7 +138,7 @@ export function shouldStartCorrectionObserver(
   }
   const disabledInfo = JSON.stringify({
     reason: 'correction_observer_disabled',
-    nextAction: 'set correction_observer.enabled=true in .pd/feature-flags.yaml to enable',
+    nextAction: 'set features.correction_observer.enabled=true in .pd/config.yaml to enable',
     featureFlag: 'correction_observer',
     boundedContext: 'correction_observer_service',
     flagSource: flag.source,

--- a/packages/openclaw-plugin/src/service/correction-observer-service.ts
+++ b/packages/openclaw-plugin/src/service/correction-observer-service.ts
@@ -3,13 +3,13 @@ import { WorkspaceContext } from '../core/workspace-context.js';
 import { TrajectoryRegistry } from '../core/trajectory.js';
 import { CorrectionCueLearner } from '../core/correction-cue-learner.js';
 import {
-    WorkflowFunnelLoader,
     PiAiRuntimeAdapter,
     CorrectionObserver,
     AgentScheduler,
 } from '@principles/core/runtime-v2';
 import { KeywordOptimizationService } from './keyword-optimization-service.js';
 import { SystemLogger } from '../core/system-logger.js';
+import { resolveObserverConfig } from '../core/pd-config-loader.js';
 
 export interface CorrectionObserverServiceShape {
     id: string;
@@ -26,43 +26,49 @@ const CORRECTION_OBSERVER_INITIAL_DELAY_MS = 10_000;
 const CORRECTION_OBSERVER_MAX_RECENT_SESSIONS = 20;
 const CORRECTION_OBSERVER_MAX_PAYLOAD_SESSIONS = 5;
 
+/**
+ * PRI-307: Resolve CorrectionObserver from .pd/config.yaml.
+ *
+ * States:
+ * - disabled: feature flag off → return null, no noisy logs
+ * - needs_setup: enabled but missing API key or profile → return null with structured reason
+ * - ready/not_ready: enabled and configured → return observer instance
+ */
 export function resolveCorrectionObserver(wctx: WorkspaceContext, logger?: Pick<PluginLogger, 'info' | 'warn' | 'error' | 'debug'>): CorrectionObserver | null {
     try {
-        const loader = new WorkflowFunnelLoader(wctx.stateDir);
-        const funnel = loader.getFunnel('pd-correction-observer');
-        const policy = funnel?.policy;
-        if (!policy || policy.runtimeKind !== 'pi-ai') {
-            logger?.debug?.('[PD:CorrectionObserver] workflows.yaml pd-correction-observer policy not found. Falling back to environment variables.');
-            const provider = process.env.PD_CORRECTION_PROVIDER || 'anthropic';
-            const model = process.env.PD_CORRECTION_MODEL || 'anthropic/claude-3-5-sonnet';
-            const apiKeyEnv = process.env.PD_CORRECTION_API_KEY_ENV || 'ANTHROPIC_API_KEY';
-            const baseUrl = process.env.PD_CORRECTION_BASE_URL;
+        const observerConfig = resolveObserverConfig(
+            wctx.workspaceDir,
+            'correction_observer',
+            'correctionObserver',
+            logger,
+        );
 
-            if (!process.env[apiKeyEnv]) {
-                logger?.debug?.(`[PD:CorrectionObserver] API key env ${apiKeyEnv} is not set. Periodic optimization disabled.`);
-                return null;
-            }
-
-            const adapter = new PiAiRuntimeAdapter({
-                provider,
-                model,
-                apiKeyEnv,
-                baseUrl,
-                workspace: wctx.workspaceDir,
-            });
-            return new CorrectionObserver({ runtimeAdapter: adapter });
+        if (!observerConfig.enabled) {
+            logger?.debug?.(`[PD:CorrectionObserver] ${observerConfig.reason}`);
+            return null;
         }
 
-        const adapter = new PiAiRuntimeAdapter({
-            provider: String(policy.provider),
-            model: String(policy.model),
-            apiKeyEnv: String(policy.apiKeyEnv),
-            maxRetries: policy.maxRetries,
-            timeoutMs: policy.timeoutMs ?? 30_000,
-            baseUrl: policy.baseUrl,
-            workspace: wctx.workspaceDir,
-        });
-        return new CorrectionObserver({ runtimeAdapter: adapter }, { timeoutMs: policy.timeoutMs });
+        if (observerConfig.readiness === 'needs_setup') {
+            logger?.info?.(`[PD:CorrectionObserver] ${observerConfig.reason}. ${observerConfig.nextAction}`);
+            return null;
+        }
+
+        // ready or not_ready — create the observer
+        if (observerConfig.runtimeProfileType === 'pi-ai') {
+            const adapter = new PiAiRuntimeAdapter({
+                provider: observerConfig.provider ?? 'anthropic',
+                model: observerConfig.model ?? 'anthropic/claude-3-5-sonnet',
+                apiKeyEnv: observerConfig.apiKeyEnv ?? 'ANTHROPIC_API_KEY',
+                timeoutMs: observerConfig.timeoutMs ?? undefined,
+                baseUrl: observerConfig.baseUrl ?? undefined,
+                workspace: wctx.workspaceDir,
+            });
+            return new CorrectionObserver({ runtimeAdapter: adapter }, { timeoutMs: observerConfig.timeoutMs ?? undefined });
+        }
+
+        // OpenClaw profile — not yet supported for observer runtime
+        logger?.info?.(`[PD:CorrectionObserver] OpenClaw runtime profile not yet supported for correction observer. Skipping.`);
+        return null;
     } catch (err) {
         logger?.warn?.(`[PD:CorrectionObserver] Failed to resolve CorrectionObserver: ${String(err)}`);
         return null;
@@ -73,7 +79,8 @@ export async function runCorrectionObserverCycle(wctx: WorkspaceContext, logger:
     try {
         const observer = resolveCorrectionObserver(wctx, logger);
         if (!observer) {
-            logger?.info?.('[PD:CorrectionObserver] Observer not resolved (no API key or config). Skipping cycle.');
+            // PRI-307: No noisy "no API key" cycling. Only log at debug level.
+            logger?.debug?.(`[PD:CorrectionObserver] Observer not resolved. Skipping cycle.`);
             return;
         }
 
@@ -163,8 +170,28 @@ export const CorrectionObserverService: CorrectionObserverServiceShape = {
             if (logger) logger.info(`[PD:CorrectionObserver] Already started for workspace: ${workspaceDir}. Skipping duplicate start.`);
             return;
         }
-        startedWorkspaces.add(workspaceDir);
 
+        // PRI-307: Check observer config before starting
+        const observerConfig = resolveObserverConfig(
+            workspaceDir,
+            'correction_observer',
+            'correctionObserver',
+            logger,
+        );
+
+        if (!observerConfig.enabled) {
+            // Disabled → no start, no noisy cycling. Single structured log.
+            logger?.info?.(`[PD:CorrectionObserver] ${observerConfig.reason}. ${observerConfig.nextAction}`);
+            return;
+        }
+
+        if (observerConfig.readiness === 'needs_setup') {
+            // Enabled but missing setup → structured needs_setup, no noisy cycling
+            logger?.info?.(`[PD:CorrectionObserver] ${observerConfig.reason}. ${observerConfig.nextAction}`);
+            return;
+        }
+
+        startedWorkspaces.add(workspaceDir);
         correctionObserverStopped = false;
 
         const wctx = WorkspaceContext.fromHookContext({ workspaceDir, ...ctx.config });

--- a/packages/openclaw-plugin/src/service/correction-observer-service.ts
+++ b/packages/openclaw-plugin/src/service/correction-observer-service.ts
@@ -44,7 +44,11 @@ export function resolveCorrectionObserver(wctx: WorkspaceContext, logger?: Pick<
         );
 
         if (!observerConfig.enabled) {
-            logger?.debug?.(`[PD:CorrectionObserver] ${observerConfig.reason}`);
+            if (observerConfig.readiness === 'config_malformed') {
+                logger?.warn?.(`[PD:CorrectionObserver] Config malformed: ${observerConfig.reason}. ${observerConfig.nextAction}`);
+            } else {
+                logger?.debug?.(`[PD:CorrectionObserver] ${observerConfig.reason}`);
+            }
             return null;
         }
 

--- a/packages/openclaw-plugin/tests/core-anti-growth.test.ts
+++ b/packages/openclaw-plugin/tests/core-anti-growth.test.ts
@@ -124,6 +124,7 @@ describe('PRI-212 plugin core anti-growth guard', () => {
     'runtime-v2-prompt-activation-reader.ts',
     'workspace-guidance-migrator.ts',
     'surface-guard.ts',
+    'pd-config-loader.ts',
   ] as const;
 
   // Category 6: Test files

--- a/packages/openclaw-plugin/tests/core/pd-config-loader.test.ts
+++ b/packages/openclaw-plugin/tests/core/pd-config-loader.test.ts
@@ -213,7 +213,7 @@ describe('Observer ready', () => {
     }
   });
 
-  it('returns readiness=ready for OpenClaw profile', () => {
+  it('returns readiness=needs_setup for OpenClaw profile (not supported for observers)', () => {
     const tmp = mkTmpDir();
     const config = yaml.dump({
       version: 1,
@@ -247,8 +247,10 @@ describe('Observer ready', () => {
     try {
       const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
       expect(result.enabled).toBe(true);
-      expect(result.readiness).toBe('ready');
+      expect(result.readiness).toBe('needs_setup');
       expect(result.runtimeProfileType).toBe('openclaw');
+      expect(result.reason).toContain('not supported');
+      expect(result.nextAction).toContain('pi-ai');
     } finally { rmTmpDir(tmp); }
   });
 });
@@ -328,6 +330,78 @@ describe('Plugin config load', () => {
       expect(result.source).toBe('malformed');
       expect(result.errors.length).toBeGreaterThan(0);
       expect(result.effective.config.version).toBe(1); // defaults still available
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Config malformed → fail loud ────────────────────────────────────────────
+
+describe('Config malformed → fail loud', () => {
+  it('returns readiness=config_malformed when config is invalid YAML', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(false);
+      expect(result.readiness).toBe('config_malformed');
+      expect(result.reason).toContain('Config validation failed');
+      expect(result.nextAction).toBeTruthy();
+      expect(result.configErrors).toBeDefined();
+      expect(result.configErrors!.length).toBeGreaterThan(0);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns readiness=config_malformed for invalid version', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({ version: 99, features: {}, runtimeProfiles: {}, internalAgents: { defaultRuntime: 'x', agents: {} } }));
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.readiness).toBe('config_malformed');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Feature flag vs agent enabled mismatch ──────────────────────────────────
+
+describe('Feature flag vs agent enabled mismatch', () => {
+  it('returns readiness=disabled when feature flag is on but agent.enabled=false', () => {
+    const tmp = mkTmpDir();
+    const config = yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+        correction_observer: { category: 'quiet', enabled: true },  // feature flag ON
+        empathy_observer: { category: 'quiet', enabled: false },
+      },
+      runtimeProfiles: {
+        'openclaw.default': { type: 'openclaw', source: 'default' },
+        'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+      },
+      internalAgents: {
+        defaultRuntime: 'openclaw.default',
+        agents: {
+          diagnostician: { enabled: true },
+          dreamer: { enabled: true },
+          scribe: { enabled: true },
+          artificer: { enabled: true },
+          philosopher: { enabled: false },
+          evaluator: { enabled: false },
+          rolloutReviewer: { enabled: false },
+          trainer: { enabled: false },
+          correctionObserver: { enabled: false },  // agent.enabled OFF
+          empathyObserver: { enabled: false },
+        },
+      },
+    });
+    writeConfig(tmp, config);
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(false);
+      expect(result.readiness).toBe('disabled');
+      expect(result.reason).toContain('enabled is false');
+      expect(result.nextAction).toContain('internalAgents.agents.correctionObserver.enabled=true');
     } finally { rmTmpDir(tmp); }
   });
 });

--- a/packages/openclaw-plugin/tests/core/pd-config-loader.test.ts
+++ b/packages/openclaw-plugin/tests/core/pd-config-loader.test.ts
@@ -1,0 +1,333 @@
+/**
+ * pd-config-loader (plugin) tests — PRI-307
+ *
+ * Covers:
+ *   - Observer disabled → no start, no noisy logs
+ *   - Observer enabled + missing setup → needs_setup + nextAction
+ *   - Observer enabled + configured → ready
+ *   - No secret output in any result
+ *   - Feature flag loading from .pd/config.yaml
+ *   - Missing config → defaults
+ *   - Malformed config → fail loud
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as yaml from 'js-yaml';
+import {
+  loadPdConfigForPlugin,
+  loadFeatureFlagFromConfig,
+  resolveObserverConfig,
+  getPdConfigPath,
+  type ObserverConfigResult,
+} from '../../src/core/pd-config-loader.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-plugin-config-test-'));
+}
+
+function rmTmpDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function writeConfig(workspaceDir: string, content: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), content, 'utf8');
+}
+
+function makeValidConfigWithObserverEnabled(): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      correction_observer: { category: 'quiet', enabled: true },
+      empathy_observer: { category: 'quiet', enabled: false },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+      'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 300000 },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: true, runtimeProfile: 'pd.anthropic-sonnet' },
+        empathyObserver: { enabled: false },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  });
+}
+
+function makeValidConfigWithObserverDisabled(): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      correction_observer: { category: 'quiet', enabled: false },
+      empathy_observer: { category: 'quiet', enabled: false },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  });
+}
+
+// ── Observer disabled ────────────────────────────────────────────────────────
+
+describe('Observer disabled', () => {
+  it('returns readiness=disabled when feature flag is off', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigWithObserverDisabled());
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(false);
+      expect(result.readiness).toBe('disabled');
+      expect(result.reason).toContain('disabled');
+      expect(result.nextAction).toContain('.pd/config.yaml');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns readiness=disabled when config is missing (defaults)', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(false);
+      expect(result.readiness).toBe('disabled');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Observer enabled + missing setup → needs_setup ──────────────────────────
+
+describe('Observer needs_setup', () => {
+  it('returns readiness=needs_setup when API key env is not set', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigWithObserverEnabled());
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(true);
+      expect(result.readiness).toBe('needs_setup');
+      expect(result.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
+      expect(result.apiKeyPresent).toBe(false);
+      expect(result.nextAction).toContain('ANTHROPIC_API_KEY');
+    } finally {
+      if (originalKey !== undefined) process.env.ANTHROPIC_API_KEY = originalKey;
+      rmTmpDir(tmp);
+    }
+  });
+
+  it('returns readiness=needs_setup when runtime profile is not found', () => {
+    const tmp = mkTmpDir();
+    const config = yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+        correction_observer: { category: 'quiet', enabled: true },
+        empathy_observer: { category: 'quiet', enabled: false },
+      },
+      runtimeProfiles: {
+        'openclaw.default': { type: 'openclaw', source: 'default' },
+      },
+      internalAgents: {
+        defaultRuntime: 'openclaw.default',
+        agents: {
+          diagnostician: { enabled: true },
+          dreamer: { enabled: true },
+          scribe: { enabled: true },
+          artificer: { enabled: true },
+          philosopher: { enabled: false },
+          evaluator: { enabled: false },
+          rolloutReviewer: { enabled: false },
+          trainer: { enabled: false },
+          correctionObserver: { enabled: true, runtimeProfile: 'nonexistent.profile' },
+          empathyObserver: { enabled: false },
+        },
+      },
+    });
+    writeConfig(tmp, config);
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(true);
+      expect(result.readiness).toBe('needs_setup');
+      expect(result.reason).toContain('not found');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Observer ready ───────────────────────────────────────────────────────────
+
+describe('Observer ready', () => {
+  it('returns readiness=not_ready when pi-ai profile has API key set', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigWithObserverEnabled());
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-1234567890';
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(true);
+      expect(result.readiness).toBe('not_ready');
+      expect(result.apiKeyPresent).toBe(true);
+      expect(result.provider).toBe('anthropic');
+      expect(result.model).toBe('claude-3-5-sonnet');
+    } finally {
+      if (originalKey !== undefined) process.env.ANTHROPIC_API_KEY = originalKey;
+      else delete process.env.ANTHROPIC_API_KEY;
+      rmTmpDir(tmp);
+    }
+  });
+
+  it('returns readiness=ready for OpenClaw profile', () => {
+    const tmp = mkTmpDir();
+    const config = yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+        correction_observer: { category: 'quiet', enabled: true },
+        empathy_observer: { category: 'quiet', enabled: false },
+      },
+      runtimeProfiles: {
+        'openclaw.default': { type: 'openclaw', source: 'default' },
+      },
+      internalAgents: {
+        defaultRuntime: 'openclaw.default',
+        agents: {
+          diagnostician: { enabled: true },
+          dreamer: { enabled: true },
+          scribe: { enabled: true },
+          artificer: { enabled: true },
+          philosopher: { enabled: false },
+          evaluator: { enabled: false },
+          rolloutReviewer: { enabled: false },
+          trainer: { enabled: false },
+          correctionObserver: { enabled: true },
+          empathyObserver: { enabled: false },
+        },
+      },
+    });
+    writeConfig(tmp, config);
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      expect(result.enabled).toBe(true);
+      expect(result.readiness).toBe('ready');
+      expect(result.runtimeProfileType).toBe('openclaw');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── No secret output ─────────────────────────────────────────────────────────
+
+describe('No secret output', () => {
+  it('observer config result never contains API key values', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigWithObserverEnabled());
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-1234567890';
+    try {
+      const result = resolveObserverConfig(tmp, 'correction_observer', 'correctionObserver');
+      const json = JSON.stringify(result);
+      expect(json).not.toContain('sk-ant-test-key');
+      expect(json).not.toContain('sk-ant-');
+      expect(json).not.toMatch(/"apiKey"\s*:/);
+    } finally {
+      if (originalKey !== undefined) process.env.ANTHROPIC_API_KEY = originalKey;
+      else delete process.env.ANTHROPIC_API_KEY;
+      rmTmpDir(tmp);
+    }
+  });
+});
+
+// ── Feature flag loading ─────────────────────────────────────────────────────
+
+describe('Feature flag loading from .pd/config.yaml', () => {
+  it('loadFeatureFlagFromConfig returns enabled for MVP core flags', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadFeatureFlagFromConfig(tmp, 'prompt');
+      expect(result.enabled).toBe(true);
+      expect(result.source).toBe('defaults');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('loadFeatureFlagFromConfig returns disabled for quiet flags by default', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadFeatureFlagFromConfig(tmp, 'correction_observer');
+      expect(result.enabled).toBe(false);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('loadFeatureFlagFromConfig reads from user config', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigWithObserverEnabled());
+    try {
+      const result = loadFeatureFlagFromConfig(tmp, 'correction_observer');
+      expect(result.enabled).toBe(true);
+      expect(result.source).toBe('user_config');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Plugin config load ───────────────────────────────────────────────────────
+
+describe('Plugin config load', () => {
+  it('returns ok=true with defaults when config is missing', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfigForPlugin(tmp);
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe('defaults');
+      expect(result.effective.config.version).toBe(1);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns ok=false with errors for malformed config', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = loadPdConfigForPlugin(tmp);
+      expect(result.ok).toBe(false);
+      expect(result.source).toBe('malformed');
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.effective.config.version).toBe(1); // defaults still available
+    } finally { rmTmpDir(tmp); }
+  });
+});

--- a/packages/openclaw-plugin/tests/core/surface-guard.test.ts
+++ b/packages/openclaw-plugin/tests/core/surface-guard.test.ts
@@ -324,7 +324,7 @@ describe('surface-guard', () => {
 
     it('no quiet surface disabledReason promises a feature flag override (PRI-298 / chatgpt P2)', () => {
       // The runtime guard path (`isSurfaceEnabled(surfaceId)` with no
-      // overrides argument) does not consume `.pd/feature-flags.yaml`, so
+      // overrides argument) does not consume `.pd/config.yaml`, so
       // telling operators to "enable via feature flag override" would be
       // an impossible next action. Quiet copy must describe the surface
       // honestly without pointing to a non-existent override path.

--- a/packages/openclaw-plugin/tests/evolution-worker-quarantine.test.ts
+++ b/packages/openclaw-plugin/tests/evolution-worker-quarantine.test.ts
@@ -2,8 +2,8 @@
  * PRI-288: Quarantine EvolutionWorkerService default startup behind MVP feature flag.
  *
  * Tests prove:
- * 1. Default config (no feature-flags.yaml) → EvolutionWorkerService does NOT start.
- * 2. Explicit enable in feature-flags.yaml → EvolutionWorkerService starts.
+ * 1. Default config (no config.yaml) → EvolutionWorkerService does NOT start.
+ * 2. Explicit enable in config.yaml → EvolutionWorkerService starts.
  * 3. Disabled state has structured observability from real helper, not hand-written JSON.
  * 4. api.registerService still works regardless of flag state.
  *
@@ -60,9 +60,63 @@ function createTempWorkspace(): string {
   return dir;
 }
 
-function writeFeatureFlags(workspaceDir: string, flags: Record<string, unknown>): void {
-  const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
-  const content = yaml.dump(flags, { schema: yaml.JSON_SCHEMA });
+function deepMergeFeatures(
+  defaults: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...defaults };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (
+      value != null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.hasOwn(result, key) &&
+      result[key] != null &&
+      typeof result[key] === 'object' &&
+      !Array.isArray(result[key])
+    ) {
+      result[key] = { ...(result[key] as Record<string, unknown>), ...(value as Record<string, unknown>) };
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function writeConfigYaml(workspaceDir: string, featureOverrides: Record<string, unknown>): void {
+  const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
+  const defaultFeatures: Record<string, unknown> = {
+    prompt: { category: 'core', enabled: true },
+    code_tool_hook: { category: 'core', enabled: true },
+    defer_archive: { category: 'core', enabled: true },
+    correction_observer: { category: 'quiet', enabled: false },
+    empathy_observer: { category: 'quiet', enabled: false },
+    evolution_worker: { category: 'quiet', enabled: false },
+    nocturnal: { category: 'gone', enabled: false },
+  };
+  const config = {
+    version: 1,
+    features: deepMergeFeatures(defaultFeatures, featureOverrides),
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
+      },
+    },
+  };
+  const content = yaml.dump(config, { schema: yaml.JSON_SCHEMA });
   fs.writeFileSync(configPath, content, 'utf8');
 }
 
@@ -112,32 +166,32 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
   // ── 2. loadFeatureFlagFromWorkspace ──
 
   describe('loadFeatureFlagFromWorkspace', () => {
-    it('returns enabled=false when no feature-flags.yaml exists', () => {
+    it('returns enabled=false when no config.yaml exists', () => {
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
       expect(result.enabled).toBe(false);
       expect(result.source).toBe('defaults');
     });
 
-    it('returns enabled=false when feature-flags.yaml has no evolution_worker entry', () => {
-      writeFeatureFlags(workspaceDir, { prompt: { enabled: true } });
+    it('returns enabled=false when config.yaml has no evolution_worker entry', () => {
+      writeConfigYaml(workspaceDir, { prompt: { enabled: true } });
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
       expect(result.enabled).toBe(false);
     });
 
-    it('returns enabled=true when feature-flags.yaml explicitly enables evolution_worker', () => {
-      writeFeatureFlags(workspaceDir, {
+    it('returns enabled=true when config.yaml explicitly enables evolution_worker', () => {
+      writeConfigYaml(workspaceDir, {
         evolution_worker: { enabled: true },
       });
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
       expect(result.enabled).toBe(true);
-      expect(result.source).toBe('workspace_file');
+      expect(result.source).toBe('user_config');
     });
 
     it('returns enabled=false when YAML is malformed and warning includes error detail', () => {
-      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
       fs.writeFileSync(configPath, '  bad: [yaml: content', 'utf8');
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
@@ -152,7 +206,7 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
 
     it('returns defaults when file is unreadable', () => {
       // Create a directory where a file should be — causes read error
-      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
       fs.mkdirSync(configPath, { recursive: true });
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'evolution_worker', logger);
@@ -162,7 +216,7 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
 
     it('rejects dangerous keys (__proto__) and does not enable via prototype pollution', () => {
       // Write raw YAML with __proto__ to test dangerous key rejection on raw parsed output
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         __proto__: { enabled: true },
         evolution_worker: { enabled: false },
       });
@@ -175,7 +229,7 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
   // ── 3. shouldStartEvolutionWorker — real helper, real output ──
 
   describe('shouldStartEvolutionWorker gate helper', () => {
-    it('returns shouldStart=false by default (no feature-flags.yaml)', () => {
+    it('returns shouldStart=false by default (no config.yaml)', () => {
       const logger = createMockLogger();
       const gate = shouldStartEvolutionWorker(workspaceDir, logger);
       expect(gate.shouldStart).toBe(false);
@@ -184,13 +238,13 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
     });
 
     it('returns shouldStart=true when explicitly enabled', () => {
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         evolution_worker: { enabled: true },
       });
       const logger = createMockLogger();
       const gate = shouldStartEvolutionWorker(workspaceDir, logger);
       expect(gate.shouldStart).toBe(true);
-      expect(gate.flagSource).toBe('workspace_file');
+      expect(gate.flagSource).toBe('user_config');
       expect(gate.disabledInfo).toBeNull();
     });
 
@@ -248,18 +302,18 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
 
   describe('explicit enable: worker starts', () => {
     it('shouldStartEvolutionWorker returns true when enabled in config', () => {
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         evolution_worker: { enabled: true },
       });
 
       const logger = createMockLogger();
       const gate = shouldStartEvolutionWorker(workspaceDir, logger);
       expect(gate.shouldStart).toBe(true);
-      expect(gate.flagSource).toBe('workspace_file');
+      expect(gate.flagSource).toBe('user_config');
     });
 
     it('EvolutionWorkerService.start actually runs when gate is true', () => {
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         evolution_worker: { enabled: true },
       });
 
@@ -292,17 +346,18 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
     });
 
     it('computeEffectiveFlags preserves core flags even with evolution_worker override', () => {
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         evolution_worker: { enabled: true },
       });
 
-      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
       const raw = fs.readFileSync(configPath, 'utf8');
       const parsed: unknown = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
 
       // Use isRecord type guard instead of `as`
       expect(isRecord(parsed)).toBe(true);
-      const flags = computeEffectiveFlags(parsed as Record<string, unknown>, DEFAULT_FEATURE_FLAGS, configPath);
+      const features = (parsed as Record<string, unknown>).features;
+      const flags = computeEffectiveFlags(features as Record<string, unknown>, DEFAULT_FEATURE_FLAGS, configPath);
       expect(flags.flags['prompt']?.enabled).toBe(true);
       expect(flags.flags['code_tool_hook']?.enabled).toBe(true);
       expect(flags.flags['defer_archive']?.enabled).toBe(true);
@@ -310,17 +365,18 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
     });
 
     it('core flags cannot be disabled by user override', () => {
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         prompt: { enabled: false },
         code_tool_hook: { enabled: false },
       });
 
-      const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
+      const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
       const raw = fs.readFileSync(configPath, 'utf8');
       const parsed: unknown = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
 
       expect(isRecord(parsed)).toBe(true);
-      const flags = computeEffectiveFlags(parsed as Record<string, unknown>, DEFAULT_FEATURE_FLAGS, configPath);
+      const features = (parsed as Record<string, unknown>).features;
+      const flags = computeEffectiveFlags(features as Record<string, unknown>, DEFAULT_FEATURE_FLAGS, configPath);
       expect(flags.flags['prompt']?.enabled).toBe(true); // core cannot be disabled
       expect(flags.flags['code_tool_hook']?.enabled).toBe(true); // core cannot be disabled
       expect(flags.warnings.length).toBeGreaterThan(0); // warnings about core override attempt
@@ -331,7 +387,7 @@ describe('PRI-288: EvolutionWorkerService quarantine', () => {
 
   describe('no confirm-first gate regression', () => {
     it('no PLAN.md or confirm-first files are created in workspace', () => {
-      writeFeatureFlags(workspaceDir, {
+      writeConfigYaml(workspaceDir, {
         evolution_worker: { enabled: false },
       });
 

--- a/packages/openclaw-plugin/tests/evolution-worker-slimming.test.ts
+++ b/packages/openclaw-plugin/tests/evolution-worker-slimming.test.ts
@@ -28,9 +28,63 @@ function createTempWorkspace(): string {
   return dir;
 }
 
-function writeFeatureFlags(workspaceDir: string, flags: Record<string, unknown>): void {
-  const configPath = path.join(workspaceDir, '.pd', 'feature-flags.yaml');
-  const content = yaml.dump(flags, { schema: yaml.JSON_SCHEMA });
+function deepMergeFeatures(
+  defaults: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...defaults };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (
+      value != null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.hasOwn(result, key) &&
+      result[key] != null &&
+      typeof result[key] === 'object' &&
+      !Array.isArray(result[key])
+    ) {
+      result[key] = { ...(result[key] as Record<string, unknown>), ...(value as Record<string, unknown>) };
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function writeConfigYaml(workspaceDir: string, featureOverrides: Record<string, unknown>): void {
+  const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
+  const defaultFeatures: Record<string, unknown> = {
+    prompt: { category: 'core', enabled: true },
+    code_tool_hook: { category: 'core', enabled: true },
+    defer_archive: { category: 'core', enabled: true },
+    correction_observer: { category: 'quiet', enabled: false },
+    empathy_observer: { category: 'quiet', enabled: false },
+    evolution_worker: { category: 'quiet', enabled: false },
+    nocturnal: { category: 'gone', enabled: false },
+  };
+  const config = {
+    version: 1,
+    features: deepMergeFeatures(defaultFeatures, featureOverrides),
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
+      },
+    },
+  };
+  const content = yaml.dump(config, { schema: yaml.JSON_SCHEMA });
   fs.writeFileSync(configPath, content, 'utf8');
 }
 
@@ -151,6 +205,9 @@ describe('PRI-294: CorrectionObserver independence from EvolutionWorker', () => 
   });
 
   it('CorrectionObserver starts when EvolutionWorker is disabled (default)', () => {
+    writeConfigYaml(workspaceDir, {
+      correction_observer: { enabled: true },
+    });
     const logger = createMockLogger();
 
     // Verify EvolutionWorker is disabled
@@ -164,8 +221,9 @@ describe('PRI-294: CorrectionObserver independence from EvolutionWorker', () => 
   });
 
   it('CorrectionObserver starts when EvolutionWorker is explicitly enabled', () => {
-    writeFeatureFlags(workspaceDir, {
+    writeConfigYaml(workspaceDir, {
       evolution_worker: { enabled: true },
+      correction_observer: { enabled: true },
     });
     const logger = createMockLogger();
 
@@ -177,7 +235,7 @@ describe('PRI-294: CorrectionObserver independence from EvolutionWorker', () => 
   });
 
   it('CorrectionObserver can be independently disabled', () => {
-    writeFeatureFlags(workspaceDir, {
+    writeConfigYaml(workspaceDir, {
       correction_observer: { enabled: false },
     });
     const logger = createMockLogger();

--- a/packages/openclaw-plugin/tests/hooks/runtime-v2-prompt-activation.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/runtime-v2-prompt-activation.test.ts
@@ -494,9 +494,11 @@ describe('Runtime V2 prompt activation — additional guard tests', () => {
 
   it('malformed DB/config input fails loud with warning', async () => {
     const pdDir = path.join(tempWorkspaceDir, '.pd');
+    // PRI-305/PRI-307: Write a malformed .pd/config.yaml with dangerous keys
+    // The core validator rejects __proto__ and constructor as dangerous keys
     fs.writeFileSync(
-      path.join(pdDir, 'feature-flags.yaml'),
-      '__proto__:\n  enabled: true\nprompt:\n  enabled: true\nconstructor:\n  enabled: false\n',
+      path.join(pdDir, 'config.yaml'),
+      'version: 1\nfeatures:\n  __proto__:\n    category: core\n    enabled: true\n  prompt:\n    category: core\n    enabled: true\n  constructor:\n    category: core\n    enabled: false\nruntimeProfiles:\n  openclaw.default:\n    type: openclaw\n    source: default\ninternalAgents:\n  defaultRuntime: openclaw.default\n  agents:\n    diagnostician:\n      enabled: true\n    dreamer:\n      enabled: true\n    scribe:\n      enabled: true\n    artificer:\n      enabled: true\n    philosopher:\n      enabled: false\n    evaluator:\n      enabled: false\n    rolloutReviewer:\n      enabled: false\n    trainer:\n      enabled: false\n    correctionObserver:\n      enabled: false\n    empathyObserver:\n      enabled: false\n',
       'utf8',
     );
 
@@ -507,10 +509,14 @@ describe('Runtime V2 prompt activation — additional guard tests', () => {
     const result = await reader.readActivatedPrinciples();
 
     const warnCalls = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    // PRI-305/PRI-307: Core validator rejects dangerous keys as errors.
+    // The plugin config loader logs config errors as warnings.
     const hasDangerousKeyWarning = warnCalls.some(
-      (c: string) => c.includes('dangerous key') || c.includes('__proto__') || c.includes('constructor'),
+      (c: string) => c.includes('dangerous key') || c.includes('__proto__') || c.includes('constructor') || c.includes('Config error'),
     );
     expect(hasDangerousKeyWarning).toBe(true);
+    // With malformed config, defaults are used (prompt enabled by default),
+    // but no DB data exists, so principles should be empty
     expect(result.principles).toEqual([]);
   });
 

--- a/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/correction-observer-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as yaml from 'js-yaml';
 import { WorkspaceContext } from '../../src/core/workspace-context.js';
 
 const mockLearner = {
@@ -35,6 +36,89 @@ vi.mock('../../src/service/keyword-optimization-service.js', () => ({
   KeywordOptimizationService: { get: vi.fn(() => mockOptimizationService) },
 }));
 
+// PRI-307: Mock the pd-config-loader instead of @principles/core/runtime-v2
+// The service now reads .pd/config.yaml via resolveObserverConfig
+vi.mock('../../src/core/pd-config-loader.js', () => {
+  return {
+    loadPdConfigForPlugin: vi.fn(() => ({
+      ok: true,
+      effective: {
+        config: {
+          version: 1,
+          features: {
+            prompt: { category: 'core', enabled: true },
+            code_tool_hook: { category: 'core', enabled: true },
+            defer_archive: { category: 'core', enabled: true },
+            correction_observer: { category: 'quiet', enabled: true },
+            empathy_observer: { category: 'quiet', enabled: false },
+          },
+          runtimeProfiles: {
+            'openclaw.default': { type: 'openclaw', source: 'default' },
+            'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 30000 },
+          },
+          internalAgents: {
+            defaultRuntime: 'openclaw.default',
+            agents: {
+              diagnostician: { enabled: true },
+              dreamer: { enabled: true },
+              scribe: { enabled: true },
+              artificer: { enabled: true },
+              philosopher: { enabled: false },
+              evaluator: { enabled: false },
+              rolloutReviewer: { enabled: false },
+              trainer: { enabled: false },
+              correctionObserver: { enabled: true, runtimeProfile: 'pd.anthropic-sonnet' },
+              empathyObserver: { enabled: false },
+            },
+          },
+        },
+        warnings: [],
+      },
+      source: 'defaults',
+      configPath: '.pd/config.yaml',
+      warnings: [],
+      errors: [],
+    })),
+    loadFeatureFlagFromConfig: vi.fn(() => ({ enabled: true, source: 'defaults' })),
+    resolveObserverConfig: vi.fn((_workspaceDir: string, flagId: string, _agentName: string) => {
+      // Default: return disabled for correction_observer (no config file in test tmp dirs)
+      if (flagId === 'correction_observer') {
+        return {
+          enabled: true,
+          readiness: 'not_ready',
+          source: 'defaults',
+          reason: 'pi-ai profile configured with apiKeyEnv',
+          nextAction: 'Run pd runtime probe',
+          runtimeProfileId: 'pd.anthropic-sonnet',
+          runtimeProfileType: 'pi-ai',
+          apiKeyEnv: 'ANTHROPIC_API_KEY',
+          apiKeyPresent: !!process.env.ANTHROPIC_API_KEY,
+          provider: 'anthropic',
+          model: 'claude-3-5-sonnet',
+          timeoutMs: 30000,
+          baseUrl: null,
+        };
+      }
+      return {
+        enabled: false,
+        readiness: 'disabled',
+        source: 'defaults',
+        reason: `${flagId} is disabled`,
+        nextAction: `Set features.${flagId}.enabled=true in .pd/config.yaml`,
+        runtimeProfileId: null,
+        runtimeProfileType: null,
+        apiKeyEnv: null,
+        apiKeyPresent: false,
+        provider: null,
+        model: null,
+        timeoutMs: null,
+        baseUrl: null,
+      };
+    }),
+    getPdConfigPath: vi.fn((workspaceDir: string) => path.join(workspaceDir, '.pd', 'config.yaml')),
+  };
+});
+
 const mockDispatch = vi.fn().mockResolvedValue({
   updated: true,
   summary: 'Keyword store optimized',
@@ -45,23 +129,12 @@ const mockRegister = vi.fn();
 
 vi.mock('@principles/core/runtime-v2', () => {
   return {
-    WorkflowFunnelLoader: class {
-      getFunnel = vi.fn(() => ({
-        policy: {
-          runtimeKind: 'pi-ai',
-          provider: 'anthropic',
-          model: 'anthropic/claude-3-5-sonnet',
-          apiKeyEnv: 'ANTHROPIC_API_KEY',
-          timeoutMs: 30000,
-        }
-      }));
-    },
     PiAiRuntimeAdapter: class {},
     CorrectionObserver: class {},
     AgentScheduler: class {
       register = mockRegister;
       dispatch = mockDispatch;
-    }
+    },
   };
 });
 
@@ -330,12 +403,12 @@ describe('runCorrectionObserverCycle — Independent Execution', () => {
   });
 });
 
-describe('resolveCorrectionObserver — Configuration Resolution', () => {
+describe('resolveCorrectionObserver — Configuration Resolution (PRI-307)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns observer when API key env is set with mocked policy', async () => {
+  it('returns observer when API key env is set with pi-ai profile', async () => {
     const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-resolve-'));
     const stateDir = path.join(workspaceDir, '.state');
     fs.mkdirSync(stateDir, { recursive: true });
@@ -348,7 +421,7 @@ describe('resolveCorrectionObserver — Configuration Resolution', () => {
       const wctx = WorkspaceContext.fromHookContext({ workspaceDir });
       const result = resolveCorrectionObserver(wctx, logger as any);
 
-      // With mocked WorkflowFunnelLoader returning valid policy, should return observer
+      // With mocked resolveObserverConfig returning enabled + not_ready, should return observer
       expect(result).not.toBeNull();
     } finally {
       delete process.env.ANTHROPIC_API_KEY;
@@ -356,23 +429,76 @@ describe('resolveCorrectionObserver — Configuration Resolution', () => {
     }
   });
 
-  it('returns observer when workflows.yaml provides valid policy', async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-policy-'));
+  it('returns null when observer is disabled in config', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-disabled-'));
     const stateDir = path.join(workspaceDir, '.state');
     fs.mkdirSync(stateDir, { recursive: true });
 
-    process.env.ANTHROPIC_API_KEY = 'test-key';
-
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    // Override the mock to return disabled
+    const { resolveObserverConfig } = await import('../../src/core/pd-config-loader.js');
+    vi.mocked(resolveObserverConfig).mockReturnValueOnce({
+      enabled: false,
+      readiness: 'disabled',
+      source: 'defaults',
+      reason: 'correction_observer is disabled in .pd/config.yaml',
+      nextAction: 'Set features.correction_observer.enabled=true in .pd/config.yaml to enable',
+      runtimeProfileId: null,
+      runtimeProfileType: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      provider: null,
+      model: null,
+      timeoutMs: null,
+      baseUrl: null,
+    });
 
     try {
       const wctx = WorkspaceContext.fromHookContext({ workspaceDir });
       const result = resolveCorrectionObserver(wctx, logger as any);
 
-      // With mocked WorkflowFunnelLoader returning valid policy, should return observer
-      expect(result).not.toBeNull();
+      expect(result).toBeNull();
     } finally {
-      delete process.env.ANTHROPIC_API_KEY;
+      safeRmDir(workspaceDir);
+    }
+  });
+
+  it('returns null when observer needs setup (no API key)', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-corr-needs-setup-'));
+    const stateDir = path.join(workspaceDir, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    // Override the mock to return needs_setup
+    const { resolveObserverConfig } = await import('../../src/core/pd-config-loader.js');
+    vi.mocked(resolveObserverConfig).mockReturnValueOnce({
+      enabled: true,
+      readiness: 'needs_setup',
+      source: 'defaults',
+      reason: "Environment variable 'ANTHROPIC_API_KEY' is not set or empty",
+      nextAction: 'Set the environment variable ANTHROPIC_API_KEY with a valid API key',
+      runtimeProfileId: 'pd.anthropic-sonnet',
+      runtimeProfileType: 'pi-ai',
+      apiKeyEnv: 'ANTHROPIC_API_KEY',
+      apiKeyPresent: false,
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      timeoutMs: 30000,
+      baseUrl: null,
+    });
+
+    try {
+      const wctx = WorkspaceContext.fromHookContext({ workspaceDir });
+      const result = resolveCorrectionObserver(wctx, logger as any);
+
+      expect(result).toBeNull();
+      // Should log the needs_setup reason, not noisy "no API key" cycling
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('ANTHROPIC_API_KEY')
+      );
+    } finally {
       safeRmDir(workspaceDir);
     }
   });

--- a/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
@@ -14,7 +14,7 @@ describe('Correction Observer Ownership — Feature Flag & Surface Registry Cons
     const result = computeEffectiveFlags(
       { correction_observer: { enabled: false } },
       DEFAULT_FEATURE_FLAGS,
-      '.pd/feature-flags.yaml',
+      '.pd/config.yaml',
     );
     expect(result.flags['correction_observer'].enabled).toBe(false);
     expect(result.warnings).not.toContain(expect.stringContaining('core flag cannot be disabled'));

--- a/packages/pd-cli/src/commands/config-doctor.ts
+++ b/packages/pd-cli/src/commands/config-doctor.ts
@@ -1,12 +1,9 @@
 /**
  * pd config doctor — Discover and explain PD / OpenClaw configuration state.
  *
- * PRI-299 MVP UX:
- *   - Reports workspace + OpenClaw config paths and existence
- *   - Lists effective feature flags and enabled MVP channels
- *   - Classifies provider/model/auth connectivity (healthy, auth_missing, rate_limit, etc.)
- *   - Emits `reason` + `nextActions` for failures
- *   - NEVER leaks tokens, env var values, or raw config bytes
+ * PRI-305: Cutover to .pd/config.yaml.
+ *   - Feature flags and internal agent runtime bindings come from .pd/config.yaml
+ *   - .pd/feature-flags.yaml and .state/workflows.yaml are no longer production inputs
  *
  * Usage:
  *   pd config doctor [--workspace <path>] [--json]
@@ -33,7 +30,8 @@ function formatTextOutput(output: DoctorOutput): string {
   lines.push('PD config paths:');
   for (const [k, v] of Object.entries(output.pdConfigPaths)) {
     const exists = v.exists ? '[exists]' : '[missing]';
-    lines.push(`  ${k.padEnd(16)} ${exists.padEnd(10)} ${v.path}`);
+    const parseable = v.parseable === false ? ' [unparseable]' : '';
+    lines.push(`  ${k.padEnd(16)} ${exists.padEnd(10)}${parseable} ${v.path}`);
   }
   lines.push('');
 
@@ -54,17 +52,34 @@ function formatTextOutput(output: DoctorOutput): string {
   }
   lines.push('');
 
+  lines.push('Internal agents:');
+  if (output.internalAgents.length === 0) {
+    lines.push('  (no internal agents diagnosed)');
+  } else {
+    for (const agent of output.internalAgents) {
+      const readiness = agent.readiness.toUpperCase();
+      const enabledLabel = agent.enabled ? 'enabled' : 'disabled';
+      lines.push(`  ${agent.name}: [${readiness}] (${enabledLabel})`);
+      lines.push(`    profile:      ${agent.runtimeProfileLabel} (${agent.runtimeProfileId})`);
+      if (agent.apiKeyEnv) {
+        const apiKeyState = agent.apiKeyPresent ? 'present' : 'absent';
+        lines.push(`    apiKeyEnv:    ${agent.apiKeyEnv} (${apiKeyState})`);
+      }
+      lines.push(`    reason:       ${agent.reason}`);
+      lines.push(`    nextAction:   ${agent.nextAction}`);
+    }
+  }
+  lines.push('');
+
   lines.push('Provider health:');
   if (output.providerHealth.length === 0) {
     lines.push('  (no providers discovered)');
   } else {
     for (const p of output.providerHealth) {
       const cls = p.classification.toUpperCase();
-      const provider = p.provider ?? '(unset)';
-      const model = p.model ?? '(unset)';
       const apiKeyEnv = p.apiKeyEnv ?? '(unset)';
       const apiKeyState = p.apiKeyPresent ? 'present' : 'absent';
-      lines.push(`  [${cls}] ${provider} / ${model}`);
+      lines.push(`  [${cls}]`);
       lines.push(`    apiKeyEnv:   ${apiKeyEnv} (${apiKeyState})`);
       lines.push(`    source:      ${p.source}`);
       lines.push(`    reason:      ${p.reason}`);
@@ -73,28 +88,13 @@ function formatTextOutput(output: DoctorOutput): string {
   }
   lines.push('');
 
-  lines.push('Internal agents:');
-  if (output.internalAgents && output.internalAgents.correctionObserver) {
-    const co = output.internalAgents.correctionObserver;
-    const coStatus = co.status.toUpperCase();
-    const coProvider = co.provider ?? '(unset)';
-    const coModel = co.model ?? '(unset)';
-    const coApiKeyEnv = co.apiKeyEnv ?? '(unset)';
-    const coApiKeyState = co.apiKeyPresent ? 'present' : 'absent';
-    lines.push(`  correctionObserver: [${coStatus}]`);
-    lines.push(`    enabled:     ${co.enabled}`);
-    lines.push(`    flagSource:  ${co.flagSource}`);
-    lines.push(`    configSource:${co.configSource}`);
-    if (co.provider || co.model) {
-      lines.push(`    provider:    ${coProvider} / ${coModel}`);
+  if (output.legacyFilesDetected.length > 0) {
+    lines.push('Legacy files detected (not used for resolution):');
+    for (const f of output.legacyFilesDetected) {
+      lines.push(`  [!] ${f}`);
     }
-    lines.push(`    apiKeyEnv:   ${coApiKeyEnv} (${coApiKeyState})`);
-    lines.push(`    reason:      ${co.reason}`);
-    lines.push(`    nextAction:  ${co.nextAction}`);
-  } else {
-    lines.push('  (no internal agents diagnosed)');
+    lines.push('');
   }
-  lines.push('');
 
   if (output.warnings.length > 0) {
     lines.push('Warnings:');

--- a/packages/pd-cli/src/commands/runtime-features.ts
+++ b/packages/pd-cli/src/commands/runtime-features.ts
@@ -1,91 +1,140 @@
+/**
+ * pd runtime features — Show effective feature flags from .pd/config.yaml.
+ *
+ * PRI-305: Cutover from .pd/feature-flags.yaml to .pd/config.yaml.
+ * Uses core computeFeatureFlagsFromConfig for flag computation.
+ * --json outputs a single parseable JSON object.
+ * Missing config uses core defaults with nextAction.
+ * Malformed config fails loud with reason and nextAction.
+ * No secret output.
+ */
+
 import * as path from 'path';
-import { loadEffectiveFeatureFlags } from '../services/feature-flag-loader.js';
+import { loadPdConfig, computeFlagsFromLoadResult } from '../services/pd-config-loader.js';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 
-export interface FeatureFlagsStatusOutput {
-  status: 'ok' | 'degraded';
-  source: string;
+// ── Output types ─────────────────────────────────────────────────────────────
+
+export interface RuntimeFeaturesOutput {
+  status: 'ok' | 'degraded' | 'failed';
+  source: 'defaults' | 'user_config' | 'malformed';
   configPath: string;
-  flags: {
+  features: {
     id: string;
     category: string;
     enabled: boolean;
-    since: string;
-    description?: string;
   }[];
-  warnings: string[];
+  enabledMvpChannels: string[];
   totalFlags: number;
   enabledCount: number;
   disabledCount: number;
+  warnings: string[];
   reason?: string;
   nextAction?: string;
+  /** Malformed config errors (only present when source=malformed) */
+  errors?: { path: string; reason: string; nextAction: string }[];
 }
 
-interface FeaturesOptions {
-  workspace?: string;
-  json?: boolean;
-}
+// ── Build output ─────────────────────────────────────────────────────────────
 
-export function buildFeatureFlagsStatus(workspaceDir: string): FeatureFlagsStatusOutput {
-  const effective = loadEffectiveFeatureFlags(workspaceDir);
-  const flags = Object.values(effective.flags);
-  const enabledCount = flags.filter(f => f.enabled).length;
-  const hasWarnings = effective.warnings.length > 0;
+export function buildRuntimeFeaturesStatus(workspaceDir: string): RuntimeFeaturesOutput {
+  const loadResult = loadPdConfig(workspaceDir);
+  const flags = computeFlagsFromLoadResult(loadResult);
 
-  return {
-    status: hasWarnings ? 'degraded' : 'ok',
-    source: effective.source,
-    configPath: effective.configPath,
-    flags: flags.map(f => ({
-      id: f.id,
-      category: f.category,
-      enabled: f.enabled,
-      since: f.since,
-      ...(f.description ? { description: f.description } : {}),
-    })),
-    warnings: effective.warnings,
-    totalFlags: flags.length,
+  const allFlags = Object.values(flags.flags);
+  const enabledCount = allFlags.filter(f => f.enabled).length;
+  const features = allFlags.map(f => ({
+    id: f.id,
+    category: f.category,
+    enabled: f.enabled,
+  }));
+
+  // Determine status
+  let status: RuntimeFeaturesOutput['status'] = 'ok';
+  const warnings = [...loadResult.warnings, ...flags.warnings];
+
+  if (!loadResult.ok) {
+    status = 'failed';
+  } else if (warnings.length > 0) {
+    status = 'degraded';
+  }
+
+  const output: RuntimeFeaturesOutput = {
+    status,
+    source: loadResult.ok ? loadResult.source : 'malformed',
+    configPath: loadResult.configPath,
+    features,
+    enabledMvpChannels: [...flags.enabledChannels],
+    totalFlags: allFlags.length,
     enabledCount,
-    disabledCount: flags.length - enabledCount,
-    ...(hasWarnings ? {
-      reason: `Config warnings: ${effective.warnings.join('; ')}`,
-      nextAction: 'Review feature-flags.yaml for malformed overrides or unknown flags',
-    } : {}),
+    disabledCount: allFlags.length - enabledCount,
+    warnings,
   };
+
+  // Add reason and nextAction for non-ok states
+  if (!loadResult.ok) {
+    output.reason = `Config validation failed: ${loadResult.errors.map(e => e.reason).join('; ')}`;
+    output.nextAction = loadResult.errors[0]?.nextAction ?? 'Fix .pd/config.yaml and retry';
+    output.errors = loadResult.errors;
+  } else if (warnings.length > 0) {
+    output.reason = `Config warnings: ${warnings.slice(0, 3).join('; ')}`;
+    output.nextAction = 'Review .pd/config.yaml for warnings';
+  }
+
+  return output;
 }
 
-function formatTextOutput(output: FeatureFlagsStatusOutput): string {
+// ── Text formatting ──────────────────────────────────────────────────────────
+
+function formatTextOutput(output: RuntimeFeaturesOutput): string {
   const lines: string[] = [];
 
-  lines.push('PD Feature Flags Status');
+  lines.push('PD Runtime Features');
   lines.push(`source: ${output.source}`);
   lines.push(`config: ${output.configPath}`);
   lines.push('');
 
-  const categoryOrder = ['core', 'quiet', 'gone', 'legacy_retire'] as const;
+  const categoryOrder = ['core', 'quiet', 'gone'] as const;
   for (const category of categoryOrder) {
-    const categoryFlags = output.flags.filter(f => f.category === category);
+    const categoryFlags = output.features.filter(f => f.category === category);
     if (categoryFlags.length === 0) continue;
 
     lines.push(`  ${category.toUpperCase()} (${categoryFlags.length})`);
     for (const flag of categoryFlags) {
       const icon = flag.enabled ? '+' : '-';
-      lines.push(`    [${icon}] ${flag.id} (since ${flag.since})${flag.description ? ` — ${flag.description}` : ''}`);
+      lines.push(`    [${icon}] ${flag.id}`);
     }
     lines.push('');
   }
 
   lines.push(`Total: ${output.totalFlags} flags, ${output.enabledCount} enabled, ${output.disabledCount} disabled`);
+  lines.push(`MVP channels: ${output.enabledMvpChannels.length > 0 ? output.enabledMvpChannels.join(', ') : '(none)'}`);
 
   if (output.warnings.length > 0) {
     lines.push('');
     lines.push('Warnings:');
-    for (const warning of output.warnings) {
-      lines.push(`  [!] ${warning}`);
+    for (const w of output.warnings) {
+      lines.push(`  [!] ${w}`);
+    }
+  }
+
+  if (output.errors && output.errors.length > 0) {
+    lines.push('');
+    lines.push('Errors:');
+    for (const e of output.errors) {
+      lines.push(`  [x] ${e.path}: ${e.reason}`);
+      lines.push(`      → ${e.nextAction}`);
     }
   }
 
   return lines.join('\n');
+}
+
+// ── CLI handler ──────────────────────────────────────────────────────────────
+
+interface FeaturesOptions {
+  workspace?: string;
+  json?: boolean;
 }
 
 export async function handleRuntimeFeaturesStatus(opts: FeaturesOptions): Promise<void> {
@@ -93,11 +142,16 @@ export async function handleRuntimeFeaturesStatus(opts: FeaturesOptions): Promis
     ? path.resolve(opts.workspace)
     : resolveWorkspaceDir();
 
-  const output = buildFeatureFlagsStatus(workspaceDir);
+  const output = buildRuntimeFeaturesStatus(workspaceDir);
 
   if (opts.json) {
+    // JSON mode: single parseable object on stdout
     console.log(JSON.stringify(output, null, 2));
   } else {
     console.log(formatTextOutput(output));
+  }
+
+  if (output.status === 'failed') {
+    process.exitCode = 1;
   }
 }

--- a/packages/pd-cli/src/services/config-doctor.ts
+++ b/packages/pd-cli/src/services/config-doctor.ts
@@ -1,10 +1,16 @@
 /**
- * PD Config Doctor — discovers and explains PD / OpenClaw configuration state.
+ * pd config doctor — Discover and explain PD / OpenClaw configuration state.
+ *
+ * PRI-305: Cutover to .pd/config.yaml.
+ *   - Feature flags and internal agent runtime bindings come from .pd/config.yaml
+ *   - .pd/feature-flags.yaml and .state/workflows.yaml are no longer production inputs
+ *   - Legacy files are detected and reported as warnings
  *
  * PRI-299 MVP UX: provides a single, read-only view of:
  *   - PD workspace config paths (with existence checks)
  *   - OpenClaw config paths (with existence checks)
- *   - Effective feature flags
+ *   - Effective feature flags from .pd/config.yaml
+ *   - Internal agent runtime binding readiness from .pd/config.yaml
  *   - Provider/model/auth status (classified)
  *
  * Constraints:
@@ -16,11 +22,19 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import yaml from 'js-yaml';
 import Database from 'better-sqlite3';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
-import { loadEffectiveFeatureFlags } from './feature-flag-loader.js';
-import { FEATURE_FLAGS_CONFIG_FILENAME, FEATURE_FLAGS_CONFIG_DIR } from './feature-flag-loader.js';
+import {
+  loadPdConfig,
+  computeFlagsFromLoadResult,
+  redactLoadResult,
+  getPdConfigPath,
+} from './pd-config-loader.js';
+import { MVP_CHANNEL_IDS } from '@principles/core/runtime-v2';
+import type {
+  RedactedAgentSummary,
+  RedactedRuntimeProfileSummary,
+} from '@principles/core/runtime-v2';
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -38,7 +52,6 @@ export type DoctorStatus = 'ok' | 'degraded' | 'failed';
 export interface ConfigPathEntry {
   path: string;
   exists: boolean;
-  /** Optional structural check (file is parseable JSON/YAML, etc.) */
   parseable?: boolean;
 }
 
@@ -46,12 +59,10 @@ export interface ProviderHealthEntry {
   provider: string | null;
   model: string | null;
   apiKeyEnv: string | null;
-  /** True if the env var name is non-empty and the env var is set. */
   apiKeyPresent: boolean;
   classification: DoctorClassification;
   reason: string;
   nextAction: string;
-  /** Source of the discovered config (e.g., 'workflows.yaml', 'cli_flag', 'default'). */
   source: string;
 }
 
@@ -63,14 +74,27 @@ export interface FeatureFlagSummary {
   warnings: string[];
 }
 
+export interface InternalAgentDiagnostics {
+  name: string;
+  enabled: boolean;
+  runtimeProfileId: string;
+  runtimeProfileLabel: string;
+  readiness: 'ready' | 'not_ready' | 'needs_setup' | 'disabled' | 'unknown';
+  provider: string | null;
+  model: string | null;
+  apiKeyEnv: string | null;
+  apiKeyPresent: boolean;
+  reason: string;
+  nextAction: string;
+}
+
 export interface DoctorOutput {
   status: DoctorStatus;
   workspaceDir: string;
   pdConfigPaths: {
     workspaceDir: ConfigPathEntry;
     pdDir: ConfigPathEntry;
-    featureFlags: ConfigPathEntry;
-    workflowsYaml: ConfigPathEntry;
+    configYaml: ConfigPathEntry;
     stateDb: ConfigPathEntry;
   };
   openclawConfigPaths: {
@@ -78,36 +102,17 @@ export interface DoctorOutput {
     openclawConfig: ConfigPathEntry;
   };
   featureFlags: FeatureFlagSummary;
+  internalAgents: InternalAgentDiagnostics[];
   providerHealth: ProviderHealthEntry[];
-  internalAgents: {
-    correctionObserver: {
-      enabled: boolean;
-      flagSource: string;
-      status: 'disabled' | 'configured' | 'auth_missing' | 'config_missing' | 'unavailable';
-      configSource: 'workflows.yaml' | 'env' | 'missing' | 'unavailable';
-      provider: string | null;
-      model: string | null;
-      apiKeyEnv: string | null;
-      apiKeyPresent: boolean;
-      reason: string;
-      nextAction: string;
-    };
-  };
   warnings: string[];
   reason?: string;
   nextActions: string[];
+  /** Legacy files detected (informational only, not used for resolution) */
+  legacyFilesDetected: string[];
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-/**
- * Resolve the OpenClaw home directory used to look up `openclaw.json` and
- * extension state. PD does not own this path — it only reports its existence.
- */
 export function getOpenClawHome(): string {
   const home = process.env.HOME
     || process.env.USERPROFILE
@@ -120,9 +125,6 @@ export function getOpenClawConfigPath(): string {
   return path.join(getOpenClawHome(), 'openclaw.json');
 }
 
-/**
- * Build a `ConfigPathEntry` with existence check.
- */
 function pathEntry(p: string): ConfigPathEntry {
   return { path: p, exists: fs.existsSync(p) };
 }
@@ -145,10 +147,10 @@ function classifyText(text: string): DoctorClassification | null {
   return null;
 }
 
+// ─── State DB Inspection (unchanged from PRI-299) ────────────────────────────
+
 export interface InspectStateDbOptions {
-  /** Max rows to scan from tasks table. */
   maxRows?: number;
-  /** Max age in ms — only signals within this window are considered "recent". */
   maxAgeMs?: number;
 }
 
@@ -160,23 +162,13 @@ export interface RecentProviderSignal {
 
 export interface StateDbSignalResult {
   signal: RecentProviderSignal | null;
-  /** True if the DB was found and could be opened in readonly mode. */
   dbReachable: boolean;
-  /** Optional warning when the DB exists but couldn't be read. */
   warning?: string;
 }
 
 const DEFAULT_MAX_ROWS = 50;
-const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-/**
- * Read the state.db recent provider error signal (best-effort, structural only).
- *
- * We inspect recent task/run rows in `<workspaceDir>/.pd/state.db` to detect
- * `rate_limit` / `auth_missing` / `unavailable` signals from the live pipeline.
- * This is a bounded best-effort probe — if the DB is missing or unreadable we
- * return `null` and let the doctor fall back to config-only classification.
- */
 export async function inspectStateDbForProviderSignal(
   stateDbPath: string,
   nowMs: number = Date.now(),
@@ -201,13 +193,11 @@ export async function inspectStateDbForProviderSignal(
   }
 
   try {
-    // Check for tasks table — drift-safe (ERR-026): assert via pragma, not assumption.
     const tableInfo = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='tasks'").get() as { name: string } | undefined;
     if (!tableInfo) {
       return { signal: null, dbReachable: true, warning: 'state.db has no tasks table — pipeline not initialized yet' };
     }
 
-    // Find columns defensively.
     const taskCols = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
     const taskColNames = new Set(taskCols.map((c) => c.name));
     const hasErrorMessage = taskColNames.has('error_message');
@@ -222,7 +212,6 @@ export async function inspectStateDbForProviderSignal(
       return { signal: null, dbReachable: true, warning: 'state.db tasks table has no error_message column — provider signal unavailable' };
     }
 
-    // Build a bounded scan: read up to maxRows recent failed tasks.
     const errorCol = hasErrorMessage ? 'error_message' : 'last_error_message';
     const tsCol = hasUpdatedAt ? 'updated_at' : hasLastErrorAt ? 'last_error_at' : hasCreatedAt ? 'created_at' : null;
     const tsExpr = tsCol ? `, ${tsCol} AS ts` : '';
@@ -243,7 +232,6 @@ export async function inspectStateDbForProviderSignal(
       }
     }
 
-    // Also check for explicit error_category/failure_category columns if present.
     if (hasErrorCategory || hasFailureCategory) {
       const catCol = hasErrorCategory ? 'error_category' : 'failure_category';
       const catRows = db.prepare(
@@ -280,144 +268,127 @@ export async function inspectStateDbForProviderSignal(
   }
 }
 
-/**
- * Resolve the provider/model/apiKeyEnv from the workspace's `workflows.yaml`
- * funnel policy. Returns `null` for each field when not configured.
- *
- * NEVER leaks api key values or env var values.
- */
-export interface ProviderConfigFromWorkflows {
-  provider: string | null;
-  model: string | null;
-  apiKeyEnv: string | null;
-  baseUrl: string | null;
-  source: 'workflows.yaml' | 'cli_flag' | 'default' | 'missing';
-  /** True if the workflows.yaml file was found and parseable. */
-  workflowsFound: boolean;
-  /** Parse warning, if any. */
-  parseWarning?: string;
-}
+// ─── Internal Agent Diagnostics from .pd/config.yaml ─────────────────────────
 
-const DIAGNOSTIC_FUNNEL_ID = 'pd-runtime-v2-diagnosis';
+function diagnoseInternalAgent(
+  agent: RedactedAgentSummary,
+  profile: RedactedRuntimeProfileSummary | undefined,
+): InternalAgentDiagnostics {
+  if (!agent.enabled) {
+    return {
+      name: agent.name,
+      enabled: false,
+      runtimeProfileId: agent.runtimeProfileId,
+      runtimeProfileLabel: agent.runtimeProfileLabel,
+      readiness: 'disabled',
+      provider: null,
+      model: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      reason: `${agent.name} is disabled in .pd/config.yaml`,
+      nextAction: `Set internalAgents.agents.${agent.name}.enabled=true in .pd/config.yaml to enable`,
+    };
+  }
 
-export async function resolveProviderConfigFromWorkflows(
-  stateDir: string,
-  opts: { cliProvider?: string; cliModel?: string; cliApiKeyEnv?: string; cliBaseUrl?: string } = {},
-): Promise<ProviderConfigFromWorkflows> {
-  const workflowsPath = path.join(stateDir, 'workflows.yaml');
-  if (!fs.existsSync(workflowsPath)) {
-    // Fall back to CLI flag values if provided.
-    if (opts.cliProvider || opts.cliModel || opts.cliApiKeyEnv) {
+  // Agent is enabled — check profile readiness
+  if (!profile) {
+    return {
+      name: agent.name,
+      enabled: true,
+      runtimeProfileId: agent.runtimeProfileId,
+      runtimeProfileLabel: agent.runtimeProfileLabel,
+      readiness: 'needs_setup',
+      provider: null,
+      model: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      reason: `Runtime profile '${agent.runtimeProfileId}' not found in .pd/config.yaml`,
+      nextAction: `Add runtime profile '${agent.runtimeProfileId}' to .pd/config.yaml runtimeProfiles, or change the agent's runtimeProfile reference`,
+    };
+  }
+
+  // Check apiKeyEnv for pi-ai profiles
+  if (profile.type === 'pi-ai') {
+    const apiKeyEnv = profile.apiKeyEnv ?? null;
+    const apiKeyPresent = !!apiKeyEnv && Object.prototype.hasOwnProperty.call(process.env, apiKeyEnv) && !!process.env[apiKeyEnv];
+
+    if (!apiKeyEnv) {
       return {
-        provider: opts.cliProvider ?? null,
-        model: opts.cliModel ?? null,
-        apiKeyEnv: opts.cliApiKeyEnv ?? null,
-        baseUrl: opts.cliBaseUrl ?? null,
-        source: 'cli_flag',
-        workflowsFound: false,
+        name: agent.name,
+        enabled: true,
+        runtimeProfileId: agent.runtimeProfileId,
+        runtimeProfileLabel: agent.runtimeProfileLabel,
+        readiness: 'needs_setup',
+        provider: null,
+        model: null,
+        apiKeyEnv: null,
+        apiKeyPresent: false,
+        reason: `pi-ai profile '${profile.id}' missing apiKeyEnv`,
+        nextAction: `Add apiKeyEnv to runtime profile '${profile.id}' in .pd/config.yaml`,
       };
     }
-    return {
-      provider: null,
-      model: null,
-      apiKeyEnv: null,
-      baseUrl: null,
-      source: 'missing',
-      workflowsFound: false,
-    };
-  }
 
-  let raw: string;
-  try {
-    raw = fs.readFileSync(workflowsPath, 'utf8');
-  } catch (err) {
-    return {
-      provider: null,
-      model: null,
-      apiKeyEnv: null,
-      baseUrl: null,
-      source: 'workflows.yaml',
-      workflowsFound: true,
-      parseWarning: `workflows.yaml read failed: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = yaml.load(raw);
-  } catch (err) {
-    return {
-      provider: null,
-      model: null,
-      apiKeyEnv: null,
-      baseUrl: null,
-      source: 'workflows.yaml',
-      workflowsFound: true,
-      parseWarning: `workflows.yaml parse error: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-
-  if (!isRecord(parsed)) {
-    return {
-      provider: null,
-      model: null,
-      apiKeyEnv: null,
-      baseUrl: null,
-      source: 'workflows.yaml',
-      workflowsFound: true,
-      parseWarning: 'workflows.yaml root is not an object',
-    };
-  }
-
-  const funnelsRaw = parsed.funnels;
-  if (!Array.isArray(funnelsRaw)) {
-    return {
-      provider: null,
-      model: null,
-      apiKeyEnv: null,
-      baseUrl: null,
-      source: 'workflows.yaml',
-      workflowsFound: true,
-      parseWarning: 'workflows.yaml: funnels is not an array',
-    };
-  }
-
-  let policy: Record<string, unknown> | null = null;
-  for (const f of funnelsRaw) {
-    if (!isRecord(f)) continue;
-    if (f.workflowId === DIAGNOSTIC_FUNNEL_ID && isRecord(f.policy)) {
-      const { policy: candidate } = f;
-      if (isRecord(candidate)) {
-        policy = candidate;
-        break;
-      }
+    if (!apiKeyPresent) {
+      return {
+        name: agent.name,
+        enabled: true,
+        runtimeProfileId: agent.runtimeProfileId,
+        runtimeProfileLabel: agent.runtimeProfileLabel,
+        readiness: 'needs_setup',
+        provider: null,
+        model: null,
+        apiKeyEnv,
+        apiKeyPresent: false,
+        reason: `Environment variable '${apiKeyEnv}' is not set or empty`,
+        nextAction: `Set the environment variable '${apiKeyEnv}' with a valid API key`,
+      };
     }
-  }
 
-  if (policy === null) {
+    // pi-ai with key present — check state.db for signals
     return {
+      name: agent.name,
+      enabled: true,
+      runtimeProfileId: agent.runtimeProfileId,
+      runtimeProfileLabel: agent.runtimeProfileLabel,
+      readiness: 'not_ready', // runtime availability unknown without actual probe
       provider: null,
       model: null,
-      apiKeyEnv: null,
-      baseUrl: null,
-      source: 'workflows.yaml',
-      workflowsFound: true,
-      parseWarning: `workflows.yaml: funnel '${DIAGNOSTIC_FUNNEL_ID}' not found`,
+      apiKeyEnv,
+      apiKeyPresent: true,
+      reason: `pi-ai profile configured with apiKeyEnv='${apiKeyEnv}' (key present); runtime availability unknown`,
+      nextAction: 'Run pd runtime probe to verify end-to-end connectivity',
     };
   }
 
-  const provider = typeof policy.provider === 'string' ? policy.provider : null;
-  const model = typeof policy.model === 'string' ? policy.model : null;
-  const apiKeyEnv = typeof policy.apiKeyEnv === 'string' ? policy.apiKeyEnv : null;
-  const baseUrl = typeof policy.baseUrl === 'string' ? policy.baseUrl : null;
+  // OpenClaw profile
+  if (profile.readiness === 'needs_setup') {
+    return {
+      name: agent.name,
+      enabled: true,
+      runtimeProfileId: agent.runtimeProfileId,
+      runtimeProfileLabel: agent.runtimeProfileLabel,
+      readiness: 'needs_setup',
+      provider: null,
+      model: null,
+      apiKeyEnv: null,
+      apiKeyPresent: false,
+      reason: `OpenClaw profile '${profile.id}' needs setup (missing provider/model)`,
+      nextAction: `Configure provider and model in runtime profile '${profile.id}' in .pd/config.yaml`,
+    };
+  }
 
   return {
-    provider: provider || opts.cliProvider || null,
-    model: model || opts.cliModel || null,
-    apiKeyEnv: apiKeyEnv || opts.cliApiKeyEnv || null,
-    baseUrl: baseUrl || opts.cliBaseUrl || null,
-    source: 'workflows.yaml',
-    workflowsFound: true,
+    name: agent.name,
+    enabled: true,
+    runtimeProfileId: agent.runtimeProfileId,
+    runtimeProfileLabel: agent.runtimeProfileLabel,
+    readiness: 'ready',
+    provider: null,
+    model: null,
+    apiKeyEnv: null,
+    apiKeyPresent: false,
+    reason: `OpenClaw profile '${profile.id}' is configured and ready`,
+    nextAction: 'No action required',
   };
 }
 
@@ -425,264 +396,113 @@ export async function resolveProviderConfigFromWorkflows(
 
 export interface BuildDoctorInput {
   workspaceDir: string;
-  /** Optional CLI overrides for provider/model/apiKeyEnv. */
-  cliProvider?: string;
-  cliModel?: string;
-  cliApiKeyEnv?: string;
-  cliBaseUrl?: string;
 }
-
-const MVP_CHANNELS = new Set(['prompt', 'code_tool_hook', 'defer_archive']);
 
 export async function buildDoctorOutput(input: BuildDoctorInput): Promise<DoctorOutput> {
   const workspaceDir = path.resolve(input.workspaceDir);
-  const pdDir = path.join(workspaceDir, FEATURE_FLAGS_CONFIG_DIR);
-  const featureFlagsPath = path.join(pdDir, FEATURE_FLAGS_CONFIG_FILENAME);
-  const workflowsPath = path.join(workspaceDir, '.state', 'workflows.yaml');
+  const pdDir = path.join(workspaceDir, '.pd');
+  const configYamlPath = getPdConfigPath(workspaceDir);
   const stateDbPath = path.join(pdDir, 'state.db');
 
-  // 1) Feature flags
-  let enabledMvpChannels: string[] = [];
-  let disabledFlags: string[] = [];
-  let flagSource: string;
-  let flagWarnings: string[];
-  let hasFeatureFlagsError = false;
-  let featureFlagsErrorMessage = '';
+  // 1) Load PD config from .pd/config.yaml
+  const loadResult = loadPdConfig(workspaceDir);
+  const flags = computeFlagsFromLoadResult(loadResult);
+  const redacted = redactLoadResult(loadResult);
 
-  let correctionObserverEnabled = true;
-  let coFlagSource = 'defaults';
-
-  try {
-    const flags = loadEffectiveFeatureFlags(workspaceDir);
-    flagSource = flags.source;
-    flagWarnings = [...flags.warnings];
-    for (const flag of Object.values(flags.flags)) {
-      if (flag.enabled && MVP_CHANNELS.has(flag.id)) {
-        enabledMvpChannels.push(flag.id);
-      } else if (!flag.enabled) {
-        disabledFlags.push(flag.id);
-      }
+  // 2) Feature flag summary
+  const enabledMvpChannels: string[] = [];
+  const disabledFlags: string[] = [];
+  for (const flag of Object.values(flags.flags)) {
+    if (flag.enabled && MVP_CHANNEL_IDS.includes(flag.id as typeof MVP_CHANNEL_IDS[number])) {
+      enabledMvpChannels.push(flag.id);
+    } else if (!flag.enabled) {
+      disabledFlags.push(flag.id);
     }
-    if (flags.flags && flags.flags.correction_observer) {
-      correctionObserverEnabled = flags.flags.correction_observer.enabled;
-      coFlagSource = flags.source;
-    }
-  } catch (err) {
-    hasFeatureFlagsError = true;
-    featureFlagsErrorMessage = err instanceof Error ? err.message : String(err);
-    flagSource = 'unavailable';
-    flagWarnings = [`feature flags unavailable: ${featureFlagsErrorMessage}`];
-    coFlagSource = 'unavailable';
   }
 
-  // 2) Provider config from workflows.yaml (or CLI override)
-  const providerCfg = await resolveProviderConfigFromWorkflows(
-    path.join(workspaceDir, '.state'),
-    {
-      cliProvider: input.cliProvider,
-      cliModel: input.cliModel,
-      cliApiKeyEnv: input.cliApiKeyEnv,
-      cliBaseUrl: input.cliBaseUrl,
-    },
-  );
+  const featureFlags: FeatureFlagSummary = {
+    source: loadResult.ok ? loadResult.source : 'malformed',
+    configPath: loadResult.configPath,
+    enabledMvpChannels,
+    disabledFlags,
+    warnings: flags.warnings,
+  };
 
-  // 3) Build the provider health entry. NEVER leak env var value.
+  // 3) Internal agent diagnostics from .pd/config.yaml
+  const profileMap = new Map<string, RedactedRuntimeProfileSummary>();
+  for (const p of redacted.runtimeProfiles) {
+    profileMap.set(p.id, p);
+  }
+
+  const internalAgents: InternalAgentDiagnostics[] = [];
+  for (const agent of redacted.agents) {
+    const profile = profileMap.get(agent.runtimeProfileId);
+    internalAgents.push(diagnoseInternalAgent(agent, profile));
+  }
+
+  // 4) Provider health — derived from internal agents that are enabled
   const providerHealth: ProviderHealthEntry[] = [];
   const warnings: string[] = [];
   const nextActions: string[] = [];
 
-  if (providerCfg.source === 'missing' && !input.cliProvider) {
+  // Add config-level warnings
+  warnings.push(...loadResult.warnings);
+  warnings.push(...flags.warnings);
+
+  if (!loadResult.ok) {
+    for (const err of loadResult.errors) {
+      warnings.push(`Config error at ${err.path}: ${err.reason}`);
+    }
+    nextActions.push(loadResult.errors[0]?.nextAction ?? 'Fix .pd/config.yaml and retry');
+  }
+
+  // Check for enabled agents that need setup
+  const needsSetupAgents = internalAgents.filter(a => a.enabled && (a.readiness === 'needs_setup' || a.readiness === 'not_ready'));
+  for (const agent of needsSetupAgents) {
     providerHealth.push({
       provider: null,
       model: null,
-      apiKeyEnv: null,
-      apiKeyPresent: false,
-      classification: 'config_missing',
-      reason: 'No provider configured (workflows.yaml funnel policy missing and no CLI override)',
-      nextAction: 'Configure provider/model/apiKeyEnv in workflows.yaml pd-runtime-v2-diagnosis policy, or pass --provider/--model/--apiKeyEnv flags',
-      source: providerCfg.source,
-    });
-    warnings.push('No provider configured for the diagnostic funnel');
-    nextActions.push('Configure provider/model/apiKeyEnv in workflows.yaml or pass CLI flags');
-  } else {
-    const apiKeyEnvName = providerCfg.apiKeyEnv;
-    const apiKeyPresent = !!apiKeyEnvName && Object.prototype.hasOwnProperty.call(process.env, apiKeyEnvName) && !!process.env[apiKeyEnvName];
-
-    let classification: DoctorClassification;
-    let reason: string;
-    let nextAction: string;
-
-    if (!providerCfg.provider || !providerCfg.model) {
-      classification = 'config_missing';
-      reason = !providerCfg.provider
-        ? 'Provider not configured'
-        : 'Model not configured';
-      nextAction = 'Set provider and model in workflows.yaml funnel policy or pass --provider/--model flags';
-    } else if (!apiKeyEnvName) {
-      classification = 'auth_missing';
-      reason = 'apiKeyEnv is not set in workflows.yaml';
-      nextAction = "Add 'apiKeyEnv: <ENV_VAR_NAME>' to workflows.yaml funnel policy and ensure the env var holds a valid key";
-    } else if (!apiKeyPresent) {
-      classification = 'auth_missing';
-      reason = `Environment variable '${apiKeyEnvName}' is not set or empty`;
-      nextAction = `Set the environment variable '${apiKeyEnvName}' with a valid API key, then retry`;
-    } else {
-      // Config is well-formed and the key is present — check state.db for rate-limit / unavailable signals.
-      const signalResult = await inspectStateDbForProviderSignal(stateDbPath);
-      if (signalResult.warning) {
-        warnings.push(signalResult.warning);
-      }
-      if (signalResult.signal) {
-        const { classification: cls, reason: rsn } = signalResult.signal;
-        classification = cls;
-        reason = rsn;
-        switch (classification) {
-          case 'rate_limit':
-            nextAction = `Wait for the provider's rate limit to reset, or reduce request rate. Recent error in state.db.`;
-            break;
-          case 'auth_missing':
-            nextAction = `The env var is set, but the provider rejected the call. Verify the key value is current and has access to model '${providerCfg.model}'.`;
-            break;
-          case 'unavailable':
-            nextAction = `Provider/model temporarily unavailable. Try a different model or retry later. Check provider status page.`;
-            break;
-          default:
-            nextAction = 'Inspect recent task errors in state.db for details.';
-        }
-      } else {
-        classification = 'healthy';
-        reason = 'Provider, model, and apiKeyEnv are configured; env var is set; no recent error signals';
-        nextAction = 'Run pd diagnose run to validate end-to-end provider connectivity';
-      }
-    }
-
-    providerHealth.push({
-      provider: providerCfg.provider,
-      model: providerCfg.model,
-      apiKeyEnv: apiKeyEnvName,
-      apiKeyPresent,
-      classification,
-      reason,
-      nextAction,
-      source: providerCfg.source,
+      apiKeyEnv: agent.apiKeyEnv,
+      apiKeyPresent: agent.apiKeyPresent,
+      classification: agent.readiness === 'needs_setup' ? 'config_missing' : 'auth_missing',
+      reason: agent.reason,
+      nextAction: agent.nextAction,
+      source: 'config.yaml',
     });
   }
 
-  if (providerCfg.parseWarning) {
-    warnings.push(providerCfg.parseWarning);
-    if (!providerCfg.workflowsFound) {
-      nextActions.push('Create workflows.yaml in <workspace>/.state with a pd-runtime-v2-diagnosis funnel policy');
-    } else {
-      nextActions.push('Fix workflows.yaml parse error — see warnings for details');
+  // Check state.db for rate-limit / unavailable signals for enabled agents
+  const readyAgents = internalAgents.filter(a => a.enabled && a.readiness === 'ready');
+  if (readyAgents.length > 0) {
+    const signalResult = await inspectStateDbForProviderSignal(stateDbPath);
+    if (signalResult.warning) {
+      warnings.push(signalResult.warning);
     }
-  }
-
-  // 4) Aggregate feature-flag warnings
-  for (const w of flagWarnings) {
-    warnings.push(w);
-  }
-  if (flagWarnings.length > 0 && !hasFeatureFlagsError) {
-    nextActions.push('Review .pd/feature-flags.yaml — see warnings for details');
-  }
-  if (hasFeatureFlagsError) {
-    warnings.push(`feature flags unavailable: ${featureFlagsErrorMessage}`);
-    nextActions.push(`Check that ${featureFlagsPath} is a readable file, not a directory.`);
-    nextActions.push('Re-run npx create-principles-disciple if the config was generated incorrectly.');
-  }
-
-  // 4.5) CorrectionObserver Diagnostics
-  let coStatus: 'disabled' | 'configured' | 'auth_missing' | 'config_missing' | 'unavailable';
-  let coConfigSource: 'workflows.yaml' | 'env' | 'missing' | 'unavailable';
-  let coProvider: string | null = null;
-  let coModel: string | null = null;
-  let coApiKeyEnv: string | null = null;
-  let coApiKeyPresent = false;
-  let coReason: string;
-  let coNextAction: string;
-
-  if (!correctionObserverEnabled) {
-    coStatus = 'disabled';
-    coConfigSource = 'missing';
-    coProvider = null;
-    coModel = null;
-    coApiKeyEnv = null;
-    coApiKeyPresent = false;
-    coReason = 'CorrectionObserver is disabled via feature flags';
-    coNextAction = 'Set correction_observer.enabled=true in .pd/feature-flags.yaml to enable it';
-  } else {
-    const coWorkflowsPath = path.join(workspaceDir, '.state', 'workflows.yaml');
-    let coWorkflowsFound = false;
-    let coWorkflowsParseError = false;
-    let coWorkflowsParseErrorMessage = '';
-    let coWorkflowPolicy: Record<string, unknown> | null = null;
-
-    if (fs.existsSync(coWorkflowsPath)) {
-      coWorkflowsFound = true;
-      try {
-        const raw = fs.readFileSync(coWorkflowsPath, 'utf8');
-        const parsed = yaml.load(raw);
-        if (isRecord(parsed)) {
-          const funnelsRaw = parsed.funnels;
-          if (Array.isArray(funnelsRaw)) {
-            for (const f of funnelsRaw) {
-              if (isRecord(f) && f.workflowId === 'pd-correction-observer' && isRecord(f.policy)) {
-                coWorkflowPolicy = f.policy;
-                break;
-              }
-            }
-          }
-        }
-      } catch (err) {
-        coWorkflowsParseError = true;
-        coWorkflowsParseErrorMessage = err instanceof Error ? err.message : String(err);
-      }
-    }
-
-    if (coWorkflowsParseError) {
-      coStatus = 'unavailable';
-      coConfigSource = 'unavailable';
-      coReason = `workflows.yaml parse failure: ${coWorkflowsParseErrorMessage}`;
-      coNextAction = 'Fix workflows.yaml syntax or file access permissions';
-    } else if (coWorkflowsFound && coWorkflowPolicy && coWorkflowPolicy.runtimeKind === 'pi-ai') {
-      coConfigSource = 'workflows.yaml';
-      coProvider = typeof coWorkflowPolicy.provider === 'string' ? coWorkflowPolicy.provider : null;
-      coModel = typeof coWorkflowPolicy.model === 'string' ? coWorkflowPolicy.model : null;
-      coApiKeyEnv = typeof coWorkflowPolicy.apiKeyEnv === 'string' ? coWorkflowPolicy.apiKeyEnv : null;
-      coApiKeyPresent = !!coApiKeyEnv && Object.prototype.hasOwnProperty.call(process.env, coApiKeyEnv) && !!process.env[coApiKeyEnv];
-
-      if (!coProvider || !coModel) {
-        coStatus = 'config_missing';
-        coReason = !coProvider ? 'Provider not configured in workflows.yaml policy' : 'Model not configured in workflows.yaml policy';
-        coNextAction = 'Set provider and model in pd-correction-observer policy in workflows.yaml';
-      } else if (!coApiKeyEnv) {
-        coStatus = 'auth_missing';
-        coReason = 'apiKeyEnv is not set in workflows.yaml pd-correction-observer policy';
-        coNextAction = "Add 'apiKeyEnv: <ENV_VAR_NAME>' to workflows.yaml pd-correction-observer policy and ensure the env var holds a valid key";
-      } else if (!coApiKeyPresent) {
-        coStatus = 'auth_missing';
-        coReason = `Environment variable '${coApiKeyEnv}' is not set or empty`;
-        coNextAction = `Set the environment variable '${coApiKeyEnv}' with a valid API key, or disable correction_observer in feature flags`;
-      } else {
-        coStatus = 'configured';
-        coReason = 'CorrectionObserver is configured and ready via workflows.yaml';
-        coNextAction = 'No action required; correction observer is active';
-      }
+    if (signalResult.signal) {
+      const { classification: cls, reason: rsn } = signalResult.signal;
+      providerHealth.push({
+        provider: null,
+        model: null,
+        apiKeyEnv: null,
+        apiKeyPresent: false,
+        classification: cls,
+        reason: rsn,
+        nextAction: cls === 'rate_limit'
+          ? "Wait for the provider's rate limit to reset, or reduce request rate"
+          : 'Provider/model temporarily unavailable. Try a different model or retry later.',
+        source: 'state.db',
+      });
     } else {
-      coConfigSource = 'env';
-      coProvider = process.env.PD_CORRECTION_PROVIDER || 'anthropic';
-      coModel = process.env.PD_CORRECTION_MODEL || 'anthropic/claude-3-5-sonnet';
-      coApiKeyEnv = process.env.PD_CORRECTION_API_KEY_ENV || 'ANTHROPIC_API_KEY';
-      coApiKeyPresent = !!coApiKeyEnv && Object.prototype.hasOwnProperty.call(process.env, coApiKeyEnv) && !!process.env[coApiKeyEnv];
-
-      if (!coApiKeyPresent) {
-        coStatus = 'auth_missing';
-        coReason = `Environment variable '${coApiKeyEnv}' is not set or empty`;
-        coNextAction = `Set the environment variable '${coApiKeyEnv}' with a valid API key, or configure workflows.yaml, or disable correction_observer in feature flags`;
-      } else {
-        coStatus = 'configured';
-        coReason = 'CorrectionObserver is configured and ready via env overrides/defaults';
-        coNextAction = 'No action required; correction observer is active';
-      }
+      providerHealth.push({
+        provider: null,
+        model: null,
+        apiKeyEnv: null,
+        apiKeyPresent: false,
+        classification: 'healthy',
+        reason: 'Config is valid; no recent error signals in state.db',
+        nextAction: 'Run pd runtime probe to verify end-to-end connectivity',
+        source: 'config.yaml',
+      });
     }
   }
 
@@ -695,18 +515,23 @@ export async function buildDoctorOutput(input: BuildDoctorInput): Promise<Doctor
   if (classifications.includes('auth_missing') || classifications.includes('config_missing')) {
     status = 'failed';
   }
-  if ((warnings.length > 0 || hasFeatureFlagsError) && status === 'ok') {
+  if (!loadResult.ok) {
+    status = 'failed';
+  }
+  if ((warnings.length > 0) && status === 'ok') {
     status = 'degraded';
   }
 
   // 6) Reason
   let reason: string | undefined;
   if (status === 'failed') {
-    const failed = providerHealth.filter((p) => p.classification === 'auth_missing' || p.classification === 'config_missing');
-    if (failed.length > 0) {
-      reason = `Provider auth/config missing: ${failed.map((p) => p.classification).join(', ')}`;
+    if (!loadResult.ok) {
+      reason = `Config validation failed: ${loadResult.errors.map(e => e.reason).join('; ')}`;
     } else {
-      reason = 'Configuration is missing required fields';
+      const failed = providerHealth.filter((p) => p.classification === 'auth_missing' || p.classification === 'config_missing');
+      reason = failed.length > 0
+        ? `Provider auth/config missing: ${failed.map((p) => p.classification).join(', ')}`
+        : 'Configuration is missing required fields';
     }
   } else if (status === 'degraded') {
     const degraded = providerHealth.filter((p) => p.classification === 'rate_limit' || p.classification === 'unavailable');
@@ -717,45 +542,26 @@ export async function buildDoctorOutput(input: BuildDoctorInput): Promise<Doctor
     }
   }
 
-  // 7) Build path entries
+  // 7) Build output
   const out: DoctorOutput = {
     status,
     workspaceDir,
     pdConfigPaths: {
       workspaceDir: pathEntry(workspaceDir),
       pdDir: pathEntry(pdDir),
-      featureFlags: pathEntry(featureFlagsPath),
-      workflowsYaml: pathEntry(workflowsPath),
+      configYaml: { ...pathEntry(configYamlPath), parseable: loadResult.ok || !fs.existsSync(configYamlPath) ? true : false },
       stateDb: pathEntry(stateDbPath),
     },
     openclawConfigPaths: {
       openclawHome: pathEntry(getOpenClawHome()),
       openclawConfig: pathEntry(getOpenClawConfigPath()),
     },
-    featureFlags: {
-      source: flagSource,
-      configPath: featureFlagsPath,
-      enabledMvpChannels,
-      disabledFlags,
-      warnings: flagWarnings,
-    },
+    featureFlags,
+    internalAgents,
     providerHealth,
-    internalAgents: {
-      correctionObserver: {
-        enabled: correctionObserverEnabled,
-        flagSource: coFlagSource,
-        status: coStatus,
-        configSource: coConfigSource,
-        provider: coProvider,
-        model: coModel,
-        apiKeyEnv: coApiKeyEnv,
-        apiKeyPresent: coApiKeyPresent,
-        reason: coReason,
-        nextAction: coNextAction,
-      },
-    },
     warnings,
-    nextActions: nextActions.length > 0 ? nextActions : ['All checks passed — provider is configured and reachable'],
+    nextActions: nextActions.length > 0 ? nextActions : ['All checks passed — configuration is valid'],
+    legacyFilesDetected: loadResult.legacyFilesDetected,
   };
 
   if (reason) out.reason = reason;

--- a/packages/pd-cli/src/services/config-doctor.ts
+++ b/packages/pd-cli/src/services/config-doctor.ts
@@ -42,6 +42,7 @@ export type DoctorClassification =
   | 'healthy'
   | 'config_missing'
   | 'auth_missing'
+  | 'needs_probe'
   | 'rate_limit'
   | 'unavailable'
   | 'parse_failure'
@@ -459,12 +460,16 @@ export async function buildDoctorOutput(input: BuildDoctorInput): Promise<Doctor
   // Check for enabled agents that need setup
   const needsSetupAgents = internalAgents.filter(a => a.enabled && (a.readiness === 'needs_setup' || a.readiness === 'not_ready'));
   for (const agent of needsSetupAgents) {
+    // not_ready = key present but not probed → needs_probe (degraded), NOT auth_missing (failed)
+    const classification: DoctorClassification = agent.readiness === 'needs_setup'
+      ? 'config_missing'
+      : 'needs_probe';
     providerHealth.push({
       provider: null,
       model: null,
       apiKeyEnv: agent.apiKeyEnv,
       apiKeyPresent: agent.apiKeyPresent,
-      classification: agent.readiness === 'needs_setup' ? 'config_missing' : 'auth_missing',
+      classification,
       reason: agent.reason,
       nextAction: agent.nextAction,
       source: 'config.yaml',
@@ -509,7 +514,7 @@ export async function buildDoctorOutput(input: BuildDoctorInput): Promise<Doctor
   // 5) Compute overall status
   let status: DoctorStatus = 'ok';
   const classifications = providerHealth.map((p) => p.classification);
-  if (classifications.includes('rate_limit') || classifications.includes('unavailable')) {
+  if (classifications.includes('rate_limit') || classifications.includes('unavailable') || classifications.includes('needs_probe')) {
     status = 'degraded';
   }
   if (classifications.includes('auth_missing') || classifications.includes('config_missing')) {
@@ -534,7 +539,7 @@ export async function buildDoctorOutput(input: BuildDoctorInput): Promise<Doctor
         : 'Configuration is missing required fields';
     }
   } else if (status === 'degraded') {
-    const degraded = providerHealth.filter((p) => p.classification === 'rate_limit' || p.classification === 'unavailable');
+    const degraded = providerHealth.filter((p) => p.classification === 'rate_limit' || p.classification === 'unavailable' || p.classification === 'needs_probe');
     if (degraded.length > 0) {
       reason = `Provider connectivity degraded: ${degraded.map((p) => p.classification).join(', ')}`;
     } else if (warnings.length > 0) {

--- a/packages/pd-cli/src/services/pd-config-loader.ts
+++ b/packages/pd-cli/src/services/pd-config-loader.ts
@@ -1,0 +1,213 @@
+/**
+ * PD Config Loader — PRI-305
+ *
+ * I/O boundary: reads `.pd/config.yaml`, validates via core, computes effective config.
+ * This replaces the old `feature-flag-loader.ts` and `workflows.yaml` reading
+ * for CLI production paths.
+ *
+ * ADR-0016: PD owns exactly one user config file.
+ * - Missing config → defaults with nextAction
+ * - Malformed config → fail loud with errors and nextAction
+ * - No secrets in output
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import yaml from 'js-yaml';
+import {
+  validatePdConfig,
+  computeEffectivePdConfig,
+  computeFeatureFlagsFromConfig,
+  redactPdConfig,
+} from '@principles/core/runtime-v2';
+import type {
+  EffectivePdConfig,
+  PdConfigValidationResult,
+  RedactedPdConfigSummary,
+  FeatureFlagsResult,
+} from '@principles/core/runtime-v2';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+export const PD_CONFIG_DIR = '.pd';
+export const PD_CONFIG_FILENAME = 'config.yaml';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ConfigSource = 'defaults' | 'user_config' | 'malformed';
+
+export interface PdConfigLoadResultOk {
+  ok: true;
+  effective: EffectivePdConfig;
+  source: ConfigSource;
+  configPath: string;
+  /** Warnings from config resolution (not errors) */
+  warnings: string[];
+  /** If legacy files were detected */
+  legacyFilesDetected: string[];
+}
+
+export interface PdConfigLoadResultErr {
+  ok: false;
+  source: 'malformed';
+  configPath: string;
+  errors: { path: string; reason: string; nextAction: string }[];
+  /** Fallback defaults are still available */
+  defaults: EffectivePdConfig;
+  /** Warnings from config resolution */
+  warnings: string[];
+  legacyFilesDetected: string[];
+}
+
+export type PdConfigLoadResult = PdConfigLoadResultOk | PdConfigLoadResultErr;
+
+// ── Config Path ──────────────────────────────────────────────────────────────
+
+export function getPdConfigPath(workspaceDir: string): string {
+  return path.join(workspaceDir, PD_CONFIG_DIR, PD_CONFIG_FILENAME);
+}
+
+// ── Legacy File Detection ────────────────────────────────────────────────────
+
+function detectLegacyFiles(workspaceDir: string): string[] {
+  const detected: string[] = [];
+  const legacyPaths = [
+    path.join(workspaceDir, PD_CONFIG_DIR, 'feature-flags.yaml'),
+    path.join(workspaceDir, '.state', 'workflows.yaml'),
+  ];
+  for (const p of legacyPaths) {
+    if (fs.existsSync(p)) {
+      detected.push(p);
+    }
+  }
+  return detected;
+}
+
+// ── Load PD Config ───────────────────────────────────────────────────────────
+
+/**
+ * Load and validate `.pd/config.yaml` from the workspace.
+ *
+ * - Missing file → returns defaults with source='defaults'
+ * - Malformed file → returns error result with defaults fallback
+ * - Valid file → returns effective config with source='user_config'
+ *
+ * Never throws on malformed input. Always provides a usable fallback.
+ */
+export function loadPdConfig(workspaceDir: string): PdConfigLoadResult {
+  const configPath = getPdConfigPath(workspaceDir);
+  const legacyFilesDetected = detectLegacyFiles(workspaceDir);
+
+  // 1) Config file missing → use defaults
+  if (!fs.existsSync(configPath)) {
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: true,
+      effective,
+      source: 'defaults',
+      configPath,
+      warnings: [
+        ...effective.warnings,
+        ...(legacyFilesDetected.length > 0
+          ? [`Legacy config files detected (${legacyFilesDetected.length}): ${legacyFilesDetected.join(', ')}. PD now uses .pd/config.yaml.`]
+          : []),
+      ],
+      legacyFilesDetected,
+    };
+  }
+
+  // 2) Read the file
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: false,
+      source: 'malformed',
+      configPath,
+      errors: [{ path: '', reason: `Failed to read .pd/config.yaml: ${message}`, nextAction: 'Check file permissions for .pd/config.yaml' }],
+      warnings: [],
+      defaults: effective,
+      legacyFilesDetected,
+    };
+  }
+
+  // 3) Parse YAML — treat as unknown (ERR-001)
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: false,
+      source: 'malformed',
+      configPath,
+      errors: [{ path: '', reason: `YAML parse error in .pd/config.yaml: ${message}`, nextAction: 'Fix YAML syntax in .pd/config.yaml' }],
+      warnings: [],
+      defaults: effective,
+      legacyFilesDetected,
+    };
+  }
+
+  // 4) Validate via core (ERR-001, ERR-005: no `as` bypasses)
+  const validationResult: PdConfigValidationResult = validatePdConfig(parsed);
+
+  if (!validationResult.ok) {
+    const effective = computeEffectivePdConfig(null);
+    return {
+      ok: false,
+      source: 'malformed',
+      configPath,
+      errors: validationResult.errors.map(e => ({
+        path: e.path,
+        reason: e.reason,
+        nextAction: e.nextAction,
+      })),
+      warnings: [],
+      defaults: effective,
+      legacyFilesDetected,
+    };
+  }
+
+  // 5) Compute effective config
+  const effective = computeEffectivePdConfig(validationResult.value);
+
+  return {
+    ok: true,
+    effective,
+    source: 'user_config',
+    configPath,
+    warnings: [
+      ...effective.warnings,
+      ...(legacyFilesDetected.length > 0
+        ? [`Legacy config files detected (${legacyFilesDetected.length}): ${legacyFilesDetected.join(', ')}. PD now uses .pd/config.yaml.`]
+        : []),
+    ],
+    legacyFilesDetected,
+  };
+}
+
+// ── Feature Flags from Config ────────────────────────────────────────────────
+
+/**
+ * Compute feature flags from the loaded PD config.
+ * Works with both ok and error results (uses defaults for errors).
+ */
+export function computeFlagsFromLoadResult(result: PdConfigLoadResult): FeatureFlagsResult {
+  const effective = result.ok ? result.effective : result.defaults;
+  return computeFeatureFlagsFromConfig(effective);
+}
+
+// ── Redacted Summary from Config ─────────────────────────────────────────────
+
+/**
+ * Produce a redacted summary of the PD config for CLI/Console display.
+ * Never includes token/API key values or raw provider objects.
+ */
+export function redactLoadResult(result: PdConfigLoadResult): RedactedPdConfigSummary {
+  const effective = result.ok ? result.effective : result.defaults;
+  return redactPdConfig(effective);
+}

--- a/packages/pd-cli/tests/commands/config-doctor.test.ts
+++ b/packages/pd-cli/tests/commands/config-doctor.test.ts
@@ -1,624 +1,255 @@
 /**
- * pd config doctor tests (PRI-299).
+ * config-doctor tests — PRI-305
  *
  * Covers:
- *   - workspace + openclaw path discovery
- *   - feature-flag presence + warnings
- *   - provider classification: healthy / auth_missing / rate_limit / config_missing / parse_failure
- *   - JSON output is a single parseable object
- *   - secrets are never leaked
- *   - CLI command wiring (pd config doctor --help, --workspace, --json)
+ *   - Internal agent runtime binding readiness
+ *   - JSON purity
+ *   - Missing config → defaults
+ *   - Malformed config → fail loud
+ *   - No secret output
+ *   - Legacy file detection
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as yaml from 'js-yaml';
-import { execFileSync } from 'node:child_process';
-import { buildDoctorOutput, resolveProviderConfigFromWorkflows, getOpenClawHome, getOpenClawConfigPath } from '../../src/services/config-doctor.js';
+import { buildDoctorOutput, type DoctorOutput } from '../../src/services/config-doctor.js';
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
 function mkTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-doctor-test-'));
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-config-doctor-test-'));
 }
 
 function rmTmpDir(dir: string): void {
   try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 
-function writeWorkflowsYaml(stateDir: string, content: unknown): void {
-  fs.mkdirSync(stateDir, { recursive: true });
-  const yamlText = typeof content === 'string' ? content : yaml.dump(content);
-  fs.writeFileSync(path.join(stateDir, 'workflows.yaml'), yamlText, 'utf8');
+function writeConfig(workspaceDir: string, content: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), content, 'utf8');
 }
 
-function buildWorkflowsYaml(opts: { provider?: string; model?: string; apiKeyEnv?: string; baseUrl?: string }): unknown {
-  return {
-    version: '1',
-    funnels: [
-      {
-        workflowId: 'pd-runtime-v2-diagnosis',
-        stages: [],
-        policy: {
-          runtimeKind: 'pi-ai',
-          ...(opts.provider ? { provider: opts.provider } : {}),
-          ...(opts.model ? { model: opts.model } : {}),
-          ...(opts.apiKeyEnv ? { apiKeyEnv: opts.apiKeyEnv } : {}),
-          ...(opts.baseUrl ? { baseUrl: opts.baseUrl } : {}),
-        },
+function makeValidConfigYaml(): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      correction_observer: { category: 'quiet', enabled: false },
+      empathy_observer: { category: 'quiet', enabled: false },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+      'openclaw.model.lmstudio.qwen3': { type: 'openclaw', provider: 'lmstudio', model: 'qwen3.6-27b-mtp' },
+      'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 300000 },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: 'openclaw.model.lmstudio.qwen3' },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
       },
-    ],
-  };
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  });
 }
 
-// ─── resolveProviderConfigFromWorkflows ──────────────────────────────────────
+// ── Internal agent runtime binding readiness ─────────────────────────────────
 
-describe('resolveProviderConfigFromWorkflows', () => {
-  it('returns source=missing when workflows.yaml is absent and no CLI overrides', async () => {
+describe('Internal agent runtime binding readiness', () => {
+  it('disabled agents show readiness=disabled', async () => {
     const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
     try {
-      const result = await resolveProviderConfigFromWorkflows(path.join(tmp, '.state'));
-      expect(result.source).toBe('missing');
-      expect(result.workflowsFound).toBe(false);
-      expect(result.provider).toBeNull();
-      expect(result.model).toBeNull();
-      expect(result.apiKeyEnv).toBeNull();
+      const output = await buildDoctorOutput({ workspaceDir: tmp });
+      const philosopher = output.internalAgents.find(a => a.name === 'philosopher');
+      expect(philosopher).toBeDefined();
+      expect(philosopher!.readiness).toBe('disabled');
+      expect(philosopher!.enabled).toBe(false);
     } finally { rmTmpDir(tmp); }
   });
 
-  it('returns source=cli_flag when workflows.yaml is absent but CLI flags supplied', async () => {
+  it('enabled agent with openclaw profile shows readiness=ready', async () => {
     const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
     try {
-      const result = await resolveProviderConfigFromWorkflows(path.join(tmp, '.state'), {
-        cliProvider: 'openrouter',
-        cliModel: 'anthropic/claude-sonnet-4',
-        cliApiKeyEnv: 'OPENROUTER_API_KEY',
+      const output = await buildDoctorOutput({ workspaceDir: tmp });
+      const diagnostician = output.internalAgents.find(a => a.name === 'diagnostician');
+      expect(diagnostician).toBeDefined();
+      expect(diagnostician!.enabled).toBe(true);
+      expect(diagnostician!.readiness).toBe('ready');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('enabled agent with pi-ai profile and missing env shows readiness=needs_setup', async () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    // Ensure ANTHROPIC_API_KEY is not set
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      // Create config with an enabled agent using pi-ai profile
+      const config = yaml.dump({
+        version: 1,
+        features: {
+          prompt: { category: 'core', enabled: true },
+          code_tool_hook: { category: 'core', enabled: true },
+          defer_archive: { category: 'core', enabled: true },
+          correction_observer: { category: 'quiet', enabled: false },
+          empathy_observer: { category: 'quiet', enabled: false },
+        },
+        runtimeProfiles: {
+          'openclaw.default': { type: 'openclaw', source: 'default' },
+          'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+        },
+        internalAgents: {
+          defaultRuntime: 'openclaw.default',
+          agents: {
+            diagnostician: { enabled: true, runtimeProfile: 'pd.anthropic-sonnet' },
+            dreamer: { enabled: true },
+            scribe: { enabled: true },
+            artificer: { enabled: true },
+            philosopher: { enabled: false },
+            evaluator: { enabled: false },
+            rolloutReviewer: { enabled: false },
+            trainer: { enabled: false },
+            correctionObserver: { enabled: false },
+            empathyObserver: { enabled: false },
+          },
+        },
       });
-      expect(result.source).toBe('cli_flag');
-      expect(result.workflowsFound).toBe(false);
-      expect(result.provider).toBe('openrouter');
-      expect(result.model).toBe('anthropic/claude-sonnet-4');
-      expect(result.apiKeyEnv).toBe('OPENROUTER_API_KEY');
-    } finally { rmTmpDir(tmp); }
-  });
+      writeConfig(tmp, config);
 
-  it('parses a well-formed workflows.yaml with the diagnostic funnel', async () => {
+      const output = await buildDoctorOutput({ workspaceDir: tmp });
+      const diagnostician = output.internalAgents.find(a => a.name === 'diagnostician');
+      expect(diagnostician).toBeDefined();
+      expect(diagnostician!.readiness).toBe('needs_setup');
+      expect(diagnostician!.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
+      expect(diagnostician!.apiKeyPresent).toBe(false);
+      expect(diagnostician!.nextAction).toContain('ANTHROPIC_API_KEY');
+    } finally {
+      if (originalKey !== undefined) process.env.ANTHROPIC_API_KEY = originalKey;
+      rmTmpDir(tmp);
+    }
+  });
+});
+
+// ── JSON purity ──────────────────────────────────────────────────────────────
+
+describe('JSON purity', () => {
+  it('output is a single parseable JSON object', async () => {
     const tmp = mkTmpDir();
     try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: 'OPENROUTER_API_KEY',
-      }));
-      const result = await resolveProviderConfigFromWorkflows(path.join(tmp, '.state'));
-      expect(result.source).toBe('workflows.yaml');
-      expect(result.workflowsFound).toBe(true);
-      expect(result.parseWarning).toBeUndefined();
-      expect(result.provider).toBe('openrouter');
-      expect(result.model).toBe('anthropic/claude-sonnet-4');
-      expect(result.apiKeyEnv).toBe('OPENROUTER_API_KEY');
-    } finally { rmTmpDir(tmp); }
-  });
-
-  it('returns parseWarning on YAML parse error', async () => {
-    const tmp = mkTmpDir();
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), 'gfi: [unterminated');
-      const result = await resolveProviderConfigFromWorkflows(path.join(tmp, '.state'));
-      expect(result.workflowsFound).toBe(true);
-      expect(result.parseWarning).toBeDefined();
-      expect(result.parseWarning).toMatch(/parse error/i);
-      expect(result.provider).toBeNull();
-    } finally { rmTmpDir(tmp); }
-  });
-
-  it('returns parseWarning when diagnostic funnel is missing', async () => {
-    const tmp = mkTmpDir();
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), {
-        version: '1',
-        funnels: [{ workflowId: 'some-other-funnel', stages: [], policy: {} }],
-      });
-      const result = await resolveProviderConfigFromWorkflows(path.join(tmp, '.state'));
-      expect(result.workflowsFound).toBe(true);
-      expect(result.parseWarning).toMatch(/funnel 'pd-runtime-v2-diagnosis' not found/);
-    } finally { rmTmpDir(tmp); }
-  });
-
-  it('returns parseWarning when funnels is not an array', async () => {
-    const tmp = mkTmpDir();
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), 'version: 1\nfunnels: not-an-array\n');
-      const result = await resolveProviderConfigFromWorkflows(path.join(tmp, '.state'));
-      expect(result.workflowsFound).toBe(true);
-      expect(result.parseWarning).toMatch(/funnels is not an array/);
+      const output = await buildDoctorOutput({ workspaceDir: tmp });
+      const json = JSON.stringify(output, null, 2);
+      const parsed = JSON.parse(json);
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+      expect(Array.isArray(parsed)).toBe(false);
     } finally { rmTmpDir(tmp); }
   });
 });
 
-// ─── buildDoctorOutput ───────────────────────────────────────────────────────
+// ── Missing config → defaults ────────────────────────────────────────────────
 
-describe('buildDoctorOutput — config_missing', () => {
-  it('classifies provider as config_missing when workflows.yaml is absent and no CLI overrides', async () => {
+describe('Missing config → defaults', () => {
+  it('returns status=ok when config file is absent (uses defaults)', async () => {
     const tmp = mkTmpDir();
     try {
       const output = await buildDoctorOutput({ workspaceDir: tmp });
+      // With defaults, MVP core features are enabled, so status should be ok or degraded
+      expect(['ok', 'degraded']).toContain(output.status);
+      expect(output.featureFlags.source).toBe('defaults');
+      expect(output.featureFlags.enabledMvpChannels).toContain('prompt');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Malformed config → fail loud ────────────────────────────────────────────
+
+describe('Malformed config → fail loud', () => {
+  it('returns status=failed with reason and nextActions for YAML parse error', async () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const output = await buildDoctorOutput({ workspaceDir: tmp });
       expect(output.status).toBe('failed');
-      expect(output.reason).toBeDefined();
-      expect(output.reason).toMatch(/auth_missing|config_missing/);
-      expect(output.providerHealth).toHaveLength(1);
-      const ph = output.providerHealth[0];
-      expect(ph.classification).toBe('config_missing');
-      expect(ph.provider).toBeNull();
-      expect(ph.model).toBeNull();
-      expect(ph.apiKeyPresent).toBe(false);
-      expect(ph.reason).toBeDefined();
-      expect(ph.nextAction).toBeDefined();
+      expect(output.reason).toBeTruthy();
       expect(output.nextActions.length).toBeGreaterThan(0);
     } finally { rmTmpDir(tmp); }
   });
 });
 
-describe('buildDoctorOutput — auth_missing', () => {
-  it('classifies provider as auth_missing when apiKeyEnv is set in workflows but env var is unset', async () => {
-    const tmp = mkTmpDir();
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: 'PD_DOCTOR_TEST_KEY_NEVER_SET_X9Z',
-      }));
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(output.status).toBe('failed');
-      expect(output.reason).toMatch(/auth_missing|config_missing/);
-      const ph = output.providerHealth[0];
-      expect(ph.classification).toBe('auth_missing');
-      expect(ph.provider).toBe('openrouter');
-      expect(ph.model).toBe('anthropic/claude-sonnet-4');
-      expect(ph.apiKeyEnv).toBe('PD_DOCTOR_TEST_KEY_NEVER_SET_X9Z');
-      expect(ph.apiKeyPresent).toBe(false);
-      expect(ph.reason).toMatch(/not set or empty/);
-    } finally { rmTmpDir(tmp); }
-  });
+// ── No secret output ─────────────────────────────────────────────────────────
 
-  it('classifies provider as auth_missing when apiKeyEnv is not in workflows.yaml at all', async () => {
+describe('No secret output', () => {
+  it('output never contains raw API key values', async () => {
     const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
     try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-      }));
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(output.status).toBe('failed');
-      const ph = output.providerHealth[0];
-      expect(ph.classification).toBe('auth_missing');
-      expect(ph.apiKeyEnv).toBeNull();
-      expect(ph.apiKeyPresent).toBe(false);
-    } finally { rmTmpDir(tmp); }
-  });
-});
-
-describe('buildDoctorOutput — healthy', () => {
-  it('classifies provider as healthy when config is valid and env var is set', async () => {
-    const tmp = mkTmpDir();
-    const envName = 'PD_DOCTOR_TEST_KEY_PRESENT_OK';
-    const previous = process.env[envName];
-    process.env[envName] = 'redacted-test-value-not-leaked';
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: envName,
-      }));
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(output.status).toBe('ok');
-      const ph = output.providerHealth[0];
-      expect(ph.classification).toBe('healthy');
-      expect(ph.apiKeyEnv).toBe(envName);
-      expect(ph.apiKeyPresent).toBe(true);
-      // Ensure the env var value is NOT leaked
-      const json = JSON.stringify(output);
-      expect(json).not.toContain('redacted-test-value-not-leaked');
-    } finally {
-      if (previous === undefined) {
-        delete process.env[envName];
-      } else {
-        process.env[envName] = previous;
-      }
-      rmTmpDir(tmp);
-    }
-  });
-});
-
-describe('buildDoctorOutput — rate_limit', () => {
-  it('classifies provider as rate_limit when state.db contains a 429 signature', async () => {
-    const tmp = mkTmpDir();
-    const envName = 'PD_DOCTOR_TEST_KEY_RATELIMIT_OK';
-    const previous = process.env[envName];
-    process.env[envName] = 'redacted-test-value';
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: envName,
-      }));
-      // Plant a fake state.db that includes a 429 / rate_limit message
-      await plantStateDbWithMessage(tmp, "Error: 429 too many requests, rpm exhausted");
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const ph = output.providerHealth[0];
-      expect(ph.classification).toBe('rate_limit');
-      expect(ph.reason).toMatch(/rate_limit|signature/i);
-      expect(output.status).toBe('degraded');
-    } finally {
-      if (previous === undefined) {
-        delete process.env[envName];
-      } else {
-        process.env[envName] = previous;
-      }
-      rmTmpDir(tmp);
-    }
-  });
-
-  it('classifies provider as rate_limit when state.db has candidate_failed + rpm exhausted', async () => {
-    const tmp = mkTmpDir();
-    const envName = 'PD_DOCTOR_TEST_KEY_RATELIMIT_2';
-    const previous = process.env[envName];
-    process.env[envName] = 'redacted-test-value';
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: envName,
-      }));
-      await plantStateDbWithMessage(tmp, "candidate_failed: rpm exhausted for current model");
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const ph = output.providerHealth[0];
-      expect(ph.classification).toBe('rate_limit');
-    } finally {
-      if (previous === undefined) {
-        delete process.env[envName];
-      } else {
-        process.env[envName] = previous;
-      }
-      rmTmpDir(tmp);
-    }
-  });
-});
-
-describe('buildDoctorOutput — secrets redaction', () => {
-  it('never includes the env var value in the output', async () => {
-    const tmp = mkTmpDir();
-    const envName = 'PD_DOCTOR_TEST_KEY_REDACTION';
-    const secret = 'sk-1234567890abcdef-secret-do-not-leak';
-    const previous = process.env[envName];
-    process.env[envName] = secret;
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: envName,
-      }));
       const output = await buildDoctorOutput({ workspaceDir: tmp });
       const json = JSON.stringify(output);
-      expect(json).not.toContain(secret);
-      // env var name is allowed to appear; raw value is not
-      expect(json).toContain(envName);
-    } finally {
-      if (previous === undefined) {
-        delete process.env[envName];
-      } else {
-        process.env[envName] = previous;
+      expect(json).not.toContain('sk-ant-');
+      expect(json).not.toMatch(/"apiKey"\s*:/);
+      expect(json).not.toContain('"gatewayToken"');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('internal agents show apiKeyEnv name, not value', async () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const output = await buildDoctorOutput({ workspaceDir: tmp });
+      for (const agent of output.internalAgents) {
+        if (agent.apiKeyEnv) {
+          // apiKeyEnv should be the env var name, not the key value
+          expect(agent.apiKeyEnv).toMatch(/^[A-Z_]+$/);
+        }
       }
-      rmTmpDir(tmp);
-    }
-  });
-});
-
-describe('buildDoctorOutput — parse_failure (workflows.yaml)', () => {
-  it('reports parse_failure warning when workflows.yaml is malformed', async () => {
-    const tmp = mkTmpDir();
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), 'gfi: [unterminated');
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(output.warnings.length).toBeGreaterThan(0);
-      expect(output.warnings.some((w) => /parse error/i.test(w))).toBe(true);
-      expect(output.nextActions.some((a) => /workflows.yaml/i.test(a))).toBe(true);
     } finally { rmTmpDir(tmp); }
   });
 });
 
-describe('buildDoctorOutput — feature flags', () => {
-  it('reports enabled MVP channels from feature-flags.yaml', async () => {
+// ── Legacy file detection ────────────────────────────────────────────────────
+
+describe('Legacy file detection', () => {
+  it('detects .pd/feature-flags.yaml and reports as legacy', async () => {
     const tmp = mkTmpDir();
+    const pdDir = path.join(tmp, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    fs.writeFileSync(path.join(pdDir, 'feature-flags.yaml'), 'prompt:\n  enabled: true\n', 'utf8');
     try {
-      const pdDir = path.join(tmp, '.pd');
-      fs.mkdirSync(pdDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(pdDir, 'feature-flags.yaml'),
-        'prompt:\n  enabled: true\ncode_tool_hook:\n  enabled: true\ndefer_archive:\n  enabled: true\ngfi:\n  enabled: false\n',
-        'utf8',
-      );
       const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(output.featureFlags.source).toBe('workspace_file');
-      expect(output.featureFlags.enabledMvpChannels).toEqual(
-        expect.arrayContaining(['prompt', 'code_tool_hook', 'defer_archive']),
-      );
-      expect(output.featureFlags.disabledFlags).toContain('gfi');
+      expect(output.legacyFilesDetected.length).toBeGreaterThan(0);
+      expect(output.legacyFilesDetected[0]).toContain('feature-flags.yaml');
     } finally { rmTmpDir(tmp); }
   });
 });
 
-describe('buildDoctorOutput — paths', () => {
-  it('reports existence of PD and OpenClaw config paths', async () => {
+// ── Feature flags from config.yaml ───────────────────────────────────────────
+
+describe('Feature flags from config.yaml', () => {
+  it('shows enabled MVP channels from config', async () => {
     const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
     try {
-      fs.mkdirSync(path.join(tmp, '.pd'), { recursive: true });
       const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(output.pdConfigPaths.workspaceDir.exists).toBe(true);
-      expect(output.pdConfigPaths.pdDir.exists).toBe(true);
-      expect(output.pdConfigPaths.featureFlags.exists).toBe(false);
-      expect(output.openclawConfigPaths.openclawHome.path).toBe(getOpenClawHome());
-      expect(output.openclawConfigPaths.openclawConfig.path).toBe(getOpenClawConfigPath());
+      expect(output.featureFlags.enabledMvpChannels).toContain('prompt');
+      expect(output.featureFlags.enabledMvpChannels).toContain('code_tool_hook');
+      expect(output.featureFlags.enabledMvpChannels).toContain('defer_archive');
     } finally { rmTmpDir(tmp); }
   });
 });
-
-// ─── JSON shape contract ─────────────────────────────────────────────────────
-
-describe('buildDoctorOutput — JSON output contract', () => {
-  it('JSON.stringify produces a single parseable object containing all required fields', async () => {
-    const tmp = mkTmpDir();
-    try {
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const json = JSON.stringify(output, null, 2);
-      const parsed: unknown = JSON.parse(json);
-      expect(typeof parsed).toBe('object');
-      expect(parsed).not.toBeNull();
-      expect(parsed).not.toBeInstanceOf(Array);
-      // Required top-level fields
-      expect(parsed).toHaveProperty('status');
-      expect(parsed).toHaveProperty('workspaceDir');
-      expect(parsed).toHaveProperty('pdConfigPaths');
-      expect(parsed).toHaveProperty('openclawConfigPaths');
-      expect(parsed).toHaveProperty('featureFlags');
-      expect(parsed).toHaveProperty('providerHealth');
-      expect(parsed).toHaveProperty('warnings');
-      expect(parsed).toHaveProperty('nextActions');
-      // status is one of ok|degraded|failed
-      expect(['ok', 'degraded', 'failed']).toContain(parsed.status);
-    } finally { rmTmpDir(tmp); }
-  });
-
-  it('no env var value is present in the JSON output even when key is set', async () => {
-    const tmp = mkTmpDir();
-    const envName = 'PD_DOCTOR_TEST_JSON_REDACTION';
-    const secret = 'super-secret-value-do-not-leak-12345';
-    const previous = process.env[envName];
-    process.env[envName] = secret;
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), buildWorkflowsYaml({
-        provider: 'openrouter',
-        model: 'anthropic/claude-sonnet-4',
-        apiKeyEnv: envName,
-      }));
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const json = JSON.stringify(output, null, 2);
-      expect(json).not.toContain(secret);
-    } finally {
-      if (previous === undefined) {
-        delete process.env[envName];
-      } else {
-        process.env[envName] = previous;
-      }
-      rmTmpDir(tmp);
-    }
-  });
-});
-
-describe('buildDoctorOutput — feature flags failure resilience', () => {
-  it('does not throw when feature-flags.yaml is a directory, outputs degraded status and flag warnings', async () => {
-    const tmp = mkTmpDir();
-    try {
-      const pdDir = path.join(tmp, '.pd');
-      fs.mkdirSync(pdDir, { recursive: true });
-      fs.mkdirSync(path.join(pdDir, 'feature-flags.yaml'), { recursive: true });
-
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      expect(['degraded', 'failed']).toContain(output.status);
-      expect(output.featureFlags.source).toBe('unavailable');
-      expect(output.featureFlags.warnings.some(w => w.includes('feature flags unavailable'))).toBe(true);
-      expect(output.warnings.some(w => w.includes('feature flags unavailable'))).toBe(true);
-      expect(output.nextActions.some(a => a.includes('readable file, not a directory'))).toBe(true);
-    } finally { rmTmpDir(tmp); }
-  });
-});
-
-describe('buildDoctorOutput — CorrectionObserver diagnostics', () => {
-  it('reports auth_missing when ANTHROPIC_API_KEY is not set (default env fallback)', async () => {
-    const tmp = mkTmpDir();
-    const apiKeyEnv = 'ANTHROPIC_API_KEY';
-    const previous = process.env[apiKeyEnv];
-    delete process.env[apiKeyEnv];
-    try {
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const co = output.internalAgents.correctionObserver;
-      expect(co.enabled).toBe(true);
-      expect(co.status).toBe('auth_missing');
-      expect(co.configSource).toBe('env');
-      expect(co.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
-      expect(co.apiKeyPresent).toBe(false);
-      expect(co.nextAction).toMatch(/set the environment variable 'ANTHROPIC_API_KEY'/i);
-    } finally {
-      if (previous !== undefined) {
-        process.env[apiKeyEnv] = previous;
-      }
-      rmTmpDir(tmp);
-    }
-  });
-
-  it('reports disabled when correction_observer is disabled in feature-flags.yaml', async () => {
-    const tmp = mkTmpDir();
-    try {
-      const pdDir = path.join(tmp, '.pd');
-      fs.mkdirSync(pdDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(pdDir, 'feature-flags.yaml'),
-        'correction_observer:\n  enabled: false\n',
-        'utf8',
-      );
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const co = output.internalAgents.correctionObserver;
-      expect(co.enabled).toBe(false);
-      expect(co.status).toBe('disabled');
-      expect(co.reason).toContain('CorrectionObserver is disabled');
-      expect(co.nextAction).toContain('correction_observer.enabled=true');
-    } finally { rmTmpDir(tmp); }
-  });
-
-  it('reports configured when pd-correction-observer policy is present in workflows.yaml and key exists', async () => {
-    const tmp = mkTmpDir();
-    const customKeyEnv = 'PD_DOCTOR_TEST_CO_KEY';
-    const previous = process.env[customKeyEnv];
-    process.env[customKeyEnv] = 'dummy-key-value-not-leaked';
-    try {
-      writeWorkflowsYaml(path.join(tmp, '.state'), {
-        version: '1',
-        funnels: [
-          {
-            workflowId: 'pd-correction-observer',
-            policy: {
-              runtimeKind: 'pi-ai',
-              provider: 'anthropic',
-              model: 'anthropic/claude-3-5-sonnet',
-              apiKeyEnv: customKeyEnv,
-            },
-          },
-        ],
-      });
-      const output = await buildDoctorOutput({ workspaceDir: tmp });
-      const co = output.internalAgents.correctionObserver;
-      expect(co.enabled).toBe(true);
-      expect(co.status).toBe('configured');
-      expect(co.configSource).toBe('workflows.yaml');
-      expect(co.provider).toBe('anthropic');
-      expect(co.model).toBe('anthropic/claude-3-5-sonnet');
-      expect(co.apiKeyEnv).toBe(customKeyEnv);
-      expect(co.apiKeyPresent).toBe(true);
-      const json = JSON.stringify(output);
-      expect(json).not.toContain('dummy-key-value-not-leaked');
-    } finally {
-      if (previous === undefined) {
-        delete process.env[customKeyEnv];
-      } else {
-        process.env[customKeyEnv] = previous;
-      }
-      rmTmpDir(tmp);
-    }
-  });
-});
-
-// ─── CLI command wiring ──────────────────────────────────────────────────────
-
-describe('CLI command wiring (pd config doctor)', () => {
-  let cliPath: string;
-  let workspaceRoot: string;
-
-  beforeEach(() => {
-    workspaceRoot = path.resolve(__dirname, '../../../..');
-    cliPath = path.join(workspaceRoot, 'packages', 'pd-cli', 'dist', 'index.js');
-  });
-
-  it('config doctor is registered at pd config doctor --help', () => {
-    const out = runPd(['config', 'doctor', '--help'], workspaceRoot);
-    expect(out).toContain('PD');
-    expect(out).toContain('--workspace');
-    expect(out).toContain('--json');
-  });
-
-  it('config subcommand appears in pd --help', () => {
-    const out = runPd(['--help'], workspaceRoot);
-    expect(out).toMatch(/\bconfig\b/);
-  });
-
-  it('pd config doctor --json outputs a single parseable JSON object on stdout', () => {
-    const tmp = mkTmpDir();
-    try {
-      const out = runPd(['config', 'doctor', '--workspace', tmp, '--json'], workspaceRoot);
-      expect(out).toBeDefined();
-      const parsed = JSON.parse(out);
-      expect(typeof parsed).toBe('object');
-      expect(parsed).not.toBeNull();
-      expect(parsed).toHaveProperty('status');
-      expect(parsed).toHaveProperty('workspaceDir');
-      expect(parsed).toHaveProperty('pdConfigPaths');
-      expect(parsed).toHaveProperty('openclawConfigPaths');
-      expect(parsed).toHaveProperty('featureFlags');
-      expect(parsed).toHaveProperty('providerHealth');
-      expect(parsed).toHaveProperty('warnings');
-      expect(parsed).toHaveProperty('nextActions');
-    } finally { rmTmpDir(tmp); }
-  });
-
-  it('pd config doctor --workspace <missing> still emits structured JSON (no crash)', () => {
-    const out = runPd(['config', 'doctor', '--workspace', '/nonexistent/workspace/path/x9z', '--json'], workspaceRoot);
-    const parsed = JSON.parse(out);
-    expect(parsed.status).toBe('failed');
-    expect(parsed.providerHealth).toBeInstanceOf(Array);
-    expect(parsed.nextActions).toBeInstanceOf(Array);
-  });
-});
-
-// ─── Helpers for CLI tests ───────────────────────────────────────────────────
-
-function runPd(args: string[], cwd: string): string {
-  try {
-    return execFileSync('node', ['packages/pd-cli/dist/index.js', ...args], {
-      encoding: 'utf8',
-      cwd,
-    });
-  } catch (err: unknown) {
-    if (err && typeof err === 'object' && 'stdout' in err) {
-      return String((err as { stdout: unknown }).stdout);
-    }
-    throw err;
-  }
-}
-
-// ─── Helpers for state.db planting ───────────────────────────────────────────
-
-async function plantStateDbWithMessage(workspaceDir: string, errorMessage: string): Promise<void> {
-  let Database: typeof import('better-sqlite3');
-  try {
-    Database = (await import('better-sqlite3')).default;
-  } catch {
-    // better-sqlite3 not available; tests requiring this will be skipped.
-    return;
-  }
-  const pdDir = path.join(workspaceDir, '.pd');
-  fs.mkdirSync(pdDir, { recursive: true });
-  const dbPath = path.join(pdDir, 'state.db');
-  const db = new Database(dbPath);
-  try {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS tasks (
-        task_id TEXT,
-        kind TEXT,
-        status TEXT,
-        error_message TEXT,
-        error_category TEXT,
-        updated_at INTEGER
-      );
-    `);
-    const now = Date.now();
-    const insert = db.prepare(
-      `INSERT INTO tasks (task_id, kind, status, error_message, error_category, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    );
-    insert.run('test-task-1', 'diagnostician', 'failed', errorMessage, 'rate_limit', now);
-    insert.run('test-task-2', 'diagnostician', 'failed', 'previous unrelated error', 'other', now - 60_000);
-  } finally {
-    db.close();
-  }
-}

--- a/packages/pd-cli/tests/commands/config-doctor.test.ts
+++ b/packages/pd-cli/tests/commands/config-doctor.test.ts
@@ -8,14 +8,16 @@
  *   - Malformed config → fail loud
  *   - No secret output
  *   - Legacy file detection
+ *   - CLI handler: --json stdout purity and exit code
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as yaml from 'js-yaml';
 import { buildDoctorOutput, type DoctorOutput } from '../../src/services/config-doctor.js';
+import { handleConfigDoctor } from '../../src/commands/config-doctor.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -250,6 +252,74 @@ describe('Feature flags from config.yaml', () => {
       expect(output.featureFlags.enabledMvpChannels).toContain('prompt');
       expect(output.featureFlags.enabledMvpChannels).toContain('code_tool_hook');
       expect(output.featureFlags.enabledMvpChannels).toContain('defer_archive');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── CLI handler: --json stdout purity and exit code ──────────────────────────
+
+describe('CLI handler: --json stdout purity and exit code', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    process.exitCode = originalExitCode;
+  });
+
+  it('--json outputs exactly one parseable JSON object to stdout', async () => {
+    const tmp = mkTmpDir();
+    try {
+      await handleConfigDoctor({ workspace: tmp, json: true });
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+      expect(Array.isArray(parsed)).toBe(false);
+      expect(parsed).toHaveProperty('status');
+      expect(parsed).toHaveProperty('featureFlags');
+      expect(parsed).toHaveProperty('internalAgents');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('--json sets process.exitCode=1 on failed status', async () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      await handleConfigDoctor({ workspace: tmp, json: true });
+      expect(process.exitCode).toBe(1);
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      expect(parsed.status).toBe('failed');
+      expect(parsed.reason).toBeTruthy();
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('--json does not set exitCode=1 on ok status', async () => {
+    const tmp = mkTmpDir();
+    try {
+      await handleConfigDoctor({ workspace: tmp, json: true });
+      expect(process.exitCode).toBeUndefined();
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('--json output contains no extra stdout lines (no banners, headers)', async () => {
+    const tmp = mkTmpDir();
+    try {
+      await handleConfigDoctor({ workspace: tmp, json: true });
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      expect(() => JSON.parse(output)).not.toThrow();
     } finally { rmTmpDir(tmp); }
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-features.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-features.test.ts
@@ -1,114 +1,179 @@
+/**
+ * runtime-features tests — PRI-305
+ *
+ * Covers:
+ *   - JSON purity (single parseable JSON object)
+ *   - Missing config → defaults with nextAction
+ *   - Malformed config → fail loud with reason and nextAction
+ *   - Effective flags from .pd/config.yaml
+ *   - No secret output
+ */
+
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { buildFeatureFlagsStatus } from '../../src/commands/runtime-features.js';
-import { loadEffectiveFeatureFlags } from '../../src/services/feature-flag-loader.js';
+import * as yaml from 'js-yaml';
+import { buildRuntimeFeaturesStatus, type RuntimeFeaturesOutput } from '../../src/commands/runtime-features.js';
 
-describe('buildFeatureFlagsStatus', () => {
-  it('returns status ok with clean config (no config file)', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
-    try {
-      const output = buildFeatureFlagsStatus(tmpDir);
-      expect(output.status).toBe('ok');
-      expect(output.reason).toBeUndefined();
-      expect(output.nextAction).toBeUndefined();
-      expect(output.warnings).toEqual([]);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-runtime-features-test-'));
+}
+
+function rmTmpDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function writeConfig(workspaceDir: string, content: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), content, 'utf8');
+}
+
+function makeValidConfigYaml(): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      correction_observer: { category: 'quiet', enabled: false },
+      empathy_observer: { category: 'quiet', enabled: false },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
   });
+}
 
-  it('returns status degraded with reason/nextAction when warnings present', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
-    const configDir = path.join(tmpDir, '.pd');
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(path.join(configDir, 'feature-flags.yaml'), 'gfi:\n  enabled: "yes"\n', 'utf8');
+// ── JSON purity ──────────────────────────────────────────────────────────────
 
+describe('JSON purity', () => {
+  it('output is a single parseable JSON object', () => {
+    const tmp = mkTmpDir();
     try {
-      const output = buildFeatureFlagsStatus(tmpDir);
-      expect(output.status).toBe('degraded');
-      expect(output.reason).toBeDefined();
-      expect(output.nextAction).toBeDefined();
-      expect(output.warnings.length).toBeGreaterThan(0);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  it('JSON output contains all required fields', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
-    try {
-      const output = buildFeatureFlagsStatus(tmpDir);
-      const json = JSON.stringify(output);
+      const output = buildRuntimeFeaturesStatus(tmp);
+      const json = JSON.stringify(output, null, 2);
       const parsed = JSON.parse(json);
-
-      expect(parsed.status).toBe('ok');
-      expect(parsed.source).toBe('defaults');
-      expect(parsed.configPath).toBeTruthy();
-      expect(parsed.flags).toBeInstanceOf(Array);
-      expect(parsed.warnings).toBeInstanceOf(Array);
-      expect(typeof parsed.totalFlags).toBe('number');
-      expect(typeof parsed.enabledCount).toBe('number');
-      expect(typeof parsed.disabledCount).toBe('number');
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+      expect(Array.isArray(parsed)).toBe(false);
+    } finally { rmTmpDir(tmp); }
   });
 });
 
-describe('YAML loader integration', () => {
-  it('rejects __proto__ key in YAML', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
-    const configDir = path.join(tmpDir, '.pd');
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(configDir, 'feature-flags.yaml'),
-      '"__proto__":\n  enabled: true\n',
-      'utf8',
-    );
+// ── Missing config → defaults ────────────────────────────────────────────────
 
+describe('Missing config → defaults', () => {
+  it('returns status=ok with source=defaults when config file is absent', () => {
+    const tmp = mkTmpDir();
     try {
-      const result = loadEffectiveFeatureFlags(tmpDir);
-      expect(result.warnings.some(w => w.includes('__proto__'))).toBe(true);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
+      const output = buildRuntimeFeaturesStatus(tmp);
+      expect(output.status).toBe('ok');
+      expect(output.source).toBe('defaults');
+      expect(output.enabledMvpChannels).toContain('prompt');
+      expect(output.enabledMvpChannels).toContain('code_tool_hook');
+      expect(output.enabledMvpChannels).toContain('defer_archive');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Malformed config → fail loud ────────────────────────────────────────────
+
+describe('Malformed config → fail loud', () => {
+  it('returns status=failed with reason and nextAction for YAML parse error', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const output = buildRuntimeFeaturesStatus(tmp);
+      expect(output.status).toBe('failed');
+      expect(output.source).toBe('malformed');
+      expect(output.reason).toBeTruthy();
+      expect(output.nextAction).toBeTruthy();
+      expect(output.errors).toBeDefined();
+      expect(output.errors!.length).toBeGreaterThan(0);
+    } finally { rmTmpDir(tmp); }
   });
 
-  it('handles malformed YAML gracefully', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
-    const configDir = path.join(tmpDir, '.pd');
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(path.join(configDir, 'feature-flags.yaml'), 'gfi: [unterminated', 'utf8');
-
+  it('returns status=failed for invalid version', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({ version: 99, features: {}, runtimeProfiles: {}, internalAgents: { defaultRuntime: 'x', agents: {} } }));
     try {
-      const result = loadEffectiveFeatureFlags(tmpDir);
-      expect(result.warnings.some(w => w.includes('YAML'))).toBe(true);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
+      const output = buildRuntimeFeaturesStatus(tmp);
+      expect(output.status).toBe('failed');
+      expect(output.source).toBe('malformed');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Valid config → effective flags ───────────────────────────────────────────
+
+describe('Valid config → effective flags', () => {
+  it('returns status=ok with source=user_config for valid config', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const output = buildRuntimeFeaturesStatus(tmp);
+      expect(output.status).toBe('ok');
+      expect(output.source).toBe('user_config');
+      expect(output.enabledMvpChannels).toContain('prompt');
+    } finally { rmTmpDir(tmp); }
   });
 
-  it('enables GFI via valid YAML config', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-features-test-'));
-    const configDir = path.join(tmpDir, '.pd');
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(configDir, 'feature-flags.yaml'),
-      'gfi:\n  enabled: true\n',
-      'utf8',
-    );
-
+  it('shows all feature flags with category and enabled status', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
     try {
-      const result = loadEffectiveFeatureFlags(tmpDir);
-      expect(result.flags.gfi).toBeDefined();
-      if (result.flags.gfi) {
-        expect(result.flags.gfi.enabled).toBe(true);
-      }
-      expect(result.source).toBe('workspace_file');
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
+      const output = buildRuntimeFeaturesStatus(tmp);
+      expect(output.features.length).toBeGreaterThan(0);
+      const promptFlag = output.features.find(f => f.id === 'prompt');
+      expect(promptFlag).toBeDefined();
+      expect(promptFlag!.category).toBe('core');
+      expect(promptFlag!.enabled).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('counts enabled and disabled correctly', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const output = buildRuntimeFeaturesStatus(tmp);
+      expect(output.totalFlags).toBeGreaterThan(0);
+      expect(output.enabledCount + output.disabledCount).toBe(output.totalFlags);
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── No secret output ─────────────────────────────────────────────────────────
+
+describe('No secret output', () => {
+  it('output never contains raw API key values', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const output = buildRuntimeFeaturesStatus(tmp);
+      const json = JSON.stringify(output);
+      expect(json).not.toContain('sk-ant-');
+      expect(json).not.toContain('"apiKey"');
+      expect(json).not.toContain('"gatewayToken"');
+    } finally { rmTmpDir(tmp); }
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-features.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-features.test.ts
@@ -7,14 +7,15 @@
  *   - Malformed config → fail loud with reason and nextAction
  *   - Effective flags from .pd/config.yaml
  *   - No secret output
+ *   - CLI handler: --json stdout purity and exit code
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as yaml from 'js-yaml';
-import { buildRuntimeFeaturesStatus, type RuntimeFeaturesOutput } from '../../src/commands/runtime-features.js';
+import { buildRuntimeFeaturesStatus, handleRuntimeFeaturesStatus, type RuntimeFeaturesOutput } from '../../src/commands/runtime-features.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -174,6 +175,75 @@ describe('No secret output', () => {
       expect(json).not.toContain('sk-ant-');
       expect(json).not.toContain('"apiKey"');
       expect(json).not.toContain('"gatewayToken"');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── CLI handler: --json stdout purity and exit code ──────────────────────────
+
+describe('CLI handler: --json stdout purity and exit code', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    process.exitCode = originalExitCode;
+  });
+
+  it('--json outputs exactly one parseable JSON object to stdout', async () => {
+    const tmp = mkTmpDir();
+    try {
+      await handleRuntimeFeaturesStatus({ workspace: tmp, json: true });
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+      expect(Array.isArray(parsed)).toBe(false);
+      // Verify key fields exist
+      expect(parsed).toHaveProperty('status');
+      expect(parsed).toHaveProperty('source');
+      expect(parsed).toHaveProperty('features');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('--json sets process.exitCode=1 on failed status', async () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      await handleRuntimeFeaturesStatus({ workspace: tmp, json: true });
+      expect(process.exitCode).toBe(1);
+      // Verify the JSON output still parses
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      expect(parsed.status).toBe('failed');
+      expect(parsed.reason).toBeTruthy();
+      expect(parsed.nextAction).toBeTruthy();
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('--json does not set exitCode=1 on ok status', async () => {
+    const tmp = mkTmpDir();
+    try {
+      await handleRuntimeFeaturesStatus({ workspace: tmp, json: true });
+      expect(process.exitCode).toBeUndefined();
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('--json output contains no extra stdout lines (no banners, headers)', async () => {
+    const tmp = mkTmpDir();
+    try {
+      await handleRuntimeFeaturesStatus({ workspace: tmp, json: true });
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      // Must parse as single JSON object — no leading/trailing non-JSON
+      expect(() => JSON.parse(output)).not.toThrow();
     } finally { rmTmpDir(tmp); }
   });
 });

--- a/packages/pd-cli/tests/services/pd-config-loader.test.ts
+++ b/packages/pd-cli/tests/services/pd-config-loader.test.ts
@@ -1,0 +1,479 @@
+/**
+ * pd-config-loader tests — PRI-305
+ *
+ * Covers:
+ *   - Missing config → defaults with nextAction
+ *   - Malformed config → fail loud with errors and nextAction
+ *   - Valid config → effective config with source='user_config'
+ *   - OpenClaw reference summary shows safe label/id only
+ *   - PD-local profile summary shows apiKeyEnv, not secret value
+ *   - Per-agent override summary
+ *   - No secret output in any result
+ *   - Legacy file detection
+ *   - JSON purity of outputs
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as yaml from 'js-yaml';
+import {
+  loadPdConfig,
+  computeFlagsFromLoadResult,
+  redactLoadResult,
+  getPdConfigPath,
+  PD_CONFIG_DIR,
+  PD_CONFIG_FILENAME,
+} from '../../src/services/pd-config-loader.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-config-loader-test-'));
+}
+
+function rmTmpDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function writeConfig(workspaceDir: string, content: string): void {
+  const configDir = path.join(workspaceDir, PD_CONFIG_DIR);
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, PD_CONFIG_FILENAME), content, 'utf8');
+}
+
+function makeValidConfigYaml(): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      correction_observer: { category: 'quiet', enabled: false },
+      empathy_observer: { category: 'quiet', enabled: false },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+      'openclaw.model.lmstudio.qwen3': { type: 'openclaw', provider: 'lmstudio', model: 'qwen3.6-27b-mtp' },
+      'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 300000 },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: 'openclaw.model.lmstudio.qwen3' },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  });
+}
+
+// ── getPdConfigPath ──────────────────────────────────────────────────────────
+
+describe('getPdConfigPath', () => {
+  it('returns path under .pd/config.yaml', () => {
+    expect(getPdConfigPath('/workspace/project')).toBe(
+      path.join('/workspace/project', '.pd', 'config.yaml'),
+    );
+  });
+});
+
+// ── Missing config → defaults ────────────────────────────────────────────────
+
+describe('Missing config → defaults', () => {
+  it('returns ok=true with source=defaults when config file is absent', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(result.source).toBe('defaults');
+      expect(result.effective.config.version).toBe(1);
+      expect(result.effective.config.features.prompt.enabled).toBe(true);
+      expect(result.effective.config.features.code_tool_hook.enabled).toBe(true);
+      expect(result.effective.config.features.defer_archive.enabled).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('defaults include all MVP core features enabled', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfig(tmp);
+      if (!result.ok) throw new Error('Expected ok');
+      const { features } = result.effective.config;
+      expect(features.prompt.enabled).toBe(true);
+      expect(features.prompt.category).toBe('core');
+      expect(features.code_tool_hook.enabled).toBe(true);
+      expect(features.defer_archive.enabled).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('defaults include gone features disabled', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfig(tmp);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(result.effective.config.features.nocturnal.enabled).toBe(false);
+      expect(result.effective.config.features.nocturnal.category).toBe('gone');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('defaults include openclaw.default runtime profile', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfig(tmp);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(Object.hasOwn(result.effective.config.runtimeProfiles, 'openclaw.default')).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Malformed config → fail loud ────────────────────────────────────────────
+
+describe('Malformed config → fail loud', () => {
+  it('returns ok=false with errors for YAML parse error', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('Expected error');
+      expect(result.source).toBe('malformed');
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].reason).toMatch(/YAML parse error/i);
+      expect(result.errors[0].nextAction).toBeTruthy();
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns ok=false with errors for invalid version', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({ version: 99, features: {}, runtimeProfiles: {}, internalAgents: { defaultRuntime: 'x', agents: {} } }));
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('Expected error');
+      expect(result.errors.some(e => e.path === 'version')).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns ok=false with errors for missing features', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({ version: 1, runtimeProfiles: { 'openclaw.default': { type: 'openclaw', source: 'default' } }, internalAgents: { defaultRuntime: 'openclaw.default', agents: {} } }));
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('Expected error');
+      expect(result.errors.some(e => e.path === 'features')).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns ok=false with errors for non-boolean enabled', () => {
+    const tmp = mkTmpDir();
+    const config = yaml.dump({
+      version: 1,
+      features: { prompt: { category: 'core', enabled: 'yes' } },
+      runtimeProfiles: { 'openclaw.default': { type: 'openclaw', source: 'default' } },
+      internalAgents: { defaultRuntime: 'openclaw.default', agents: {} },
+    });
+    writeConfig(tmp, config);
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('Expected error');
+      expect(result.errors.some(e => e.path.includes('enabled'))).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns ok=false with errors for forbidden secret field', () => {
+    const tmp = mkTmpDir();
+    const config = yaml.dump({
+      version: 1,
+      features: { prompt: { category: 'core', enabled: true } },
+      runtimeProfiles: {
+        'bad.profile': { type: 'openclaw', apiKey: 'sk-1234567890abcdef' },
+        'openclaw.default': { type: 'openclaw', source: 'default' },
+      },
+      internalAgents: { defaultRuntime: 'openclaw.default', agents: {} },
+    });
+    writeConfig(tmp, config);
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('Expected error');
+      expect(result.errors.some(e => e.reason.includes('forbidden secret field'))).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('each error has reason and nextAction', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = loadPdConfig(tmp);
+      if (result.ok) throw new Error('Expected error');
+      for (const error of result.errors) {
+        expect(error.reason.length).toBeGreaterThan(0);
+        expect(error.nextAction.length).toBeGreaterThan(0);
+      }
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('malformed result still provides usable defaults', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = loadPdConfig(tmp);
+      if (result.ok) throw new Error('Expected error');
+      expect(result.defaults.config.version).toBe(1);
+      expect(result.defaults.config.features.prompt.enabled).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Valid config → effective config ──────────────────────────────────────────
+
+describe('Valid config → effective config', () => {
+  it('returns ok=true with source=user_config for valid config', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(result.source).toBe('user_config');
+      expect(result.effective.config.version).toBe(1);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('preserves user feature overrides', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(result.effective.config.features.correction_observer.enabled).toBe(false);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('preserves runtime profiles', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(Object.hasOwn(result.effective.config.runtimeProfiles, 'pd.anthropic-sonnet')).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── OpenClaw reference summary ───────────────────────────────────────────────
+
+describe('OpenClaw reference summary', () => {
+  it('shows safe label without secrets', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const ocProfile = summary.runtimeProfiles.find(p => p.id === 'openclaw.model.lmstudio.qwen3');
+      expect(ocProfile).toBeDefined();
+      expect(ocProfile!.type).toBe('openclaw');
+      expect(ocProfile!.label).toContain('openclaw');
+      expect(ocProfile!.label).toContain('lmstudio');
+      expect(ocProfile!.apiKeyEnv).toBeUndefined();
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('does not contain raw provider object', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const json = JSON.stringify(summary);
+      expect(json).not.toContain('"apiKey"');
+      expect(json).not.toContain('"gatewayToken"');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── PD-local profile summary ────────────────────────────────────────────────
+
+describe('PD-local profile summary', () => {
+  it('shows apiKeyEnv name, not value', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const pdProfile = summary.runtimeProfiles.find(p => p.id === 'pd.anthropic-sonnet');
+      expect(pdProfile).toBeDefined();
+      expect(pdProfile!.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
+      const json = JSON.stringify(summary);
+      expect(json).not.toContain('sk-ant-');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Per-agent override summary ───────────────────────────────────────────────
+
+describe('Per-agent override summary', () => {
+  it('diagnostician uses explicit override, not defaultRuntime', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const diag = summary.agents.find(a => a.name === 'diagnostician');
+      expect(diag).toBeDefined();
+      expect(diag!.runtimeProfileId).toBe('openclaw.model.lmstudio.qwen3');
+      expect(diag!.runtimeProfileLabel).toContain('lmstudio');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('agent without override uses defaultRuntime', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const dreamer = summary.agents.find(a => a.name === 'dreamer');
+      expect(dreamer).toBeDefined();
+      expect(dreamer!.runtimeProfileId).toBe('openclaw.default');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── No secret output ─────────────────────────────────────────────────────────
+
+describe('No secret output', () => {
+  it('redacted summary never contains raw API key values', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const json = JSON.stringify(summary);
+      expect(json).not.toContain('sk-ant-');
+      expect(json).not.toContain('sk-');
+      expect(json).not.toContain('"apiKey"');
+      expect(json).not.toContain('"baseUrl"');
+      expect(json).not.toContain('"gatewayToken"');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('load result itself never contains secret values', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const json = JSON.stringify(result);
+      // apiKeyEnv is a field name, not a value — the value would be like "sk-ant-..."
+      expect(json).not.toMatch(/sk-ant-[a-zA-Z0-9]{8,}/);
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Feature flags from config ────────────────────────────────────────────────
+
+describe('Feature flags from config', () => {
+  it('computeFlagsFromLoadResult returns MVP core channels enabled', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfig(tmp);
+      const flags = computeFlagsFromLoadResult(result);
+      expect(flags.enabledChannels).toContain('prompt');
+      expect(flags.enabledChannels).toContain('code_tool_hook');
+      expect(flags.enabledChannels).toContain('defer_archive');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('computeFlagsFromLoadResult works with malformed config (uses defaults)', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = loadPdConfig(tmp);
+      const flags = computeFlagsFromLoadResult(result);
+      expect(flags.enabledChannels).toContain('prompt');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── Legacy file detection ────────────────────────────────────────────────────
+
+describe('Legacy file detection', () => {
+  it('detects .pd/feature-flags.yaml', () => {
+    const tmp = mkTmpDir();
+    const pdDir = path.join(tmp, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    fs.writeFileSync(path.join(pdDir, 'feature-flags.yaml'), 'prompt:\n  enabled: true\n', 'utf8');
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.legacyFilesDetected.length).toBeGreaterThan(0);
+      expect(result.legacyFilesDetected[0]).toContain('feature-flags.yaml');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('detects .state/workflows.yaml', () => {
+    const tmp = mkTmpDir();
+    const stateDir = path.join(tmp, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'workflows.yaml'), 'version: 1\n', 'utf8');
+    try {
+      const result = loadPdConfig(tmp);
+      expect(result.legacyFilesDetected.length).toBeGreaterThan(0);
+      expect(result.legacyFilesDetected[0]).toContain('workflows.yaml');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('includes legacy warning when legacy files detected', () => {
+    const tmp = mkTmpDir();
+    const pdDir = path.join(tmp, '.pd');
+    fs.mkdirSync(pdDir, { recursive: true });
+    fs.writeFileSync(path.join(pdDir, 'feature-flags.yaml'), 'prompt:\n  enabled: true\n', 'utf8');
+    try {
+      const result = loadPdConfig(tmp);
+      if (!result.ok) throw new Error('Expected ok');
+      expect(result.warnings.some(w => w.includes('Legacy config files detected'))).toBe(true);
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+// ── JSON purity ──────────────────────────────────────────────────────────────
+
+describe('JSON purity', () => {
+  it('redacted summary is a single parseable JSON object', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidConfigYaml());
+    try {
+      const result = loadPdConfig(tmp);
+      const summary = redactLoadResult(result);
+      const json = JSON.stringify(summary, null, 2);
+      const parsed = JSON.parse(json);
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+      expect(Array.isArray(parsed)).toBe(false);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('feature flags result is a single parseable JSON object', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = loadPdConfig(tmp);
+      const flags = computeFlagsFromLoadResult(result);
+      const json = JSON.stringify(flags, null, 2);
+      const parsed = JSON.parse(json);
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+      expect(Array.isArray(parsed)).toBe(false);
+    } finally { rmTmpDir(tmp); }
+  });
+});


### PR DESCRIPTION
## Summary

CLI production paths now read .pd/config.yaml instead of .pd/feature-flags.yaml and .state/workflows.yaml. Observers read PD-owned config and stop noisy missing-key cycles.

### PRI-305: CLI cutover: config doctor and runtime features read .pd/config.yaml

- Add pd-config-loader in pd-cli (I/O boundary) that reads .pd/config.yaml
- Rewrite pd runtime features to use config.yaml via core computeFeatureFlagsFromConfig
- Rewrite pd config doctor to show internal agent runtime binding readiness from config.yaml
- --json output is strict single JSON object
- Missing config uses core defaults with nextAction
- Malformed config fails loud with errors and nextAction
- No secret output in any result

### PRI-307: Plugin cutover: observers read PD-owned config and stop noisy missing-key cycles

- Add pd-config-loader in plugin (I/O boundary) that reads .pd/config.yaml
- Update PromptActivationReader to read .pd/config.yaml instead of feature-flags.yaml
- Update CorrectionObserverService to use resolveObserverConfig from .pd/config.yaml
- Observer disabled -> no start, no noisy log cycling
- Observer enabled + missing setup -> structured needs_setup + nextAction
- No longer assumes Anthropic key by default
- MVP-Core hook behavior unchanged (prompt/code_tool_hook/defer_archive)

## ERR Checklist

- ERR-001/ERR-005: No as bypasses; validatePdConfig treats parsed YAML as unknown
- ERR-009/ERR-010: Malformed config fails loud with reason and nextAction
- ERR-020/ERR-021/ERR-022: --json is single parseable object; exit paths stop execution
- ERR-045: redactPdConfig used for all output; no secret values in any result
- ERR-047: Non-boolean enabled fields rejected by core validator

## Tests

- 47 CLI tests (pd-config-loader, runtime-features, config-doctor)
- 56 plugin tests (pd-config-loader, correction-observer-service, prompt-activation)
- 1851 full plugin suite passing
- verify:merge passing (lint + build + typecheck)

## Remaining Risk

- Pre-existing core test failures in llm-e2e-config.test.ts (unrelated to this PR)
- Pre-existing CLI test failures in candidate-audit-repair, cli-command-tree, health, plugin-config-resolution-cutover, runtime-activation (unrelated to this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 统一配置管理：将特性开关配置从多个文件合并到单一 `.pd/config.yaml` 文件。
  * 改进的诊断输出：`pd config doctor` 命令现提供更详细的内部代理就绪状态、运行时配置与错误信息。
  * 增强的配置验证：配置加载失败时返回结构化错误消息，包含具体路径和改进建议。

* **改进**
  * `runtime-features` 命令现从统一配置文件读取特性状态，提供更清晰的状态报告。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->