### PR TITLE
[PRI-323] fix: distinguish ENOENT from SQLite errors in runtime-summary-service

### DIFF
--- a/packages/openclaw-plugin/src/service/runtime-summary-service.ts
+++ b/packages/openclaw-plugin/src/service/runtime-summary-service.ts
@@ -81,6 +81,8 @@ export interface RuntimeSummary {
     candidatesCreatedToday: number;
     /** Heartbeats that injected diagnostician tasks (today from event log) */
     heartbeatsInjectedToday: number;
+    /** Error querying task store DB (e.g. SQLITE_CORRUPT, readonly, etc.) — null/undefined means healthy */
+    taskStoreError?: string;
   };
   phase3: {
     queueTruthReady: boolean;
@@ -371,6 +373,7 @@ export class RuntimeSummaryService {
     // Read heartbeat diagnosis stats from daily event log
     const diagDailyStats = dailyStats?.[todayStr]?.evolution;
     let pendingRuntimeDiagTasks = 0;
+    let taskStoreError: string | undefined;
     try {
       const taskStoreDbPath = path.join(wctx.stateDir, '.principles', 'db', 'task-store.db');
       if (fs.existsSync(taskStoreDbPath)) {
@@ -382,8 +385,15 @@ export class RuntimeSummaryService {
         pendingRuntimeDiagTasks = row?.count ?? 0;
         db.close();
       }
-    } catch { /* task store not yet initialized — 0 pending */ }
-    // TODO(PRI-XXX): distinguish "not initialized" from permission/corruption/query errors
+    } catch (err) {
+      if (err instanceof Error && 'code' in err && (err as any).code === 'ENOENT') {
+        // task store not yet initialized — 0 pending, this is expected
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        taskStoreError = msg;
+        pushWarning(warnings, `Task store query failed: ${msg}`);
+      }
+    }
     const runtimeDiagnosis = {
       pendingTasks: pendingRuntimeDiagTasks,
       tasksWrittenToday: diagDailyStats?.diagnosisTasksWritten ?? 0,
@@ -392,7 +402,17 @@ export class RuntimeSummaryService {
       reportsIncompleteFieldsToday: diagDailyStats?.reportsIncompleteFields ?? 0,
       candidatesCreatedToday: diagDailyStats?.principleCandidatesCreated ?? 0,
       heartbeatsInjectedToday: diagDailyStats?.heartbeatsInjected ?? 0,
+      taskStoreError,
     };
+
+    // D: Task store error — diagnostician query failed (corruption/permission/etc)
+    if (runtimeDiagnosis.taskStoreError) {
+      pushWarning(
+        warnings,
+        `Task store query error: ${runtimeDiagnosis.taskStoreError}. ` +
+        'Diagnostician pipeline status is degraded — pending task count is unreliable.'
+      );
+    }
 
     // D: Stall detection — high-signal warning when the diagnostician loop appears broken.
     // Conditions: tasks are being injected (heartbeats > 0) but no reports are being written.
@@ -489,7 +509,7 @@ export class RuntimeSummaryService {
       },
       gate: gateStats,
       // D: Heartbeat Diagnostician chain
-      runtimeDiagnosis,
+      runtimeDiagnosis: { ...runtimeDiagnosis, taskStoreError },
       ...(workflowFunnelsOutput && { workflowFunnels: workflowFunnelsOutput }),
       metadata: {
         generatedAt,

--- a/packages/openclaw-plugin/src/service/runtime-summary-service.ts
+++ b/packages/openclaw-plugin/src/service/runtime-summary-service.ts
@@ -198,6 +198,13 @@ function pushWarning(warnings: string[], message: string): void {
   }
 }
 
+/** EP-01 safe: access a string-typed own property on an unknown object without casts. */
+function readStringProp(obj: unknown, key: string): string | undefined {
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  const desc = Object.getOwnPropertyDescriptor(obj, key);
+  return typeof desc?.value === 'string' ? desc.value : undefined;
+}
+
 /**
  * YAML-SSOT-03: resolve a dot-path (e.g. 'evolution.nocturnalDreamerCompleted') from dailyStats.
  * Returns { count, resolvable } to distinguish "field not found / non-numeric" from "legitimate zero".
@@ -386,7 +393,7 @@ export class RuntimeSummaryService {
         db.close();
       }
     } catch (err) {
-      if (err instanceof Error && 'code' in err && (err as any).code === 'ENOENT') {
+      if (err instanceof Error && readStringProp(err, 'code') === 'ENOENT') {
         // task store not yet initialized — 0 pending, this is expected
       } else {
         const msg = err instanceof Error ? err.message : String(err);

--- a/packages/openclaw-plugin/src/service/runtime-summary-service.ts
+++ b/packages/openclaw-plugin/src/service/runtime-summary-service.ts
@@ -509,7 +509,7 @@ export class RuntimeSummaryService {
       },
       gate: gateStats,
       // D: Heartbeat Diagnostician chain
-      runtimeDiagnosis: { ...runtimeDiagnosis, taskStoreError },
+      runtimeDiagnosis,
       ...(workflowFunnelsOutput && { workflowFunnels: workflowFunnelsOutput }),
       metadata: {
         generatedAt,

--- a/packages/openclaw-plugin/tests/service/runtime-summary-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/runtime-summary-service.test.ts
@@ -41,7 +41,19 @@ function writeEvents(workspace: string, entries: unknown[]): void {
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
+    // Retry on Windows handle-lock (e.g. better-sqlite3 zombie handles)
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+        break;
+      } catch {
+        if (attempt < 2) {
+          // Wait for OS to release handles
+          const start = Date.now();
+          while (Date.now() - start < 50) { /* busy-wait */ }
+        }
+      }
+    }
   }
   WorkspaceContext.clearCache();
   clearSession('live-session');
@@ -1096,5 +1108,55 @@ describe('RuntimeSummaryService', () => {
 
       expect(summary.metadata.warnings.join('\n')).not.toContain('Diagnostician appears stalled');
     });
+  });
+
+  it('reports taskStoreError when SQLite task store DB is corrupted', () => {
+    const workspace = makeWorkspace();
+    writeJson(path.join(workspace, '.state', 'AGENT_SCORECARD.json'), {
+      trust_score: 85,
+      last_updated: '2026-03-20T10:00:00Z',
+    });
+    writeJson(path.join(workspace, '.state', 'evolution_queue.json'), []);
+
+    // Write a corrupted file (invalid SQLite) at the task store DB path
+    const dbDir = path.join(workspace, '.state', '.principles', 'db');
+    fs.mkdirSync(dbDir, { recursive: true });
+    fs.writeFileSync(path.join(dbDir, 'task-store.db'), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+
+    // Create a daily events file so readEvents does not pollute warnings
+    const today = new Date().toISOString().slice(0, 10);
+    writeEvents(workspace, [
+      { ts: `${today}T09:00:00Z`, type: 'heartbeat_diagnosis', category: 'task_injected', sessionId: 'test', data: {} },
+    ]);
+
+    const summary = RuntimeSummaryService.getSummary(workspace);
+
+    expect(summary.runtimeDiagnosis.taskStoreError).toBeDefined();
+    expect(summary.metadata.warnings.join('\n')).toContain('Task store query failed');
+    expect(summary.metadata.warnings.join('\n')).toContain('Task store query error');
+
+    // Pre-cleanup: delete DB file before afterEach to avoid Windows handle-lock on temp dir
+    try { fs.unlinkSync(path.join(dbDir, 'task-store.db')); } catch { /* ok */ }
+  });
+
+  it('shows 0 pendingTasks with no taskStoreError when task-store.db does not exist', () => {
+    const workspace = makeWorkspace();
+    writeJson(path.join(workspace, '.state', 'AGENT_SCORECARD.json'), {
+      trust_score: 85,
+      last_updated: '2026-03-20T10:00:00Z',
+    });
+    writeJson(path.join(workspace, '.state', 'evolution_queue.json'), []);
+
+    // No task-store.db created at all → ENOENT path, should be silent
+    const today = new Date().toISOString().slice(0, 10);
+    writeEvents(workspace, [
+      { ts: `${today}T09:00:00Z`, type: 'heartbeat_diagnosis', category: 'task_injected', sessionId: 'test', data: {} },
+    ]);
+
+    const summary = RuntimeSummaryService.getSummary(workspace);
+
+    expect(summary.runtimeDiagnosis.pendingTasks).toBe(0);
+    expect(summary.runtimeDiagnosis.taskStoreError).toBeUndefined();
+    expect(summary.metadata.warnings.join('\n')).not.toContain('Task store query');
   });
 });


### PR DESCRIPTION
## Summary

Fixes PRI-323 — `runtime-summary-service.ts:385` bare `catch {}` swallowed all SQLite errors (SQLITE_CORRUPT, SQLITE_READONLY, etc.) as "not initialized", returning `pendingTasks: 0` silently.

## Changes

- `catch {}` → `catch (err)` with ENOENT vs other error discrimination
- Added `taskStoreError?: string` to `runtimeDiagnosis` response type
- Stall detection now reports degraded when `taskStoreError` is present
- Removed `TODO(PRI-XXX)` — resolved

## Verification

- Typecheck: 0 errors
- Lint: ✅ passed (31.5s)
- ERR-002 compliance: every degradation has a `reason`