### PR TITLE
fix(openclaw-plugin): report retried pain diagnosis accurately

### DIFF
--- a/packages/openclaw-plugin/src/commands/pain.ts
+++ b/packages/openclaw-plugin/src/commands/pain.ts
@@ -349,10 +349,31 @@ export async function handlePainReportCommand(ctx: PluginCommandContext): Promis
       };
     }
 
+    if (result.status === 'retried') {
+      const errorInfo = result.failureCategory
+        ? (isZh ? `\n⚠️ **错误类别**: ${result.failureCategory}` : `\n⚠️ **Error category**: ${result.failureCategory}`)
+        : '';
+      const messageInfo = result.message
+        ? (isZh ? `\n📝 **详情**: ${result.message}` : `\n📝 **Detail**: ${result.message}`)
+        : '';
+      return {
+        text: isZh
+          ? `✅ Pain 已记录，诊断任务已进入重试\n\n📋 **Pain ID**: ${result.painId}\n🔧 **Task ID**: ${result.taskId}${errorInfo}${messageInfo}\n\n诊断任务将在后台自动重试。使用 \`/pd-status\` 查看任务状态。`
+          : `✅ Pain recorded, diagnosis task entered retry\n\n📋 **Pain ID**: ${result.painId}\n🔧 **Task ID**: ${result.taskId}${errorInfo}${messageInfo}\n\nThe diagnosis task will retry automatically in the background. Use \`/pd-status\` to check task status.`,
+      };
+    }
+
+    // status === 'failed' | 'skipped' | 'degraded' — pain was NOT accepted
+    const reasonInfo = result.failureCategory
+      ? (isZh ? `\n⚠️ **原因**: ${result.failureCategory}` : `\n⚠️ **Reason**: ${result.failureCategory}`)
+      : '';
+    const messageInfo = result.message
+      ? (isZh ? `\n📝 **详情**: ${result.message}` : `\n📝 **Detail**: ${result.message}`)
+      : '';
     return {
       text: isZh
-        ? `⚠️ Pain 记录未成功 (status: ${result.status})。请检查系统日志或使用 \`/pd-status\` 查看状态。`
-        : `⚠️ Pain recording not accepted (status: ${result.status}). Check system logs or use \`/pd-status\` for status.`,
+        ? `❌ Pain 记录未成功 (status: ${result.status})${reasonInfo}${messageInfo}\n\n请检查系统日志或使用 \`/pd-status\` 查看状态。`
+        : `❌ Pain recording not accepted (status: ${result.status})${reasonInfo}${messageInfo}\n\nCheck system logs or use \`/pd-status\` for status.`,
     };
   } catch (err) {
     return {

--- a/packages/openclaw-plugin/tests/commands/pain.test.ts
+++ b/packages/openclaw-plugin/tests/commands/pain.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handlePainCommand } from '../../src/commands/pain.js';
+import { handlePainCommand, handlePainReportCommand } from '../../src/commands/pain.js';
 import * as sessionTracker from '../../src/core/session-tracker.js';
 import { WorkspaceContext } from '../../src/core/workspace-context.js';
 
 vi.mock('../../src/core/session-tracker.js');
 vi.mock('../../src/core/workspace-context.js');
+vi.mock('../../src/core/pd-config-loader.js', () => ({
+  loadPdConfigForPlugin: vi.fn().mockReturnValue({ ok: true, effective: {}, source: 'defaults', warnings: [], errors: [] }),
+}));
+vi.mock('@principles/core/runtime-v2', () => ({
+  PainToPrincipleService: vi.fn(),
+  PrincipleTreeLedgerAdapter: vi.fn(function(this: any) { this.stateDir = ''; }),
+}));
+
+import { PainToPrincipleService } from '@principles/core/runtime-v2';
 
 describe('Pain Command', () => {
     const workspaceDir = '/mock/workspace';
@@ -104,5 +113,175 @@ describe('Pain Command', () => {
         expect(result.text).toContain('last ingest: 2026-03-19T10:00:00.000Z');
         expect(result.text).toContain('pending samples');
         expect(result.text).toContain('approved samples');
+    });
+});
+
+describe('Pain Report Command (/pd-pain)', () => {
+    const workspaceDir = '/mock/workspace';
+    const sessionId = 's1';
+
+    const mockEvolutionReducer = { emitSync: vi.fn() };
+    const mockWctx = {
+        workspaceDir,
+        stateDir: '/mock/workspace/.state',
+        evolutionReducer: mockEvolutionReducer,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(WorkspaceContext.fromHookContext).mockReturnValue(mockWctx as any);
+    });
+
+    async function runPainReport(args: string, lang = 'en') {
+        return handlePainReportCommand({
+            args,
+            config: { workspaceDir, language: lang },
+            sessionId,
+        } as any);
+    }
+
+    it('rejects empty args', async () => {
+        const result = await runPainReport('');
+        expect(result.text).toContain('Please provide a pain reason');
+    });
+
+    it('rejects missing session ID', async () => {
+        const result = await handlePainReportCommand({
+            args: 'something broke',
+            config: { workspaceDir, language: 'en' },
+        } as any);
+        expect(result.text).toContain('Session ID not available');
+    });
+
+    it('reports success when recordPain returns succeeded', async () => {
+        const mockRecordPain = vi.fn().mockResolvedValue({
+            status: 'succeeded',
+            painId: 'manual_123_abc',
+            taskId: 'diagnosis_manual_123_abc',
+            candidateIds: [],
+            ledgerEntryIds: [],
+            observabilityWarnings: [],
+            latencyMs: 100,
+        });
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) { this.recordPain = mockRecordPain; } as any);
+
+        const result = await runPainReport('something broke');
+        expect(result.text).toContain('Pain recorded');
+        expect(result.text).toContain('manual_');
+        expect(result.text).not.toContain('not accepted');
+    });
+
+    it('reports retried as pain recorded with retry info, NOT as "not accepted"', async () => {
+        const mockRecordPain = vi.fn().mockResolvedValue({
+            status: 'retried',
+            painId: 'manual_456_def',
+            taskId: 'diagnosis_manual_456_def',
+            failureCategory: 'output_invalid',
+            message: 'Diagnostician output failed validation',
+            candidateIds: [],
+            ledgerEntryIds: [],
+            observabilityWarnings: [],
+            latencyMs: 200,
+        });
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) { this.recordPain = mockRecordPain; } as any);
+
+        const result = await runPainReport('something broke');
+        expect(result.text).toContain('Pain recorded');
+        expect(result.text).toContain('retry');
+        expect(result.text).toContain('diagnosis_manual_456_def');
+        expect(result.text).toContain('output_invalid');
+        expect(result.text).toContain('/pd-status');
+        // Must NOT say "not accepted" or "failed"
+        expect(result.text).not.toContain('not accepted');
+        expect(result.text).not.toContain('未成功');
+    });
+
+    it('reports retried in Chinese correctly', async () => {
+        const mockRecordPain = vi.fn().mockResolvedValue({
+            status: 'retried',
+            painId: 'manual_789_xyz',
+            taskId: 'diagnosis_manual_789_xyz',
+            failureCategory: 'output_invalid',
+            candidateIds: [],
+            ledgerEntryIds: [],
+            observabilityWarnings: [],
+            latencyMs: 200,
+        });
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) { this.recordPain = mockRecordPain; } as any);
+
+        const result = await runPainReport('something broke', 'zh');
+        expect(result.text).toContain('Pain 已记录');
+        expect(result.text).toContain('重试');
+        expect(result.text).not.toContain('未成功');
+        expect(result.text).not.toContain('not accepted');
+    });
+
+    it('reports retried without failureCategory or message', async () => {
+        const mockRecordPain = vi.fn().mockResolvedValue({
+            status: 'retried',
+            painId: 'manual_000_nocat',
+            taskId: 'diagnosis_manual_000_nocat',
+            candidateIds: [],
+            ledgerEntryIds: [],
+            observabilityWarnings: [],
+            latencyMs: 150,
+        });
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) { this.recordPain = mockRecordPain; } as any);
+
+        const result = await runPainReport('something broke');
+        expect(result.text).toContain('Pain recorded');
+        expect(result.text).toContain('retry');
+        expect(result.text).toContain('diagnosis_manual_000_nocat');
+        // No error category or detail lines when absent
+        expect(result.text).not.toContain('Error category');
+        expect(result.text).not.toContain('Detail');
+    });
+
+    it('reports failed as "not accepted" with reason', async () => {
+        const mockRecordPain = vi.fn().mockResolvedValue({
+            status: 'failed',
+            painId: 'manual_fail_1',
+            taskId: 'diagnosis_manual_fail_1',
+            failureCategory: 'runtime_unavailable',
+            message: 'No runner available',
+            candidateIds: [],
+            ledgerEntryIds: [],
+            observabilityWarnings: [],
+            latencyMs: 50,
+        });
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) { this.recordPain = mockRecordPain; } as any);
+
+        const result = await runPainReport('something broke');
+        expect(result.text).toContain('not accepted');
+        expect(result.text).toContain('failed');
+        expect(result.text).toContain('runtime_unavailable');
+        expect(result.text).toContain('No runner available');
+    });
+
+    it('reports degraded as "not accepted"', async () => {
+        const mockRecordPain = vi.fn().mockResolvedValue({
+            status: 'degraded',
+            painId: 'manual_deg_1',
+            taskId: 'diagnosis_manual_deg_1',
+            candidateIds: [],
+            ledgerEntryIds: [],
+            observabilityWarnings: [],
+            latencyMs: 30,
+        });
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) { this.recordPain = mockRecordPain; } as any);
+
+        const result = await runPainReport('something broke');
+        expect(result.text).toContain('not accepted');
+        expect(result.text).toContain('degraded');
+    });
+
+    it('reports error on exception', async () => {
+        vi.mocked(PainToPrincipleService).mockImplementation(function(this: any) {
+            throw new Error('DB connection failed');
+        });
+
+        const result = await runPainReport('something broke');
+        expect(result.text).toContain('Failed to record pain');
+        expect(result.text).toContain('DB connection failed');
     });
 });


### PR DESCRIPTION
## Bug Root Cause

The `/pd-pain` command conflated pain intake failure with diagnosis retry. When `PainToPrincipleService.recordPain()` returned `status: 'retried'`, the command displayed:

> Pain recording not accepted (status: retried)

But the pain signal was already recorded, the event log entry existed, and the Runtime V2 diagnosis task was simply entering a retry cycle (`task status = retry_wait`, `error_category = output_invalid`).

## Evidence

User ran `/pd-pain` and got "not accepted" message, but investigation showed:
- pain_signal recorded to event log
- painId: `manual_1780799247483_e198d6c5`
- taskId: `diagnosis_manual_1780799247483_e198d6c5`
- Runtime V2 task created with `status = retry_wait`

## Fix

Distinguish three outcomes in the command output:

| Status | Before | After |
|--------|--------|-------|
| `succeeded` | Pain recorded | Pain recorded (unchanged) |
| `retried` | "not accepted" | Pain recorded, diagnosis entered retry (includes taskId, failureCategory, message, nextAction) |
| `failed/skipped/degraded` | "not accepted" (bare status) | Pain NOT accepted (includes failureCategory, message, nextAction) |

No changes to `PainToPrincipleService` return type — all required fields (`failureCategory`, `taskId`, `painId`, `message`) already existed.

## ERR Checklist

- **ERR-002** (catch-and-degrade silently swallows failure reasons): Fixed — `retried` now includes structured reason (`failureCategory`) and nextAction (`/pd-status`)
- **ERR-009** (validator silently skips missing/malformed required fields): Fixed — `failed`/`degraded` paths now include `failureCategory` and `message` instead of bare status string
- **ERR-029** (CLI unknown input silently dropped): N/A — no input parsing changed, but same class of status-meaning-lost-in-translation bug

## Tests Run

- `npx vitest run tests/commands/pain.test.ts` — 13 passed (7 new for `handlePainReportCommand` covering succeeded, retried EN/ZH, retried without category, failed, degraded, exception)
- `npm run build` — passed
- `npm run lint` — 0 errors
- `npm run verify:merge` — passed (pre-push gate)

## Remaining Risk

- The `skipped` status path now falls through to the "not accepted" branch, which is semantically correct (skipped means pain was not processed). If a future use case adds a benign skip reason, the message may need refinement.
- No JSON-mode output path exists for the OpenClaw plugin command (it returns `PluginCommandResult` with text only). If structured output is needed later, that would be a separate change.
