### PR TITLE
fix(core): remove dangling eventSummaries field from prompt and schema (PRI-352)

### DIFF
--- a/packages/principles-core/src/runtime-v2/context-payload.ts
+++ b/packages/principles-core/src/runtime-v2/context-payload.ts
@@ -209,7 +209,6 @@ export const ContextPayloadSchema = Type.Object({
   targetAgent: Type.Optional(Type.String({ minLength: 1 })),
   diagnosisTarget: Type.Optional(DiagnosisTargetSchema),
   conversationWindow: Type.Array(HistoryQueryEntrySchema),
-  eventSummaries: Type.Optional(Type.Array(Type.Record(Type.String(), Type.Unknown()))),
   artifactRefs: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
   ambiguityNotes: Type.Optional(Type.Array(Type.String())),
   summary: Type.String({ minLength: 1 }),
@@ -227,7 +226,6 @@ export const DiagnosticianContextPayloadSchema = Type.Object({
   sourceRefs: Type.Array(Type.String({ minLength: 1 })),
   diagnosisTarget: DiagnosisTargetSchema,
   conversationWindow: Type.Array(HistoryQueryEntrySchema),
-  eventSummaries: Type.Optional(Type.Array(Type.Record(Type.String(), Type.Unknown()))),
   ambiguityNotes: Type.Optional(Type.Array(Type.String())),
   fullTrace: Type.Optional(Type.Union([FullTracePayloadSchema, FullTracePayloadV2SchemaImport, Type.Null()])),
 });

--- a/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
@@ -111,7 +111,7 @@ export interface PromptBuildResult {
  * Per DPB-02 (LOCKED): Output is ONLY JSON — no markdown, no file ops, no tool calls.
  * Per DPB-04: LLM can only analyze the context provided in the prompt; it must NOT
  *   read files, call tools, or write to databases. All evidence must be drawn from
- *   the context payload (sourceRefs, conversationWindow, eventSummaries).
+ *   the context payload (sourceRefs, conversationWindow).
  *
  * The 5-phase protocol is embedded directly in the prompt so the LLM follows it
  * regardless of whether OpenClaw loads SKILL.md as the agent system prompt.
@@ -128,8 +128,8 @@ export function buildDiagnosticProtocolInstruction(
   return `You are a root cause analysis expert. Follow this protocol:
 
 PHASE 1 — Evidence Review:
-Review the provided sourceRefs, diagnosisTarget.evidence entries, conversationWindow
-entries, and eventSummaries from the context payload. Do NOT read any files or call any tools.
+Review the provided sourceRefs, diagnosisTarget.evidence entries, and conversationWindow
+entries from the context payload. Do NOT read any files or call any tools.
 Record all evidence by referencing the sourceRef identifiers and conversation
 entries already present in the context. Each evidence item must cite its source.
 Pay special attention to diagnosisTarget.evidence — these are the primary behavioral

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/__snapshots__/diagnostician-prompt-builder.test.ts.snap
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/__snapshots__/diagnostician-prompt-builder.test.ts.snap
@@ -4,8 +4,8 @@ exports[`DiagnosticianPromptBuilder > buildDiagnosticProtocolInstruction() > bui
 "You are a root cause analysis expert. Follow this protocol:
 
 PHASE 1 — Evidence Review:
-Review the provided sourceRefs, diagnosisTarget.evidence entries, conversationWindow
-entries, and eventSummaries from the context payload. Do NOT read any files or call any tools.
+Review the provided sourceRefs, diagnosisTarget.evidence entries, and conversationWindow
+entries from the context payload. Do NOT read any files or call any tools.
 Record all evidence by referencing the sourceRef identifiers and conversation
 entries already present in the context. Each evidence item must cite its source.
 Pay special attention to diagnosisTarget.evidence — these are the primary behavioral

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.integration.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.integration.test.ts
@@ -40,7 +40,6 @@ const REALISTIC_PAYLOAD: DiagnosticianContextPayload = {
     { ts: '2026-04-24T10:00:01Z', role: 'assistant', text: 'I will use the planner agent', toolName: undefined, toolResultSummary: undefined, eventType: undefined },
     { ts: '2026-04-24T10:00:02Z', role: 'tool', text: undefined, toolName: 'planner_agent', toolResultSummary: 'Agent not found in registry', eventType: undefined },
   ],
-  eventSummaries: [{ eventType: 'tool-call-failure', toolName: 'planner_agent' }],
   ambiguityNotes: ['Multiple failure modes detected — gate rejection vs agent not found'],
 };
 

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { DiagnosticianPromptBuilder, buildDiagnosticProtocolInstruction } from '../../diagnostician-prompt-builder.js';
 import type { DiagnosticianContextPayload } from '../../context-payload.js';
+import { DiagnosticianContextPayloadSchema, ContextPayloadSchema } from '../../context-payload.js';
 import { extractJsonObject } from '../../adapter/json-extractor.js';
 import { DefaultSchemaPromptAdapter } from '../../adapter/schema-prompt-adapter.js';
 import { DiagnosticianOutputV1Schema } from '../../diagnostician-output.js';
@@ -462,6 +463,34 @@ describe('DiagnosticianPromptBuilder', () => {
       const parsed = extractJsonObject(instruction);
       expect(parsed).not.toBeNull();
       expect(Value.Check(DiagnosticianOutputV1Schema, parsed)).toBe(true);
+    });
+  });
+
+  // ── PRI-352: eventSummaries removal (dangling field with no producer) ────
+
+  describe('eventSummaries removal (PRI-352)', () => {
+    const adapter = new DefaultSchemaPromptAdapter();
+
+    it('buildDiagnosticProtocolInstruction() does NOT reference eventSummaries', () => {
+      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      expect(instruction).not.toContain('eventSummaries');
+    });
+
+    it('DiagnosticianContextPayloadSchema does NOT contain eventSummaries field', () => {
+      const schemaKeys = Object.keys(DiagnosticianContextPayloadSchema.properties);
+      expect(schemaKeys).not.toContain('eventSummaries');
+    });
+
+    it('ContextPayloadSchema does NOT contain eventSummaries field', () => {
+      const schemaKeys = Object.keys(ContextPayloadSchema.properties);
+      expect(schemaKeys).not.toContain('eventSummaries');
+    });
+
+    it('buildPrompt() output JSON does NOT contain eventSummaries', () => {
+      const builder = new DiagnosticianPromptBuilder();
+      const result = builder.buildPrompt(MINIMAL_PAYLOAD);
+      const parsed = JSON.parse(result.message);
+      expect(parsed.context).not.toHaveProperty('eventSummaries');
     });
   });
 


### PR DESCRIPTION
## Summary

Removes the dangling `eventSummaries` field that was declared in schemas and referenced in the diagnostician prompt, but never populated by any producer.

**MVP-First choice (ADR-0014)**: remove rather than build a new producer, since `evidence` + `conversationWindow` (after PRI-349/350 fixes) already cover diagnostic context needs.

## Changes

- Remove `eventSummaries` from `DiagnosticianContextPayloadSchema`
- Remove `eventSummaries` from `ContextPayloadSchema`
- Remove "and eventSummaries" from PHASE 1 prompt text in `buildDiagnosticProtocolInstruction()`
- Remove `eventSummaries` from DPB-04 comment
- Remove `eventSummaries` from integration test fixture
- Update snapshot
- Add 4 TDD tests asserting no `eventSummaries` in prompt/schema/output

## Verification

- `cd packages/principles-core && npm run build` — pass
- `cd packages/principles-core && npx vitest run src/runtime-v2/diagnostician/` — 62/62 pass
- `npm run lint` — pass
- `npm run verify:merge` — pass (pre-push gate)
- `grep -r eventSummaries packages/` — only in test assertions (negative checks)

## Grep confirmation (no dangling references)

```
packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
  → only in PRI-352 test assertions (not.toContain / not.toHaveProperty)
packages/principles-core/src/runtime-v2/diagnostician/__tests__/__snapshots__/diagnostician-prompt-builder.test.ts.snap
  → no eventSummaries references remain
```

## ERR Checklist

- EP-02 (Production Path Wiring): field declared but never wired — removal eliminates the gap
- EP-07 (Source Alignment): schema declared field with no source — removal restores alignment
- EP-03 (Fail Loud): silent undefined degraded diagnosis quality — removal prevents false prompt expectations

## Acceptance Criteria (from PRI-352 comment)

- [x] 工单留言写明选择「移除」及理由
- [x] prompt 与 schema 一致：不存在"声明了但无产者/无引用"的悬空字段
- [x] 搜索确认无遗漏引用
- [x] `npm run build && npm run test && npm run lint` 通过

Closes PRI-352
