### PR TITLE
fix(installer): do not recreate plugins.allow if user removed it

### DIFF
--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -295,9 +295,10 @@ function registerPlugin() {
     if (!config.plugins) { config.plugins = {}; modified = true; }
     const plugins = config.plugins;
 
-    // Add to plugins.allow (idempotent)
-    if (!Array.isArray(plugins.allow)) { plugins.allow = []; modified = true; }
-    if (!plugins.allow.includes('principles-disciple')) {
+    // Add to plugins.allow only if the user already uses an allowlist.
+    // Do NOT create plugins.allow if it doesn't exist — that would block
+    // all other plugins the user hasn't explicitly listed.
+    if (Array.isArray(plugins.allow) && !plugins.allow.includes('principles-disciple')) {
       plugins.allow.push('principles-disciple');
       modified = true;
     }


### PR DESCRIPTION
## Problem

安装脚本 `registerPlugin()` 在 `plugins.allow` 不存在时会**强制创建空数组**，然后加入 `principles-disciple`。这导致：

- 用户删除 `plugins.allow` 后，每次运行安装脚本都会把它加回来
- 所有未在白名单中的插件被阻止加载（如 QQ Bot）

## Fix

```diff
- if (!Array.isArray(plugins.allow)) { plugins.allow = []; modified = true; }
- if (!plugins.allow.includes('principles-disciple')) {
+ if (Array.isArray(plugins.allow) && !plugins.allow.includes('principles-disciple')) {
```

只在 `plugins.allow` **已存在**时追加，不主动创建。用户选择不使用白名单时，安装脚本不再多此一举。

## Verification

- `plugins.allow` 已存在 → 正常追加（行为不变）
- `plugins.allow` 不存在 → 跳过，不创建（修复）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了插件允许列表的处理方式，防止意外阻止未显式配置的插件。

* **Chores**
  * 优化了插件注册时的配置合并逻辑，提升了系统可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->