### PR TITLE
fix(runtime): harden diagnostician structured output across runtimes

### DIFF
--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/json-extractor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractJsonObject } from '../json-extractor.js';
+import { extractJsonObject, repairMalformedJson } from '../json-extractor.js';
 
 describe('extractJsonObject', () => {
   it('parses pure JSON object', () => {
@@ -171,5 +171,64 @@ describe('extractJsonObject', () => {
     const input = '[{"template":"Use {braces} here"}]';
     const result = extractJsonObject(input);
     expect(result).toBeNull();
+  });
+});
+
+// ── repairMalformedJson ──────────────────────────────────────────────────────
+
+describe('repairMalformedJson', () => {
+  it('returns valid JSON unchanged', () => {
+    const input = '{"diagnosisId":"d1","summary":"ok"}';
+    const result = repairMalformedJson(input);
+    expect(result).toEqual({ diagnosisId: 'd1', summary: 'ok' });
+  });
+
+  it('repairs unescaped double quotes inside string values', () => {
+    // This is the real failure case: LLM outputs "wrong" inside a string value
+    const input = '{"rootCause":"Design: the "wrong" approach caused failure"}';
+    const result = repairMalformedJson(input);
+    expect(result).not.toBeNull();
+    expect(result?.rootCause).toContain('wrong');
+  });
+
+  it('repairs multiple unescaped quotes in different fields', () => {
+    const input = '{"summary":"He said "hello" and "goodbye"","rootCause":"the "bug" was here"}';
+    const result = repairMalformedJson(input);
+    expect(result).not.toBeNull();
+    expect(result?.summary).toContain('hello');
+    expect(result?.rootCause).toContain('bug');
+  });
+
+  it('handles already-escaped quotes correctly (no double-escaping)', () => {
+    const input = '{"msg":"He said \\"hello\\""}';
+    const result = repairMalformedJson(input);
+    expect(result).not.toBeNull();
+    expect(result?.msg).toBe('He said "hello"');
+  });
+
+  it('extracts from prose-wrapped malformed JSON', () => {
+    const input = 'Here is the result:\n{"diagnosisId":"d1","rootCause":"the "bug" was here"}\nEnd.';
+    const result = repairMalformedJson(input);
+    expect(result).not.toBeNull();
+    expect(result?.diagnosisId).toBe('d1');
+  });
+
+  it('returns null for completely unparseable text', () => {
+    const result = repairMalformedJson('no json here at all');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for text with no opening brace', () => {
+    const result = repairMalformedJson('just some text "with quotes"');
+    expect(result).toBeNull();
+  });
+
+  it('repairs DiagnosticianOutputV1-like malformed JSON', () => {
+    const input = '{"diagnosisId":"diag-1","summary":"test","rootCause":"the "primary" issue","violatedPrinciples":[],"evidence":[],"recommendations":[],"confidence":0.8}';
+    const result = repairMalformedJson(input);
+    expect(result).not.toBeNull();
+    expect(result?.diagnosisId).toBe('diag-1');
+    expect(result?.rootCause).toContain('primary');
+    expect(result?.confidence).toBe(0.8);
   });
 });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts
@@ -653,4 +653,157 @@ describe('OpenClawCliRuntimeAdapter', () => {
       expect(result.warnings.some(w => w.includes('probe returned unexpected result') || w.includes('unparseable'))).toBe(true);
     });
   });
+
+  // ── OCRA-05: Malformed JSON repair + evidence persistence ──────────────────
+
+  describe('OCRA-05: malformed JSON repair', () => {
+    it('repairs JSON-like text with unescaped quotes inside string values', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      // Simulate LLM output where a string value contains an unescaped quote
+      // e.g., {"rootCause": "Design: the "wrong" approach"} → balanced-bracket extraction finds the object
+      const malformedJson = '{"valid":true,"diagnosisId":"diag-repair-1","summary":"test","rootCause":"Design: the approach","violatedPrinciples":[],"evidence":[],"recommendations":[],"confidence":0.8}';
+      const mockOutput = makeCliOutput({ stdout: malformedJson, exitCode: 0 });
+      mockRunCliProcess.mockResolvedValue(mockOutput);
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+      });
+
+      const result = await adapter.fetchOutput(handle.runId);
+      expect(result.payload).toMatchObject({ diagnosisId: 'diag-repair-1' });
+    });
+
+    it('repairs JSON embedded in prose with surrounding text', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      const validJson = JSON.stringify(VALID_PAYLOAD);
+      const proseWrapped = `Here is the diagnosis result:\n${validJson}\nEnd of result.`;
+      const mockOutput = makeCliOutput({ stdout: proseWrapped, exitCode: 0 });
+      mockRunCliProcess.mockResolvedValue(mockOutput);
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+      });
+
+      const result = await adapter.fetchOutput(handle.runId);
+      expect(result.payload).toMatchObject({ diagnosisId: 'diag-1' });
+    });
+
+    it('repairs JSON from stderr when stdout is empty', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      const validJson = JSON.stringify(VALID_PAYLOAD);
+      const mockOutput = makeCliOutput({ stdout: '', stderr: validJson, exitCode: 0 });
+      mockRunCliProcess.mockResolvedValue(mockOutput);
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+      });
+
+      const result = await adapter.fetchOutput(handle.runId);
+      expect(result.payload).toMatchObject({ diagnosisId: 'diag-1' });
+    });
+  });
+
+  describe('OCRA-05: output_invalid evidence persistence', () => {
+    it('includes parseFailureReason, boundedRawOutputPreview, and nextAction when JSON parse fails', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      const mockOutput = makeCliOutput({ stdout: 'this is not JSON at all!!!', stderr: '', exitCode: 0 });
+      mockRunCliProcess.mockResolvedValue(mockOutput);
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+      });
+
+      try {
+        await adapter.fetchOutput(handle.runId);
+        expect.fail('Expected PDRuntimeError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PDRuntimeError);
+        const pdErr = err as PDRuntimeError;
+        expect(pdErr.category).toBe('output_invalid');
+        expect(pdErr.details).toBeDefined();
+        expect(pdErr.details?.parseFailureReason).toBe('no_json_object_found');
+        expect(pdErr.details?.boundedRawOutputPreview).toBeDefined();
+        expect(typeof pdErr.details?.boundedRawOutputPreview).toBe('string');
+        expect(pdErr.details?.nextAction).toBeDefined();
+        // Privacy: preview must be bounded (max 500 chars)
+        expect((pdErr.details?.boundedRawOutputPreview as string).length).toBeLessThanOrEqual(500);
+      }
+    });
+
+    it('includes schemaErrors and boundedRawOutputPreview when schema validation fails', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      const invalidPayload = { valid: true /* missing required fields */ };
+      const mockOutput = makeCliOutput({ stdout: JSON.stringify(invalidPayload), exitCode: 0 });
+      mockRunCliProcess.mockResolvedValue(mockOutput);
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+      });
+
+      try {
+        await adapter.fetchOutput(handle.runId);
+        expect.fail('Expected PDRuntimeError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PDRuntimeError);
+        const pdErr = err as PDRuntimeError;
+        expect(pdErr.category).toBe('output_invalid');
+        expect(pdErr.details?.parseFailureReason).toBe('schema_validation_failed');
+        expect(pdErr.details?.boundedRawOutputPreview).toBeDefined();
+        expect(Array.isArray(pdErr.details?.schemaErrors)).toBe(true);
+        expect((pdErr.details?.schemaErrors as unknown[])?.length).toBeGreaterThan(0);
+        expect(pdErr.details?.nextAction).toBeDefined();
+        // Privacy: preview must be bounded
+        expect((pdErr.details?.boundedRawOutputPreview as string).length).toBeLessThanOrEqual(500);
+      }
+    });
+
+    it('does not leak API keys or full trajectories in boundedRawOutputPreview', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      // Simulate output that might contain sensitive data
+      const sensitivePayload = {
+        valid: true,
+        apiKey: 'sk-super-secret-key-12345',
+        trajectory: 'x'.repeat(5000),
+      };
+      const mockOutput = makeCliOutput({ stdout: JSON.stringify(sensitivePayload), exitCode: 0 });
+      mockRunCliProcess.mockResolvedValue(mockOutput);
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+      });
+
+      try {
+        await adapter.fetchOutput(handle.runId);
+        expect.fail('Expected PDRuntimeError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PDRuntimeError);
+        const pdErr = err as PDRuntimeError;
+        // The preview is bounded — the full 5000-char trajectory should NOT appear in full
+        const preview = pdErr.details?.boundedRawOutputPreview as string;
+        expect(preview.length).toBeLessThanOrEqual(500);
+        // The preview must end with "..." truncation marker (safeStringifyPreview truncates)
+        expect(preview.endsWith('...')).toBe(true);
+        // The full 5000-char trajectory is not present (only a truncated prefix)
+        expect(preview.length).toBeLessThan(JSON.stringify(sensitivePayload).length);
+      }
+    });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts
@@ -660,8 +660,8 @@ describe('OpenClawCliRuntimeAdapter', () => {
     it('repairs JSON-like text with unescaped quotes inside string values', async () => {
       const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
       // Simulate LLM output where a string value contains an unescaped quote
-      // e.g., {"rootCause": "Design: the "wrong" approach"} → balanced-bracket extraction finds the object
-      const malformedJson = '{"valid":true,"diagnosisId":"diag-repair-1","summary":"test","rootCause":"Design: the approach","violatedPrinciples":[],"evidence":[],"recommendations":[],"confidence":0.8}';
+      // This is genuinely malformed JSON: the "wrong" inside the rootCause value is not escaped
+      const malformedJson = '{"valid":true,"diagnosisId":"diag-repair-1","summary":"test diagnosis","rootCause":"Design: the "wrong" approach caused failure","violatedPrinciples":[{"rationale":"bad design"}],"evidence":[{"sourceRef":"src","note":"note"}],"recommendations":[{"kind":"principle","description":"fix it"}],"confidence":0.8}';
       const mockOutput = makeCliOutput({ stdout: malformedJson, exitCode: 0 });
       mockRunCliProcess.mockResolvedValue(mockOutput);
 
@@ -674,6 +674,10 @@ describe('OpenClawCliRuntimeAdapter', () => {
 
       const result = await adapter.fetchOutput(handle.runId);
       expect(result.payload).toMatchObject({ diagnosisId: 'diag-repair-1' });
+      // Verify the unescaped quotes were repaired correctly
+      const payload = result.payload as Record<string, unknown>;
+      expect(typeof payload.rootCause).toBe('string');
+      expect(payload.rootCause).toContain('wrong');
     });
 
     it('repairs JSON embedded in prose with surrounding text', async () => {
@@ -777,7 +781,7 @@ describe('OpenClawCliRuntimeAdapter', () => {
       // Simulate output that might contain sensitive data
       const sensitivePayload = {
         valid: true,
-        apiKey: 'sk-super-secret-key-12345',
+        apiKey: 'sk-super-secret-key-1234567890abcdef',
         trajectory: 'x'.repeat(5000),
       };
       const mockOutput = makeCliOutput({ stdout: JSON.stringify(sensitivePayload), exitCode: 0 });
@@ -803,6 +807,10 @@ describe('OpenClawCliRuntimeAdapter', () => {
         expect(preview.endsWith('...')).toBe(true);
         // The full 5000-char trajectory is not present (only a truncated prefix)
         expect(preview.length).toBeLessThan(JSON.stringify(sensitivePayload).length);
+        // ERR-055/056: API key must be redacted, not leaked verbatim
+        expect(preview).not.toContain('sk-super-secret-key-1234567890abcdef');
+        // The apiKey field should be redacted by redactSensitiveFields
+        expect(preview).toContain('[REDACTED]');
       }
     });
   });

--- a/packages/principles-core/src/runtime-v2/adapter/json-extractor.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/json-extractor.ts
@@ -73,3 +73,112 @@ export function extractJsonObject(text: string): Record<string, unknown> | null 
   }
   return null;
 }
+
+/**
+ * Attempt syntactic repair of malformed JSON where string values contain
+ * unescaped double quotes (a common LLM output error).
+ *
+ * Strategy: find the outermost `{...}` via balanced-bracket scan, then
+ * try to fix unescaped quotes by escaping inner double-quote characters
+ * that appear between key-value separators (`: `) and field separators (`,`).
+ *
+ * This is a BEST-EFFORT heuristic — it handles the most common LLM mistake
+ * (unescaped quotes in string values) but is not a general JSON repair.
+ * Returns the parsed object, or null if repair fails.
+ */
+export function repairMalformedJson(text: string): Record<string, unknown> | null {
+  // Find the outermost {...} via balanced-bracket scan
+  let start = -1;
+  let depth = 0;
+  let end = -1;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '{') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+
+  if (start < 0 || end < 0) return null;
+
+  let candidate = text.slice(start, end + 1);
+
+  // Try parsing as-is first
+  try {
+    const parsed = JSON.parse(candidate);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch { /* needs repair */ }
+
+  // Heuristic: escape unescaped double quotes inside string values.
+  // Walk character-by-character tracking JSON structure state.
+  // When inside a string value (after `: ` and before `,` or `}`),
+  // escape any unescaped `"` that is NOT at a structural boundary.
+  const chars = [...candidate];
+  let inString = false;
+  let escaped = false;
+  let result = '';
+
+  for (let i = 0; i < chars.length; i++) {
+    const ch = chars[i];
+
+    if (escaped) {
+      result += ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\' && inString) {
+      result += ch;
+      escaped = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      if (!inString) {
+        // Opening quote
+        inString = true;
+        result += ch;
+      } else {
+        // Closing quote — but is it really a closing quote?
+        // Look ahead: if followed by `:` it's a key end (valid)
+        // If followed by `,` or `}` or `]` or whitespace+`,` etc. it's a value end (valid)
+        // Otherwise it's likely an unescaped quote inside a string value
+        const rest = candidate.slice(i + 1).trimStart();
+        if (
+          rest.startsWith(':') ||      // end of key
+          rest.startsWith(',') ||      // end of value
+          rest.startsWith('}') ||      // end of last value in object
+          rest.startsWith(']') ||      // end of last value in array
+          rest.length === 0            // end of text
+        ) {
+          // This is a structural closing quote
+          inString = false;
+          result += ch;
+        } else {
+          // This is an unescaped quote inside a string value — escape it
+          result += '\\"';
+        }
+      }
+      continue;
+    }
+
+    result += ch;
+  }
+
+  try {
+    const parsed = JSON.parse(result);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch { /* repair failed */ }
+
+  return null;
+}

--- a/packages/principles-core/src/runtime-v2/adapter/openclaw-cli-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/openclaw-cli-runtime-adapter.ts
@@ -21,6 +21,9 @@ import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
 import type { StoreEventEmitter} from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { safeStringifyPreview, truncatePreview } from './output-repair-contract.js';
+import { redactTelemetryString } from '../feedback/redact-sensitive.js';
+import { redactSensitiveFields } from '../feedback/redact-sensitive.js';
+import { repairMalformedJson } from './json-extractor.js';
 import type {
   PDRuntimeAdapter,
   RuntimeKind,
@@ -790,9 +793,9 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
     }
 
     // OCRA-05: When initial JSON parse fails, attempt bounded repair via extractJsonObject
-    // on the raw stdout/stderr text before giving up.
+    // and repairMalformedJson on the raw stdout/stderr text before giving up.
     if (parsed === null) {
-      // Try repair: scan raw text for a JSON object using balanced-bracket extraction
+      // Repair step 1: scan raw text for a JSON object using balanced-bracket extraction
       const repairSources = [cliOutput.stdout, cliOutput.stderr ?? ''];
       for (const source of repairSources) {
         if (!source) continue;
@@ -803,10 +806,25 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
         }
       }
 
+      // Repair step 2: attempt syntactic repair of malformed JSON (e.g., unescaped quotes)
+      if (parsed === null) {
+        for (const source of repairSources) {
+          if (!source) continue;
+          const repaired = repairMalformedJson(source);
+          if (repaired !== null) {
+            parsed = repaired;
+            break;
+          }
+        }
+      }
+
       if (parsed === null) {
         // OCRA-05: Evidence persistence on output_invalid — no silent fallback (ERR-002)
+        // ERR-055/056: redact tokens/paths from raw output before persisting preview
+        const rawText = cliOutput.stdout || cliOutput.stderr || '';
+        const redacted = redactTelemetryString(rawText.substring(0, 2000));
         const boundedPreview = truncatePreview(
-          (cliOutput.stdout || cliOutput.stderr || '').substring(0, 2000),
+          typeof redacted === 'string' ? redacted : '',
           500,
         );
         throw new PDRuntimeError(
@@ -823,11 +841,15 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
 
     // OCRA-03: Validate DiagnosticianOutputV1Schema
     // OCRA-05: On schema mismatch, include evidence with bounded preview (ERR-014/016/017)
+    // ERR-055/056: redact sensitive fields from parsed payload before persisting preview
     if (!Value.Check(DiagnosticianOutputV1Schema, parsed)) {
       const schemaErrors = [...Value.Errors(DiagnosticianOutputV1Schema, parsed)]
         .slice(0, 10)
         .map(e => ({ path: e.path, message: e.message }));
-      const boundedPreview = safeStringifyPreview(parsed, 500);
+      const redacted = redactSensitiveFields(parsed);
+      const boundedPreview = redacted.ok
+        ? safeStringifyPreview(redacted.value, 500)
+        : safeStringifyPreview(parsed, 500);
 
       throw new PDRuntimeError(
         'output_invalid',

--- a/packages/principles-core/src/runtime-v2/adapter/openclaw-cli-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/openclaw-cli-runtime-adapter.ts
@@ -20,6 +20,7 @@ import { PDRuntimeError } from '../error-categories.js';
 import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
 import type { StoreEventEmitter} from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
+import { safeStringifyPreview, truncatePreview } from './output-repair-contract.js';
 import type {
   PDRuntimeAdapter,
   RuntimeKind,
@@ -742,6 +743,7 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
   }
 
   // OCRA-03: fetchOutput parses CliOutput.stdout and returns DiagnosticianOutputV1
+  // OCRA-05: Malformed JSON repair + evidence persistence on output_invalid
   async fetchOutput(runId: string): Promise<StructuredRunOutput> {
     const state = this.runStateMap.get(runId);
     if (!state || !state.completed || !state.cliOutput) {
@@ -787,15 +789,56 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
       parsed = null;
     }
 
+    // OCRA-05: When initial JSON parse fails, attempt bounded repair via extractJsonObject
+    // on the raw stdout/stderr text before giving up.
     if (parsed === null) {
-      // OCRA-04: JSON parse failure → output_invalid
-      throw new PDRuntimeError('output_invalid', 'Failed to parse CLI output as JSON');
+      // Try repair: scan raw text for a JSON object using balanced-bracket extraction
+      const repairSources = [cliOutput.stdout, cliOutput.stderr ?? ''];
+      for (const source of repairSources) {
+        if (!source) continue;
+        const repaired = extractJsonObject(source);
+        if (repaired !== null) {
+          parsed = repaired;
+          break;
+        }
+      }
+
+      if (parsed === null) {
+        // OCRA-05: Evidence persistence on output_invalid — no silent fallback (ERR-002)
+        const boundedPreview = truncatePreview(
+          (cliOutput.stdout || cliOutput.stderr || '').substring(0, 2000),
+          500,
+        );
+        throw new PDRuntimeError(
+          'output_invalid',
+          'Failed to parse CLI output as JSON',
+          {
+            parseFailureReason: 'no_json_object_found',
+            boundedRawOutputPreview: boundedPreview,
+            nextAction: 'Check openclaw agent output format; ensure agent returns valid JSON',
+          },
+        );
+      }
     }
 
     // OCRA-03: Validate DiagnosticianOutputV1Schema
-    // OCRA-04: Schema mismatch → output_invalid
+    // OCRA-05: On schema mismatch, include evidence with bounded preview (ERR-014/016/017)
     if (!Value.Check(DiagnosticianOutputV1Schema, parsed)) {
-      throw new PDRuntimeError('output_invalid', 'CLI output does not match DiagnosticianOutputV1 schema');
+      const schemaErrors = [...Value.Errors(DiagnosticianOutputV1Schema, parsed)]
+        .slice(0, 10)
+        .map(e => ({ path: e.path, message: e.message }));
+      const boundedPreview = safeStringifyPreview(parsed, 500);
+
+      throw new PDRuntimeError(
+        'output_invalid',
+        'CLI output does not match DiagnosticianOutputV1 schema',
+        {
+          parseFailureReason: 'schema_validation_failed',
+          boundedRawOutputPreview: boundedPreview,
+          schemaErrors,
+          nextAction: 'Review schema errors; check LLM output format and required fields',
+        },
+      );
     }
 
     return { runId, payload: parsed };

--- a/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-agent-binding.test.ts
+++ b/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-agent-binding.test.ts
@@ -667,4 +667,104 @@ describe('createAdapterConfigFromProfile', () => {
     if (openclawResult.runtimeKind !== 'openclaw-cli') return;
     expect(openclawResult.workspaceDir).toBe('/another/workspace/path');
   });
+
+  // ── pi-ai.lmstudio profile resolution ─────────────────────────────────────
+
+  it('pi-ai.lmstudio profile resolves to runtimeKind=pi-ai with baseUrl', () => {
+    const result = createAdapterConfigFromProfile(
+      {
+        type: 'pi-ai',
+        provider: 'lmstudio',
+        model: 'qwen3.6-27b-mtp',
+        apiKeyEnv: 'LMSTUDIO_API_KEY',
+        baseUrl: 'http://localhost:12341/v1',
+        timeoutMs: 600_000,
+      },
+      '/workspace/test',
+    );
+
+    expect(result.runtimeKind).toBe('pi-ai');
+    if (result.runtimeKind !== 'pi-ai') return;
+    expect(result.provider).toBe('lmstudio');
+    expect(result.model).toBe('qwen3.6-27b-mtp');
+    expect(result.apiKeyEnv).toBe('LMSTUDIO_API_KEY');
+    expect(result.baseUrl).toBe('http://localhost:12341/v1');
+    expect(result.timeoutMs).toBe(600_000);
+  });
+
+  it('pi-ai.lmstudio readiness check with LMSTUDIO_API_KEY set', () => {
+    const result = checkAgentRuntimeReadiness(
+      {
+        type: 'pi-ai',
+        provider: 'lmstudio',
+        model: 'qwen3.6-27b-mtp',
+        apiKeyEnv: 'LMSTUDIO_API_KEY',
+        baseUrl: 'http://localhost:12341/v1',
+        timeoutMs: 600_000,
+      },
+      (name) => name === 'LMSTUDIO_API_KEY' ? 'lm-test-key' : undefined,
+    );
+    expect(result.readiness).toBe('ready');
+  });
+
+  it('pi-ai.lmstudio readiness check with LMSTUDIO_API_KEY missing', () => {
+    const result = checkAgentRuntimeReadiness(
+      {
+        type: 'pi-ai',
+        provider: 'lmstudio',
+        model: 'qwen3.6-27b-mtp',
+        apiKeyEnv: 'LMSTUDIO_API_KEY',
+        baseUrl: 'http://localhost:12341/v1',
+        timeoutMs: 600_000,
+      },
+      () => undefined,
+    );
+    expect(result.readiness).toBe('not_ready');
+    expect(result.reason).toContain('LMSTUDIO_API_KEY');
+    expect(result.nextAction).toBeTruthy();
+  });
+
+  it('diagnostician resolves to pi-ai.lmstudio when configured', () => {
+    const config = makeConfigWithOverrides({
+      runtimeProfiles: {
+        'openclaw.default': { type: 'openclaw', source: 'default' },
+        'pi-ai.lmstudio': {
+          type: 'pi-ai',
+          provider: 'lmstudio',
+          model: 'qwen3.6-27b-mtp',
+          apiKeyEnv: 'LMSTUDIO_API_KEY',
+          baseUrl: 'http://localhost:12341/v1',
+          timeoutMs: 600_000,
+        },
+      },
+      internalAgents: {
+        defaultRuntime: 'openclaw.default',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.lmstudio' },
+          dreamer: { enabled: true },
+          philosopher: { enabled: false },
+          scribe: { enabled: true },
+          artificer: { enabled: true },
+          evaluator: { enabled: false },
+          rolloutReviewer: { enabled: false },
+          trainer: { enabled: false },
+          correctionObserver: { enabled: false },
+          empathyObserver: { enabled: false },
+        },
+      },
+    });
+    const effective = computeEffectivePdConfig(config);
+    const result = resolveAgentRuntimeBinding(effective, 'diagnostician');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profileId).toBe('pi-ai.lmstudio');
+    expect(result.profile.type).toBe('pi-ai');
+    if (result.profile.type === 'pi-ai') {
+      expect(result.profile.provider).toBe('lmstudio');
+      expect(result.profile.model).toBe('qwen3.6-27b-mtp');
+      expect(result.profile.baseUrl).toBe('http://localhost:12341/v1');
+    }
+    expect(result.source).toBe('agent_override');
+  });
 });

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/diagnostician-runner.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/diagnostician-runner.test.ts
@@ -853,4 +853,57 @@ describe('DiagnosticianRunner', () => {
       expect(mocks._stateManager.markTaskRetryWait).not.toHaveBeenCalled();
     });
   });
+
+  // ── ERR-001/005: Runner boundary schema validation ──────────────────────────
+
+  describe('Runner boundary schema validation (ERR-001/005)', () => {
+    it('rejects adapter payload that does not match DiagnosticianOutputV1Schema', async () => {
+      const mocks = createMocks();
+      // Adapter returns payload that bypasses its own validation (defense-in-depth test)
+      mocks._runtimeAdapter.fetchOutput = vi.fn().mockResolvedValue({
+        runId: RUN_ID,
+        payload: { wrong: 'shape', missing: 'all required fields' },
+      });
+
+      const runner = createRunner(mocks);
+      const result = await runner.run(TASK_ID);
+
+      // Should end up in retry_wait/output_invalid, not silently accepted
+      expect(result.status).toBe('retried');
+      expect(result.errorCategory).toBe('output_invalid');
+    });
+
+    it('includes evidence in output_invalid error when runner boundary rejects payload', async () => {
+      const mocks = createMocks();
+      mocks._runtimeAdapter.fetchOutput = vi.fn().mockResolvedValue({
+        runId: RUN_ID,
+        payload: { invalid: true },
+      });
+
+      const runner = createRunner(mocks);
+      const result = await runner.run(TASK_ID);
+
+      expect(result.status).toBe('retried');
+      expect(result.errorCategory).toBe('output_invalid');
+      // The retry_wait call should have been made with output_invalid
+      expect(mocks._stateManager.markTaskRetryWait).toHaveBeenCalledWith(
+        TASK_ID,
+        'output_invalid',
+      );
+    });
+
+    it('accepts valid DiagnosticianOutputV1 payload through runner boundary', async () => {
+      const mocks = createMocks();
+      const validOutput = makeDiagnosticianOutput();
+      mocks._runtimeAdapter.fetchOutput = vi.fn().mockResolvedValue({
+        runId: RUN_ID,
+        payload: validOutput,
+      });
+
+      const runner = createRunner(mocks);
+      const result = await runner.run(TASK_ID);
+
+      expect(result.status).toBe('succeeded');
+    });
+  });
 });

--- a/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
@@ -26,6 +26,7 @@ import type {
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import type { DiagnosticianContextPayload } from '../context-payload.js';
 import type { DiagnosticianOutputV1 } from '../diagnostician-output.js';
+import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
 import { DiagnosticianPromptBuilder } from '../diagnostician-prompt-builder.js';
 import type { TaskRecord } from '../task-status.js';
 import type { PDErrorCategory } from '../error-categories.js';
@@ -35,6 +36,8 @@ import type { RunnerResult } from './runner-result.js';
 import type { DiagnosticianCommitter, CommitResult } from '../store/commit/diagnostician-committer.js';
 import type { TelemetryEvent } from '../../telemetry-event.js';
 import { PDRuntimeError } from '../error-categories.js';
+import { Value } from '@sinclair/typebox/value';
+import { safeStringifyPreview } from '../adapter/output-repair-contract.js';
 import { RunnerPhase } from './runner-phase.js';
 import { resolveRunnerOptions } from './diagnostician-runner-options.js';
 
@@ -126,7 +129,7 @@ export class DiagnosticianRunner {
     this.phase = RunnerPhase.Idle;
 
     // 1. Acquire lease — isolated try/catch so lease_conflict never uses synthetic TaskRecord
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let leasedTask: TaskRecord;
     try {
       leasedTask = await this.stateManager.acquireLease({
@@ -297,7 +300,33 @@ export class DiagnosticianRunner {
     if (!result || !result.payload) {
       throw new PDRuntimeError('output_invalid', `No output available for run ${runId}`);
     }
-    return result.payload as DiagnosticianOutputV1;
+
+    // ERR-001/ERR-005: Do NOT use `as DiagnosticianOutputV1` to bypass validation.
+    // The adapter may return payload that passed its own schema check, but the runner
+    // must independently verify the shape before trusting it (defense-in-depth).
+    // Adapters that already validated (e.g., PiAiRuntimeAdapter, OpenClawCliRuntimeAdapter)
+    // will pass this check trivially; adapters that don't validate will be caught here.
+    if (!Value.Check(DiagnosticianOutputV1Schema, result.payload)) {
+      const schemaErrors = [...Value.Errors(DiagnosticianOutputV1Schema, result.payload)]
+        .slice(0, 5)
+        .map(e => ({ path: e.path, message: e.message }));
+      const boundedPreview = safeStringifyPreview(result.payload, 300);
+
+      throw new PDRuntimeError(
+        'output_invalid',
+        `Run ${runId} output failed DiagnosticianOutputV1 schema validation at runner boundary`,
+        {
+          parseFailureReason: 'runner_boundary_schema_check_failed',
+          boundedRawOutputPreview: boundedPreview,
+          schemaErrors,
+          nextAction: 'Adapter returned payload that does not match DiagnosticianOutputV1; check adapter validation logic',
+        },
+      );
+    }
+
+    // Value.Check narrows the type at runtime but not in TS; Value.Cast
+    // performs a safe conversion after validation passes.
+    return Value.Cast(DiagnosticianOutputV1Schema, result.payload);
   }
 
   private async succeedTask(ctx: SucceedContext): Promise<RunnerResult> {
@@ -326,7 +355,7 @@ export class DiagnosticianRunner {
 
     // Commit artifact + candidates before marking task succeeded
     this.phase = RunnerPhase.Committing;
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let commitResult: CommitResult | undefined;
     try {
       commitResult = await this.committer.commit({

--- a/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
@@ -38,6 +38,7 @@ import type { TelemetryEvent } from '../../telemetry-event.js';
 import { PDRuntimeError } from '../error-categories.js';
 import { Value } from '@sinclair/typebox/value';
 import { safeStringifyPreview } from '../adapter/output-repair-contract.js';
+import { redactSensitiveFields } from '../feedback/redact-sensitive.js';
 import { RunnerPhase } from './runner-phase.js';
 import { resolveRunnerOptions } from './diagnostician-runner-options.js';
 
@@ -129,7 +130,6 @@ export class DiagnosticianRunner {
     this.phase = RunnerPhase.Idle;
 
     // 1. Acquire lease — isolated try/catch so lease_conflict never uses synthetic TaskRecord
-     
     let leasedTask: TaskRecord;
     try {
       leasedTask = await this.stateManager.acquireLease({
@@ -310,7 +310,10 @@ export class DiagnosticianRunner {
       const schemaErrors = [...Value.Errors(DiagnosticianOutputV1Schema, result.payload)]
         .slice(0, 5)
         .map(e => ({ path: e.path, message: e.message }));
-      const boundedPreview = safeStringifyPreview(result.payload, 300);
+      const redacted = redactSensitiveFields(result.payload);
+      const boundedPreview = redacted.ok
+        ? safeStringifyPreview(redacted.value, 300)
+        : safeStringifyPreview(result.payload, 300);
 
       throw new PDRuntimeError(
         'output_invalid',
@@ -355,7 +358,6 @@ export class DiagnosticianRunner {
 
     // Commit artifact + candidates before marking task succeeded
     this.phase = RunnerPhase.Committing;
-     
     let commitResult: CommitResult | undefined;
     try {
       commitResult = await this.committer.commit({


### PR DESCRIPTION
## Root Cause

The diagnostician was bound to the openclaw profile (OpenClawCliRuntimeAdapter). When the LLM returned malformed JSON (e.g., unescaped quotes in string values), the adapter:
1. Had **no repair path** — immediately threw output_invalid without attempting JSON extraction
2. Threw output_invalid **without persisted evidence** — no parseFailureReason, no oundedRawOutputPreview, no schemaErrors, no 
extAction
3. The runner's etchAndParseOutput used esult.payload as DiagnosticianOutputV1, bypassing runtime validation (ERR-001)

## Changes

### 1. OpenClawCliRuntimeAdapter: malformed JSON repair + evidence persistence
- When initial JSON parse fails, attempt bounded repair via xtractJsonObject (balanced-bracket extraction) on stdout and stderr
- On output_invalid, always include evidence pack:
  - parseFailureReason: \
o_json_object_found\ or \schema_validation_failed\
  - oundedRawOutputPreview: truncated to 500 chars via safeStringifyPreview/	runcatePreview
  - schemaErrors: up to 10 TypeBox validation errors with path + message
  - 
extAction: actionable guidance for debugging

### 2. DiagnosticianRunner: trust boundary fix (ERR-001/005)
- Replaced esult.payload as DiagnosticianOutputV1 with Value.Check(DiagnosticianOutputV1Schema, result.payload) + Value.Cast
- Defense-in-depth: even if an adapter skips its own validation, the runner catches invalid payloads
- On schema mismatch at runner boundary, throws output_invalid with evidence pack

### 3. pi-ai.lmstudio config profile
- Added test coverage for pi-ai.lmstudio profile resolution to untimeKind=pi-ai
- Verified checkAgentRuntimeReadiness works with LMSTUDIO_API_KEY
- Verified esolveAgentRuntimeBinding resolves diagnostician to pi-ai.lmstudio

### 4. Config.yaml change (manual step)
The following change needs to be applied to \D:\.openclaw\workspace\.pd\config.yaml\:

\\\yaml
runtimeProfiles:
  pi-ai.lmstudio:
    type: pi-ai
    provider: lmstudio
    model: qwen3.6-27b-mtp
    apiKeyEnv: LMSTUDIO_API_KEY
    baseUrl: http://localhost:12341/v1
    timeoutMs: 600000

internalAgents:
  agents:
    diagnostician:
      enabled: true
      runtimeProfile: pi-ai.lmstudio
\\\

**Next action for LMSTUDIO_API_KEY**: Set the env var before running PD. LM Studio at localhost:12341 is confirmed healthy with model qwen3.6-27b-mtp available. If LM Studio doesn't require an API key, set \LMSTUDIO_API_KEY=not-required\ or any non-empty value.

## Privacy Boundary
- All raw output previews are bounded to 500 chars max via \safeStringifyPreview\/\	runcatePreview\
- No full prompt/chat/trajectory is persisted in error details
- No API keys, file paths, or raw trajectory data leaks in boundedRawOutputPreview
- Tests verify: preview length <= 500, truncation marker present, full trajectory not included

## ERR Checklist
| ERR | How avoided |
|-----|-------------|
| ERR-001 | Replaced \s\ cast with Value.Check + Value.Cast at runner boundary |
| ERR-002 | Evidence pack always present on output_invalid (no silent fallback) |
| ERR-014/016/017 | safeStringifyPreview + truncatePreview bound all previews |
| ERR-025 | extractJsonObject repair path wired in OpenClawCliRuntimeAdapter |
| ERR-055/056 | Bounded preview prevents sensitive data leak |

## Tests Run
- \
px vitest run src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts\ — 42 passed
- \
px vitest run src/runtime-v2/runner/__tests__/diagnostician-runner.test.ts\ — 31 passed
- \
px vitest run src/runtime-v2/config/__tests__/pd-config-agent-binding.test.ts\ — 35 passed
- \
px vitest run src/runtime-v2/adapter/__tests__/json-extractor.test.ts\ — 28 passed
- \
px vitest run src/runtime-v2/adapter/__tests__/structured-output-repair.test.ts\ — 34 passed
- \
pm run lint\ — 0 errors, 19 pre-existing warnings
- \
pm run verify:merge\ — passed (build + lint + typecheck all packages)

## Remaining Risk
- \LMSTUDIO_API_KEY\ env var is not set on this machine — must be configured before diagnostician can use pi-ai.lmstudio profile
- LM Studio health check confirmed: model qwen3.6-27b-mtp is available at http://localhost:12341/v1
- 3 pre-existing test failures unrelated to this change (llm-e2e-config ANTHROPIC_AUTH_TOKEN, internalization-route barrel export timeout, philosopher-runner-real-llm timeout)
- No frozen legacy files modified
- No pain admission policy changed