### PR TITLE
feat(pd-cli): run-once default successor enqueue + integrity recommendedAction

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -99,6 +99,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-060 | Emitted telemetry event not registered in schema — event silently dropped or degraded | PR #808/#809/#810 |
 | ERR-061 | Runtime shape check validates wrong field name — guessed structure instead of verifying against actual type | PR #823 |
 | ERR-062 | Collapsed details section renders empty-state copy instead of actual data when data exists | PRI-319 / PR #825 |
+| ERR-063 | Commander `--no-<flag>` option property accessed via incorrect name — flag silently ignored | PR #844 |
 
 ---
 
@@ -849,6 +850,18 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: When creating a new BasePeerRunner subclass, the PR checklist must include: (1) list all events the runner can emit, (2) verify each is in TelemetryEventType, (3) add a test proving the schema accepts each event. Review trigger: any PR that adds a new runner or new emitEvent() call must also update telemetry-event.ts.
 - **Source**: PR #808/#809/#810
 - **Date**: 2026-06-03
+- **Recurrence**: None
+
+---
+
+**[ERR-063]** | Commander `--no-<flag>` option property accessed via incorrect name — flag silently ignored
+
+- **What happened**: When changing `--enqueue-next` to `--no-enqueue-next` (inverting the default), the CLI registration used `.option('--no-enqueue-next', ...)` but the `.action()` handler accessed `opts.noEnqueueNext`. Commander's `--no-` prefix convention stores the option as the *positive* form: `--no-enqueue-next` → `opts.enqueueNext`. Since `opts.noEnqueueNext` is always `undefined`, `!opts.noEnqueueNext` is always `true`, meaning the `--no-enqueue-next` flag was silently ignored and enqueue always happened regardless of the flag.
+- **Why it's wrong**: The Commander.js `--no-` prefix negation convention is well-documented but non-obvious. The property name is derived by removing the `--no-` prefix and camelCasing the remainder, NOT by camelCasing the full flag name. Using `opts.noEnqueueNext` (the full flag name camelCased) accesses a non-existent property that is always `undefined`. This makes `--no-enqueue-next` a no-op — the most dangerous kind of bug because the flag appears to work (no error thrown) but has no effect.
+- **Correct approach**: When using Commander's `--no-<flag>` negation, the option value is stored as `opts.<flag>` (positive form). For `--no-enqueue-next`, access `opts.enqueueNext`. Always verify Commander property names by testing with `console.log(JSON.stringify(opts))` or writing a parser-level test that calls `program.parseAsync()` with the flag.
+- **How to prevent**: When registering `--no-<flag>` Commander options, immediately write a parser-level test that verifies the option value is correctly parsed with AND without the flag. The test should assert `opts.<positiveForm> === false` when the flag is present and `opts.<positiveForm> === true` when absent. Review trigger: any PR that uses Commander's `--no-` prefix must include a parser test.
+- **Source**: PR #844
+- **Date**: 2026-06-07
 - **Recurrence**: None
 
 ---

--- a/docs/ERROR_PATTERN_INDEX.md
+++ b/docs/ERROR_PATTERN_INDEX.md
@@ -34,8 +34,8 @@ For a task, pick the matching pattern cards, read the listed ERR entries, and st
 
 - **Use when**: touching `packages/pd-cli`, operator commands, installers, command registration, or JSON mode.
 - **Failure mode**: flags parse differently than handlers expect, `process.exit()` falls through, dry-run mutates, JSON stdout is polluted, or nextAction is unusable.
-- **Must check**: parser-level tests use the real Commander program; failed paths stop execution and do not mutate state; `--json` emits exactly one parseable object.
-- **Representative ERRs**: ERR-020, ERR-021, ERR-022, ERR-023, ERR-029, ERR-033, ERR-043, ERR-053.
+- **Must check**: parser-level tests use the real Commander program; failed paths stop execution and do not mutate state; `--json` emits exactly one parseable object; `--no-<flag>` options are stored as the positive form (e.g., `--no-enqueue-next` → `opts.enqueueNext`), never `opts.noEnqueueNext`.
+- **Representative ERRs**: ERR-020, ERR-021, ERR-022, ERR-023, ERR-029, ERR-033, ERR-043, ERR-053, ERR-063.
 - **Automation target**: command wiring tests that call `program.parseAsync()` with full command paths.
 
 ### EP-05 Loop State Freshness

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -63,9 +63,13 @@ interface RunOnceOutput {
   conflictReason?: string;
   reason?: string;
   inspectedCount?: number;
-  successorTaskId?: string;
+  successorEnqueueAttempted?: boolean;
+  successorTasksCreated?: number;
+  successorTaskIds?: string[];
   successorKind?: string;
   enqueueDecision?: string;
+  enqueueReason?: string;
+  nextAction?: string;
   effectiveTimeoutMs?: number;
   timeoutSource?: string;
 }
@@ -163,12 +167,28 @@ function formatTextOutput(output: RunOnceOutput): string {
     lines.push(`  reason: ${output.reason}`);
   }
 
-  if (output.successorTaskId) {
-    lines.push(`  successor: ${output.successorTaskId} (${output.successorKind ?? 'unknown'})`);
+  if (output.successorTaskIds && output.successorTaskIds.length > 0) {
+    lines.push(`  successor: ${output.successorTaskIds.join(', ')} (${output.successorKind ?? 'unknown'})`);
+  }
+
+  if (output.successorEnqueueAttempted !== undefined) {
+    lines.push(`  enqueue_attempted: ${output.successorEnqueueAttempted}`);
+  }
+
+  if (output.successorTasksCreated !== undefined) {
+    lines.push(`  successors_created: ${output.successorTasksCreated}`);
   }
 
   if (output.enqueueDecision) {
     lines.push(`  enqueue: ${output.enqueueDecision}`);
+  }
+
+  if (output.enqueueReason) {
+    lines.push(`  enqueue_reason: ${output.enqueueReason}`);
+  }
+
+  if (output.nextAction) {
+    lines.push(`  nextAction: ${output.nextAction}`);
   }
 
   if (output.effectiveTimeoutMs) {
@@ -619,12 +639,43 @@ export async function handleRuntimeInternalizationRunOnce(opts: RunOnceOptions):
       }
     }
 
-    if (opts.enqueueNext && runnerResult?.status === 'succeeded' && wakeResult.decision === 'would_lease') {
-      const commitResult = await orchestrator.commitNextTaskProposal(wakeResult.taskId);
-      output.enqueueDecision = commitResult.decision;
-      if (commitResult.decision === 'successor_created' || commitResult.decision === 'successor_exists') {
-        output.successorTaskId = commitResult.successorTaskId;
-        output.successorKind = commitResult.successorKind;
+    // Default: auto-enqueue successor on runner success (unless opted out via --no-enqueue-next)
+    const shouldEnqueue = opts.enqueueNext !== false;
+
+    if (shouldEnqueue && runnerResult?.status === 'succeeded' && wakeResult.decision === 'would_lease') {
+      output.successorEnqueueAttempted = true;
+      try {
+        const commitResult = await orchestrator.commitNextTaskProposal(wakeResult.taskId);
+        output.enqueueDecision = commitResult.decision;
+        output.successorTasksCreated = 0;
+        output.successorTaskIds = [];
+        if (commitResult.decision === 'successor_created' || commitResult.decision === 'successor_exists') {
+          output.successorKind = commitResult.successorKind;
+          output.successorTaskIds.push(commitResult.successorTaskId);
+          output.successorTasksCreated = commitResult.decision === 'successor_created' ? 1 : 0;
+        } else if (commitResult.decision === 'no_successor') {
+          output.enqueueReason = commitResult.reason;
+          output.nextAction = 'No successor in job graph for this task kind and channel. This is expected for terminal runners.';
+        } else {
+          output.enqueueReason = `Unexpected commitNextTaskProposal decision: ${commitResult.decision}`;
+          output.nextAction = 'Investigate orchestrator logic; re-run with --no-enqueue-next to skip auto-enqueue.';
+        }
+      } catch (enqueueErr: unknown) {
+        const enqueueMessage = enqueueErr instanceof Error ? enqueueErr.message : String(enqueueErr);
+        output.enqueueDecision = 'enqueue_failed';
+        output.enqueueReason = enqueueMessage;
+        output.successorTasksCreated = 0;
+        output.successorTaskIds = [];
+        output.nextAction = `Runner succeeded but successor enqueue failed. Run: pd runtime internalization enqueue-successors --workspace ${workspaceDir} --confirm`;
+        // Runner success is real; downgrade to partial_success, not error
+        if (output.decision === 'would_lease') {
+          output.decision = 'partial_success';
+        }
+      }
+    } else if (!shouldEnqueue) {
+      output.successorEnqueueAttempted = false;
+      if (runnerResult?.status === 'succeeded' && wakeResult.decision === 'would_lease') {
+        output.nextAction = 'Successor auto-enqueue was skipped (--no-enqueue-next). To enqueue: pd runtime internalization enqueue-successors --confirm';
       }
     }
 

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -548,11 +548,11 @@ internalizationCmd
   .option('--runner <kind>', 'Runner kind to execute (default: dreamer)', 'dreamer')
   .option('--runtime <kind>', 'Runtime adapter kind: config (from workflows.yaml), pi-ai, openclaw-cli, test-double (default: config)', 'config')
   .option('--allow-test-double', 'Acknowledge that test-double runtime will mutate real queue state')
-  .option('--enqueue-next', 'After successful runner execution, commit successor task to queue')
+  .option('--no-enqueue-next', 'Skip successor enqueue after successful runner (default: auto-enqueue)')
   .option('--timeout-ms <ms>', 'Runner timeout in milliseconds (default: 300000, overrides workflows.yaml)', parseInt)
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
-    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble, enqueueNext: opts.enqueueNext, timeoutMs: opts.timeoutMs });
+    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble, enqueueNext: !opts.noEnqueueNext, timeoutMs: opts.timeoutMs });
   });
 
 internalizationCmd

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -552,7 +552,7 @@ internalizationCmd
   .option('--timeout-ms <ms>', 'Runner timeout in milliseconds (default: 300000, overrides workflows.yaml)', parseInt)
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
-    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble, enqueueNext: !opts.noEnqueueNext, timeoutMs: opts.timeoutMs });
+    await handleRuntimeInternalizationRunOnce({ workspace: opts.workspace, json: opts.json, runtime: opts.runtime, runner: opts.runner, allowTestDouble: opts.allowTestDouble, enqueueNext: opts.enqueueNext, timeoutMs: opts.timeoutMs });
   });
 
 internalizationCmd

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -535,7 +535,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(text).toContain('resultRef: philosopher://run-phil-002');
   });
 
-  it('successful dreamer + --enqueue-next returns successorTaskId', async () => {
+  it('auto-enqueue: successful dreamer returns successor info by default', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-dreamer-enq-001',
@@ -568,7 +568,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.successorKind).toBe('philosopher');
   });
 
-  it('repeated --enqueue-next returns existing successorTaskId', async () => {
+  it('auto-enqueue: repeated run returns existing successorTaskId', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-dreamer-enq-002',
@@ -601,7 +601,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.successorKind).toBe('philosopher');
   });
 
-  it('--enqueue-next with no_successor does not set successorTaskId', async () => {
+  it('auto-enqueue: no_successor does not set successor info', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-dreamer-enq-003',
@@ -632,7 +632,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.successorTaskIds).toEqual([]);
   });
 
-  it('--enqueue-next with failed run does not call commitNextTaskProposal', async () => {
+  it('auto-enqueue: failed run does not call commitNextTaskProposal', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-dreamer-enq-004',
@@ -652,7 +652,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
   });
 
-  it('--enqueue-next without --allow-test-double still blocked', async () => {
+  it('auto-enqueue without --allow-test-double still blocked', async () => {
     await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', enqueueNext: true });
 
     expect(process.exitCode).toBe(1);
@@ -880,7 +880,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.runnerResult.status).toBe('succeeded');
   });
 
-  it('--runner scribe --enqueue-next creates artificer successor', async () => {
+  it('auto-enqueue: --runner scribe creates artificer successor', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-scribe-enq-001',
@@ -979,7 +979,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.runnerResult.status).toBe('succeeded');
   });
 
-  it('--runner artificer --enqueue-next returns successor decision', async () => {
+  it('auto-enqueue: --runner artificer returns successor decision', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-artificer-enq-001',
@@ -1112,7 +1112,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.runnerResult.status).toBe('succeeded');
   });
 
-  it('--runner evaluator --enqueue-next returns successor decision', async () => {
+  it('auto-enqueue: --runner evaluator returns successor decision', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-evaluator-enq-001',
@@ -1208,7 +1208,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.runnerResult.status).toBe('succeeded');
   });
 
-  it('--runner rollout_reviewer --enqueue-next returns no_successor for prompt channel', async () => {
+  it('auto-enqueue: --runner rollout_reviewer returns no_successor for prompt channel', async () => {
     mockWakeOnce.mockResolvedValue({
       decision: 'would_lease',
       taskId: 'task-rollout-reviewer-enq-001',
@@ -1504,5 +1504,87 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(text).toContain('successor: task-phil-text-001');
     expect(text).toContain('enqueue_attempted: true');
     expect(text).toContain('successors_created: 1');
+  });
+});
+
+// === Commander parser-level tests for --no-enqueue-next ===
+// These tests verify that Commander correctly maps --no-enqueue-next to opts.enqueueNext.
+// They exercise the real Commander parsing path, NOT the handler directly.
+// See ERR-063: previous code used opts.noEnqueueNext (always undefined) instead of opts.enqueueNext.
+
+describe('Commander --no-enqueue-next parser wiring', () => {
+  function buildRunOnceCommand(capturedOpts: Record<string, unknown>) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Command } = require('commander') as typeof import('commander');
+    const program = new Command();
+    program.exitOverride(); // prevent process.exit during tests
+
+    const internalizationCmd = program.command('internalization');
+    internalizationCmd
+      .command('run-once')
+      .description('Wake-and-run: lease the next PI task and execute it')
+      .option('-w, --workspace <path>', 'Workspace directory')
+      .option('--runner <kind>', 'Runner kind', 'dreamer')
+      .option('--runtime <kind>', 'Runtime adapter kind', 'config')
+      .option('--allow-test-double', 'Acknowledge test-double runtime')
+      .option('--no-enqueue-next', 'Skip successor enqueue after successful runner')
+      .option('--timeout-ms <ms>', 'Runner timeout', parseInt)
+      .option('--json', 'Output raw JSON')
+      .action(async (opts) => {
+        Object.assign(capturedOpts, opts);
+      });
+
+    return program;
+  }
+
+  it('with --no-enqueue-next, Commander sets enqueueNext=false', async () => {
+    const captured: Record<string, unknown> = {};
+    const program = buildRunOnceCommand(captured);
+
+    await program.parseAsync([
+      'node', 'pd', 'internalization', 'run-once',
+      '--no-enqueue-next',
+      '--workspace', '/tmp/test',
+      '--runtime', 'test-double',
+      '--allow-test-double',
+      '--json',
+    ]);
+
+    expect(captured).toHaveProperty('enqueueNext', false);
+    expect(captured).not.toHaveProperty('noEnqueueNext');
+  });
+
+  it('without --no-enqueue-next, Commander sets enqueueNext=true (default)', async () => {
+    const captured: Record<string, unknown> = {};
+    const program = buildRunOnceCommand(captured);
+
+    await program.parseAsync([
+      'node', 'pd', 'internalization', 'run-once',
+      '--workspace', '/tmp/test',
+      '--runtime', 'test-double',
+      '--allow-test-double',
+      '--json',
+    ]);
+
+    expect(captured).toHaveProperty('enqueueNext', true);
+  });
+
+  it('opts has no noEnqueueNext property regardless of flag presence', async () => {
+    const capturedWith: Record<string, unknown> = {};
+    const programWith = buildRunOnceCommand(capturedWith);
+    await programWith.parseAsync([
+      'node', 'pd', 'internalization', 'run-once',
+      '--no-enqueue-next', '--workspace', '/tmp/test',
+    ]);
+
+    const capturedWithout: Record<string, unknown> = {};
+    const programWithout = buildRunOnceCommand(capturedWithout);
+    await programWithout.parseAsync([
+      'node', 'pd', 'internalization', 'run-once',
+      '--workspace', '/tmp/test',
+    ]);
+
+    expect(capturedWith).not.toHaveProperty('noEnqueueNext');
+    expect(capturedWithout).not.toHaveProperty('noEnqueueNext');
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-run-once.test.ts
@@ -564,7 +564,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('successor_created');
-    expect(output.successorTaskId).toBe('task-phil-enq-001');
+    expect(output.successorTaskIds![0]).toBe('task-phil-enq-001');
     expect(output.successorKind).toBe('philosopher');
   });
 
@@ -597,7 +597,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('successor_exists');
-    expect(output.successorTaskId).toBe('task-phil-enq-002');
+    expect(output.successorTaskIds![0]).toBe('task-phil-enq-002');
     expect(output.successorKind).toBe('philosopher');
   });
 
@@ -629,7 +629,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('no_successor');
-    expect(output.successorTaskId).toBeUndefined();
+    expect(output.successorTaskIds).toEqual([]);
   });
 
   it('--enqueue-next with failed run does not call commitNextTaskProposal', async () => {
@@ -916,7 +916,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('successor_created');
-    expect(output.successorTaskId).toBe('task-artificer-enq-001');
+    expect(output.successorTaskIds![0]).toBe('task-artificer-enq-001');
     expect(output.successorKind).toBe('artificer');
   });
 
@@ -1022,7 +1022,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('successor_created');
-    expect(output.successorTaskId).toBe('task-evaluator-enq-001');
+    expect(output.successorTaskIds![0]).toBe('task-evaluator-enq-001');
     expect(output.successorKind).toBe('evaluator');
   });
 
@@ -1155,7 +1155,7 @@ describe('handleRuntimeInternalizationRunOnce', () => {
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.enqueueDecision).toBe('successor_created');
-    expect(output.successorTaskId).toBe('task-rollout-reviewer-enq-001');
+    expect(output.successorTaskIds![0]).toBe('task-rollout-reviewer-enq-001');
     expect(output.successorKind).toBe('rollout_reviewer');
   });
 
@@ -1314,5 +1314,195 @@ describe('handleRuntimeInternalizationRunOnce', () => {
     expect(output.reason).toContain('artifact write failed');
     expect(output.nextAction).toBeTruthy();
     expect(process.exitCode).toBe(1);
+  });
+
+  // === Default enqueue successor tests ===
+
+  it('default behavior (no --no-enqueue-next) auto-enqueues successor on runner success', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-auto-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-auto-001',
+      runId: 'run-auto-001',
+      artifactId: 'pi-art-auto-001',
+      resultRef: 'dreamer://run-auto-001',
+      contextHash: 'ctx-auto',
+      output: { valid: true, taskId: 'task-dreamer-auto-001', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'task-dreamer-auto-001',
+      successorTaskId: 'task-phil-auto-001',
+      successorKind: 'philosopher',
+    });
+
+    // No enqueueNext specified — default should auto-enqueue
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.successorEnqueueAttempted).toBe(true);
+    expect(output.successorTasksCreated).toBe(1);
+    expect(output.successorTaskIds).toContain('task-phil-auto-001');
+    expect(output.enqueueDecision).toBe('successor_created');
+    expect(output.successorKind).toBe('philosopher');
+    expect(mockCommitNextTaskProposal).toHaveBeenCalledWith('task-dreamer-auto-001');
+  });
+
+  it('--no-enqueue-next (enqueueNext: false) skips successor enqueue', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-skip-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-skip-001',
+      runId: 'run-skip-001',
+      artifactId: 'pi-art-skip-001',
+      resultRef: 'dreamer://run-skip-001',
+      contextHash: 'ctx-skip',
+      output: { valid: true, taskId: 'task-dreamer-skip-001', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, enqueueNext: false, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.successorEnqueueAttempted).toBe(false);
+    expect(output.nextAction).toContain('--no-enqueue-next');
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+  });
+
+  it('successor enqueue failure outputs partial_success with reason and nextAction', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-fail-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-fail-001',
+      runId: 'run-fail-001',
+      artifactId: 'pi-art-fail-001',
+      resultRef: 'dreamer://run-fail-001',
+      contextHash: 'ctx-fail',
+      output: { valid: true, taskId: 'task-dreamer-fail-001', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockRejectedValue(new Error('database locked'));
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.decision).toBe('partial_success');
+    expect(output.successorEnqueueAttempted).toBe(true);
+    expect(output.enqueueDecision).toBe('enqueue_failed');
+    expect(output.enqueueReason).toContain('database locked');
+    expect(output.nextAction).toContain('enqueue-successors');
+    expect(output.successorTasksCreated).toBe(0);
+    expect(output.successorTaskIds).toEqual([]);
+  });
+
+  it('runner failure never enqueues successor (default behavior)', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-nofail-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'failed',
+      taskId: 'task-dreamer-nofail-001',
+      errorCategory: 'execution_failed',
+      failureReason: 'Runtime unavailable',
+      attemptCount: 1,
+    });
+
+    // Default behavior (no --no-enqueue-next)
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    expect(mockCommitNextTaskProposal).not.toHaveBeenCalled();
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.successorEnqueueAttempted).toBeUndefined();
+  });
+
+  it('JSON output is single parseable JSON with successor fields', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-json-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-json-001',
+      runId: 'run-json-001',
+      artifactId: 'pi-art-json-001',
+      resultRef: 'dreamer://run-json-001',
+      contextHash: 'ctx-json',
+      output: { valid: true, taskId: 'task-dreamer-json-001', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'task-dreamer-json-001',
+      successorTaskId: 'task-phil-json-001',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: true });
+
+    const rawOutput = consoleLogSpy.mock.calls[0][0];
+    // Must be single parseable JSON
+    const output = JSON.parse(rawOutput);
+    expect(output).toHaveProperty('successorEnqueueAttempted');
+    expect(output).toHaveProperty('successorTasksCreated');
+    expect(output).toHaveProperty('successorTaskIds');
+    // nextAction may be undefined when successor is successfully created
+    // but must be present on partial_success / no_successor / skipped
+  });
+
+  it('text output for auto-enqueue shows successor info', async () => {
+    mockWakeOnce.mockResolvedValue({
+      decision: 'would_lease',
+      taskId: 'task-dreamer-text-001',
+      taskKind: 'dreamer',
+    });
+
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'task-dreamer-text-001',
+      runId: 'run-text-001',
+      artifactId: 'pi-art-text-001',
+      resultRef: 'dreamer://run-text-001',
+      contextHash: 'ctx-text',
+      output: { valid: true, taskId: 'task-dreamer-text-001', candidates: VALID_DREAMER_CANDIDATES, contextRefs: [], generatedAt: new Date().toISOString() },
+      attemptCount: 1,
+    });
+
+    mockCommitNextTaskProposal.mockResolvedValue({
+      decision: 'successor_created',
+      sourceTaskId: 'task-dreamer-text-001',
+      successorTaskId: 'task-phil-text-001',
+      successorKind: 'philosopher',
+    });
+
+    await handleRuntimeInternalizationRunOnce({ workspace: WS, runner: 'dreamer', runtime: 'test-double', allowTestDouble: true, json: false });
+
+    const text = consoleLogSpy.mock.calls.map((c: string[]) => c[0]).join('\n');
+    expect(text).toContain('successor: task-phil-text-001');
+    expect(text).toContain('enqueue_attempted: true');
+    expect(text).toContain('successors_created: 1');
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-chain-integrity-read-model.ts
@@ -276,7 +276,7 @@ export class InternalizationChainIntegrityReadModel {
             severity: 'warning',
             taskId: dreamerTask.task_id,
             reason: `Succeeded dreamer task ${dreamerTask.task_id} has no philosopher successor task`,
-            recommendedAction: 'Check orchestrator successor proposal logic or manually enqueue philosopher task.',
+            recommendedAction: `pd runtime internalization enqueue-successors --workspace <workspace> --confirm, then pd runtime internalization run-once --workspace <workspace> --runner philosopher`,
           });
         }
       }


### PR DESCRIPTION
Fixes usability gap where run-once succeeded but did NOT auto-enqueue successor tasks. Changes: (1) run-once defaults to auto-enqueue, --no-enqueue-next to opt-out; (2) partial_success on enqueue failure with reason+nextAction; (3) JSON output adds successorEnqueueAttempted/successorTasksCreated/successorTaskIds; (4) integrity missing_philosopher_successor recommendedAction now includes complete CLI commands. Tests: 48 run-once tests (6 new), 125 internalization tests, 72 integrity tests all passing. verify:merge clean.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  ## 鍙戝竷璇存槑  * **鏂板姛鑳?*   * 杩愯鏃跺唴閮ㄥ寲鍛戒护鐜板凡榛樿鑷姩鍏ラ槦鍚庣户浠诲姟锛屽彲閫氳繃 `--no-enqueue-next` 閫夐」绂佺敤姝よ涓恒€? * **鏀硅繘**   * 浼樺寲杈撳嚭淇℃伅锛屾柊澧炲悗缁т换鍔″垪琛ㄣ€佸叆闃熷喅绛栬鎯呭拰涓嬩竴姝ユ搷浣滄彁绀恒€?  * 瀹屽杽鏂摼妫€娴嬪缓璁紝鎻愪緵鏄庣‘鐨勪慨澶嶆寚瀵煎懡浠ゃ€? <!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Linear:** [PRI-328](https://linear.app/principlesdisciple/issue/PRI-328/run-once-默认自动-enqueue-successor-integrity-recommendedaction-cli-命令)