### PR TITLE
test: add test coverage for evidence-sanitizer and source-descriptors

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/evidence-sanitizer.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evidence-sanitizer.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Evidence Sanitizer Tests — Core Package
+ *
+ * Direct tests for the shared evidence sanitizer module.
+ * This module is security-critical and used by both core and plugin packages.
+ *
+ * Tests verify:
+ * - Token redaction (sk-*, ghp_*, JWT, base64)
+ * - PD tag stripping
+ * - Path convergence (workspace-relative vs basename)
+ * - Recursive sanitization with depth/key/array limits
+ * - Platform-agnostic path handling (Windows/POSIX)
+ *
+ * ERR checklist:
+ * - ERR-001: No `as` casts — input is `unknown`, narrowed with typeof guards
+ * - ERR-055: ANY-segment sensitive field matching
+ * - ERR-056: Token redaction runs on ALL strings
+ * - EP-08: Platform-agnostic path basename
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeString,
+  sanitizeValue,
+  sanitizeToolParams,
+  convergePath,
+  MAX_EVIDENCE_VALUE_CHARS,
+} from '../evidence-sanitizer.js';
+
+// ── convergePath ─────────────────────────────────────────────────────────────
+
+describe('convergePath', () => {
+  it('returns relative path unchanged', () => {
+    expect(convergePath('src/index.ts')).toBe('src/index.ts');
+    expect(convergePath('./config.json')).toBe('./config.json');
+  });
+
+  it('returns basename for absolute path without workspaceDir', () => {
+    expect(convergePath('/home/user/secrets/token.json')).toBe('token.json');
+    expect(convergePath('D:\\Code\\secrets\\key.txt')).toBe('key.txt');
+  });
+
+  it('returns repo-relative for workspace-internal path', () => {
+    expect(convergePath('/workspace/my-repo/src/index.ts', '/workspace/my-repo')).toBe('src/index.ts');
+    expect(convergePath('D:\\Code\\principles\\src\\file.ts', 'D:\\Code\\principles')).toBe('src\\file.ts');
+  });
+
+  it('returns basename for workspace-external absolute path', () => {
+    expect(convergePath('/etc/passwd', '/workspace/my-repo')).toBe('passwd');
+    expect(convergePath('C:\\Windows\\System32\\config', '/workspace/my-repo')).toBe('config');
+  });
+
+  it('handles trailing separators in workspaceDir', () => {
+    expect(convergePath('/workspace/repo/src/file.ts', '/workspace/repo/')).toBe('src/file.ts');
+  });
+
+  it('handles Windows drive case-insensitivity', () => {
+    expect(convergePath('d:\\code\\repo\\src\\file.ts', 'D:\\Code\\repo')).toBe('src\\file.ts');
+  });
+
+  it('returns basename when workspaceDir matches exactly', () => {
+    // When the path equals workspaceDir, return basename
+    expect(convergePath('/workspace/repo', '/workspace/repo')).toBe('repo');
+  });
+
+  it('handles UNC paths', () => {
+    expect(convergePath('\\\\server\\share\\file.txt')).toBe('file.txt');
+  });
+});
+
+// ── sanitizeString ───────────────────────────────────────────────────────────
+
+describe('sanitizeString', () => {
+  // ── Token redaction ──
+
+  it('redacts OpenAI-style keys (sk-*)', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const result = sanitizeString(`token is ${token}`);
+    expect(result).toContain('___REDACTED___');
+    expect(result).not.toContain(token);
+  });
+
+  it('redacts GitHub PATs (ghp_*)', () => {
+    const token = 'ghp_' + 'a'.repeat(40);
+    const result = sanitizeString(token);
+    expect(result).toContain('___REDACTED___');
+    expect(result).not.toContain(token);
+  });
+
+  it('redacts GitHub OAuth tokens (gho_*)', () => {
+    const token = 'gho_' + 'a'.repeat(40);
+    const result = sanitizeString(token);
+    expect(result).toContain('___REDACTED___');
+  });
+
+  it('redacts Slack tokens (xoxb-*)', () => {
+    const token = 'xoxb-' + 'a'.repeat(30);
+    const result = sanitizeString(token);
+    expect(result).toContain('___REDACTED___');
+  });
+
+  it('redacts JWT-like patterns (eyJ*)', () => {
+    const jwt = 'eyJ' + 'a'.repeat(30) + '.bc';
+    const result = sanitizeString(`Bearer ${jwt}`);
+    expect(result).toContain('___REDACTED___');
+    expect(result).not.toContain(jwt);
+  });
+
+  it('redacts long base64-like strings', () => {
+    const token = 'A'.repeat(50);
+    const result = sanitizeString(`hash: ${token}`);
+    expect(result).toContain('___REDACTED___');
+    expect(result).not.toContain(token);
+  });
+
+  it('preserves short strings without tokens', () => {
+    const result = sanitizeString('normal text without secrets');
+    expect(result).toBe('normal text without secrets');
+  });
+
+  // ── PD tag stripping ──
+
+  it('strips EMOTIONAL_DAMAGE_DETECTED tags', () => {
+    const result = sanitizeString('[EMOTIONAL_DAMAGE_DETECTED:severe] something went wrong');
+    expect(result).not.toContain('EMOTIONAL_DAMAGE_DETECTED');
+    expect(result).toContain('something went wrong');
+  });
+
+  it('strips EMPATHY_ROLLBACK_REQUEST tags', () => {
+    const result = sanitizeString('[EMPATHY_ROLLBACK_REQUEST] rollback needed');
+    expect(result).not.toContain('EMPATHY_ROLLBACK_REQUEST');
+    expect(result).toContain('rollback needed');
+  });
+
+  it('strips empathy XML tags', () => {
+    const result = sanitizeString('<empathy signal="damage" severity="moderate"/> text');
+    expect(result).not.toContain('<empathy');
+    expect(result).toContain('text');
+  });
+
+  // ── Path convergence ──
+
+  it('converges absolute paths in string without workspaceDir', () => {
+    const result = sanitizeString('error in /home/user/project/src/file.ts');
+    expect(result).not.toContain('/home/user/project');
+    expect(result).toContain('file.ts');
+  });
+
+  it('converges Windows absolute paths in string', () => {
+    const result = sanitizeString('cd D:\\Code\\principles && git status');
+    expect(result).not.toContain('D:\\Code\\principles');
+    expect(result).toContain('principles');
+  });
+
+  it('converges workspace-internal paths to repo-relative', () => {
+    const result = sanitizeString(
+      'edit failed on D:\\Code\\principles\\src\\index.ts',
+      'D:\\Code\\principles',
+    );
+    expect(result).not.toContain('D:\\Code\\principles');
+    expect(result).toContain('src\\index.ts');
+  });
+
+  // ── Length bounding ──
+
+  it('truncates long strings', () => {
+    const long = ' data '.repeat(100);
+    const result = sanitizeString(long);
+    expect(result.length).toBeLessThanOrEqual(MAX_EVIDENCE_VALUE_CHARS + 20);
+    expect(result).toMatch(/___TRUNCATED___$/);
+  });
+
+  it('preserves short strings intact', () => {
+    const short = 'short text';
+    expect(sanitizeString(short)).toBe(short);
+  });
+
+  // ── Combined operations ──
+
+  it('applies all sanitization steps in order', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const input = `[EMOTIONAL_DAMAGE_DETECTED] ${token} at /home/user/secrets/key.json`;
+    const result = sanitizeString(input);
+    // PD tag stripped
+    expect(result).not.toContain('EMOTIONAL_DAMAGE_DETECTED');
+    // Token redacted
+    expect(result).toContain('___REDACTED___');
+    expect(result).not.toContain(token);
+    // Path converged
+    expect(result).not.toContain('/home/user/secrets');
+    expect(result).toContain('key.json');
+  });
+});
+
+// ── sanitizeValue ────────────────────────────────────────────────────────────
+
+describe('sanitizeValue', () => {
+  // ── Primitive handling ──
+
+  it('returns null unchanged', () => {
+    expect(sanitizeValue(null)).toBe(null);
+  });
+
+  it('returns undefined unchanged', () => {
+    expect(sanitizeValue(undefined)).toBe(undefined);
+  });
+
+  it('returns numbers unchanged', () => {
+    expect(sanitizeValue(42)).toBe(42);
+    expect(sanitizeValue(3.14)).toBe(3.14);
+  });
+
+  it('returns booleans unchanged', () => {
+    expect(sanitizeValue(true)).toBe(true);
+    expect(sanitizeValue(false)).toBe(false);
+  });
+
+  it('sanitizes strings', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const result = sanitizeValue(token);
+    expect(result).toContain('___REDACTED___');
+  });
+
+  // ── Array handling ──
+
+  it('sanitizes arrays with item limit', () => {
+    const arr = Array.from({ length: 100 }, (_, i) => `item-${i}`);
+    const result = sanitizeValue(arr) as unknown[];
+    expect(result.length).toBeLessThanOrEqual(21); // MAX_ARRAY_ITEMS + overflow indicator
+    expect(result[result.length - 1]).toMatch(/more items/);
+  });
+
+  it('sanitizes array elements recursively', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const arr = [token, 'safe-string', { nested: token }];
+    const result = sanitizeValue(arr) as unknown[];
+    expect(result[0]).toContain('___REDACTED___');
+    expect(result[1]).toBe('safe-string');
+    const nested = result[2] as Record<string, unknown>;
+    expect(nested.nested).toContain('___REDACTED___');
+  });
+
+  // ── Object handling ──
+
+  it('sanitizes objects with key limit', () => {
+    const obj: Record<string, unknown> = {};
+    for (let i = 0; i < 100; i++) {
+      obj[`key-${i}`] = `value-${i}`;
+    }
+    const result = sanitizeValue(obj) as Record<string, unknown>;
+    expect(Object.keys(result).length).toBeLessThanOrEqual(51); // MAX_KEYS + overflow indicator
+    expect(result['<truncated>']).toBeDefined();
+  });
+
+  it('sanitizes nested objects recursively', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const input = { a: { b: { c: token } } };
+    const result = sanitizeValue(input) as Record<string, unknown>;
+    const nested = ((result.a as Record<string, unknown>).b as Record<string, unknown>).c as string;
+    expect(nested).toContain('___REDACTED___');
+  });
+
+  // ── Depth limit ──
+
+  it('returns <max-depth> for deeply nested objects', () => {
+    const deep: Record<string, unknown> = { a: { b: { c: { d: { e: 'too deep' } } } } };
+    const result = sanitizeValue(deep) as Record<string, unknown>;
+    const a = result.a as Record<string, unknown>;
+    const b = a.b as Record<string, unknown>;
+    const c = b.c as Record<string, unknown>;
+    const d = c.d as Record<string, unknown>;
+    expect(d.e).toBe('<max-depth>');
+  });
+
+  it('respects depth parameter', () => {
+    const input = { a: { b: { c: 'value' } } };
+    // Starting at depth 3, b would be at depth 4 (exceeds MAX_DEPTH=4)
+    const result = sanitizeValue(input, 3) as Record<string, unknown>;
+    const a = result.a as Record<string, unknown>;
+    // b is at depth 4 from the starting depth 3, so it gets max-depth
+    expect(a.b).toBe('<max-depth>');
+  });
+
+  // ── Unsupported types ──
+
+  it('returns <unsupported-type> for functions', () => {
+    expect(sanitizeValue(() => {})).toBe('<unsupported-type>');
+  });
+
+  it('returns <unsupported-type> for symbols', () => {
+    expect(sanitizeValue(Symbol('test'))).toBe('<unsupported-type>');
+  });
+});
+
+// ── sanitizeToolParams ───────────────────────────────────────────────────────
+
+describe('sanitizeToolParams', () => {
+  it('returns {} for null input', () => {
+    expect(sanitizeToolParams(null)).toEqual({});
+  });
+
+  it('returns {} for undefined input', () => {
+    expect(sanitizeToolParams(undefined)).toEqual({});
+  });
+
+  it('returns {} for number input', () => {
+    expect(sanitizeToolParams(42)).toEqual({});
+  });
+
+  it('returns {} for boolean input', () => {
+    expect(sanitizeToolParams(true)).toEqual({});
+  });
+
+  it('wraps string input in <string-input> key', () => {
+    const result = sanitizeToolParams('raw string input');
+    expect(result['<string-input>']).toBeDefined();
+    expect(typeof result['<string-input>']).toBe('string');
+  });
+
+  it('wraps array input in <array-input> key', () => {
+    const result = sanitizeToolParams(['a', 'b', 'c']);
+    expect(result['<array-input>']).toBeDefined();
+  });
+
+  it('sanitizes object params', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const params = {
+      file_path: 'src/file.ts',
+      content: `key is ${token}`,
+    };
+    const result = sanitizeToolParams(params);
+    expect(result.file_path).toBe('src/file.ts');
+    expect(result.content).toContain('___REDACTED___');
+  });
+
+  it('converges paths with workspaceDir', () => {
+    const params = {
+      file_path: '/workspace/repo/src/config.ts',
+    };
+    const result = sanitizeToolParams(params, '/workspace/repo');
+    expect(result.file_path).toBe('src/config.ts');
+  });
+
+  it('handles nested edits array', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    const params = {
+      file_path: '/repo/src/config.ts',
+      edits: [
+        { oldText: token, newText: 'safe-value' },
+      ],
+    };
+    const result = sanitizeToolParams(params, '/repo') as Record<string, unknown>;
+    const edits = result.edits as Array<Record<string, unknown>>;
+    expect(edits[0].oldText).toContain('___REDACTED___');
+    expect(edits[0].newText).toBe('safe-value');
+    expect(result.file_path).toBe('src/config.ts');
+  });
+
+  it('truncates long content fields', () => {
+    const params = {
+      content: ' data '.repeat(100),
+    };
+    const result = sanitizeToolParams(params);
+    expect(result.content).toMatch(/___TRUNCATED___$/);
+  });
+});
+
+// ── Platform-agnostic path handling (EP-08) ───────────────────────────────────
+
+describe('Platform-agnostic path handling', () => {
+  it('handles Windows paths on POSIX runner', () => {
+    // This test runs on Linux CI but should handle Windows paths
+    const result = sanitizeString('error in D:\\Code\\principles\\src\\file.ts');
+    // Should extract basename using platformAgnosticBasename
+    expect(result).toContain('file.ts');
+    expect(result).not.toContain('D:\\Code');
+  });
+
+  it('handles POSIX paths on Windows runner', () => {
+    // This test runs on Windows but should handle POSIX paths
+    const result = sanitizeString('error in /home/user/project/src/file.ts');
+    expect(result).toContain('file.ts');
+    expect(result).not.toContain('/home/user/project');
+  });
+
+  it('handles mixed separators in single string', () => {
+    const result = sanitizeString('path1: C:\\Users\\admin\\file1.txt, path2: /etc/file2.conf');
+    expect(result).toContain('file1.txt');
+    expect(result).toContain('file2.conf');
+    expect(result).not.toContain('C:\\Users\\admin');
+    expect(result).not.toContain('/etc');
+  });
+});
+
+// ── Security regression tests ────────────────────────────────────────────────
+
+describe('Security regression tests', () => {
+  it('redacts tokens in deeply nested structures', () => {
+    const token = 'sk-proj-' + 'a'.repeat(30);
+    // Use a structure that stays within MAX_DEPTH (4)
+    const input = {
+      level1: {
+        level2: {
+          level3: {
+            secret: token,
+          },
+        },
+      },
+    };
+    const result = sanitizeValue(input) as Record<string, unknown>;
+    const l1 = result.level1 as Record<string, unknown>;
+    const l2 = l1.level2 as Record<string, unknown>;
+    const l3 = l2.level3 as Record<string, unknown>;
+    expect(l3.secret).toContain('___REDACTED___');
+  });
+
+  it('does not reveal token prefix beyond safe limit', () => {
+    const token = 'sk-proj-abcdefghijklmnopqrstuvwxy' + 'z'.repeat(20);
+    const result = sanitizeString(token);
+    // Prefix should be limited (8 chars for >50 length, 4 for shorter)
+    expect(result).not.toContain(token.slice(10));
+  });
+
+  it('handles empty strings gracefully', () => {
+    expect(sanitizeString('')).toBe('');
+    expect(sanitizeValue('')).toBe('');
+  });
+
+  it('handles strings with only whitespace', () => {
+    expect(sanitizeString('   ')).toBe('');
+    expect(sanitizeString('\n\t')).toBe('');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/evidence-sanitizer.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evidence-sanitizer.test.ts
@@ -351,8 +351,8 @@ describe('sanitizeToolParams', () => {
     };
     const result = sanitizeToolParams(params, '/repo') as Record<string, unknown>;
     const edits = result.edits as Array<Record<string, unknown>>;
-    expect(edits[0].oldText).toContain('___REDACTED___');
-    expect(edits[0].newText).toBe('safe-value');
+    expect(edits[0]!.oldText).toContain('___REDACTED___');
+    expect(edits[0]!.newText).toBe('safe-value');
     expect(result.file_path).toBe('src/config.ts');
   });
 

--- a/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/source-descriptors.test.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/source-descriptors.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Source Descriptors Tests — PEAT-B1
+ *
+ * Direct tests for the source descriptor registry.
+ * This module defines the declarative policy mapping from SourceKind to default TriageDecision.
+ *
+ * Tests verify:
+ * - All source kinds have descriptors registered
+ * - Every descriptor has required fields (kind, defaultDecision, reason, nextAction, canUpgrade)
+ * - Descriptor invariants (owner_reported always admit, tool_failure never admit, etc.)
+ * - canUpgrade flag is correctly set for upgradable kinds
+ *
+ * ERR checklist:
+ * - ERR-002: Every descriptor carries reason + nextAction
+ * - ERR-005: Descriptors are data, not assumptions about callers
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SOURCE_DESCRIPTORS,
+  getSourceDescriptor,
+  type SourceDescriptor,
+} from '../source-descriptors.js';
+import type { SourceKind, TriageDecision } from '../types.js';
+import { isSourceKind } from '../types.js';
+
+// ── Descriptor Registry Completeness ───────────────────────────────────────────
+
+describe('SOURCE_DESCRIPTORS registry', () => {
+  it('has exactly 13 registered descriptors', () => {
+    expect(SOURCE_DESCRIPTORS.size).toBe(13);
+  });
+
+  it('contains all valid SourceKinds', () => {
+    const expectedKinds: SourceKind[] = [
+      'owner_reported',
+      'agent_on_owner_request',
+      'tool_failure',
+      'dispatch_error',
+      'provider_failure',
+      'rate_limit',
+      'rulehost_block',
+      'empathy_inferred',
+      'semantic',
+      'llm_paralysis',
+      'subagent_error',
+      'gfi_threshold',
+      'unknown',
+    ];
+
+    for (const kind of expectedKinds) {
+      expect(SOURCE_DESCRIPTORS.has(kind)).toBe(true);
+    }
+  });
+
+  it('every descriptor has all required fields', () => {
+    for (const [kind, descriptor] of SOURCE_DESCRIPTORS) {
+      expect(descriptor.kind).toBe(kind);
+      expect(descriptor.defaultDecision).toBeDefined();
+      expect(typeof descriptor.defaultDecision).toBe('string');
+      expect(descriptor.reason).toBeDefined();
+      expect(typeof descriptor.reason).toBe('string');
+      expect(descriptor.reason.length).toBeGreaterThan(0);
+      expect(descriptor.nextAction).toBeDefined();
+      expect(typeof descriptor.nextAction).toBe('string');
+      expect(descriptor.nextAction.length).toBeGreaterThan(0);
+      expect(typeof descriptor.canUpgrade).toBe('boolean');
+    }
+  });
+});
+
+// ── getSourceDescriptor ───────────────────────────────────────────────────────
+
+describe('getSourceDescriptor', () => {
+  it('returns descriptor for every registered kind', () => {
+    const kinds: SourceKind[] = [
+      'owner_reported',
+      'agent_on_owner_request',
+      'tool_failure',
+      'dispatch_error',
+      'provider_failure',
+      'rate_limit',
+      'rulehost_block',
+      'empathy_inferred',
+      'semantic',
+      'llm_paralysis',
+      'subagent_error',
+      'gfi_threshold',
+      'unknown',
+    ];
+
+    for (const kind of kinds) {
+      const descriptor = getSourceDescriptor(kind);
+      expect(descriptor).toBeDefined();
+      expect(descriptor?.kind).toBe(kind);
+    }
+  });
+
+  it('returns undefined for unregistered kind', () => {
+    const result = getSourceDescriptor('not_a_kind' as SourceKind);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    const result = getSourceDescriptor('' as SourceKind);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ── Descriptor Decision Invariants ─────────────────────────────────────────────
+
+describe('Descriptor decision invariants', () => {
+  it('owner_reported always has defaultDecision=admit', () => {
+    const descriptor = getSourceDescriptor('owner_reported');
+    expect(descriptor?.defaultDecision).toBe('admit');
+  });
+
+  it('agent_on_owner_request always has defaultDecision=admit', () => {
+    const descriptor = getSourceDescriptor('agent_on_owner_request');
+    expect(descriptor?.defaultDecision).toBe('admit');
+  });
+
+  it('tool_failure has defaultDecision=evidence_only (never admit)', () => {
+    const descriptor = getSourceDescriptor('tool_failure');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+    expect(descriptor?.defaultDecision).not.toBe('admit');
+  });
+
+  it('dispatch_error has defaultDecision=evidence_only', () => {
+    const descriptor = getSourceDescriptor('dispatch_error');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+  });
+
+  it('provider_failure has defaultDecision=health_only', () => {
+    const descriptor = getSourceDescriptor('provider_failure');
+    expect(descriptor?.defaultDecision).toBe('health_only');
+  });
+
+  it('rate_limit has defaultDecision=health_only', () => {
+    const descriptor = getSourceDescriptor('rate_limit');
+    expect(descriptor?.defaultDecision).toBe('health_only');
+  });
+
+  it('rulehost_block has defaultDecision=evidence_only with canUpgrade=true', () => {
+    const descriptor = getSourceDescriptor('rulehost_block');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+    expect(descriptor?.canUpgrade).toBe(true);
+  });
+
+  it('empathy_inferred has defaultDecision=owner_confirm (never directly admit)', () => {
+    const descriptor = getSourceDescriptor('empathy_inferred');
+    expect(descriptor?.defaultDecision).toBe('owner_confirm');
+    expect(descriptor?.defaultDecision).not.toBe('admit');
+  });
+
+  it('semantic has defaultDecision=evidence_only', () => {
+    const descriptor = getSourceDescriptor('semantic');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+  });
+
+  it('llm_paralysis has defaultDecision=evidence_only', () => {
+    const descriptor = getSourceDescriptor('llm_paralysis');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+  });
+
+  it('subagent_error has defaultDecision=evidence_only', () => {
+    const descriptor = getSourceDescriptor('subagent_error');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+  });
+
+  it('gfi_threshold has defaultDecision=evidence_only (GFI alone cannot admit)', () => {
+    const descriptor = getSourceDescriptor('gfi_threshold');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+    expect(descriptor?.defaultDecision).not.toBe('admit');
+  });
+
+  it('unknown has defaultDecision=evidence_only (conservative default)', () => {
+    const descriptor = getSourceDescriptor('unknown');
+    expect(descriptor?.defaultDecision).toBe('evidence_only');
+  });
+});
+
+// ── canUpgrade Flag ────────────────────────────────────────────────────────────
+
+describe('canUpgrade flag', () => {
+  it('only rulehost_block has canUpgrade=true', () => {
+    for (const [kind, descriptor] of SOURCE_DESCRIPTORS) {
+      if (kind === 'rulehost_block') {
+        expect(descriptor.canUpgrade).toBe(true);
+      } else {
+        expect(descriptor.canUpgrade).toBe(false);
+      }
+    }
+  });
+
+  it('owner_reported cannot be upgraded (highest confidence)', () => {
+    const descriptor = getSourceDescriptor('owner_reported');
+    expect(descriptor?.canUpgrade).toBe(false);
+  });
+
+  it('tool_failure cannot be upgraded (infrastructure noise)', () => {
+    const descriptor = getSourceDescriptor('tool_failure');
+    expect(descriptor?.canUpgrade).toBe(false);
+  });
+
+  it('empathy_inferred cannot be upgraded (requires owner confirmation)', () => {
+    const descriptor = getSourceDescriptor('empathy_inferred');
+    expect(descriptor?.canUpgrade).toBe(false);
+  });
+});
+
+// ── Descriptor Reason Quality ──────────────────────────────────────────────────
+
+describe('Descriptor reason quality', () => {
+  it('owner_reported reason mentions highest confidence', () => {
+    const descriptor = getSourceDescriptor('owner_reported');
+    expect(descriptor?.reason.toLowerCase()).toContain('owner');
+    expect(descriptor?.reason.toLowerCase()).toContain('highest');
+  });
+
+  it('tool_failure reason mentions infrastructure or ADR-0014', () => {
+    const descriptor = getSourceDescriptor('tool_failure');
+    expect(
+      descriptor?.reason.toLowerCase().includes('infrastructure') ||
+      descriptor?.reason.includes('ADR-0014')
+    ).toBe(true);
+  });
+
+  it('empathy_inferred reason mentions owner confirmation or PRODUCT_IDENTITY', () => {
+    const descriptor = getSourceDescriptor('empathy_inferred');
+    expect(
+      descriptor?.reason.toLowerCase().includes('owner') ||
+      descriptor?.reason.includes('PRODUCT_IDENTITY')
+    ).toBe(true);
+  });
+
+  it('gfi_threshold reason mentions GFI alone cannot create diagnosis', () => {
+    const descriptor = getSourceDescriptor('gfi_threshold');
+    expect(descriptor?.reason.toLowerCase()).toContain('gfi');
+    expect(descriptor?.reason.toLowerCase()).toContain('alone');
+  });
+
+  it('rulehost_block reason mentions near-miss or evidence', () => {
+    const descriptor = getSourceDescriptor('rulehost_block');
+    expect(
+      descriptor?.reason.toLowerCase().includes('near-miss') ||
+      descriptor?.reason.toLowerCase().includes('evidence')
+    ).toBe(true);
+  });
+});
+
+// ── Descriptor NextAction Quality ──────────────────────────────────────────────
+
+describe('Descriptor nextAction quality', () => {
+  it('owner_reported nextAction is none (direct diagnosis)', () => {
+    const descriptor = getSourceDescriptor('owner_reported');
+    expect(descriptor?.nextAction).toBe('none');
+  });
+
+  it('agent_on_owner_request nextAction is none (direct diagnosis)', () => {
+    const descriptor = getSourceDescriptor('agent_on_owner_request');
+    expect(descriptor?.nextAction).toBe('none');
+  });
+
+  it('tool_failure nextAction mentions evidence or correlation', () => {
+    const descriptor = getSourceDescriptor('tool_failure');
+    expect(descriptor?.nextAction.toLowerCase()).toContain('evidence');
+  });
+
+  it('provider_failure nextAction mentions health or telemetry', () => {
+    const descriptor = getSourceDescriptor('provider_failure');
+    expect(descriptor?.nextAction.toLowerCase()).toContain('health');
+  });
+
+  it('empathy_inferred nextAction mentions owner confirmation', () => {
+    const descriptor = getSourceDescriptor('empathy_inferred');
+    expect(descriptor?.nextAction.toLowerCase()).toContain('owner');
+  });
+
+  it('unknown nextAction mentions classify', () => {
+    const descriptor = getSourceDescriptor('unknown');
+    expect(descriptor?.nextAction.toLowerCase()).toContain('classify');
+  });
+});
+
+// ── ReadonlyMap Immutability ───────────────────────────────────────────────────
+
+describe('SOURCE_DESCRIPTORS immutability', () => {
+  it('SOURCE_DESCRIPTORS is a ReadonlyMap', () => {
+    // TypeScript enforces readonly, but runtime check ensures Map
+    expect(SOURCE_DESCRIPTORS instanceof Map).toBe(true);
+  });
+
+  it('descriptor objects are frozen or readonly', () => {
+    // Each descriptor should have readonly properties
+    for (const [kind, descriptor] of SOURCE_DESCRIPTORS) {
+      // Attempting to modify should either fail or not affect original
+      const originalDecision = descriptor.defaultDecision;
+      // This test verifies the descriptor structure is correct
+      expect(descriptor.defaultDecision).toBe(originalDecision);
+    }
+  });
+});
+
+// ── Integration with isSourceKind ──────────────────────────────────────────────
+
+describe('Integration with isSourceKind', () => {
+  it('every descriptor kind is a valid SourceKind', () => {
+    for (const [kind] of SOURCE_DESCRIPTORS) {
+      expect(isSourceKind(kind)).toBe(true);
+    }
+  });
+
+  it('descriptor lookup succeeds for all isSourceKind-valid values', () => {
+    const validKinds = [
+      'owner_reported',
+      'agent_on_owner_request',
+      'tool_failure',
+      'dispatch_error',
+      'provider_failure',
+      'rate_limit',
+      'rulehost_block',
+      'empathy_inferred',
+      'semantic',
+      'llm_paralysis',
+      'subagent_error',
+      'gfi_threshold',
+      'unknown',
+    ] as const;
+
+    for (const kind of validKinds) {
+      expect(isSourceKind(kind)).toBe(true);
+      expect(getSourceDescriptor(kind)).toBeDefined();
+    }
+  });
+});

--- a/packages/principles-core/vitest.config.ts
+++ b/packages/principles-core/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/**/*.test.ts', 'src/prompt-builder/__tests__/**/*.test.ts', 'src/runtime-v2/store/**/*.test.ts', 'src/runtime-v2/runner/**/*.test.ts', 'src/runtime-v2/utils/**/*.test.ts', 'src/runtime-v2/adapter/**/*.test.ts', 'src/runtime-v2/diagnostician/**/*.test.ts', 'src/runtime-v2/__tests__/**/*.test.ts', 'src/runtime-v2/gfi/__tests__/**/*.test.ts', 'src/runtime-v2/idle-trigger/__tests__/**/*.test.ts', 'src/runtime-v2/activation/__tests__/**/*.test.ts', 'src/runtime-v2/activation/writers/__tests__/**/*.test.ts', 'src/runtime-v2/internalization/__tests__/**/*.test.ts', 'src/runtime-v2/feature-flags/__tests__/**/*.test.ts', 'src/runtime-v2/observer/__tests__/**/*.test.ts', 'src/runtime-v2/config/__tests__/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/prompt-builder/__tests__/**/*.test.ts', 'src/runtime-v2/store/**/*.test.ts', 'src/runtime-v2/runner/**/*.test.ts', 'src/runtime-v2/utils/**/*.test.ts', 'src/runtime-v2/adapter/**/*.test.ts', 'src/runtime-v2/diagnostician/**/*.test.ts', 'src/runtime-v2/__tests__/**/*.test.ts', 'src/runtime-v2/gfi/__tests__/**/*.test.ts', 'src/runtime-v2/idle-trigger/__tests__/**/*.test.ts', 'src/runtime-v2/activation/__tests__/**/*.test.ts', 'src/runtime-v2/activation/writers/__tests__/**/*.test.ts', 'src/runtime-v2/internalization/__tests__/**/*.test.ts', 'src/runtime-v2/feature-flags/__tests__/**/*.test.ts', 'src/runtime-v2/observer/__tests__/**/*.test.ts', 'src/runtime-v2/config/__tests__/**/*.test.ts', 'src/runtime-v2/evidence-triage/__tests__/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for two security-critical modules in the `@principles/core` package.

### 1. `evidence-sanitizer.test.ts` (54 tests)

Tests for the shared evidence sanitizer module:
- Token redaction (sk-*, ghp_*, gho_*, xoxb-*, JWT, base64)
- PD tag stripping
- Path convergence (workspace-relative vs basename)
- Recursive sanitization with depth/key/array limits
- Platform-agnostic path handling

### 2. `source-descriptors.test.ts` (38 tests)

Tests for the declarative policy mapping:
- Descriptor registry completeness (13 source kinds)
- Required fields validation
- Decision invariants
- canUpgrade flag correctness

### Configuration Update

Updated `vitest.config.ts` to include `evidence-triage/__tests__` directory.

## Test Results

All 122 tests pass.