### PR TITLE
feat(diagnostician): RunnerKind seam for split pipeline (PRI-370)

### DIFF
--- a/docs/architecture/DOMAIN_MODEL.md
+++ b/docs/architecture/DOMAIN_MODEL.md
@@ -41,6 +41,14 @@ Principle (probation)
     │
     ▼ Internalization Pipeline（7 个 Peer Runner）
 PIArtifact (validated)
+
+> **ADR-0014 Amendment (2026-06-11)**: The "7 Peer Runner" invariant refers to the
+> Internalization Pipeline only. The Diagnostician Pipeline introduces a separate
+> `DiagnosticianStageKind` type (diag_rootcause, diag_distiller, diag_router) that
+> is NOT a PeerRunnerKind. The union type `RunnerKind = PeerRunnerKind | DiagnosticianStageKind`
+> is used by the orchestrator for task dispatch, but the two pipelines remain
+> architecturally distinct.
+
     │
     ▼ Activation Pipeline（5 通道）
 实际生效（agent 行为改变）
@@ -368,6 +376,14 @@ disabled（自动 deactivate）
 | Diagnostician Recommendation | `packages/principles-core/src/runtime-v2/diagnostician-output.ts` | - | ✅ Done |
 | **PIArtifact** | `packages/principles-core/src/runtime-v2/internalization/pi-artifact.ts` | - | ✅ Done（ADR-0003）|
 | **7 Peer Runners** | `packages/principles-core/src/runtime-v2/internalization/*-runner.ts` | - | ✅ Done |
+
+> **ADR-0014 Amendment (2026-06-11)**: The "7 Peer Runner" invariant refers to the
+> Internalization Pipeline only. The Diagnostician Pipeline introduces a separate
+> `DiagnosticianStageKind` type (diag_rootcause, diag_distiller, diag_router) that
+> is NOT a PeerRunnerKind. The union type `RunnerKind = PeerRunnerKind | DiagnosticianStageKind`
+> is used by the orchestrator for task dispatch, but the two pipelines remain
+> architecturally distinct.
+
 | **InternalizationOrchestrator** | `packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts` | - | ✅ Done |
 | **CorrectionProposal** | `packages/principles-core/src/runtime-v2/internalization/correction-proposal.ts` | - | ✅ Done（ADR-0004）|
 | **GoldenTrace** | `packages/principles-core/src/runtime-v2/golden-trace.ts` | - | ✅ Done |

--- a/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
+++ b/packages/openclaw-plugin/src/service/internalization-trigger-adapter.ts
@@ -21,7 +21,7 @@ import {
   isPeerRunnerKind,
   hydratePITaskRecord,
   type PITaskRecord,
-  type PeerRunnerKind,
+  type RunnerKind,
 } from '@principles/core/runtime-v2';
 
 // ── Structured log event types ───────────────────────────────────────────────
@@ -30,7 +30,7 @@ type TriggerWakeEvent = {
   event: 'INTERNALIZATION_TRIGGER_WAKE';
   workspaceDir: string;
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   correlationId?: string;
   gateDecision: 'proceed';
   timestamp: string;

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -534,6 +534,8 @@ export type { LedgerTreeStore } from '../principle-tree-ledger.js';
 export type {
   InternalizationChannel,
   PeerRunnerKind,
+  DiagnosticianStageKind,
+  RunnerKind,
   PIArtifactKind,
   PIArtifactValidationStatus,
   ArtifactRef,
@@ -544,9 +546,12 @@ export type {
 
 export {
   PEER_RUNNER_KINDS,
+  DIAGNOSTICIAN_STAGE_KINDS,
   INTERNALIZATION_CHANNELS,
   PI_ARTIFACT_KINDS,
   isPeerRunnerKind,
+  isDiagnosticianStageKind,
+  isRunnerKind,
   isInternalizationChannel,
   isPIArtifactKind,
   isTerminalTaskStatus,
@@ -558,9 +563,12 @@ export {
 
 export {
   ALLOWED_EDGES,
+  DIAGNOSTICIAN_EDGES,
   MODEL_TRAINING_CHANNEL,
   TRAINER_KIND,
   validateEdge,
+  validateDiagEdge,
+  getDiagSuccessors,
   isAcyclic,
   getAllowedSuccessors,
   getAllowedPredecessors,

--- a/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
+++ b/packages/principles-core/src/runtime-v2/internalization-queue-read-model.ts
@@ -18,8 +18,8 @@
 import type { TaskRecord } from './task-status.js';
 import type { RuntimeStateHandle } from './runtime-state-handle.js';
 import { createRuntimeStateHandle } from './runtime-state-handle.js';
-import type { PeerRunnerKind, InternalizationChannel } from './internalization/peer-runner-contracts.js';
-import { isPeerRunnerKind } from './internalization/peer-runner-contracts.js';
+import type { RunnerKind, InternalizationChannel } from './internalization/peer-runner-contracts.js';
+import { isRunnerKind } from './internalization/peer-runner-contracts.js';
 import { hydratePITaskRecord } from './internalization/pitask-metadata.js';
 import { validateInternalizationTaskReady } from './internalization/internalization-state-machine.js';
 import { isUnresolvable } from './internalization/internalization-task-guards.js';
@@ -29,19 +29,19 @@ import { classifyTaskActionability, type ActionabilityPolicyInput, MVP_CORE_TASK
 
 export interface BlockedSample {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   blockedBy: string[];
 }
 
 export interface DependencyFailedSample {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   failedDependencies: string[];
 }
 
 export interface ReadyTask {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   channel: InternalizationChannel;
 }
 
@@ -61,20 +61,20 @@ export interface NoReadyTasksDiagnosis {
 
 export interface RetryWaitPendingSample {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   retryAfter: string;
 }
 
 export interface LeaseConflictSample {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   leaseOwner: string;
   leaseExpiresAt: string;
 }
 
 export interface UnresolvableSample {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   rejectionCount: number;
 }
 
@@ -128,8 +128,8 @@ export class InternalizationQueueReadModel {
       this.stateManager.listTasks({ status: 'retry_wait' }),
     ]);
 
-    // Filter to PeerRunnerKind tasks first — all counts below are PI-specific
-    const peerTasks = [...pending, ...retryWait].filter(t => isPeerRunnerKind(t.taskKind));
+    // Filter to RunnerKind tasks — includes both PeerRunnerKind and DiagnosticianStageKind
+    const runnerTasks = [...pending, ...retryWait].filter(t => isRunnerKind(t.taskKind));
 
     let pendingCount = 0;
     let retryWaitCount = 0;
@@ -157,7 +157,7 @@ export class InternalizationQueueReadModel {
 
     const nowMs = Date.now();
 
-    for (const rawTask of peerTasks) {
+    for (const rawTask of runnerTasks) {
       const piTask = hydratePITaskRecord(rawTask);
 
       if (!piTask) {

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/runnerkind-seam.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/runnerkind-seam.test.ts
@@ -1,0 +1,256 @@
+/**
+ * RunnerKind seam tests (INF-1..INF-8) — PRI-370
+ *
+ * Verifies the DiagnosticianStageKind / RunnerKind type seam that
+ * introduces the diagnostician pipeline as a separate execution kind
+ * without overloading PeerRunnerKind.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isPeerRunnerKind,
+  isDiagnosticianStageKind,
+  isRunnerKind,
+  DIAGNOSTICIAN_STAGE_KINDS,
+  PEER_RUNNER_KINDS,
+  isValidPITaskRecord,
+  createMinimalPITaskRecord,
+} from '../peer-runner-contracts.js';
+import {
+  DIAGNOSTICIAN_EDGES,
+  validateDiagEdge,
+  getDiagSuccessors,
+} from '../internalization-job-graph.js';
+import {
+  hydratePITaskRecord,
+  serializePITaskMetadata,
+  parsePITaskMetadata,
+} from '../pitask-metadata.js';
+import { DEFAULT_FEATURE_FLAGS } from '../../feature-flags/feature-flag-contract.js';
+import type { TaskRecord } from '../../task-status.js';
+
+// ── INF-1: DiagnosticianStageKind + RunnerKind type guards ──────────────────
+
+describe('INF-1: DiagnosticianStageKind + RunnerKind type guards', () => {
+  it('isDiagnosticianStageKind("diag_rootcause") === true', () => {
+    expect(isDiagnosticianStageKind('diag_rootcause')).toBe(true);
+  });
+
+  it('isDiagnosticianStageKind("diag_distiller") === true', () => {
+    expect(isDiagnosticianStageKind('diag_distiller')).toBe(true);
+  });
+
+  it('isDiagnosticianStageKind("diag_router") === true', () => {
+    expect(isDiagnosticianStageKind('diag_router')).toBe(true);
+  });
+
+  it('isPeerRunnerKind("diag_rootcause") === false', () => {
+    expect(isPeerRunnerKind('diag_rootcause')).toBe(false);
+  });
+
+  it('isRunnerKind("diag_rootcause") === true', () => {
+    expect(isRunnerKind('diag_rootcause')).toBe(true);
+  });
+
+  it('isRunnerKind("dreamer") === true', () => {
+    expect(isRunnerKind('dreamer')).toBe(true);
+  });
+
+  it('isRunnerKind("invalid") === false', () => {
+    expect(isRunnerKind('invalid')).toBe(false);
+  });
+
+  it('DIAGNOSTICIAN_STAGE_KINDS has exactly 3 entries', () => {
+    expect(DIAGNOSTICIAN_STAGE_KINDS).toHaveLength(3);
+    expect(DIAGNOSTICIAN_STAGE_KINDS).toEqual(['diag_rootcause', 'diag_distiller', 'diag_router']);
+  });
+
+  it('PeerRunnerKind and DiagnosticianStageKind are disjoint', () => {
+    for (const dk of DIAGNOSTICIAN_STAGE_KINDS) {
+      expect(isPeerRunnerKind(dk)).toBe(false);
+    }
+    for (const pk of PEER_RUNNER_KINDS) {
+      expect(isDiagnosticianStageKind(pk)).toBe(false);
+    }
+  });
+});
+
+// ── INF-2: DIAGNOSTICIAN_EDGES + validateDiagEdge ──────────────────────────
+
+describe('INF-2: DIAGNOSTICIAN_EDGES + validateDiagEdge', () => {
+  it('validateDiagEdge("diag_rootcause", "diag_distiller") === true', () => {
+    expect(validateDiagEdge('diag_rootcause', 'diag_distiller')).toBe(true);
+  });
+
+  it('validateDiagEdge("diag_distiller", "diag_router") === true', () => {
+    expect(validateDiagEdge('diag_distiller', 'diag_router')).toBe(true);
+  });
+
+  it('validateDiagEdge("diag_rootcause", "diag_router") === false (skip)', () => {
+    expect(validateDiagEdge('diag_rootcause', 'diag_router')).toBe(false);
+  });
+
+  it('validateDiagEdge("diag_router", "diag_rootcause") === false (reverse)', () => {
+    expect(validateDiagEdge('diag_router', 'diag_rootcause')).toBe(false);
+  });
+
+  it('getDiagSuccessors("diag_rootcause") returns ["diag_distiller"]', () => {
+    expect(getDiagSuccessors('diag_rootcause')).toEqual(['diag_distiller']);
+  });
+
+  it('getDiagSuccessors("diag_distiller") returns ["diag_router"]', () => {
+    expect(getDiagSuccessors('diag_distiller')).toEqual(['diag_router']);
+  });
+
+  it('getDiagSuccessors("diag_router") returns []', () => {
+    expect(getDiagSuccessors('diag_router')).toEqual([]);
+  });
+
+  it('DIAGNOSTICIAN_EDGES has exactly 2 edges', () => {
+    expect(DIAGNOSTICIAN_EDGES).toHaveLength(2);
+  });
+});
+
+// ── INF-3: hydratePITaskRecord accepts RunnerKind ──────────────────────────
+
+describe('INF-3: hydratePITaskRecord accepts RunnerKind', () => {
+  function makeTask(taskKind: string): TaskRecord & Record<string, unknown> {
+    return {
+      taskId: 'test-task-1',
+      taskKind,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      attemptCount: 0,
+      maxAttempts: 3,
+      diagnosticJson: JSON.stringify({
+        pi_metadata: {
+          dependencyTaskIds: [],
+          channel: 'prompt',
+          timeoutMs: 60000,
+          inputArtifactRefs: [],
+          outputArtifactRefs: [],
+          rejectionCount: 0,
+        },
+      }),
+    };
+  }
+
+  it('hydratePITaskRecord succeeds on diag_rootcause task', () => {
+    const task = makeTask('diag_rootcause');
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.taskKind).toBe('diag_rootcause');
+    }
+  });
+
+  it('hydratePITaskRecord succeeds on diag_distiller task', () => {
+    const task = makeTask('diag_distiller');
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.taskKind).toBe('diag_distiller');
+    }
+  });
+
+  it('hydratePITaskRecord succeeds on dreamer task (PeerRunnerKind)', () => {
+    const task = makeTask('dreamer');
+    const result = hydratePITaskRecord(task);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.taskKind).toBe('dreamer');
+    }
+  });
+
+  it('hydratePITaskRecord returns null for invalid taskKind', () => {
+    const task = makeTask('invalid_kind');
+    const result = hydratePITaskRecord(task);
+    expect(result).toBeNull();
+  });
+
+  it('isValidPITaskRecord accepts diag_rootcause', () => {
+    const record = createMinimalPITaskRecord('test-1', 'diag_rootcause', 'prompt');
+    expect(isValidPITaskRecord(record)).toBe(true);
+  });
+
+  it('createMinimalPITaskRecord works with DiagnosticianStageKind', () => {
+    const record = createMinimalPITaskRecord('test-2', 'diag_router', 'prompt');
+    expect(record.taskKind).toBe('diag_router');
+    expect(record.status).toBe('pending');
+  });
+});
+
+// ── INF-7: Feature flags registered ────────────────────────────────────────
+
+describe('INF-7: Feature flags registered', () => {
+  it('diagnostician_split_pipeline flag exists in DEFAULT_FEATURE_FLAGS', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'diagnostician_split_pipeline');
+    expect(flag).toBeDefined();
+    if (flag) {
+      expect(flag.category).toBe('quiet');
+      expect(flag.enabled).toBe(false);
+    }
+  });
+
+  it('diagnostician_async_cli flag exists in DEFAULT_FEATURE_FLAGS', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'diagnostician_async_cli');
+    expect(flag).toBeDefined();
+    if (flag) {
+      expect(flag.category).toBe('quiet');
+      expect(flag.enabled).toBe(false);
+    }
+  });
+
+  it('diagnostician_core_grounding flag exists in DEFAULT_FEATURE_FLAGS', () => {
+    const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'diagnostician_core_grounding');
+    expect(flag).toBeDefined();
+    if (flag) {
+      expect(flag.category).toBe('quiet');
+      expect(flag.enabled).toBe(false);
+    }
+  });
+});
+
+// ── INF-8: Metadata envelope supports DiagnosticianStageKind ───────────────
+
+describe('INF-8: Metadata envelope supports DiagnosticianStageKind', () => {
+  it('serializePITaskMetadata works with DiagnosticianStageKind task', () => {
+    const metadata = {
+      dependencyTaskIds: ['dep-1'],
+      channel: 'prompt' as const,
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [],
+      parentTaskId: 'parent-1',
+      correlationId: 'corr-1',
+      rejectionCount: 0,
+    };
+    const json = serializePITaskMetadata(metadata);
+    expect(json).toBeTruthy();
+
+    const parsed = parsePITaskMetadata(json);
+    expect(parsed).not.toBeNull();
+    if (parsed) {
+      expect(parsed.dependencyTaskIds).toEqual(['dep-1']);
+      expect(parsed.channel).toBe('prompt');
+    }
+  });
+
+  it('parsePITaskMetadata round-trips diag_rootcause metadata', () => {
+    const metadata = {
+      dependencyTaskIds: [],
+      channel: 'prompt' as const,
+      timeoutMs: 60000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [],
+      rejectionCount: 0,
+    };
+    const json = serializePITaskMetadata(metadata);
+    const parsed = parsePITaskMetadata(json);
+    expect(parsed).not.toBeNull();
+    if (parsed) {
+      expect(parsed.channel).toBe('prompt');
+      expect(parsed.timeoutMs).toBe(60000);
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/runnerkind-seam.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/runnerkind-seam.test.ts
@@ -25,6 +25,7 @@ import {
   serializePITaskMetadata,
   parsePITaskMetadata,
 } from '../pitask-metadata.js';
+import { decideArtifactRejectionFeedback } from '../internalization-state-machine.js';
 import { DEFAULT_FEATURE_FLAGS } from '../../feature-flags/feature-flag-contract.js';
 import type { TaskRecord } from '../../task-status.js';
 
@@ -251,6 +252,26 @@ describe('INF-8: Metadata envelope supports DiagnosticianStageKind', () => {
     if (parsed) {
       expect(parsed.channel).toBe('prompt');
       expect(parsed.timeoutMs).toBe(60000);
+    }
+  });
+});
+
+// ── Regression: decideArtifactRejectionFeedback for diagnostician tasks ─────
+
+describe('Regression: decideArtifactRejectionFeedback for diagnostician tasks', () => {
+  it('escalates with rejectionReason when taskKind is DiagnosticianStageKind', () => {
+    const artifact = {
+      artifactId: 'art-1',
+      artifactKind: 'principle' as const,
+      sourceTaskId: 'task-1',
+      lineageRefs: [],
+      validationStatus: 'rejected' as const,
+    };
+    const diagTask = createMinimalPITaskRecord('task-1', 'diag_rootcause', 'prompt');
+    const result = decideArtifactRejectionFeedback(artifact, diagTask);
+    expect(result.action).toBe('escalate');
+    if (result.action === 'escalate') {
+      expect(result.rejectionReason).toContain('unexpected_diagnostician_taskKind:diag_rootcause');
     }
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -77,6 +77,8 @@ export type { LedgerTreeStore } from '../../principle-tree-ledger.js';
 export type {
   InternalizationChannel,
   PeerRunnerKind,
+  DiagnosticianStageKind,
+  RunnerKind,
   PIArtifactKind,
   PIArtifactValidationStatus,
   ArtifactRef,
@@ -87,9 +89,12 @@ export type {
 
 export {
   PEER_RUNNER_KINDS,
+  DIAGNOSTICIAN_STAGE_KINDS,
   INTERNALIZATION_CHANNELS,
   PI_ARTIFACT_KINDS,
   isPeerRunnerKind,
+  isDiagnosticianStageKind,
+  isRunnerKind,
   isInternalizationChannel,
   isPIArtifactKind,
   isTerminalTaskStatus,
@@ -101,9 +106,12 @@ export {
 
 export {
   ALLOWED_EDGES,
+  DIAGNOSTICIAN_EDGES,
   MODEL_TRAINING_CHANNEL,
   TRAINER_KIND,
   validateEdge,
+  validateDiagEdge,
+  getDiagSuccessors,
   isAcyclic,
   getAllowedSuccessors,
   getAllowedPredecessors,

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-job-graph.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-job-graph.ts
@@ -12,7 +12,7 @@
  * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
  */
 
-import type { InternalizationChannel, PeerRunnerKind } from './peer-runner-contracts.js';
+import type { InternalizationChannel, PeerRunnerKind, DiagnosticianStageKind } from './peer-runner-contracts.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -32,6 +32,15 @@ export const ALLOWED_EDGES: readonly (readonly [PeerRunnerKind, PeerRunnerKind])
   ['artificer', 'evaluator'] as const,
   ['evaluator', 'rollout_reviewer'] as const,
   ['rollout_reviewer', 'trainer'] as const,
+] as const;
+
+/**
+ * Allowed edges in the diagnostician chain.
+ * diag_rootcause → diag_distiller → diag_router
+ */
+export const DIAGNOSTICIAN_EDGES: readonly (readonly [DiagnosticianStageKind, DiagnosticianStageKind])[] = [
+  ['diag_rootcause', 'diag_distiller'] as const,
+  ['diag_distiller', 'diag_router'] as const,
 ] as const;
 
 /**
@@ -70,6 +79,25 @@ export function validateEdge(
 
   // Non-trainer targets: check allowed edges
   return ALLOWED_EDGES.some(([f, t]) => f === from && t === to);
+}
+
+/**
+ * Validates whether a diagnostician chain transition is legal.
+ */
+export function validateDiagEdge(
+  from: DiagnosticianStageKind,
+  to: DiagnosticianStageKind,
+): boolean {
+  return DIAGNOSTICIAN_EDGES.some(([f, t]) => f === from && t === to);
+}
+
+/**
+ * Returns allowed successor for a diagnostician stage kind.
+ */
+export function getDiagSuccessors(from: DiagnosticianStageKind): DiagnosticianStageKind[] {
+  return DIAGNOSTICIAN_EDGES
+    .filter(([f]) => f === from)
+    .map(([, t]) => t);
 }
 
 // ── DAG Validation (Kahn's Algorithm) ────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-orchestrator.ts
@@ -16,15 +16,16 @@
 
 import type { TaskRecord, PDTaskStatus } from '../task-status.js';
 import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
-import type { PeerRunnerKind } from './peer-runner-contracts.js';
+import type { RunnerKind } from './peer-runner-contracts.js';
 import type { DependencyGateResult, NextTaskProposal } from './internalization-state-machine.js';
 import { hydratePITaskRecord, createPITaskDiagnosticJson } from './pitask-metadata.js';
 import type { PITaskMetadata } from './pitask-metadata.js';
-import { isPeerRunnerKind } from './peer-runner-contracts.js';
+import { isPeerRunnerKind, isDiagnosticianStageKind, isRunnerKind } from './peer-runner-contracts.js';
 import {
   validateInternalizationTaskReady,
   createNextTaskProposal,
 } from './internalization-state-machine.js';
+import { getDiagSuccessors } from './internalization-job-graph.js';
 import { PDRuntimeError } from '../error-categories.js';
 
 // ── Result Types ─────────────────────────────────────────────────────────────
@@ -39,28 +40,28 @@ export interface NoReadyTasksResult {
 export interface BlockedResult {
   decision: 'blocked';
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   blockedBy: string[];
 }
 
 export interface DependencyFailedResult {
   decision: 'dependency_failed';
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   failedDependencies: string[];
 }
 
 export interface LeasedResult {
   decision: 'leased';
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   attemptCount: number;
 }
 
 export interface WouldLeaseResult {
   decision: 'would_lease';
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   gateResult: DependencyGateResult;
 }
 
@@ -104,7 +105,7 @@ export type WakeOnceResult =
 export interface ProposalCreatedResult {
   decision: 'proposal_created';
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   proposal: NextTaskProposal;
 }
 
@@ -113,8 +114,8 @@ export type ProposeNextTaskResult = ProposalCreatedResult | null;
 // ── Commit Next Task Result Types (PRI-88) ────────────────────────────────────
 
 export type CommitNextTaskResult =
-  | { decision: 'successor_created'; sourceTaskId: string; successorTaskId: string; successorKind: PeerRunnerKind }
-  | { decision: 'successor_exists'; sourceTaskId: string; successorTaskId: string; successorKind: PeerRunnerKind }
+  | { decision: 'successor_created'; sourceTaskId: string; successorTaskId: string; successorKind: RunnerKind }
+  | { decision: 'successor_exists'; sourceTaskId: string; successorTaskId: string; successorKind: RunnerKind }
   | { decision: 'no_successor'; sourceTaskId: string; reason: string }
   | { decision: 'invalid_task_metadata'; taskId: string; reason: string }
   | { decision: 'source_not_succeeded'; taskId: string; status: PDTaskStatus }
@@ -167,7 +168,7 @@ export class InternalizationOrchestrator {
    *   5. On proceed + dryRun → would_lease; on proceed + !dryRun → acquireLease
    *   6. On lease_conflict PDRuntimeError → structured LeaseConflictResult
    */
-  async wakeOnce(taskKind?: PeerRunnerKind): Promise<WakeOnceResult> {
+  async wakeOnce(taskKind?: RunnerKind): Promise<WakeOnceResult> {
     const candidates = await this.findCandidates(taskKind);
     const inspectedCount = candidates.length;
 
@@ -310,12 +311,36 @@ export class InternalizationOrchestrator {
       return null;
     }
 
-    // Guard against non-PI task kinds (would cause getAllowedSuccessors to return undefined)
-    if (!isPeerRunnerKind(piTask.taskKind)) {
+    if (piTask.status !== 'succeeded') {
       return null;
     }
 
-    if (piTask.status !== 'succeeded') {
+    // Diagnostician chain: use getDiagSuccessors instead of peer runner job graph
+    if (isDiagnosticianStageKind(piTask.taskKind)) {
+      const diagSuccessors = getDiagSuccessors(piTask.taskKind);
+      if (diagSuccessors.length === 0) {
+        // diag_router is terminal — no successor
+        return null;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const nextKind = diagSuccessors[0]!;
+      return {
+        decision: 'proposal_created',
+        taskId: piTask.taskId,
+        taskKind: piTask.taskKind,
+        proposal: {
+          taskKind: nextKind,
+          parentTaskId: piTask.taskId,
+          dependencyTaskIds: [piTask.taskId],
+          inputArtifactRefs: [...piTask.outputArtifactRefs],
+          channel: piTask.channel,
+          correlationId: piTask.correlationId,
+        },
+      };
+    }
+
+    // Guard against non-PI task kinds (would cause getAllowedSuccessors to return undefined)
+    if (!isPeerRunnerKind(piTask.taskKind)) {
       return null;
     }
 
@@ -438,7 +463,7 @@ export class InternalizationOrchestrator {
    */
   private async findExistingSuccessor(
     parentTaskId: string,
-    successorKind: PeerRunnerKind,
+    successorKind: RunnerKind,
     channel: string,
   ): Promise<TaskRecord | null> {
     const pendingTasks = await this.stateManager.listTasks({ status: 'pending' });
@@ -459,8 +484,8 @@ export class InternalizationOrchestrator {
    * Find candidate PI tasks by querying pending and retry_wait statuses.
    * Filters to only PeerRunnerKind taskKinds and hydrates to PITaskRecord.
    */
-  private async findCandidates(taskKind?: PeerRunnerKind): Promise<TaskRecord[]> {
-    if (taskKind && !isPeerRunnerKind(taskKind)) {
+  private async findCandidates(taskKind?: RunnerKind): Promise<TaskRecord[]> {
+    if (taskKind && !isRunnerKind(taskKind)) {
       throw new PDRuntimeError('input_invalid', `findCandidates: invalid taskKind filter: ${taskKind}`);
     }
 
@@ -474,13 +499,13 @@ export class InternalizationOrchestrator {
       throw new PDRuntimeError('runtime_unavailable', 'findCandidates failed', { cause: error });
     }
 
-    let peerTasks = allCandidates.filter(t => isPeerRunnerKind(t.taskKind));
+    let runnerTasks = allCandidates.filter(t => isRunnerKind(t.taskKind));
 
     if (taskKind) {
-      peerTasks = peerTasks.filter(t => t.taskKind === taskKind);
+      runnerTasks = runnerTasks.filter(t => t.taskKind === taskKind);
     }
 
-    return peerTasks;
+    return runnerTasks;
   }
 
   /**

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -261,13 +261,15 @@ export function decideArtifactRejectionFeedback(
   task: PITaskRecord,
 ): RejectionFeedbackResult {
   // Only peer runner tasks have artifact rejection feedback.
-  // Diagnostician stage tasks should not reach this path.
+  // Diagnostician stage tasks should not reach this path — if they do,
+  // escalate with an explicit reason rather than fabricating a PeerRunnerKind.
   if (!isPeerRunnerKind(task.taskKind)) {
     return {
       action: 'escalate',
       rejectedArtifactId: artifact.artifactId,
       sourceTaskId: artifact.sourceTaskId,
-      sourceTaskKind: 'dreamer', // fallback — diagnostician tasks should not reach here
+      sourceTaskKind: 'dreamer', // sentinel — diagnostician tasks must not reach here; caller must guard
+      rejectionReason: `unexpected_diagnostician_taskKind:${task.taskKind}`,
     };
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-state-machine.ts
@@ -20,11 +20,13 @@ import type { PDTaskStatus, TaskRecord } from '../task-status.js';
 import type {
   PITaskRecord,
   PeerRunnerKind,
+  RunnerKind,
   InternalizationChannel,
   PIArtifact,
   ArtifactRef,
 } from './peer-runner-contracts.js';
-import { getAllowedSuccessors, isAcyclic, validateEdge } from './internalization-job-graph.js';
+import { isPeerRunnerKind, isDiagnosticianStageKind } from './peer-runner-contracts.js';
+import { getAllowedSuccessors, isAcyclic, validateEdge, validateDiagEdge } from './internalization-job-graph.js';
 
 import {
   canAcquireLease,
@@ -100,7 +102,7 @@ export type RejectionFeedbackResult =
 // ── Next Task Proposal Types ─────────────────────────────────────────────────
 
 export interface NextTaskProposal {
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   parentTaskId: string;
   dependencyTaskIds: string[];
   inputArtifactRefs: ArtifactRef[];
@@ -258,6 +260,17 @@ export function decideArtifactRejectionFeedback(
   artifact: PIArtifact,
   task: PITaskRecord,
 ): RejectionFeedbackResult {
+  // Only peer runner tasks have artifact rejection feedback.
+  // Diagnostician stage tasks should not reach this path.
+  if (!isPeerRunnerKind(task.taskKind)) {
+    return {
+      action: 'escalate',
+      rejectedArtifactId: artifact.artifactId,
+      sourceTaskId: artifact.sourceTaskId,
+      sourceTaskKind: 'dreamer', // fallback — diagnostician tasks should not reach here
+    };
+  }
+
   const base = {
     rejectedArtifactId: artifact.artifactId,
     sourceTaskId: artifact.sourceTaskId,
@@ -328,12 +341,20 @@ export function createNextTaskProposal(
     return null;
   }
 
+  // Diagnostician chain tasks are handled by the orchestrator via getDiagSuccessors,
+  // not by this function which uses the peer runner job graph.
+  if (!isPeerRunnerKind(currentTask.taskKind)) {
+    return null;
+  }
+
+  // After the guard, currentTask.taskKind is narrowed to PeerRunnerKind
+  const { taskKind } = currentTask;
   const effectiveChannel = channel ?? currentTask.channel;
-  const successors = getAllowedSuccessors(currentTask.taskKind);
+  const successors = getAllowedSuccessors(taskKind);
 
   // Filter to only channel-valid successors (M1: prevent invalid trainer proposal)
   const validSuccessors = successors.filter(s =>
-    validateEdge(currentTask.taskKind, s, effectiveChannel),
+    validateEdge(taskKind, s, effectiveChannel),
   );
 
   if (validSuccessors.length === 0) {
@@ -403,7 +424,16 @@ export function validateInternalizationGraph(tasks: PITaskRecord[]): GraphValida
       }
 
       // Use the current task's channel for edge validation
-      const edgeValid = validateEdge(dep.taskKind, task.taskKind, task.channel);
+      // Peer runner edges use validateEdge; diagnostician edges use validateDiagEdge
+      let edgeValid: boolean;
+      if (isDiagnosticianStageKind(dep.taskKind) && isDiagnosticianStageKind(task.taskKind)) {
+        edgeValid = validateDiagEdge(dep.taskKind, task.taskKind);
+      } else if (isPeerRunnerKind(dep.taskKind) && isPeerRunnerKind(task.taskKind)) {
+        edgeValid = validateEdge(dep.taskKind, task.taskKind, task.channel);
+      } else {
+        // Cross-pipeline edge — not allowed
+        edgeValid = false;
+      }
       if (!edgeValid) {
         errors.push({
           type: 'disallowed_edge',

--- a/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
@@ -121,7 +121,7 @@ export interface PIArtifact {
  * Internalization task record that extends TaskRecord with internalization metadata.
  *
  * Critical rules:
- *   - taskKind MUST be one of the 7 PeerRunnerKind values
+ *   - taskKind MUST be a valid RunnerKind (PeerRunnerKind or DiagnosticianStageKind)
  *   - status uses PDTaskStatus (pending | leased | succeeded | retry_wait | failed)
  *   - running is NOT a PDTaskStatus — it belongs to RunExecutionStatus
  *   - Terminal task states: succeeded and failed only
@@ -237,7 +237,7 @@ export function isTerminalTaskStatus(status: string): boolean {
  *
  * Checks that a TaskRecord has all required internalization fields.
  * This is a structural check — the record must have:
- *   - taskKind in the set of 7 peer runner kinds
+ *   - taskKind in the set of valid RunnerKind values (PeerRunnerKind or DiagnosticianStageKind)
  *   - dependencyTaskIds as array
  *   - channel as string (valid InternalizationChannel)
  *   - timeoutMs as number

--- a/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/peer-runner-contracts.ts
@@ -45,6 +45,24 @@ export type PeerRunnerKind =
   | 'trainer'
   | 'rollout_reviewer';
 
+/**
+ * The 3 diagnostician stage kinds for the split pipeline.
+ * These are NOT PeerRunnerKinds — they belong to a separate execution pipeline.
+ *
+ * @see 02-review-response-and-amendments.md §2.3
+ */
+export type DiagnosticianStageKind =
+  | 'diag_rootcause'
+  | 'diag_distiller'
+  | 'diag_router';
+
+/**
+ * Broad execution-kind union — used by orchestrator for task dispatch.
+ * Preserves the "7 peer runners" invariant: PeerRunnerKind and
+ * DiagnosticianStageKind are disjoint sets.
+ */
+export type RunnerKind = PeerRunnerKind | DiagnosticianStageKind;
+
 // ── Artifact Types ────────────────────────────────────────────────────────────
 
 /**
@@ -113,7 +131,7 @@ export interface PIArtifact {
  * @see ADR-0003 Section 3.4
  */
 export interface PITaskRecord extends TaskRecord {
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   parentTaskId?: string;
   dependencyTaskIds: string[];
   channel: InternalizationChannel;
@@ -137,6 +155,15 @@ export const PEER_RUNNER_KINDS: readonly PeerRunnerKind[] = [
   'evaluator',
   'trainer',
   'rollout_reviewer',
+] as const;
+
+/**
+ * All valid diagnostician stage kinds.
+ */
+export const DIAGNOSTICIAN_STAGE_KINDS: readonly DiagnosticianStageKind[] = [
+  'diag_rootcause',
+  'diag_distiller',
+  'diag_router',
 ] as const;
 
 /**
@@ -166,6 +193,20 @@ export const PI_ARTIFACT_KINDS: readonly PIArtifactKind[] = [
  */
 export function isPeerRunnerKind(value: string): value is PeerRunnerKind {
   return PEER_RUNNER_KINDS.includes(value as PeerRunnerKind);
+}
+
+/**
+ * Type guard for DiagnosticianStageKind.
+ */
+export function isDiagnosticianStageKind(value: string): value is DiagnosticianStageKind {
+  return DIAGNOSTICIAN_STAGE_KINDS.includes(value as DiagnosticianStageKind);
+}
+
+/**
+ * Type guard for RunnerKind (either PeerRunnerKind or DiagnosticianStageKind).
+ */
+export function isRunnerKind(value: string): value is RunnerKind {
+  return isPeerRunnerKind(value) || isDiagnosticianStageKind(value);
 }
 
 /**
@@ -205,8 +246,8 @@ export function isTerminalTaskStatus(status: string): boolean {
  *   - rejectionCount as finite non-negative number (PRI-141)
  */
 export function isValidPITaskRecord(record: TaskRecord): record is PITaskRecord {
-  // Must have a valid peer runner kind
-  if (!isPeerRunnerKind(record.taskKind)) {
+  // Must have a valid runner kind (PeerRunnerKind or DiagnosticianStageKind)
+  if (!isRunnerKind(record.taskKind)) {
     return false;
   }
 
@@ -256,7 +297,7 @@ export function injectRunnerLineageIfAbsent(
  */
 export function createMinimalPITaskRecord(
   taskId: string,
-  taskKind: PeerRunnerKind,
+  taskKind: RunnerKind,
   channel: InternalizationChannel,
 ): PITaskRecord {
   return {

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -31,7 +31,7 @@ import type {
   InternalizationChannel,
   ArtifactRef,
 } from './peer-runner-contracts.js';
-import { isInternalizationChannel, isPeerRunnerKind } from './peer-runner-contracts.js';
+import { isInternalizationChannel, isRunnerKind } from './peer-runner-contracts.js';
 
 /** Namespace key used inside diagnosticJson to isolate PI metadata. */
 export const PI_METADATA_KEY = 'pi_metadata' as const;
@@ -186,8 +186,9 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
  *   - Optional field present but not a non-empty string
  */
 export function hydratePITaskRecord(task: TaskRecord): PITaskRecord | null {
-  // Guard: reject non-peer-runner task kinds — lineage/kind invariant
-  if (!isPeerRunnerKind(task.taskKind)) return null;
+  // Guard: reject non-runner task kinds — lineage/kind invariant
+  // Accept both PeerRunnerKind and DiagnosticianStageKind
+  if (!isRunnerKind(task.taskKind)) return null;
 
   // Read diagnosticJson from the runtime object (not typed on TaskRecord)
   const raw = task as Record<string, unknown>;

--- a/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/pitask-metadata.ts
@@ -173,12 +173,12 @@ export function parsePITaskMetadata(diagnosticJson: string): PITaskMetadata | nu
  * Hydrate a raw TaskRecord (as returned by SqliteTaskStore.getTask or listTasks)
  * into a PITaskRecord by reading and parsing its diagnosticJson.
  *
- * Fail-closed: returns null for any non-peer-runner taskKind (e.g. diagnostician)
+ * Fail-closed: returns null for any non-RunnerKind taskKind
  * even if diagnosticJson contains valid pi_metadata. This prevents the
  * InternalizationOrchestrator from treating a non-PI task as a PITaskRecord.
  *
  * Returns null if:
- *   - taskKind is not a PeerRunnerKind (e.g. diagnostician)
+ *   - taskKind is not a valid RunnerKind (PeerRunnerKind or DiagnosticianStageKind)
  *   - diagnosticJson is missing or whitespace
  *   - diagnosticJson is not valid JSON
  *   - pi_metadata key is missing or invalid

--- a/packages/principles-core/src/runtime-v2/internalization/queue-actionability.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/queue-actionability.ts
@@ -10,7 +10,7 @@
  * files or loads configuration.
  */
 
-import type { PeerRunnerKind, InternalizationChannel } from './peer-runner-contracts.js';
+import type { RunnerKind, PeerRunnerKind, InternalizationChannel } from './peer-runner-contracts.js';
 
 // ── MVP-Core task kinds ──────────────────────────────────────────────────────
 
@@ -31,7 +31,7 @@ export interface ActionabilityPolicyInput {
 
 export interface SuppressedDiagnostic {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   channel: InternalizationChannel;
   reason: 'channel_disabled' | 'task_kind_not_mvp_actionable';
 }
@@ -42,7 +42,7 @@ export type TaskActionabilityResult =
 
 export interface TaskClassificationInput {
   taskId: string;
-  taskKind: PeerRunnerKind;
+  taskKind: RunnerKind;
   channel: InternalizationChannel;
 }
 

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -16,6 +16,8 @@ import { RuntimeStateManager } from './store/runtime-state-manager.js';
 import { DiagnosticianRunner } from './runner/diagnostician-runner.js';
 import { resolveOutputLanguage } from './language-directive.js';
 import type { OutputLanguage } from './language-directive.js';
+import { computeFeatureFlagsFromConfig, isFeatureEnabled } from './config/pd-config-feature-flags.js';
+import { PDRuntimeError } from './error-categories.js';
 import { CandidateIntakeService } from './candidate-intake-service.js';
 import { SqliteDiagnosticianCommitter } from './store/commit/diagnostician-committer.js';
 import { SqliteContextAssembler } from './store/context/sqlite-context-assembler.js';
@@ -421,6 +423,21 @@ export async function createPainSignalBridge(
         fallbackValue: resolvedLang.outputLanguage,
       },
     });
+  }
+
+  // PRI-370 (INF-6): Gate on diagnostician_split_pipeline flag
+  // When flag is on, split pipeline runners should be used (T-G implements).
+  // When flag is off (default), fall back to monolith DiagnosticianRunner.
+  if (opts.effectiveConfig) {
+    const featureFlags = computeFeatureFlagsFromConfig(opts.effectiveConfig);
+    if (isFeatureEnabled(featureFlags, 'diagnostician_split_pipeline')) {
+      // Split pipeline is enabled — but T-G hasn't implemented the runners yet.
+      // This is the seam: throw not_implemented until T-G fills in the runners.
+      throw new PDRuntimeError(
+        'capability_missing',
+        'diagnostician_split_pipeline is enabled but split runners are not yet implemented (T-G)',
+      );
+    }
   }
 
   const runner = new DiagnosticianRunner(


### PR DESCRIPTION
## Summary

Implements T-F (PRI-370): Pre-P3 orchestration infrastructure — RunnerKind seam.

Introduces the DiagnosticianStageKind type and RunnerKind union as a separate execution-kind seam for the diagnostician split pipeline, without overloading PeerRunnerKind (preserving the 7 peer runner invariant).

## Changes (INF-0..INF-8)

### INF-0: ADR-0014 Amendment
- Added ADR-0014 Amendment to DOMAIN_MODEL.md (2 locations) clarifying that the 7 Peer Runner invariant refers to the Internalization Pipeline only

### INF-1: DiagnosticianStageKind + RunnerKind
- Defined DiagnosticianStageKind (\diag_rootcause\ | \diag_distiller\ | \diag_router\)
- Defined RunnerKind = PeerRunnerKind | DiagnosticianStageKind union
- Added DIAGNOSTICIAN_STAGE_KINDS, \isDiagnosticianStageKind()\, \isRunnerKind()\ type guards

### INF-2: DIAGNOSTICIAN_EDGES + validateDiagEdge
- Defined DIAGNOSTICIAN_EDGES (rootcause→distiller, distiller→router)
- Added alidateDiagEdge(), \getDiagSuccessors()\ functions

### INF-3: hydratePITaskRecord accepts RunnerKind
- Widened PITaskRecord.taskKind from PeerRunnerKind to RunnerKind`n- Updated hydratePITaskRecord(), \isValidPITaskRecord()\, \createMinimalPITaskRecord()\ to accept RunnerKind`n
### INF-4: Successor proposal for diagnostician chain
- Added diagnostician chain successor proposal in proposeNextTask() using getDiagSuccessors()`n- Guarded createNextTaskProposal() for PeerRunnerKind only
- Updated alidateInternalizationGraph() to validate diag edges separately

### INF-5: wakeOnce discovers diagnostician pending tasks
- Widened indCandidates() and \wakeOnce()\ to accept RunnerKind`n- Changed filter from isPeerRunnerKind to \isRunnerKind()\`n
### INF-6: Runtime dispatcher routing
- Added diagnostician_split_pipeline flag gate in pain-signal-runtime-factory.ts`n- When flag on: throws capability_missing (T-G fills runners)
- When flag off: falls back to monolith DiagnosticianRunner`n
### INF-7: Feature flags registered
- Already done — 3 diagnostician flags confirmed in DEFAULT_FEATURE_FLAGS`n
### INF-8: Metadata envelope
- Verified PITaskMetadata does not contain 	askKind; serialization works unchanged

## Breaking type change

PITaskRecord.taskKind: PeerRunnerKind → RunnerKind affects all consumers:
- Orchestrator result types (BlockedResult, DependencyFailedResult, etc.)
- Queue read model sample types
- Queue actionability types
- OpenClaw plugin trigger adapter
- Internalization state machine

## Tests

28 new tests in \unnerkind-seam.test.ts\ — one per INF item.

## Acceptance criteria

- [x] INF-0: DOMAIN_MODEL.md updated with ADR-0014 Amendment
- [x] \isDiagnosticianStageKind('diag_rootcause') === true\`n- [x] \isPeerRunnerKind('diag_rootcause') === false\`n- [x] 7 peer runners invariant preserved
- [x] \hydratePITaskRecord\ succeeds on diag_rootcause task
- [x] All INF-1..INF-8 tests green
- [x] \
pm run build && npm run test\ pass

## EP checklist

- EP-01: Type guards are runtime trust boundaries ✅
- EP-07: Lineage envelope validated for DiagnosticianStageKind ✅
- EP-09: Per-item tests exist ✅