### PR TITLE
ci: fix pnpm version duplication in deploy workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
This PR fixes the pnpm duplicate version configuration in the Deploy Website workflow so that action-setup can read the version directly from package.json.