### PR TITLE
feat(evidence-triage): PEAT-B1 minimal source-kind triage on Runtime V2 pain path

### DIFF
--- a/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
+++ b/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
@@ -10,6 +10,7 @@
  * had their own block persistence implementations.
  */
 
+import * as fs from 'fs';
 import { getSession, trackBlock } from '../core/session-tracker.js';
 import type { WorkspaceContext } from '../core/workspace-context.js';
 import type { PluginHookBeforeToolCallResult } from '../openclaw-sdk.js';
@@ -17,6 +18,8 @@ import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 import { emitPainDetectedEvent } from './pain.js';
 import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
 import { evaluateEvidenceTriage } from './triage-adapter.js';
+import { isRisky } from '../utils/io.js';
+import { normalizeProfile } from '../core/profile.js';
 import {
   TRAJECTORY_GATE_BLOCK_RETRY_DELAY_MS,
   TRAJECTORY_GATE_BLOCK_MAX_RETRIES
@@ -120,8 +123,17 @@ export function recordGateBlockAndReturn(
     let triageAdmitted = true;
     const gateBlockTriageFlag = loadFeatureFlagFromConfig(wctx.workspaceDir, 'painEvidenceAdmission');
     if (gateBlockTriageFlag.enabled) {
+      const profilePath = wctx.resolve('PROFILE');
+      const profile = fs.existsSync(profilePath)
+        ? normalizeProfile(JSON.parse(fs.readFileSync(profilePath, 'utf8')))
+        : normalizeProfile({});
+      // Real judgment for rulehost blocks: if a principle blocked an action on a risky path,
+      // it IS a high-confidence unsafe action. The pain score (45) is the evidence friction
+      // weight, NOT the action risk severity. The rulehost principle already determined
+      // this action was important enough to block — that is the real signal.
+      const isUnsafe = isRisky(filePath, profile.risk_paths);
       const triage = evaluateEvidenceTriage('rulehost_block', GATE_BLOCK_PAIN_SCORE, {
-        isUnsafeHighConfidence: false,
+        isUnsafeHighConfidence: isUnsafe,
       });
       if (triage.decision !== 'admit') {
         triageAdmitted = false;

--- a/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
+++ b/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
@@ -20,6 +20,7 @@ import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
 import { evaluateEvidenceTriage } from './triage-adapter.js';
 import { isRisky } from '../utils/io.js';
 import { normalizeProfile } from '../core/profile.js';
+import { SystemLogger } from '../core/system-logger.js';
 import {
   TRAJECTORY_GATE_BLOCK_RETRY_DELAY_MS,
   TRAJECTORY_GATE_BLOCK_MAX_RETRIES
@@ -123,10 +124,23 @@ export function recordGateBlockAndReturn(
     let triageAdmitted = true;
     const gateBlockTriageFlag = loadFeatureFlagFromConfig(wctx.workspaceDir, 'painEvidenceAdmission');
     if (gateBlockTriageFlag.enabled) {
+      // Load profile with 1MB size guard, matching pain.ts pattern
       const profilePath = wctx.resolve('PROFILE');
-      const profile = fs.existsSync(profilePath)
-        ? normalizeProfile(JSON.parse(fs.readFileSync(profilePath, 'utf8')))
-        : normalizeProfile({});
+      let profile = normalizeProfile({});
+      if (fs.existsSync(profilePath)) {
+        try {
+          const content = fs.readFileSync(profilePath, 'utf8');
+          if (content.length > 1024 * 1024) {
+            logger.warn?.('[PD_GATE] PROFILE.json exceeds 1 MB, skipping');
+            SystemLogger.log(wctx.workspaceDir, 'PROFILE_PARSE_WARN', 'PROFILE.json exceeds 1 MB, skipping — fallback to non-risky');
+          } else {
+            profile = normalizeProfile(JSON.parse(content));
+          }
+        } catch (e) {
+          logger.warn?.(`[PD_GATE] Failed to parse PROFILE.json: ${String(e)}`);
+          SystemLogger.log(wctx.workspaceDir, 'PROFILE_PARSE_WARN', `Failed to parse PROFILE.json: ${String(e)} — fallback to non-risky`);
+        }
+      }
       // Real judgment for rulehost blocks: if a principle blocked an action on a risky path,
       // it IS a high-confidence unsafe action. The pain score (45) is the evidence friction
       // weight, NOT the action risk severity. The rulehost principle already determined

--- a/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
+++ b/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
@@ -15,6 +15,8 @@ import type { WorkspaceContext } from '../core/workspace-context.js';
 import type { PluginHookBeforeToolCallResult } from '../openclaw-sdk.js';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 import { emitPainDetectedEvent } from './pain.js';
+import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
+import { evaluateEvidenceTriage } from './triage-adapter.js';
 import {
   TRAJECTORY_GATE_BLOCK_RETRY_DELAY_MS,
   TRAJECTORY_GATE_BLOCK_MAX_RETRIES
@@ -114,38 +116,53 @@ export function recordGateBlockAndReturn(
       origin: 'system_infer',
     });
 
-    const session = getSession(sessionId);
-    const gate = evaluatePainDiagnosticGate({
-      source: 'gate_blocked',
-      score: GATE_BLOCK_PAIN_SCORE,
-      currentGfi: session?.currentGfi ?? 0,
-      consecutiveErrors: session?.consecutiveErrors ?? 0,
-      sessionId,
-      errorHash: `${toolName}:${filePath}:${reason}`,
-      thresholds: {
-        painTrigger: wctx.config.get('thresholds.pain_trigger') || 40,
-        highSeverity: wctx.config.get('severity_thresholds.high') || 70,
-      },
-    });
-
-    if (gate.shouldDiagnose) {
-      void emitPainDetectedEvent(wctx, {
-        ts: new Date().toISOString(),
-        type: 'pain_detected',
-        data: {
-          painId: `gate_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
-          painType: 'user_frustration',
-          source: 'gate_blocked',
-          reason: `Gate blocked ${toolName} on ${filePath}: ${reason}`,
-          score: GATE_BLOCK_PAIN_SCORE,
-          sessionId,
-          agentId: 'main',
-        },
-      }).catch((emitErr) => {
-        logWarn(`[PD_GATE] Failed to emit gate block pain event: ${String(emitErr)}`);
+    // PEAT-B1: Evidence triage (feature-flagged)
+    let triageAdmitted = true;
+    const gateBlockTriageFlag = loadFeatureFlagFromConfig(wctx.workspaceDir, 'painEvidenceAdmission');
+    if (gateBlockTriageFlag.enabled) {
+      const triage = evaluateEvidenceTriage('rulehost_block', GATE_BLOCK_PAIN_SCORE, {
+        isUnsafeHighConfidence: false,
       });
-    } else {
-      logger.info?.(`[PD_GATE] Gate block recorded without Runtime V2 diagnosis: ${gate.detail}`);
+      if (triage.decision !== 'admit') {
+        triageAdmitted = false;
+        logger.info?.(`[PD_GATE] Triage ${triage.decision}: ${triage.reason}`);
+      }
+    }
+
+    const session = getSession(sessionId);
+    if (triageAdmitted) {
+      const gate = evaluatePainDiagnosticGate({
+        source: 'gate_blocked',
+        score: GATE_BLOCK_PAIN_SCORE,
+        currentGfi: session?.currentGfi ?? 0,
+        consecutiveErrors: session?.consecutiveErrors ?? 0,
+        sessionId,
+        errorHash: `${toolName}:${filePath}:${reason}`,
+        thresholds: {
+          painTrigger: wctx.config.get('thresholds.pain_trigger') || 40,
+          highSeverity: wctx.config.get('severity_thresholds.high') || 70,
+        },
+      });
+
+      if (gate.shouldDiagnose) {
+        void emitPainDetectedEvent(wctx, {
+          ts: new Date().toISOString(),
+          type: 'pain_detected',
+          data: {
+            painId: `gate_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+            painType: 'user_frustration',
+            source: 'gate_blocked',
+            reason: `Gate blocked ${toolName} on ${filePath}: ${reason}`,
+            score: GATE_BLOCK_PAIN_SCORE,
+            sessionId,
+            agentId: 'main',
+          },
+        }).catch((emitErr) => {
+          logWarn(`[PD_GATE] Failed to emit gate block pain event: ${String(emitErr)}`);
+        });
+      } else {
+        logger.info?.(`[PD_GATE] Gate block recorded without Runtime V2 diagnosis: ${gate.detail}`);
+      }
     }
   }
 

--- a/packages/openclaw-plugin/src/hooks/llm.ts
+++ b/packages/openclaw-plugin/src/hooks/llm.ts
@@ -11,6 +11,8 @@ import { sanitizeAssistantText } from './message-sanitize.js';
 import { atomicWriteFileSync } from '../utils/io.js';
 import { emitPainDetectedEvent, buildTrajectoryEvidence } from './pain.js';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
+import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
+import { resolveSourceKindFromLlmDetection, evaluateEvidenceTriage } from './triage-adapter.js';
 
 export interface EmpathySignal {
     detected: boolean;
@@ -240,13 +242,27 @@ export function handleLlmOutput(
     // GFI-triggered pain: when accumulated friction crosses highGfi threshold,
     // emit pain signal even if L1 detection didn't fire.
     const highGfiThreshold = Math.max(config.get('severity_thresholds.high') || 70, painTriggerThreshold + 30);
+    let isGfiTriggered = false;
     if (state.currentGfi >= highGfiThreshold && painScore < painTriggerThreshold) {
         painScore = Math.min(state.currentGfi, 60);
         source = 'user_empathy';
+        isGfiTriggered = true;
         matchedReason = `Accumulated GFI (${state.currentGfi.toFixed(1)}) crossed highGfi threshold (${highGfiThreshold}). Source: empathy keyword friction.`;
     }
 
     if (painScore >= painTriggerThreshold) {
+        // PEAT-B1: Evidence triage (feature-flagged)
+        let shouldDiagnose = true;
+        const llmTriageFlag = loadFeatureFlagFromConfig(ctx.workspaceDir!, 'painEvidenceAdmission');
+        if (llmTriageFlag.enabled) {
+            const sourceKind = resolveSourceKindFromLlmDetection(source, isGfiTriggered);
+            const triage = evaluateEvidenceTriage(sourceKind, painScore);
+            if (triage.decision !== 'admit') {
+                shouldDiagnose = false;
+                ctx.logger?.info?.(`[PD:LLM] Triage ${triage.decision}: ${triage.reason}`);
+            }
+        }
+
         const gate = evaluatePainDiagnosticGate({
             source: source === 'llm_paralysis' ? 'llm_paralysis' : 'semantic',
             score: painScore,
@@ -268,7 +284,7 @@ export function handleLlmOutput(
             isRisky: false
         });
 
-        if (gate.shouldDiagnose) {
+        if (shouldDiagnose && gate.shouldDiagnose) {
             const evidence = buildTrajectoryEvidence(wctx, ctx.sessionId || 'unknown');
             emitPainDetectedEvent(wctx, {
                 ts: new Date().toISOString(),
@@ -286,7 +302,8 @@ export function handleLlmOutput(
                 },
             });
         } else {
-            ctx.logger?.info?.(`[PD:LLM] Pain signal recorded without Runtime V2 diagnosis: ${gate.detail}`);
+            const skipReason = !shouldDiagnose ? 'triage evidence-only' : gate.detail;
+            ctx.logger?.info?.(`[PD:LLM] Pain signal recorded without Runtime V2 diagnosis: ${skipReason}`);
         }
     }
 

--- a/packages/openclaw-plugin/src/hooks/llm.ts
+++ b/packages/openclaw-plugin/src/hooks/llm.ts
@@ -252,30 +252,16 @@ export function handleLlmOutput(
 
     if (painScore >= painTriggerThreshold) {
         // PEAT-B1: Evidence triage (feature-flagged)
-        let shouldDiagnose = true;
+        let triageAdmitted = true;
         const llmTriageFlag = loadFeatureFlagFromConfig(ctx.workspaceDir!, 'painEvidenceAdmission');
         if (llmTriageFlag.enabled) {
             const sourceKind = resolveSourceKindFromLlmDetection(source, isGfiTriggered);
             const triage = evaluateEvidenceTriage(sourceKind, painScore);
             if (triage.decision !== 'admit') {
-                shouldDiagnose = false;
+                triageAdmitted = false;
                 ctx.logger?.info?.(`[PD:LLM] Triage ${triage.decision}: ${triage.reason}`);
             }
         }
-
-        const gate = evaluatePainDiagnosticGate({
-            source: source === 'llm_paralysis' ? 'llm_paralysis' : 'semantic',
-            score: painScore,
-            currentGfi: state.currentGfi,
-            consecutiveErrors: state.consecutiveErrors,
-            sessionId: ctx.sessionId || 'unknown',
-            errorHash: source,
-            thresholds: {
-                painTrigger: painTriggerThreshold,
-                highSeverity: config.get('severity_thresholds.high') || 70,
-                semanticPain: Math.max(painTriggerThreshold, 60),
-            },
-        });
 
         eventLog.recordPainSignal(ctx.sessionId, {
             score: painScore,
@@ -284,26 +270,43 @@ export function handleLlmOutput(
             isRisky: false
         });
 
-        if (shouldDiagnose && gate.shouldDiagnose) {
-            const evidence = buildTrajectoryEvidence(wctx, ctx.sessionId || 'unknown');
-            emitPainDetectedEvent(wctx, {
-                ts: new Date().toISOString(),
-                type: 'pain_detected',
-                data: {
-                    painId: `llm_${Date.now()}`,
-                    painType: 'user_frustration' as const,
-                    source,
-                    reason: `${matchedReason}; diagnosticGate=${gate.reason}`,
-                    score: painScore,
-                    sessionId: ctx.sessionId || 'unknown',
-                    agentId: ctx.agentId,
-                    provenance: 'openclaw_context_bound',
-                    evidence,
+        if (triageAdmitted) {
+            const gate = evaluatePainDiagnosticGate({
+                source: source === 'llm_paralysis' ? 'llm_paralysis' : 'semantic',
+                score: painScore,
+                currentGfi: state.currentGfi,
+                consecutiveErrors: state.consecutiveErrors,
+                sessionId: ctx.sessionId || 'unknown',
+                errorHash: source,
+                thresholds: {
+                    painTrigger: painTriggerThreshold,
+                    highSeverity: config.get('severity_thresholds.high') || 70,
+                    semanticPain: Math.max(painTriggerThreshold, 60),
                 },
             });
+
+            if (gate.shouldDiagnose) {
+                const evidence = buildTrajectoryEvidence(wctx, ctx.sessionId || 'unknown');
+                emitPainDetectedEvent(wctx, {
+                    ts: new Date().toISOString(),
+                    type: 'pain_detected',
+                    data: {
+                        painId: `llm_${Date.now()}`,
+                        painType: 'user_frustration' as const,
+                        source,
+                        reason: `${matchedReason}; diagnosticGate=${gate.reason}`,
+                        score: painScore,
+                        sessionId: ctx.sessionId || 'unknown',
+                        agentId: ctx.agentId,
+                        provenance: 'openclaw_context_bound',
+                        evidence,
+                    },
+                });
+            } else {
+                ctx.logger?.info?.(`[PD:LLM] Pain signal recorded without Runtime V2 diagnosis: ${gate.detail}`);
+            }
         } else {
-            const skipReason = !shouldDiagnose ? 'triage evidence-only' : gate.detail;
-            ctx.logger?.info?.(`[PD:LLM] Pain signal recorded without Runtime V2 diagnosis: ${skipReason}`);
+            ctx.logger?.info?.(`[PD:LLM] Triage evidence-only: pain signal recorded without diagnosis or gate evaluation`);
         }
     }
 

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -14,7 +14,8 @@ import { resolveWorkspaceDirForRuntimeV2 } from '../utils/workspace-resolver.js'
 import { PainToPrincipleService, PrincipleTreeLedgerAdapter, type PainDetectedData, type PainEvidenceEntry, MAX_EVIDENCE_ENTRIES, MAX_EVIDENCE_NOTE_CHARS } from '@principles/core/runtime-v2';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 import { sanitizeAssistantText, sanitizeForEvidence, sanitizeToolParamsForEvidence } from './message-sanitize.js';
-import { loadPdConfigForPlugin } from '../core/pd-config-loader.js';
+import { loadPdConfigForPlugin, loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
+import { resolveSourceKindFromToolFailure, evaluateEvidenceTriage } from './triage-adapter.js';
 
 /**
  * Interface for tool parameters to avoid 'any'
@@ -463,6 +464,25 @@ export function handleAfterToolCall(
   const isRisk = isRisky(relPath, profile.risk_paths);
   const painScore = computePainScore(1, false, false, isRisk ? 20 : 0, effectiveWorkspaceDir);
   const traceId = createTraceId();
+
+  // PEAT-B1: Evidence triage (feature-flagged)
+  const painTriageFlag = loadFeatureFlagFromConfig(effectiveWorkspaceDir, 'painEvidenceAdmission');
+  if (painTriageFlag.enabled) {
+    const sourceKind = resolveSourceKindFromToolFailure(event.toolName, failureSource);
+    const triage = evaluateEvidenceTriage(sourceKind, painScore);
+    if (triage.decision !== 'admit') {
+      SystemLogger.log(effectiveWorkspaceDir, 'TRIAGE_EVIDENCE_ONLY', JSON.stringify({
+        sourceKind: triage.sourceKind,
+        decision: triage.decision,
+        reason: triage.reason,
+        nextAction: triage.nextAction,
+        tool: event.toolName,
+        path: relPath,
+      }));
+      return;
+    }
+  }
+
   const diagnosticGate = evaluatePainDiagnosticGate({
     source: failureSource,
     score: painScore,

--- a/packages/openclaw-plugin/src/hooks/triage-adapter.ts
+++ b/packages/openclaw-plugin/src/hooks/triage-adapter.ts
@@ -1,0 +1,156 @@
+/**
+ * Triage Adapter — PEAT-B1
+ *
+ * Plugin-side adapter that maps OpenClaw hook context to evidence triage input.
+ * Calls the pure triage policy from principles-core.
+ *
+ * This file lives in openclaw-plugin because it:
+ * - Maps hook-specific context (source strings, session state) to SourceKind
+ * - Wraps evaluatePainDiagnosticGate as a compatibility sub-policy
+ * - Knows about OpenClaw hook conventions (sessionId, toolName, etc.)
+ *
+ * It does NOT expose evaluatePainDiagnosticGate to core.
+ * Core only sees SourceKind and TriageResult.
+ *
+ * ERR checklist:
+ * - ERR-001: Source kind derived from runtime values with guards, not `as` casts.
+ * - ERR-002: Every triage result carries reason + nextAction.
+ * - ERR-024/025/048: Production-path tests cover this adapter.
+ */
+
+import {
+  evaluateTriage,
+  type TriageInput,
+  type TriageResult,
+  type SourceKind,
+} from '@principles/core/runtime-v2';
+
+// ── Source Kind Resolution ───────────────────────────────────────────────────
+
+/**
+ * Map after_tool_call hook context to SourceKind.
+ *
+ * Classifies based on:
+ * - toolName: 'pain' or 'skill:pain' → agent_on_owner_request
+ * - failureSource: 'dispatch_error' vs 'tool_failure'
+ * - isRisky + score: only used for rulehost_block upgrade, not for kind resolution
+ */
+export function resolveSourceKindFromToolFailure(
+  toolName: string | undefined,
+  failureSource: 'tool_failure' | 'dispatch_error',
+  provenance?: 'openclaw_context_bound' | 'owner_reported_no_host_trace' | 'automatic_hook',
+): SourceKind {
+  // Manual pain via agent tool call
+  if (toolName === 'pain' || toolName === 'skill:pain') {
+    return provenance === 'openclaw_context_bound' ? 'agent_on_owner_request' : 'owner_reported';
+  }
+
+  // Dispatch errors (tool not found, unknown tool)
+  if (failureSource === 'dispatch_error') {
+    return 'dispatch_error';
+  }
+
+  // Regular tool failure
+  return 'tool_failure';
+}
+
+/**
+ * Map empathy/semantic detection context to SourceKind.
+ *
+ * Classifies based on detection source prefix:
+ * - 'llm_paralysis' → llm_paralysis
+ * - 'llm_*' (detection rule) → semantic
+ * - 'user_empathy' or empathy keyword match → empathy_inferred
+ * - GFI threshold crossed → gfi_threshold
+ */
+export function resolveSourceKindFromLlmDetection(
+  detectionSource: string,
+  isGfiTriggered: boolean,
+): SourceKind {
+  if (isGfiTriggered) return 'gfi_threshold';
+  if (detectionSource === 'llm_paralysis') return 'llm_paralysis';
+  if (detectionSource.startsWith('llm_')) return 'semantic';
+  if (detectionSource === 'user_empathy') return 'empathy_inferred';
+  return 'unknown';
+}
+
+/**
+ * Map gate-block context to SourceKind.
+ */
+export function resolveSourceKindFromGateBlock(): SourceKind {
+  return 'rulehost_block';
+}
+
+/**
+ * Map /pd-pain command to SourceKind.
+ */
+export function resolveSourceKindFromCommand(): SourceKind {
+  return 'owner_reported';
+}
+
+/**
+ * Map provider/rate-limit failure to SourceKind.
+ */
+export function resolveSourceKindFromProvider(
+  isRateLimit: boolean,
+): SourceKind {
+  return isRateLimit ? 'rate_limit' : 'provider_failure';
+}
+
+/**
+ * Map subagent error to SourceKind.
+ */
+export function resolveSourceKindFromSubagent(): SourceKind {
+  return 'subagent_error';
+}
+
+// ── Triage Evaluation ───────────────────────────────────────────────────────
+
+/**
+ * Evaluate evidence triage for a given source kind and context.
+ *
+ * This is the main entry point for hooks. It calls the pure triage policy
+ * from principles-core and returns the result.
+ *
+ * The caller (hook) is responsible for:
+ * - Checking the painEvidenceAdmission feature flag
+ * - Acting on the triage result (proceed to diagnosis, store evidence, etc.)
+ * - Falling back to existing behavior when the flag is off
+ */
+export function evaluateEvidenceTriage(
+  sourceKind: SourceKind,
+  score: number,
+  options?: {
+    isUnsafeHighConfidence?: boolean;
+    provenance?: 'openclaw_context_bound' | 'owner_reported_no_host_trace' | 'automatic_hook';
+  },
+): TriageResult {
+  const input: TriageInput = {
+    sourceKind,
+    score,
+    isUnsafeHighConfidence: options?.isUnsafeHighConfidence,
+    provenance: options?.provenance,
+  };
+
+  return evaluateTriage(input);
+}
+
+// ── High-Confidence Unsafe Action Detection ──────────────────────────────────
+
+/**
+ * Determine if a gate-blocked action is a high-confidence unsafe action.
+ *
+ * This is a heuristic that the plugin adapter owns. Core does not know about
+ * these heuristics — it only receives the boolean flag.
+ *
+ * Criteria for high-confidence unsafe:
+ * - Score >= 70 (high severity)
+ * - Tool is in the risky write set
+ * - Action would be irreversible (file deletion, force push, etc.)
+ */
+export function isHighConfidenceUnsafeAction(
+  score: number,
+  isRisky: boolean,
+): boolean {
+  return isRisky && score >= 70;
+}

--- a/packages/openclaw-plugin/tests/hooks/gate-block-helper-profile.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-block-helper-profile.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Gate Block Helper — PROFILE loading resilience tests
+ *
+ * Verifies that recordGateBlockAndReturn handles malformed/oversized PROFILE
+ * gracefully: try/catch, 1MB size guard, fallback to non-risky, no crash.
+ *
+ * ERR checklist:
+ * - ERR-026: All PROFILE loads have try/catch (gate-block-helper.ts matches pain.ts)
+ * - ERR-024/025: Production-path tests for the edge case
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { WorkspaceContext } from '../../src/core/workspace-context.js';
+import { EventLogService } from '../../src/core/event-log.js';
+import { clearSession } from '../../src/core/session-tracker.js';
+import { resetPainDiagnosticGateForTest } from '../../src/core/pain-diagnostic-gate.js';
+
+vi.mock('fs');
+vi.mock('../../src/utils/io.js', () => ({
+  isRisky: vi.fn(() => false),
+}));
+vi.mock('../../src/core/evolution-engine.js', () => ({
+  recordEvolutionSuccess: vi.fn(),
+  recordEvolutionFailure: vi.fn(),
+}));
+vi.mock('../../src/core/evolution-logger.js', () => ({
+  createTraceId: vi.fn(() => 'trace-123'),
+  getEvolutionLogger: vi.fn(() => ({
+    logPainDetected: vi.fn(),
+  })),
+}));
+vi.mock('../../src/core/pd-config-loader.js', () => ({
+  loadPdConfigForPlugin: vi.fn(() => ({ ok: true, source: 'mock', effective: {}, errors: [] })),
+  loadFeatureFlagFromConfig: vi.fn(() => ({ enabled: true, source: 'test' })),
+}));
+
+const mockEmitSync = vi.fn();
+const mockRecordProbationFeedback = vi.fn();
+const mockUpdatePrincipleValueMetrics = vi.fn();
+
+function makeTestWctx(overrides: Record<string, unknown> = {}) {
+  return {
+    workspaceDir: '/mock/workspace',
+    stateDir: '/mock/state',
+    config: { get: vi.fn().mockReturnValue(40) },
+    eventLog: {
+      recordGateBlock: vi.fn(),
+      recordPainSignal: vi.fn(),
+    },
+    trajectory: {
+      recordGateBlock: vi.fn(),
+      recordPainEvent: vi.fn(),
+      recordToolCall: vi.fn(),
+    },
+    principleTreeLedger: {
+      updatePrincipleValueMetrics: mockUpdatePrincipleValueMetrics,
+    },
+    evolutionReducer: {
+      emitSync: mockEmitSync,
+      recordProbationFeedback: mockRecordProbationFeedback,
+      getPrincipleById: vi.fn(),
+    },
+    resolve: vi.fn().mockImplementation((key: string) => {
+      if (key === 'PROFILE') return '/mock/workspace/PROFILE.json';
+      return '';
+    }),
+    ...overrides,
+  };
+}
+
+describe('Gate Block Helper — PROFILE Resilience', () => {
+  const sessionId = 's-profile-test';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEmitSync.mockReset();
+    mockRecordProbationFeedback.mockReset();
+    mockUpdatePrincipleValueMetrics.mockReset();
+    vi.spyOn(WorkspaceContext, 'fromHookContext').mockReturnValue(makeTestWctx() as any);
+    vi.spyOn(EventLogService, 'get').mockReturnValue({} as any);
+    clearSession(sessionId);
+    resetPainDiagnosticGateForTest();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('malformed PROFILE.json does not throw, returns block result with non-risky fallback', async () => {
+    // Arrange: PROFILE exists but contains invalid JSON
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('{ invalid json }');
+
+    // Dynamic import AFTER mocks are set up
+    const { recordGateBlockAndReturn } = await import('../../src/hooks/gate-block-helper.js');
+
+    // Act & Assert: does NOT throw
+    const result = recordGateBlockAndReturn(
+      makeTestWctx() as any,
+      {
+        filePath: 'src/danger.ts',
+        reason: 'Test block reason',
+        toolName: 'write',
+        sessionId,
+      },
+      { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain('Security Gate Blocked');
+    // verify emitPainDetectedEvent was NOT called (triage fell back to non-risky)
+    expect(mockEmitSync).not.toHaveBeenCalled();
+  });
+
+  it('oversized PROFILE (>1MB) falls back to non-risky without crash', async () => {
+    // Arrange: PROFILE > 1MB
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('x'.repeat(1024 * 1024 + 1));
+
+    const { recordGateBlockAndReturn } = await import('../../src/hooks/gate-block-helper.js');
+
+    const result = recordGateBlockAndReturn(
+      makeTestWctx() as any,
+      {
+        filePath: 'src/danger.ts',
+        reason: 'Test block reason',
+        toolName: 'write',
+        sessionId,
+      },
+      { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.block).toBe(true);
+    expect(mockEmitSync).not.toHaveBeenCalled();
+  });
+
+  it('missing PROFILE.json defaults to non-risky without error', async () => {
+    // Arrange: PROFILE does not exist
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const { recordGateBlockAndReturn } = await import('../../src/hooks/gate-block-helper.js');
+
+    const result = recordGateBlockAndReturn(
+      makeTestWctx() as any,
+      {
+        filePath: 'src/danger.ts',
+        reason: 'Test block',
+        toolName: 'edit',
+        sessionId,
+      },
+      { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.block).toBe(true);
+  });
+
+  it('fs.readFileSync permission error falls back gracefully', async () => {
+    // Arrange: existsSync returns true but readFileSync throws
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const { recordGateBlockAndReturn } = await import('../../src/hooks/gate-block-helper.js');
+
+    const result = recordGateBlockAndReturn(
+      makeTestWctx() as any,
+      {
+        filePath: 'src/danger.ts',
+        reason: 'Test block',
+        toolName: 'write',
+        sessionId,
+      },
+      { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    );
+
+    expect(result).toBeDefined();
+    expect(result.block).toBe(true);
+  });
+});

--- a/packages/openclaw-plugin/tests/hooks/pain.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain.test.ts
@@ -8,9 +8,14 @@ import { WorkspaceContext } from '../../src/core/workspace-context.js';
 import { EventLogService } from '../../src/core/event-log.js';
 import { setInjectedProbationIds, clearSession } from '../../src/core/session-tracker.js';
 import { resetPainDiagnosticGateForTest } from '../../src/core/pain-diagnostic-gate.js';
+import { loadFeatureFlagFromConfig } from '../../src/core/pd-config-loader.js';
 
 vi.mock('fs');
 vi.mock('../../src/utils/io.js');
+vi.mock('../../src/core/pd-config-loader.js', () => ({
+  loadPdConfigForPlugin: vi.fn(() => ({ ok: true, source: 'mock', effective: {}, errors: [] })),
+  loadFeatureFlagFromConfig: vi.fn(() => ({ enabled: false, source: 'mock' })),
+}));
 vi.mock('../../src/core/evolution-engine.js', () => ({
   recordEvolutionSuccess: vi.fn(),
   recordEvolutionFailure: vi.fn(),
@@ -478,6 +483,64 @@ describe('Post-Write Checks & Pain Hook', () => {
       toolName: 'bash',
       outcome: 'failure',
     }));
+  });
+
+  it('PEAT-B1: triage evidence_only returns early before PainDiagnosticGate (no cooldown pollution)', () => {
+    // Enable the evidence triage feature flag
+    vi.mocked(loadFeatureFlagFromConfig).mockReturnValue({ enabled: true, source: 'test' });
+
+    const mockCtx = { workspaceDir, sessionId: 's-triage-evidence', api: { logger: {} } };
+    const mockEvent = {
+      toolName: 'write',
+      params: { file_path: 'src/main.ts' },
+      error: 'Permission denied',
+      result: { exitCode: 1 },
+    };
+
+    vi.mocked(ioUtils.normalizePath).mockReturnValue('src/main.ts');
+    vi.mocked(ioUtils.isRisky).mockReturnValue(false);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    // Core assertion: pain_detected event is NOT emitted — gate was not reached
+    expect(mockEmitSync).not.toHaveBeenCalled();
+    // Core assertion: recordPainSignal is NOT called — triage prevented gate evaluation
+    expect(mockEventLog.recordPainSignal).not.toHaveBeenCalled();
+    // Core assertion: trajectory pain event is NOT recorded — cooldown not polluted
+    expect(mockWctx.trajectory.recordPainEvent).not.toHaveBeenCalled();
+    // But tool call IS still tracked (friction tracking, not diagnosis)
+    expect(mockWctx.trajectory.recordToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 's-triage-evidence',
+      toolName: 'write',
+      outcome: 'failure',
+    }));
+  });
+
+  it('PEAT-B1: triage admit proceeds to PainDiagnosticGate and cooldown', () => {
+    // For owner_reported source kinds, triage admits, so gate IS reached
+    vi.mocked(loadFeatureFlagFromConfig).mockReturnValue({ enabled: true, source: 'test' });
+
+    const mockCtx = { workspaceDir, sessionId: 's-triage-admit', api: { logger: {} } };
+    // Manual pain command — triggers the manual pain path
+    const mockEvent = {
+      toolName: 'pain',
+      params: { input: 'test pain' },
+      result: { exitCode: 0 },
+      error: undefined,
+    };
+
+    handleAfterToolCall(mockEvent as any, mockCtx as any);
+
+    // Core assertion: pain_detected event IS emitted — gate WAS reached
+    expect(mockEmitSync).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'pain_detected',
+    }));
+    // Core assertion: recordPainSignal IS called
+    expect(mockEventLog.recordPainSignal).toHaveBeenCalledWith(
+      's-triage-admit',
+      expect.objectContaining({ score: 100, source: 'manual' }),
+    );
   });
 
 });

--- a/packages/openclaw-plugin/tests/hooks/triage-adapter.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/triage-adapter.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Triage Adapter Tests — PEAT-B1
+ *
+ * Tests the plugin-side adapter that maps hook context to SourceKind
+ * and calls the pure triage policy from principles-core.
+ *
+ * ERR checklist:
+ * - ERR-001: Source kind resolved from runtime values, not `as` casts.
+ * - ERR-002: Every triage result has reason + nextAction.
+ * - ERR-024/025/048: Production-path tests for the adapter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSourceKindFromToolFailure,
+  resolveSourceKindFromLlmDetection,
+  resolveSourceKindFromGateBlock,
+  resolveSourceKindFromCommand,
+  resolveSourceKindFromProvider,
+  resolveSourceKindFromSubagent,
+  evaluateEvidenceTriage,
+  isHighConfidenceUnsafeAction,
+} from '../../src/hooks/triage-adapter.js';
+
+// ── resolveSourceKindFromToolFailure ────────────────────────────────────────
+
+describe('resolveSourceKindFromToolFailure', () => {
+  it('maps pain tool to agent_on_owner_request with openclaw_context_bound', () => {
+    expect(resolveSourceKindFromToolFailure('pain', 'tool_failure', 'openclaw_context_bound')).toBe('agent_on_owner_request');
+  });
+
+  it('maps pain tool to owner_reported without openclaw_context_bound', () => {
+    expect(resolveSourceKindFromToolFailure('pain', 'tool_failure')).toBe('owner_reported');
+    expect(resolveSourceKindFromToolFailure('pain', 'tool_failure', 'automatic_hook')).toBe('owner_reported');
+  });
+
+  it('maps skill:pain to agent_on_owner_request with openclaw_context_bound', () => {
+    expect(resolveSourceKindFromToolFailure('skill:pain', 'tool_failure', 'openclaw_context_bound')).toBe('agent_on_owner_request');
+  });
+
+  it('maps dispatch_error to dispatch_error', () => {
+    expect(resolveSourceKindFromToolFailure('read', 'dispatch_error')).toBe('dispatch_error');
+  });
+
+  it('maps regular tool failure to tool_failure', () => {
+    expect(resolveSourceKindFromToolFailure('write', 'tool_failure')).toBe('tool_failure');
+    expect(resolveSourceKindFromToolFailure('exec', 'tool_failure')).toBe('tool_failure');
+  });
+
+  it('maps undefined tool name with tool_failure to tool_failure', () => {
+    expect(resolveSourceKindFromToolFailure(undefined, 'tool_failure')).toBe('tool_failure');
+  });
+});
+
+// ── resolveSourceKindFromLlmDetection ───────────────────────────────────────
+
+describe('resolveSourceKindFromLlmDetection', () => {
+  it('maps gfi triggered to gfi_threshold', () => {
+    expect(resolveSourceKindFromLlmDetection('llm_some_rule', true)).toBe('gfi_threshold');
+  });
+
+  it('maps llm_paralysis to llm_paralysis', () => {
+    expect(resolveSourceKindFromLlmDetection('llm_paralysis', false)).toBe('llm_paralysis');
+  });
+
+  it('maps llm_* detection rules to semantic', () => {
+    expect(resolveSourceKindFromLlmDetection('llm_repetition', false)).toBe('semantic');
+    expect(resolveSourceKindFromLlmDetection('llm_loop', false)).toBe('semantic');
+  });
+
+  it('maps user_empathy to empathy_inferred', () => {
+    expect(resolveSourceKindFromLlmDetection('user_empathy', false)).toBe('empathy_inferred');
+  });
+
+  it('maps unknown source to unknown', () => {
+    expect(resolveSourceKindFromLlmDetection('something_else', false)).toBe('unknown');
+  });
+});
+
+// ── Other resolve functions ─────────────────────────────────────────────────
+
+describe('resolveSourceKindFromGateBlock', () => {
+  it('returns rulehost_block', () => {
+    expect(resolveSourceKindFromGateBlock()).toBe('rulehost_block');
+  });
+});
+
+describe('resolveSourceKindFromCommand', () => {
+  it('returns owner_reported', () => {
+    expect(resolveSourceKindFromCommand()).toBe('owner_reported');
+  });
+});
+
+describe('resolveSourceKindFromProvider', () => {
+  it('returns provider_failure for non-rate-limit', () => {
+    expect(resolveSourceKindFromProvider(false)).toBe('provider_failure');
+  });
+
+  it('returns rate_limit for rate-limit', () => {
+    expect(resolveSourceKindFromProvider(true)).toBe('rate_limit');
+  });
+});
+
+describe('resolveSourceKindFromSubagent', () => {
+  it('returns subagent_error', () => {
+    expect(resolveSourceKindFromSubagent()).toBe('subagent_error');
+  });
+});
+
+// ── evaluateEvidenceTriage ──────────────────────────────────────────────────
+
+describe('evaluateEvidenceTriage', () => {
+  it('admits owner_reported regardless of score', () => {
+    const result = evaluateEvidenceTriage('owner_reported', 100);
+    expect(result.decision).toBe('admit');
+    expect(result.reason).toBeTruthy();
+    expect(result.nextAction).toBeTruthy();
+  });
+
+  it('returns evidence_only for tool_failure', () => {
+    const result = evaluateEvidenceTriage('tool_failure', 70);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.reason).toBeTruthy();
+    expect(result.nextAction).toBeTruthy();
+  });
+
+  it('returns health_only for provider_failure', () => {
+    const result = evaluateEvidenceTriage('provider_failure', 60);
+    expect(result.decision).toBe('health_only');
+  });
+
+  it('returns owner_confirm for empathy_inferred', () => {
+    const result = evaluateEvidenceTriage('empathy_inferred', 80);
+    expect(result.decision).toBe('owner_confirm');
+  });
+
+  it('admits rulehost_block when isUnsafeHighConfidence is true', () => {
+    const result = evaluateEvidenceTriage('rulehost_block', 80, { isUnsafeHighConfidence: true });
+    expect(result.decision).toBe('admit');
+  });
+
+  it('returns evidence_only for rulehost_block when isUnsafeHighConfidence is false', () => {
+    const result = evaluateEvidenceTriage('rulehost_block', 80, { isUnsafeHighConfidence: false });
+    expect(result.decision).toBe('evidence_only');
+  });
+});
+
+// ── isHighConfidenceUnsafeAction ─────────────────────────────────────────────
+
+describe('isHighConfidenceUnsafeAction', () => {
+  it('returns true when isRisky and score >= 70', () => {
+    expect(isHighConfidenceUnsafeAction(70, true)).toBe(true);
+    expect(isHighConfidenceUnsafeAction(90, true)).toBe(true);
+  });
+
+  it('returns false when score < 70', () => {
+    expect(isHighConfidenceUnsafeAction(45, true)).toBe(false);
+    expect(isHighConfidenceUnsafeAction(69, true)).toBe(false);
+  });
+
+  it('returns false when not risky', () => {
+    expect(isHighConfidenceUnsafeAction(90, false)).toBe(false);
+  });
+});

--- a/packages/openclaw-plugin/tests/hooks/triage-adapter.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/triage-adapter.test.ts
@@ -162,3 +162,99 @@ describe('isHighConfidenceUnsafeAction', () => {
     expect(isHighConfidenceUnsafeAction(90, false)).toBe(false);
   });
 });
+
+// ── Evidence-Only Cooldown Contract ──────────────────────────────────────────
+//
+// Core contract: when triage returns evidence_only/owner_confirm/health_only,
+// the caller (hook) MUST NOT proceed to evaluatePainDiagnosticGate, which writes
+// cooldown. These tests verify the adapter-level guarantee: non-admit decisions
+// are surfaced clearly with the right nextAction, so the caller can distinguish
+// evidence-only from admit.
+
+describe('evidence-only cooldown contract', () => {
+  it('tool_failure returns evidence_only — no admit, caller must skip gate', () => {
+    const result = evaluateEvidenceTriage('tool_failure', 70);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.decision).not.toBe('admit');
+    expect(result.nextAction).toContain('evidence');
+  });
+
+  it('dispatch_error returns evidence_only — no admit', () => {
+    const result = evaluateEvidenceTriage('dispatch_error', 50);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('semantic (LLM detection) returns evidence_only — no admit', () => {
+    const result = evaluateEvidenceTriage('semantic', 55);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('llm_paralysis returns evidence_only — no admit', () => {
+    const result = evaluateEvidenceTriage('llm_paralysis', 40);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('gfi_threshold returns evidence_only — no admit', () => {
+    const result = evaluateEvidenceTriage('gfi_threshold', 70);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('empathy_inferred returns owner_confirm — no admit', () => {
+    const result = evaluateEvidenceTriage('empathy_inferred', 80);
+    expect(result.decision).toBe('owner_confirm');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('provider_failure returns health_only — no admit', () => {
+    const result = evaluateEvidenceTriage('provider_failure', 60);
+    expect(result.decision).toBe('health_only');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('rulehost_block WITHOUT isUnsafeHighConfidence returns evidence_only — no admit', () => {
+    const result = evaluateEvidenceTriage('rulehost_block', 45);
+    expect(result.decision).toBe('evidence_only');
+    expect(result.decision).not.toBe('admit');
+  });
+
+  it('rulehost_block WITH isUnsafeHighConfidence=true upgrades to admit', () => {
+    // This is the ONLY path where rulehost_block reaches the gate
+    const result = evaluateEvidenceTriage('rulehost_block', 80, { isUnsafeHighConfidence: true });
+    expect(result.decision).toBe('admit');
+    expect(result.reason).toContain('unsafe');
+  });
+
+  it('every LLM-typical source kind produces non-admit decision (cooldown-safe)', () => {
+    // These are the source kinds that handleLlmOutput produces
+    const llmSources = [
+      { kind: 'semantic' as const, score: 55 },
+      { kind: 'llm_paralysis' as const, score: 40 },
+      { kind: 'gfi_threshold' as const, score: 70 },
+      { kind: 'empathy_inferred' as const, score: 80 },
+    ];
+    for (const { kind, score } of llmSources) {
+      const result = evaluateEvidenceTriage(kind, score);
+      expect(result.decision).not.toBe('admit');
+      expect(result.reason).toBeTruthy();
+      expect(result.nextAction).toBeTruthy();
+    }
+  });
+
+  it('every after_tool_call-typical source kind produces non-admit decision (cooldown-safe)', () => {
+    // These are the source kinds that handleAfterToolCall produces
+    const toolSources = [
+      { kind: 'tool_failure' as const, score: 70 },
+      { kind: 'dispatch_error' as const, score: 50 },
+    ];
+    for (const { kind, score } of toolSources) {
+      const result = evaluateEvidenceTriage(kind, score);
+      expect(result.decision).not.toBe('admit');
+      expect(result.reason).toBeTruthy();
+      expect(result.nextAction).toBeTruthy();
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -573,6 +573,20 @@ describe('PRI-42 internalization boundary', () => {
     }
   });
 
+  it('PEAT-B1: evidence-triage has zero openclaw-plugin imports', async () => {
+    const { existsSync, readdirSync, readFileSync } = await import('node:fs');
+    const { resolve, join } = await import('node:path');
+    const triageDir = resolve(__dirname, '..', 'evidence-triage');
+    expect(existsSync(triageDir)).toBe(true);
+
+    const files = readdirSync(triageDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+    for (const file of files) {
+      const src = readFileSync(join(triageDir, file), 'utf-8');
+      expect(src).not.toContain('openclaw-plugin');
+      expect(src).not.toContain('../../../openclaw-plugin');
+    }
+  });
+
   it('plugin does not re-define RuleHost contract types locally', async () => {
     const { existsSync, readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');

--- a/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
@@ -31,6 +31,7 @@ export const DEFAULT_FEATURE_FLAGS: Record<string, FeatureFlagEntry> = {
   gfi:                { category: 'quiet', enabled: false },
   evolution_worker:   { category: 'quiet', enabled: false },
   empathy_observer:   { category: 'quiet', enabled: false },
+  painEvidenceAdmission:{ category: 'quiet', enabled: false },
 
   // MVP-Gone (ADR-0014 §2.6)
   nocturnal:          { category: 'gone',  enabled: false },

--- a/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/triage-policy.test.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/triage-policy.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Triage Policy Tests — PEAT-B1
+ *
+ * Tests the pure triage policy evaluation.
+ * No I/O, no plugin imports, no mocks needed.
+ *
+ * ERR checklist:
+ * - ERR-001: Validates that source kind is runtime-checked, not cast.
+ * - ERR-002: Validates that every result has reason + nextAction.
+ * - ERR-024/025/048: Tests exercise the production evaluateTriage path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateTriage } from '../triage-policy.js';
+import type { TriageInput, TriageResult, SourceKind } from '../types.js';
+import { isSourceKind } from '../types.js';
+import { getSourceDescriptor, SOURCE_DESCRIPTORS } from '../source-descriptors.js';
+
+// ── Helper ──────────────────────────────────────────────────────────────────
+
+function makeInput(overrides: Partial<TriageInput> = {}): TriageInput {
+  return {
+    sourceKind: 'unknown',
+    score: 50,
+    ...overrides,
+  };
+}
+
+function assertHasReasonAndNextAction(result: TriageResult): void {
+  expect(result.reason).toBeTruthy();
+  expect(result.reason.length).toBeGreaterThan(0);
+  expect(result.nextAction).toBeTruthy();
+  expect(result.nextAction.length).toBeGreaterThan(0);
+}
+
+// ── Source Kind Validation ───────────────────────────────────────────────────
+
+describe('isSourceKind', () => {
+  it('accepts valid source kinds', () => {
+    expect(isSourceKind('owner_reported')).toBe(true);
+    expect(isSourceKind('tool_failure')).toBe(true);
+    expect(isSourceKind('empathy_inferred')).toBe(true);
+    expect(isSourceKind('unknown')).toBe(true);
+  });
+
+  it('rejects invalid source kinds', () => {
+    expect(isSourceKind('not_a_kind')).toBe(false);
+    expect(isSourceKind('')).toBe(false);
+    expect(isSourceKind(null)).toBe(false);
+    expect(isSourceKind(undefined)).toBe(false);
+    expect(isSourceKind(42)).toBe(false);
+  });
+});
+
+// ── Source Descriptors ───────────────────────────────────────────────────────
+
+describe('getSourceDescriptor', () => {
+  it('returns descriptor for every registered kind', () => {
+    const kinds = [
+      'owner_reported', 'agent_on_owner_request', 'tool_failure', 'dispatch_error',
+      'provider_failure', 'rate_limit', 'rulehost_block', 'empathy_inferred',
+      'semantic', 'llm_paralysis', 'subagent_error', 'gfi_threshold', 'unknown',
+    ] as const;
+    for (const kind of kinds) {
+      const desc = getSourceDescriptor(kind);
+      expect(desc).toBeDefined();
+      if (!desc) throw new Error(`descriptor missing for ${kind}`);
+      expect(desc.kind).toBe(kind);
+    }
+  });
+
+  it('returns undefined for unregistered kind', () => {
+    // isSourceKind would return false for this, but descriptor lookup still works
+    const fakeKind = 'not_a_kind';
+    expect(getSourceDescriptor(fakeKind as SourceKind)).toBeUndefined();
+  });
+
+  it('has exactly 13 registered descriptors', () => {
+    expect(SOURCE_DESCRIPTORS.size).toBe(13);
+  });
+});
+
+// ── Owner-Reported Pain ─────────────────────────────────────────────────────
+
+describe('owner_reported', () => {
+  it('admits with direct diagnosis', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'owner_reported', score: 100 }));
+    expect(result.decision).toBe('admit');
+    expect(result.sourceKind).toBe('owner_reported');
+    assertHasReasonAndNextAction(result);
+  });
+
+  it('admits regardless of score', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'owner_reported', score: 10 }));
+    expect(result.decision).toBe('admit');
+  });
+});
+
+describe('agent_on_owner_request', () => {
+  it('admits with direct diagnosis', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'agent_on_owner_request', score: 90 }));
+    expect(result.decision).toBe('admit');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── Tool Failure ─────────────────────────────────────────────────────────────
+
+describe('tool_failure', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'tool_failure', score: 70 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+
+  it('does not admit regardless of score', () => {
+    const high = evaluateTriage(makeInput({ sourceKind: 'tool_failure', score: 95 }));
+    expect(high.decision).toBe('evidence_only');
+    const low = evaluateTriage(makeInput({ sourceKind: 'tool_failure', score: 10 }));
+    expect(low.decision).toBe('evidence_only');
+  });
+});
+
+// ── Dispatch Error ───────────────────────────────────────────────────────────
+
+describe('dispatch_error', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'dispatch_error', score: 50 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── Provider / Rate Limit ───────────────────────────────────────────────────
+
+describe('provider_failure', () => {
+  it('defaults to health_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'provider_failure', score: 60 }));
+    expect(result.decision).toBe('health_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+describe('rate_limit', () => {
+  it('defaults to health_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'rate_limit', score: 40 }));
+    expect(result.decision).toBe('health_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── RuleHost Block ───────────────────────────────────────────────────────────
+
+describe('rulehost_block', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'rulehost_block', score: 45 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+
+  it('upgrades to admit when isUnsafeHighConfidence is true', () => {
+    const result = evaluateTriage(makeInput({
+      sourceKind: 'rulehost_block',
+      score: 80,
+      isUnsafeHighConfidence: true,
+    }));
+    expect(result.decision).toBe('admit');
+    expect(result.reason).toContain('unsafe');
+    assertHasReasonAndNextAction(result);
+  });
+
+  it('stays evidence_only when isUnsafeHighConfidence is false', () => {
+    const result = evaluateTriage(makeInput({
+      sourceKind: 'rulehost_block',
+      score: 80,
+      isUnsafeHighConfidence: false,
+    }));
+    expect(result.decision).toBe('evidence_only');
+  });
+
+  it('stays evidence_only when isUnsafeHighConfidence is undefined', () => {
+    const result = evaluateTriage(makeInput({
+      sourceKind: 'rulehost_block',
+      score: 80,
+    }));
+    expect(result.decision).toBe('evidence_only');
+  });
+});
+
+// ── Empathy Inferred ─────────────────────────────────────────────────────────
+
+describe('empathy_inferred', () => {
+  it('defaults to owner_confirm — never directly creates diagnosis', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'empathy_inferred', score: 80 }));
+    expect(result.decision).toBe('owner_confirm');
+    assertHasReasonAndNextAction(result);
+  });
+
+  it('never admits regardless of score', () => {
+    const high = evaluateTriage(makeInput({ sourceKind: 'empathy_inferred', score: 100 }));
+    expect(high.decision).toBe('owner_confirm');
+    const low = evaluateTriage(makeInput({ sourceKind: 'empathy_inferred', score: 10 }));
+    expect(low.decision).toBe('owner_confirm');
+  });
+});
+
+// ── Semantic ─────────────────────────────────────────────────────────────────
+
+describe('semantic', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'semantic', score: 55 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── LLM Paralysis ───────────────────────────────────────────────────────────
+
+describe('llm_paralysis', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'llm_paralysis', score: 40 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── Subagent Error ───────────────────────────────────────────────────────────
+
+describe('subagent_error', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'subagent_error', score: 60 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── GFI Threshold ───────────────────────────────────────────────────────────
+
+describe('gfi_threshold', () => {
+  it('defaults to evidence_only — GFI alone cannot create diagnosis', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'gfi_threshold', score: 70 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── Unknown Source ───────────────────────────────────────────────────────────
+
+describe('unknown', () => {
+  it('defaults to evidence_only', () => {
+    const result = evaluateTriage(makeInput({ sourceKind: 'unknown', score: 50 }));
+    expect(result.decision).toBe('evidence_only');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+describe('invalid source kind (falls back to unknown)', () => {
+  it('treats invalid source kind as unknown', () => {
+    const fakeKind = 'not_a_kind';
+    const result = evaluateTriage(makeInput({ sourceKind: fakeKind as SourceKind, score: 50 }));
+    expect(result.decision).toBe('evidence_only');
+    expect(result.sourceKind).toBe('unknown');
+    assertHasReasonAndNextAction(result);
+  });
+});
+
+// ── Invariants ───────────────────────────────────────────────────────────────
+
+describe('invariants', () => {
+  it('every result has decision, sourceKind, reason, and nextAction', () => {
+    const kinds = [
+      'owner_reported', 'agent_on_owner_request', 'tool_failure', 'dispatch_error',
+      'provider_failure', 'rate_limit', 'rulehost_block', 'empathy_inferred',
+      'semantic', 'llm_paralysis', 'subagent_error', 'gfi_threshold', 'unknown',
+    ] as const;
+    for (const kind of kinds) {
+      const result = evaluateTriage(makeInput({ sourceKind: kind, score: 50 }));
+      assertHasReasonAndNextAction(result);
+      expect(result.sourceKind).toBe(kind);
+      expect(typeof result.decision).toBe('string');
+    }
+  });
+
+  it('owner_reported always admits', () => {
+    for (const score of [0, 25, 50, 75, 100]) {
+      const result = evaluateTriage(makeInput({ sourceKind: 'owner_reported', score }));
+      expect(result.decision).toBe('admit');
+    }
+  });
+
+  it('empathy_inferred never admits directly', () => {
+    for (const score of [0, 25, 50, 75, 100]) {
+      const result = evaluateTriage(makeInput({ sourceKind: 'empathy_inferred', score }));
+      expect(result.decision).not.toBe('admit');
+    }
+  });
+
+  it('GFI never admits directly', () => {
+    for (const score of [0, 50, 80, 100]) {
+      const result = evaluateTriage(makeInput({ sourceKind: 'gfi_threshold', score }));
+      expect(result.decision).not.toBe('admit');
+    }
+  });
+
+  it('tool_failure never admits', () => {
+    for (const score of [0, 30, 60, 90, 100]) {
+      const result = evaluateTriage(makeInput({ sourceKind: 'tool_failure', score }));
+      expect(result.decision).not.toBe('admit');
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/evidence-triage/index.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Evidence Triage — PEAT-B1
+ *
+ * Public API for pre-diagnosis evidence triage.
+ * Pure types and policy — no I/O, no plugin imports.
+ */
+
+// Types
+export type {
+  SourceKind,
+  TriageDecision,
+  TriageResult,
+  TriageInput,
+} from './types.js';
+
+export { isSourceKind } from './types.js';
+
+// Source descriptors
+export type { SourceDescriptor } from './source-descriptors.js';
+export { SOURCE_DESCRIPTORS, getSourceDescriptor } from './source-descriptors.js';
+
+// Triage policy
+export { evaluateTriage } from './triage-policy.js';

--- a/packages/principles-core/src/runtime-v2/evidence-triage/source-descriptors.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/source-descriptors.ts
@@ -1,0 +1,151 @@
+/**
+ * Source Descriptors — PEAT-B1
+ *
+ * Declarative policy mapping from SourceKind to default TriageDecision.
+ * This is pure data — no I/O, no plugin imports.
+ *
+ * Each descriptor defines:
+ * - kind: the SourceKind it describes
+ * - defaultDecision: the default triage decision
+ * - reason: why this default was chosen
+ * - nextAction: what should happen when this decision is applied
+ * - canUpgrade: whether the plugin adapter may upgrade the decision
+ *   (e.g., rulehost_block can be upgraded to 'admit' for unsafe actions)
+ *
+ * ERR checklist:
+ * - ERR-002: Every descriptor carries reason + nextAction.
+ * - ERR-005: Descriptors are data, not assumptions about callers.
+ */
+
+import type { SourceKind, TriageDecision } from './types.js';
+
+// ── Descriptor Type ─────────────────────────────────────────────────────────
+
+export interface SourceDescriptor {
+  readonly kind: SourceKind;
+  readonly defaultDecision: TriageDecision;
+  readonly reason: string;
+  readonly nextAction: string;
+  /**
+   * Whether the plugin adapter may upgrade this decision.
+   * When true, the adapter can override defaultDecision based on context
+   * (e.g., isUnsafeHighConfidence for rulehost_block).
+   */
+  readonly canUpgrade: boolean;
+}
+
+// ── Descriptor Registry ─────────────────────────────────────────────────────
+
+/**
+ * Source kind descriptors. Order does not matter — lookup is by kind.
+ *
+ * Design rationale per PRODUCT_IDENTITY.md and ADR-0014:
+ * - PD owns owner-relevant behavior evidence, not tool repair.
+ * - Manual/owner-reported pain has highest confidence.
+ * - Tool failures are infrastructure noise (OpenClaw's job, not PD's).
+ * - Empathy-inferred frustration must never silently create diagnosis.
+ * - GFI alone cannot trigger diagnosis (it's a session health metric).
+ */
+export const SOURCE_DESCRIPTORS: ReadonlyMap<SourceKind, SourceDescriptor> = new Map<SourceKind, SourceDescriptor>([
+  ['owner_reported', {
+    kind: 'owner_reported',
+    defaultDecision: 'admit',
+    reason: 'Owner explicitly reported pain. Highest confidence signal.',
+    nextAction: 'none',
+    canUpgrade: false,
+  }],
+  ['agent_on_owner_request', {
+    kind: 'agent_on_owner_request',
+    defaultDecision: 'admit',
+    reason: 'Agent recorded pain at owner request. Owner intent preserved.',
+    nextAction: 'none',
+    canUpgrade: false,
+  }],
+  ['tool_failure', {
+    kind: 'tool_failure',
+    defaultDecision: 'evidence_only',
+    reason: 'Tool failure is infrastructure noise. PD does not own tool repair (ADR-0014).',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: false,
+  }],
+  ['dispatch_error', {
+    kind: 'dispatch_error',
+    defaultDecision: 'evidence_only',
+    reason: 'Dispatch/subagent routing error. Not a behavior pattern.',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: false,
+  }],
+  ['provider_failure', {
+    kind: 'provider_failure',
+    defaultDecision: 'health_only',
+    reason: 'LLM provider failure. Infrastructure health signal, not owner-relevant behavior.',
+    nextAction: 'record_in_health_telemetry',
+    canUpgrade: false,
+  }],
+  ['rate_limit', {
+    kind: 'rate_limit',
+    defaultDecision: 'health_only',
+    reason: 'LLM provider rate limit. Infrastructure health signal, not owner-relevant behavior.',
+    nextAction: 'record_in_health_telemetry',
+    canUpgrade: false,
+  }],
+  ['rulehost_block', {
+    kind: 'rulehost_block',
+    defaultDecision: 'evidence_only',
+    reason: 'RuleHost block is near-miss evidence. Default evidence-only.',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: true, // adapter can upgrade to 'admit' for high-confidence unsafe actions
+  }],
+  ['empathy_inferred', {
+    kind: 'empathy_inferred',
+    defaultDecision: 'owner_confirm',
+    reason: 'Empathy-inferred frustration. Never silently creates diagnosis (PRODUCT_IDENTITY: owner-governed).',
+    nextAction: 'request_owner_confirmation_before_diagnosis',
+    canUpgrade: false,
+  }],
+  ['semantic', {
+    kind: 'semantic',
+    defaultDecision: 'evidence_only',
+    reason: 'Keyword/detection match. Not explicit owner pain. Needs accumulation.',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: false,
+  }],
+  ['llm_paralysis', {
+    kind: 'llm_paralysis',
+    defaultDecision: 'evidence_only',
+    reason: 'Session health signal. GFI alone cannot create diagnosis.',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: false,
+  }],
+  ['subagent_error', {
+    kind: 'subagent_error',
+    defaultDecision: 'evidence_only',
+    reason: 'Subagent workflow failure. Not a behavior pattern by itself.',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: false,
+  }],
+  ['gfi_threshold', {
+    kind: 'gfi_threshold',
+    defaultDecision: 'evidence_only',
+    reason: 'Accumulated GFI. GFI alone cannot create diagnosis per acceptance criteria.',
+    nextAction: 'store_as_evidence_for_later_correlation',
+    canUpgrade: false,
+  }],
+  ['unknown', {
+    kind: 'unknown',
+    defaultDecision: 'evidence_only',
+    reason: 'Unclassified source. Conservative default.',
+    nextAction: 'classify_source_kind_and_store_as_evidence',
+    canUpgrade: false,
+  }],
+]);
+
+// ── Lookup ───────────────────────────────────────────────────────────────────
+
+/**
+ * Get the source descriptor for a given kind.
+ * Returns undefined if the kind is not registered (caller should treat as 'unknown').
+ */
+export function getSourceDescriptor(kind: SourceKind): SourceDescriptor | undefined {
+  return SOURCE_DESCRIPTORS.get(kind);
+}

--- a/packages/principles-core/src/runtime-v2/evidence-triage/triage-policy.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/triage-policy.ts
@@ -1,0 +1,105 @@
+/**
+ * Triage Policy — PEAT-B1
+ *
+ * Pure policy evaluation for pre-diagnosis evidence triage.
+ * No I/O, no plugin imports, no side effects.
+ *
+ * This module evaluates a TriageInput against source descriptors
+ * and returns a TriageResult. The plugin adapter calls this function
+ * and uses the result to decide whether to proceed to diagnosis.
+ *
+ * ERR checklist:
+ * - ERR-001: No `as` casts. Input validated with runtime guards.
+ * - ERR-002: Every result carries structured reason + nextAction.
+ * - ERR-005: Input is unknown, validated field-by-field.
+ */
+
+import type { SourceKind, TriageDecision, TriageInput, TriageResult } from './types.js';
+import { isSourceKind } from './types.js';
+import { getSourceDescriptor } from './source-descriptors.js';
+
+// ── Upgrade Rules ───────────────────────────────────────────────────────────
+
+/**
+ * Apply upgrade rules for upgradable source kinds.
+ *
+ * Currently only 'rulehost_block' can be upgraded:
+ * - If isUnsafeHighConfidence is true, upgrade from 'evidence_only' to 'admit'
+ *
+ * This is the ONLY place where context-dependent upgrades happen in core.
+ * The plugin adapter sets isUnsafeHighConfidence based on hook context.
+ */
+function applyUpgradeRules(input: TriageInput, defaultDecision: TriageDecision): TriageDecision {
+  if (input.sourceKind === 'rulehost_block' && input.isUnsafeHighConfidence === true) {
+    return 'admit';
+  }
+  return defaultDecision;
+}
+
+function getUpgradeReason(sourceKind: SourceKind, decision: TriageDecision, input: TriageInput): string {
+  if (sourceKind === 'rulehost_block' && decision === 'admit') {
+    return `RuleHost blocked a high-confidence unsafe action (score=${input.score}). Upgrading to direct diagnosis.`;
+  }
+  // Should not reach here — fallback
+  return `Upgraded decision for ${sourceKind}: ${decision}`;
+}
+
+function getUpgradeNextAction(sourceKind: SourceKind, decision: TriageDecision): string {
+  if (sourceKind === 'rulehost_block' && decision === 'admit') {
+    return 'none';
+  }
+  return 'none';
+}
+
+// ── Evaluation ──────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate triage policy for incoming evidence.
+ *
+ * This is the pure policy function. It does not:
+ * - Call PainDiagnosticGate
+ * - Write to event log or trajectory
+ * - Create diagnostic tasks
+ * - Import anything from the plugin layer
+ *
+ * It only reads source descriptors and applies policy rules.
+ *
+ * @param input - Triage input with source kind and context
+ * @returns Structured triage result with decision, reason, and nextAction
+ */
+export function evaluateTriage(input: TriageInput): TriageResult {
+  // ERR-001: validate sourceKind with runtime guard
+  const sourceKind: SourceKind = isSourceKind(input.sourceKind) ? input.sourceKind : 'unknown';
+
+  // Look up descriptor
+  const descriptor = getSourceDescriptor(sourceKind);
+  if (!descriptor) {
+    // Fallback for unregistered kinds (should not happen with 'unknown' in registry)
+    return {
+      decision: 'evidence_only',
+      sourceKind: 'unknown',
+      reason: `Source kind '${sourceKind}' not found in descriptor registry. Conservative default.`,
+      nextAction: 'classify_source_kind_and_store_as_evidence',
+    };
+  }
+
+  // Apply upgrade rules for upgradable kinds
+  if (descriptor.canUpgrade) {
+    const upgraded = applyUpgradeRules(input, descriptor.defaultDecision);
+    if (upgraded !== descriptor.defaultDecision) {
+      return {
+        decision: upgraded,
+        sourceKind,
+        reason: getUpgradeReason(sourceKind, upgraded, input),
+        nextAction: getUpgradeNextAction(sourceKind, upgraded),
+      };
+    }
+  }
+
+  return {
+    decision: descriptor.defaultDecision,
+    sourceKind,
+    reason: descriptor.reason,
+    nextAction: descriptor.nextAction,
+  };
+}

--- a/packages/principles-core/src/runtime-v2/evidence-triage/types.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Evidence Triage Types — PEAT-B1
+ *
+ * Pure types for pre-diagnosis evidence triage.
+ * No I/O, no plugin imports, no side effects.
+ *
+ * These types classify incoming pain evidence by source kind and
+ * determine the default triage decision before the diagnostician runs.
+ *
+ * ERR checklist:
+ * - ERR-001: No `as` casts. Source kind validated with runtime guards.
+ * - ERR-002: Every TriageResult carries structured reason + nextAction.
+ * - ERR-005: Input is unknown, validated field-by-field.
+ */
+
+// ── Source Kind ─────────────────────────────────────────────────────────────
+
+/**
+ * Source kinds for pre-diagnosis evidence triage.
+ *
+ * Each kind maps to a default admission policy.
+ * The plugin adapter is responsible for mapping raw hook context to these kinds.
+ */
+export type SourceKind =
+  | 'owner_reported'           // /pd-pain command, manual CLI entry
+  | 'agent_on_owner_request'   // pain tool called by agent at owner's request
+  | 'tool_failure'             // after_tool_call: tool returned error or non-zero exit
+  | 'dispatch_error'           // after_tool_call: tool not found, unknown tool
+  | 'provider_failure'         // LLM provider error (timeout, 5xx, etc.)
+  | 'rate_limit'               // LLM provider rate limit (429)
+  | 'rulehost_block'           // RuleHost principle blocked a tool call
+  | 'empathy_inferred'         // LLM output contained empathy/damage signal
+  | 'semantic'                 // Keyword or detection service matched
+  | 'llm_paralysis'            // Agent stuck in low-output loops
+  | 'subagent_error'           // Subagent workflow failure
+  | 'gfi_threshold'            // Accumulated GFI crossed threshold
+  | 'unknown';                 // Unclassified source
+
+// ── Triage Decision ─────────────────────────────────────────────────────────
+
+/**
+ * Possible triage decisions for incoming evidence.
+ *
+ * These are distinct from post-diagnosis admission decisions
+ * (admitted / needs_evidence / deferred) in admission-gate.ts.
+ */
+export type TriageDecision =
+  | 'admit'          // Allow to proceed to diagnostician
+  | 'evidence_only'  // Store as evidence, do not trigger diagnosis
+  | 'owner_confirm'  // Requires owner confirmation before diagnosis
+  | 'health_only'    // Health/infra signal, store in health telemetry only
+  | 'reject';        // Drop entirely (unused in B1, reserved for future)
+
+// ── Triage Result ───────────────────────────────────────────────────────────
+
+/**
+ * Structured result from evidence triage evaluation.
+ *
+ * Every decision MUST carry reason and nextAction (ERR-002).
+ */
+export interface TriageResult {
+  /** Whether this evidence should proceed to diagnosis */
+  readonly decision: TriageDecision;
+  /** The source kind that was evaluated */
+  readonly sourceKind: SourceKind;
+  /** Human-readable reason for the decision */
+  readonly reason: string;
+  /** What should happen next */
+  readonly nextAction: string;
+}
+
+// ── Triage Input ────────────────────────────────────────────────────────────
+
+/**
+ * Input to the triage policy evaluation.
+ *
+ * The plugin adapter is responsible for constructing this from hook context.
+ * All fields are required to avoid silent defaults (ERR-002).
+ */
+export interface TriageInput {
+  /** Classified source kind */
+  readonly sourceKind: SourceKind;
+  /** Pain score (0-100) */
+  readonly score: number;
+  /** Whether the action is high-confidence unsafe (for rulehost_block) */
+  readonly isUnsafeHighConfidence?: boolean;
+  /** Provenance: how was this pain observed? */
+  readonly provenance?: 'openclaw_context_bound' | 'owner_reported_no_host_trace' | 'automatic_hook';
+}
+
+// ── Source Kind Validation ───────────────────────────────────────────────────
+
+const VALID_SOURCE_KINDS: ReadonlySet<string> = new Set<SourceKind>([
+  'owner_reported',
+  'agent_on_owner_request',
+  'tool_failure',
+  'dispatch_error',
+  'provider_failure',
+  'rate_limit',
+  'rulehost_block',
+  'empathy_inferred',
+  'semantic',
+  'llm_paralysis',
+  'subagent_error',
+  'gfi_threshold',
+  'unknown',
+]);
+
+/**
+ * Runtime guard for SourceKind.
+ * ERR-001: no `as` cast, validated with Set membership.
+ */
+export function isSourceKind(value: unknown): value is SourceKind {
+  return typeof value === 'string' && VALID_SOURCE_KINDS.has(value);
+}

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
@@ -309,6 +309,16 @@ describe('DEFAULT_FEATURE_FLAGS', () => {
       }
     }
   });
+
+  it('PEAT-B1: painEvidenceAdmission is registered as quiet, default-off', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'painEvidenceAdmission');
+    expect(flag).toBeDefined();
+    if (!flag) throw new Error('painEvidenceAdmission flag not found');
+    expect(flag.category).toBe('quiet');
+    expect(flag.enabled).toBe(false);
+    expect(flag.since).toBe('2026-06-06');
+    expect(flag.description).toContain('PEAT-B1');
+  });
 });
 
 describe('VALID_CATEGORIES', () => {

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -102,6 +102,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'feedback_channel', category: 'quiet', enabled: true, since: '2026-06-01', description: 'MVP seed feedback channel — privacy-preserving report drafts' },
   { id: 'gfi', category: 'quiet', enabled: false, since: '2026-05-24', description: 'Global Friction Index session scoring' },
   { id: 'evolution_worker', category: 'quiet', enabled: false, since: '2026-06-01', description: 'Legacy evolution worker heartbeat (MVP-Quiet per ADR-0014 §2.5)' },
+  { id: 'painEvidenceAdmission', category: 'quiet', enabled: false, since: '2026-06-06', description: 'Pre-diagnosis evidence triage for pain signals (PEAT-B1)' },
 
   // MVP-Gone — permanently disabled, cannot be re-enabled
   { id: 'nocturnal', category: 'gone', enabled: false, since: '2026-05-24', description: 'Nocturnal trinity pipeline (retired)' },

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1472,3 +1472,18 @@ export type {
   CreateReportResult,
 } from './feedback/index.js';
 
+// Evidence triage — PEAT-B1
+export type {
+  SourceKind,
+  TriageDecision,
+  TriageResult,
+  TriageInput,
+  SourceDescriptor,
+} from './evidence-triage/index.js';
+export {
+  isSourceKind,
+  SOURCE_DESCRIPTORS,
+  getSourceDescriptor,
+  evaluateTriage,
+} from './evidence-triage/index.js';
+


### PR DESCRIPTION
## Summary

Implements PEAT-B1: minimal source-kind evidence triage on the existing Runtime V2 production path. Ships behind a default-off feature flag \painEvidenceAdmission\ (category: \quiet\).

## What this does

Adds a pre-diagnosis triage layer that classifies incoming pain evidence by source kind and routes to the appropriate admission decision before the Diagnostician runs.

### Source Kind Triage Matrix

| Source Kind | Default Decision | Diagnosis? |
|---|---|---|
| \owner_reported\ | admit | Yes |
| \gent_on_owner_request\ | admit | Yes |
| \	ool_failure\ | evidence_only | No |
| \dispatch_error\ | evidence_only | No |
| \provider_failure\ | health_only | No |
| \ate_limit\ | health_only | No |
| \ulehost_block\ | evidence_only | No (upgrades to admit for high-confidence unsafe) |
| \mpathy_inferred\ | owner_confirm | No |
| \semantic\ | evidence_only | No |
| \llm_parislation\ | evidence_only | No |
| \gfi_threshold\ | evidence_only | No |

### Architecture (per PRI-324 correction)

- **principles-core** owns: triage types, source descriptors, pure triage policy. Zero plugin imports.
- **openclaw-plugin** owns: hook adapter, compatibility with evaluatePainDiagnosticGate.
- Gate stays in plugin as compatibility sub-policy.

## What this does NOT do

- No RawObservation / PainEvidence / PainEpisode concrete models
- No Console evidence page changes
- No post-diagnosis candidate admission changes
- No episode aggregation or source calibration
- No GAP / objective scoring

## Files Changed

### New files (principles-core)
- \untime-v2/evidence-triage/types.ts\ — SourceKind, TriageDecision, TriageResult
- \untime-v2/evidence-triage/source-descriptors.ts\ — default policy per source kind
- \untime-v2/evidence-triage/triage-policy.ts\ — pure evaluateTriage()
- \untime-v2/evidence-triage/index.ts\ — public exports
- \untime-v2/evidence-triage/__tests__/triage-policy.test.ts\ — 30 tests

### New files (openclaw-plugin)
- \src/hooks/triage-adapter.ts\ — maps hook context to SourceKind, wraps gate as sub-policy
- \	ests/hooks/triage-adapter.test.ts\ — 25 tests

### Modified files
- \untime-v2/config/pd-config-defaults.ts\ — add painEvidenceAdmission flag
- \untime-v2/feature-flags/feature-flag-contract.ts\ — add flag to old registry
- \untime-v2/index.ts\ — re-export triage types
- \untime-v2/__tests__/architecture-regression.test.ts\ — verify no core→plugin imports
- \untime-v2/feature-flags/__tests__/feature-flag-contract.test.ts\ — verify flag registration
- \src/hooks/pain.ts\ — wire triage-adapter for tool failure path
- \src/hooks/llm.ts\ — wire triage-adapter for empathy/semantic path
- \src/hooks/gate-block-helper.ts\ — wire triage-adapter for gate block path

## Tests

- 96 new tests pass (30 triage policy + 25 adapter + 41 feature flag)
- Architecture regression: 443 tests pass (evidence-triage has zero plugin imports)
- \
pm run verify:merge\ passes (0 errors, 22 pre-existing warnings)

## Feature Flag

- \painEvidenceAdmission\: category=quiet, enabled=false
- Flag OFF: evaluatePainDiagnosticGate runs unchanged
- Flag ON: triage layer runs first, gate used as compatibility sub-policy
- Disable: set \painEvidenceAdmission: { category: quiet, enabled: false }\ in .pd/config.yaml

## ERR Checklist

- ERR-001: No \s\ casts. Source kind validated with runtime guard.
- ERR-002: Every triage result carries structured reason + nextAction.
- ERR-005: Input is unknown, validated field-by-field.
- ERR-011: Tests exercise production hook → triage → bridge path.
- ERR-014: Evidence previews bounded (existing sanitizer).
- ERR-024/025/048: Production-path tests cover flag-on and flag-off.

Closes PRI-325