### PR TITLE
feat(pd-console): PRI-332 principles output language preference and seed-user clarity

### DIFF
--- a/packages/pd-console/src/server/config/pd-config-store.ts
+++ b/packages/pd-console/src/server/config/pd-config-store.ts
@@ -632,6 +632,7 @@ export interface OutputLanguageResultOk {
 export interface OutputLanguageResultErr {
   ok: false;
   error: string;
+  statusCode: number;
   message: string;
   nextAction: string;
 }
@@ -658,7 +659,7 @@ export function getPrinciplesOutputLanguage(workspaceDir: string): OutputLanguag
     raw = fs.readFileSync(configPath, 'utf8');
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, error: 'read_error', message: `Failed to read config: ${message}`, nextAction: 'Check file permissions for .pd/config.yaml' };
+    return { ok: false, error: 'read_error', statusCode: 500, message: `Failed to read config: ${message}`, nextAction: 'Check file permissions for .pd/config.yaml' };
   }
 
   let parsed: unknown;
@@ -666,7 +667,7 @@ export function getPrinciplesOutputLanguage(workspaceDir: string): OutputLanguag
     parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, error: 'yaml_error', message: `YAML parse error: ${message}`, nextAction: 'Fix YAML syntax in .pd/config.yaml' };
+    return { ok: false, error: 'yaml_error', statusCode: 500, message: `YAML parse error: ${message}`, nextAction: 'Fix YAML syntax in .pd/config.yaml' };
   }
 
   if (!isRecord(parsed)) {
@@ -683,6 +684,7 @@ export function getPrinciplesOutputLanguage(workspaceDir: string): OutputLanguag
     return {
       ok: false,
       error: 'invalid_config',
+      statusCode: 500,
       message: 'principles section must be a mapping',
       nextAction: 'Fix principles section in .pd/config.yaml to be a YAML mapping',
     };
@@ -697,6 +699,7 @@ export function getPrinciplesOutputLanguage(workspaceDir: string): OutputLanguag
     return {
       ok: false,
       error: 'invalid_output_language',
+      statusCode: 500,
       message: `principles.outputLanguage must be one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}. Got: ${String(outputLangRaw)}`,
       nextAction: `Set principles.outputLanguage to one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}`,
     };
@@ -715,17 +718,18 @@ export function updatePrinciplesOutputLanguage(
 ): OutputLanguageResult {
   // 1. Validate payload
   if (!isRecord(payload)) {
-    return { ok: false, error: 'bad_request', message: 'Payload must be a JSON object with an outputLanguage field', nextAction: 'Send { outputLanguage: "zh-CN" } or { outputLanguage: "en" }' };
+    return { ok: false, error: 'bad_request', statusCode: 400, message: 'Payload must be a JSON object with an outputLanguage field', nextAction: 'Send { outputLanguage: "zh-CN" } or { outputLanguage: "en" }' };
   }
 
   const outputLangRaw = Object.hasOwn(payload, 'outputLanguage') ? payload.outputLanguage : undefined;
   if (outputLangRaw === undefined) {
-    return { ok: false, error: 'bad_request', message: 'Missing required field: outputLanguage', nextAction: `Send { outputLanguage: "${DEFAULT_OUTPUT_LANGUAGE}" }` };
+    return { ok: false, error: 'bad_request', statusCode: 400, message: 'Missing required field: outputLanguage', nextAction: `Send { outputLanguage: "${DEFAULT_OUTPUT_LANGUAGE}" }` };
   }
   if (!isValidOutputLanguage(outputLangRaw)) {
     return {
       ok: false,
       error: 'bad_request',
+      statusCode: 400,
       message: `outputLanguage must be one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}. Got: ${String(outputLangRaw)}`,
       nextAction: `Set outputLanguage to one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}`,
     };
@@ -735,8 +739,20 @@ export function updatePrinciplesOutputLanguage(
   const configPath = getPdConfigPath(workspaceDir);
   let rawConfig: Record<string, unknown>;
   if (fs.existsSync(configPath)) {
-    const rawContent = fs.readFileSync(configPath, 'utf8');
-    const rawParsed = yaml.load(rawContent, { schema: yaml.JSON_SCHEMA });
+    let rawContent: string;
+    try {
+      rawContent = fs.readFileSync(configPath, 'utf8');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: 'read_error', statusCode: 500, message: `Failed to read config for update: ${message}`, nextAction: 'Check file permissions for .pd/config.yaml' };
+    }
+    let rawParsed: unknown;
+    try {
+      rawParsed = yaml.load(rawContent, { schema: yaml.JSON_SCHEMA });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: 'yaml_error', statusCode: 500, message: `YAML parse error during update: ${message}`, nextAction: 'Fix YAML syntax in .pd/config.yaml' };
+    }
     if (isRecord(rawParsed)) {
       rawConfig = { ...rawParsed };
     } else {
@@ -757,13 +773,19 @@ export function updatePrinciplesOutputLanguage(
     return {
       ok: false,
       error: 'validation_error',
+      statusCode: 500,
       message: `Updated config would be invalid: ${validation.errors.map(e => e.reason).join('; ')}`,
       nextAction: 'Fix config validation errors before retrying',
     };
   }
 
   // 5. Atomic write
-  writeConfigAtomic(configPath, rawConfig);
+  try {
+    writeConfigAtomic(configPath, rawConfig);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: 'write_error', statusCode: 500, message: `Failed to write config: ${message}`, nextAction: 'Check disk space and file permissions for .pd/config.yaml' };
+  }
 
   return { ok: true, outputLanguage: outputLangRaw, source: 'user_config' };
 }

--- a/packages/pd-console/src/server/config/pd-config-store.ts
+++ b/packages/pd-console/src/server/config/pd-config-store.ts
@@ -613,6 +613,161 @@ export function updateDefaultRuntime(
   };
 }
 
+// ── Principles Output Language (PRI-332 P1-1) ─────────────────────────────
+
+/** Valid values for principles.outputLanguage in config.yaml */
+export const VALID_OUTPUT_LANGUAGES = ['zh-CN', 'en'] as const;
+export type OutputLanguage = typeof VALID_OUTPUT_LANGUAGES[number];
+
+function isValidOutputLanguage(value: unknown): value is OutputLanguage {
+  return typeof value === 'string' && (VALID_OUTPUT_LANGUAGES as readonly string[]).includes(value);
+}
+
+export interface OutputLanguageResultOk {
+  ok: true;
+  outputLanguage: OutputLanguage;
+  source: 'user_config' | 'default';
+}
+
+export interface OutputLanguageResultErr {
+  ok: false;
+  error: string;
+  message: string;
+  nextAction: string;
+}
+
+export type OutputLanguageResult = OutputLanguageResultOk | OutputLanguageResultErr;
+
+/** Default output language when not configured. */
+const DEFAULT_OUTPUT_LANGUAGE: OutputLanguage = 'zh-CN';
+
+/**
+ * Read principles.outputLanguage from config.yaml.
+ * Returns default ('zh-CN') when not set.
+ * Fail loud if set to an invalid value (ERR-009).
+ */
+export function getPrinciplesOutputLanguage(workspaceDir: string): OutputLanguageResult {
+  const configPath = getPdConfigPath(workspaceDir);
+
+  if (!fs.existsSync(configPath)) {
+    return { ok: true, outputLanguage: DEFAULT_OUTPUT_LANGUAGE, source: 'default' };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: 'read_error', message: `Failed to read config: ${message}`, nextAction: 'Check file permissions for .pd/config.yaml' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: 'yaml_error', message: `YAML parse error: ${message}`, nextAction: 'Fix YAML syntax in .pd/config.yaml' };
+  }
+
+  if (!isRecord(parsed)) {
+    return { ok: true, outputLanguage: DEFAULT_OUTPUT_LANGUAGE, source: 'default' };
+  }
+
+  // Extract principles section — unknown-first, no `as` bypass (ERR-001)
+  const principlesRaw = Object.hasOwn(parsed, 'principles') ? parsed.principles : undefined;
+  if (principlesRaw === undefined) {
+    return { ok: true, outputLanguage: DEFAULT_OUTPUT_LANGUAGE, source: 'default' };
+  }
+
+  if (!isRecord(principlesRaw)) {
+    return {
+      ok: false,
+      error: 'invalid_config',
+      message: 'principles section must be a mapping',
+      nextAction: 'Fix principles section in .pd/config.yaml to be a YAML mapping',
+    };
+  }
+
+  const outputLangRaw = Object.hasOwn(principlesRaw, 'outputLanguage') ? principlesRaw.outputLanguage : undefined;
+  if (outputLangRaw === undefined) {
+    return { ok: true, outputLanguage: DEFAULT_OUTPUT_LANGUAGE, source: 'default' };
+  }
+
+  if (!isValidOutputLanguage(outputLangRaw)) {
+    return {
+      ok: false,
+      error: 'invalid_output_language',
+      message: `principles.outputLanguage must be one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}. Got: ${String(outputLangRaw)}`,
+      nextAction: `Set principles.outputLanguage to one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}`,
+    };
+  }
+
+  return { ok: true, outputLanguage: outputLangRaw, source: 'user_config' };
+}
+
+/**
+ * Update principles.outputLanguage in config.yaml.
+ * Safe partial write: preserves unknown sections, validates before write.
+ */
+export function updatePrinciplesOutputLanguage(
+  workspaceDir: string,
+  payload: unknown,
+): OutputLanguageResult {
+  // 1. Validate payload
+  if (!isRecord(payload)) {
+    return { ok: false, error: 'bad_request', message: 'Payload must be a JSON object with an outputLanguage field', nextAction: 'Send { outputLanguage: "zh-CN" } or { outputLanguage: "en" }' };
+  }
+
+  const outputLangRaw = Object.hasOwn(payload, 'outputLanguage') ? payload.outputLanguage : undefined;
+  if (outputLangRaw === undefined) {
+    return { ok: false, error: 'bad_request', message: 'Missing required field: outputLanguage', nextAction: `Send { outputLanguage: "${DEFAULT_OUTPUT_LANGUAGE}" }` };
+  }
+  if (!isValidOutputLanguage(outputLangRaw)) {
+    return {
+      ok: false,
+      error: 'bad_request',
+      message: `outputLanguage must be one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}. Got: ${String(outputLangRaw)}`,
+      nextAction: `Set outputLanguage to one of: ${VALID_OUTPUT_LANGUAGES.join(', ')}`,
+    };
+  }
+
+  // 2. Read raw config to preserve unknown sections
+  const configPath = getPdConfigPath(workspaceDir);
+  let rawConfig: Record<string, unknown>;
+  if (fs.existsSync(configPath)) {
+    const rawContent = fs.readFileSync(configPath, 'utf8');
+    const rawParsed = yaml.load(rawContent, { schema: yaml.JSON_SCHEMA });
+    if (isRecord(rawParsed)) {
+      rawConfig = { ...rawParsed };
+    } else {
+      rawConfig = {};
+    }
+  } else {
+    rawConfig = {};
+  }
+
+  // 3. Update principles.outputLanguage
+  const existingPrinciples = isRecord(rawConfig.principles) ? { ...rawConfig.principles } : {};
+  existingPrinciples.outputLanguage = outputLangRaw;
+  rawConfig.principles = existingPrinciples;
+
+  // 4. Validate via core (principles is an unknown section — safe to pass through)
+  const validation = validatePdConfig(rawConfig);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      error: 'validation_error',
+      message: `Updated config would be invalid: ${validation.errors.map(e => e.reason).join('; ')}`,
+      nextAction: 'Fix config validation errors before retrying',
+    };
+  }
+
+  // 5. Atomic write
+  writeConfigAtomic(configPath, rawConfig);
+
+  return { ok: true, outputLanguage: outputLangRaw, source: 'user_config' };
+}
+
 // ── Check Readiness ──────────────────────────────────────────────────────────
 
 export function checkReadiness(

--- a/packages/pd-console/src/server/models/PrinciplesConsoleModel.ts
+++ b/packages/pd-console/src/server/models/PrinciplesConsoleModel.ts
@@ -79,8 +79,8 @@ export interface PrincipleListItem {
   updatedAt: string;
   /** Detected language of the principle text ('en' | 'zh' | 'unknown'). PRI-332 */
   detectedLanguage: 'en' | 'zh' | 'unknown';
-  /** Human-readable warning when the title may be hard to read. PRI-332 */
-  readabilityWarning?: string;
+  /** Structured readability warning code — front-end renders via i18n. PRI-332 P1-5 */
+  readabilityWarningCode?: ReadabilityWarningCode;
 }
 
 export interface RuleItem {
@@ -142,24 +142,28 @@ const CJK_REGEX = /[\u4e00-\u9fff\u3400-\u4dbf]/;
 const REGEX_LIKE_PATTERN = /^[/^.*+?()[\]{}|$\\]|\/.*\/[gimsuy]*$/;
 const TECHNICAL_RESIDUE_PATTERN = /^[a-zA-Z_]+\.[a-zA-Z_]+\(|^Error:|^TypeError:|\{\{.*\}\}|<\/?\w+>/;
 
+/** Structured readability warning codes — front-end renders via i18n (PRI-332 P1-5). */
+export type ReadabilityWarningCode = 'technical_pattern' | 'diagnostic_residue' | 'title_too_long';
+
 /** Simple CJK-based language detection for principle text. */
 function detectLanguage(text: string): 'en' | 'zh' | 'unknown' {
   if (!text || text.trim().length === 0) return 'unknown';
   return CJK_REGEX.test(text) ? 'zh' : 'en';
 }
 
-/** Check if a triggerPattern/title looks like unreadable technical residue. */
-function checkReadabilityWarning(triggerPattern: string, text: string): string | undefined {
+/** Check if a triggerPattern/title looks like unreadable technical residue.
+ *  Returns a structured code instead of an English string (PRI-332 P1-5). */
+function checkReadabilityWarning(triggerPattern: string, text: string): ReadabilityWarningCode | undefined {
   const title = triggerPattern || text.slice(0, 80);
   if (!title) return undefined;
   if (REGEX_LIKE_PATTERN.test(title.trim())) {
-    return 'Title appears to be a technical pattern. Review the behavior evidence below.';
+    return 'technical_pattern';
   }
   if (TECHNICAL_RESIDUE_PATTERN.test(title.trim())) {
-    return 'Title may contain diagnostic residue. Review the full text for context.';
+    return 'diagnostic_residue';
   }
   if (title.length > 120) {
-    return 'Title is unusually long. The readable summary may be in the text below.';
+    return 'title_too_long';
   }
   return undefined;
 }
@@ -310,7 +314,7 @@ export class PrinciplesConsoleModel {
         createdAt: p.createdAt ?? '',
         updatedAt: p.updatedAt ?? '',
         detectedLanguage: detectLanguage(principleText),
-        readabilityWarning: checkReadabilityWarning(principleTrigger, principleText),
+        readabilityWarningCode: checkReadabilityWarning(principleTrigger, principleText),
       });
     }
 
@@ -384,7 +388,7 @@ export class PrinciplesConsoleModel {
       updatedAt: p.updatedAt ?? '',
       rules,
       detectedLanguage: detectLanguage(detailText),
-      readabilityWarning: checkReadabilityWarning(detailTrigger, detailText),
+      readabilityWarningCode: checkReadabilityWarning(detailTrigger, detailText),
     };
 
     return { principle };

--- a/packages/pd-console/src/server/models/PrinciplesConsoleModel.ts
+++ b/packages/pd-console/src/server/models/PrinciplesConsoleModel.ts
@@ -77,6 +77,10 @@ export interface PrincipleListItem {
   conflictsWithCount: number;
   createdAt: string;
   updatedAt: string;
+  /** Detected language of the principle text ('en' | 'zh' | 'unknown'). PRI-332 */
+  detectedLanguage: 'en' | 'zh' | 'unknown';
+  /** Human-readable warning when the title may be hard to read. PRI-332 */
+  readabilityWarning?: string;
 }
 
 export interface RuleItem {
@@ -131,6 +135,34 @@ const VALID_EVALUABILITIES: readonly PrincipleEvaluability[] = ['manual_only', '
 const VALID_RULE_TYPES: readonly RuleType[] = ['hook', 'gate', 'skill', 'lora', 'test', 'prompt'];
 const VALID_RULE_STATUSES: readonly RuleStatus[] = ['proposed', 'implemented', 'enforced', 'retired'];
 const VALID_ENFORCEMENTS: readonly ('block' | 'warn' | 'log')[] = ['block', 'warn', 'log'];
+
+// ── PRI-332: Language detection & readability helpers ────────────────────────
+
+const CJK_REGEX = /[\u4e00-\u9fff\u3400-\u4dbf]/;
+const REGEX_LIKE_PATTERN = /^[/^.*+?()[\]{}|$\\]|\/.*\/[gimsuy]*$/;
+const TECHNICAL_RESIDUE_PATTERN = /^[a-zA-Z_]+\.[a-zA-Z_]+\(|^Error:|^TypeError:|\{\{.*\}\}|<\/?\w+>/;
+
+/** Simple CJK-based language detection for principle text. */
+function detectLanguage(text: string): 'en' | 'zh' | 'unknown' {
+  if (!text || text.trim().length === 0) return 'unknown';
+  return CJK_REGEX.test(text) ? 'zh' : 'en';
+}
+
+/** Check if a triggerPattern/title looks like unreadable technical residue. */
+function checkReadabilityWarning(triggerPattern: string, text: string): string | undefined {
+  const title = triggerPattern || text.slice(0, 80);
+  if (!title) return undefined;
+  if (REGEX_LIKE_PATTERN.test(title.trim())) {
+    return 'Title appears to be a technical pattern. Review the behavior evidence below.';
+  }
+  if (TECHNICAL_RESIDUE_PATTERN.test(title.trim())) {
+    return 'Title may contain diagnostic residue. Review the full text for context.';
+  }
+  if (title.length > 120) {
+    return 'Title is unusually long. The readable summary may be in the text below.';
+  }
+  return undefined;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -258,10 +290,12 @@ export class PrinciplesConsoleModel {
         case 'archived': summary.archived++; break;
       }
 
+      const principleText = p.text ?? '';
+      const principleTrigger = p.triggerPattern ?? '';
       items.push({
         id: p.id,
-        text: p.text ?? '',
-        triggerPattern: p.triggerPattern ?? '',
+        text: principleText,
+        triggerPattern: principleTrigger,
         action: p.action ?? '',
         status,
         priority: safeCastEnum(p.priority, VALID_PRIORITIES, 'P2'),
@@ -275,6 +309,8 @@ export class PrinciplesConsoleModel {
         conflictsWithCount: (p.conflictsWithPrincipleIds ?? []).length,
         createdAt: p.createdAt ?? '',
         updatedAt: p.updatedAt ?? '',
+        detectedLanguage: detectLanguage(principleText),
+        readabilityWarning: checkReadabilityWarning(principleTrigger, principleText),
       });
     }
 
@@ -321,10 +357,12 @@ export class PrinciplesConsoleModel {
 
     const status = safeCastEnum(p.status, VALID_STATUSES, 'candidate');
 
+    const detailText = p.text ?? '';
+    const detailTrigger = p.triggerPattern ?? '';
     const principle: PrincipleDetail = {
       id: p.id,
-      text: p.text ?? '',
-      triggerPattern: p.triggerPattern ?? '',
+      text: detailText,
+      triggerPattern: detailTrigger,
       action: p.action ?? '',
       status,
       priority: safeCastEnum(p.priority, VALID_PRIORITIES, 'P2'),
@@ -345,6 +383,8 @@ export class PrinciplesConsoleModel {
       createdAt: p.createdAt ?? '',
       updatedAt: p.updatedAt ?? '',
       rules,
+      detectedLanguage: detectLanguage(detailText),
+      readabilityWarning: checkReadabilityWarning(detailTrigger, detailText),
     };
 
     return { principle };

--- a/packages/pd-console/src/server/routes/config.ts
+++ b/packages/pd-console/src/server/routes/config.ts
@@ -29,6 +29,8 @@ import {
   updateAgentBinding,
   updateDefaultRuntime,
   checkReadiness,
+  getPrinciplesOutputLanguage,
+  updatePrinciplesOutputLanguage,
 } from '../config/pd-config-store.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -195,6 +197,42 @@ export async function handleConfigRoute(
     return;
   }
 
+  // GET/PATCH /principles/output-language — PRI-332 P1-1
+  if (subPath === '/principles/output-language') {
+    if (method === 'GET') {
+      const result = getPrinciplesOutputLanguage(workspaceDir);
+      if (!result.ok) {
+        sendError(res, 400, result.error, result.message);
+        return;
+      }
+      sendSuccess(res, { outputLanguage: result.outputLanguage, source: result.source });
+      return;
+    }
+    if (method === 'PATCH') {
+      let bodyText: string;
+      try {
+        bodyText = await readBody(req);
+      } catch {
+        sendBadRequest(res, 'Request body is too large or unreadable');
+        return;
+      }
+      const body = safeParseBody(bodyText);
+      const result = updatePrinciplesOutputLanguage(workspaceDir, body);
+      if (!result.ok) {
+        sendError(res, 400, result.error, result.message);
+        return;
+      }
+      // Re-read to confirm actual persisted state
+      const confirmResult = getPrinciplesOutputLanguage(workspaceDir);
+      const confirmed = confirmResult.ok ? confirmResult.outputLanguage : result.outputLanguage;
+      sendSuccess(res, { outputLanguage: confirmed, source: 'user_config' });
+      return;
+    }
+    sendMethodNotAllowed(res);
+    return;
+  }
+
   // 404 fallback
   sendNotFound(res, `Route /api/v1/config${subPath} not found`);
 }
+

--- a/packages/pd-console/src/server/routes/config.ts
+++ b/packages/pd-console/src/server/routes/config.ts
@@ -202,7 +202,7 @@ export async function handleConfigRoute(
     if (method === 'GET') {
       const result = getPrinciplesOutputLanguage(workspaceDir);
       if (!result.ok) {
-        sendError(res, 400, result.error, result.message);
+        sendError(res, result.statusCode, result.error, result.message);
         return;
       }
       sendSuccess(res, { outputLanguage: result.outputLanguage, source: result.source });
@@ -219,13 +219,16 @@ export async function handleConfigRoute(
       const body = safeParseBody(bodyText);
       const result = updatePrinciplesOutputLanguage(workspaceDir, body);
       if (!result.ok) {
-        sendError(res, 400, result.error, result.message);
+        sendError(res, result.statusCode, result.error, result.message);
         return;
       }
-      // Re-read to confirm actual persisted state
+      // Re-read to confirm actual persisted state — fail loud if re-read fails (ERR-002)
       const confirmResult = getPrinciplesOutputLanguage(workspaceDir);
-      const confirmed = confirmResult.ok ? confirmResult.outputLanguage : result.outputLanguage;
-      sendSuccess(res, { outputLanguage: confirmed, source: 'user_config' });
+      if (!confirmResult.ok) {
+        sendError(res, confirmResult.statusCode, 'confirm_read_failed', `Write succeeded but re-read failed: ${confirmResult.message}`);
+        return;
+      }
+      sendSuccess(res, { outputLanguage: confirmResult.outputLanguage, source: confirmResult.source });
       return;
     }
     sendMethodNotAllowed(res);

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -16,6 +16,7 @@ import {
   validateAgentBindingUpdate,
   validateReadinessCheck,
   validateDefaultRuntimeUpdate,
+  validateOutputLanguage,
   validateGovernanceQueue,
   validateActivations,
   validateDisableActivation,
@@ -42,6 +43,7 @@ import type {
   AgentBindingUpdateData,
   ReadinessCheckData,
   DefaultRuntimeUpdateData,
+  OutputLanguageData,
   GovernanceQueueData,
   ActivationsData,
   DisableActivationData,
@@ -328,6 +330,23 @@ async function updateDefaultRuntime(defaultRuntime: string): Promise<ApiResponse
   );
 }
 
+// ── Principles Output Language (PRI-332 P1-1) ────────────────────────────────
+
+async function fetchOutputLanguage(): Promise<ApiResponse<OutputLanguageData>> {
+  return request<OutputLanguageData>('/api/v1/config/principles/output-language', undefined, validateOutputLanguage);
+}
+
+async function updateOutputLanguage(outputLanguage: string): Promise<ApiResponse<OutputLanguageData>> {
+  return request<OutputLanguageData>(
+    '/api/v1/config/principles/output-language',
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ outputLanguage }),
+    },
+    validateOutputLanguage,
+  );
+}
+
 // ── CR8: Backend Data Contract (G.1) ─────────────────────────────────────────
 
 async function fetchGovernanceQueue(): Promise<ApiResponse<GovernanceQueueData>> {
@@ -396,6 +415,8 @@ export {
   updateAgentBinding,
   checkAgentReadiness,
   updateDefaultRuntime,
+  fetchOutputLanguage,
+  updateOutputLanguage,
   fetchWorkspaces,
   addWorkspace,
   removeWorkspace,
@@ -429,6 +450,7 @@ export type {
   AgentBindingUpdateData,
   ReadinessCheckData,
   DefaultRuntimeUpdateData,
+  OutputLanguageData,
   GovernanceQueueData,
   ActivationsData,
   DisableActivationData,

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -472,7 +472,7 @@
       "addNamePlaceholder": "Workspace name",
       "addPathPlaceholder": "Workspace path",
       "principleLanguage": "Principle Language",
-      "principleLanguageDescription": "Set the output language for new principle generation. Existing principles are not affected.",
+      "principleLanguageDescription": "Save your language preference for principle display. Generation integration is deferred.",
       "languageZhCN": "中文 (Chinese)",
       "languageEn": "English",
       "languageSaved": "Language preference saved",

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -124,7 +124,9 @@
         "check_task_status": "Check internalization pipeline status, or wait for automatic retry.",
         "fix_and_retry": "Check failure details, fix the issue and retry.",
         "run_integrity_check": "Run pd runtime internalization integrity to check and repair table structure."
-      }
+      },
+      "zeroStateHealthy": "No items need your judgment right now. PD has checked behavior evidence, principle review queue, and system signals.",
+      "zeroStateDbMissing": "PD has not run in this workspace yet. Once the state database is initialized, governance data will appear here."
     },
     "pain": {
       "eyebrow": "Behavior Evidence",
@@ -263,6 +265,12 @@
       "channelDeferArchive": "Defer Archive",
       "channelCodeToolHook": "Code Tool Hook",
       "confidence": "Confidence",
+      "languageHintEn": "Generated in English",
+      "languageHintZh": "Generated in Chinese",
+      "languageHintUnknown": "Language unknown",
+      "languageMismatchHint": "This principle was generated in {{lang}}. Review the behavior, not only the wording.",
+      "readabilityFallbackTitle": "Principle candidate",
+      "readabilityOriginalLabel": "Original technical text",
       "detail": {
         "loading": "Loading…",
         "backToList": "← Back to list",

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -271,6 +271,11 @@
       "languageMismatchHint": "This principle was generated in {{lang}}. Review the behavior, not only the wording.",
       "readabilityFallbackTitle": "Principle candidate",
       "readabilityOriginalLabel": "Original technical text",
+      "readabilityWarning": {
+        "technical_pattern": "Title appears to be a technical pattern. Review the behavior evidence below.",
+        "diagnostic_residue": "Title may contain diagnostic residue. Review the full text for context.",
+        "title_too_long": "Title is unusually long. The readable summary may be in the text below."
+      },
       "detail": {
         "loading": "Loading…",
         "backToList": "← Back to list",
@@ -465,7 +470,13 @@
       "lastSync": "Last Sync",
       "loadError": "Unable to load settings. You can try refreshing the page.",
       "addNamePlaceholder": "Workspace name",
-      "addPathPlaceholder": "Workspace path"
+      "addPathPlaceholder": "Workspace path",
+      "principleLanguage": "Principle Language",
+      "principleLanguageDescription": "Set the output language for new principle generation. Existing principles are not affected.",
+      "languageZhCN": "中文 (Chinese)",
+      "languageEn": "English",
+      "languageSaved": "Language preference saved",
+      "languageLoadError": "Failed to load language preference"
     },
     "controlCenter": {
       "eyebrow": "Control Center",

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -472,7 +472,7 @@
       "addNamePlaceholder": "工作空间名称",
       "addPathPlaceholder": "工作空间路径",
       "principleLanguage": "原则语言",
-      "principleLanguageDescription": "设置新原则的生成语言。已有原则不受影响。",
+      "principleLanguageDescription": "保存语言偏好，用于原则展示。生成接线 deferred。",
       "languageZhCN": "中文",
       "languageEn": "英文 (English)",
       "languageSaved": "语言偏好已保存",

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -124,7 +124,9 @@
         "check_task_status": "检查内化管线状态，或等待自动重试。",
         "fix_and_retry": "检查失败详情，修复问题后重试。",
         "run_integrity_check": "运行 pd runtime internalization integrity 检查并修复表结构。"
-      }
+      },
+      "zeroStateHealthy": "当前没有需要你判断的事项。PD 已检查行为证据、原则审查队列和系统信号。",
+      "zeroStateDbMissing": "PD 尚未在此工作空间中运行。状态数据库初始化后，治理数据将在这里呈现。"
     },
     "pain": {
       "eyebrow": "行为证据",
@@ -263,6 +265,12 @@
       "channelDeferArchive": "延迟归档",
       "channelCodeToolHook": "Code Tool Hook",
       "confidence": "置信度",
+      "languageHintEn": "以英文生成",
+      "languageHintZh": "以中文生成",
+      "languageHintUnknown": "语言未知",
+      "languageMismatchHint": "此原则以{{lang}}生成。请审查行为本身，而不仅是措辞。",
+      "readabilityFallbackTitle": "原则候选",
+      "readabilityOriginalLabel": "原始技术文本",
       "detail": {
         "loading": "加载中…",
         "backToList": "← 返回列表",

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -271,6 +271,11 @@
       "languageMismatchHint": "此原则以{{lang}}生成。请审查行为本身，而不仅是措辞。",
       "readabilityFallbackTitle": "原则候选",
       "readabilityOriginalLabel": "原始技术文本",
+      "readabilityWarning": {
+        "technical_pattern": "标题似乎是技术模式。请审查下方的行为证据。",
+        "diagnostic_residue": "标题可能包含诊断残留。请审查全文以获取上下文。",
+        "title_too_long": "标题异常长。可读摘要可能在下方的正文中。"
+      },
       "detail": {
         "loading": "加载中…",
         "backToList": "← 返回列表",
@@ -465,7 +470,13 @@
       "lastSync": "上次同步",
       "loadError": "无法加载设置。你可以尝试刷新页面。",
       "addNamePlaceholder": "工作空间名称",
-      "addPathPlaceholder": "工作空间路径"
+      "addPathPlaceholder": "工作空间路径",
+      "principleLanguage": "原则语言",
+      "principleLanguageDescription": "设置新原则的生成语言。已有原则不受影响。",
+      "languageZhCN": "中文",
+      "languageEn": "英文 (English)",
+      "languageSaved": "语言偏好已保存",
+      "languageLoadError": "加载语言偏好失败"
     },
     "controlCenter": {
       "eyebrow": "控制中心",

--- a/packages/pd-console/src/ui/pages/focus/FocusPage.tsx
+++ b/packages/pd-console/src/ui/pages/focus/FocusPage.tsx
@@ -345,6 +345,39 @@ function OnboardingGuide() {
   );
 }
 
+/**
+ * PRI-332: Shown when all counts are zero and sources are healthy.
+ * Explains to the owner that PD has checked everything — not that PD is broken.
+ */
+function ZeroStateHealthy() {
+  const { t } = useTranslation();
+  return (
+    <div className="bg-panel border border-line rounded-[6px] p-6">
+      <p className="text-ink-2 text-sm leading-relaxed">
+        {t("pages.focus.zeroStateHealthy")}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * PRI-332: Shown when state_db_missing — first-time setup explanation.
+ */
+function ZeroStateDbMissing() {
+  const { t } = useTranslation();
+  return (
+    <div className="bg-panel border border-line rounded-[6px] p-6">
+      <p className="text-ink-2 text-sm leading-relaxed">
+        {t("pages.focus.zeroStateDbMissing")}
+      </p>
+      <div className="mt-3 text-ink-4 text-[13px]">
+        <span className="font-medium">{t("pages.focus.nextActionLabel")}</span>{" "}
+        {getNextActionText("run_config_doctor", t)}
+      </div>
+    </div>
+  );
+}
+
 function InProgressGuide({ summary }: { summary: string }) {
   const { t } = useTranslation();
   return (
@@ -522,16 +555,27 @@ export function FocusPage() {
         stagnationCount={stagnationCount}
       />
 
-      {/* State-specific guides */}
+      {/* State-specific guides — PRI-332: distinguish healthy empty from degraded */}
       {governanceState === "none" && pendingCount === 0 && deviationCount === 0 && stagnationCount === 0 && (
-        <OnboardingGuide />
+        stateReasonCode === "state_db_missing" ? (
+          <ZeroStateDbMissing />
+        ) : (
+          <>
+            <ZeroStateHealthy />
+            <div className="mt-4">
+              <OnboardingGuide />
+            </div>
+          </>
+        )
       )}
 
       {governanceState === "in_progress" && inProgressSummary && (
         <InProgressGuide summary={inProgressSummary} />
       )}
 
-      {governanceState === "degraded" && degradedSignals && degradedSignals.length > 0 && (
+      {/* PRI-332: Always show degraded signals when present, regardless of governance state.
+          Don't hide degraded sources behind state-specific guides (ERR-002). */}
+      {degradedSignals && degradedSignals.length > 0 && (
         <DegradedSummary signals={degradedSignals} />
       )}
 

--- a/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
@@ -22,6 +22,10 @@ type ReviewStatus = "pending" | "approved" | "rejected" | "parked";
 interface PrincipleCard {
   principleId: string;
   title: string;
+  /** Original title before fallback (shown in details when title is unreadable). PRI-332 */
+  originalTitle: string;
+  /** Whether the title was replaced with a bounded fallback. PRI-332 */
+  titleUsedFallback: boolean;
   text: string;
   status: ReviewStatus;
   channels: string[];
@@ -29,6 +33,10 @@ interface PrincipleCard {
   updatedAt: string;
   createdAt: string;
   priority: string;
+  /** PRI-332: detected language of the principle text */
+  detectedLanguage: string;
+  /** PRI-332: optional readability warning for the title */
+  readabilityWarning?: string;
 }
 
 // ── Map principle status to review status ───────────────────────────────────
@@ -114,7 +122,7 @@ function validateApprovalsGrouped(data: unknown): ApprovalsGroupedData | null {
 
 // ── Component ───────────────────────────────────────────────────────────────
 export function PrinciplesPage() {
-  const { t } = useTranslation("pages");
+  const { t, i18n } = useTranslation("pages");
   const navigate = useNavigate();
 
   const [principles, setPrinciples] = useState<PrincipleListItem[]>([]);
@@ -186,9 +194,23 @@ export function PrinciplesPage() {
         : p.evaluability === "weak_heuristic"
           ? "low"
           : "medium";
+
+    // PRI-332: Determine display title with bounded fallback for unreadable titles
+    const rawTitle = p.triggerPattern || p.text.slice(0, 80);
+    const detectedLang = p.detectedLanguage ?? 'unknown';
+    const readWarning = p.readabilityWarning;
+    let displayTitle = rawTitle;
+    let usedFallback = false;
+    if (readWarning) {
+      displayTitle = t("principles.readabilityFallbackTitle");
+      usedFallback = true;
+    }
+
     return {
       principleId: p.id,
-      title: p.triggerPattern || p.text.slice(0, 80),
+      title: displayTitle,
+      originalTitle: rawTitle,
+      titleUsedFallback: usedFallback,
       text: p.text,
       status: toReviewStatus(p.status, ag?.status),
       channels: uniqueChannels,
@@ -196,6 +218,8 @@ export function PrinciplesPage() {
       updatedAt: p.updatedAt,
       createdAt: p.createdAt,
       priority: p.priority,
+      detectedLanguage: detectedLang,
+      readabilityWarning: readWarning,
     };
   });
 
@@ -387,16 +411,53 @@ export function PrinciplesPage() {
                     key={ch}
                     className="font-mono text-[11px] uppercase tracking-[0.02em] border border-line rounded-[2px] px-2 py-0.5 text-ink-3"
                   >
-                    {t("principles." + (CHANNEL_LABELS[ch] ?? ch))}
+                    {/* PRI-332: Use known label or display channel name directly — never raw i18n key */}
+                    {CHANNEL_LABELS[ch]
+                      ? t("principles." + CHANNEL_LABELS[ch])
+                      : ch}
                   </span>
                 ))}
+                {/* PRI-332: Language hint badge when principle language differs from UI language */}
+                {card.detectedLanguage && card.detectedLanguage !== 'unknown' && (
+                  <span className="font-mono text-[11px] tracking-[0.02em] border border-line rounded-[2px] px-2 py-0.5 text-ink-4">
+                    {card.detectedLanguage === 'zh'
+                      ? t("principles.languageHintZh")
+                      : t("principles.languageHintEn")}
+                  </span>
+                )}
                 <span className="font-mono text-[11px] text-ink-4">
                   {t("principles.confidence")}: {card.confidence}
                 </span>
               </div>
 
+              {/* PRI-332: Readability warning — gentle hint when title looks technical */}
+              {card.readabilityWarning && (
+                <div className="mb-2 px-3 py-1.5 bg-amber/5 border border-amber/20 rounded-[3px] text-ink-3 text-[12px] leading-snug">
+                  {card.readabilityWarning}
+                </div>
+              )}
+
+              {/* PRI-332: Language mismatch hint when principle language ≠ current UI language */}
+              {card.detectedLanguage && card.detectedLanguage !== 'unknown' && i18n.language && !i18n.language.startsWith(card.detectedLanguage) && (
+                <div className="mb-2 px-3 py-1.5 bg-surface/60 border-l-2 border-line rounded-[3px] text-ink-4 text-[12px] leading-snug">
+                  {t("principles.languageMismatchHint", { lang: card.detectedLanguage === 'en' ? 'English' : '中文' })}
+                </div>
+              )}
+
               {/* Title */}
               <h3 className="font-semibold text-ink mb-1">{card.title}</h3>
+
+              {/* PRI-332: When title used fallback, show original technical text in collapsed details */}
+              {card.titleUsedFallback && card.originalTitle && (
+                <details className="mb-1">
+                  <summary className="text-ink-4 text-[11px] font-mono cursor-pointer hover:underline">
+                    {t("principles.readabilityOriginalLabel")}
+                  </summary>
+                  <div className="text-ink-4 text-[12px] leading-snug mt-1 font-mono bg-surface/40 px-2 py-1 rounded-[3px] break-all">
+                    {card.originalTitle}
+                  </div>
+                </details>
+              )}
 
               {/* Text preview */}
               <p className="text-ink-3 text-[13px] line-clamp-3 leading-relaxed">

--- a/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
@@ -35,8 +35,8 @@ interface PrincipleCard {
   priority: string;
   /** PRI-332: detected language of the principle text */
   detectedLanguage: string;
-  /** PRI-332: optional readability warning for the title */
-  readabilityWarning?: string;
+  /** PRI-332 P1-5: structured readability warning code */
+  readabilityWarningCode?: string;
 }
 
 // ── Map principle status to review status ───────────────────────────────────
@@ -198,10 +198,10 @@ export function PrinciplesPage() {
     // PRI-332: Determine display title with bounded fallback for unreadable titles
     const rawTitle = p.triggerPattern || p.text.slice(0, 80);
     const detectedLang = p.detectedLanguage ?? 'unknown';
-    const readWarning = p.readabilityWarning;
+    const readWarningCode = p.readabilityWarningCode;
     let displayTitle = rawTitle;
     let usedFallback = false;
-    if (readWarning) {
+    if (readWarningCode) {
       displayTitle = t("principles.readabilityFallbackTitle");
       usedFallback = true;
     }
@@ -219,7 +219,7 @@ export function PrinciplesPage() {
       createdAt: p.createdAt,
       priority: p.priority,
       detectedLanguage: detectedLang,
-      readabilityWarning: readWarning,
+      readabilityWarningCode: readWarningCode,
     };
   });
 
@@ -430,10 +430,10 @@ export function PrinciplesPage() {
                 </span>
               </div>
 
-              {/* PRI-332: Readability warning — gentle hint when title looks technical */}
-              {card.readabilityWarning && (
+              {/* PRI-332 P1-5: Readability warning — rendered via i18n code, never raw English string */}
+              {card.readabilityWarningCode && (
                 <div className="mb-2 px-3 py-1.5 bg-amber/5 border border-amber/20 rounded-[3px] text-ink-3 text-[12px] leading-snug">
-                  {card.readabilityWarning}
+                  {t("principles.readabilityWarning." + card.readabilityWarningCode, { defaultValue: t("principles.readabilityFallbackTitle") })}
                 </div>
               )}
 

--- a/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
@@ -10,6 +10,8 @@ import {
   addWorkspace,
   removeWorkspace,
   syncWorkspace,
+  fetchOutputLanguage,
+  updateOutputLanguage,
 } from "../../api.js";
 import type { WorkspaceEntry } from "../../api.js";
 
@@ -110,6 +112,9 @@ export function SettingsPage() {
   const [addName, setAddName] = useState("");
   const [addPath, setAddPath] = useState("");
 
+  // PRI-332: Principle output language state
+  const [outputLanguage, setOutputLanguage] = useState<"zh-CN" | "en">("zh-CN");
+
   // Inline confirm for remove (J.1 pattern)
   const [confirmRemove, setConfirmRemove] = useState<ConfirmState | null>(null);
 
@@ -139,6 +144,17 @@ export function SettingsPage() {
     }
 
     setWorkspaces(validated);
+
+    // PRI-332: Load output language preference
+    const langResult = await fetchOutputLanguage();
+    if (langResult.success && langResult.data) {
+      const lang = langResult.data.outputLanguage;
+      if (lang === "zh-CN" || lang === "en") {
+        setOutputLanguage(lang);
+      }
+    }
+    // Non-fatal: if language load fails, keep default zh-CN
+
     setLoadingState("loaded");
   }, []);
 
@@ -212,6 +228,24 @@ export function SettingsPage() {
       toast.success(t("pages.settings.syncWorkspace"));
     },
     [loadData, t],
+  );
+
+  // ── PRI-332: Output language handler ────────────────────────────────
+
+  const handleOutputLanguageChange = useCallback(
+    async (newLang: "zh-CN" | "en") => {
+      const result = await updateOutputLanguage(newLang);
+      if (!result.success) {
+        toast.error(result.error ?? t("pages.settings.languageLoadError"));
+        return;
+      }
+      // Re-read to confirm persisted state
+      if (result.data && (result.data.outputLanguage === "zh-CN" || result.data.outputLanguage === "en")) {
+        setOutputLanguage(result.data.outputLanguage);
+      }
+      toast.success(t("pages.settings.languageSaved"));
+    },
+    [t],
   );
 
   // ── Loading state ────────────────────────────────────────────────────────
@@ -300,7 +334,34 @@ export function SettingsPage() {
         </div>
       </section>
 
-      {/* Section 2: Workspaces */}
+      {/* Section 2: PRI-332 Principle Language */}
+      <section className="mb-8" aria-labelledby="section-principle-language">
+        <SectionTitle id="section-principle-language">
+          {t("pages.settings.principleLanguage")}
+        </SectionTitle>
+
+        <div className="bg-panel border border-line rounded-[6px] p-5">
+          <p className="text-ink-3 text-[13px] leading-relaxed mb-3">
+            {t("pages.settings.principleLanguageDescription")}
+          </p>
+          <div className="flex items-center gap-3">
+            <label htmlFor="output-language-select" className="text-sm font-medium text-ink">
+              {t("pages.settings.principleLanguage")}:
+            </label>
+            <select
+              id="output-language-select"
+              value={outputLanguage}
+              onChange={(e) => handleOutputLanguageChange(e.target.value as "zh-CN" | "en")}
+              className="border border-line bg-surface rounded-[3px] px-3 py-2 text-sm text-ink focus:outline-none focus:border-gov focus:ring-1 focus:ring-gov"
+            >
+              <option value="zh-CN">{t("pages.settings.languageZhCN")}</option>
+              <option value="en">{t("pages.settings.languageEn")}</option>
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 3: Workspaces */}
       <section aria-labelledby="section-workspaces">
         <SectionTitle id="section-workspaces">
           {t("pages.settings.workspace")}

--- a/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
@@ -233,7 +233,8 @@ export function SettingsPage() {
   // ── PRI-332: Output language handler ────────────────────────────────
 
   const handleOutputLanguageChange = useCallback(
-    async (newLang: "zh-CN" | "en") => {
+    async (newLang: string) => {
+      if (newLang !== 'zh-CN' && newLang !== 'en') return;
       const result = await updateOutputLanguage(newLang);
       if (!result.success) {
         toast.error(result.error ?? t("pages.settings.languageLoadError"));
@@ -351,7 +352,7 @@ export function SettingsPage() {
             <select
               id="output-language-select"
               value={outputLanguage}
-              onChange={(e) => handleOutputLanguageChange(e.target.value as "zh-CN" | "en")}
+              onChange={(e) => handleOutputLanguageChange(e.target.value)}
               className="border border-line bg-surface rounded-[3px] px-3 py-2 text-sm text-ink focus:outline-none focus:border-gov focus:ring-1 focus:ring-gov"
             >
               <option value="zh-CN">{t("pages.settings.languageZhCN")}</option>

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -887,8 +887,8 @@ export interface PrincipleListItemData {
   updatedAt: string;
   /** PRI-332: Detected language of the principle text */
   detectedLanguage: string;
-  /** PRI-332: Human-readable warning when the title may be hard to read */
-  readabilityWarning?: string;
+  /** PRI-332 P1-5: Structured readability warning code */
+  readabilityWarningCode?: 'technical_pattern' | 'diagnostic_residue' | 'title_too_long';
 }
 
 function validatePrincipleListItem(v: unknown): PrincipleListItemData | null {
@@ -920,10 +920,11 @@ function validatePrincipleListItem(v: unknown): PrincipleListItemData | null {
     // PRI-332: detectedLanguage defaults to 'unknown' when absent
     detectedLanguage: Object.hasOwn(v, 'detectedLanguage') && isString(v.detectedLanguage) ? v.detectedLanguage : 'unknown',
   };
-  // PRI-332: readabilityWarning is optional — fail loud when present but wrong type (ERR-009)
-  if (Object.hasOwn(v, 'readabilityWarning')) {
-    if (!isString(v.readabilityWarning)) return null;
-    result.readabilityWarning = v.readabilityWarning;
+  // PRI-332 P1-5: readabilityWarningCode is optional — fail loud when present but invalid (ERR-009)
+  if (Object.hasOwn(v, 'readabilityWarningCode')) {
+    const VALID_WARNING_CODES = ['technical_pattern', 'diagnostic_residue', 'title_too_long'] as const;
+    if (!isString(v.readabilityWarningCode) || !VALID_WARNING_CODES.includes(v.readabilityWarningCode as typeof VALID_WARNING_CODES[number])) return null;
+    result.readabilityWarningCode = v.readabilityWarningCode as typeof VALID_WARNING_CODES[number];
   }
   return result;
 }
@@ -1166,4 +1167,21 @@ export function validateEvidenceChain(v: unknown): EvidenceChainData | null {
   }
 
   return result;
+}
+
+// ── Principles Output Language (PRI-332 P1-1) ──────────────────────────────
+
+export interface OutputLanguageData {
+  outputLanguage: string;
+  source: string;
+}
+
+const VALID_OUTPUT_LANGUAGE_VALUES = ['zh-CN', 'en'] as const;
+
+export function validateOutputLanguage(v: unknown): OutputLanguageData | null {
+  if (!isObject(v)) return null;
+  if (!Object.hasOwn(v, 'outputLanguage') || !isString(v.outputLanguage)) return null;
+  if (!(VALID_OUTPUT_LANGUAGE_VALUES as readonly string[]).includes(v.outputLanguage)) return null;
+  if (!Object.hasOwn(v, 'source') || !isString(v.source)) return null;
+  return { outputLanguage: v.outputLanguage, source: v.source };
 }

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -885,6 +885,10 @@ export interface PrincipleListItemData {
   conflictsWithCount: number;
   createdAt: string;
   updatedAt: string;
+  /** PRI-332: Detected language of the principle text */
+  detectedLanguage: string;
+  /** PRI-332: Human-readable warning when the title may be hard to read */
+  readabilityWarning?: string;
 }
 
 function validatePrincipleListItem(v: unknown): PrincipleListItemData | null {
@@ -906,14 +910,22 @@ function validatePrincipleListItem(v: unknown): PrincipleListItemData | null {
   if (!Object.hasOwn(v, 'conflictsWithCount') || !isNumber(v.conflictsWithCount)) return null;
   if (!Object.hasOwn(v, 'createdAt') || !isString(v.createdAt)) return null;
   if (!Object.hasOwn(v, 'updatedAt') || !isString(v.updatedAt)) return null;
-  return {
+  const result: PrincipleListItemData = {
     id: v.id, text: v.text, triggerPattern: v.triggerPattern, action: v.action,
     status: v.status, priority: v.priority, scope: v.scope,
     domain: domain.value,
     evaluability: v.evaluability, valueScore: v.valueScore, adherenceRate: v.adherenceRate,
     painPreventedCount: v.painPreventedCount, ruleCount: v.ruleCount,
     conflictsWithCount: v.conflictsWithCount, createdAt: v.createdAt, updatedAt: v.updatedAt,
+    // PRI-332: detectedLanguage defaults to 'unknown' when absent
+    detectedLanguage: Object.hasOwn(v, 'detectedLanguage') && isString(v.detectedLanguage) ? v.detectedLanguage : 'unknown',
   };
+  // PRI-332: readabilityWarning is optional — fail loud when present but wrong type (ERR-009)
+  if (Object.hasOwn(v, 'readabilityWarning')) {
+    if (!isString(v.readabilityWarning)) return null;
+    result.readabilityWarning = v.readabilityWarning;
+  }
+  return result;
 }
 
 export interface PrinciplesListData {

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -891,6 +891,13 @@ export interface PrincipleListItemData {
   readabilityWarningCode?: 'technical_pattern' | 'diagnostic_residue' | 'title_too_long';
 }
 
+const VALID_WARNING_CODES = ['technical_pattern', 'diagnostic_residue', 'title_too_long'] as const;
+type ReadabilityWarningCode = typeof VALID_WARNING_CODES[number];
+
+function isReadabilityWarningCode(value: unknown): value is ReadabilityWarningCode {
+  return isString(value) && (VALID_WARNING_CODES as readonly string[]).includes(value);
+}
+
 function validatePrincipleListItem(v: unknown): PrincipleListItemData | null {
   if (!isObject(v)) return null;
   if (!Object.hasOwn(v, 'id') || !isString(v.id)) return null;
@@ -917,14 +924,17 @@ function validatePrincipleListItem(v: unknown): PrincipleListItemData | null {
     evaluability: v.evaluability, valueScore: v.valueScore, adherenceRate: v.adherenceRate,
     painPreventedCount: v.painPreventedCount, ruleCount: v.ruleCount,
     conflictsWithCount: v.conflictsWithCount, createdAt: v.createdAt, updatedAt: v.updatedAt,
-    // PRI-332: detectedLanguage defaults to 'unknown' when absent
-    detectedLanguage: Object.hasOwn(v, 'detectedLanguage') && isString(v.detectedLanguage) ? v.detectedLanguage : 'unknown',
+    // PRI-332: detectedLanguage — absent defaults to 'unknown'; present but malformed → fail loud (ERR-009)
+    detectedLanguage: 'unknown',
   };
+  if (Object.hasOwn(v, 'detectedLanguage')) {
+    if (!isString(v.detectedLanguage)) return null;
+    result.detectedLanguage = v.detectedLanguage;
+  }
   // PRI-332 P1-5: readabilityWarningCode is optional — fail loud when present but invalid (ERR-009)
   if (Object.hasOwn(v, 'readabilityWarningCode')) {
-    const VALID_WARNING_CODES = ['technical_pattern', 'diagnostic_residue', 'title_too_long'] as const;
-    if (!isString(v.readabilityWarningCode) || !VALID_WARNING_CODES.includes(v.readabilityWarningCode as typeof VALID_WARNING_CODES[number])) return null;
-    result.readabilityWarningCode = v.readabilityWarningCode as typeof VALID_WARNING_CODES[number];
+    if (!isReadabilityWarningCode(v.readabilityWarningCode)) return null;
+    result.readabilityWarningCode = v.readabilityWarningCode;
   }
   return result;
 }

--- a/packages/pd-console/tests/models/principles-console-model.test.ts
+++ b/packages/pd-console/tests/models/principles-console-model.test.ts
@@ -605,6 +605,143 @@ describe('PrinciplesConsoleModel', () => {
 
     expect(result.principles).toHaveLength(2);
   });
+
+  // ── PRI-332: Language detection & readability tests ──────────────────────
+
+  it('PRI-332: detects Chinese text language as zh', async () => {
+    ws = await createTestWorkspace();
+    writeLedger(ws.workspaceDir, {
+      principles: {
+        'p-zh': {
+          id: 'p-zh',
+          text: '修改配置前展示影响范围',
+          triggerPattern: '配置变更',
+          action: '展示影响',
+          status: 'candidate',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const model = new PrinciplesConsoleModel(ws.workspaceDir);
+    const result = await model.listPrinciples();
+    expect(result.principles).toHaveLength(1);
+    expect(result.principles[0].detectedLanguage).toBe('zh');
+    expect(result.principles[0].readabilityWarning).toBeUndefined();
+  });
+
+  it('PRI-332: detects English text language as en', async () => {
+    ws = await createTestWorkspace();
+    writeLedger(ws.workspaceDir, {
+      principles: {
+        'p-en': {
+          id: 'p-en',
+          text: 'Always show impact scope before modifying configuration',
+          triggerPattern: 'config change',
+          action: 'show impact',
+          status: 'candidate',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const model = new PrinciplesConsoleModel(ws.workspaceDir);
+    const result = await model.listPrinciples();
+    expect(result.principles).toHaveLength(1);
+    expect(result.principles[0].detectedLanguage).toBe('en');
+  });
+
+  it('PRI-332: detects empty text as unknown', async () => {
+    ws = await createTestWorkspace();
+    writeLedger(ws.workspaceDir, {
+      principles: {
+        'p-empty': {
+          id: 'p-empty',
+          text: '',
+          triggerPattern: '',
+          action: '',
+          status: 'candidate',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const model = new PrinciplesConsoleModel(ws.workspaceDir);
+    const result = await model.listPrinciples();
+    expect(result.principles).toHaveLength(1);
+    expect(result.principles[0].detectedLanguage).toBe('unknown');
+  });
+
+  it('PRI-332: sets readabilityWarning for regex-like triggerPattern', async () => {
+    ws = await createTestWorkspace();
+    writeLedger(ws.workspaceDir, {
+      principles: {
+        'p-regex': {
+          id: 'p-regex',
+          text: 'Some principle text',
+          triggerPattern: '/^error\\s+\\d+/gi',
+          action: 'log',
+          status: 'candidate',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const model = new PrinciplesConsoleModel(ws.workspaceDir);
+    const result = await model.listPrinciples();
+    expect(result.principles).toHaveLength(1);
+    expect(result.principles[0].readabilityWarning).toBeDefined();
+    expect(result.principles[0].readabilityWarning).toMatch(/technical pattern/i);
+  });
+
+  it('PRI-332: sets readabilityWarning for Error:-prefixed triggerPattern', async () => {
+    ws = await createTestWorkspace();
+    writeLedger(ws.workspaceDir, {
+      principles: {
+        'p-err': {
+          id: 'p-err',
+          text: 'Handle errors gracefully',
+          triggerPattern: 'Error: ECONNREFUSED',
+          action: 'retry',
+          status: 'candidate',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const model = new PrinciplesConsoleModel(ws.workspaceDir);
+    const result = await model.listPrinciples();
+    expect(result.principles).toHaveLength(1);
+    expect(result.principles[0].readabilityWarning).toBeDefined();
+    expect(result.principles[0].readabilityWarning).toMatch(/diagnostic residue/i);
+  });
+
+  it('PRI-332: no readabilityWarning for normal human-readable title', async () => {
+    ws = await createTestWorkspace();
+    writeLedger(ws.workspaceDir, {
+      principles: {
+        'p-normal': {
+          id: 'p-normal',
+          text: 'Always confirm before deleting files',
+          triggerPattern: 'User deletes file',
+          action: 'ask confirmation',
+          status: 'candidate',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const model = new PrinciplesConsoleModel(ws.workspaceDir);
+    const result = await model.listPrinciples();
+    expect(result.principles).toHaveLength(1);
+    expect(result.principles[0].readabilityWarning).toBeUndefined();
+  });
 });
 
 function writeLedger(workspaceDir: string, tree: Record<string, unknown>): void {

--- a/packages/pd-console/tests/models/principles-console-model.test.ts
+++ b/packages/pd-console/tests/models/principles-console-model.test.ts
@@ -628,7 +628,7 @@ describe('PrinciplesConsoleModel', () => {
     const result = await model.listPrinciples();
     expect(result.principles).toHaveLength(1);
     expect(result.principles[0].detectedLanguage).toBe('zh');
-    expect(result.principles[0].readabilityWarning).toBeUndefined();
+    expect(result.principles[0].readabilityWarningCode).toBeUndefined();
   });
 
   it('PRI-332: detects English text language as en', async () => {
@@ -675,7 +675,7 @@ describe('PrinciplesConsoleModel', () => {
     expect(result.principles[0].detectedLanguage).toBe('unknown');
   });
 
-  it('PRI-332: sets readabilityWarning for regex-like triggerPattern', async () => {
+  it('PRI-332: sets readabilityWarningCode for regex-like triggerPattern', async () => {
     ws = await createTestWorkspace();
     writeLedger(ws.workspaceDir, {
       principles: {
@@ -694,11 +694,10 @@ describe('PrinciplesConsoleModel', () => {
     const model = new PrinciplesConsoleModel(ws.workspaceDir);
     const result = await model.listPrinciples();
     expect(result.principles).toHaveLength(1);
-    expect(result.principles[0].readabilityWarning).toBeDefined();
-    expect(result.principles[0].readabilityWarning).toMatch(/technical pattern/i);
+    expect(result.principles[0].readabilityWarningCode).toBe('technical_pattern');
   });
 
-  it('PRI-332: sets readabilityWarning for Error:-prefixed triggerPattern', async () => {
+  it('PRI-332: sets readabilityWarningCode for Error:-prefixed triggerPattern', async () => {
     ws = await createTestWorkspace();
     writeLedger(ws.workspaceDir, {
       principles: {
@@ -717,11 +716,10 @@ describe('PrinciplesConsoleModel', () => {
     const model = new PrinciplesConsoleModel(ws.workspaceDir);
     const result = await model.listPrinciples();
     expect(result.principles).toHaveLength(1);
-    expect(result.principles[0].readabilityWarning).toBeDefined();
-    expect(result.principles[0].readabilityWarning).toMatch(/diagnostic residue/i);
+    expect(result.principles[0].readabilityWarningCode).toBe('diagnostic_residue');
   });
 
-  it('PRI-332: no readabilityWarning for normal human-readable title', async () => {
+  it('PRI-332: no readabilityWarningCode for normal human-readable title', async () => {
     ws = await createTestWorkspace();
     writeLedger(ws.workspaceDir, {
       principles: {
@@ -740,7 +738,7 @@ describe('PrinciplesConsoleModel', () => {
     const model = new PrinciplesConsoleModel(ws.workspaceDir);
     const result = await model.listPrinciples();
     expect(result.principles).toHaveLength(1);
-    expect(result.principles[0].readabilityWarning).toBeUndefined();
+    expect(result.principles[0].readabilityWarningCode).toBeUndefined();
   });
 });
 

--- a/packages/pd-console/tests/server/routes/config.test.ts
+++ b/packages/pd-console/tests/server/routes/config.test.ts
@@ -1032,3 +1032,127 @@ describe('validateBindingPayload — deep secret detection', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// PRI-332: Principles Output Language Route
+// ---------------------------------------------------------------------------
+
+describe('PRI-332: GET/PATCH /principles/output-language', () => {
+  it('GET returns default zh-CN when no config exists', async () => {
+    const req = createMockRequest('GET', { url: '/api/v1/config/principles/output-language' });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(200);
+    const data = okEnvelope<{ outputLanguage: string; source: string }>(res);
+    expect(data.outputLanguage).toBe('zh-CN');
+    expect(data.source).toBe('default');
+  });
+
+  it('GET returns configured value', async () => {
+    writeConfig({ principles: { outputLanguage: 'en' } });
+    const req = createMockRequest('GET', { url: '/api/v1/config/principles/output-language' });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(200);
+    const data = okEnvelope<{ outputLanguage: string; source: string }>(res);
+    expect(data.outputLanguage).toBe('en');
+    expect(data.source).toBe('user_config');
+  });
+
+  it('GET returns 500 on malformed YAML (server-side config error)', async () => {
+    writeMalformedConfig('version: [unclosed\n');
+    const req = createMockRequest('GET', { url: '/api/v1/config/principles/output-language' });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(500);
+    const err = errorEnvelope(res);
+    expect(err.error).toBe('yaml_error');
+  });
+
+  it('GET returns 500 on invalid outputLanguage in config', async () => {
+    writeConfig({ principles: { outputLanguage: 'fr' } });
+    const req = createMockRequest('GET', { url: '/api/v1/config/principles/output-language' });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(500);
+    const err = errorEnvelope(res);
+    expect(err.error).toBe('invalid_output_language');
+  });
+
+  it('PATCH updates language and confirms via re-read', async () => {
+    writeConfig(VALID_CONFIG);
+    const req = createMockRequest('PATCH', {
+      url: '/api/v1/config/principles/output-language',
+      body: { outputLanguage: 'en' },
+    });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(200);
+    const data = okEnvelope<{ outputLanguage: string; source: string }>(res);
+    expect(data.outputLanguage).toBe('en');
+  });
+
+  it('PATCH returns 400 on invalid payload', async () => {
+    const req = createMockRequest('PATCH', {
+      url: '/api/v1/config/principles/output-language',
+      body: { outputLanguage: 'fr' },
+    });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(400);
+    const err = errorEnvelope(res);
+    expect(err.error).toBe('bad_request');
+  });
+
+  it('PATCH returns 400 on missing outputLanguage field', async () => {
+    const req = createMockRequest('PATCH', {
+      url: '/api/v1/config/principles/output-language',
+      body: {},
+    });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(400);
+    const err = errorEnvelope(res);
+    expect(err.error).toBe('bad_request');
+  });
+
+  it('PATCH returns 500 on malformed YAML during read-before-write', async () => {
+    writeMalformedConfig('version: [unclosed\n');
+    const req = createMockRequest('PATCH', {
+      url: '/api/v1/config/principles/output-language',
+      body: { outputLanguage: 'en' },
+    });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(500);
+    const err = errorEnvelope(res);
+    expect(err.error).toBe('yaml_error');
+  });
+
+  it('PATCH preserves existing config sections when updating language', async () => {
+    writeConfig(VALID_CONFIG);
+    const req = createMockRequest('PATCH', {
+      url: '/api/v1/config/principles/output-language',
+      body: { outputLanguage: 'en' },
+    });
+    const res = createMockResponse();
+    await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
+
+    expect(res.statusCode).toBe(200);
+    // Verify existing config sections are preserved
+    const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const parsed = yaml.load(raw) as Record<string, unknown>;
+    expect(parsed.version).toBe(1);
+    expect((parsed.principles as Record<string, unknown>).outputLanguage).toBe('en');
+    expect(parsed.features).toBeDefined();
+  });
+});

--- a/packages/pd-console/tests/server/routes/config.test.ts
+++ b/packages/pd-console/tests/server/routes/config.test.ts
@@ -68,6 +68,10 @@ function createMockResponse(): ServerResponse {
   return res;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function parseResponseBody<T>(res: ServerResponse): T {
   const mockRes = res as unknown as { _body: string };
   return JSON.parse(mockRes._body) as T;
@@ -1147,12 +1151,16 @@ describe('PRI-332: GET/PATCH /principles/output-language', () => {
     await handleConfigRoute(req, res, { workspaceDir, subPath: '/principles/output-language' });
 
     expect(res.statusCode).toBe(200);
-    // Verify existing config sections are preserved
+    // Verify existing config sections are preserved (no `as` bypass — ERR-001)
     const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
     const raw = fs.readFileSync(configPath, 'utf8');
-    const parsed = yaml.load(raw) as Record<string, unknown>;
+    const parsed = yaml.load(raw);
+    expect(isRecord(parsed)).toBe(true);
+    if (!isRecord(parsed)) throw new Error('unreachable: parsed config is not a record');
     expect(parsed.version).toBe(1);
-    expect((parsed.principles as Record<string, unknown>).outputLanguage).toBe('en');
+    expect(isRecord(parsed.principles)).toBe(true);
+    if (!isRecord(parsed.principles)) throw new Error('unreachable: principles is not a record');
+    expect(parsed.principles.outputLanguage).toBe('en');
     expect(parsed.features).toBeDefined();
   });
 });

--- a/packages/pd-console/tests/ui/cr10-api-validators.test.ts
+++ b/packages/pd-console/tests/ui/cr10-api-validators.test.ts
@@ -686,6 +686,60 @@ describe('validatePrinciplesList', () => {
     // ERR-009: field present but wrong type → reject, not silently discard
     expect(validatePrinciplesList(badReason)).toBeNull();
   });
+
+  // PRI-332: detectedLanguage and readabilityWarning validation
+  it('accepts principle with detectedLanguage field', () => {
+    const withLang = {
+      ...validList,
+      principles: [{ ...validList.principles[0], detectedLanguage: 'zh' }],
+    };
+    const result = validatePrinciplesList(withLang);
+    expect(result).not.toBeNull();
+    expect(result!.principles[0].detectedLanguage).toBe('zh');
+  });
+
+  it('defaults detectedLanguage to unknown when absent', () => {
+    const result = validatePrinciplesList(validList);
+    expect(result).not.toBeNull();
+    expect(result!.principles[0].detectedLanguage).toBe('unknown');
+  });
+
+  it('defaults detectedLanguage to unknown when not a string', () => {
+    const withBadLang = {
+      ...validList,
+      principles: [{ ...validList.principles[0], detectedLanguage: 42 }],
+    };
+    const result = validatePrinciplesList(withBadLang);
+    expect(result).not.toBeNull();
+    // detectedLanguage is optional with default 'unknown' — non-string values are ignored
+    expect(result!.principles[0].detectedLanguage).toBe('unknown');
+  });
+
+  it('accepts principle with readabilityWarning string', () => {
+    const withWarning = {
+      ...validList,
+      principles: [{ ...validList.principles[0], readabilityWarning: 'Title looks technical' }],
+    };
+    const result = validatePrinciplesList(withWarning);
+    expect(result).not.toBeNull();
+    expect(result!.principles[0].readabilityWarning).toBe('Title looks technical');
+  });
+
+  it('accepts principle without readabilityWarning (optional)', () => {
+    const result = validatePrinciplesList(validList);
+    expect(result).not.toBeNull();
+    expect(result!.principles[0].readabilityWarning).toBeUndefined();
+  });
+
+  it('rejects readabilityWarning when not a string (fail loud, ERR-009)', () => {
+    const withBadWarning = {
+      ...validList,
+      principles: [{ ...validList.principles[0], readabilityWarning: 123 }],
+    };
+    const result = validatePrinciplesList(withBadWarning);
+    // readabilityWarning present but wrong type → fail loud
+    expect(result).toBeNull();
+  });
 });
 
 // ── validateApprovalsGrouped ──────────────────────────────────────────────────

--- a/packages/pd-console/tests/ui/cr10-api-validators.test.ts
+++ b/packages/pd-console/tests/ui/cr10-api-validators.test.ts
@@ -687,7 +687,7 @@ describe('validatePrinciplesList', () => {
     expect(validatePrinciplesList(badReason)).toBeNull();
   });
 
-  // PRI-332: detectedLanguage and readabilityWarning validation
+  // PRI-332: detectedLanguage and readabilityWarningCode validation
   it('accepts principle with detectedLanguage field', () => {
     const withLang = {
       ...validList,
@@ -715,29 +715,29 @@ describe('validatePrinciplesList', () => {
     expect(result!.principles[0].detectedLanguage).toBe('unknown');
   });
 
-  it('accepts principle with readabilityWarning string', () => {
+  it('accepts principle with readabilityWarningCode', () => {
     const withWarning = {
       ...validList,
-      principles: [{ ...validList.principles[0], readabilityWarning: 'Title looks technical' }],
+      principles: [{ ...validList.principles[0], readabilityWarningCode: 'technical_pattern' }],
     };
     const result = validatePrinciplesList(withWarning);
     expect(result).not.toBeNull();
-    expect(result!.principles[0].readabilityWarning).toBe('Title looks technical');
+    expect(result!.principles[0].readabilityWarningCode).toBe('technical_pattern');
   });
 
-  it('accepts principle without readabilityWarning (optional)', () => {
+  it('accepts principle without readabilityWarningCode (optional)', () => {
     const result = validatePrinciplesList(validList);
     expect(result).not.toBeNull();
-    expect(result!.principles[0].readabilityWarning).toBeUndefined();
+    expect(result!.principles[0].readabilityWarningCode).toBeUndefined();
   });
 
-  it('rejects readabilityWarning when not a string (fail loud, ERR-009)', () => {
+  it('rejects readabilityWarningCode when invalid (fail loud, ERR-009)', () => {
     const withBadWarning = {
       ...validList,
-      principles: [{ ...validList.principles[0], readabilityWarning: 123 }],
+      principles: [{ ...validList.principles[0], readabilityWarningCode: 'invalid_code' }],
     };
     const result = validatePrinciplesList(withBadWarning);
-    // readabilityWarning present but wrong type → fail loud
+    // readabilityWarningCode present but invalid value → fail loud
     expect(result).toBeNull();
   });
 });

--- a/packages/pd-console/tests/ui/cr10-api-validators.test.ts
+++ b/packages/pd-console/tests/ui/cr10-api-validators.test.ts
@@ -704,15 +704,14 @@ describe('validatePrinciplesList', () => {
     expect(result!.principles[0].detectedLanguage).toBe('unknown');
   });
 
-  it('defaults detectedLanguage to unknown when not a string', () => {
+  it('fails loud when detectedLanguage is present but not a string (ERR-009)', () => {
     const withBadLang = {
       ...validList,
       principles: [{ ...validList.principles[0], detectedLanguage: 42 }],
     };
     const result = validatePrinciplesList(withBadLang);
-    expect(result).not.toBeNull();
-    // detectedLanguage is optional with default 'unknown' — non-string values are ignored
-    expect(result!.principles[0].detectedLanguage).toBe('unknown');
+    // detectedLanguage present but malformed → validateArray rejects the item → null (ERR-009)
+    expect(result).toBeNull();
   });
 
   it('accepts principle with readabilityWarningCode', () => {

--- a/packages/pd-console/tests/ui/cr10-i18n-governance.test.ts
+++ b/packages/pd-console/tests/ui/cr10-i18n-governance.test.ts
@@ -191,7 +191,7 @@ describe('en has no Chinese characters', () => {
 
   // languageSwitcher.chinese = "中文" is intentional: the language picker
   // must display the native name of the target language.
-  const ALLOWED_CJK_IN_EN = ['中文'];
+  const ALLOWED_CJK_IN_EN = ['中文', '中文 (Chinese)'];
 
   it('no CJK characters in English strings (except language switcher native names)', () => {
     const violations = enValues.filter(v => containsChinese(v) && !ALLOWED_CJK_IN_EN.includes(v));

--- a/packages/pd-console/tests/ui/cr9-tool-pages.test.ts
+++ b/packages/pd-console/tests/ui/cr9-tool-pages.test.ts
@@ -249,8 +249,11 @@ describe("CR9: no mixed zh/en in i18n values", () => {
       const page = expectRecord(enPages[pageKey], `enPages.${pageKey}`);
       if (!page) continue;
       const entries = Object.entries(page);
+      // languageZhCN intentionally contains native CJK name for the language picker
+      const ALLOWED_CJK_KEYS = ['languageZhCN'];
       for (const [key, value] of entries) {
         if (typeof value !== "string") continue;
+        if (ALLOWED_CJK_KEYS.includes(key)) continue;
         // Skip nested objects like form.types
         expect(value, `en.pages.${pageKey}.${key} should not contain Chinese`).not.toMatch(cjkPattern);
       }

--- a/packages/pd-console/tests/ui/focus-page.test.ts
+++ b/packages/pd-console/tests/ui/focus-page.test.ts
@@ -323,6 +323,33 @@ describe("FocusPage: validateApprovalsGroupedData edge cases", () => {
 
 // ── Forbidden terms test ─────────────────────────────────────────────────────
 
+// Type guard helpers for untrusted JSON (replaces `as` bypasses — ERR-001/005)
+// Note: isRecord is already defined above (line 157)
+
+function getOwnRecord(obj: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const val = Object.hasOwn(obj, key) ? obj[key] : undefined;
+  return isRecord(val) ? val : undefined;
+}
+
+function getOwnString(obj: Record<string, unknown>, key: string): string | undefined {
+  const val = Object.hasOwn(obj, key) ? obj[key] : undefined;
+  return typeof val === "string" ? val : undefined;
+}
+
+function requireJson(path: string): Record<string, unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const raw: unknown = require(path);
+  if (!isRecord(raw)) throw new Error(`Expected JSON object at ${path}`);
+  return raw;
+}
+
+function loadFocusI18n(langFile: string): Record<string, unknown> {
+  const root = requireJson(langFile);
+  const pages = getOwnRecord(root, "pages");
+  if (!pages) return {};
+  return getOwnRecord(pages, "focus") ?? {};
+}
+
 describe("FocusPage: forbidden terms never appear", () => {
   const forbiddenTerms = [
     "Cockpit",
@@ -341,13 +368,8 @@ describe("FocusPage: forbidden terms never appear", () => {
   ];
 
   // Read real i18n files so the test catches production regressions
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const enJson = require("../../src/ui/i18n/en.json") as Record<string, unknown>;
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const zhJson = require("../../src/ui/i18n/zh-CN.json") as Record<string, unknown>;
-
-  const enFocusCopy = (enJson.pages as Record<string, unknown>)?.focus as Record<string, unknown> ?? {};
-  const zhFocusCopy = (zhJson.pages as Record<string, unknown>)?.focus as Record<string, unknown> ?? {};
+  const enFocusCopy = loadFocusI18n("../../src/ui/i18n/en.json");
+  const zhFocusCopy = loadFocusI18n("../../src/ui/i18n/zh-CN.json");
 
   it("English i18n focus keys exist and contain no forbidden terms", () => {
     const entries = Object.entries(enFocusCopy);
@@ -374,10 +396,10 @@ describe("FocusPage: forbidden terms never appear", () => {
   it("empty states guide next steps, not '暂无数据'", () => {
     const emptyKeys = ["emptyPending", "emptyDeviation", "emptySignals"];
     for (const key of emptyKeys) {
-      const value = zhFocusCopy[key];
-      expect(typeof value, `zh.pages.focus.${key} should be a string`).toBe("string");
-      expect(value as string, `zh.pages.focus.${key} should not contain "暂无数据"`).not.toContain("暂无数据");
-      expect((value as string).length, `zh.pages.focus.${key} should have guidance text`).toBeGreaterThan(10);
+      const value = getOwnString(zhFocusCopy, key);
+      expect(value, `zh.pages.focus.${key} should be a string`).toBeDefined();
+      expect(value, `zh.pages.focus.${key} should not contain "暂无数据"`).not.toContain("暂无数据");
+      expect((value ?? "").length, `zh.pages.focus.${key} should have guidance text`).toBeGreaterThan(10);
     }
   });
 
@@ -392,13 +414,13 @@ describe("FocusPage: forbidden terms never appear", () => {
 
   it("evidenceSummary does not duplicate count", () => {
     // evidenceSummary should use {{count}} interpolation, not output the number separately
-    const enValue = enFocusCopy.evidenceSummary;
-    const zhValue = zhFocusCopy.evidenceSummary;
+    const enValue = getOwnString(enFocusCopy, "evidenceSummary");
+    const zhValue = getOwnString(zhFocusCopy, "evidenceSummary");
     expect(typeof enValue).toBe("string");
     expect(typeof zhValue).toBe("string");
     // Should contain exactly one {{count}} placeholder
-    expect((enValue as string).match(/\{\{count\}\}/g)).toHaveLength(1);
-    expect((zhValue as string).match(/\{\{count\}\}/g)).toHaveLength(1);
+    expect((enValue ?? "").match(/\{\{count\}\}/g)).toHaveLength(1);
+    expect((zhValue ?? "").match(/\{\{count\}\}/g)).toHaveLength(1);
   });
 });
 
@@ -415,29 +437,26 @@ describe("FocusPage: component can be imported", () => {
 // ── PRI-332: Zero state clarity tests ─────────────────────────────────────────
 
 describe("FocusPage: PRI-332 zero state clarity", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const enJson = require("../../src/ui/i18n/en.json") as Record<string, unknown>;
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const zhJson = require("../../src/ui/i18n/zh-CN.json") as Record<string, unknown>;
-
-  const enFocus = (enJson.pages as Record<string, unknown>)?.focus as Record<string, unknown> ?? {};
-  const zhFocus = (zhJson.pages as Record<string, unknown>)?.focus as Record<string, unknown> ?? {};
+  const enFocus = loadFocusI18n("../../src/ui/i18n/en.json");
+  const zhFocus = loadFocusI18n("../../src/ui/i18n/zh-CN.json");
 
   it("zeroStateHealthy key exists in both languages", () => {
-    expect(typeof enFocus.zeroStateHealthy).toBe("string");
-    expect(typeof zhFocus.zeroStateHealthy).toBe("string");
-    expect((enFocus.zeroStateHealthy as string).length).toBeGreaterThan(10);
-    expect((zhFocus.zeroStateHealthy as string).length).toBeGreaterThan(5);
+    const en = getOwnString(enFocus, "zeroStateHealthy");
+    const zh = getOwnString(zhFocus, "zeroStateHealthy");
+    expect(typeof en).toBe("string");
+    expect(typeof zh).toBe("string");
+    expect((en ?? "").length).toBeGreaterThan(10);
+    expect((zh ?? "").length).toBeGreaterThan(5);
   });
 
   it("zeroStateDbMissing key exists in both languages", () => {
-    expect(typeof enFocus.zeroStateDbMissing).toBe("string");
-    expect(typeof zhFocus.zeroStateDbMissing).toBe("string");
+    expect(typeof getOwnString(enFocus, "zeroStateDbMissing")).toBe("string");
+    expect(typeof getOwnString(zhFocus, "zeroStateDbMissing")).toBe("string");
   });
 
   it("zeroStateHealthy does not claim PD is broken or inactive", () => {
-    const en = enFocus.zeroStateHealthy as string;
-    const zh = zhFocus.zeroStateHealthy as string;
+    const en = getOwnString(enFocus, "zeroStateHealthy") ?? "";
+    const zh = getOwnString(zhFocus, "zeroStateHealthy") ?? "";
     // Should not contain misleading terms
     expect(en).not.toMatch(/broken|error|not working|disabled/i);
     expect(zh).not.toMatch(/\u6545\u969c|\u9519\u8bef|\u505c\u6b62/);
@@ -472,3 +491,4 @@ describe("FocusPage: PRI-332 zero state clarity", () => {
     expect(src).not.toMatch(/governanceState === "degraded" && degradedSignals/);
   });
 });
+

--- a/packages/pd-console/tests/ui/focus-page.test.ts
+++ b/packages/pd-console/tests/ui/focus-page.test.ts
@@ -411,3 +411,64 @@ describe("FocusPage: component can be imported", () => {
     expect(typeof mod.FocusPage).toBe("function");
   });
 });
+
+// ── PRI-332: Zero state clarity tests ─────────────────────────────────────────
+
+describe("FocusPage: PRI-332 zero state clarity", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const enJson = require("../../src/ui/i18n/en.json") as Record<string, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const zhJson = require("../../src/ui/i18n/zh-CN.json") as Record<string, unknown>;
+
+  const enFocus = (enJson.pages as Record<string, unknown>)?.focus as Record<string, unknown> ?? {};
+  const zhFocus = (zhJson.pages as Record<string, unknown>)?.focus as Record<string, unknown> ?? {};
+
+  it("zeroStateHealthy key exists in both languages", () => {
+    expect(typeof enFocus.zeroStateHealthy).toBe("string");
+    expect(typeof zhFocus.zeroStateHealthy).toBe("string");
+    expect((enFocus.zeroStateHealthy as string).length).toBeGreaterThan(10);
+    expect((zhFocus.zeroStateHealthy as string).length).toBeGreaterThan(5);
+  });
+
+  it("zeroStateDbMissing key exists in both languages", () => {
+    expect(typeof enFocus.zeroStateDbMissing).toBe("string");
+    expect(typeof zhFocus.zeroStateDbMissing).toBe("string");
+  });
+
+  it("zeroStateHealthy does not claim PD is broken or inactive", () => {
+    const en = enFocus.zeroStateHealthy as string;
+    const zh = zhFocus.zeroStateHealthy as string;
+    // Should not contain misleading terms
+    expect(en).not.toMatch(/broken|error|not working|disabled/i);
+    expect(zh).not.toMatch(/\u6545\u969c|\u9519\u8bef|\u505c\u6b62/);
+    // Should mention that PD has checked things
+    expect(en).toMatch(/checked|check/i);
+    expect(zh).toMatch(/\u68c0\u67e5/);
+  });
+
+  it("FocusPage source contains ZeroStateHealthy component", () => {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../src/ui/pages/focus/FocusPage.tsx"),
+      "utf-8",
+    );
+    expect(src).toMatch(/function ZeroStateHealthy/);
+    expect(src).toMatch(/function ZeroStateDbMissing/);
+    expect(src).toMatch(/zeroStateHealthy/);
+    expect(src).toMatch(/zeroStateDbMissing/);
+  });
+
+  it("FocusPage shows degraded signals regardless of governance state", () => {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../src/ui/pages/focus/FocusPage.tsx"),
+      "utf-8",
+    );
+    // Should always show degraded signals when present, not gated by state === 'degraded'
+    expect(src).toMatch(/degradedSignals && degradedSignals\.length > 0/);
+    // Should NOT have the old pattern that gates on governanceState === "degraded"
+    expect(src).not.toMatch(/governanceState === "degraded" && degradedSignals/);
+  });
+});

--- a/packages/pd-console/tests/ui/principle-review.test.ts
+++ b/packages/pd-console/tests/ui/principle-review.test.ts
@@ -581,3 +581,95 @@ describe("PrincipleDetail validator normalizes all page-accessed fields", () => 
     expect(principleDetailSrc).toMatch(/safeStringArray\(raw\.derivedFromPainIds\)/);
   });
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// 15. PRI-332: Principle Review readability
+// ════════════════════════════════════════════════════════════════════════════
+describe("PRI-332: Principle Review readability", () => {
+  it("PrinciplesPage uses detectedLanguage field from backend", () => {
+    expect(principlesPageSrc).toMatch(/detectedLanguage/);
+  });
+
+  it("PrinciplesPage shows language hint badge", () => {
+    expect(principlesPageSrc).toMatch(/languageHintEn/);
+    expect(principlesPageSrc).toMatch(/languageHintZh/);
+  });
+
+  it("PrinciplesPage shows language mismatch hint", () => {
+    expect(principlesPageSrc).toMatch(/languageMismatchHint/);
+  });
+
+  it("PrinciplesPage uses readabilityWarning from backend", () => {
+    expect(principlesPageSrc).toMatch(/readabilityWarning/);
+  });
+
+  it("PrinciplesPage uses bounded fallback title when readabilityWarning exists", () => {
+    expect(principlesPageSrc).toMatch(/readabilityFallbackTitle/);
+    expect(principlesPageSrc).toMatch(/titleUsedFallback/);
+  });
+
+  it("PrinciplesPage shows original text in details when fallback used", () => {
+    expect(principlesPageSrc).toMatch(/readabilityOriginalLabel/);
+    expect(principlesPageSrc).toMatch(/originalTitle/);
+  });
+
+  it("PrinciplesPage never shows raw i18n key for unknown channels", () => {
+    // Old pattern: t("principles." + (CHANNEL_LABELS[ch] ?? ch))
+    // This would show "principles.model_training" as raw key for unknown channels
+    // New pattern: CHANNEL_LABELS[ch] ? t(...) : ch
+    expect(principlesPageSrc).not.toMatch(/CHANNEL_LABELS\[ch\] \?\? ch/);
+    expect(principlesPageSrc).toMatch(/CHANNEL_LABELS\[ch\]/);
+  });
+
+  it("language hint i18n keys exist in both languages", () => {
+    expect(getPagesKey("principles.languageHintEn")).toBeTruthy();
+    expect(getPagesKeyZh("principles.languageHintEn")).toBeTruthy();
+    expect(getPagesKey("principles.languageHintZh")).toBeTruthy();
+    expect(getPagesKeyZh("principles.languageHintZh")).toBeTruthy();
+    expect(getPagesKey("principles.languageHintUnknown")).toBeTruthy();
+    expect(getPagesKeyZh("principles.languageHintUnknown")).toBeTruthy();
+  });
+
+  it("language mismatch hint supports interpolation", () => {
+    const en = String(getPagesKey("principles.languageMismatchHint"));
+    const zh = String(getPagesKeyZh("principles.languageMismatchHint"));
+    expect(en).toContain("{{lang}}");
+    expect(zh).toContain("{{lang}}");
+  });
+
+  it("readability fallback title exists in both languages", () => {
+    expect(getPagesKey("principles.readabilityFallbackTitle")).toBeTruthy();
+    expect(getPagesKeyZh("principles.readabilityFallbackTitle")).toBeTruthy();
+  });
+
+  it("readability original label exists in both languages", () => {
+    expect(getPagesKey("principles.readabilityOriginalLabel")).toBeTruthy();
+    expect(getPagesKeyZh("principles.readabilityOriginalLabel")).toBeTruthy();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 16. PRI-332: Backend contract — detectedLanguage and readabilityWarning
+// ════════════════════════════════════════════════════════════════════════════
+describe("PRI-332: Backend contract validators", () => {
+  it("validators.ts includes detectedLanguage in PrincipleListItemData", () => {
+    expect(validatorsSrc).toMatch(/detectedLanguage.*string/);
+  });
+
+  it("validators.ts includes readabilityWarning as optional in PrincipleListItemData", () => {
+    expect(validatorsSrc).toMatch(/readabilityWarning\?.*string/);
+  });
+
+  it("validators.ts validates detectedLanguage with Object.hasOwn (ERR-013)", () => {
+    expect(validatorsSrc).toMatch(/Object\.hasOwn.*detectedLanguage/);
+  });
+
+  it("validators.ts validates readabilityWarning with Object.hasOwn (ERR-013)", () => {
+    expect(validatorsSrc).toMatch(/Object\.hasOwn.*readabilityWarning/);
+  });
+
+  it("validators.ts fails loud on non-string readabilityWarning (ERR-009)", () => {
+    // When readabilityWarning is present but not a string, validation should return null
+    expect(validatorsSrc).toMatch(/readabilityWarning.*return null/);
+  });
+});

--- a/packages/pd-console/tests/ui/principle-review.test.ts
+++ b/packages/pd-console/tests/ui/principle-review.test.ts
@@ -599,11 +599,11 @@ describe("PRI-332: Principle Review readability", () => {
     expect(principlesPageSrc).toMatch(/languageMismatchHint/);
   });
 
-  it("PrinciplesPage uses readabilityWarning from backend", () => {
-    expect(principlesPageSrc).toMatch(/readabilityWarning/);
+  it("PrinciplesPage uses readabilityWarningCode from backend", () => {
+    expect(principlesPageSrc).toMatch(/readabilityWarningCode/);
   });
 
-  it("PrinciplesPage uses bounded fallback title when readabilityWarning exists", () => {
+  it("PrinciplesPage uses bounded fallback title when readabilityWarningCode exists", () => {
     expect(principlesPageSrc).toMatch(/readabilityFallbackTitle/);
     expect(principlesPageSrc).toMatch(/titleUsedFallback/);
   });
@@ -649,27 +649,27 @@ describe("PRI-332: Principle Review readability", () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 16. PRI-332: Backend contract — detectedLanguage and readabilityWarning
+// 16. PRI-332: Backend contract — detectedLanguage and readabilityWarningCode
 // ════════════════════════════════════════════════════════════════════════════
 describe("PRI-332: Backend contract validators", () => {
   it("validators.ts includes detectedLanguage in PrincipleListItemData", () => {
     expect(validatorsSrc).toMatch(/detectedLanguage.*string/);
   });
 
-  it("validators.ts includes readabilityWarning as optional in PrincipleListItemData", () => {
-    expect(validatorsSrc).toMatch(/readabilityWarning\?.*string/);
+  it("validators.ts includes readabilityWarningCode as optional in PrincipleListItemData", () => {
+    expect(validatorsSrc).toMatch(/readabilityWarningCode\?.*technical_pattern|diagnostic_residue|title_too_long/);
   });
 
   it("validators.ts validates detectedLanguage with Object.hasOwn (ERR-013)", () => {
     expect(validatorsSrc).toMatch(/Object\.hasOwn.*detectedLanguage/);
   });
 
-  it("validators.ts validates readabilityWarning with Object.hasOwn (ERR-013)", () => {
-    expect(validatorsSrc).toMatch(/Object\.hasOwn.*readabilityWarning/);
+  it("validators.ts validates readabilityWarningCode with Object.hasOwn (ERR-013)", () => {
+    expect(validatorsSrc).toMatch(/Object\.hasOwn.*readabilityWarningCode/);
   });
 
-  it("validators.ts fails loud on non-string readabilityWarning (ERR-009)", () => {
-    // When readabilityWarning is present but not a string, validation should return null
-    expect(validatorsSrc).toMatch(/readabilityWarning.*return null/);
+  it("validators.ts fails loud on invalid readabilityWarningCode (ERR-009)", () => {
+    // When readabilityWarningCode is present but invalid, validation should return null
+    expect(validatorsSrc).toMatch(/readabilityWarningCode.*return null/);
   });
 });


### PR DESCRIPTION
## Summary

Resolves PRI-332 — Principles output language preference configuration and console seed-user clarity.

This PR delivers the PRI-332 config/UI/display path: a user-configurable `principles.outputLanguage` preference (`zh-CN` | `en`) saved to `.pd/config.yaml`, Settings UI for saving the preference, structured readability warning codes with i18n rendering, and zero-state improvements.

**Important**: The generation integration (diagnostician/scribe prompt builder) is explicitly deferred. The outputLanguage preference is currently saved and readable but not yet consumed by any generation path. UI text reflects this: "Save your language preference for principle display. Generation integration is deferred."

## Deliverables

### P1-1: Principles Output Language Preference (saved, not yet consumed)

- **Config store** (pd-config-store.ts): `getPrinciplesOutputLanguage()` / `updatePrinciplesOutputLanguage()` with `VALID_OUTPUT_LANGUAGES = ['zh-CN', 'en']`
- **Default**: `zh-CN` (matches current product language strategy)
- **API routes** (config.ts): `GET /principles/output-language` and `PATCH /principles/output-language`
- **Error handling**: try/catch around all IO/YAML operations; structured errors with statusCode, reason, nextAction
- **Confirm re-read**: PATCH re-reads after write; if re-read fails, returns error (no silent fallback, ERR-002)
- **Status codes**: 500 for server-side config errors (read/yaml/validation), 400 for bad request payload

### P1-2: Settings UI for Language Preference

- Select dropdown in Settings page
- Save with re-read confirmation from canonical config
- Full i18n (en + zh-CN); no mixed-language UI
- No raw YAML editor exposed

### P1-3: Principle Review Display Fallback

- Language-matched owner-readable field displayed when available
- Missing language content shows original with localized i18n hint
- No English warnings rendered directly in Chinese UI

### P1-4: Diagnostician Prompt Builder Integration — DEFERRED

- Evaluated diagnostician-prompt-builder.ts
- LOCKED constraints DPB-02 (JSON-only output) and DPB-07 (no extraSystemPrompt) prevent safe minimal integration
- Config + UI + display paths complete; generation wiring deferred to a follow-up issue

### P1-5: Structured Readability Warning Codes

- Backend returns `readabilityWarningCode` (ReadabilityWarningCode = 'technical_pattern' | 'diagnostic_residue' | 'title_too_long') instead of English strings
- Frontend renders via i18n keys, no mixed-language UI
- Whitelist validation via `isReadabilityWarningCode` type guard

### P2: Clean Up `as` Casts

- Type guard helpers in focus-page.test.ts: `getOwnRecord`, `getOwnString`, `requireJson`, `loadFocusI18n`
- `isReadabilityWarningCode` type guard in validators.ts
- SettingsPage.tsx validates select value without `as` cast
- `detectedLanguage` fail loud when present but malformed (ERR-009)

### Zero-State Improvements (incidental fix)

- Zero state distinguishes ZeroStateHealthy / ZeroStateDbMissing / degraded
- Degraded signals always display regardless of governance state

## Files Modified (15 files)

| File | Change |
|------|--------|
| pd-config-store.ts | Output language read/write with try/catch, statusCode |
| PrinciplesConsoleModel.ts | ReadabilityWarningCode type, structured codes |
| config.ts (routes) | GET/PATCH with statusCode mapping, confirm re-read |
| validators.ts | isReadabilityWarningCode type guard, detectedLanguage fail loud |
| api.ts | fetchOutputLanguage / updateOutputLanguage |
| SettingsPage.tsx | Language preference UI, no `as` cast |
| PrinciplesPage.tsx | Render warning via i18n code |
| en.json / zh-CN.json | Warning codes + settings language keys (deferred scope text) |
| 7 test files | Route tests, type guard tests, fail-loud tests |

## ERR Avoidance Checklist

| ERR | Risk | Avoidance |
|-----|------|-----------|
| ERR-001 | as bypasses validation | isReadabilityWarningCode type guard; no as in production code |
| ERR-002 | Silent fallback = bug | Confirm re-read failure returns error; IO/YAML try/catch with reason+nextAction |
| ERR-005 | Array element type unchecked | VALID_OUTPUT_LANGUAGES whitelist with includes() |
| ERR-009 | Required fields fail loud | detectedLanguage malformed returns null; invalid outputLanguage rejected |
| ERR-013 | in vs Object.hasOwn | All property checks use Object.hasOwn() |

## Test Results

```
843 tests passed (30 files)
verify:merge passed (lint 0 errors, build, typecheck all green)
```

## Boundaries Respected

- No automatic translation service
- No principle content upload
- No pain admission / diagnosis policy changes
- No frozen legacy file modifications
- No dashboard metrics expansion
- No batch modification of existing English principles
- Zero-state changes are incidental, not a substitute for PRI-332 language preference

## Remaining Risk

- outputLanguage is saved but not consumed by any generation path (deferred)
- Language detection is heuristic (CJK regex only)
- readabilityWarningCode patterns are conservative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 设置页新增“原则输出语言”偏好（中文/英文）并可持久化
  * 原则列表与详情展示检测到的语言标记与可读性警告，并在标题不可读时回退显示备用标题
  * 治理焦点页完善零状态与降级显示逻辑，区分数据库缺失场景
* **测试**
  * 新增/更新多项单元与合约测试，覆盖语言检测、可读性告警、路由与 API 行为与 i18n 文案验证

<!-- end of auto-generated comment: release notes by coderabbit.ai -->