### PR TITLE
feat(diagnostician): core grounding on single agent (T-E PRI-371)

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -851,7 +851,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **How to prevent**: When creating a new BasePeerRunner subclass, the PR checklist must include: (1) list all events the runner can emit, (2) verify each is in TelemetryEventType, (3) add a test proving the schema accepts each event. Review trigger: any PR that adds a new runner or new emitEvent() call must also update telemetry-event.ts.
 - **Source**: PR #808/#809/#810
 - **Date**: 2026-06-03
-- **Recurrence**: None
+- **Recurrence**: Yes - 2026-06-11 PR #902 (PRI-371): `diagnostician_core_grounding_result` telemetry event emitted by DiagnosticianRunner.succeedTask() but not registered in TelemetryEventType union in telemetry-event.ts. Event would be silently dropped and replaced with `degradation_triggered` fallback by StoreEventEmitter. Same class as original: new event literal added to runner but telemetry schema not updated.
 
 ---
 

--- a/packages/principles-core/src/runtime-v2/__tests__/diagnostician-core-grounding.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/diagnostician-core-grounding.test.ts
@@ -87,7 +87,7 @@ describe('Core grounding on single agent (T-E)', () => {
     const validatedIds = ids.filter(id => isCorePrincipleId(id));
     const uniqueIds = new Set(validatedIds);
     expect(uniqueIds.size).toBe(3); // T-01, T-03, T-07 (T-99 is not a valid core principle id)
-    expect((uniqueIds.size / 10) * 100).toBe(30);
+    expect((uniqueIds.size / CORE_PRINCIPLES.length) * 100).toBe(30);
   });
 
   // 7. Downstream contract unchanged

--- a/packages/principles-core/src/runtime-v2/__tests__/diagnostician-core-grounding.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/diagnostician-core-grounding.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Core grounding on single agent (T-E / PRI-371) — TDD tests.
+ *
+ * When `diagnostician_core_grounding` flag is on, CORE_PRINCIPLES (T-01..T-10)
+ * are injected into DiagnosticianPromptBuilder's prompt as PHASE 3.5.
+ * Flag off: output must be byte-identical to current behavior.
+ *
+ * EP-01: axiom IDs in ambiguityNotes are untrusted LLM output — validated via
+ *        regex + isCorePrincipleId().
+ * EP-03: flag off = no change, no silent fallback.
+ */
+import { describe, it, expect } from 'vitest';
+import { DiagnosticianPromptBuilder, buildDiagnosticProtocolInstruction } from '../diagnostician-prompt-builder.js';
+import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
+import { CORE_PRINCIPLES, isCorePrincipleId } from '../core-principles/core-principle-registry.js';
+import type { DiagnosticianContextPayload } from '../context-payload.js';
+
+// ── Test fixtures ──────────────────────────────────────────────────────────
+
+const makeTestPayload = (): DiagnosticianContextPayload => ({
+  contextId: 'ctx-test',
+  contextHash: 'hash-test',
+  taskId: 'task-test',
+  workspaceDir: 'D:/work',
+  sourceRefs: ['ref-1'],
+  diagnosisTarget: {
+    painId: 'pain-1',
+    reasonSummary: 'Agent failed to use tool',
+  },
+  conversationWindow: [
+    { ts: '2026-04-24T10:00:00Z', role: 'user', text: 'Hello', toolName: undefined, toolResultSummary: undefined, eventType: undefined },
+  ],
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Core grounding on single agent (T-E)', () => {
+  // 1. Flag off: byte-identical
+  it('buildPrompt with coreGrounding=false produces identical output to no flag', () => {
+    const builder = new DiagnosticianPromptBuilder();
+    const payload = makeTestPayload();
+    const without = builder.buildPrompt(payload);
+    const withFlag = builder.buildPrompt(payload, { coreGrounding: false });
+    expect(withFlag.message).toBe(without.message);
+  });
+
+  // 2. Flag on: PHASE 3.5 present in prompt
+  it('buildPrompt with coreGrounding=true includes PHASE 3.5 in diagnosticInstruction', () => {
+    const builder = new DiagnosticianPromptBuilder();
+    const payload = makeTestPayload();
+    const result = builder.buildPrompt(payload, { coreGrounding: true });
+    expect(result.promptInput.diagnosticInstruction).toContain('PHASE 3.5');
+    expect(result.promptInput.diagnosticInstruction).toContain('Core Axiom Grounding');
+  });
+
+  // 3. Flag on: all 10 core principles present
+  it('grounded prompt contains all 10 core principle statements', () => {
+    const builder = new DiagnosticianPromptBuilder();
+    const payload = makeTestPayload();
+    const result = builder.buildPrompt(payload, { coreGrounding: true });
+    for (const p of CORE_PRINCIPLES) {
+      expect(result.promptInput.diagnosticInstruction).toContain(p.id);
+      expect(result.promptInput.diagnosticInstruction).toContain(p.statement);
+    }
+  });
+
+  // 4. Flag on: ambiguityNotes instruction present
+  it('grounded prompt instructs LLM to note axiom IDs in ambiguityNotes', () => {
+    const builder = new DiagnosticianPromptBuilder();
+    const payload = makeTestPayload();
+    const result = builder.buildPrompt(payload, { coreGrounding: true });
+    expect(result.promptInput.diagnosticInstruction).toContain('ambiguityNotes');
+  });
+
+  // 5. Flag off: no PHASE 3.5
+  it('buildPrompt with coreGrounding=false does NOT include PHASE 3.5', () => {
+    const builder = new DiagnosticianPromptBuilder();
+    const payload = makeTestPayload();
+    const result = builder.buildPrompt(payload, { coreGrounding: false });
+    expect(result.promptInput.diagnosticInstruction).not.toContain('PHASE 3.5');
+  });
+
+  // 6. Telemetry: linkage metric calculation (EP-01: validate with isCorePrincipleId)
+  it('linkage metric correctly counts validated T-XX patterns in ambiguityNotes', () => {
+    const notes = ['Related to T-01 and T-03', 'Also T-07', 'Invalid T-99'];
+    const ids = notes.join(' ').match(/T-\d{2}/g) ?? [];
+    const validatedIds = ids.filter(id => isCorePrincipleId(id));
+    const uniqueIds = new Set(validatedIds);
+    expect(uniqueIds.size).toBe(3); // T-01, T-03, T-07 (T-99 is not a valid core principle id)
+    expect((uniqueIds.size / 10) * 100).toBe(30);
+  });
+
+  // 7. Downstream contract unchanged
+  it('DiagnosticianOutputV1Schema is NOT modified — ambiguityNotes field still exists', () => {
+    expect(DiagnosticianOutputV1Schema.properties.ambiguityNotes).toBeDefined();
+  });
+
+  // 8. buildDiagnosticProtocolInstruction also accepts coreGrounding
+  it('buildDiagnosticProtocolInstruction with coreGrounding=true includes PHASE 3.5', () => {
+    const instruction = buildDiagnosticProtocolInstruction({ coreGrounding: true });
+    expect(instruction).toContain('PHASE 3.5');
+    expect(instruction).toContain('Core Axiom Grounding');
+  });
+
+  // 9. buildDiagnosticProtocolInstruction with coreGrounding=false is identical to no flag
+  it('buildDiagnosticProtocolInstruction with coreGrounding=false produces identical output to no flag', () => {
+    const without = buildDiagnosticProtocolInstruction();
+    const withFlag = buildDiagnosticProtocolInstruction({ coreGrounding: false });
+    expect(withFlag).toBe(without);
+  });
+
+  // 10. PHASE 3.5 appears between PHASE 3 and PHASE 4
+  it('PHASE 3.5 appears between PHASE 3 and PHASE 4 in grounded prompt', () => {
+    const builder = new DiagnosticianPromptBuilder();
+    const payload = makeTestPayload();
+    const result = builder.buildPrompt(payload, { coreGrounding: true });
+    const instruction = result.promptInput.diagnosticInstruction;
+    const phase3Index = instruction.indexOf('PHASE 3 —');
+    const phase35Index = instruction.indexOf('PHASE 3.5 —');
+    const phase4Index = instruction.indexOf('PHASE 4 —');
+    expect(phase3Index).toBeGreaterThan(-1);
+    expect(phase35Index).toBeGreaterThan(-1);
+    expect(phase4Index).toBeGreaterThan(-1);
+    expect(phase35Index).toBeGreaterThan(phase3Index);
+    expect(phase4Index).toBeGreaterThan(phase35Index);
+  });
+
+  // 11. EP-01: T-99 (invalid) is filtered by isCorePrincipleId
+  it('isCorePrincipleId rejects invalid axiom IDs (EP-01 trust boundary)', () => {
+    expect(isCorePrincipleId('T-01')).toBe(true);
+    expect(isCorePrincipleId('T-10')).toBe(true);
+    expect(isCorePrincipleId('T-99')).toBe(false);
+    expect(isCorePrincipleId('T-00')).toBe(false);
+    expect(isCorePrincipleId('')).toBe(false);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
@@ -32,6 +32,7 @@ export const DEFAULT_FEATURE_FLAGS: Record<string, FeatureFlagEntry> = {
   evolution_worker:   { category: 'quiet', enabled: false },
   empathy_observer:   { category: 'quiet', enabled: false },
   painEvidenceAdmission:{ category: 'quiet', enabled: false },
+  diagnostician_core_grounding: { category: 'quiet', enabled: false },
 
   // MVP-Gone (ADR-0014 §2.6)
   nocturnal:          { category: 'gone',  enabled: false },

--- a/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
@@ -38,6 +38,17 @@ import { DefaultSchemaPromptAdapter } from './adapter/schema-prompt-adapter.js';
 import { DiagnosticianOutputV1Schema } from './diagnostician-output.js';
 import type { OutputLanguage } from './language-directive.js';
 import { buildLanguageDirective } from './language-directive.js';
+import { CORE_PRINCIPLES } from './core-principles/core-principle-registry.js';
+
+/** Options for DiagnosticianPromptBuilder.buildPrompt() beyond the required payload. */
+export interface BuildPromptOptions {
+  /** Size limits to prevent token overflow (default: DEFAULT_PROMPT_BUILDER_LIMITS) */
+  limits?: PromptBuilderLimits;
+  /** Output language directive (default: none) */
+  outputLanguage?: OutputLanguage;
+  /** T-E (PRI-371): Inject core axiom grounding as PHASE 3.5 (default: false) */
+  coreGrounding?: boolean;
+}
 
 /**
  * PromptInput — the JSON message sent to openclaw agent via --message flag.
@@ -106,6 +117,21 @@ export interface PromptBuildResult {
 }
 
 /**
+ * Options for buildDiagnosticProtocolInstruction.
+ * Uses an options object to stay within max-params limit.
+ */
+export interface DiagnosticProtocolInstructionOptions {
+  /** Schema prompt adapter (default: DefaultSchemaPromptAdapter) */
+  adapter?: SchemaPromptAdapter;
+  /** TypeBox schema for output validation (default: DiagnosticianOutputV1Schema) */
+  schema?: TSchema;
+  /** Output language directive (default: none) */
+  outputLanguage?: OutputLanguage;
+  /** T-E (PRI-371): Inject core axiom grounding as PHASE 3.5 (default: false) */
+  coreGrounding?: boolean;
+}
+
+/**
  * 5-phase diagnostic protocol instruction for the LLM.
  *
  * Per DPB-02 (LOCKED): Output is ONLY JSON — no markdown, no file ops, no tool calls.
@@ -117,13 +143,31 @@ export interface PromptBuildResult {
  * regardless of whether OpenClaw loads SKILL.md as the agent system prompt.
  */
 export function buildDiagnosticProtocolInstruction(
-  adapter: SchemaPromptAdapter = new DefaultSchemaPromptAdapter(),
-  schema: TSchema = DiagnosticianOutputV1Schema,
-  outputLanguage?: OutputLanguage,
+  opts: DiagnosticProtocolInstructionOptions = {},
 ): string {
+  const adapter = opts.adapter ?? new DefaultSchemaPromptAdapter();
+  const schema = opts.schema ?? DiagnosticianOutputV1Schema;
+  const { outputLanguage, coreGrounding } = opts;
+
   const example = adapter.generateExample(schema);
   const constraints = adapter.generateConstraints(schema);
   const languageDirective = buildLanguageDirective(outputLanguage);
+
+  // T-E (PRI-371): When coreGrounding is true, insert PHASE 3.5 between
+  // PHASE 3 and PHASE 4. When false or undefined, output is byte-identical
+  // to the original (EP-03: no silent fallback).
+  const phase35Block = coreGrounding
+    ? `
+PHASE 3.5 — Core Axiom Grounding:
+The following core axioms are the system's foundational behavioral principles.
+If the root cause relates to any of these axioms, note the axiom ID (e.g. T-01)
+in the ambiguityNotes field of your output.
+
+Core Axioms:
+${CORE_PRINCIPLES.map(p => `${p.id}: ${p.statement}`).join('\n')}
+
+`
+    : '\n';
 
   return `You are a root cause analysis expert. Follow this protocol:
 
@@ -150,8 +194,7 @@ Classify into ONE: People | Design | Assumption | Tooling
 - Design: architecture defects, missing gates, process gaps
 - Assumption: wrong assumptions about env/versions/deps
 - Tooling: tool misconfiguration, API changes
-
-PHASE 4 — Recommendation Taxonomy & Distillation:
+${phase35Block}PHASE 4 — Recommendation Taxonomy & Distillation:
 Analyze the root cause and propose actionable recommendations. Classify each recommendation into one of FIVE categories based on the taxonomy below.
 
 TAXONOMY DEFINITIONS:
@@ -213,7 +256,7 @@ export class DiagnosticianPromptBuilder {
    * then serialize to JSON for the --message argument.
    *
    * @param payload — DiagnosticianContextPayload from context assembly (DPB-01)
-   * @param limits — Size limits to prevent token overflow (default: DEFAULT_PROMPT_BUILDER_LIMITS)
+   * @param opts — Build options (limits, outputLanguage, coreGrounding)
    * @returns PromptBuildResult with JSON string + PromptInput object (DPB-02, DPB-03, DPB-04, DPB-06)
    *
    * Per DPB-05: This method only builds the prompt; it does NOT commit to PD database.
@@ -223,9 +266,11 @@ export class DiagnosticianPromptBuilder {
    */
   buildPrompt(
     payload: DiagnosticianContextPayload,
-    limits: PromptBuilderLimits = DEFAULT_PROMPT_BUILDER_LIMITS,
-    outputLanguage?: OutputLanguage,
+    opts: BuildPromptOptions = {},
   ): PromptBuildResult {
+    const limits = opts.limits ?? DEFAULT_PROMPT_BUILDER_LIMITS;
+    const { outputLanguage, coreGrounding } = opts;
+
     const truncationWarnings: string[] = [];
 
     // DPB-04: Apply truncation to conversationWindow to prevent token overflow
@@ -255,7 +300,12 @@ export class DiagnosticianPromptBuilder {
       conversationWindow,
     };
 
-    const diagnosticInstruction = buildDiagnosticProtocolInstruction(this.adapter, this.schema, outputLanguage);
+    const diagnosticInstruction = buildDiagnosticProtocolInstruction({
+      adapter: this.adapter,
+      schema: this.schema,
+      outputLanguage,
+      coreGrounding,
+    });
 
     // DPB-04: Explicit top-level fields at the prompt level
     const promptInput: PromptInput = {

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-builder.test.ts
@@ -303,7 +303,7 @@ describe('DiagnosticianPromptBuilder', () => {
 
   describe('prompt contract hardening (PRI-109)', () => {
     const adapter = new DefaultSchemaPromptAdapter();
-    const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+    const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
 
     it('instruction contains CRITICAL JSON-only emphasis', () => {
       expect(instruction).toContain('CRITICAL');
@@ -383,45 +383,45 @@ describe('DiagnosticianPromptBuilder', () => {
     const adapter = new DefaultSchemaPromptAdapter();
 
     it('buildDiagnosticProtocolInstruction matches snapshot', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).toMatchSnapshot();
     });
 
     it('contains 5-phase protocol keywords', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).toContain('PHASE 1');
       expect(instruction).toContain('5 Whys');
       expect(instruction).toContain('Root Cause Classification');
     });
 
     it('contains taxonomy definitions', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).toContain('TAXONOMY DEFINITIONS');
       expect(instruction).toContain('"rule"');
       expect(instruction).toContain('"principle"');
     });
 
     it('contains schema-derived JSON example', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).toContain('COMPLETE EXAMPLE OUTPUT');
       const parsed = extractJsonObject(instruction);
       expect(parsed).not.toBeNull();
     });
 
     it('example passes Value.Check', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       const parsed = extractJsonObject(instruction);
       expect(Value.Check(DiagnosticianOutputV1Schema, parsed)).toBe(true);
     });
 
     it('contains schema-derived constraints', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).toContain('CONSTRAINTS');
       expect(instruction).toContain('category prefix');
     });
 
     it('contains CRITICAL JSON-only emphasis', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).toContain('CRITICAL');
       expect(instruction).toContain('ONLY the JSON object');
     });
@@ -472,7 +472,7 @@ describe('DiagnosticianPromptBuilder', () => {
     const adapter = new DefaultSchemaPromptAdapter();
 
     it('buildDiagnosticProtocolInstruction() does NOT reference eventSummaries', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
       expect(instruction).not.toContain('eventSummaries');
     });
 
@@ -501,7 +501,7 @@ describe('DiagnosticianPromptBuilder', () => {
 
     // 用例 1: prompt must contain explicit empty-evidence → confidence<0.3 + defer instruction
     it('contains empty evidence degradation instruction with confidence<0.3 and defer', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
 
       // Must reference diagnosisTarget.evidence emptiness
       expect(instruction).toContain('diagnosisTarget.evidence');
@@ -516,7 +516,7 @@ describe('DiagnosticianPromptBuilder', () => {
 
     // 用例 1b: must explicitly prohibit fabricating evidence
     it('prohibits fabricating evidence when input evidence is empty', () => {
-      const instruction = buildDiagnosticProtocolInstruction(adapter, DiagnosticianOutputV1Schema);
+      const instruction = buildDiagnosticProtocolInstruction({ adapter, schema: DiagnosticianOutputV1Schema });
 
       expect(instruction).toMatch(/MUST NOT.*fabricat|fabricat.*MUST NOT/i);
     });
@@ -536,7 +536,7 @@ describe('DiagnosticianPromptBuilder', () => {
         })),
       };
       const limits = { maxConversationEntries: 100, maxEntryTextChars: 2000, maxMessageChars: 500 };
-      const result = builder.buildPrompt(hugePayload, limits);
+      const result = builder.buildPrompt(hugePayload, { limits });
 
       // Truncation should have occurred
       expect(result.promptInput.truncationWarnings).toBeDefined();

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-language.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diagnostician-prompt-language.test.ts
@@ -39,7 +39,7 @@ const MINIMAL_PAYLOAD: DiagnosticianContextPayload = {
 describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
   it('includes Chinese language directive when outputLanguage is zh-CN', () => {
     const builder = new DiagnosticianPromptBuilder();
-    const result = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, 'zh-CN');
+    const result = builder.buildPrompt(MINIMAL_PAYLOAD, { outputLanguage: 'zh-CN' });
     const parsed = parsePromptJson(result.message);
 
     expect(parsed.diagnosticInstruction).toContain('Simplified Chinese');
@@ -49,7 +49,7 @@ describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
 
   it('includes English language directive when outputLanguage is en', () => {
     const builder = new DiagnosticianPromptBuilder();
-    const result = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, 'en');
+    const result = builder.buildPrompt(MINIMAL_PAYLOAD, { outputLanguage: 'en' });
     const parsed = parsePromptJson(result.message);
 
     expect(parsed.diagnosticInstruction).toContain('English');
@@ -58,7 +58,7 @@ describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
 
   it('does NOT include language directive when outputLanguage is undefined', () => {
     const builder = new DiagnosticianPromptBuilder();
-    const result = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, undefined);
+    const result = builder.buildPrompt(MINIMAL_PAYLOAD);
     const parsed = parsePromptJson(result.message);
 
     expect(parsed.diagnosticInstruction).not.toContain('LANGUAGE DIRECTIVE');
@@ -67,7 +67,7 @@ describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
 
   it('includes technical identifiers not translated instruction', () => {
     const builder = new DiagnosticianPromptBuilder();
-    const result = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, 'zh-CN');
+    const result = builder.buildPrompt(MINIMAL_PAYLOAD, { outputLanguage: 'zh-CN' });
     const parsed = parsePromptJson(result.message);
 
     expect(parsed.diagnosticInstruction).toContain('taskId');
@@ -77,7 +77,7 @@ describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
 
   it('includes lineage fields not translated instruction', () => {
     const builder = new DiagnosticianPromptBuilder();
-    const result = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, 'en');
+    const result = builder.buildPrompt(MINIMAL_PAYLOAD, { outputLanguage: 'en' });
     const parsed = parsePromptJson(result.message);
 
     expect(parsed.diagnosticInstruction).toContain('Lineage and evidence fields MUST NOT be translated');
@@ -85,8 +85,8 @@ describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
 
   it('preserves all other prompt fields when outputLanguage is provided', () => {
     const builder = new DiagnosticianPromptBuilder();
-    const resultWithout = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, undefined);
-    const resultWith = builder.buildPrompt(MINIMAL_PAYLOAD, undefined, 'zh-CN');
+    const resultWithout = builder.buildPrompt(MINIMAL_PAYLOAD);
+    const resultWith = builder.buildPrompt(MINIMAL_PAYLOAD, { outputLanguage: 'zh-CN' });
 
     const parsedWithout = parsePromptJson(resultWithout.message);
     const parsedWith = parsePromptJson(resultWith.message);
@@ -103,13 +103,13 @@ describe('DiagnosticianPromptBuilder — outputLanguage (PRI-336)', () => {
 
 describe('buildDiagnosticProtocolInstruction — outputLanguage (PRI-336)', () => {
   it('includes language directive when outputLanguage is provided', () => {
-    const instruction = buildDiagnosticProtocolInstruction(undefined, undefined, 'zh-CN');
+    const instruction = buildDiagnosticProtocolInstruction({ outputLanguage: 'zh-CN' });
     expect(instruction).toContain('LANGUAGE DIRECTIVE');
     expect(instruction).toContain('Simplified Chinese');
   });
 
   it('does not include language directive when outputLanguage is undefined', () => {
-    const instruction = buildDiagnosticProtocolInstruction(undefined, undefined, undefined);
+    const instruction = buildDiagnosticProtocolInstruction();
     expect(instruction).not.toContain('LANGUAGE DIRECTIVE');
   });
 });

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -456,6 +456,7 @@ export async function createPainSignalBridge(
       timeoutMs: runtimeConfig.timeoutMs,
       agentId: runtimeConfig.agentId,
       outputLanguage,
+      effectiveConfig: opts.effectiveConfig,
     },
   );
 

--- a/packages/principles-core/src/runtime-v2/runner/diagnostician-runner-options.ts
+++ b/packages/principles-core/src/runtime-v2/runner/diagnostician-runner-options.ts
@@ -5,6 +5,7 @@
  * Per CONTEXT.md D-04: owner and runtimeKind required for lease acquisition.
  */
 import type { OutputLanguage } from '../language-directive.js';
+import type { EffectivePdConfig } from '../config/pd-config-types.js';
 
 export interface DiagnosticianRunnerOptions {
   /** Polling interval in ms (default: 5000 = 5 seconds). */
@@ -29,6 +30,13 @@ export interface DiagnosticianRunnerOptions {
    * Undefined = no language directive (backward compatible).
    */
   readonly outputLanguage?: OutputLanguage;
+  /**
+   * Effective PD config for feature flag resolution (PRI-371).
+   * When provided, the runner reads `diagnostician_core_grounding` flag
+   * to decide whether to inject core axioms into the prompt.
+   * Undefined = flag off (backward compatible).
+   */
+  readonly effectiveConfig?: EffectivePdConfig;
 }
 
 /** Resolved options with defaults applied. */
@@ -41,6 +49,8 @@ export interface ResolvedDiagnosticianRunnerOptions {
   readonly agentId: string;
   /** Owner's preferred language for principle generation (PRI-336). Undefined = no directive. */
   readonly outputLanguage?: OutputLanguage;
+  /** Effective PD config for feature flag resolution (PRI-371). Undefined = flags off. */
+  readonly effectiveConfig?: EffectivePdConfig;
 }
 
 /** Default option values. */
@@ -61,5 +71,6 @@ export function resolveRunnerOptions(options: DiagnosticianRunnerOptions): Resol
     runtimeKind: options.runtimeKind,
     agentId: options.agentId ?? DEFAULT_RUNNER_OPTIONS.agentId,
     outputLanguage: options.outputLanguage,
+    effectiveConfig: options.effectiveConfig,
   };
 }

--- a/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
@@ -41,6 +41,8 @@ import { safeStringifyPreview } from '../adapter/output-repair-contract.js';
 import { redactSensitiveFields } from '../feedback/redact-sensitive.js';
 import { RunnerPhase } from './runner-phase.js';
 import { resolveRunnerOptions } from './diagnostician-runner-options.js';
+import { computeFeatureFlagsFromConfig, isFeatureEnabled } from '../config/pd-config-feature-flags.js';
+import { isCorePrincipleId } from '../core-principles/core-principle-registry.js';
 
 /** Dependencies injected into DiagnosticianRunner. */
 export interface DiagnosticianRunnerDeps {
@@ -86,6 +88,8 @@ export class DiagnosticianRunner {
   private readonly eventEmitter: StoreEventEmitter;
   private readonly validator: DiagnosticianValidator;
   private readonly committer: DiagnosticianCommitter;
+  /** Whether core grounding was active for the current run (set in invokeRuntime, read in succeedTask). */
+  private coreGroundingActive = false;
 
   constructor(deps: DiagnosticianRunnerDeps, options: DiagnosticianRunnerOptions) {
     this.stateManager = deps.stateManager;
@@ -255,8 +259,17 @@ export class DiagnosticianRunner {
   }
 
   private async invokeRuntime(context: DiagnosticianContextPayload, taskId: string): Promise<RunHandle> {
+    // T-E (PRI-371): Read diagnostician_core_grounding flag from effective config.
+    // EP-03: Flag off (default) = no change to prompt. Flag on = inject PHASE 3.5.
+    let coreGrounding = false;
+    if (this.resolvedOptions.effectiveConfig) {
+      const featureFlags = computeFeatureFlagsFromConfig(this.resolvedOptions.effectiveConfig);
+      coreGrounding = isFeatureEnabled(featureFlags, 'diagnostician_core_grounding');
+    }
+    this.coreGroundingActive = coreGrounding;
+
     const builder = new DiagnosticianPromptBuilder();
-    const { message } = builder.buildPrompt(context, undefined, this.resolvedOptions.outputLanguage);
+    const { message } = builder.buildPrompt(context, { outputLanguage: this.resolvedOptions.outputLanguage, coreGrounding });
 
     const startInput: StartRunInput = {
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
@@ -421,6 +434,24 @@ export class DiagnosticianRunner {
       commitId: commitResult.commitId,
       candidateCount: commitResult.candidateCount,
     });
+
+    // T-E (PRI-371): Emit core grounding telemetry when flag was on.
+    // EP-01: axiom IDs from ambiguityNotes are untrusted LLM output —
+    // validate with regex + isCorePrincipleId() before counting.
+    if (this.coreGroundingActive) {
+      const ambiguityNotes = ctx.output.ambiguityNotes ?? [];
+      const allNotes = ambiguityNotes.join(' ');
+      const axiomIdMatches = allNotes.match(/T-\d{2}/g) ?? [];
+      const validatedIds = axiomIdMatches.filter(id => isCorePrincipleId(id));
+      const uniqueIds = new Set(validatedIds);
+      const linkagePercent = (uniqueIds.size / 10) * 100;
+
+      this.emitDiagnosticianEvent('diagnostician_core_grounding_result', ctx.taskId, {
+        taskId: ctx.taskId,
+        axiomRefCount: uniqueIds.size,
+        linkagePercent,
+      });
+    }
 
     this.phase = RunnerPhase.Completed;
     return {

--- a/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/diagnostician-runner.ts
@@ -42,7 +42,7 @@ import { redactSensitiveFields } from '../feedback/redact-sensitive.js';
 import { RunnerPhase } from './runner-phase.js';
 import { resolveRunnerOptions } from './diagnostician-runner-options.js';
 import { computeFeatureFlagsFromConfig, isFeatureEnabled } from '../config/pd-config-feature-flags.js';
-import { isCorePrincipleId } from '../core-principles/core-principle-registry.js';
+import { CORE_PRINCIPLES, isCorePrincipleId } from '../core-principles/core-principle-registry.js';
 
 /** Dependencies injected into DiagnosticianRunner. */
 export interface DiagnosticianRunnerDeps {
@@ -132,6 +132,7 @@ export class DiagnosticianRunner {
    */
   async run(taskId: string): Promise<RunnerResult> {
     this.phase = RunnerPhase.Idle;
+    this.coreGroundingActive = false;
 
     // 1. Acquire lease — isolated try/catch so lease_conflict never uses synthetic TaskRecord
     let leasedTask: TaskRecord;
@@ -444,7 +445,7 @@ export class DiagnosticianRunner {
       const axiomIdMatches = allNotes.match(/T-\d{2}/g) ?? [];
       const validatedIds = axiomIdMatches.filter(id => isCorePrincipleId(id));
       const uniqueIds = new Set(validatedIds);
-      const linkagePercent = (uniqueIds.size / 10) * 100;
+      const linkagePercent = (uniqueIds.size / CORE_PRINCIPLES.length) * 100;
 
       this.emitDiagnosticianEvent('diagnostician_core_grounding_result', ctx.taskId, {
         taskId: ctx.taskId,

--- a/packages/principles-core/src/telemetry-event.ts
+++ b/packages/principles-core/src/telemetry-event.ts
@@ -89,6 +89,8 @@ export const TelemetryEventType = Type.Union([
   Type.Literal('diagnostician_task_failed'),
   Type.Literal('diagnostician_cancel_run_failed'),
   Type.Literal('diagnostician_mark_succeeded_failed'),
+  // PRI-371: Core grounding telemetry
+  Type.Literal('diagnostician_core_grounding_result'),
   // M5: Artifact commit events
   Type.Literal('diagnostician_artifact_committed'),
   Type.Literal('diagnostician_artifact_commit_failed'),


### PR DESCRIPTION
## Summary

When \diagnostician_core_grounding\ flag is on, inject CORE_PRINCIPLES (T-01..T-10) into DiagnosticianPromptBuilder as PHASE 3.5 between PHASE 3 and PHASE 4. Flag off: byte-identical to current output.

## Changes

- **diagnostician-prompt-builder.ts**: Add \coreGrounding\ option, refactor to opts-object signatures for max-params compliance
- **diagnostician-runner.ts**: Read flag from effectiveConfig, pass to builder, emit \diagnostician_core_grounding_result\ telemetry
- **diagnostician-runner-options.ts**: Add \ffectiveConfig\ field
- **pain-signal-runtime-factory.ts**: Pass effectiveConfig to runner
- **11 new TDD tests** in \diagnostician-core-grounding.test.ts\`n
## Key constraints

- **Zero schema change**: DiagnosticianOutputV1Schema NOT modified. Axiom references captured via existing \mbiguityNotes\ field.
- **EP-01**: Axiom IDs validated with \isCorePrincipleId()\ before counting
- **EP-03**: Flag off = no change (byte-identical)
- **No committer/intake changes**: Downstream contract unchanged

## Test results

- 4497 tests passed (11 new + 4486 existing)
- Build, lint, typecheck all pass

Closes PRI-371