### PR TITLE
fix(config): add missing diagnostician flags to pd-config-defaults

### DIFF
--- a/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-contract.test.ts
@@ -25,6 +25,7 @@ import {
   PD_CONFIG_VERSION,
   INTERNAL_AGENT_NAMES,
 } from '../index.js';
+import { DEFAULT_FEATURE_FLAGS as FLAGS_ARRAY } from '../../feature-flags/index.js';
 import type {
   PdConfig,
   RuntimeProfile,
@@ -739,5 +740,48 @@ describe('Edge cases', () => {
     const summary = redactPdConfig(effective);
     const minimal = summary.runtimeProfiles.find(p => p.id === 'oc.minimal');
     expect(nn(minimal).readiness).toBe('needs_setup');
+  });
+});
+
+// ── Regression: Flag Registry Consistency ────────────────────────────────────
+
+describe('Regression: Flag Registry Consistency', () => {
+  /**
+   * All flags registered in feature-flag-contract.ts (FLAGS_ARRAY) MUST be
+   * present in pd-config-defaults.ts (getDefaultPdConfig().features).
+   *
+   * This prevents a bug where isFeatureEnabled() returns false for registered
+   * flags because they were missing from the defaults record used by
+   * computeFeatureFlagsFromConfig().
+   */
+  it('all registered flags are in pd-config-defaults', () => {
+    const defaults = getDefaultPdConfig();
+    const missingFlags: string[] = [];
+
+    for (const flagDef of FLAGS_ARRAY) {
+      if (!Object.hasOwn(defaults.features, flagDef.id)) {
+        missingFlags.push(flagDef.id);
+      }
+    }
+
+    expect(missingFlags).toEqual([]);
+  });
+
+  it('diagnostician_async_cli is in defaults', () => {
+    const defaults = getDefaultPdConfig();
+    expect(Object.hasOwn(defaults.features, 'diagnostician_async_cli')).toBe(true);
+    expect(defaults.features.diagnostician_async_cli).toEqual({ category: 'quiet', enabled: false });
+  });
+
+  it('diagnostician_split_pipeline is in defaults', () => {
+    const defaults = getDefaultPdConfig();
+    expect(Object.hasOwn(defaults.features, 'diagnostician_split_pipeline')).toBe(true);
+    expect(defaults.features.diagnostician_split_pipeline).toEqual({ category: 'quiet', enabled: false });
+  });
+
+  it('diagnostician_core_grounding is in defaults', () => {
+    const defaults = getDefaultPdConfig();
+    expect(Object.hasOwn(defaults.features, 'diagnostician_core_grounding')).toBe(true);
+    expect(defaults.features.diagnostician_core_grounding).toEqual({ category: 'quiet', enabled: false });
   });
 });

--- a/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
@@ -32,7 +32,9 @@ export const DEFAULT_FEATURE_FLAGS: Record<string, FeatureFlagEntry> = {
   evolution_worker:   { category: 'quiet', enabled: false },
   empathy_observer:   { category: 'quiet', enabled: false },
   painEvidenceAdmission:{ category: 'quiet', enabled: false },
+  diagnostician_async_cli: { category: 'quiet', enabled: false },
   diagnostician_core_grounding: { category: 'quiet', enabled: false },
+  diagnostician_split_pipeline: { category: 'quiet', enabled: false },
 
   // MVP-Gone (ADR-0014 §2.6)
   nocturnal:          { category: 'gone',  enabled: false },


### PR DESCRIPTION
## Summary

diagnostician_async_cli and diagnostician_split_pipeline were registered in `feature-flag-contract.ts` `DEFAULT_FEATURE_FLAGS` array but were **missing** from `pd-config-defaults.ts` `DEFAULT_FEATURE_FLAGS` record.

## Bug Analysis

When `computeFeatureFlagsFromConfig()` is called:
1. It starts with defaults from `pd-config-defaults.ts`'s `DEFAULT_FEATURE_FLAGS` record
2. The missing flags would not be present unless explicitly configured in user config
3. `isFeatureEnabled()` would return `false` for these flags even when explicitly configured

## Fix

Added the missing flags to `pd-config-defaults.ts`:
```typescript
diagnostician_async_cli: { category: 'quiet', enabled: false },
diagnostician_split_pipeline: { category: 'quiet', enabled: false },
```

## Testing

Added regression test `Regression: Flag Registry Consistency` that verifies all flags from `feature-flag-contract.ts` are in `pd-config-defaults.ts`, with specific assertions for the three diagnostician flags.

## Files Changed

- `packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts`
- `packages/principles-core/src/runtime-v2/config/__tests__/pd-config-contract.test.ts`

---

**Note**: The full test suite has 1 pre-existing flaky test (`cli-process-runner.test.ts` timeout case) unrelated to this change.