### PR TITLE
fix(core): upgrade service:trajectory from quiet to core (PRI-353)

### DIFF
--- a/packages/openclaw-plugin/tests/core/surface-guard.test.ts
+++ b/packages/openclaw-plugin/tests/core/surface-guard.test.ts
@@ -278,17 +278,17 @@ describe('surface-guard', () => {
       const mockLogger = { info: vi.fn(), debug: vi.fn() };
       const service: OpenClawPluginService = { id: 'test-service' };
 
-      // First registration call: the disabled reason is logged once.
-      const first = guardService('service:trajectory', service, mockLogger);
+      // service:evolution-worker is quiet/disabled — use it for the rate-limit test.
+      const first = guardService('service:evolution-worker', service, mockLogger);
       expect(first).toBeNull();
       expect(mockLogger.info).toHaveBeenCalledTimes(1);
       expect(mockLogger.info).toHaveBeenCalledWith(
-        expect.stringContaining('SKIP service service:trajectory'),
+        expect.stringContaining('SKIP service service:evolution-worker'),
       );
 
       // Subsequent guardService calls for the same surfaceId stay silent.
-      guardService('service:trajectory', service, mockLogger);
-      guardService('service:trajectory', service, mockLogger);
+      guardService('service:evolution-worker', service, mockLogger);
+      guardService('service:evolution-worker', service, mockLogger);
       expect(mockLogger.info).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
@@ -435,11 +435,11 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       expect(guarded).toBeNull();
     });
 
-    it('guardService returns null for quiet surfaces', async () => {
+    it('guardService returns the service for core surfaces (trajectory is now core)', async () => {
       const { guardService } = await import('../../src/core/surface-guard.js');
       const service = { api: null, start: () => {} };
       const guarded = guardService('service:trajectory', service);
-      expect(guarded).toBeNull();
+      expect(guarded).toBe(service);
     });
 
     it('guardService returns null for unregistered surfaces', async () => {

--- a/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
@@ -126,11 +126,10 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
   {
     id: 'service:trajectory',
     kind: 'service',
-    category: 'quiet',
-    enabledByDefault: false,
+    category: 'core',
+    enabledByDefault: true,
     since: '2026-05-24',
-    description: 'Trajectory collection service',
-    disabledReason: 'Disabled by default: trajectory service is opt-in; default off per ADR-0014 §2.5 (preserved in plugin code, not active in production).',
+    description: 'Trajectory collection service — pre-initializes TrajectoryDB registry; hooks (llm_output, before_message_write) are the primary writers (PRI-346/353)',
   },
   {
     id: 'service:pd-task',


### PR DESCRIPTION
## Summary

Upgrades \service:trajectory\ from \quiet\ (disabled by default) to \core\ (enabled by default) in the plugin surface registry.

## Context

Trajectory collection is already fully functional via two core hooks:
- \hook:llm_output\ (core, enabled) — primary path, writes SQLite via \ecordAssistantTurn\
- \hook:before_message_write\ (core, enabled) — fallback path when \llowConversationAccess\ is missing (PRI-346)

The \service:trajectory\ surface only pre-initializes the TrajectoryDB registry on startup. Keeping it disabled means the first trajectory write incurs lazy-init latency. Since trajectory collection is now a core MVP function (both hooks are core), the service should also be core.

## Changes

| File | Change |
|------|--------|
| \plugin-surface-registry.ts\ | \service:trajectory\: quiet→core, enabledByDefault: false→true |
| \surface-guard.test.ts\ | Use \service:evolution-worker\ for rate-limit test (trajectory no longer disabled) |
| \mvp-surface-registry-guard.test.ts\ | Assert trajectory returns service (not null) |

## Verification

- \principles-core\: 195 passed, 4 skipped
- \openclaw-plugin\: 149 passed (2 pre-existing flaky failures unrelated to this change)
- \rchitecture-regression\: 443 passed
- \lint\ + \erify:merge\: passed

## ERR Considered

- **ERR-002**: Surface guard logs reason when disabled — no silent degradation
- **ERR-009**: Core surface must have \nabledByDefault=true\ — validated by registry

Closes #PRI-353