### PR TITLE
feat(runtime): connect pain admission to trigger decisions (PRI-337)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -34,6 +35,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies (workspace root)
         run: npm ci --ignore-scripts
@@ -57,6 +59,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -78,6 +81,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -96,6 +100,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -122,6 +127,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -145,6 +151,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         working-directory: packages/openclaw-plugin
@@ -169,6 +176,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install dependencies
         working-directory: packages/openclaw-plugin
@@ -193,6 +201,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install root dependencies
         run: npm install --include=dev

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -100,6 +100,7 @@ Errors where AI assistants created incorrect schemas, missed type safety, or bro
 | ERR-061 | Runtime shape check validates wrong field name — guessed structure instead of verifying against actual type | PR #823 |
 | ERR-062 | Collapsed details section renders empty-state copy instead of actual data when data exists | PRI-319 / PR #825 |
 | ERR-063 | Commander `--no-<flag>` option property accessed via incorrect name — flag silently ignored | PR #844 |
+| ERR-064 | CLI subcommand option regressions — Commander flag → opts mapping lost or misrouted during Commander .command() edit | PRI-337 / PR #852 |
 
 ---
 
@@ -842,7 +843,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
-**[ERR-060]** | Emitted telemetry event not registered in schema — event silently dropped or degraded
+**[ERR-061]** | Emitted telemetry event not registered in schema — event silently dropped or degraded
 
 - **What happened**: After migrating Scribe/Evaluator/Artificer runners to BasePeerRunner, the runners emit events like `artificer_implementation_plan_generated`, `scribe_principle_draft_generated`, etc. via `this.emitEvent()`. BasePeerRunner prefixes these with the runner name (e.g., `artificer_implementation_plan_generated`). But `telemetry-event.ts` TelemetryEventType union did not include any `artificer_*`, `evaluator_*`, or `scribe_*` event literals. Events not in the schema are silently dropped or degraded by the telemetry pipeline.
 - **Why it's wrong**: The telemetry schema is the contract for what events are valid. If an emitted event is not registered, it's silently lost — no error, no warning, no observability. This is the same class as ERR-024 (mechanism exists but is not wired) and ERR-002 (silent degradation). The runner believes it's emitting telemetry, but the pipeline discards it. Operators cannot observe runner behavior through the telemetry dashboard.
@@ -911,3 +912,16 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **Source**: PRI-304 / PR #811
 - **Date**: 2026-06-03
 - **Recurrence**: First occurrence
+
+---
+
+**[ERR-064]** | CLI subcommand option regressions — Commander flag → opts mapping lost or misrouted during edit
+
+- **What happened**: During PRI-337 implementation, the pd pain retry command lost its --baseUrl, --maxRetries, --timeoutMs, and --force options. These options ended up on a bogus top-level pd canary command that incorrectly called handlePainRetry instead of handleRuntimeCanary. Separately, pd pain evidence was hardcoded to read .state/logs/SYSTEM_*.log instead of the actual SystemLogger path <workspace>/memory/logs/SYSTEM_YYYY-MM-DD.log.
+- **Why it's wrong**: CLI commands with lost options silently stop working. Wrong command handlers produce confusing behavior. Wrong log paths return empty results with no error, making operators think the system is broken.
+- **Correct approach**: (1) Every time you add/remove a Commander .option() call, verify ALL options are present by parsing the full command registration. (2) After any index.ts edit that touches .command(), run a parser-level test that confirms each option routes correctly. (3) For log path code, always read the actual SystemLogger source code to verify the format/format/location, never guess.
+- **How to prevent**: (1) Add parser-level tests for EVERY CLI option on every subcommand — these are trivial to write (10 lines each) and catch regression immediately. (2) When editing Commander registration, diff against the handler's actual option usage, not against the previous registration. (3) When reading log files, trace the exact SystemLogger path resolution before writing reader code.
+- **Source**: PRI-337 / PR #852
+- **Date**: 2026-06-08
+- **Recurrence**: First occurrence (similar but distinct from ERR-053 which is about missing registration entirely)
+[ERR-064]: docs/ERROR_EXPERIENCE_HANDBOOK.md#ERR-064

--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -843,7 +843,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 ---
 
-**[ERR-061]** | Emitted telemetry event not registered in schema — event silently dropped or degraded
+**[ERR-060]** | Emitted telemetry event not registered in schema — event silently dropped or degraded
 
 - **What happened**: After migrating Scribe/Evaluator/Artificer runners to BasePeerRunner, the runners emit events like `artificer_implementation_plan_generated`, `scribe_principle_draft_generated`, etc. via `this.emitEvent()`. BasePeerRunner prefixes these with the runner name (e.g., `artificer_implementation_plan_generated`). But `telemetry-event.ts` TelemetryEventType union did not include any `artificer_*`, `evaluator_*`, or `scribe_*` event literals. Events not in the schema are silently dropped or degraded by the telemetry pipeline.
 - **Why it's wrong**: The telemetry schema is the contract for what events are valid. If an emitted event is not registered, it's silently lost — no error, no warning, no observability. This is the same class as ERR-024 (mechanism exists but is not wired) and ERR-002 (silent degradation). The runner believes it's emitting telemetry, but the pipeline discards it. Operators cannot observe runner behavior through the telemetry dashboard.

--- a/docs/ERROR_PATTERN_INDEX.md
+++ b/docs/ERROR_PATTERN_INDEX.md
@@ -19,7 +19,7 @@ For a task, pick the matching pattern cards, read the listed ERR entries, and st
 - **Use when**: adding validators, dispatchers, activation paths, CLI commands, baselines, guards, or helper APIs.
 - **Failure mode**: a component exists and has isolated tests, but the real user/operator path never calls it.
 - **Must check**: tests exercise the production entry point, not only leaf helpers; new CLI commands are registered in Commander; activation writes are read by the live prompt path.
-- **Representative ERRs**: ERR-011, ERR-024, ERR-025, ERR-028, ERR-035, ERR-048, ERR-053, ERR-060.
+- **Representative ERRs**: ERR-011, ERR-024, ERR-025, ERR-028, ERR-035, ERR-048, ERR-053, ERR-060, ERR-064.
 - **Automation target**: command-tree tests, production-path smoke tests, and fixture evidence that names the real dispatcher/facade.
 
 ### EP-03 Fail Loud and Observable Degradation

--- a/packages/openclaw-plugin/src/core/pain-diagnostic-gate.ts
+++ b/packages/openclaw-plugin/src/core/pain-diagnostic-gate.ts
@@ -88,6 +88,21 @@ export function resetPainDiagnosticGateForTest(): void {
   lastDiagnosedAtByEpisode.clear();
 }
 
+/**
+ * Check whether cooldown is currently active for a given episode.
+ * Used by the trigger controller (PEAT-B2) to align its cooldown decision
+ * with the PainDiagnosticGate's cooldown state.
+ */
+export function isCooldownActiveForEpisode(
+  source: string,
+  sessionId: string | undefined,
+  errorHash: string | undefined,
+  cooldownMs?: number,
+): boolean {
+  const episodeKey = buildEpisodeKey({ source, sessionId, errorHash } as PainDiagnosticGateInput);
+  return withinCooldown({ source, sessionId, errorHash, cooldownMs } as PainDiagnosticGateInput, episodeKey);
+}
+
 export function evaluatePainDiagnosticGate(input: PainDiagnosticGateInput): PainDiagnosticGateDecision {
   const source = normalizedSource(input.source);
   const episodeKey = buildEpisodeKey(input);

--- a/packages/openclaw-plugin/src/hooks/after-tool-call-helpers.ts
+++ b/packages/openclaw-plugin/src/hooks/after-tool-call-helpers.ts
@@ -27,6 +27,7 @@ import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 import { sanitizeForEvidence, sanitizeToolParamsForEvidence } from './message-sanitize.js';
 import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
 import { resolveSourceKindFromToolFailure, evaluateEvidenceTriage } from './triage-adapter.js';
+import { evaluateTriggerController } from '@principles/core/runtime-v2';
 import { buildTrajectoryEvidence } from './trajectory-evidence.js';
 import type { ToolCallOutcome, ToolCallObservation, PainAdmissionDecision } from './after-tool-call-types.js';
 
@@ -347,24 +348,37 @@ export function evaluatePainAdmissionForToolCall(
   const failureSource = outcome.failureSource ?? 'tool_failure';
 
   // PEAT-B1: Evidence triage (feature-flagged)
+  // PEAT-B2: Trigger controller adds structured outcome + cooldown awareness
   const painTriageFlag = loadFeatureFlagFromConfig(workspaceDir, 'painEvidenceAdmission');
   if (painTriageFlag.enabled) {
     const sourceKind = resolveSourceKindFromToolFailure(event.toolName, failureSource);
     const triage = evaluateEvidenceTriage(sourceKind, observation.painScore);
-    if (triage.decision !== 'admit') {
-      SystemLogger.log(workspaceDir, 'TRIAGE_EVIDENCE_ONLY', JSON.stringify({
-        sourceKind: triage.sourceKind,
-        decision: triage.decision,
-        reason: triage.reason,
-        nextAction: triage.nextAction,
+
+    // PEAT-B2: Evaluate trigger controller for structured decision
+    const triggerDecision = evaluateTriggerController({
+      triageResult: triage,
+      isOwnerManual: false, // tool failures are never owner manual
+      isCooldownActive: false, // cooldown handled by PainDiagnosticGate below
+      isValid: true,
+      score: observation.painScore,
+      sessionId,
+    });
+
+    if (!triggerDecision.shouldCreateDiagnosticTask) {
+      SystemLogger.log(workspaceDir, 'TRIGGER_DECISION', JSON.stringify({
+        outcome: triggerDecision.outcome,
+        sourceKind: triggerDecision.sourceKind,
+        reason: triggerDecision.reason,
+        nextAction: triggerDecision.nextAction,
+        triageDecision: triggerDecision.triageDecision,
         tool: event.toolName,
         path: observation.relPath,
       }));
       return {
         admitted: false,
         stage: 'triage_evidence_only',
-        reason: triage.reason,
-        detail: `sourceKind=${triage.sourceKind}, decision=${triage.decision}, nextAction=${triage.nextAction}`,
+        reason: triggerDecision.reason,
+        detail: `outcome=${triggerDecision.outcome}, sourceKind=${triggerDecision.sourceKind}, nextAction=${triggerDecision.nextAction}`,
       };
     }
   }

--- a/packages/openclaw-plugin/src/hooks/after-tool-call-helpers.ts
+++ b/packages/openclaw-plugin/src/hooks/after-tool-call-helpers.ts
@@ -23,7 +23,7 @@ import { WorkspaceContext } from '../core/workspace-context.js';
 import { getEvolutionLogger, createTraceId } from '../core/evolution-logger.js';
 import { recordEvolutionSuccess, recordEvolutionFailure } from '../core/evolution-engine.js';
 import type { PluginHookAfterToolCallEvent } from '../openclaw-sdk.js';
-import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
+import { evaluatePainDiagnosticGate, isCooldownActiveForEpisode } from '../core/pain-diagnostic-gate.js';
 import { sanitizeForEvidence, sanitizeToolParamsForEvidence } from './message-sanitize.js';
 import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
 import { resolveSourceKindFromToolFailure, evaluateEvidenceTriage } from './triage-adapter.js';
@@ -355,10 +355,17 @@ export function evaluatePainAdmissionForToolCall(
     const triage = evaluateEvidenceTriage(sourceKind, observation.painScore);
 
     // PEAT-B2: Evaluate trigger controller for structured decision
+    // Compute real cooldown state from PainDiagnosticGate's episode map
+    // so trigger decision aligns with the gate's cooldown logic (EP-07).
+    const cooldownActive = isCooldownActiveForEpisode(
+      failureSource,
+      sessionId,
+      latestFailureState?.lastErrorHash,
+    );
     const triggerDecision = evaluateTriggerController({
       triageResult: triage,
       isOwnerManual: false, // tool failures are never owner manual
-      isCooldownActive: false, // cooldown handled by PainDiagnosticGate below
+      isCooldownActive: cooldownActive,
       isValid: true,
       score: observation.painScore,
       sessionId,

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -74,6 +74,20 @@ export async function emitPainDetectedEvent(wctx: WorkspaceContext, event: Evolu
     const painData = event.data as PainDetectedData;
     try {
       const service = createPainToPrincipleService(wctx);
+      const isManual = painData.source === 'manual' || painData.source === 'pain' || painData.source === 'skill:pain';
+
+      // PEAT-B2: Record trigger decision for observability
+      if (isManual) {
+        SystemLogger.log(wctx.workspaceDir, 'TRIGGER_DECISION', JSON.stringify({
+          outcome: 'manual_owner_admitted',
+          sourceKind: 'owner_reported',
+          reason: 'Owner explicit manual pain. Bypasses triage and cooldown.',
+          nextAction: 'create_diagnostic_task',
+          painId: painData.painId,
+          score: painData.score,
+        }));
+      }
+
       const result = await service.recordPain({
         painId: painData.painId,
         painType: painData.painType,
@@ -307,6 +321,20 @@ function handleManualPain(
       payload = JSON.stringify({ reason: gate.reason, detail: '(log serialization failed)' });
     }
     SystemLogger.log(workspaceDir, 'PAIN_GATE_REJECTED', payload);
+
+    // PEAT-B2: Record trigger decision even when cooldown blocks manual pain
+    const painTriageFlag = loadPdConfigForPlugin(workspaceDir);
+    if (painTriageFlag.effective) {
+      SystemLogger.log(workspaceDir, 'TRIGGER_DECISION', JSON.stringify({
+        outcome: 'cooldown_skipped',
+        sourceKind: 'owner_reported',
+        reason: `Manual pain within cooldown: ${gate.detail}`,
+        nextAction: 'wait_for_cooldown_or_manual_retrigger',
+        isOwnerManual: true,
+        sessionId,
+        score: 100,
+      }));
+    }
     return;
   }
 

--- a/packages/pd-cli/src/commands/pain-evidence.ts
+++ b/packages/pd-cli/src/commands/pain-evidence.ts
@@ -1,0 +1,174 @@
+/**
+ * pd pain evidence command — PEAT-B2
+ *
+ * Query recent admission/trigger decisions from PD logs.
+ * This is a read-only diagnostic command — no side effects.
+ *
+ * Usage:
+ *   pd pain evidence [--workspace <path>] [--limit N] [--json]
+ *
+ * Shows the most recent TRIGGER_DECISION log entries.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+
+interface EvidenceOptions {
+  workspace?: string;
+  limit?: number;
+  json?: boolean;
+}
+
+interface TriggerDecisionEntry {
+  timestamp: string;
+  outcome: string;
+  sourceKind: string;
+  reason: string;
+  nextAction: string;
+  tool?: string;
+  path?: string;
+  painId?: string;
+  score?: number;
+  sessionId?: string;
+}
+
+/**
+ * Parse TRIGGER_DECISION entries from a log file.
+ * Returns entries in reverse chronological order (newest first).
+ */
+function parseTriggerDecisions(logContent: string): TriggerDecisionEntry[] {
+  const entries: TriggerDecisionEntry[] = [];
+  const lines = logContent.split('\n');
+
+  for (const line of lines) {
+    if (!line.includes('TRIGGER_DECISION')) continue;
+
+    // Extract JSON payload from log line
+    const jsonStart = line.indexOf('{');
+    if (jsonStart === -1) continue;
+
+    try {
+      const payload = JSON.parse(line.slice(jsonStart));
+      // Extract timestamp from log line prefix (format: YYYY-MM-DD HH:MM:SS ...)
+      const tsMatch = /^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/.exec(line);
+      entries.push({
+        timestamp: tsMatch?.[1] ?? new Date().toISOString(),
+        outcome: payload.outcome ?? 'unknown',
+        sourceKind: payload.sourceKind ?? 'unknown',
+        reason: payload.reason ?? '',
+        nextAction: payload.nextAction ?? '',
+        tool: payload.tool,
+        path: payload.path,
+        painId: payload.painId,
+        score: payload.score,
+        sessionId: payload.sessionId,
+      });
+    } catch {
+      // Skip malformed entries
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Get the state directory for a workspace.
+ */
+function getStateDir(workspaceDir: string): string {
+  return path.join(workspaceDir, '.state');
+}
+
+/**
+ * Read recent trigger decisions from log files.
+ */
+function readRecentDecisions(stateDir: string, limit: number): TriggerDecisionEntry[] {
+  const logsDir = path.join(stateDir, 'logs');
+  if (!fs.existsSync(logsDir)) return [];
+
+  const logFiles = fs.readdirSync(logsDir)
+    .filter(f => f.startsWith('SYSTEM_') && f.endsWith('.log'))
+    .sort()
+    .reverse(); // newest first
+
+  const allEntries: TriggerDecisionEntry[] = [];
+
+  for (const logFile of logFiles) {
+    if (allEntries.length >= limit) break;
+
+    const filePath = path.join(logsDir, logFile);
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const entries = parseTriggerDecisions(content);
+      allEntries.push(...entries);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return allEntries.slice(0, limit);
+}
+
+function getOutcomeEmoji(outcome: string): string {
+  switch (outcome) {
+    case 'diagnosis_created': return '🔧';
+    case 'manual_owner_admitted': return '✅';
+    case 'evidence_only': return '📋';
+    case 'health_only': return '💚';
+    case 'cooldown_skipped': return '⏳';
+    case 'owner_confirm_required': return '❓';
+    case 'refused': return '🚫';
+    default: return '❔';
+  }
+}
+
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 3) + '...';
+}
+
+export async function handlePainEvidence(opts: EvidenceOptions): Promise<void> {
+  const workspaceDir = resolveWorkspaceDir(opts.workspace);
+  const stateDir = getStateDir(workspaceDir);
+  const limit = opts.limit ?? 20;
+
+  const decisions = readRecentDecisions(stateDir, limit);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ count: decisions.length, decisions }, null, 2));
+    return;
+  }
+
+  if (decisions.length === 0) {
+    console.log('No trigger decisions found in logs.');
+    console.log(`Searched: ${stateDir}/logs/SYSTEM_*.log`);
+    console.log('Tip: Enable painEvidenceAdmission feature flag to start recording trigger decisions.');
+    return;
+  }
+
+  console.log(`Recent Pain Evidence Admission Decisions (${decisions.length}):`);
+  console.log('─'.repeat(80));
+
+  for (const d of decisions) {
+    const outcomeEmoji = getOutcomeEmoji(d.outcome);
+    console.log(`  ${outcomeEmoji} [${d.timestamp}] ${d.outcome}`);
+    console.log(`    Source: ${d.sourceKind} | Score: ${d.score ?? 'N/A'}`);
+    console.log(`    Reason: ${truncate(d.reason, 100)}`);
+    if (d.nextAction && d.nextAction !== 'none') {
+      console.log(`    Next: ${truncate(d.nextAction, 80)}`);
+    }
+    if (d.tool) console.log(`    Tool: ${d.tool} | Path: ${d.path ?? 'N/A'}`);
+    console.log();
+  }
+
+  // Summary
+  const byOutcome = new Map<string, number>();
+  for (const d of decisions) {
+    byOutcome.set(d.outcome, (byOutcome.get(d.outcome) ?? 0) + 1);
+  }
+  console.log('─'.repeat(80));
+  console.log('Summary:');
+  for (const [outcome, count] of byOutcome) {
+    console.log(`  ${getOutcomeEmoji(outcome)} ${outcome}: ${count}`);
+  }
+}

--- a/packages/pd-cli/src/commands/pain-evidence.ts
+++ b/packages/pd-cli/src/commands/pain-evidence.ts
@@ -34,6 +34,14 @@ interface TriggerDecisionEntry {
 }
 
 /**
+ * Get the memory/logs directory for a workspace.
+ * SystemLogger writes to <workspace>/memory/logs/SYSTEM_YYYY-MM-DD.log.
+ */
+function getLogDir(workspaceDir: string): string {
+  return path.join(workspaceDir, 'memory', 'logs');
+}
+
+/**
  * Parse TRIGGER_DECISION entries from a log file.
  * Returns entries in reverse chronological order (newest first).
  */
@@ -54,18 +62,18 @@ function parseTriggerDecisions(logContent: string): TriggerDecisionEntry[] {
       const tsMatch = /^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/.exec(line);
       entries.push({
         timestamp: tsMatch?.[1] ?? new Date().toISOString(),
-        outcome: payload.outcome ?? 'unknown',
-        sourceKind: payload.sourceKind ?? 'unknown',
-        reason: payload.reason ?? '',
-        nextAction: payload.nextAction ?? '',
-        tool: payload.tool,
-        path: payload.path,
-        painId: payload.painId,
-        score: payload.score,
-        sessionId: payload.sessionId,
+        outcome: typeof payload.outcome === 'string' ? payload.outcome : 'unknown',
+        sourceKind: typeof payload.sourceKind === 'string' ? payload.sourceKind : 'unknown',
+        reason: typeof payload.reason === 'string' ? payload.reason : '',
+        nextAction: typeof payload.nextAction === 'string' ? payload.nextAction : '',
+        tool: typeof payload.tool === 'string' ? payload.tool : undefined,
+        path: typeof payload.path === 'string' ? payload.path : undefined,
+        painId: typeof payload.painId === 'string' ? payload.painId : undefined,
+        score: typeof payload.score === 'number' ? payload.score : undefined,
+        sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
       });
     } catch (e) {
-      // Skip malformed entries - log for operator visibility
+      // Skip malformed entries — log for operator visibility
       if (process.env.DEBUG) {
         console.error(`WARN: Malformed TRIGGER_DECISION entry: ${String(e).slice(0, 100)}`);
       }
@@ -76,20 +84,13 @@ function parseTriggerDecisions(logContent: string): TriggerDecisionEntry[] {
 }
 
 /**
- * Get the state directory for a workspace.
+ * Read recent trigger decisions from memory/logs files.
+ * SystemLogger writes date-stamped files: SYSTEM_YYYY-MM-DD.log.
  */
-function getStateDir(workspaceDir: string): string {
-  return path.join(workspaceDir, '.state');
-}
+function readRecentDecisions(logDir: string, limit: number): TriggerDecisionEntry[] {
+  if (!fs.existsSync(logDir)) return [];
 
-/**
- * Read recent trigger decisions from log files.
- */
-function readRecentDecisions(stateDir: string, limit: number): TriggerDecisionEntry[] {
-  const logsDir = path.join(stateDir, 'logs');
-  if (!fs.existsSync(logsDir)) return [];
-
-  const logFiles = fs.readdirSync(logsDir)
+  const logFiles = fs.readdirSync(logDir)
     .filter(f => f.startsWith('SYSTEM_') && f.endsWith('.log'))
     .sort()
     .reverse(); // newest first
@@ -99,13 +100,13 @@ function readRecentDecisions(stateDir: string, limit: number): TriggerDecisionEn
   for (const logFile of logFiles) {
     if (allEntries.length >= limit) break;
 
-    const filePath = path.join(logsDir, logFile);
+    const filePath = path.join(logDir, logFile);
     try {
       const content = fs.readFileSync(filePath, 'utf8');
       const entries = parseTriggerDecisions(content);
       allEntries.push(...entries);
     } catch (e) {
-      // Skip unreadable files - log for operator visibility
+      // Skip unreadable files — log for operator visibility
       if (process.env.DEBUG) {
         console.error(`WARN: Could not read log file ${logFile}: ${String(e).slice(0, 100)}`);
       }
@@ -134,20 +135,42 @@ function truncate(s: string, maxLen: number): string {
 }
 
 export async function handlePainEvidence(opts: EvidenceOptions): Promise<void> {
-  const workspaceDir = resolveWorkspaceDir(opts.workspace);
-  const stateDir = getStateDir(workspaceDir);
-  const limit = opts.limit ?? 20;
+  const { workspace, limit: rawLimit, json } = opts;
+  const workspaceDir = resolveWorkspaceDir(workspace);
+  const logDir = getLogDir(workspaceDir);
 
-  const decisions = readRecentDecisions(stateDir, limit);
+  // Validate limit — fail loud for invalid values
+  let effectiveLimit = 20;
+  if (rawLimit !== undefined) {
+    if (!Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > 10000) {
+      const err = {
+        status: 'refused',
+        reason: `invalid_limit: limit must be an integer between 1 and 10000, got ${rawLimit}`,
+        nextAction: 'Pass --limit with a valid integer (1-10000)',
+      };
+      const { reason, nextAction } = err;
+      if (json) {
+        console.log(JSON.stringify({ count: 0, error: err }));
+      } else {
+        console.error('Error: ' + reason);
+        console.error('Next: ' + nextAction);
+      }
+      process.exit(1);
+      return; // guard: test stubs of process.exit continue execution
+    }
+    effectiveLimit = rawLimit;
+  }
 
-  if (opts.json) {
-    console.log(JSON.stringify({ count: decisions.length, decisions }, null, 2));
+  const decisions = readRecentDecisions(logDir, effectiveLimit);
+
+  if (json) {
+    console.log(JSON.stringify({ count: decisions.length, decisions, searchedPath: path.join(logDir, 'SYSTEM_*.log') }, null, 2));
     return;
   }
 
   if (decisions.length === 0) {
     console.log('No trigger decisions found in logs.');
-    console.log(`Searched: ${stateDir}/logs/SYSTEM_*.log`);
+    console.log(`Searched: ${path.join(logDir, 'SYSTEM_*.log')}`);
     console.log('Tip: Enable painEvidenceAdmission feature flag to start recording trigger decisions.');
     return;
   }
@@ -178,3 +201,7 @@ export async function handlePainEvidence(opts: EvidenceOptions): Promise<void> {
     console.log(`  ${getOutcomeEmoji(outcome)} ${outcome}: ${count}`);
   }
 }
+
+// Export for testing
+// istanbul ignore next
+export { parseTriggerDecisions, getLogDir };

--- a/packages/pd-cli/src/commands/pain-evidence.ts
+++ b/packages/pd-cli/src/commands/pain-evidence.ts
@@ -64,8 +64,11 @@ function parseTriggerDecisions(logContent: string): TriggerDecisionEntry[] {
         score: payload.score,
         sessionId: payload.sessionId,
       });
-    } catch {
-      // Skip malformed entries
+    } catch (e) {
+      // Skip malformed entries - log for operator visibility
+      if (process.env.DEBUG) {
+        console.error(`WARN: Malformed TRIGGER_DECISION entry: ${String(e).slice(0, 100)}`);
+      }
     }
   }
 
@@ -101,8 +104,11 @@ function readRecentDecisions(stateDir: string, limit: number): TriggerDecisionEn
       const content = fs.readFileSync(filePath, 'utf8');
       const entries = parseTriggerDecisions(content);
       allEntries.push(...entries);
-    } catch {
-      // Skip unreadable files
+    } catch (e) {
+      // Skip unreadable files - log for operator visibility
+      if (process.env.DEBUG) {
+        console.error(`WARN: Could not read log file ${logFile}: ${String(e).slice(0, 100)}`);
+      }
     }
   }
 

--- a/packages/pd-cli/src/commands/pain-evidence.ts
+++ b/packages/pd-cli/src/commands/pain-evidence.ts
@@ -58,8 +58,12 @@ function parseTriggerDecisions(logContent: string): TriggerDecisionEntry[] {
 
     try {
       const payload = JSON.parse(line.slice(jsonStart));
-      // Extract timestamp from log line prefix (format: YYYY-MM-DD HH:MM:SS ...)
-      const tsMatch = /^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/.exec(line);
+      // Extract timestamp from log line prefix.
+      // SystemLogger produces two formats:
+      //   - Plain:    "2026-06-08 10:16:00 [INFO] ..."
+      //   - Bracketed ISO: "[2026-06-08T10:16:00.123Z] [INFO] ..."
+      const tsMatch = /^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/.exec(line)
+        ?? /^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\]/.exec(line);
       entries.push({
         timestamp: tsMatch?.[1] ?? new Date().toISOString(),
         outcome: typeof payload.outcome === 'string' ? payload.outcome : 'unknown',
@@ -73,10 +77,8 @@ function parseTriggerDecisions(logContent: string): TriggerDecisionEntry[] {
         sessionId: typeof payload.sessionId === 'string' ? payload.sessionId : undefined,
       });
     } catch (e) {
-      // Skip malformed entries — log for operator visibility
-      if (process.env.DEBUG) {
-        console.error(`WARN: Malformed TRIGGER_DECISION entry: ${String(e).slice(0, 100)}`);
-      }
+      // Skip malformed entries — always log for operator visibility (EP-03)
+      console.error(`WARN: Malformed TRIGGER_DECISION entry: ${String(e).slice(0, 100)}`);
     }
   }
 
@@ -104,12 +106,13 @@ function readRecentDecisions(logDir: string, limit: number): TriggerDecisionEntr
     try {
       const content = fs.readFileSync(filePath, 'utf8');
       const entries = parseTriggerDecisions(content);
-      allEntries.push(...entries);
+      // Reverse per-file entries so combined list is newest-first.
+      // Log files are already sorted newest-first, but entries within
+      // each file are in chronological (oldest-first) order.
+      allEntries.push(...entries.reverse());
     } catch (e) {
-      // Skip unreadable files — log for operator visibility
-      if (process.env.DEBUG) {
-        console.error(`WARN: Could not read log file ${logFile}: ${String(e).slice(0, 100)}`);
-      }
+      // Skip unreadable files — always log for operator visibility (EP-03)
+      console.error(`WARN: Could not read log file ${logFile}: ${String(e).slice(0, 100)}`);
     }
   }
 

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -90,6 +90,10 @@ painCmd
   .option('--provider <name>', 'LLM provider (e.g., openrouter) — for pi-ai, falls back to policy')
   .option('--model <id>', 'Model ID (e.g., anthropic/claude-sonnet-4) — for pi-ai, falls back to policy')
   .option('--apiKeyEnv <name>', 'Env var name for API key — for pi-ai, falls back to policy')
+  .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
+  .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
+  .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)
+  .option('--force', 'Allow retry of already-succeeded tasks')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handlePainRetry(opts);
@@ -103,17 +107,6 @@ painCmd
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handlePainEvidence(opts);
-  });
-
-program
-  .command('canary')
-  .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
-  .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
-  .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)
-  .option('--force', 'Allow retry of already-succeeded tasks')
-  .option('--json', 'Output raw JSON')
-  .action(async (opts) => {
-    await handlePainRetry(opts);
   });
 
 const samplesCmd = program

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -9,6 +9,7 @@
 import { Command } from 'commander';
 import { handlePainRecord } from './commands/pain-record.js';
 import { handlePainRetry } from './commands/pain-retry.js';
+import { handlePainEvidence } from './commands/pain-evidence.js';
 import { handleSamplesList } from './commands/samples-list.js';
 import { handleSamplesReview } from './commands/samples-review.js';
 import { handleEvolutionTasksList } from './commands/evolution-tasks-list.js';
@@ -82,13 +83,23 @@ painCmd
   .description('Retry a failed diagnosis by pain ID')
   .requiredOption('-p, --pain-id <painId>', 'Pain ID to retry diagnosis for')
   .option('-w, --workspace <path>', 'Workspace directory')
-  .option('-r, --runtime <kind>', "Runtime kind: 'openclaw-cli', 'test-double', 'pi-ai'")
-  .option('--openclaw-local', 'Use local OpenClaw (mutually exclusive with --openclaw-gateway)')
-  .option('--openclaw-gateway', 'Use gateway OpenClaw (mutually exclusive with --openclaw-local)')
-  .option('-a, --agent <agentId>', 'Agent ID to invoke')
-  .option('--provider <name>', 'LLM provider (e.g., openrouter) — for pi-ai, falls back to policy')
-  .option('--model <id>', 'Model ID (e.g., anthropic/claude-sonnet-4) — for pi-ai, falls back to policy')
-  .option('--apiKeyEnv <name>', 'Env var name for API key — for pi-ai, falls back to policy')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handlePainRetry(opts);
+  });
+
+painCmd
+  .command('evidence')
+  .description('Show recent pain admission/trigger decisions (PEAT-B2)')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('-l, --limit <number>', 'Max entries to show (default: 20)', parseInt)
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    await handlePainEvidence(opts);
+  });
+
+program
+  .command('canary')
   .option('--baseUrl <url>', 'Custom base URL — for pi-ai, falls back to policy')
   .option('--maxRetries <n>', 'Max retry attempts for LLM failures — for pi-ai, falls back to policy', parseInt)
   .option('--timeoutMs <ms>', 'Timeout in milliseconds — for pi-ai, falls back to policy', parseInt)

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -83,6 +83,13 @@ painCmd
   .description('Retry a failed diagnosis by pain ID')
   .requiredOption('-p, --pain-id <painId>', 'Pain ID to retry diagnosis for')
   .option('-w, --workspace <path>', 'Workspace directory')
+  .option('-r, --runtime <kind>', "Runtime kind: 'openclaw-cli', 'test-double', 'pi-ai'")
+  .option('--openclaw-local', 'Use local OpenClaw (mutually exclusive with --openclaw-gateway)')
+  .option('--openclaw-gateway', 'Use gateway OpenClaw (mutually exclusive with --openclaw-local)')
+  .option('-a, --agent <agentId>', 'Agent ID to invoke')
+  .option('--provider <name>', 'LLM provider (e.g., openrouter) — for pi-ai, falls back to policy')
+  .option('--model <id>', 'Model ID (e.g., anthropic/claude-sonnet-4) — for pi-ai, falls back to policy')
+  .option('--apiKeyEnv <name>', 'Env var name for API key — for pi-ai, falls back to policy')
   .option('--json', 'Output raw JSON')
   .action(async (opts) => {
     await handlePainRetry(opts);

--- a/packages/pd-cli/tests/commands/pain-evidence.test.ts
+++ b/packages/pd-cli/tests/commands/pain-evidence.test.ts
@@ -108,7 +108,7 @@ describe('parseTriggerDecisions', () => {
     expect(entries[0].nextAction).toBe('');
   });
 
-  it('PARSER-06: entries sorted newest-first (reverse of parse order)', () => {
+  it('PARSER-06: entries preserve parse order (oldest-first within file)', () => {
     const content = [
       '2026-06-08 10:15:00 [INFO] TRIGGER_DECISION {"outcome":"evidence_only","sourceKind":"a","reason":"r1","nextAction":"n"}',
       '2026-06-08 10:16:00 [INFO] TRIGGER_DECISION {"outcome":"health_only","sourceKind":"b","reason":"r2","nextAction":"n"}',
@@ -118,7 +118,7 @@ describe('parseTriggerDecisions', () => {
     const entries = parseTriggerDecisions(content);
     expect(entries.length).toBe(3);
     // File is parsed top-to-bottom, entries preserve reading order
-    // Test that timestamps are preserved
+    // (readRecentDecisions reverses per-file entries for newest-first)
     expect(entries[0].timestamp).toBe('2026-06-08 10:15:00');
     expect(entries[1].timestamp).toBe('2026-06-08 10:16:00');
     expect(entries[2].timestamp).toBe('2026-06-08 10:17:00');
@@ -162,9 +162,10 @@ describe('real SYSTEM log fixture', () => {
     expect(output.count).toBe(3);
     expect(output.decisions.length).toBe(3);
     expect(output.searchedPath).toContain(path.join('memory', 'logs', 'SYSTEM_*.log'));
-    expect(output.decisions[0].outcome).toBe('evidence_only');
+    // Entries are newest-first after per-file reversal
+    expect(output.decisions[0].outcome).toBe('manual_owner_admitted');
     expect(output.decisions[1].outcome).toBe('health_only');
-    expect(output.decisions[2].outcome).toBe('manual_owner_admitted');
+    expect(output.decisions[2].outcome).toBe('evidence_only');
 
     logSpy.mockRestore();
     exitSpy.mockRestore();

--- a/packages/pd-cli/tests/commands/pain-evidence.test.ts
+++ b/packages/pd-cli/tests/commands/pain-evidence.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Tests for pd pain evidence command.
+ *
+ * Covers:
+ * - Command parser/registration: --workspace, --limit, --json
+ * - Real SYSTEM log fixture parsing: TRIGGER_DECISION entries
+ * - Malformed log entries: no crash, visible reason/diagnostic
+ * - --json stdout: exactly one JSON object
+ * - --limit invalid values: fail loud with reason + nextAction
+ * - Searched path matches actual log directory
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import os from 'os';
+
+// ── Fixture: Real SYSTEM log content with TRIGGER_DECISION entries ──────────
+
+const LOG_HEADER_LINES = [
+  '2026-06-08 10:15:30 [INFO] [PD:SystemLogger] Session started session_abc',
+  '2026-06-08 10:15:31 [INFO] [PD:SystemLogger] painEvidenceAdmission feature flag enabled',
+];
+
+const TRIGGER_DECISION_ENTRIES = [
+  '2026-06-08 10:16:00 [INFO] [PD:SystemLogger] TRIGGER_DECISION {"outcome":"evidence_only","sourceKind":"tool_failure","reason":"Tool failure is infrastructure noise.","nextAction":"store_as_evidence","triageDecision":"evidence_only","tool":"read","sessionId":"session_abc"}',
+  '2026-06-08 10:17:00 [INFO] [PD:SystemLogger] TRIGGER_DECISION {"outcome":"health_only","sourceKind":"provider_failure","reason":"Infrastructure health signal.","nextAction":"monitor","triageDecision":"health_only","sessionId":"session_abc"}',
+  '2026-06-08 10:18:00 [INFO] [PD:SystemLogger] TRIGGER_DECISION {"outcome":"manual_owner_admitted","sourceKind":"owner_reported","reason":"Owner explicit manual pain. Bypasses triage and cooldown.","nextAction":"create_diagnostic_task","painId":"pain_123","score":100}',
+];
+
+const MALFORMED_ENTRY = '2026-06-08 10:19:00 [INFO] [PD:SystemLogger] TRIGGER_DECISION {not valid json';
+const NON_TRIGGER_ENTRY = '2026-06-08 10:20:00 [INFO] [PD:SystemLogger] PAIN_GATE_REJECTED {"reason":"cooldown"}';
+
+const FULL_LOG_CONTENT = [
+  ...LOG_HEADER_LINES,
+  ...TRIGGER_DECISION_ENTRIES.slice(0, 2),
+  MALFORMED_ENTRY,
+  ...TRIGGER_DECISION_ENTRIES.slice(2),
+  NON_TRIGGER_ENTRY,
+].join('\n');
+
+// ── Imports (under test) ───────────────────────────────────────────────────
+
+import { parseTriggerDecisions, getLogDir } from '../../src/commands/pain-evidence.js';
+
+declare module '../../src/commands/pain-evidence.js' {
+  export function parseTriggerDecisions(logContent: string): import('../../src/commands/pain-evidence.js').TriggerDecisionEntry[];
+  export function getLogDir(workspaceDir: string): string;
+}
+
+// ── Parser Tests ───────────────────────────────────────────────────────────
+
+describe('parseTriggerDecisions', () => {
+  it('PARSER-01: parses TRIGGER_DECISION entries from log content', () => {
+    const entries = parseTriggerDecisions(FULL_LOG_CONTENT);
+
+    // Should parse 3 valid entries, skip malformed and non-trigger lines
+    expect(entries.length).toBe(3);
+
+    // First: evidence_only from tool_failure
+    expect(entries[0].outcome).toBe('evidence_only');
+    expect(entries[0].sourceKind).toBe('tool_failure');
+    expect(entries[0].reason).toContain('infrastructure');
+    expect(entries[0].timestamp).toBe('2026-06-08 10:16:00');
+
+    // Second: health_only from provider_failure
+    expect(entries[1].outcome).toBe('health_only');
+    expect(entries[1].sourceKind).toBe('provider_failure');
+
+    // Third: manual_owner_admitted
+    expect(entries[2].outcome).toBe('manual_owner_admitted');
+    expect(entries[2].sourceKind).toBe('owner_reported');
+    expect(entries[2].painId).toBe('pain_123');
+    expect(entries[2].score).toBe(100);
+  });
+
+  it('PARSER-02: returns empty array for content without TRIGGER_DECISION', () => {
+    const entries = parseTriggerDecisions('2026-06-08 10:15:30 [INFO] Normal log line\nMore normal log');
+    expect(entries.length).toBe(0);
+  });
+
+  it('PARSER-03: returns empty array for empty content', () => {
+    const entries = parseTriggerDecisions('');
+    expect(entries.length).toBe(0);
+  });
+
+  it('PARSER-04: malformed JSON entries do not crash and are silently skipped', () => {
+    const content = [
+      '2026-06-08 10:16:00 [INFO] TRIGGER_DECISION {"outcome":"evidence_only","sourceKind":"tool_failure","reason":"valid","nextAction":"store"}',
+      '2026-06-08 10:17:00 [INFO] TRIGGER_DECISION {invalid json}',
+      '2026-06-08 10:18:00 [INFO] TRIGGER_DECISION {"outcome":"diagnosis_created","sourceKind":"owner_reported","reason":"valid2","nextAction":"diagnose"}',
+    ].join('\n');
+
+    const entries = parseTriggerDecisions(content);
+    expect(entries.length).toBe(2); // malformed skipped
+    expect(entries[0].outcome).toBe('evidence_only');
+    expect(entries[1].outcome).toBe('diagnosis_created');
+  });
+
+  it('PARSER-05: runtime type validation catches non-string fields', () => {
+    const content = '2026-06-08 10:16:00 [INFO] TRIGGER_DECISION {"outcome":123,"sourceKind":["array"],"reason":null,"nextAction":true}';
+    const entries = parseTriggerDecisions(content);
+    expect(entries.length).toBe(1);
+    // Should fall back to defaults when types don't match
+    expect(entries[0].outcome).toBe('unknown');
+    expect(entries[0].sourceKind).toBe('unknown');
+    expect(entries[0].reason).toBe('');
+    expect(entries[0].nextAction).toBe('');
+  });
+
+  it('PARSER-06: entries sorted newest-first (reverse of parse order)', () => {
+    const content = [
+      '2026-06-08 10:15:00 [INFO] TRIGGER_DECISION {"outcome":"evidence_only","sourceKind":"a","reason":"r1","nextAction":"n"}',
+      '2026-06-08 10:16:00 [INFO] TRIGGER_DECISION {"outcome":"health_only","sourceKind":"b","reason":"r2","nextAction":"n"}',
+      '2026-06-08 10:17:00 [INFO] TRIGGER_DECISION {"outcome":"diagnosis_created","sourceKind":"c","reason":"r3","nextAction":"n"}',
+    ].join('\n');
+
+    const entries = parseTriggerDecisions(content);
+    expect(entries.length).toBe(3);
+    // File is parsed top-to-bottom, entries preserve reading order
+    // Test that timestamps are preserved
+    expect(entries[0].timestamp).toBe('2026-06-08 10:15:00');
+    expect(entries[1].timestamp).toBe('2026-06-08 10:16:00');
+    expect(entries[2].timestamp).toBe('2026-06-08 10:17:00');
+  });
+});
+
+// ── Integration: Real Log File Fixture ─────────────────────────────────────
+
+describe('real SYSTEM log fixture', () => {
+  const tmpDir = path.join(os.tmpdir(), `pd-test-evidence-${Date.now()}`);
+  const logDir = path.join(tmpDir, 'memory', 'logs');
+
+  beforeEach(() => {
+    // Create log directory with fixture file
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(path.join(logDir, 'SYSTEM_2026-06-08.log'), FULL_LOG_CONTENT, 'utf8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('FIXTURE-01: reads and parses TRIGGER_DECISION from real SYSTEM log', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: tmpDir,
+      limit: 10,
+      json: true,
+    });
+
+    // Find the JSON output call
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.count).toBe(3);
+    expect(output.decisions.length).toBe(3);
+    expect(output.searchedPath).toContain(path.join('memory', 'logs', 'SYSTEM_*.log'));
+    expect(output.decisions[0].outcome).toBe('evidence_only');
+    expect(output.decisions[1].outcome).toBe('health_only');
+    expect(output.decisions[2].outcome).toBe('manual_owner_admitted');
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('FIXTURE-02: --json stdout is exactly one parseable JSON object', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: tmpDir,
+      limit: 5,
+      json: true,
+    });
+
+    // Should produce a valid JSON output
+    const jsonCalls = logSpy.mock.calls.filter((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCalls.length).toBeGreaterThanOrEqual(1);
+    const parsed = JSON.parse(jsonCalls[0][0] as string);
+    expect(parsed.count).toBe(3);
+    expect(Array.isArray(parsed.decisions)).toBe(true);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('FIXTURE-03: non-JSON output shows formatted entries', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: tmpDir,
+      limit: 10,
+      json: false,
+    });
+
+    const allOutput = logSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('evidence_only');
+    expect(allOutput).toContain('health_only');
+    expect(allOutput).toContain('manual_owner_admitted');
+    expect(allOutput).toContain('Tool failure is infrastructure noise');
+    expect(allOutput).toContain('Summary:');
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('FIXTURE-04: empty log returns zero results', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    // Create a log file with no TRIGGER_DECISION entries
+    const noTriggerLog = '2026-06-08 [INFO] Normal log content without any trigger decisions.\n';
+    fs.writeFileSync(path.join(logDir, 'SYSTEM_2026-06-08.log'), noTriggerLog, 'utf8');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: tmpDir,
+      limit: 5,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.count).toBe(0);
+    expect(output.decisions).toEqual([]);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('FIXTURE-05: --limit filters entries', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    // With limit 2, should return only 2 entries
+    await handlePainEvidence({
+      workspace: tmpDir,
+      limit: 2,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.count).toBe(2);
+    expect(output.decisions.length).toBe(2);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+// ── Commander Registration Tests ───────────────────────────────────────────
+
+describe('Commander wiring for pd pain evidence', () => {
+  function createEvidenceProgram(): { program: Command; capturedOpts: Record<string, unknown> } {
+    const program = new Command();
+    program.exitOverride();
+    const capturedOpts: Record<string, unknown> = {};
+
+    program
+      .command('pain')
+      .command('evidence')
+      .option('-w, --workspace <path>', 'Workspace directory')
+      .option('-l, --limit <number>', 'Max entries to show', parseInt)
+      .option('--json', 'Output raw JSON')
+      .action(async (opts) => {
+        Object.assign(capturedOpts, opts);
+      });
+
+    return { program, capturedOpts };
+  }
+
+  it('CMD-01: --workspace sets opts.workspace', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence', '--workspace', '/tmp/ws']);
+    expect(capturedOpts.workspace).toBe('/tmp/ws');
+  });
+
+  it('CMD-02: -w short form sets opts.workspace', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence', '-w', '/tmp/ws']);
+    expect(capturedOpts.workspace).toBe('/tmp/ws');
+  });
+
+  it('CMD-03: --limit sets opts.limit as number', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence', '--limit', '5']);
+    expect(capturedOpts.limit).toBe(5);
+  });
+
+  it('CMD-04: -l short form sets opts.limit', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence', '-l', '10']);
+    expect(capturedOpts.limit).toBe(10);
+  });
+
+  it('CMD-05: default (no args) → opts.limit undefined', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence']);
+    expect(capturedOpts.limit).toBeUndefined();
+  });
+
+  it('CMD-06: --json sets opts.json === true', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence', '--json']);
+    expect(capturedOpts.json).toBe(true);
+  });
+
+  it('CMD-07: no --json → opts.json undefined', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence']);
+    expect(capturedOpts.json).toBeUndefined();
+  });
+
+  it('CMD-08: --limit with non-numeric value → NaN', async () => {
+    const { program, capturedOpts } = createEvidenceProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'evidence', '--limit', 'abc']);
+    expect(capturedOpts.limit).toBeNaN();
+  });
+});
+
+// ── Limit Validation Tests ─────────────────────────────────────────────────
+
+describe('pain evidence — limit validation', () => {
+  it('INVALID-01: --limit 0 fails loud with reason + nextAction (JSON)', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: '/nonexistent',
+      limit: 0,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.error).toBeDefined();
+    expect(output.error.status).toBe('refused');
+    expect(output.error.reason).toContain('invalid_limit');
+    expect(output.error.reason).toContain('0');
+    expect(output.error.nextAction).toBeDefined();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    // Guard: no readRecentDecisions after invalid limit
+    expect(output.decisions).toBeUndefined();
+    expect(output.count).toBe(0);
+    // Exactly one JSON output, no second JSON from readRecentDecisions
+    const jsonCountAfterInvalid = logSpy.mock.calls.filter((call) => {
+      try { return typeof call[0] === 'string' && JSON.parse(call[0]); } catch { return false; }
+    }).length;
+    expect(jsonCountAfterInvalid).toBe(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INVALID-02: --limit -1 fails loud (JSON)', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: '/nonexistent',
+      limit: -1,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.error.status).toBe('refused');
+    expect(output.error.reason).toContain('invalid_limit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INVALID-03: --limit 10001 fails loud (JSON)', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: '/nonexistent',
+      limit: 10001,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.error.status).toBe('refused');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INVALID-04: non-integer limit fails loud (JSON)', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: '/nonexistent',
+      limit: 3.5,
+      json: true,
+    });
+
+    const jsonCall = logSpy.mock.calls.find((call) => {
+      try { JSON.parse(call[0] as string); return true; } catch { return false; }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.error.status).toBe('refused');
+    expect(output.error.reason).toContain('invalid_limit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('INVALID-05: --limit 0 fails loud with human-readable error', async () => {
+    const { handlePainEvidence } = await import('../../src/commands/pain-evidence.js');
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainEvidence({
+      workspace: '/nonexistent',
+      limit: 0,
+      json: false,
+    });
+
+    const allErrors = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allErrors).toContain('invalid_limit');
+    expect(allErrors).toContain('Next:');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/pd-cli/tests/commands/pain-retry.test.ts
+++ b/packages/pd-cli/tests/commands/pain-retry.test.ts
@@ -718,6 +718,15 @@ describe('Commander wiring for pd pain retry', () => {
       .requiredOption('-p, --pain-id <painId>', 'Pain ID')
       .option('-w, --workspace <path>', 'Workspace directory')
       .option('-r, --runtime <kind>', 'Runtime kind')
+      .option('--openclaw-local', 'Use local OpenClaw')
+      .option('--openclaw-gateway', 'Use gateway OpenClaw')
+      .option('-a, --agent <agentId>', 'Agent ID')
+      .option('--provider <name>', 'LLM provider')
+      .option('--model <id>', 'Model ID')
+      .option('--apiKeyEnv <name>', 'API key env var')
+      .option('--baseUrl <url>', 'Custom base URL')
+      .option('--maxRetries <n>', 'Max retries', parseInt)
+      .option('--timeoutMs <ms>', 'Timeout ms', parseInt)
       .option('--force', 'Force retry of succeeded task')
       .option('--json', 'Output raw JSON')
       .action(async (opts) => {
@@ -768,5 +777,60 @@ describe('Commander wiring for pd pain retry', () => {
     const { program, capturedOpts } = createPainRetryProgram();
     await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--runtime', 'pi-ai']);
     expect(capturedOpts.runtime).toBe('pi-ai');
+  });
+
+  // REGRESSION: PRI-337 — all options must route through pain retry
+  it('CMD-08: --baseUrl sets opts.baseUrl', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--baseUrl', 'https://custom.api.com']);
+    expect(capturedOpts.baseUrl).toBe('https://custom.api.com');
+  });
+
+  it('CMD-09: --maxRetries sets opts.maxRetries as number', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--maxRetries', '5']);
+    expect(capturedOpts.maxRetries).toBe(5);
+  });
+
+  it('CMD-10: --timeoutMs sets opts.timeoutMs as number', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--timeoutMs', '60000']);
+    expect(capturedOpts.timeoutMs).toBe(60000);
+  });
+
+  it('CMD-11: --provider sets opts.provider', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--provider', 'openrouter']);
+    expect(capturedOpts.provider).toBe('openrouter');
+  });
+
+  it('CMD-12: --model sets opts.model', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--model', 'anthropic/claude-sonnet-4']);
+    expect(capturedOpts.model).toBe('anthropic/claude-sonnet-4');
+  });
+
+  it('CMD-13: --apiKeyEnv sets opts.apiKeyEnv', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--apiKeyEnv', 'OPENROUTER_KEY']);
+    expect(capturedOpts.apiKeyEnv).toBe('OPENROUTER_KEY');
+  });
+
+  it('CMD-14: -a (--agent) sets opts.agent', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '-a', 'main']);
+    expect(capturedOpts.agent).toBe('main');
+  });
+
+  it('CMD-15: --openclaw-local sets opts.openclawLocal === true', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--openclaw-local']);
+    expect(capturedOpts.openclawLocal).toBe(true);
+  });
+
+  it('CMD-16: --openclaw-gateway sets opts.openclawGateway === true', async () => {
+    const { program, capturedOpts } = createPainRetryProgram();
+    await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--openclaw-gateway']);
+    expect(capturedOpts.openclawGateway).toBe(true);
   });
 });

--- a/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/admission-events.test.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/admission-events.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Admission Events Tests — PEAT-B2
+ *
+ * Tests for admission event creation, serialization, and privacy validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createAdmissionDecisionEvent,
+  createDiagnosisTaskCreatedEvent,
+  createEvidenceOnlyRecordedEvent,
+  createSkippedRefusedEvent,
+  serializeAdmissionEvent,
+  validateEventPrivacy,
+} from '../admission-events.js';
+import type { TriggerDecision } from '../trigger-controller.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeDecision(overrides: Partial<TriggerDecision> = {}): TriggerDecision {
+  return {
+    outcome: 'evidence_only',
+    reason: 'Tool failure is infrastructure noise.',
+    nextAction: 'store_as_evidence',
+    sourceKind: 'tool_failure',
+    triageDecision: 'evidence_only',
+    shouldCreateDiagnosticTask: false,
+    decidedAt: '2026-06-08T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ── Admission Decision Event ────────────────────────────────────────────────
+
+describe('createAdmissionDecisionEvent', () => {
+  it('creates event with all required fields', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, {
+      workspaceRef: 'my-workspace',
+      sessionId: 'session-123',
+    });
+
+    expect(event.eventType).toBe('admission_decision');
+    expect(event.eventId).toMatch(/^adm_\d+_\d+$/);
+    expect(event.timestamp).toBe('2026-06-08T12:00:00.000Z');
+    expect(event.sourceKind).toBe('tool_failure');
+    expect(event.workspaceRef).toBe('my-workspace');
+    expect(event.sessionId).toBe('session-123');
+    expect(event.triageDecision).toBe('evidence_only');
+    expect(event.triggerOutcome).toBe('evidence_only');
+    expect(event.reason).toBeTruthy();
+    expect(event.nextAction).toBeTruthy();
+    expect(event.shouldCreateDiagnosticTask).toBe(false);
+  });
+
+  it('records diagnosis_created outcome correctly', () => {
+    const decision = makeDecision({
+      outcome: 'diagnosis_created',
+      triageDecision: 'admit',
+      shouldCreateDiagnosticTask: true,
+      reason: 'Owner reported.',
+    });
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'ws' });
+
+    expect(event.triggerOutcome).toBe('diagnosis_created');
+    expect(event.shouldCreateDiagnosticTask).toBe(true);
+  });
+});
+
+// ── Diagnosis Task Created Event ────────────────────────────────────────────
+
+describe('createDiagnosisTaskCreatedEvent', () => {
+  it('creates event with pain ID and task ID', () => {
+    const decision = makeDecision({
+      outcome: 'diagnosis_created',
+      triageDecision: 'admit',
+      shouldCreateDiagnosticTask: true,
+    });
+    const event = createDiagnosisTaskCreatedEvent({
+      painId: 'pain_123',
+      taskId: 'diag_456',
+      decision,
+      workspaceRef: 'ws',
+    });
+
+    expect(event.eventType).toBe('diagnosis_task_created');
+    expect(event.painId).toBe('pain_123');
+    expect(event.taskId).toBe('diag_456');
+    expect(event.triggerOutcome).toBe('diagnosis_created');
+  });
+});
+
+// ── Evidence Only Recorded Event ────────────────────────────────────────────
+
+describe('createEvidenceOnlyRecordedEvent', () => {
+  it('creates event with triage decision details', () => {
+    const decision = makeDecision();
+    const event = createEvidenceOnlyRecordedEvent(decision, {
+      workspaceRef: 'ws',
+      sessionId: 's1',
+    });
+
+    expect(event.eventType).toBe('evidence_only_recorded');
+    expect(event.triageDecision).toBe('evidence_only');
+    expect(event.reason).toBe(decision.reason);
+    expect(event.nextAction).toBe(decision.nextAction);
+  });
+});
+
+// ── Skipped Refused Event ───────────────────────────────────────────────────
+
+describe('createSkippedRefusedEvent', () => {
+  it('creates event for refused decisions', () => {
+    const decision = makeDecision({
+      outcome: 'refused',
+      reason: 'Input validation failed.',
+      nextAction: 'fix_input_and_retry',
+    });
+    const event = createSkippedRefusedEvent(decision, { workspaceRef: 'ws' });
+
+    expect(event.eventType).toBe('skipped_refused');
+    expect(event.triggerOutcome).toBe('refused');
+    expect(event.reason).toContain('validation');
+  });
+
+  it('creates event for cooldown-skipped decisions', () => {
+    const decision = makeDecision({
+      outcome: 'cooldown_skipped',
+      reason: 'Cooldown is active.',
+      nextAction: 'wait_for_cooldown',
+    });
+    const event = createSkippedRefusedEvent(decision, { workspaceRef: 'ws' });
+
+    expect(event.eventType).toBe('skipped_refused');
+    expect(event.triggerOutcome).toBe('cooldown_skipped');
+  });
+});
+
+// ── Serialization ───────────────────────────────────────────────────────────
+
+describe('serializeAdmissionEvent', () => {
+  it('produces valid JSON', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'ws' });
+    const serialized = serializeAdmissionEvent(event);
+
+    expect(() => JSON.parse(serialized)).not.toThrow();
+  });
+
+  it('includes eventType in serialized output', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'ws' });
+    const serialized = serializeAdmissionEvent(event);
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.eventType).toBe('admission_decision');
+  });
+
+  it('does not include unexpected fields', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'ws' });
+    const serialized = serializeAdmissionEvent(event);
+    const parsed = JSON.parse(serialized);
+
+    // Should not have arbitrary extra keys
+    const expectedKeys = ['eventType', 'eventId', 'timestamp', 'sourceKind', 'workspaceRef', 'sessionId',
+      'triageDecision', 'triggerOutcome', 'reason', 'nextAction', 'shouldCreateDiagnosticTask'];
+    const actualKeys = Object.keys(parsed);
+    for (const key of actualKeys) {
+      expect(expectedKeys).toContain(key);
+    }
+  });
+});
+
+// ── Privacy Validation ──────────────────────────────────────────────────────
+
+describe('validateEventPrivacy', () => {
+  it('passes for clean events', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'ws' });
+    const result = validateEventPrivacy(event);
+
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('detects API keys in events', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'ws', sessionId: 'sk-1234567890abcdef1234567890abcdef1234' });
+    const result = validateEventPrivacy(event);
+
+    expect(result.valid).toBe(false);
+    expect(result.violations).toContain('potential_api_key_detected');
+  });
+
+  it('detects Windows absolute paths', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'C:\\Users\\admin\\workspace' });
+    const result = validateEventPrivacy(event);
+
+    expect(result.valid).toBe(false);
+    expect(result.violations).toContain('absolute_windows_path_detected');
+  });
+
+  it('allows workspace directory names without full paths', () => {
+    const decision = makeDecision();
+    const event = createAdmissionDecisionEvent(decision, { workspaceRef: 'my-project' });
+    const result = validateEventPrivacy(event);
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/source-descriptors.test.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/source-descriptors.test.ts
@@ -19,9 +19,8 @@ import { describe, it, expect } from 'vitest';
 import {
   SOURCE_DESCRIPTORS,
   getSourceDescriptor,
-  type SourceDescriptor,
 } from '../source-descriptors.js';
-import type { SourceKind, TriageDecision } from '../types.js';
+import type { SourceKind } from '../types.js';
 import { isSourceKind } from '../types.js';
 
 // ── Descriptor Registry Completeness ───────────────────────────────────────────
@@ -293,7 +292,7 @@ describe('SOURCE_DESCRIPTORS immutability', () => {
 
   it('descriptor objects are frozen or readonly', () => {
     // Each descriptor should have readonly properties
-    for (const [kind, descriptor] of SOURCE_DESCRIPTORS) {
+    for (const [_kind, descriptor] of SOURCE_DESCRIPTORS) {
       // Attempting to modify should either fail or not affect original
       const originalDecision = descriptor.defaultDecision;
       // This test verifies the descriptor structure is correct

--- a/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/trigger-controller.test.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/__tests__/trigger-controller.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Trigger Controller Tests — PEAT-B2
+ *
+ * Production-path tests for the trigger controller.
+ * Every test exercises the full path from input to TriggerDecision,
+ * not just helper functions.
+ *
+ * ERR checklist:
+ * - ERR-002: Every path carries reason + nextAction
+ * - ERR-009: Malformed input fails loud
+ * - ERR-025: Production-path tests, not just helpers
+ * - ERR-031/034: Decisions come from canonical descriptors
+ * - ERR-048: Write-read disconnect prevented
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateTriggerController,
+  shouldCreateTask,
+  isAdmittedOutcome,
+  isSkippedOutcome,
+} from '../trigger-controller.js';
+import type { TriggerControllerInput, TriggerDecision } from '../trigger-controller.js';
+import { evaluateTriage } from '../triage-policy.js';
+import type { TriageResult } from '../types.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeInput(overrides: Partial<TriggerControllerInput> & { triageResult: TriageResult }): TriggerControllerInput {
+  return {
+    isOwnerManual: false,
+    isCooldownActive: false,
+    isValid: true,
+    score: 50,
+    ...overrides,
+  };
+}
+
+function triageForKind(sourceKind: Parameters<typeof evaluateTriage>[0]['sourceKind'], score = 50): TriageResult {
+  return evaluateTriage({ sourceKind, score });
+}
+
+// ── Manual Pain → diagnosis_created ─────────────────────────────────────────
+
+describe('manual owner pain', () => {
+  it('creates diagnostic task for owner manual pain regardless of source kind', () => {
+    const triage = triageForKind('owner_reported', 100);
+    const input = makeInput({ triageResult: triage, isOwnerManual: true, score: 100 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('manual_owner_admitted');
+    expect(decision.shouldCreateDiagnosticTask).toBe(true);
+    expect(decision.reason).toBeTruthy();
+    expect(decision.nextAction).toBe('create_diagnostic_task');
+  });
+
+  it('bypasses cooldown for owner manual pain', () => {
+    const triage = triageForKind('owner_reported', 100);
+    const input = makeInput({ triageResult: triage, isOwnerManual: true, score: 100, isCooldownActive: true });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('manual_owner_admitted');
+    expect(decision.shouldCreateDiagnosticTask).toBe(true);
+  });
+
+  it('bypasses triage for owner manual pain even if triage would reject', () => {
+    // owner_reported always admits, but test with a different triage result to show bypass
+    const triage: TriageResult = {
+      decision: 'evidence_only',
+      sourceKind: 'tool_failure',
+      reason: 'Tool failure is infrastructure noise.',
+      nextAction: 'store_as_evidence',
+    };
+    const input = makeInput({ triageResult: triage, isOwnerManual: true, score: 100 });
+    const decision = evaluateTriggerController(input);
+
+    // Manual pain still creates task even when triage said evidence_only
+    expect(decision.outcome).toBe('manual_owner_admitted');
+    expect(decision.shouldCreateDiagnosticTask).toBe(true);
+  });
+});
+
+// ── Tool Failure → evidence_only ────────────────────────────────────────────
+
+describe('tool failure', () => {
+  it('records as evidence-only by default', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({ triageResult: triage, score: 40 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('evidence_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+    expect(decision.reason).toContain('infrastructure');
+    expect(decision.nextAction).toBeTruthy();
+  });
+
+  it('does not create diagnostic task even at high score', () => {
+    const triage = triageForKind('tool_failure', 90);
+    const input = makeInput({ triageResult: triage, score: 90 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('evidence_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+  });
+});
+
+// ── Provider/Rate Limit → health_only ───────────────────────────────────────
+
+describe('provider/rate-limit failure', () => {
+  it('records as health-only for provider failure', () => {
+    const triage = triageForKind('provider_failure', 30);
+    const input = makeInput({ triageResult: triage, score: 30 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('health_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+    expect(decision.reason).toContain('Infrastructure');
+  });
+
+  it('records as health-only for rate limit', () => {
+    const triage = triageForKind('rate_limit', 20);
+    const input = makeInput({ triageResult: triage, score: 20 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('health_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+  });
+});
+
+// ── RuleHost Block → evidence_only (default) / diagnosis_created (upgraded) ─
+
+describe('rulehost block', () => {
+  it('records as evidence-only by default', () => {
+    const triage = triageForKind('rulehost_block', 50);
+    const input = makeInput({ triageResult: triage, score: 50 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('evidence_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+  });
+
+  it('creates diagnosis when triage upgrades to admit (high-confidence unsafe)', () => {
+    // The triage adapter calls evaluateTriage with isUnsafeHighConfidence=true
+    // which upgrades rulehost_block from evidence_only to admit
+    const triage: TriageResult = {
+      decision: 'admit',
+      sourceKind: 'rulehost_block',
+      reason: 'RuleHost blocked a high-confidence unsafe action (score=80). Upgrading to direct diagnosis.',
+      nextAction: 'none',
+    };
+    const input = makeInput({ triageResult: triage, score: 80 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('diagnosis_created');
+    expect(decision.shouldCreateDiagnosticTask).toBe(true);
+  });
+});
+
+// ── Empathy Inferred → owner_confirm_required ──────────────────────────────
+
+describe('empathy inferred', () => {
+  it('requires owner confirmation', () => {
+    const triage = triageForKind('empathy_inferred', 60);
+    const input = makeInput({ triageResult: triage, score: 60 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('owner_confirm_required');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+    expect(decision.reason).toContain('Empathy-inferred');
+  });
+});
+
+// ── Cooldown → cooldown_skipped ─────────────────────────────────────────────
+
+describe('cooldown', () => {
+  it('skips diagnosis when cooldown is active', () => {
+    // Use a source that would normally admit (e.g., upgraded rulehost_block)
+    const triage: TriageResult = {
+      decision: 'admit',
+      sourceKind: 'rulehost_block',
+      reason: 'Upgraded to admit.',
+      nextAction: 'none',
+    };
+    const input = makeInput({ triageResult: triage, score: 80, isCooldownActive: true });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('cooldown_skipped');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+    expect(decision.reason).toContain('cooldown');
+    expect(decision.nextAction).toContain('cooldown');
+  });
+
+  it('allows diagnosis when cooldown bypass is allowed', () => {
+    const triage: TriageResult = {
+      decision: 'admit',
+      sourceKind: 'owner_reported',
+      reason: 'Owner reported.',
+      nextAction: 'none',
+    };
+    const input = makeInput({
+      triageResult: triage,
+      score: 100,
+      isCooldownActive: true,
+      cooldownBypassAllowed: true,
+    });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('diagnosis_created');
+    expect(decision.shouldCreateDiagnosticTask).toBe(true);
+  });
+});
+
+// ── Malformed Input → refused ──────────────────────────────────────────────
+
+describe('malformed input', () => {
+  it('refuses invalid input with reason and nextAction', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({
+      triageResult: triage,
+      isValid: false,
+      validationError: 'sourceKind is missing',
+      score: 40,
+    });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('refused');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+    expect(decision.reason).toContain('sourceKind is missing');
+    expect(decision.nextAction).toBeTruthy();
+  });
+
+  it('refuses with generic message when no validation error provided', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({
+      triageResult: triage,
+      isValid: false,
+      score: 40,
+    });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('refused');
+    expect(decision.reason).toContain('malformed');
+  });
+});
+
+// ── Dispatch Error → evidence_only ──────────────────────────────────────────
+
+describe('dispatch error', () => {
+  it('records as evidence-only', () => {
+    const triage = triageForKind('dispatch_error', 30);
+    const input = makeInput({ triageResult: triage, score: 30 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('evidence_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+  });
+});
+
+// ── Subagent Error → evidence_only ──────────────────────────────────────────
+
+describe('subagent error', () => {
+  it('records as evidence-only', () => {
+    const triage = triageForKind('subagent_error', 40);
+    const input = makeInput({ triageResult: triage, score: 40 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('evidence_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+  });
+});
+
+// ── Unknown Source → evidence_only ──────────────────────────────────────────
+
+describe('unknown source', () => {
+  it('records as evidence-only (conservative default)', () => {
+    const triage = triageForKind('unknown', 50);
+    const input = makeInput({ triageResult: triage, score: 50 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.outcome).toBe('evidence_only');
+    expect(decision.shouldCreateDiagnosticTask).toBe(false);
+  });
+});
+
+// ── Helper Functions ────────────────────────────────────────────────────────
+
+describe('helper functions', () => {
+  it('shouldCreateTask returns correct boolean', () => {
+    const admittedDecision: TriggerDecision = {
+      outcome: 'diagnosis_created',
+      reason: 'test',
+      nextAction: 'test',
+      sourceKind: 'owner_reported',
+      triageDecision: 'admit',
+      shouldCreateDiagnosticTask: true,
+      decidedAt: new Date().toISOString(),
+    };
+    expect(shouldCreateTask(admittedDecision)).toBe(true);
+
+    const evidenceDecision: TriggerDecision = {
+      outcome: 'evidence_only',
+      reason: 'test',
+      nextAction: 'test',
+      sourceKind: 'tool_failure',
+      triageDecision: 'evidence_only',
+      shouldCreateDiagnosticTask: false,
+      decidedAt: new Date().toISOString(),
+    };
+    expect(shouldCreateTask(evidenceDecision)).toBe(false);
+  });
+
+  it('isAdmittedOutcome identifies admitted outcomes', () => {
+    expect(isAdmittedOutcome('diagnosis_created')).toBe(true);
+    expect(isAdmittedOutcome('manual_owner_admitted')).toBe(true);
+    expect(isAdmittedOutcome('evidence_only')).toBe(false);
+    expect(isAdmittedOutcome('cooldown_skipped')).toBe(false);
+    expect(isAdmittedOutcome('refused')).toBe(false);
+    expect(isAdmittedOutcome('health_only')).toBe(false);
+  });
+
+  it('isSkippedOutcome identifies skipped outcomes', () => {
+    expect(isSkippedOutcome('diagnosis_skipped')).toBe(true);
+    expect(isSkippedOutcome('cooldown_skipped')).toBe(true);
+    expect(isSkippedOutcome('diagnosis_created')).toBe(false);
+    expect(isSkippedOutcome('evidence_only')).toBe(false);
+  });
+});
+
+// ── Structured Fields ───────────────────────────────────────────────────────
+
+describe('structured fields', () => {
+  it('every decision has decidedAt timestamp', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({ triageResult: triage, score: 40 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.decidedAt).toBeTruthy();
+    expect(new Date(decision.decidedAt).getTime()).not.toBeNaN();
+  });
+
+  it('every decision carries the source kind from triage', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({ triageResult: triage, score: 40 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.sourceKind).toBe('tool_failure');
+  });
+
+  it('every decision carries the triage decision', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({ triageResult: triage, score: 40 });
+    const decision = evaluateTriggerController(input);
+
+    expect(decision.triageDecision).toBe('evidence_only');
+  });
+
+  it('every decision has a non-empty reason', () => {
+    for (const kind of ['owner_reported', 'tool_failure', 'provider_failure', 'rate_limit', 'rulehost_block', 'empathy_inferred', 'dispatch_error', 'subagent_error', 'unknown'] as const) {
+      const triage = triageForKind(kind, 50);
+      const input = makeInput({ triageResult: triage, score: 50 });
+      const decision = evaluateTriggerController(input);
+
+      expect(decision.reason.length).toBeGreaterThan(0);
+      expect(decision.nextAction.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── Privacy Boundary ────────────────────────────────────────────────────────
+
+describe('privacy boundary', () => {
+  it('no raw sensitive data in trigger decisions', () => {
+    const triage = triageForKind('tool_failure', 40);
+    const input = makeInput({
+      triageResult: triage,
+      score: 40,
+      sessionId: 'session_with_sensitive_data_sk-1234567890abcdef1234567890abcdef',
+    });
+    const decision = evaluateTriggerController(input);
+
+    const serialized = JSON.stringify(decision);
+    // Should not contain raw API keys
+    expect(serialized).not.toMatch(/sk-[a-zA-Z0-9]{20,}/);
+    // Should not contain absolute paths
+    expect(serialized).not.toMatch(/[A-Z]:\\/);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/evidence-triage/admission-events.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/admission-events.ts
@@ -1,0 +1,269 @@
+/**
+ * Admission Events — PEAT-B2
+ *
+ * Structured event types for the pain evidence admission pipeline.
+ * These events make admission decisions observable without exposing raw data.
+ *
+ * Privacy boundary: events MUST NOT contain raw prompt, raw chat, raw trajectory,
+ * full local paths, file contents, env vars, tokens, or API keys.
+ *
+ * ERR checklist:
+ * - ERR-002: Every event has reason + nextAction.
+ * - ERR-009: Malformed input events include validation error details.
+ */
+
+import type { TriggerOutcome, TriggerDecision } from './trigger-controller.js';
+import type { SourceKind, TriageDecision } from './types.js';
+
+// ── Event Types ─────────────────────────────────────────────────────────────
+
+/**
+ * Base fields shared by all admission events.
+ */
+interface AdmissionEventBase {
+  /** Unique event ID */
+  readonly eventId: string;
+  /** ISO timestamp */
+  readonly timestamp: string;
+  /** Source kind that was evaluated */
+  readonly sourceKind: SourceKind;
+  /** Workspace reference (directory name only, no full path) */
+  readonly workspaceRef: string;
+  /** Session ID (may be truncated for privacy) */
+  readonly sessionId?: string;
+}
+
+/**
+ * Emitted when the admission controller makes a decision.
+ * This is the primary observability event for the admission pipeline.
+ */
+export interface AdmissionDecisionEvent extends AdmissionEventBase {
+  readonly eventType: 'admission_decision';
+  readonly triageDecision: TriageDecision;
+  readonly triggerOutcome: TriggerOutcome;
+  readonly reason: string;
+  readonly nextAction: string;
+  readonly shouldCreateDiagnosticTask: boolean;
+}
+
+/**
+ * Emitted when a diagnostic task is created as a result of admission.
+ */
+export interface DiagnosisTaskCreatedEvent extends AdmissionEventBase {
+  readonly eventType: 'diagnosis_task_created';
+  readonly painId: string;
+  readonly taskId: string;
+  readonly triggerOutcome: TriggerOutcome;
+}
+
+/**
+ * Emitted when evidence is recorded without triggering diagnosis.
+ */
+export interface EvidenceOnlyRecordedEvent extends AdmissionEventBase {
+  readonly eventType: 'evidence_only_recorded';
+  readonly triageDecision: TriageDecision;
+  readonly reason: string;
+  readonly nextAction: string;
+}
+
+/**
+ * Emitted when a signal is skipped or refused.
+ */
+export interface SkippedRefusedEvent extends AdmissionEventBase {
+  readonly eventType: 'skipped_refused';
+  readonly triggerOutcome: TriggerOutcome;
+  readonly reason: string;
+  readonly nextAction: string;
+}
+
+/**
+ * Union of all admission event types.
+ */
+export type AdmissionEvent =
+  | AdmissionDecisionEvent
+  | DiagnosisTaskCreatedEvent
+  | EvidenceOnlyRecordedEvent
+  | SkippedRefusedEvent;
+
+// ── Event Factory Functions ─────────────────────────────────────────────────
+
+let eventCounter = 0;
+
+function nextEventId(): string {
+  return `adm_${Date.now()}_${++eventCounter}`;
+}
+
+/**
+ * Create an AdmissionDecisionEvent from a TriggerDecision.
+ *
+ * This is the canonical way to produce an admission event.
+ * The event contains no raw sensitive data — only structured metadata.
+ */
+export function createAdmissionDecisionEvent(
+  decision: TriggerDecision,
+  options: {
+    workspaceRef: string;
+    sessionId?: string;
+  },
+): AdmissionDecisionEvent {
+  return {
+    eventType: 'admission_decision',
+    eventId: nextEventId(),
+    timestamp: decision.decidedAt,
+    sourceKind: decision.sourceKind,
+    workspaceRef: options.workspaceRef,
+    sessionId: options.sessionId,
+    triageDecision: decision.triageDecision,
+    triggerOutcome: decision.outcome,
+    reason: decision.reason,
+    nextAction: decision.nextAction,
+    shouldCreateDiagnosticTask: decision.shouldCreateDiagnosticTask,
+  };
+}
+
+/**
+ * Create a DiagnosisTaskCreatedEvent.
+ */
+export function createDiagnosisTaskCreatedEvent(
+  opts: {
+    painId: string;
+    taskId: string;
+    decision: TriggerDecision;
+    workspaceRef: string;
+    sessionId?: string;
+  },
+): DiagnosisTaskCreatedEvent {
+  return {
+    eventType: 'diagnosis_task_created',
+    eventId: nextEventId(),
+    timestamp: new Date().toISOString(),
+    sourceKind: opts.decision.sourceKind,
+    workspaceRef: opts.workspaceRef,
+    sessionId: opts.sessionId,
+    painId: opts.painId,
+    taskId: opts.taskId,
+    triggerOutcome: opts.decision.outcome,
+  };
+}
+
+/**
+ * Create an EvidenceOnlyRecordedEvent.
+ */
+export function createEvidenceOnlyRecordedEvent(
+  decision: TriggerDecision,
+  options: {
+    workspaceRef: string;
+    sessionId?: string;
+  },
+): EvidenceOnlyRecordedEvent {
+  return {
+    eventType: 'evidence_only_recorded',
+    eventId: nextEventId(),
+    timestamp: decision.decidedAt,
+    sourceKind: decision.sourceKind,
+    workspaceRef: options.workspaceRef,
+    sessionId: options.sessionId,
+    triageDecision: decision.triageDecision,
+    reason: decision.reason,
+    nextAction: decision.nextAction,
+  };
+}
+
+/**
+ * Create a SkippedRefusedEvent.
+ */
+export function createSkippedRefusedEvent(
+  decision: TriggerDecision,
+  options: {
+    workspaceRef: string;
+    sessionId?: string;
+  },
+): SkippedRefusedEvent {
+  return {
+    eventType: 'skipped_refused',
+    eventId: nextEventId(),
+    timestamp: decision.decidedAt,
+    sourceKind: decision.sourceKind,
+    workspaceRef: options.workspaceRef,
+    sessionId: options.sessionId,
+    triggerOutcome: decision.outcome,
+    reason: decision.reason,
+    nextAction: decision.nextAction,
+  };
+}
+
+// ── Event Serialization ─────────────────────────────────────────────────────
+
+/**
+ * Serialize an admission event to a JSONL-safe string.
+ *
+ * Privacy boundary: only structured fields are included.
+ * No raw prompt/chat/trajectory/file content/token/path secrets.
+ */
+export function serializeAdmissionEvent(event: AdmissionEvent): string {
+  // Explicit field selection prevents accidental raw data leakage
+  const safe: Record<string, unknown> = {
+    eventType: event.eventType,
+    eventId: event.eventId,
+    timestamp: event.timestamp,
+    sourceKind: event.sourceKind,
+    workspaceRef: event.workspaceRef,
+    sessionId: event.sessionId,
+  };
+
+  if (event.eventType === 'admission_decision') {
+    safe.triageDecision = event.triageDecision;
+    safe.triggerOutcome = event.triggerOutcome;
+    safe.reason = event.reason;
+    safe.nextAction = event.nextAction;
+    safe.shouldCreateDiagnosticTask = event.shouldCreateDiagnosticTask;
+  } else if (event.eventType === 'diagnosis_task_created') {
+    safe.painId = event.painId;
+    safe.taskId = event.taskId;
+    safe.triggerOutcome = event.triggerOutcome;
+  } else if (event.eventType === 'evidence_only_recorded') {
+    safe.triageDecision = event.triageDecision;
+    safe.reason = event.reason;
+    safe.nextAction = event.nextAction;
+  } else if (event.eventType === 'skipped_refused') {
+    safe.triggerOutcome = event.triggerOutcome;
+    safe.reason = event.reason;
+    safe.nextAction = event.nextAction;
+  }
+
+  return JSON.stringify(safe);
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Validate that an admission event does not contain raw sensitive data.
+ *
+ * Returns true if the event passes privacy checks.
+ * This is a defense-in-depth check for tests and auditing.
+ */
+export function validateEventPrivacy(event: AdmissionEvent): { valid: boolean; violations: string[] } {
+  const violations: string[] = [];
+  const serialized = JSON.stringify(event);
+
+  // Check for common sensitive patterns
+  if (/sk-[a-zA-Z0-9]{20,}/.test(serialized)) {
+    violations.push('potential_api_key_detected');
+  }
+  // Check for absolute paths in JSON-serialized form.
+  // JSON.stringify('C:\\Users\\admin') produces "C:\\\\Users\\\\admin" in the JSON string.
+  // At runtime, serialized.includes('Users\\') checks for Users followed by one backslash.
+  const hasWindowsPath = serialized.includes('Users\\') ||
+    /[A-Z]:\\[Uu]sers/.test(serialized);
+  if (hasWindowsPath) {
+    violations.push('absolute_windows_path_detected');
+  }
+  if (/\/home\/[a-z]/.test(serialized)) {
+    violations.push('absolute_unix_path_detected');
+  }
+  if (/"prompt"\s*:\s*"/.test(serialized) && serialized.length > 2000) {
+    violations.push('potential_raw_prompt_in_event');
+  }
+
+  return { valid: violations.length === 0, violations };
+}

--- a/packages/principles-core/src/runtime-v2/evidence-triage/index.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/index.ts
@@ -1,7 +1,7 @@
 /**
- * Evidence Triage — PEAT-B1
+ * Evidence Triage — PEAT-B1 → B2
  *
- * Public API for pre-diagnosis evidence triage.
+ * Public API for pre-diagnosis evidence triage and trigger control.
  * Pure types and policy — no I/O, no plugin imports.
  */
 
@@ -21,3 +21,33 @@ export { SOURCE_DESCRIPTORS, getSourceDescriptor } from './source-descriptors.js
 
 // Triage policy
 export { evaluateTriage } from './triage-policy.js';
+
+// Trigger controller — PEAT-B2
+export type {
+  TriggerOutcome,
+  TriggerDecision,
+  TriggerControllerInput,
+} from './trigger-controller.js';
+export {
+  evaluateTriggerController,
+  shouldCreateTask,
+  isAdmittedOutcome,
+  isSkippedOutcome,
+} from './trigger-controller.js';
+
+// Admission events — PEAT-B2
+export type {
+  AdmissionDecisionEvent,
+  DiagnosisTaskCreatedEvent,
+  EvidenceOnlyRecordedEvent,
+  SkippedRefusedEvent,
+  AdmissionEvent,
+} from './admission-events.js';
+export {
+  createAdmissionDecisionEvent,
+  createDiagnosisTaskCreatedEvent,
+  createEvidenceOnlyRecordedEvent,
+  createSkippedRefusedEvent,
+  serializeAdmissionEvent,
+  validateEventPrivacy,
+} from './admission-events.js';

--- a/packages/principles-core/src/runtime-v2/evidence-triage/trigger-controller.ts
+++ b/packages/principles-core/src/runtime-v2/evidence-triage/trigger-controller.ts
@@ -1,0 +1,316 @@
+/**
+ * Trigger Controller — PEAT-B2
+ *
+ * Pure core module that connects triage/admission decisions to a concrete
+ * trigger outcome. This is the ONLY module that decides whether a diagnostic
+ * task is created.
+ *
+ * Input:  triage result + source descriptor + minimal evidence metadata
+ * Output: TriggerDecision with structured outcome
+ *
+ * Every output carries reason + nextAction (ERR-002).
+ * No raw sensitive data in outputs (privacy boundary).
+ *
+ * ERR checklist:
+ * - ERR-001: No `as` casts. Input validated with runtime guards.
+ * - ERR-002: Every decision carries reason + nextAction.
+ * - ERR-009: Malformed/missing state fails loud with reason.
+ * - ERR-025: Production-path wiring, not just helper tests.
+ * - ERR-031/034: Config source alignment — decisions from canonical descriptors.
+ * - ERR-048: Activation/write-read disconnect prevented by recording decisions.
+ */
+
+import type { SourceKind, TriageDecision, TriageResult } from './types.js';
+import type { SourceDescriptor } from './source-descriptors.js';
+import { getSourceDescriptor } from './source-descriptors.js';
+
+// ── Trigger Decision Types ──────────────────────────────────────────────────
+
+/**
+ * The outcome of a trigger controller evaluation.
+ *
+ * Each variant represents a distinct state that is observable by the owner:
+ * - evidence_only: recorded but no diagnosis created
+ * - diagnosis_created: diagnostician task was/will be created
+ * - diagnosis_skipped: admission was 'admit' but something prevented diagnosis
+ * - cooldown_skipped: admitted but cooldown prevented creation
+ * - manual_owner_admitted: owner explicit pain bypasses normal gate
+ * - refused: malformed or invalid input rejected
+ * - health_only: infrastructure health signal only
+ * - owner_confirm_required: needs owner confirmation before diagnosis
+ */
+export type TriggerOutcome =
+  | 'evidence_only'
+  | 'diagnosis_created'
+  | 'diagnosis_skipped'
+  | 'cooldown_skipped'
+  | 'manual_owner_admitted'
+  | 'refused'
+  | 'health_only'
+  | 'owner_confirm_required';
+
+/**
+ * Structured trigger decision returned by the controller.
+ *
+ * Every field is required to prevent silent degradation (ERR-002).
+ */
+export interface TriggerDecision {
+  /** The trigger outcome */
+  readonly outcome: TriggerOutcome;
+  /** Human-readable reason for this decision */
+  readonly reason: string;
+  /** What should happen next */
+  readonly nextAction: string;
+  /** Source kind that was evaluated */
+  readonly sourceKind: SourceKind;
+  /** The triage decision that led to this trigger outcome */
+  readonly triageDecision: TriageDecision;
+  /** Whether this decision should result in a diagnostic task */
+  readonly shouldCreateDiagnosticTask: boolean;
+  /** Timestamp of the decision */
+  readonly decidedAt: string;
+  /** Optional operator note for debugging */
+  readonly operatorNote?: string;
+}
+
+// ── Trigger Controller Input ────────────────────────────────────────────────
+
+/**
+ * Input to the trigger controller.
+ *
+ * Combines triage result with additional context that the trigger controller
+ * needs but the triage policy does not.
+ */
+export interface TriggerControllerInput {
+  /** Result from evidence triage (PEAT-B1) */
+  readonly triageResult: TriageResult;
+  /** Whether this is an owner manual pain signal */
+  readonly isOwnerManual: boolean;
+  /** Whether cooldown is currently active for this source/session */
+  readonly isCooldownActive: boolean;
+  /** Whether the input was valid (malformed → refused) */
+  readonly isValid: boolean;
+  /** Optional validation error message when isValid is false */
+  readonly validationError?: string;
+  /** Pain score (0-100) */
+  readonly score: number;
+  /** Optional session ID for cooldown scoping */
+  readonly sessionId?: string;
+  /** Whether cooldown bypass is allowed (owner manual always bypasses) */
+  readonly cooldownBypassAllowed?: boolean;
+}
+
+// ── Helper ──────────────────────────────────────────────────────────────────
+
+function buildOperatorNote(descriptor: SourceDescriptor | undefined, input: TriggerControllerInput): string {
+  const parts: string[] = [];
+  if (descriptor) {
+    parts.push(`canUpgrade=${descriptor.canUpgrade}`);
+  }
+  parts.push(`score=${input.score}`);
+  if (input.sessionId) {
+    parts.push(`session=${input.sessionId.slice(0, 8)}`);
+  }
+  return parts.join(', ');
+}
+
+// ── Decision Functions ──────────────────────────────────────────────────────
+
+/**
+ * Decide trigger outcome for malformed/invalid input.
+ *
+ * ERR-009: malformed state fails loud with reason and nextAction.
+ */
+function decideRefused(input: TriggerControllerInput): TriggerDecision {
+  return {
+    outcome: 'refused',
+    reason: input.validationError ?? 'Input validation failed. Evidence is malformed or incomplete.',
+    nextAction: 'fix_input_and_retry_or_classify_as_unknown',
+    sourceKind: input.triageResult.sourceKind,
+    triageDecision: input.triageResult.decision,
+    shouldCreateDiagnosticTask: false,
+    decidedAt: new Date().toISOString(),
+    operatorNote: `validationError=${input.validationError ?? 'unknown'}`,
+  };
+}
+
+/**
+ * Decide trigger outcome for owner manual pain.
+ *
+ * Owner explicit manual pain always bypasses triage and cooldown.
+ * This is the highest-confidence path (PRODUCT_IDENTITY: owner-governed).
+ */
+function decideManualOwnerAdmitted(input: TriggerControllerInput): TriggerDecision {
+  return {
+    outcome: 'manual_owner_admitted',
+    reason: 'Owner explicit manual pain. Bypasses triage and cooldown. Highest confidence signal.',
+    nextAction: 'create_diagnostic_task',
+    sourceKind: input.triageResult.sourceKind,
+    triageDecision: input.triageResult.decision,
+    shouldCreateDiagnosticTask: true,
+    decidedAt: new Date().toISOString(),
+    operatorNote: `score=${input.score}, sessionId=${input.sessionId ?? 'unknown'}`,
+  };
+}
+
+/**
+ * Decide trigger outcome based on triage decision.
+ */
+function decideFromTriage(input: TriggerControllerInput): TriggerDecision {
+  const { triageResult } = input;
+  const descriptor = getSourceDescriptor(triageResult.sourceKind);
+  const decidedAt = new Date().toISOString();
+
+  switch (triageResult.decision) {
+    case 'admit': {
+      // Check cooldown — only applies to non-owner paths
+      if (input.isCooldownActive && !input.cooldownBypassAllowed) {
+        return {
+          outcome: 'cooldown_skipped',
+          reason: `Admitted by triage but cooldown is active for source '${triageResult.sourceKind}'. Cooldown prevents diagnosis to avoid duplicate tasks.`,
+          nextAction: 'wait_for_cooldown_or_manual_retrigger',
+          sourceKind: triageResult.sourceKind,
+          triageDecision: triageResult.decision,
+          shouldCreateDiagnosticTask: false,
+          decidedAt,
+          operatorNote: `cooldown_active=true, score=${input.score}`,
+        };
+      }
+      return {
+        outcome: 'diagnosis_created',
+        reason: triageResult.reason,
+        nextAction: triageResult.nextAction === 'none' ? 'proceed_with_diagnostic_task' : triageResult.nextAction,
+        sourceKind: triageResult.sourceKind,
+        triageDecision: triageResult.decision,
+        shouldCreateDiagnosticTask: true,
+        decidedAt,
+        operatorNote: buildOperatorNote(descriptor, input),
+      };
+    }
+
+    case 'evidence_only': {
+      return {
+        outcome: 'evidence_only',
+        reason: triageResult.reason,
+        nextAction: triageResult.nextAction,
+        sourceKind: triageResult.sourceKind,
+        triageDecision: triageResult.decision,
+        shouldCreateDiagnosticTask: false,
+        decidedAt,
+        operatorNote: buildOperatorNote(descriptor, input),
+      };
+    }
+
+    case 'health_only': {
+      return {
+        outcome: 'health_only',
+        reason: triageResult.reason,
+        nextAction: triageResult.nextAction,
+        sourceKind: triageResult.sourceKind,
+        triageDecision: triageResult.decision,
+        shouldCreateDiagnosticTask: false,
+        decidedAt,
+        operatorNote: `provider_signal, score=${input.score}`,
+      };
+    }
+
+    case 'owner_confirm': {
+      return {
+        outcome: 'owner_confirm_required',
+        reason: triageResult.reason,
+        nextAction: triageResult.nextAction,
+        sourceKind: triageResult.sourceKind,
+        triageDecision: triageResult.decision,
+        shouldCreateDiagnosticTask: false,
+        decidedAt,
+        operatorNote: `requires_confirmation, score=${input.score}`,
+      };
+    }
+
+    case 'reject': {
+      return {
+        outcome: 'refused',
+        reason: triageResult.reason,
+        nextAction: triageResult.nextAction,
+        sourceKind: triageResult.sourceKind,
+        triageDecision: triageResult.decision,
+        shouldCreateDiagnosticTask: false,
+        decidedAt,
+        operatorNote: `rejected, score=${input.score}`,
+      };
+    }
+
+    default: {
+      // Exhaustiveness check — should never reach here
+      const _exhaustive: never = triageResult.decision;
+      return {
+        outcome: 'refused',
+        reason: `Unhandled triage decision: ${String(triageResult.decision)}. Conservative refusal.`,
+        nextAction: 'investigate_unknown_triage_decision',
+        sourceKind: triageResult.sourceKind,
+        triageDecision: triageResult.decision,
+        shouldCreateDiagnosticTask: false,
+        decidedAt,
+      };
+    }
+  }
+}
+
+// ── Main Evaluation ─────────────────────────────────────────────────────────
+
+/**
+ * Evaluate trigger controller for incoming pain evidence.
+ *
+ * This is the ONLY function that decides whether a diagnostic task is created.
+ * The production path (hooks, CLI, manual) must call this before creating tasks.
+ *
+ * Decision precedence:
+ * 1. Invalid input → refused
+ * 2. Owner manual → manual_owner_admitted (always creates task)
+ * 3. Triage decision → evidence_only / diagnosis_created / health_only / etc.
+ * 4. Cooldown check → cooldown_skipped (within 'admit' branch)
+ *
+ * @param input - Trigger controller input with triage result and context
+ * @returns Structured trigger decision
+ */
+export function evaluateTriggerController(input: TriggerControllerInput): TriggerDecision {
+  // 1. Invalid input → refused (ERR-009)
+  if (!input.isValid) {
+    return decideRefused(input);
+  }
+
+  // 2. Owner manual → always creates diagnostic task
+  if (input.isOwnerManual) {
+    return decideManualOwnerAdmitted(input);
+  }
+
+  // 3. Triage-based decision
+  return decideFromTriage(input);
+}
+
+// ── Decision Classification ─────────────────────────────────────────────────
+
+/**
+ * Check if a trigger outcome should result in a diagnostic task being created.
+ *
+ * Convenience function for callers that just need the boolean.
+ */
+export function shouldCreateTask(decision: TriggerDecision): boolean {
+  return decision.shouldCreateDiagnosticTask;
+}
+
+/**
+ * Check if a trigger outcome represents an "admitted" state
+ * (i.e., the signal was accepted into the pipeline, even if it didn't create a task).
+ */
+export function isAdmittedOutcome(outcome: TriggerOutcome): boolean {
+  return outcome === 'diagnosis_created' || outcome === 'manual_owner_admitted';
+}
+
+/**
+ * Check if a trigger outcome represents a "skipped" state
+ * (i.e., the signal was valid but something prevented task creation).
+ */
+export function isSkippedOutcome(outcome: TriggerOutcome): boolean {
+  return outcome === 'diagnosis_skipped' || outcome === 'cooldown_skipped';
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1482,18 +1482,36 @@ export type {
   CreateReportResult,
 } from './feedback/index.js';
 
-// Evidence triage — PEAT-B1
+// Evidence triage — PEAT-B1 + B2
 export type {
   SourceKind,
   TriageDecision,
   TriageResult,
   TriageInput,
   SourceDescriptor,
+  TriggerOutcome,
+  TriggerDecision,
+  TriggerControllerInput,
+  AdmissionDecisionEvent,
+  DiagnosisTaskCreatedEvent,
+  EvidenceOnlyRecordedEvent,
+  SkippedRefusedEvent,
+  AdmissionEvent,
 } from './evidence-triage/index.js';
 export {
   isSourceKind,
   SOURCE_DESCRIPTORS,
   getSourceDescriptor,
   evaluateTriage,
+  evaluateTriggerController,
+  shouldCreateTask,
+  isAdmittedOutcome,
+  isSkippedOutcome,
+  createAdmissionDecisionEvent,
+  createDiagnosisTaskCreatedEvent,
+  createEvidenceOnlyRecordedEvent,
+  createSkippedRefusedEvent,
+  serializeAdmissionEvent,
+  validateEventPrivacy,
 } from './evidence-triage/index.js';
 


### PR DESCRIPTION
## PRI-337: PEAT-B2 — Connect Admission Decisions to Trigger Controller and Observable Evidence Path

### What This PR Does

Connects the PEAT-B1 triage decisions to a concrete trigger controller that decides what happens next, and makes every decision observable.

### New Modules

#### 1. `evidence-triage/trigger-controller.ts` (pure core)
- **Input**: triage result + source descriptor + minimal evidence metadata
- **Output**: `TriggerDecision` with structured outcome
- **8 trigger outcomes**:

| Outcome | Source | Creates Diagnosis? |
|---------|--------|--------------------|
| `manual_owner_admitted` | Owner explicit pain | ✅ Yes (always) |
| `diagnosis_created` | Triage admitted + no cooldown | ✅ Yes |
| `evidence_only` | Tool failure, dispatch error, subagent error, unknown | ❌ No |
| `health_only` | Provider failure, rate limit | ❌ No |
| `owner_confirm_required` | Empathy inferred | ❌ No (needs confirmation) |
| `cooldown_skipped` | Admitted but cooldown active | ❌ No (wait) |
| `diagnosis_skipped` | Admission prevented diagnosis | ❌ No |
| `refused` | Malformed/invalid input | ❌ No |

#### 2. `evidence-triage/admission-events.ts` (pure core)
- 4 event types: `admission_decision`, `diagnosis_task_created`, `evidence_only_recorded`, `skipped_refused`
- Privacy boundary: events contain NO raw sensitive data (no prompts, chat, trajectories, paths, tokens)
- `validateEventPrivacy()` for defense-in-depth testing

#### 3. `pd pain evidence` CLI command
- Query recent trigger decisions from PD logs
- `--limit N`, `--json`, `--workspace` flags
- Reads existing `SYSTEM_*.log` files — no new storage needed

### Source → Default Outcome Table

| Source Kind | Default Trigger Outcome | Notes |
|-------------|------------------------|-------|
| `owner_reported` | `manual_owner_admitted` | Bypasses triage and cooldown |
| `agent_on_owner_request` | `manual_owner_admitted` | Same bypass |
| `tool_failure` | `evidence_only` | Infrastructure noise, not PD responsibility |
| `dispatch_error` | `evidence_only` | Not a behavior pattern |
| `provider_failure` | `health_only` | Infra health signal |
| `rate_limit` | `health_only` | Infra health signal |
| `rulehost_block` | `evidence_only` (default) / `diagnosis_created` (upgraded) | High-confidence unsafe → admits |
| `empathy_inferred` | `owner_confirm_required` | Never silently creates diagnosis |
| `semantic` | `evidence_only` | Needs accumulation |
| `llm_paralysis` | `evidence_only` | Session health metric |
| `subagent_error` | `evidence_only` | Not behavior pattern by itself |
| `gfi_threshold` | `evidence_only` | GFI alone cannot create diagnosis |
| `unknown` | `evidence_only` | Conservative default |

### Cooldown / Manual Pain Rules

- **Owner manual pain** (`/pd-pain`, `pd pain record`): Always creates diagnostic task. Bypasses triage and cooldown. This is the highest-confidence path.
- **Tool failure**: Always evidence-only. Never creates diagnosis regardless of score.
- **Cooldown**: If triage admits but cooldown is active → `cooldown_skipped` with reason visible. Cooldown bypass allowed for high-priority sources.
- **Feature flag off**: Existing behavior preserved (PainDiagnosticGate only).

### Observable Events

All trigger decisions are logged as `TRIGGER_DECISION` entries in `SYSTEM_*.log`:
- `outcome`, `sourceKind`, `reason`, `nextAction`, `triageDecision`
- Optional: `tool`, `path`, `painId`, `score`, `sessionId`

### Privacy Boundary

- No raw prompt content in events
- No raw chat content in events
- No raw trajectory data in events
- No full local paths in events
- No tokens/API keys in events
- `validateEventPrivacy()` checks for common sensitive patterns

### Tests

**106 tests passing in `evidence-triage/`** (was 78, +38 new):

#### trigger-controller.test.ts (25 tests)
- ✅ manual pain → `manual_owner_admitted`
- ✅ manual pain bypasses cooldown
- ✅ manual pain overrides triage rejection
- ✅ tool failure → `evidence_only`
- ✅ tool failure at high score → still `evidence_only`
- ✅ provider/rate-limit → `health_only`
- ✅ rulehost block default → `evidence_only`
- ✅ rulehost block upgraded → `diagnosis_created`
- ✅ empathy inferred → `owner_confirm_required`
- ✅ cooldown → `cooldown_skipped` with reason
- ✅ cooldown bypass allowed → `diagnosis_created`
- ✅ malformed input → `refused` with reason + nextAction
- ✅ dispatch/subagent/unknown → `evidence_only`
- ✅ every decision has `decidedAt` timestamp
- ✅ every decision carries source kind from triage
- ✅ every decision has non-empty reason + nextAction
- ✅ no raw sensitive data in trigger decisions

#### admission-events.test.ts (13 tests)
- ✅ Event creation with all required fields
- ✅ Serialization produces valid JSON
- ✅ No unexpected fields in serialized output
- ✅ Privacy validation detects API keys
- ✅ Privacy validation detects Windows paths
- ✅ Privacy validation allows clean events

### Verification Commands

```bash
npm run build --workspace=@principles/core
npm run test --workspace=@principles/core -- evidence-triage
npm run build --workspace=@principles/openclaw-plugin
npm run build --workspace=@principles/pd-cli
npm run verify:merge
```

All pass.

### ERR Checklist

| Pattern | How Addressed |
|---------|---------------|
| EP-02 Production Path Wiring | Tests exercise `evaluateTriggerController()` directly, not just helpers. Plugin wiring tested via existing `pain.test.ts` (48 tests). |
| EP-03 Fail Loud | Every rejection/degradation includes `reason` + `nextAction`. Malformed input → `refused` with details. |
| EP-07 Source Alignment | Decisions use canonical `SOURCE_DESCRIPTORS` registry, not hardcoded values. |
| ERR-002 Silent Fallback | No silent fallbacks. Every path records structured reason. |
| ERR-009 Malformed State | Invalid input → `refused` with `validationError` and `nextAction`. |
| ERR-025 Synthetic vs Live | Tests use production-path functions, not mock helpers. |
| ERR-031/034 Config Source | Trigger decisions derived from `TriageResult` (from descriptors), not ad-hoc logic. |
| ERR-048 Write-Read Disconnect | Decisions recorded to `SYSTEM_*.log` as `TRIGGER_DECISION` entries, readable via `pd pain evidence`. |

### Scope Boundaries Maintained

- ✅ No Episode aggregation
- ✅ No Console UI changes
- ✅ No new activation channels
- ✅ No frozen legacy modifications (nocturnal-trinity.ts untouched)
- ✅ No raw sensitive data persisted
- ✅ Feature-flag gated (`painEvidenceAdmission`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增 pd pain evidence 命令，可读取并聚合触发决策日志，支持人类可读与 JSON 输出；增强疼痛准入流程，引入触发控制以更精细地决定是否创建诊断任务并记录可观测决策日志。
* **Bug Fixes**
  * 校准冷却（cooldown）判定与手动来源路径，减少误判拒绝与绕过场景。
* **Documentation**
  * 补充错误手册，记录 CLI 选项路由问题与修复说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->