### PR TITLE
fix(cli): add pain retry command and clear stale diagnosis errors

### DIFF
--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -130,7 +130,7 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore, { sourceTraceLocator });
 
     // Select runtime adapter based on --runtime flag (CLI-02)
-    // eslint-disable-next-line @typescript-eslint/init-declarations
+     
     let runtimeAdapter: PDRuntimeAdapter;
     if (runtimeKind === 'openclaw-cli') {
       const stateDir = `${workspaceDir}/.state`;
@@ -370,12 +370,17 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     }
 
     if (opts.json) {
+      const candidateIds = candidates.map((c) => c.candidateId);
+      const internalizeNextAction = candidateIds.length > 0
+        ? `Candidates generated but internalization has NOT started automatically. To begin internalization, run:\n  ${candidateIds.map((id) => `pd candidate internalize --candidate-id ${id} --workspace "${workspaceDir}"`).join('\n  ')}`
+        : 'No candidates were generated from this diagnosis.';
       const jsonOutput = {
         ...result,
         intake: {
           enabled: opts.intake !== false,
           candidates: intakeResults,
         },
+        nextAction: internalizeNextAction,
       };
       console.log(JSON.stringify(jsonOutput, null, 2));
       if (intakeFailed) {
@@ -421,6 +426,15 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
       console.log(`  To intake manually:`);
       for (const c of candidates) {
         console.log(`    pd candidate intake --candidate-id ${c.candidateId} --workspace "${workspaceDir}"`);
+      }
+    }
+
+    if (candidates.length > 0) {
+      console.log(`\n  Next Action:`);
+      console.log(`  Candidates generated but internalization has NOT started automatically.`);
+      console.log(`  To begin internalization:`);
+      for (const c of candidates) {
+        console.log(`    pd candidate internalize --candidate-id ${c.candidateId} --workspace "${workspaceDir}"`);
       }
     }
 

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -288,32 +288,47 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
         return;
       }
 
-      const validProvider: string = provider as string;
-      const validModel: string = model as string;
-      const validApiKeyEnv: string = apiKeyEnv as string;
+      if (typeof provider !== 'string' || typeof model !== 'string' || typeof apiKeyEnv !== 'string') {
+        // Should be unreachable after the missing check above, but guard for type safety
+        if (opts.json) {
+          console.log(JSON.stringify({
+            status: 'refused',
+            painId: opts.painId,
+            taskId,
+            reason: 'invalid_config_type',
+            message: 'Provider, model, or apiKeyEnv resolved to a non-string value',
+            nextAction: 'Ensure provider, model, and apiKeyEnv are string values.',
+          }));
+        } else {
+          console.error('error: provider, model, or apiKeyEnv resolved to a non-string value');
+          console.error('nextAction: Ensure provider, model, and apiKeyEnv are string values.');
+        }
+        process.exit(1);
+        return;
+      }
 
-      if (!process.env[validApiKeyEnv]) {
+      if (!process.env[apiKeyEnv]) {
         if (opts.json) {
           console.log(JSON.stringify({
             status: 'refused',
             painId: opts.painId,
             taskId,
             reason: 'missing_api_key',
-            message: `Environment variable '${validApiKeyEnv}' is not set`,
-            nextAction: `Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`,
+            message: `Environment variable '${apiKeyEnv}' is not set`,
+            nextAction: `Set the environment variable: export ${apiKeyEnv}=<your-api-key>`,
           }));
         } else {
-          console.error(`error: environment variable '${validApiKeyEnv}' is not set`);
-          console.error(`nextAction: Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`);
+          console.error(`error: environment variable '${apiKeyEnv}' is not set`);
+          console.error(`nextAction: Set the environment variable: export ${apiKeyEnv}=<your-api-key>`);
         }
         process.exit(1);
         return;
       }
 
       runtimeAdapter = new PiAiRuntimeAdapter({
-        provider: validProvider,
-        model: validModel,
-        apiKeyEnv: validApiKeyEnv,
+        provider,
+        model,
+        apiKeyEnv,
         baseUrl,
         maxRetries,
         timeoutMs: effectiveTimeoutMs,

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -266,10 +266,11 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
       const maxRetries = opts.maxRetries ?? policyConfig?.maxRetries;
       const effectiveTimeoutMs = opts.timeoutMs ?? policyConfig?.timeoutMs;
 
+      // Validate required string fields: must be non-blank strings
       const missing: string[] = [];
-      if (!provider) missing.push('provider');
-      if (!model) missing.push('model');
-      if (!apiKeyEnv) missing.push('apiKeyEnv');
+      if (typeof provider !== 'string' || provider.trim().length === 0) missing.push('provider');
+      if (typeof model !== 'string' || model.trim().length === 0) missing.push('model');
+      if (typeof apiKeyEnv !== 'string' || apiKeyEnv.trim().length === 0) missing.push('apiKeyEnv');
       if (missing.length > 0) {
         if (opts.json) {
           console.log(JSON.stringify({
@@ -277,58 +278,71 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
             painId: opts.painId,
             taskId,
             reason: `missing_required_config: ${missing.join(', ')}`,
-            message: `Missing required pi-ai config: ${missing.join(', ')}`,
+            message: `Missing or blank required pi-ai config: ${missing.join(', ')}`,
             nextAction: `Pass via --flag or add to workflows.yaml. Example: pd pain retry --pain-id ${opts.painId} --runtime pi-ai --provider openrouter --model anthropic/claude-sonnet-4 --apiKeyEnv OPENROUTER_API_KEY`,
           }));
         } else {
-          console.error(`error: missing required pi-ai config: ${missing.join(', ')}.`);
+          console.error(`error: missing or blank required pi-ai config: ${missing.join(', ')}.`);
           console.error(`nextAction: Pass via --flag or add to workflows.yaml.`);
         }
         process.exit(1);
         return;
       }
 
-      if (typeof provider !== 'string' || typeof model !== 'string' || typeof apiKeyEnv !== 'string') {
-        // Should be unreachable after the missing check above, but guard for type safety
+      // Validate numeric options: must be finite, integer, non-negative if provided
+      const invalidNumeric: string[] = [];
+      if (maxRetries !== undefined && maxRetries !== null && !(Number.isFinite(maxRetries) && Number.isInteger(maxRetries) && maxRetries >= 0)) {
+        invalidNumeric.push(`maxRetries (got: ${maxRetries})`);
+      }
+      if (effectiveTimeoutMs !== undefined && effectiveTimeoutMs !== null && !(Number.isFinite(effectiveTimeoutMs) && effectiveTimeoutMs > 0)) {
+        invalidNumeric.push(`timeoutMs (got: ${effectiveTimeoutMs})`);
+      }
+      if (invalidNumeric.length > 0) {
         if (opts.json) {
           console.log(JSON.stringify({
             status: 'refused',
             painId: opts.painId,
             taskId,
-            reason: 'invalid_config_type',
-            message: 'Provider, model, or apiKeyEnv resolved to a non-string value',
-            nextAction: 'Ensure provider, model, and apiKeyEnv are string values.',
+            reason: `invalid_numeric_config: ${invalidNumeric.join(', ')}`,
+            message: `Invalid numeric pi-ai config: ${invalidNumeric.join(', ')}. maxRetries must be a non-negative integer; timeoutMs must be a positive number.`,
+            nextAction: 'Fix the numeric values and retry.',
           }));
         } else {
-          console.error('error: provider, model, or apiKeyEnv resolved to a non-string value');
-          console.error('nextAction: Ensure provider, model, and apiKeyEnv are string values.');
+          console.error(`error: invalid numeric pi-ai config: ${invalidNumeric.join(', ')}.`);
+          console.error(`nextAction: maxRetries must be a non-negative integer; timeoutMs must be a positive number.`);
         }
         process.exit(1);
         return;
       }
 
-      if (!process.env[apiKeyEnv]) {
+      // After validation, these are guaranteed non-blank strings
+      // Type assertion is safe because the validation above already checked typeof + trim
+      const validProvider = provider as string;
+      const validModel = model as string;
+      const validApiKeyEnv = apiKeyEnv as string;
+
+      if (!process.env[validApiKeyEnv]) {
         if (opts.json) {
           console.log(JSON.stringify({
             status: 'refused',
             painId: opts.painId,
             taskId,
             reason: 'missing_api_key',
-            message: `Environment variable '${apiKeyEnv}' is not set`,
-            nextAction: `Set the environment variable: export ${apiKeyEnv}=<your-api-key>`,
+            message: `Environment variable '${validApiKeyEnv}' is not set`,
+            nextAction: `Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`,
           }));
         } else {
-          console.error(`error: environment variable '${apiKeyEnv}' is not set`);
-          console.error(`nextAction: Set the environment variable: export ${apiKeyEnv}=<your-api-key>`);
+          console.error(`error: environment variable '${validApiKeyEnv}' is not set`);
+          console.error(`nextAction: Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`);
         }
         process.exit(1);
         return;
       }
 
       runtimeAdapter = new PiAiRuntimeAdapter({
-        provider,
-        model,
-        apiKeyEnv,
+        provider: validProvider,
+        model: validModel,
+        apiKeyEnv: validApiKeyEnv,
         baseUrl,
         maxRetries,
         timeoutMs: effectiveTimeoutMs,

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -77,6 +77,11 @@ function resolveTaskIdFromPainId(painId: string): { taskId: string } | { reason:
   return { taskId: `diagnosis_${painId}` };
 }
 
+/** Return value as a non-blank string if it is one, otherwise null. */
+function readNonBlankString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
 /** Output a refused/not_found result, respecting --json mode. Exits with code 1. */
 function refuseExit(opts: PainRetryOptions, payload: { status?: string; painId: string; taskId?: string; reason: string; message?: string; nextAction: string }): never {
   if (opts.json) {
@@ -272,9 +277,9 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
 
       // Validate required string fields: must be non-blank strings
       const missing: string[] = [];
-      if (typeof provider !== 'string' || provider.trim().length === 0) missing.push('provider');
-      if (typeof model !== 'string' || model.trim().length === 0) missing.push('model');
-      if (typeof apiKeyEnv !== 'string' || apiKeyEnv.trim().length === 0) missing.push('apiKeyEnv');
+      if (readNonBlankString(provider) === null) missing.push('provider');
+      if (readNonBlankString(model) === null) missing.push('model');
+      if (readNonBlankString(apiKeyEnv) === null) missing.push('apiKeyEnv');
       if (missing.length > 0) {
         refuseExit(opts, {
           painId: opts.painId,
@@ -304,10 +309,18 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
       }
 
       // After validation, these are guaranteed non-blank strings.
-      // Type assertion is safe because the validation above checked typeof + trim.
-      const validProvider = provider as string;
-      const validModel = model as string;
-      const validApiKeyEnv = apiKeyEnv as string;
+      const validProvider = readNonBlankString(provider);
+      const validModel = readNonBlankString(model);
+      const validApiKeyEnv = readNonBlankString(apiKeyEnv);
+      if (validProvider === null || validModel === null || validApiKeyEnv === null) {
+        refuseExit(opts, {
+          painId: opts.painId,
+          taskId,
+          reason: 'internal_validation_error',
+          message: 'Internal error: validated string fields became null after validation.',
+          nextAction: 'This should not happen. Please report this bug.',
+        });
+      }
 
       if (!process.env[validApiKeyEnv]) {
         refuseExit(opts, {

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -1,0 +1,532 @@
+/**
+ * pd pain retry command — Retry a failed diagnosis by pain ID.
+ *
+ * Looks up the diagnostician task for a given painId, validates retry eligibility,
+ * then delegates to the existing diagnose run logic.
+ *
+ * Usage:
+ *   pd pain retry --pain-id <painId> --workspace <path> [runtime flags] [--json] [--force]
+ */
+import {
+  RuntimeStateManager,
+  SqliteHistoryQuery,
+  SqliteContextAssembler,
+  SqliteDiagnosticianCommitter,
+  SqliteTrajectoryLocator,
+  SqliteSourceTraceLocator,
+  StoreEventEmitter,
+  DiagnosticianRunner,
+  DefaultDiagnosticianValidator,
+  TestDoubleRuntimeAdapter,
+  OpenClawCliRuntimeAdapter,
+  PiAiRuntimeAdapter,
+  PDRuntimeError,
+  resolveRuntimeConfig,
+  isRuntimeConfigError,
+  CandidateIntakeService,
+  run as diagnoseRun,
+} from '@principles/core/runtime-v2';
+import type { PDRuntimeAdapter, RuntimeConfig } from '@principles/core/runtime-v2';
+import type { PDTaskStatus } from '@principles/core/runtime-v2';
+import { PrincipleTreeLedgerAdapter } from '../principle-tree-ledger-adapter.js';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import * as path from 'path';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface PainRetryOptions {
+  painId: string;
+  workspace?: string;
+  json?: boolean;
+  force?: boolean;
+  runtime?: string;
+  openclawLocal?: boolean;
+  openclawGateway?: boolean;
+  agent?: string;
+  provider?: string;
+  model?: string;
+  apiKeyEnv?: string;
+  baseUrl?: string;
+  maxRetries?: number;
+  timeoutMs?: number;
+}
+
+/** Allowed task statuses for retry without --force. */
+const RETRYABLE_STATUSES: ReadonlySet<PDTaskStatus> = new Set([
+  'retry_wait',
+  'failed',
+  'needs_human_review',
+]);
+
+/**
+ * Resolve a painId to a diagnostician taskId.
+ *
+ * Convention: task_id = `diagnosis_<painId>` (see PainToPrincipleService).
+ * If the painId already has the `diagnosis_` prefix, reject to avoid double-prefixing.
+ */
+function resolveTaskIdFromPainId(painId: string): { taskId: string } | { reason: string; nextAction: string } {
+  if (painId.startsWith('diagnosis_')) {
+    return {
+      reason: `painId '${painId}' already has 'diagnosis_' prefix — this looks like a taskId, not a painId`,
+      nextAction: `Use the raw painId (without 'diagnosis_' prefix), or use 'pd diagnose run --task-id ${painId}' directly`,
+    };
+  }
+  return { taskId: `diagnosis_${painId}` };
+}
+
+// ── Handler ────────────────────────────────────────────────────────────────────
+
+export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
+  const workspaceDir = resolveWorkspaceDir(opts.workspace);
+
+  // Step 1: Resolve painId → taskId
+  const resolution = resolveTaskIdFromPainId(opts.painId);
+  if ('reason' in resolution) {
+    if (opts.json) {
+      console.log(JSON.stringify({
+        status: 'refused',
+        painId: opts.painId,
+        reason: resolution.reason,
+        nextAction: resolution.nextAction,
+      }));
+    } else {
+      console.error(`error: ${resolution.reason}`);
+      console.error(`nextAction: ${resolution.nextAction}`);
+    }
+    process.exit(1);
+    return;
+  }
+
+  const { taskId } = resolution;
+
+  // Step 2: Look up task and validate
+  const stateManager = new RuntimeStateManager({ workspaceDir });
+
+  try {
+    await stateManager.initialize();
+
+    const task = await stateManager.getTask(taskId);
+    if (!task) {
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'not_found',
+          painId: opts.painId,
+          taskId,
+          reason: `No task found for painId '${opts.painId}' (looked for taskId '${taskId}')`,
+          nextAction: `Verify the painId is correct. Use 'pd task list --kind diagnostician' to see all diagnostician tasks.`,
+        }));
+      } else {
+        console.error(`error: No task found for painId '${opts.painId}' (looked for taskId '${taskId}')`);
+        console.error(`nextAction: Verify the painId is correct. Use 'pd task list --kind diagnostician' to see all diagnostician tasks.`);
+      }
+      process.exit(1);
+      return;
+    }
+
+    if (task.taskKind !== 'diagnostician') {
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'refused',
+          painId: opts.painId,
+          taskId,
+          reason: `Task '${taskId}' is not a diagnostician task (taskKind='${task.taskKind}')`,
+          nextAction: `pd pain retry only retries diagnostician tasks. Use 'pd diagnose run --task-id ${taskId}' for other task kinds.`,
+        }));
+      } else {
+        console.error(`error: Task '${taskId}' is not a diagnostician task (taskKind='${task.taskKind}')`);
+        console.error(`nextAction: pd pain retry only retries diagnostician tasks.`);
+      }
+      process.exit(1);
+      return;
+    }
+
+    const previousTaskStatus = task.status;
+    const previousLastError = task.lastError ?? null;
+
+    if (task.status === 'succeeded' && !opts.force) {
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'refused',
+          painId: opts.painId,
+          taskId,
+          reason: `Task '${taskId}' already succeeded. Use --force to re-run a succeeded task.`,
+          nextAction: `Add --force to retry: pd pain retry --pain-id ${opts.painId} --force`,
+        }));
+      } else {
+        console.error(`error: Task '${taskId}' already succeeded. Use --force to re-run.`);
+        console.error(`nextAction: Add --force to retry: pd pain retry --pain-id ${opts.painId} --force`);
+      }
+      process.exit(1);
+      return;
+    }
+
+    if (!RETRYABLE_STATUSES.has(task.status) && task.status !== 'succeeded') {
+      // Status like 'pending' or 'leased' — not retryable
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'refused',
+          painId: opts.painId,
+          taskId,
+          reason: `Task '${taskId}' has status '${task.status}' which is not retryable. Retryable statuses: ${[...RETRYABLE_STATUSES].join(', ')}`,
+          nextAction: `Wait for the task to reach a terminal state, or use 'pd diagnose run --task-id ${taskId}' directly.`,
+        }));
+      } else {
+        console.error(`error: Task '${taskId}' has status '${task.status}' which is not retryable.`);
+        console.error(`nextAction: Wait for the task to reach a terminal state (retry_wait, failed, needs_human_review).`);
+      }
+      process.exit(1);
+      return;
+    }
+
+    // Step 3: Build runtime adapter (same logic as diagnose run)
+    if (opts.openclawLocal && opts.openclawGateway) {
+      console.error('error: --openclaw-local and --openclaw-gateway are mutually exclusive');
+      process.exit(1);
+      return;
+    }
+
+    const runtimeKind = opts.runtime ?? 'test-double';
+
+    let runtimeAdapter: PDRuntimeAdapter;
+    if (runtimeKind === 'openclaw-cli') {
+      const stateDir = `${workspaceDir}/.state`;
+      const configResult = resolveRuntimeConfig(stateDir, { openclawLocal: opts.openclawLocal, openclawGateway: opts.openclawGateway, requestedRuntimeKind: 'openclaw-cli' });
+      if (isRuntimeConfigError(configResult)) {
+        if (opts.json) {
+          console.log(JSON.stringify({ status: 'refused', painId: opts.painId, taskId, reason: configResult.reason, message: configResult.message, nextAction: configResult.nextAction }));
+        } else {
+          console.error(`error: ${configResult.message}`);
+          console.error(`nextAction: ${configResult.nextAction}`);
+        }
+        process.exit(1);
+        return;
+      }
+      const { openclawMode } = configResult;
+      if (!openclawMode) {
+        if (opts.json) {
+          console.log(JSON.stringify({ status: 'refused', painId: opts.painId, taskId, reason: 'missing_openclaw_mode', message: 'runtimeKind is openclaw-cli but no mode resolved', nextAction: 'Provide --openclaw-local or --openclaw-gateway' }));
+        } else {
+          console.error('error: runtimeKind is openclaw-cli but no mode resolved');
+          console.error('nextAction: Provide --openclaw-local or --openclaw-gateway');
+        }
+        process.exit(1);
+        return;
+      }
+
+      runtimeAdapter = new OpenClawCliRuntimeAdapter({
+        runtimeMode: openclawMode,
+        workspaceDir,
+        agentId: opts.agent ?? 'main',
+      });
+    } else if (runtimeKind === 'test-double') {
+      runtimeAdapter = new TestDoubleRuntimeAdapter({
+        onPollRun: (_runId: string) => ({
+          runId: _runId,
+          status: 'succeeded',
+          startedAt: new Date().toISOString(),
+          endedAt: new Date().toISOString(),
+        }),
+        onFetchOutput: (_runId: string) => ({
+          runId: _runId,
+          payload: {
+            valid: true,
+            diagnosisId: `diag-retry-${Date.now()}`,
+            taskId,
+            summary: 'CLI retry test diagnosis — validate tool arguments before execution',
+            rootCause: 'Test root cause — missing argument validation',
+            violatedPrinciples: [],
+            evidence: [],
+            recommendations: [
+              { kind: 'principle', description: 'Always validate tool arguments before execution to prevent silent failures' },
+              { kind: 'rule', description: 'Use schema validation for external inputs' },
+            ],
+            confidence: 0.9,
+          },
+        }),
+      });
+    } else if (runtimeKind === 'pi-ai') {
+      const stateDir = `${workspaceDir}/.state`;
+      let policyConfig: RuntimeConfig | null = null;
+      try {
+        const configResult = resolveRuntimeConfig(stateDir);
+        if (!isRuntimeConfigError(configResult)) {
+          policyConfig = configResult;
+        } else {
+          console.warn(`[pd pain retry] workflows.yaml policy load failed: ${configResult.message}. Using CLI flags if provided.`);
+        }
+      } catch (err: unknown) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.warn(`[pd pain retry] workflows.yaml policy load failed: ${detail}. Using CLI flags if provided.`);
+      }
+
+      const provider = opts.provider ?? policyConfig?.provider;
+      const model = opts.model ?? policyConfig?.model;
+      const apiKeyEnv = opts.apiKeyEnv ?? policyConfig?.apiKeyEnv;
+      const baseUrl = opts.baseUrl ?? policyConfig?.baseUrl;
+      const maxRetries = opts.maxRetries ?? policyConfig?.maxRetries;
+      const effectiveTimeoutMs = opts.timeoutMs ?? policyConfig?.timeoutMs;
+
+      const missing: string[] = [];
+      if (!provider) missing.push('provider');
+      if (!model) missing.push('model');
+      if (!apiKeyEnv) missing.push('apiKeyEnv');
+      if (missing.length > 0) {
+        if (opts.json) {
+          console.log(JSON.stringify({
+            status: 'refused',
+            painId: opts.painId,
+            taskId,
+            reason: `missing_required_config: ${missing.join(', ')}`,
+            message: `Missing required pi-ai config: ${missing.join(', ')}`,
+            nextAction: `Pass via --flag or add to workflows.yaml. Example: pd pain retry --pain-id ${opts.painId} --runtime pi-ai --provider openrouter --model anthropic/claude-sonnet-4 --apiKeyEnv OPENROUTER_API_KEY`,
+          }));
+        } else {
+          console.error(`error: missing required pi-ai config: ${missing.join(', ')}.`);
+          console.error(`nextAction: Pass via --flag or add to workflows.yaml.`);
+        }
+        process.exit(1);
+        return;
+      }
+
+      const validProvider: string = provider as string;
+      const validModel: string = model as string;
+      const validApiKeyEnv: string = apiKeyEnv as string;
+
+      if (!process.env[validApiKeyEnv]) {
+        if (opts.json) {
+          console.log(JSON.stringify({
+            status: 'refused',
+            painId: opts.painId,
+            taskId,
+            reason: 'missing_api_key',
+            message: `Environment variable '${validApiKeyEnv}' is not set`,
+            nextAction: `Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`,
+          }));
+        } else {
+          console.error(`error: environment variable '${validApiKeyEnv}' is not set`);
+          console.error(`nextAction: Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`);
+        }
+        process.exit(1);
+        return;
+      }
+
+      runtimeAdapter = new PiAiRuntimeAdapter({
+        provider: validProvider,
+        model: validModel,
+        apiKeyEnv: validApiKeyEnv,
+        baseUrl,
+        maxRetries,
+        timeoutMs: effectiveTimeoutMs,
+        workspace: workspaceDir,
+      });
+    } else {
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'refused',
+          painId: opts.painId,
+          taskId,
+          reason: `unknown_runtime: '${runtimeKind}'`,
+          message: `Unknown runtime kind '${runtimeKind}'`,
+          nextAction: `Supported runtimes: openclaw-cli, test-double, pi-ai`,
+        }));
+      } else {
+        console.error(`error: unknown runtime kind '${runtimeKind}' (supported: openclaw-cli, test-double, pi-ai)`);
+      }
+      process.exit(1);
+      return;
+    }
+
+    // Step 4: Build runner and execute (same as diagnose run)
+    const sqliteConn = stateManager.connection;
+    const { taskStore } = stateManager;
+    const { runStore } = stateManager;
+    const historyQuery = new SqliteHistoryQuery(sqliteConn);
+    const trajectoryLocator = new SqliteTrajectoryLocator(sqliteConn);
+    const sourceTraceLocator = new SqliteSourceTraceLocator(taskStore, trajectoryLocator);
+    const contextAssembler = new SqliteContextAssembler(taskStore, historyQuery, runStore, { sourceTraceLocator });
+
+    const eventEmitter = new StoreEventEmitter();
+    const committer = new SqliteDiagnosticianCommitter(sqliteConn);
+    const runner = new DiagnosticianRunner(
+      {
+        stateManager,
+        contextAssembler,
+        runtimeAdapter,
+        eventEmitter,
+        validator: new DefaultDiagnosticianValidator(),
+        committer,
+      },
+      {
+        owner: 'pd-cli-pain-retry',
+        runtimeKind,
+        pollIntervalMs: 100,
+        timeoutMs: 300_000,
+        agentId: opts.agent,
+      },
+    );
+
+    if (!opts.json) {
+      console.log(`\nRetrying diagnosis for pain: ${opts.painId}`);
+      console.log(`  Task ID:  ${taskId}`);
+      console.log(`  Previous: ${previousTaskStatus}${previousLastError ? ` (${previousLastError})` : ''}`);
+      console.log(`  Runtime:  ${runtimeKind}`);
+      console.log(`  Workspace: ${workspaceDir}\n`);
+    }
+
+    const result = await diagnoseRun({
+      taskId,
+      stateManager,
+      runner,
+    });
+
+    if (result.status !== 'succeeded') {
+      if (opts.json) {
+        console.log(JSON.stringify({
+          status: 'failed',
+          painId: opts.painId,
+          taskId,
+          runId: null,
+          runtimeKind,
+          previousTaskStatus,
+          previousLastError,
+          newTaskStatus: result.status,
+          errorCategory: result.errorCategory ?? null,
+          failureReason: result.failureReason ?? null,
+          nextAction: result.errorCategory === 'output_invalid'
+            ? 'The LLM output failed validation. Try a different model or provider.'
+            : 'Check the error category and retry with adjusted parameters.',
+        }, null, 2));
+      } else {
+        console.log(`\nRetry failed:`);
+        console.log(`  Status:         ${result.status}`);
+        console.log(`  Task ID:        ${result.taskId}`);
+        if (result.errorCategory) {
+          console.log(`  Error Category: ${result.errorCategory}`);
+        }
+        if (result.failureReason) {
+          console.log(`  Failure Reason: ${result.failureReason}`);
+        }
+        console.log('');
+      }
+      process.exit(1);
+      return;
+    }
+
+    // Step 5: Intake candidates
+    const candidates = await stateManager.getCandidatesByTaskId(taskId);
+    const intakeResults: { candidateId: string; ledgerEntryId?: string; status: string; error?: string; nextAction?: string }[] = [];
+    let intakeFailed = false;
+
+    const ledgerAdapter = new PrincipleTreeLedgerAdapter({ stateDir: path.join(workspaceDir, '.state') });
+    const intakeService = new CandidateIntakeService({ stateManager, ledgerAdapter });
+
+    for (const candidate of candidates) {
+      try {
+        const entry = await intakeService.intake(candidate.candidateId);
+        if (candidate.status !== 'consumed') {
+          await stateManager.updateCandidateStatus(candidate.candidateId, { status: 'consumed' });
+        }
+        intakeResults.push({
+          candidateId: candidate.candidateId,
+          ledgerEntryId: entry.id,
+          status: 'consumed',
+        });
+      } catch (intakeErr: unknown) {
+        intakeFailed = true;
+        const intakeErrorMessage = intakeErr instanceof Error ? intakeErr.message : String(intakeErr);
+        intakeResults.push({
+          candidateId: candidate.candidateId,
+          status: 'intake_failed',
+          error: intakeErrorMessage,
+          nextAction: `pd candidate intake --candidate-id ${candidate.candidateId} --workspace "${workspaceDir}"`,
+        });
+      }
+    }
+
+    const candidateIds = candidates.map((c) => c.candidateId);
+    const ledgerEntryIds = intakeResults
+      .filter((ir): ir is { candidateId: string; ledgerEntryId: string; status: string } => ir.status === 'consumed' && typeof ir.ledgerEntryId === 'string')
+      .map((ir) => ir.ledgerEntryId);
+
+    // Build nextAction: candidates generated but internalization not automatic
+    const internalizeNextAction = candidateIds.length > 0
+      ? `Candidates generated but internalization has NOT started automatically. To begin internalization, run:\n  ${candidateIds.map((id) => `pd candidate internalize --candidate-id ${id} --workspace "${workspaceDir}"`).join('\n  ')}`
+      : 'No candidates were generated from this diagnosis.';
+
+    if (opts.json) {
+      // Strict single JSON object output
+      console.log(JSON.stringify({
+        status: 'succeeded',
+        painId: opts.painId,
+        taskId,
+        runId: null,
+        runtimeKind,
+        previousTaskStatus,
+        previousLastError,
+        newTaskStatus: 'succeeded',
+        candidateIds,
+        ledgerEntryIds,
+        intake: {
+          candidates: intakeResults,
+        },
+        nextAction: internalizeNextAction,
+      }, null, 2));
+      if (intakeFailed) {
+        process.exit(1);
+      }
+      return;
+    }
+
+    // Text output
+    console.log(`\nRetry succeeded:`);
+    console.log(`  Pain ID:         ${opts.painId}`);
+    console.log(`  Task ID:         ${taskId}`);
+    console.log(`  Previous Status: ${previousTaskStatus}${previousLastError ? ` (${previousLastError})` : ''}`);
+    console.log(`  New Status:      succeeded`);
+    console.log(`  Candidates:      ${candidateIds.length}`);
+    if (result.contextHash) {
+      console.log(`  Context Hash:    ${result.contextHash.substring(0, 16)}...`);
+    }
+
+    if (intakeResults.length > 0) {
+      console.log(`\n  Candidate Intake:`);
+      for (const ir of intakeResults) {
+        if (ir.status === 'consumed') {
+          console.log(`    ${ir.candidateId}: consumed (ledger: ${ir.ledgerEntryId})`);
+        } else if (ir.status === 'intake_failed') {
+          console.log(`    ${ir.candidateId}: INTAKE FAILED — ${ir.error}`);
+          console.log(`      Next action: ${ir.nextAction}`);
+        }
+      }
+    }
+
+    console.log(`\n  Next Action:`);
+    console.log(`  ${internalizeNextAction}`);
+    console.log('');
+
+    if (intakeFailed) {
+      process.exit(1);
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    let errorCategory = 'execution_failed';
+    if (error instanceof PDRuntimeError) {
+      errorCategory = error.category;
+    }
+    if (opts.json) {
+      console.log(JSON.stringify({
+        status: 'failed',
+        painId: opts.painId,
+        taskId: `diagnosis_${opts.painId}`,
+        errorCategory,
+        message,
+        nextAction: 'Check the error message and retry with adjusted parameters.',
+      }, null, 2));
+    } else {
+      console.error(`error: ${message} (${errorCategory})`);
+    }
+    process.exit(1);
+  } finally {
+    await stateManager.close();
+  }
+}

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -5,7 +5,10 @@
  * then delegates to the existing diagnose run logic.
  *
  * Usage:
- *   pd pain retry --pain-id <painId> --workspace <path> [runtime flags] [--json] [--force]
+ *   pd pain retry --pain-id <painId> --workspace <path> --runtime <kind> [runtime flags] [--json] [--force]
+ *
+ * IMPORTANT: --runtime is required (no default). test-double would generate fake
+ * candidates/ledger in a real workspace, so it must be explicitly requested.
  */
 import {
   RuntimeStateManager,
@@ -74,27 +77,34 @@ function resolveTaskIdFromPainId(painId: string): { taskId: string } | { reason:
   return { taskId: `diagnosis_${painId}` };
 }
 
+/** Output a refused/not_found result, respecting --json mode. Exits with code 1. */
+function refuseExit(opts: PainRetryOptions, payload: { status?: string; painId: string; taskId?: string; reason: string; message?: string; nextAction: string }): never {
+  if (opts.json) {
+    console.log(JSON.stringify({
+      status: payload.status ?? 'refused',
+      painId: payload.painId,
+      taskId: payload.taskId ?? null,
+      reason: payload.reason,
+      ...(payload.message ? { message: payload.message } : {}),
+      nextAction: payload.nextAction,
+    }));
+  } else {
+    console.error(`error: ${payload.message ?? payload.reason}`);
+    console.error(`nextAction: ${payload.nextAction}`);
+  }
+  process.exit(1);
+}
+
 // ── Handler ────────────────────────────────────────────────────────────────────
 
 export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
   const workspaceDir = resolveWorkspaceDir(opts.workspace);
+  const stateDir = `${workspaceDir}/.state`;
 
   // Step 1: Resolve painId → taskId
   const resolution = resolveTaskIdFromPainId(opts.painId);
   if ('reason' in resolution) {
-    if (opts.json) {
-      console.log(JSON.stringify({
-        status: 'refused',
-        painId: opts.painId,
-        reason: resolution.reason,
-        nextAction: resolution.nextAction,
-      }));
-    } else {
-      console.error(`error: ${resolution.reason}`);
-      console.error(`nextAction: ${resolution.nextAction}`);
-    }
-    process.exit(1);
-    return;
+    refuseExit(opts, { painId: opts.painId, reason: resolution.reason, nextAction: resolution.nextAction });
   }
 
   const { taskId } = resolution;
@@ -107,110 +117,105 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
 
     const task = await stateManager.getTask(taskId);
     if (!task) {
-      if (opts.json) {
-        console.log(JSON.stringify({
-          status: 'not_found',
-          painId: opts.painId,
-          taskId,
-          reason: `No task found for painId '${opts.painId}' (looked for taskId '${taskId}')`,
-          nextAction: `Verify the painId is correct. Use 'pd task list --kind diagnostician' to see all diagnostician tasks.`,
-        }));
-      } else {
-        console.error(`error: No task found for painId '${opts.painId}' (looked for taskId '${taskId}')`);
-        console.error(`nextAction: Verify the painId is correct. Use 'pd task list --kind diagnostician' to see all diagnostician tasks.`);
-      }
-      process.exit(1);
-      return;
+      refuseExit(opts, {
+        status: 'not_found',
+        painId: opts.painId,
+        taskId,
+        reason: 'task_not_found',
+        message: `No task found for painId '${opts.painId}' (looked for taskId '${taskId}')`,
+        nextAction: `Verify the painId is correct. Use 'pd task list --kind diagnostician' to see all diagnostician tasks.`,
+      });
     }
 
     if (task.taskKind !== 'diagnostician') {
-      if (opts.json) {
-        console.log(JSON.stringify({
-          status: 'refused',
-          painId: opts.painId,
-          taskId,
-          reason: `Task '${taskId}' is not a diagnostician task (taskKind='${task.taskKind}')`,
-          nextAction: `pd pain retry only retries diagnostician tasks. Use 'pd diagnose run --task-id ${taskId}' for other task kinds.`,
-        }));
-      } else {
-        console.error(`error: Task '${taskId}' is not a diagnostician task (taskKind='${task.taskKind}')`);
-        console.error(`nextAction: pd pain retry only retries diagnostician tasks.`);
-      }
-      process.exit(1);
-      return;
+      refuseExit(opts, {
+        painId: opts.painId,
+        taskId,
+        reason: 'wrong_task_kind',
+        message: `Task '${taskId}' is not a diagnostician task (taskKind='${task.taskKind}')`,
+        nextAction: `pd pain retry only retries diagnostician tasks. Use 'pd diagnose run --task-id ${taskId}' for other task kinds.`,
+      });
     }
 
     const previousTaskStatus = task.status;
     const previousLastError = task.lastError ?? null;
 
     if (task.status === 'succeeded' && !opts.force) {
-      if (opts.json) {
-        console.log(JSON.stringify({
-          status: 'refused',
-          painId: opts.painId,
-          taskId,
-          reason: `Task '${taskId}' already succeeded. Use --force to re-run a succeeded task.`,
-          nextAction: `Add --force to retry: pd pain retry --pain-id ${opts.painId} --force`,
-        }));
-      } else {
-        console.error(`error: Task '${taskId}' already succeeded. Use --force to re-run.`);
-        console.error(`nextAction: Add --force to retry: pd pain retry --pain-id ${opts.painId} --force`);
-      }
-      process.exit(1);
-      return;
+      refuseExit(opts, {
+        painId: opts.painId,
+        taskId,
+        reason: 'already_succeeded',
+        message: `Task '${taskId}' already succeeded. Use --force to re-run a succeeded task.`,
+        nextAction: `Add --force to retry: pd pain retry --pain-id ${opts.painId} --force`,
+      });
     }
 
     if (!RETRYABLE_STATUSES.has(task.status) && task.status !== 'succeeded') {
-      // Status like 'pending' or 'leased' — not retryable
-      if (opts.json) {
-        console.log(JSON.stringify({
-          status: 'refused',
-          painId: opts.painId,
-          taskId,
-          reason: `Task '${taskId}' has status '${task.status}' which is not retryable. Retryable statuses: ${[...RETRYABLE_STATUSES].join(', ')}`,
-          nextAction: `Wait for the task to reach a terminal state, or use 'pd diagnose run --task-id ${taskId}' directly.`,
-        }));
-      } else {
-        console.error(`error: Task '${taskId}' has status '${task.status}' which is not retryable.`);
-        console.error(`nextAction: Wait for the task to reach a terminal state (retry_wait, failed, needs_human_review).`);
-      }
-      process.exit(1);
-      return;
+      refuseExit(opts, {
+        painId: opts.painId,
+        taskId,
+        reason: 'status_not_retryable',
+        message: `Task '${taskId}' has status '${task.status}' which is not retryable. Retryable statuses: ${[...RETRYABLE_STATUSES].join(', ')}`,
+        nextAction: `Wait for the task to reach a terminal state, or use 'pd diagnose run --task-id ${taskId}' directly.`,
+      });
     }
 
-    // Step 3: Build runtime adapter (same logic as diagnose run)
+    // Step 3: Resolve runtime kind
+    // P1 fix: --openclaw-local and --openclaw-gateway are mutually exclusive.
+    // Must output JSON when --json is set (CLI operator gate).
     if (opts.openclawLocal && opts.openclawGateway) {
-      console.error('error: --openclaw-local and --openclaw-gateway are mutually exclusive');
-      process.exit(1);
-      return;
+      refuseExit(opts, {
+        painId: opts.painId,
+        taskId,
+        reason: 'conflicting_flags',
+        message: '--openclaw-local and --openclaw-gateway are mutually exclusive',
+        nextAction: 'Provide exactly one of --openclaw-local or --openclaw-gateway, not both.',
+      });
     }
 
-    const runtimeKind = opts.runtime ?? 'test-double';
+    // P1 fix: pd pain retry must NOT default to test-double.
+    // This command is for real workspace pain fixes — test-double would generate
+    // fake candidates/ledger in a real .pd/state.db. Require explicit --runtime
+    // or fall back to workflows.yaml config.
+    let runtimeKind = opts.runtime;
+    if (!runtimeKind) {
+      try {
+        const configResult = resolveRuntimeConfig(stateDir);
+        if (!isRuntimeConfigError(configResult) && configResult.runtimeKind) {
+          ({ runtimeKind } = configResult);
+        }
+      } catch {
+        // Config load failed — fall through to refusal
+      }
+    }
 
+    if (!runtimeKind) {
+      refuseExit(opts, {
+        painId: opts.painId,
+        taskId,
+        reason: 'missing_runtime',
+        message: 'No --runtime specified and no workflows.yaml config found. pd pain retry must not default to test-double to prevent fake data in real workspaces.',
+        nextAction: `Specify --runtime explicitly: pd pain retry --pain-id ${opts.painId} --runtime pi-ai --provider <provider> --model <model> --apiKeyEnv <ENV>`,
+      });
+    }
+
+    // Step 4: Build runtime adapter
     let runtimeAdapter: PDRuntimeAdapter;
+
     if (runtimeKind === 'openclaw-cli') {
-      const stateDir = `${workspaceDir}/.state`;
       const configResult = resolveRuntimeConfig(stateDir, { openclawLocal: opts.openclawLocal, openclawGateway: opts.openclawGateway, requestedRuntimeKind: 'openclaw-cli' });
       if (isRuntimeConfigError(configResult)) {
-        if (opts.json) {
-          console.log(JSON.stringify({ status: 'refused', painId: opts.painId, taskId, reason: configResult.reason, message: configResult.message, nextAction: configResult.nextAction }));
-        } else {
-          console.error(`error: ${configResult.message}`);
-          console.error(`nextAction: ${configResult.nextAction}`);
-        }
-        process.exit(1);
-        return;
+        refuseExit(opts, { painId: opts.painId, taskId, reason: configResult.reason, message: configResult.message, nextAction: configResult.nextAction });
       }
       const { openclawMode } = configResult;
       if (!openclawMode) {
-        if (opts.json) {
-          console.log(JSON.stringify({ status: 'refused', painId: opts.painId, taskId, reason: 'missing_openclaw_mode', message: 'runtimeKind is openclaw-cli but no mode resolved', nextAction: 'Provide --openclaw-local or --openclaw-gateway' }));
-        } else {
-          console.error('error: runtimeKind is openclaw-cli but no mode resolved');
-          console.error('nextAction: Provide --openclaw-local or --openclaw-gateway');
-        }
-        process.exit(1);
-        return;
+        refuseExit(opts, {
+          painId: opts.painId,
+          taskId,
+          reason: 'missing_openclaw_mode',
+          message: 'runtimeKind is openclaw-cli but no mode resolved',
+          nextAction: 'Provide --openclaw-local or --openclaw-gateway',
+        });
       }
 
       runtimeAdapter = new OpenClawCliRuntimeAdapter({
@@ -245,7 +250,6 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
         }),
       });
     } else if (runtimeKind === 'pi-ai') {
-      const stateDir = `${workspaceDir}/.state`;
       let policyConfig: RuntimeConfig | null = null;
       try {
         const configResult = resolveRuntimeConfig(stateDir);
@@ -272,21 +276,13 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
       if (typeof model !== 'string' || model.trim().length === 0) missing.push('model');
       if (typeof apiKeyEnv !== 'string' || apiKeyEnv.trim().length === 0) missing.push('apiKeyEnv');
       if (missing.length > 0) {
-        if (opts.json) {
-          console.log(JSON.stringify({
-            status: 'refused',
-            painId: opts.painId,
-            taskId,
-            reason: `missing_required_config: ${missing.join(', ')}`,
-            message: `Missing or blank required pi-ai config: ${missing.join(', ')}`,
-            nextAction: `Pass via --flag or add to workflows.yaml. Example: pd pain retry --pain-id ${opts.painId} --runtime pi-ai --provider openrouter --model anthropic/claude-sonnet-4 --apiKeyEnv OPENROUTER_API_KEY`,
-          }));
-        } else {
-          console.error(`error: missing or blank required pi-ai config: ${missing.join(', ')}.`);
-          console.error(`nextAction: Pass via --flag or add to workflows.yaml.`);
-        }
-        process.exit(1);
-        return;
+        refuseExit(opts, {
+          painId: opts.painId,
+          taskId,
+          reason: `missing_required_config: ${missing.join(', ')}`,
+          message: `Missing or blank required pi-ai config: ${missing.join(', ')}`,
+          nextAction: `Pass via --flag or add to workflows.yaml. Example: pd pain retry --pain-id ${opts.painId} --runtime pi-ai --provider openrouter --model anthropic/claude-sonnet-4 --apiKeyEnv OPENROUTER_API_KEY`,
+        });
       }
 
       // Validate numeric options: must be finite, integer, non-negative if provided
@@ -298,45 +294,29 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
         invalidNumeric.push(`timeoutMs (got: ${effectiveTimeoutMs})`);
       }
       if (invalidNumeric.length > 0) {
-        if (opts.json) {
-          console.log(JSON.stringify({
-            status: 'refused',
-            painId: opts.painId,
-            taskId,
-            reason: `invalid_numeric_config: ${invalidNumeric.join(', ')}`,
-            message: `Invalid numeric pi-ai config: ${invalidNumeric.join(', ')}. maxRetries must be a non-negative integer; timeoutMs must be a positive number.`,
-            nextAction: 'Fix the numeric values and retry.',
-          }));
-        } else {
-          console.error(`error: invalid numeric pi-ai config: ${invalidNumeric.join(', ')}.`);
-          console.error(`nextAction: maxRetries must be a non-negative integer; timeoutMs must be a positive number.`);
-        }
-        process.exit(1);
-        return;
+        refuseExit(opts, {
+          painId: opts.painId,
+          taskId,
+          reason: `invalid_numeric_config: ${invalidNumeric.join(', ')}`,
+          message: `Invalid numeric pi-ai config: ${invalidNumeric.join(', ')}. maxRetries must be a non-negative integer; timeoutMs must be a positive number.`,
+          nextAction: 'Fix the numeric values and retry.',
+        });
       }
 
-      // After validation, these are guaranteed non-blank strings
-      // Type assertion is safe because the validation above already checked typeof + trim
+      // After validation, these are guaranteed non-blank strings.
+      // Type assertion is safe because the validation above checked typeof + trim.
       const validProvider = provider as string;
       const validModel = model as string;
       const validApiKeyEnv = apiKeyEnv as string;
 
       if (!process.env[validApiKeyEnv]) {
-        if (opts.json) {
-          console.log(JSON.stringify({
-            status: 'refused',
-            painId: opts.painId,
-            taskId,
-            reason: 'missing_api_key',
-            message: `Environment variable '${validApiKeyEnv}' is not set`,
-            nextAction: `Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`,
-          }));
-        } else {
-          console.error(`error: environment variable '${validApiKeyEnv}' is not set`);
-          console.error(`nextAction: Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`);
-        }
-        process.exit(1);
-        return;
+        refuseExit(opts, {
+          painId: opts.painId,
+          taskId,
+          reason: 'missing_api_key',
+          message: `Environment variable '${validApiKeyEnv}' is not set`,
+          nextAction: `Set the environment variable: export ${validApiKeyEnv}=<your-api-key>`,
+        });
       }
 
       runtimeAdapter = new PiAiRuntimeAdapter({
@@ -349,23 +329,16 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
         workspace: workspaceDir,
       });
     } else {
-      if (opts.json) {
-        console.log(JSON.stringify({
-          status: 'refused',
-          painId: opts.painId,
-          taskId,
-          reason: `unknown_runtime: '${runtimeKind}'`,
-          message: `Unknown runtime kind '${runtimeKind}'`,
-          nextAction: `Supported runtimes: openclaw-cli, test-double, pi-ai`,
-        }));
-      } else {
-        console.error(`error: unknown runtime kind '${runtimeKind}' (supported: openclaw-cli, test-double, pi-ai)`);
-      }
-      process.exit(1);
-      return;
+      refuseExit(opts, {
+        painId: opts.painId,
+        taskId,
+        reason: `unknown_runtime: '${runtimeKind}'`,
+        message: `Unknown runtime kind '${runtimeKind}'`,
+        nextAction: 'Supported runtimes: openclaw-cli, test-double, pi-ai',
+      });
     }
 
-    // Step 4: Build runner and execute (same as diagnose run)
+    // Step 5: Build runner and execute (same as diagnose run)
     const sqliteConn = stateManager.connection;
     const { taskStore } = stateManager;
     const { runStore } = stateManager;
@@ -441,7 +414,7 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
       return;
     }
 
-    // Step 5: Intake candidates
+    // Step 6: Intake candidates
     const candidates = await stateManager.getCandidatesByTaskId(taskId);
     const intakeResults: { candidateId: string; ledgerEntryId?: string; status: string; error?: string; nextAction?: string }[] = [];
     let intakeFailed = false;

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -8,6 +8,7 @@
 
 import { Command } from 'commander';
 import { handlePainRecord } from './commands/pain-record.js';
+import { handlePainRetry } from './commands/pain-retry.js';
 import { handleSamplesList } from './commands/samples-list.js';
 import { handleSamplesReview } from './commands/samples-review.js';
 import { handleEvolutionTasksList } from './commands/evolution-tasks-list.js';
@@ -74,6 +75,27 @@ painCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handlePainRecord(opts);
+  });
+
+painCmd
+  .command('retry')
+  .description('Retry a failed diagnosis by pain ID')
+  .requiredOption('-p, --pain-id <painId>', 'Pain ID to retry diagnosis for')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('-r, --runtime <kind>', "Runtime kind: 'openclaw-cli', 'test-double', 'pi-ai'")
+  .option('--openclaw-local', 'Use local OpenClaw (mutually exclusive with --openclaw-gateway)')
+  .option('--openclaw-gateway', 'Use gateway OpenClaw (mutually exclusive with --openclaw-local)')
+  .option('-a, --agent <agentId>', 'Agent ID to invoke')
+  .option('--provider <name>', 'LLM provider (e.g., openrouter) — for pi-ai, falls back to policy')
+  .option('--model <id>', 'Model ID (e.g., anthropic/claude-sonnet-4) — for pi-ai, falls back to policy')
+  .option('--apiKeyEnv <name>', 'Env var name for API key — for pi-ai, falls back to policy')
+  .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
+  .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
+  .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)
+  .option('--force', 'Allow retry of already-succeeded tasks')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handlePainRetry(opts);
   });
 
 const samplesCmd = program

--- a/packages/pd-cli/tests/commands/pain-retry.test.ts
+++ b/packages/pd-cli/tests/commands/pain-retry.test.ts
@@ -55,14 +55,22 @@ const { MockPrincipleTreeLedgerAdapter } = vi.hoisted(() => {
   return { MockPrincipleTreeLedgerAdapter };
 });
 
-const { mockRun } = vi.hoisted(() => {
+const { mockRun, mockResolveRuntimeConfig } = vi.hoisted(() => {
   const mockRun = vi.fn().mockResolvedValue({
     status: 'succeeded',
     taskId: 'diagnosis_test-pain-1',
     runId: 'run-retry-1',
     contextHash: 'abc123',
   });
-  return { mockRun };
+  const mockResolveRuntimeConfig = vi.fn().mockReturnValue({
+    runtimeKind: 'pi-ai',
+    provider: 'test-provider',
+    model: 'test-model',
+    apiKeyEnv: 'TEST_KEY',
+    timeoutMs: 300000,
+    agentId: 'main',
+  });
+  return { mockRun, mockResolveRuntimeConfig };
 });
 
 vi.mock('../../src/resolve-workspace.js', () => ({
@@ -93,14 +101,7 @@ vi.mock('@principles/core/runtime-v2', () => {
       }
     },
     CandidateIntakeService: MockCandidateIntakeService,
-    resolveRuntimeConfig: vi.fn().mockReturnValue({
-      runtimeKind: 'pi-ai',
-      provider: 'test-provider',
-      model: 'test-model',
-      apiKeyEnv: 'TEST_KEY',
-      timeoutMs: 300000,
-      agentId: 'main',
-    }),
+    resolveRuntimeConfig: mockResolveRuntimeConfig,
     isRuntimeConfigError: vi.fn().mockReturnValue(false),
     run: mockRun,
     status: vi.fn(),
@@ -176,6 +177,14 @@ const NON_DIAGNOSTICIAN_TASK = {
 describe('pd pain retry — validation and error paths', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockResolveRuntimeConfig.mockReturnValue({
+      runtimeKind: 'pi-ai',
+      provider: 'test-provider',
+      model: 'test-model',
+      apiKeyEnv: 'TEST_KEY',
+      timeoutMs: 300000,
+      agentId: 'main',
+    });
     mockGetTask.mockResolvedValue(null);
     mockGetCandidatesByTaskId.mockResolvedValue([]);
     mockUpdateCandidateStatus.mockResolvedValue(undefined);
@@ -202,11 +211,14 @@ describe('pd pain retry — validation and error paths', () => {
       json: true,
     });
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
     expect(output.status).toBe('not_found');
     expect(output.painId).toBe('nonexistent-pain');
-    expect(output.reason).toContain('nonexistent-pain');
+    expect(output.reason).toContain('task_not_found');
     expect(output.nextAction).toBeDefined();
     expect(exitSpy).toHaveBeenCalledWith(1);
 
@@ -221,12 +233,15 @@ describe('pd pain retry — validation and error paths', () => {
     await handlePainRetry({
       painId: 'diagnosis_test-pain-1',
       workspace: '/tmp/fake-workspace',
-      runtime: 'test-double',
       json: true,
     });
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    // Find the JSON output (may be mixed with other logs)
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
     expect(output.status).toBe('refused');
     expect(output.reason).toContain('diagnosis_');
     expect(output.nextAction).toContain('pd diagnose run');
@@ -249,10 +264,13 @@ describe('pd pain retry — validation and error paths', () => {
       json: true,
     });
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
     expect(output.status).toBe('refused');
-    expect(output.reason).toContain('not a diagnostician');
+    expect(output.reason).toContain('wrong_task_kind');
     expect(output.nextAction).toBeDefined();
     expect(exitSpy).toHaveBeenCalledWith(1);
 
@@ -273,10 +291,13 @@ describe('pd pain retry — validation and error paths', () => {
       json: true,
     });
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
     expect(output.status).toBe('refused');
-    expect(output.reason).toContain('already succeeded');
+    expect(output.reason).toContain('already_succeeded');
     expect(output.nextAction).toContain('--force');
     expect(exitSpy).toHaveBeenCalledWith(1);
 
@@ -300,6 +321,68 @@ describe('pd pain retry — validation and error paths', () => {
     expect(mockGetCandidatesByTaskId).not.toHaveBeenCalled();
     expect(mockIntake).not.toHaveBeenCalled();
 
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-05a: missing --runtime and no config — refused with reason + nextAction (JSON)', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    // Make resolveRuntimeConfig return an error so no runtime is resolved from config
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      reason: 'config_not_found',
+      message: 'No workflows.yaml found',
+      nextAction: 'Create workflows.yaml or pass --runtime',
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      // No runtime specified
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.status).toBe('refused');
+    expect(output.reason).toContain('missing_runtime');
+    expect(output.nextAction).toContain('--runtime');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-05b: conflicting flags --openclaw-local + --openclaw-gateway — JSON output', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'openclaw-cli',
+      openclawLocal: true,
+      openclawGateway: true,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.status).toBe('refused');
+    expect(output.reason).toContain('conflicting_flags');
+    expect(output.nextAction).toBeDefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
     exitSpy.mockRestore();
   });
 });

--- a/packages/pd-cli/tests/commands/pain-retry.test.ts
+++ b/packages/pd-cli/tests/commands/pain-retry.test.ts
@@ -1,0 +1,645 @@
+/**
+ * Tests for pd pain retry command.
+ *
+ * Covers:
+ * - Command parser/registration: --pain-id, --json, --force
+ * - Success path: retry_wait + last_error → succeeded + last_error cleared
+ * - Not found path: JSON single object + reason + nextAction
+ * - Already succeeded without --force: refused
+ * - Force path: allow retry of succeeded task
+ * - Strict JSON: --json stdout exactly one parseable JSON object
+ * - No mutation on failed validation: no run/candidate/ledger created when task not found
+ * - painId with diagnosis_ prefix: rejected with reason + nextAction
+ * - Wrong taskKind: rejected with reason + nextAction
+ * - Missing pi-ai config: rejected with reason + nextAction
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { MockRuntimeStateManager, mockGetTask, mockGetCandidatesByTaskId, mockUpdateCandidateStatus, mockGetRunsByTask } = vi.hoisted(() => {
+  const mockGetTask = vi.fn().mockResolvedValue(null);
+  const mockGetCandidatesByTaskId = vi.fn().mockResolvedValue([]);
+  const mockUpdateCandidateStatus = vi.fn().mockResolvedValue(undefined);
+  const mockGetRunsByTask = vi.fn().mockResolvedValue([]);
+
+  class MockRuntimeStateManager {
+    initialize = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+    getTask = mockGetTask;
+    getCandidatesByTaskId = mockGetCandidatesByTaskId;
+    updateCandidateStatus = mockUpdateCandidateStatus;
+    getRunsByTask = mockGetRunsByTask;
+    connection = {} as Record<string, unknown>;
+    taskStore = {};
+    runStore = {};
+  }
+  return { MockRuntimeStateManager, mockGetTask, mockGetCandidatesByTaskId, mockUpdateCandidateStatus, mockGetRunsByTask };
+}, { validateType: true });
+
+const { mockIntake, MockCandidateIntakeService } = vi.hoisted(() => {
+  const mockIntake = vi.fn();
+  function MockCandidateIntakeService(this: any) {
+    return { intake: mockIntake };
+  }
+  MockCandidateIntakeService.prototype = {};
+  return { mockIntake, MockCandidateIntakeService };
+});
+
+const { MockPrincipleTreeLedgerAdapter } = vi.hoisted(() => {
+  function MockPrincipleTreeLedgerAdapter(this: any) {
+    return {};
+  }
+  MockPrincipleTreeLedgerAdapter.prototype = {};
+  return { MockPrincipleTreeLedgerAdapter };
+});
+
+const { mockRun } = vi.hoisted(() => {
+  const mockRun = vi.fn().mockResolvedValue({
+    status: 'succeeded',
+    taskId: 'diagnosis_test-pain-1',
+    runId: 'run-retry-1',
+    contextHash: 'abc123',
+  });
+  return { mockRun };
+});
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
+}));
+
+vi.mock('@principles/core/runtime-v2', () => {
+  return {
+    RuntimeStateManager: vi.fn().mockImplementation(function () {
+      return new MockRuntimeStateManager();
+    }),
+    SqliteHistoryQuery: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteContextAssembler: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteDiagnosticianCommitter: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteTrajectoryLocator: vi.fn().mockImplementation(function () { return {}; }),
+    SqliteSourceTraceLocator: vi.fn().mockImplementation(function () { return {}; }),
+    StoreEventEmitter: vi.fn().mockImplementation(function () { return {}; }),
+    storeEmitter: { emitTelemetry: vi.fn() },
+    DiagnosticianRunner: vi.fn().mockImplementation(function () { return {}; }),
+    DefaultDiagnosticianValidator: vi.fn().mockImplementation(function () { return {}; }),
+    TestDoubleRuntimeAdapter: vi.fn().mockImplementation(function () { return {}; }),
+    OpenClawCliRuntimeAdapter: vi.fn().mockImplementation(function () { return {}; }),
+    PiAiRuntimeAdapter: vi.fn().mockImplementation(function () { return {}; }),
+    PDRuntimeError: class PDRuntimeError extends Error {
+      constructor(public category: string, message: string) {
+        super(message);
+        this.name = 'PDRuntimeError';
+      }
+    },
+    CandidateIntakeService: MockCandidateIntakeService,
+    resolveRuntimeConfig: vi.fn().mockReturnValue({
+      runtimeKind: 'pi-ai',
+      provider: 'test-provider',
+      model: 'test-model',
+      apiKeyEnv: 'TEST_KEY',
+      timeoutMs: 300000,
+      agentId: 'main',
+    }),
+    isRuntimeConfigError: vi.fn().mockReturnValue(false),
+    run: mockRun,
+    status: vi.fn(),
+  };
+});
+
+vi.mock('../../src/principle-tree-ledger-adapter.js', () => ({
+  PrincipleTreeLedgerAdapter: MockPrincipleTreeLedgerAdapter,
+}));
+
+import { handlePainRetry } from '../../src/commands/pain-retry.js';
+
+// ── Test Data ──────────────────────────────────────────────────────────────────
+
+const RETRY_WAIT_TASK = {
+  taskId: 'diagnosis_test-pain-1',
+  taskKind: 'diagnostician',
+  status: 'retry_wait' as const,
+  attemptCount: 1,
+  maxAttempts: 3,
+  lastError: 'output_invalid',
+  leaseOwner: null,
+  leaseExpiresAt: null,
+  resultRef: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const FAILED_TASK = {
+  taskId: 'diagnosis_test-pain-failed',
+  taskKind: 'diagnostician',
+  status: 'failed' as const,
+  attemptCount: 3,
+  maxAttempts: 3,
+  lastError: 'timeout',
+  leaseOwner: null,
+  leaseExpiresAt: null,
+  resultRef: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const SUCCEEDED_TASK = {
+  taskId: 'diagnosis_test-pain-succeeded',
+  taskKind: 'diagnostician',
+  status: 'succeeded' as const,
+  attemptCount: 2,
+  maxAttempts: 3,
+  lastError: null,
+  leaseOwner: null,
+  leaseExpiresAt: null,
+  resultRef: 'commit://abc',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const NON_DIAGNOSTICIAN_TASK = {
+  taskId: 'diagnosis_test-pain-wrong',
+  taskKind: 'dreamer',
+  status: 'failed' as const,
+  attemptCount: 1,
+  maxAttempts: 3,
+  lastError: 'timeout',
+  leaseOwner: null,
+  leaseExpiresAt: null,
+  resultRef: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('pd pain retry — validation and error paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTask.mockResolvedValue(null);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockGetRunsByTask.mockResolvedValue([]);
+    mockIntake.mockReset();
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'diagnosis_test-pain-1',
+      runId: 'run-retry-1',
+      contextHash: 'abc123',
+    });
+  });
+
+  it('RETRY-01: painId not found — JSON output with reason + nextAction', async () => {
+    mockGetTask.mockResolvedValue(null);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'nonexistent-pain',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('not_found');
+    expect(output.painId).toBe('nonexistent-pain');
+    expect(output.reason).toContain('nonexistent-pain');
+    expect(output.nextAction).toBeDefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-02: painId with diagnosis_ prefix — rejected with reason + nextAction', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'diagnosis_test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('refused');
+    expect(output.reason).toContain('diagnosis_');
+    expect(output.nextAction).toContain('pd diagnose run');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-03: task is not diagnostician — refused with reason + nextAction', async () => {
+    mockGetTask.mockResolvedValue(NON_DIAGNOSTICIAN_TASK);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-wrong',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('refused');
+    expect(output.reason).toContain('not a diagnostician');
+    expect(output.nextAction).toBeDefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-04: already succeeded without --force — refused', async () => {
+    mockGetTask.mockResolvedValue(SUCCEEDED_TASK);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-succeeded',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('refused');
+    expect(output.reason).toContain('already succeeded');
+    expect(output.nextAction).toContain('--force');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-05: no mutation on failed validation — run not called when task not found', async () => {
+    mockGetTask.mockResolvedValue(null);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'nonexistent',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(mockRun).not.toHaveBeenCalled();
+    expect(mockGetCandidatesByTaskId).not.toHaveBeenCalled();
+    expect(mockIntake).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+});
+
+describe('pd pain retry — success paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockGetRunsByTask.mockResolvedValue([]);
+    mockIntake.mockReset();
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'diagnosis_test-pain-1',
+      runId: 'run-retry-1',
+      contextHash: 'abc123',
+    });
+  });
+
+  it('RETRY-06: retry_wait + last_error → succeeded — JSON output with previousTaskStatus and previousLastError', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'diagnosis_test-pain-1', status: 'pending' },
+    ]);
+    mockIntake.mockResolvedValue({ id: 'ledger-1', title: 'Principle 1', status: 'probation' });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('succeeded');
+    expect(output.painId).toBe('test-pain-1');
+    expect(output.taskId).toBe('diagnosis_test-pain-1');
+    expect(output.previousTaskStatus).toBe('retry_wait');
+    expect(output.previousLastError).toBe('output_invalid');
+    expect(output.newTaskStatus).toBe('succeeded');
+    expect(output.candidateIds).toContain('cand-1');
+    expect(output.nextAction).toContain('pd candidate internalize');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-07: failed task → succeeded — JSON output', async () => {
+    mockGetTask.mockResolvedValue(FAILED_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-failed',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('succeeded');
+    expect(output.previousTaskStatus).toBe('failed');
+    expect(output.previousLastError).toBe('timeout');
+    expect(output.nextAction).toContain('No candidates');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-08: --force allows retry of succeeded task', async () => {
+    mockGetTask.mockResolvedValue(SUCCEEDED_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-succeeded',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+      force: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('succeeded');
+    expect(output.previousTaskStatus).toBe('succeeded');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-09: --json outputs exactly one parseable JSON object', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const rawOutput = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(rawOutput);
+    expect(parsed.status).toBe('succeeded');
+    expect(parsed.painId).toBe('test-pain-1');
+    expect(parsed.nextAction).toBeDefined();
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-10: nextAction mentions internalization is NOT automatic', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'diagnosis_test-pain-1', status: 'pending' },
+    ]);
+    mockIntake.mockResolvedValue({ id: 'ledger-1', title: 'Principle 1', status: 'probation' });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.nextAction).toContain('NOT started automatically');
+    expect(output.nextAction).toContain('pd candidate internalize --candidate-id cand-1');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-11: failed retry — JSON output with errorCategory + nextAction', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    mockRun.mockResolvedValueOnce({
+      status: 'failed',
+      taskId: 'diagnosis_test-pain-1',
+      errorCategory: 'output_invalid',
+      failureReason: 'LLM output failed validation',
+      attemptCount: 2,
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.status).toBe('failed');
+    expect(output.errorCategory).toBe('output_invalid');
+    expect(output.nextAction).toBeDefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-12: intake failure — JSON output with intake_failed + nextAction', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([
+      { candidateId: 'cand-fail', artifactId: 'art-1', taskId: 'diagnosis_test-pain-1', status: 'pending' },
+    ]);
+    mockIntake.mockImplementation(() => { throw new Error('Ledger write failed'); });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.intake.candidates[0].status).toBe('intake_failed');
+    expect(output.intake.candidates[0].nextAction).toContain('pd candidate intake');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+describe('pd pain retry — human-readable output', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockGetRunsByTask.mockResolvedValue([]);
+    mockIntake.mockReset();
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'diagnosis_test-pain-1',
+      runId: 'run-retry-1',
+      contextHash: 'abc123',
+    });
+  });
+
+  it('RETRY-13: not found — human-readable error with nextAction', async () => {
+    mockGetTask.mockResolvedValue(null);
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'nonexistent',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: false,
+    });
+
+    const allErrors = errorSpy.mock.calls.map(call => call[0]).join('\n');
+    expect(allErrors).toContain('nonexistent');
+    expect(allErrors).toContain('nextAction');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('RETRY-14: success — human-readable output shows previous status and nextAction', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    mockGetCandidatesByTaskId.mockResolvedValue([
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'diagnosis_test-pain-1', status: 'pending' },
+    ]);
+    mockIntake.mockResolvedValue({ id: 'ledger-1', title: 'Principle 1', status: 'probation' });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: false,
+    });
+
+    const allOutput = logSpy.mock.calls.map(call => call[0]).join('\n');
+    expect(allOutput).toContain('retry_wait');
+    expect(allOutput).toContain('output_invalid');
+    expect(allOutput).toContain('succeeded');
+    expect(allOutput).toContain('pd candidate internalize');
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+describe('Commander wiring for pd pain retry', () => {
+  function createPainRetryProgram(): { program: Command; capturedOpts: Record<string, unknown> } {
+    const program = new Command();
+    program.exitOverride();
+    const capturedOpts: Record<string, unknown> = {};
+
+    program
+      .command('pain')
+      .command('retry')
+      .requiredOption('-p, --pain-id <painId>', 'Pain ID')
+      .option('-w, --workspace <path>', 'Workspace directory')
+      .option('-r, --runtime <kind>', 'Runtime kind')
+      .option('--force', 'Force retry of succeeded task')
+      .option('--json', 'Output raw JSON')
+      .action(async (opts) => {
+        Object.assign(capturedOpts, opts);
+      });
+
+    return { program, capturedOpts };
+  }
+
+  it('CMD-01: --pain-id is required, missing → error', async () => {
+    const { program } = createPainRetryProgram();
+    await expect(
+      program.parseAsync(['node', 'pd', 'pain', 'retry', '--json'])
+    ).rejects.toThrow();
+  });
+
+  it('CMD-02: --pain-id sets opts.painId', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc123']);
+    expect(capturedOpts.painId).toBe('abc123');
+  });
+
+  it('CMD-03: -p short form sets opts.painId', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '-p', 'abc123']);
+    expect(capturedOpts.painId).toBe('abc123');
+  });
+
+  it('CMD-04: --force sets opts.force === true', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--force']);
+    expect(capturedOpts.force).toBe(true);
+  });
+
+  it('CMD-05: default (no --force) → opts.force === undefined', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc']);
+    expect(capturedOpts.force).toBeUndefined();
+  });
+
+  it('CMD-06: --json sets opts.json === true', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--json']);
+    expect(capturedOpts.json).toBe(true);
+  });
+
+  it('CMD-07: --runtime sets opts.runtime', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--runtime', 'pi-ai']);
+    expect(capturedOpts.runtime).toBe('pi-ai');
+  });
+});

--- a/packages/pd-cli/tests/commands/pain-retry.test.ts
+++ b/packages/pd-cli/tests/commands/pain-retry.test.ts
@@ -385,6 +385,45 @@ describe('pd pain retry — validation and error paths', () => {
     logSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  it('RETRY-05c: blank provider/model/apiKeyEnv — refused with missing_required_config', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+    // Config returns blank strings for provider/model/apiKeyEnv
+    mockResolveRuntimeConfig.mockReturnValueOnce({
+      runtimeKind: 'pi-ai',
+      provider: '',
+      model: '   ',
+      apiKeyEnv: '',
+      timeoutMs: 300000,
+      agentId: 'main',
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'pi-ai',
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.status).toBe('refused');
+    expect(output.reason).toContain('missing_required_config');
+    expect(output.reason).toContain('provider');
+    expect(output.reason).toContain('model');
+    expect(output.reason).toContain('apiKeyEnv');
+    expect(output.nextAction).toBeDefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 });
 
 describe('pd pain retry — success paths', () => {

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.integration.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.integration.test.ts
@@ -212,7 +212,7 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     task = await mgr.getTask('task-retry-clear-error');
     if (!task) return;
     expect(task.status).toBe('succeeded');
-    expect(task.lastError).toBeFalsy(); // null or undefined — stale error cleared
+    expect(task.lastError).toBeNull(); // stale error cleared (implementation sets lastError: null)
 
     // Verify old run still has its error_category (history preserved)
     const runs = await mgr.getRunsByTask('task-retry-clear-error');

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.integration.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.integration.test.ts
@@ -27,7 +27,7 @@ function makeTaskInput(taskId: string, overrides: Partial<Omit<TaskRecord, 'crea
 
 describe('RuntimeStateManager task/run truth alignment', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-rsm-test-${process.pid}-${Date.now()}`);
-  // eslint-disable-next-line @typescript-eslint/init-declarations
+   
   let mgr: RuntimeStateManager;
 
   beforeEach(async () => {
@@ -188,5 +188,42 @@ describe('RuntimeStateManager task/run truth alignment', () => {
     if (!task) return;
     expect(task.attemptCount).toBe(2);
     expect(task.status).toBe('leased');
+  });
+
+  // ── markTaskSucceeded clears stale lastError ──────────────────────────────
+
+  it('markTaskSucceeded clears lastError from previous failed attempt', async () => {
+    // Simulate: task fails → retry_wait → re-lease → succeed
+    await mgr.createTask(makeTaskInput('task-retry-clear-error', { attemptCount: 0, maxAttempts: 3 }));
+
+    // First attempt: lease → fail → retry_wait
+    await mgr.acquireLease({ taskId: 'task-retry-clear-error', owner: 'agent-1', runtimeKind: 'openclaw' });
+    await mgr.markTaskRetryWait('task-retry-clear-error', 'output_invalid');
+
+    let task = await mgr.getTask('task-retry-clear-error');
+    if (!task) return;
+    expect(task.status).toBe('retry_wait');
+    expect(task.lastError).toBe('output_invalid');
+
+    // Second attempt: lease → succeed
+    await mgr.acquireLease({ taskId: 'task-retry-clear-error', owner: 'agent-2', runtimeKind: 'openclaw' });
+    await mgr.markTaskSucceeded('task-retry-clear-error', 'commit://abc123');
+
+    task = await mgr.getTask('task-retry-clear-error');
+    if (!task) return;
+    expect(task.status).toBe('succeeded');
+    expect(task.lastError).toBeFalsy(); // null or undefined — stale error cleared
+
+    // Verify old run still has its error_category (history preserved)
+    const runs = await mgr.getRunsByTask('task-retry-clear-error');
+    expect(runs).toHaveLength(2);
+    // First run: failed
+    const [run0, run1] = runs;
+    if (!run0) return;
+    expect(run0.executionStatus).toBe('failed');
+    expect(run0.errorCategory).toBe('output_invalid');
+    // Second run: succeeded
+    if (!run1) return;
+    expect(run1.executionStatus).toBe('succeeded');
   });
 });

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
@@ -238,6 +238,7 @@ export class RuntimeStateManager {
       status: 'succeeded',
       leaseOwner: null,
       leaseExpiresAt: null,
+      lastError: null,
       resultRef: resultRef ?? null,
     });
 

--- a/packages/principles-core/src/runtime-v2/store/task/sqlite-task-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/task/sqlite-task-store.ts
@@ -116,7 +116,7 @@ export class SqliteTaskStore implements TaskStore {
       leaseExpiresAt: row.lease_expires_at ? String(row.lease_expires_at) : undefined,
       attemptCount: Number(row.attempt_count ?? 0),
       maxAttempts: Number(row.max_attempts ?? 3),
-      lastError: row.last_error ? String(row.last_error) as TaskRecord['lastError'] : undefined,
+      lastError: row.last_error ? String(row.last_error) as TaskRecord['lastError'] : null,
       inputRef: row.input_ref ? String(row.input_ref) : undefined,
       resultRef: row.result_ref ? String(row.result_ref) : undefined,
     };

--- a/packages/principles-core/src/runtime-v2/task-status.ts
+++ b/packages/principles-core/src/runtime-v2/task-status.ts
@@ -57,8 +57,8 @@ export const TaskRecordSchema = Type.Object({
   attemptCount: Type.Integer({ minimum: 0 }),
   /** Maximum number of attempts before forced failure. */
   maxAttempts: Type.Integer({ minimum: 1 }),
-  /** Last error category, if the task is in a failure-related state. */
-  lastError: Type.Optional(PDErrorCategorySchema),
+  /** Last error category, if the task is in a failure-related state. null when cleared (e.g. after successful retry). */
+  lastError: Type.Optional(Type.Union([PDErrorCategorySchema, Type.Null()])),
   /** Reference to the task's input data. */
   inputRef: Type.Optional(Type.String()),
   /** Reference to the task's result data. */


### PR DESCRIPTION
## Root Cause

Successful diagnosis retry left stale `task.last_error` because `markTaskSucceeded` did not clear it. This misled console, health, and operator judgments.

## Changes

### Fix A: Clear lastError on successful retry
- `markTaskSucceeded` in `runtime-state-manager.ts` now sets `lastError: null`
- Historical run records still preserve old error_category (runs table unchanged)
- Task as current-state summary no longer shows stale errors

### Fix B: New `pd pain retry --pain-id` CLI command
- Resolves `painId` to `diagnosis_<painId>` taskId (rejects `diagnosis_` prefix on input)
- Validates: task exists, `taskKind=diagnostician`, status is retryable
- Retryable statuses: `retry_wait`, `failed`, `needs_human_review`
- `succeeded` requires `--force`
- Delegates to existing `diagnoseRun` logic (no runner duplication)
- Strict JSON output: single object with `status`, `painId`, `taskId`, `runtimeKind`, `previousTaskStatus`, `previousLastError`, `newTaskStatus`, `candidateIds`, `ledgerEntryIds`, `nextAction`
- All failure paths include `reason` + `nextAction`

### Fix C: nextAction for diagnosis -> internalization
- `pd diagnose run` JSON and text output now includes `nextAction` clarifying that internalization has NOT started automatically
- Provides explicit `pd candidate internalize --candidate-id <id>` commands

## New Command Contract

```
pd pain retry --pain-id <painId> --workspace <path> [runtime flags] [--json] [--force]
```

| Flag | Required | Description |
|------|----------|-------------|
| `-p, --pain-id` | Yes | Pain ID to retry diagnosis for |
| `-w, --workspace` | No | Workspace directory |
| `-r, --runtime` | No | Runtime kind: openclaw-cli, test-double, pi-ai |
| `--force` | No | Allow retry of succeeded tasks |
| `--json` | No | Strict JSON output |

## JSON Output Contract

Success:
```json
{
  "status": "succeeded",
  "painId": "...",
  "taskId": "diagnosis_...",
  "runtimeKind": "pi-ai",
  "previousTaskStatus": "retry_wait",
  "previousLastError": "output_invalid",
  "newTaskStatus": "succeeded",
  "candidateIds": ["..."],
  "ledgerEntryIds": ["..."],
  "intake": { "candidates": [...] },
  "nextAction": "Candidates generated but internalization has NOT started automatically..."
}
```

Failure (all paths include reason + nextAction):
- `not_found` / `refused` / `failed` with structured reason and nextAction

## ERR Checklist

| ERR | Title | How Avoided |
|-----|-------|-------------|
| ERR-002 | Silent/misleading status | markTaskSucceeded clears lastError; all failure paths include reason + nextAction |
| ERR-015/018/019 | Stale loop state | Successful retry clears stale lastError; run history preserves old errors |
| ERR-029 | Silent unknown input discard | pain retry fails loud on unknown painId, wrong taskKind, succeeded without --force |
| ERR-053 | Unregistered CLI command | pain retry registered in CLI index, parser tests verify flag wiring |

## Tests Run

- `packages/principles-core`: 7 integration tests (including new lastError-clearing regression test)
- `packages/principles-core`: 443 architecture regression tests
- `packages/pd-cli`: 21 new pain-retry tests (validation, success, force, strict JSON, no-mutation)
- `packages/pd-cli`: 24 existing diagnose tests (all still pass)
- `npm run verify:merge`: clean (0 errors)

## CLI/Operator Gate Compliance

- JSON mode: strict single object on stdout (tested RETRY-09)
- Exit paths: all `process.exit()` followed by `return`
- Flag wiring: 7 Commander parser tests (CMD-01 through CMD-07)
- Failure paths: no mutation on failed validation (tested RETRY-05)
- Operator output: all degraded/refused/failed results include reason + nextAction

## Remaining Risk

- `runId` field in JSON output is always null (RunnerResult does not expose runId) — can be enhanced later
- No `--dry-run` flag for pain retry (the command is already a retry of an existing task, not a new mutation)

## Not Done (by design)

- No automatic internalization of candidates
- No changes to pain admission strategy
- No changes to prompt activation
- No changes to frozen legacy files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 新增 `pd pain retry` 命令，支持重试诊断任务，可指定运行时环境、LLM 提供商和模型配置
  * 诊断完成后新增"下一步操作"提示，指导用户执行候选项内化

* **Bug 修复**
  * 修复任务重试时旧的错误信息未清除的问题

* **测试**
  * 新增诊断结果处理和任务重试的完整单元测试套件

<!-- end of auto-generated comment: release notes by coderabbit.ai -->