### PR TITLE
test(pd-console): add ERR-013 inheritance property tests for 6 validators

### DIFF
--- a/packages/pd-console/tests/ui/cr10-api-validators.test.ts
+++ b/packages/pd-console/tests/ui/cr10-api-validators.test.ts
@@ -885,6 +885,11 @@ describe('validateFeedbackDraftEnvelope', () => {
     expect(validateFeedbackDraftEnvelope({ report: 42 })).toBeNull();
     expect(validateFeedbackDraftEnvelope({ report: [] })).toBeNull();
   });
+
+  it('rejects inherited properties (ERR-013)', () => {
+    const obj = Object.create({ report: { id: '1' } });
+    expect(validateFeedbackDraftEnvelope(obj)).toBeNull();
+  });
 });
 
 // ── validateRemovedEnvelope ────────────────────────────────────────────────────
@@ -912,6 +917,11 @@ describe('validateRemovedEnvelope', () => {
   it('rejects wrong type for removed', () => {
     expect(validateRemovedEnvelope({ removed: 42 })).toBeNull();
     expect(validateRemovedEnvelope({ removed: [] })).toBeNull();
+  });
+
+  it('rejects inherited properties (ERR-013)', () => {
+    const obj = Object.create({ removed: 'workspace-name' });
+    expect(validateRemovedEnvelope(obj)).toBeNull();
   });
 });
 
@@ -943,6 +953,11 @@ describe('validateSyncResult', () => {
   it('rejects wrong types', () => {
     expect(validateSyncResult({ success: 'true', syncedAt: '2026-06-01' })).toBeNull();
     expect(validateSyncResult({ success: true, syncedAt: 42 })).toBeNull();
+  });
+
+  it('rejects inherited properties (ERR-013)', () => {
+    const obj = Object.create({ success: true, syncedAt: '2026-06-01T00:00:00Z' });
+    expect(validateSyncResult(obj)).toBeNull();
   });
 });
 
@@ -1050,6 +1065,11 @@ describe('validateAgentBindingUpdate', () => {
     expect(validateAgentBindingUpdate({ agent: 'diag', runtimeProfile: 123, enabled: true })).toBeNull();
     expect(validateAgentBindingUpdate({ agent: 'diag', runtimeProfile: 'openclaw.default', enabled: 'yes' })).toBeNull();
   });
+
+  it('rejects inherited properties (ERR-013)', () => {
+    const obj = Object.create({ agent: 'diagnostician', runtimeProfile: 'openclaw.default', enabled: true });
+    expect(validateAgentBindingUpdate(obj)).toBeNull();
+  });
 });
 
 // ── validateReadinessCheck ────────────────────────────────────────────────────
@@ -1141,6 +1161,11 @@ describe('validateDefaultRuntimeUpdate', () => {
   it('rejects wrong type', () => {
     expect(validateDefaultRuntimeUpdate({ defaultRuntime: 123 })).toBeNull();
     expect(validateDefaultRuntimeUpdate({ defaultRuntime: [] })).toBeNull();
+  });
+
+  it('rejects inherited properties (ERR-013)', () => {
+    const obj = Object.create({ defaultRuntime: 'lmstudio-local' });
+    expect(validateDefaultRuntimeUpdate(obj)).toBeNull();
   });
 });
 
@@ -1283,5 +1308,17 @@ describe('validateApprovalRecordDirect', () => {
       requestedAt: '2026-06-01T00:00:00Z',
     });
     expect(result).toBeNull();
+  });
+
+  it('rejects inherited properties (ERR-013)', () => {
+    const obj = Object.create({
+      approvalId: 'apr_123',
+      artifactId: 'art_456',
+      channel: 'prompt',
+      riskLevel: 'medium',
+      status: 'pending',
+      requestedAt: '2026-06-01T00:00:00Z',
+    });
+    expect(validateApprovalRecordDirect(obj)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #849 based on CodeRabbit review feedback.

CodeRabbit identified that only `validateOutputLanguage` had ERR-013 inherited property tests, while 6 other simple-object validators were missing them.

### Added ERR-013 Tests

Each test uses `Object.create(proto)` to create an object with inherited properties, then verifies the validator rejects it:

- `validateFeedbackDraftEnvelope` - rejects inherited `report` property
- `validateRemovedEnvelope` - rejects inherited `removed` property
- `validateSyncResult` - rejects inherited `success`/`syncedAt` properties
- `validateAgentBindingUpdate` - rejects inherited `agent`/`runtimeProfile`/`enabled` properties
- `validateDefaultRuntimeUpdate` - rejects inherited `defaultRuntime` property
- `validateApprovalRecordDirect` - rejects inherited `approvalId`/`artifactId` etc. properties

### Why This Matters

ERR-013 requires validators to use `Object.hasOwn()` instead of the `in` operator. Without these tests, a refactor could silently break the inheritance guard, allowing prototype-polluted objects to pass validation.

**Tests**: 182 passing (6 new ERR-013 tests added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 增强了数据验证器的测试覆盖，确保通过原型链继承的属性在验证时能被正确拒绝，提升系统的数据验证可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->