### PR TITLE
fix(health): checkConversationAccessConfig false positive — check entry root instead of pluginConfig (PRI-348)

### DIFF
--- a/packages/openclaw-plugin/src/core/config-health.ts
+++ b/packages/openclaw-plugin/src/core/config-health.ts
@@ -10,6 +10,20 @@
  * needs to check conversation access state (PRI-346).
  */
 
+/**
+ * PRI-348: Extract the full plugin entry (including hooks) from the global OpenClaw config.
+ * Unlike api.pluginConfig (which is only the entry.config sub-object), this returns
+ * the entire entry including hooks, config, enabled, etc.
+ */
+export function getPluginEntry(config: unknown, pluginId: string): unknown {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return undefined;
+  const plugins = (config as Record<string, unknown>).plugins;
+  if (!plugins || typeof plugins !== 'object' || Array.isArray(plugins)) return undefined;
+  const entries = (plugins as Record<string, unknown>).entries;
+  if (!entries || typeof entries !== 'object' || Array.isArray(entries)) return undefined;
+  return (entries as Record<string, unknown>)[pluginId];
+}
+
 /** Keep in sync with @principles/core CONVERSATION_ACCESS_CONFIG_KEY */
 const CONVERSATION_ACCESS_CONFIG_KEY = 'allowConversationAccess' as const;
 

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -20,8 +20,8 @@ import type {
 } from './openclaw-sdk.js';
 import * as path from 'path';
 import { loadFeatureFlagFromConfig } from './core/pd-config-loader.js';
-import { checkConversationAccessConfig } from './core/config-health.js';
-export { checkConversationAccessConfig } from './core/config-health.js';
+import { checkConversationAccessConfig, getPluginEntry } from './core/config-health.js';
+export { checkConversationAccessConfig, getPluginEntry } from './core/config-health.js';
 export type { ConversationAccessCheckResult } from './core/config-health.js';
 import { classifyTask } from './core/local-worker-routing.js';
 import { completeShadowObservation, recordShadowRouting } from './core/shadow-observation-registry.js';
@@ -171,7 +171,7 @@ const plugin = {
       }
 
       // PRI-343: Check allowConversationAccess — warn if llm_output/trajectory hooks blocked
-      const accessCheck = checkConversationAccessConfig(api.pluginConfig);
+      const accessCheck = checkConversationAccessConfig(getPluginEntry(api.config, api.id));
       if (!accessCheck.authorized) {
         api.logger.error(
           `[PD:health] conversation hooks (llm_output / trajectory) will be BLOCKED by OpenClaw.\n` +
@@ -539,7 +539,7 @@ const plugin = {
           TrajectoryCollector.handleBeforeMessageWrite(event, {
             ...ctx,
             workspaceDir: wsResult.workspaceDir,
-            pluginConfig: api.pluginConfig,
+            pluginConfig: getPluginEntry(api.config, api.id),
           });
         } catch (err) {
           // Non-critical: don't surface to user

--- a/packages/openclaw-plugin/src/openclaw-sdk.ts
+++ b/packages/openclaw-plugin/src/openclaw-sdk.ts
@@ -80,6 +80,7 @@ export interface OpenClawPluginService {
 }
 
 export interface OpenClawPluginApi {
+  id: string;
   rootDir?: string;
   pluginConfig?: Record<string, unknown>;
   logger: PluginLogger;


### PR DESCRIPTION
## Summary

PD 插件启动时健康检查始终报错 `allowConversationAccess is not set to true`，即使配置已正确设置。根因是 `checkConversationAccessConfig` 收到了错误的配置层级。

## Root Cause

OpenClaw 的 `loader.ts` 给插件 API 传了两个不同层级的配置：

| 字段 | 来源 | 内容 |
|------|------|------|
| `api.pluginConfig` | `entry.config` | 插件私有配置（language 等） |
| `entry.hooks` | `entry.hooks` | allowConversationAccess 等 |

健康检查查的是 `api.pluginConfig.hooks.allowConversationAccess`，但 `api.pluginConfig` 是 `entry.config`（不包含 hooks），所以永远是 `undefined` → 误报。

OpenClaw 实际的 hook 门禁（`registerTypedHook`）查的是 `entry.hooks.allowConversationAccess`，值是 `true`，所以 hook 实际上是正常工作的。**这是一个 false positive，不影响功能。**

## Changes

### 1. `config-health.ts` — 新增 `getPluginEntry()` 辅助函数
类型安全地从 `api.config`（全局 OpenClaw 配置）中提取插件 entry 根对象（包含 hooks 同级字段）。

### 2. `index.ts:174` — 健康检查改用 entry 根对象
```diff
- checkConversationAccessConfig(api.pluginConfig)
+ checkConversationAccessConfig(getPluginEntry(api.config, api.id))
```

### 3. `index.ts:542` — trajectory-collector 降级判断同步修改
```diff
- pluginConfig: api.pluginConfig,
+ pluginConfig: getPluginEntry(api.config, api.id),
```

### 4. `openclaw-sdk.ts` — OpenClawPluginApi 类型补全 `id` 字段

## Impact

- **修复前**: 每次启动误报 BLOCKED + trajectory-collector 因 false negative 写入不必要的 SQLite fallback + CONVERSATION_HOOK_BLOCKED 噪声日志
- **修复后**: 健康检查正确通过，trajectory-collector 正常跳过 SQLite 写入（llm_output 已正常工作）

## Verification

- ✅ 5/5 `checkConversationAccessConfig` 专项测试通过
- ✅ verify:merge 全量通过（lint + build + typecheck + check:error-handbook + check:generated-artifacts）
- ✅ llm_output hook 实际运行记录：11 条（证明 hook 本身一直正常工作）

## Linear

Fixes PRI-348


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更说明

* **重构**
  * 优化了插件配置的提取和验证机制，增强了系统的稳定性和容错能力。
  * 更新了插件 API 接口声明，现要求必须提供 ID 字段。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->