### PR TITLE
fix(internalization): prevent ready dreamer tasks from staying pending forever (PRI-381)

### DIFF
--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -166,7 +166,7 @@ export function shouldStartInternalizationAutoConsumer(
   }
   const disabledInfo = JSON.stringify({
     reason: 'internalization_auto_consumer_disabled',
-    nextAction: 'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+    nextAction: `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`,
     featureFlag: 'internalization_auto_consumer',
     boundedContext: 'internalization_auto_consumer',
     flagSource: flag.source,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -52,6 +52,7 @@ import { handleSamplesCommand } from './commands/samples.js';
 import { handleWorkflowDebugCommand } from './commands/workflow-debug.js';
 import { EvolutionWorkerService } from './service/evolution-worker.js';
 import { CorrectionObserverService } from './service/correction-observer-service.js';
+import { InternalizationAutoConsumerService } from './service/internalization-auto-consumer-service.js';
 import { TrajectoryService } from './service/trajectory-service.js';
 import { PDTaskService } from './core/pd-task-service.js';
 import { CentralSyncService } from './service/central-sync-service.js';
@@ -144,6 +145,30 @@ export function shouldStartCorrectionObserver(
     nextAction: 'set features.correction_observer.enabled=true in .pd/config.yaml to enable',
     featureFlag: 'correction_observer',
     boundedContext: 'correction_observer_service',
+    flagSource: flag.source,
+  });
+  return { shouldStart: false, flagSource: flag.source, disabledInfo };
+}
+
+export interface InternalizationAutoConsumerGateResult {
+  shouldStart: boolean;
+  flagSource: string;
+  disabledInfo: string | null;
+}
+
+export function shouldStartInternalizationAutoConsumer(
+  workspaceDir: string,
+  logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+): InternalizationAutoConsumerGateResult {
+  const flag = loadFeatureFlagFromWorkspace(workspaceDir, 'internalization_auto_consumer', logger);
+  if (flag.enabled) {
+    return { shouldStart: true, flagSource: flag.source, disabledInfo: null };
+  }
+  const disabledInfo = JSON.stringify({
+    reason: 'internalization_auto_consumer_disabled',
+    nextAction: 'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+    featureFlag: 'internalization_auto_consumer',
+    boundedContext: 'internalization_auto_consumer',
     flagSource: flag.source,
   });
   return { shouldStart: false, flagSource: flag.source, disabledInfo };
@@ -257,6 +282,23 @@ const plugin = {
             } else {
               api.logger.info(`[PD] CorrectionObserver NOT started for workspace: ${workspaceDir}. ${corrGate.disabledInfo}`);
               SystemLogger.log(workspaceDir, 'CORRECTION_OBSERVER_DISABLED', corrGate.disabledInfo ?? '');
+            }
+
+            // ── Start InternalizationAutoConsumer for THIS workspace ──
+            // PRI-381: Bounded auto-consumer for dreamer ready tasks.
+            // Default ON for dogfood; kill switch via features.internalization_auto_consumer.enabled=false.
+            const autoConsGate = shouldStartInternalizationAutoConsumer(workspaceDir, api.logger);
+            if (autoConsGate.shouldStart) {
+              InternalizationAutoConsumerService.start({
+                config: api.config,
+                workspaceDir,
+                stateDir: path.join(workspaceDir, '.state'),
+                logger: api.logger,
+              });
+              api.logger.info(`[PD] InternalizationAutoConsumer started for workspace: ${workspaceDir} (flag source: ${autoConsGate.flagSource})`);
+            } else {
+              api.logger.info(`[PD] InternalizationAutoConsumer NOT started for workspace: ${workspaceDir}. ${autoConsGate.disabledInfo}`);
+              SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_DISABLED', autoConsGate.disabledInfo ?? '');
             }
           }
 
@@ -562,6 +604,8 @@ const plugin = {
       if (guardedPdTask) api.registerService(guardedPdTask);
       const guardedCentralSync = guardService('service:central-sync', CentralSyncService, api.logger);
       if (guardedCentralSync) api.registerService(guardedCentralSync);
+      const guardedAutoConsumer = guardService('service:internalization-auto-consumer', InternalizationAutoConsumerService, api.logger);
+      if (guardedAutoConsumer) api.registerService(guardedAutoConsumer);
     } catch (err) {
       api.logger.error(`[PD] Failed to register services: ${String(err)}`);
     }

--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -1,0 +1,251 @@
+import type { OpenClawPluginServiceContext, PluginLogger } from '../openclaw-sdk.js';
+import {
+  createRuntimeStateHandle,
+  InternalizationOrchestrator,
+  DreamerRunner,
+  DefaultDreamerValidator,
+  PiAiRuntimeAdapter,
+  storeEmitter,
+  resolveRuntimeConfigFromPdConfig,
+  isRuntimeConfigError,
+  computeConsumerDecision,
+} from '@principles/core/runtime-v2';
+import { loadPdConfigForPlugin, loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
+import { SystemLogger } from '../core/system-logger.js';
+
+const INTERNALIZATION_AUTO_CONSUMER_INTERVAL_MS = 120_000;
+const INTERNALIZATION_AUTO_CONSUMER_INITIAL_DELAY_MS = 30_000;
+const INTERNALIZATION_AUTO_CONSUMER_FLAG_ID = 'internalization_auto_consumer';
+
+export interface InternalizationAutoConsumerServiceShape {
+  id: string;
+  start: (ctx: OpenClawPluginServiceContext) => void;
+  stop?: (ctx: OpenClawPluginServiceContext) => void;
+}
+
+let consumerTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let consumerStopped = false;
+const startedWorkspaces = new Set<string>();
+
+async function runConsumerCycle(
+  workspaceDir: string,
+  logger: PluginLogger,
+): Promise<void> {
+  const flag = loadFeatureFlagFromConfig(workspaceDir, INTERNALIZATION_AUTO_CONSUMER_FLAG_ID, {
+    info: (msg: string) => logger.info(msg),
+    warn: (msg: string) => logger.warn(msg),
+  });
+
+  if (!flag.enabled) {
+    const disabledInfo = JSON.stringify({
+      reason: 'internalization_auto_consumer_disabled',
+      nextAction:
+        'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+      flagSource: flag.source,
+    });
+    SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', disabledInfo);
+    logger.info(`[PD:AutoConsumer] Cycle skipped: auto-consumer disabled. Source: ${flag.source}`);
+    return;
+  }
+
+  const configResult = loadPdConfigForPlugin(workspaceDir);
+  if (!configResult.ok) {
+    const malformedInfo = JSON.stringify({
+      reason: 'config_malformed',
+      nextAction: configResult.errors[0]?.nextAction ?? 'Fix .pd/config.yaml and retry',
+      errors: configResult.errors.map((e) => e.reason),
+    });
+    SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', malformedInfo);
+    logger.warn(`[PD:AutoConsumer] Config malformed, skipping cycle.`);
+    return;
+  }
+
+  const runtimeConfigResult = resolveRuntimeConfigFromPdConfig(
+    configResult.effective,
+    (name: string) => process.env[name],
+  );
+
+  if (isRuntimeConfigError(runtimeConfigResult)) {
+    const rtInfo = JSON.stringify({
+      reason: 'runtime_config_error',
+      message: runtimeConfigResult.message,
+      nextAction: runtimeConfigResult.nextAction,
+    });
+    SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', rtInfo);
+    logger.warn(`[PD:AutoConsumer] Runtime config error: ${runtimeConfigResult.message}`);
+    return;
+  }
+
+  let handle: Awaited<ReturnType<typeof createRuntimeStateHandle>> | null = null;
+  try {
+    handle = await createRuntimeStateHandle({ workspaceDir, readonly: false });
+    const { stateManager } = handle;
+
+    const decision = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 1,
+    });
+
+    if (!decision.shouldConsume) {
+      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify({
+        reason: decision.reason,
+      }));
+      return;
+    }
+
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: 'auto-consumer', runtimeKind: 'config', dryRun: false },
+    );
+
+    const wakeResult = await orchestrator.wakeOnce('dreamer');
+
+    if (wakeResult.decision !== 'would_lease') {
+      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify({
+        decision: wakeResult.decision,
+        reason: wakeResult.decision === 'no_ready_tasks'
+          ? (wakeResult as { reason: string }).reason
+          : undefined,
+      }));
+      logger.info(`[PD:AutoConsumer] No task to consume: ${wakeResult.decision}`);
+      return;
+    }
+
+    const adapter = new PiAiRuntimeAdapter({
+      provider: runtimeConfigResult.provider ?? 'openai',
+      model: runtimeConfigResult.model ?? 'gpt-4o',
+      apiKeyEnv: runtimeConfigResult.apiKeyEnv ?? 'OPENAI_API_KEY',
+      maxRetries: runtimeConfigResult.maxRetries,
+      timeoutMs: runtimeConfigResult.timeoutMs,
+      baseUrl: runtimeConfigResult.baseUrl,
+      workspace: workspaceDir,
+    });
+
+    const validator = new DefaultDreamerValidator();
+    const runner = new DreamerRunner(
+      {
+        stateManager,
+        runtimeAdapter: adapter,
+        eventEmitter: storeEmitter,
+        artifactStore: stateManager.piArtifactStore,
+        validator,
+      },
+      {
+        owner: 'auto-consumer',
+        runtimeKind: 'config',
+      },
+    );
+
+    const taskId = wakeResult.taskId;
+    logger.info(`[PD:AutoConsumer] Running dreamer task: ${taskId}`);
+    SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_RUN', JSON.stringify({
+      taskId,
+      taskKind: 'dreamer',
+    }));
+
+    const runResult = await runner.run(taskId);
+
+    if (runResult.status === 'succeeded') {
+      const commitResult = await orchestrator.commitNextTaskProposal(taskId);
+      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SUCCESS', JSON.stringify({
+        taskId,
+        status: runResult.status,
+        successorDecision: commitResult.decision,
+      }));
+      logger.info(
+        `[PD:AutoConsumer] Task ${taskId} succeeded. Successor: ${commitResult.decision}`,
+      );
+    } else {
+      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_TASK_FAILED', JSON.stringify({
+        taskId,
+        status: runResult.status,
+      }));
+      logger.warn(`[PD:AutoConsumer] Task ${taskId} status: ${runResult.status}`);
+    }
+  } catch (err) {
+    SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_ERROR', String(err));
+    logger.error(`[PD:AutoConsumer] Cycle error: ${String(err)}`);
+  } finally {
+    if (handle) {
+      await handle.close().catch(() => {});
+    }
+  }
+}
+
+export const InternalizationAutoConsumerService: InternalizationAutoConsumerServiceShape = {
+  id: 'principles-internalization-auto-consumer',
+
+  start(ctx: OpenClawPluginServiceContext): void {
+    const maybeWorkspaceDir = ctx?.workspaceDir;
+    const logger = ctx?.logger || console;
+
+    if (!maybeWorkspaceDir) {
+      logger.warn('[PD:AutoConsumer] No workspace directory, not starting.');
+      return;
+    }
+
+    const workspaceDir: string = maybeWorkspaceDir;
+
+    if (startedWorkspaces.has(workspaceDir)) {
+      logger.info(`[PD:AutoConsumer] Already started for workspace: ${workspaceDir}`);
+      return;
+    }
+
+    const flag = loadFeatureFlagFromConfig(workspaceDir, INTERNALIZATION_AUTO_CONSUMER_FLAG_ID, {
+      info: (msg: string) => logger.info(msg),
+      warn: (msg: string) => logger.warn(msg),
+    });
+
+    if (!flag.enabled) {
+      const disabledInfo = JSON.stringify({
+        reason: 'internalization_auto_consumer_disabled',
+        nextAction:
+          'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+        flagSource: flag.source,
+      });
+      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_DISABLED', disabledInfo);
+      logger.info(
+        `[PD:AutoConsumer] NOT started for workspace: ${workspaceDir}. Disabled (source: ${flag.source}).`,
+      );
+      return;
+    }
+
+    startedWorkspaces.add(workspaceDir);
+    consumerStopped = false;
+
+    const interval = INTERNALIZATION_AUTO_CONSUMER_INTERVAL_MS;
+
+    async function runCycle(): Promise<void> {
+      if (consumerStopped) return;
+      await runConsumerCycle(workspaceDir, logger);
+      if (consumerStopped) return;
+      consumerTimeoutId = setTimeout(runCycle, interval);
+      consumerTimeoutId.unref();
+    }
+
+    consumerTimeoutId = setTimeout(() => {
+      void runCycle().catch((err: unknown) => {
+        logger.error(`[PD:AutoConsumer] Startup cycle failed: ${String(err)}`);
+        if (consumerStopped) return;
+        consumerTimeoutId = setTimeout(runCycle, interval);
+        consumerTimeoutId.unref();
+      });
+    }, INTERNALIZATION_AUTO_CONSUMER_INITIAL_DELAY_MS);
+    consumerTimeoutId.unref();
+
+    SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_STARTED', JSON.stringify({
+      intervalMs: interval,
+      initialDelayMs: INTERNALIZATION_AUTO_CONSUMER_INITIAL_DELAY_MS,
+    }));
+    logger.info(
+      `[PD:AutoConsumer] Started for workspace: ${workspaceDir} (interval: ${interval}ms, initial delay: ${INTERNALIZATION_AUTO_CONSUMER_INITIAL_DELAY_MS}ms)`,
+    );
+  },
+
+  stop(_ctx: OpenClawPluginServiceContext): void {
+    consumerStopped = true;
+    startedWorkspaces.clear();
+    if (consumerTimeoutId) clearTimeout(consumerTimeoutId);
+    consumerTimeoutId = null;
+  },
+};

--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -129,11 +129,8 @@ async function runConsumerCycle(
       const skipPayload: Record<string, unknown> = {
         decision: wakeResult.decision,
       };
-      if (Object.hasOwn(wakeResult, 'reason')) {
-        const rawReason = (wakeResult as unknown as Record<string, unknown>).reason;
-        if (typeof rawReason === 'string') {
-          skipPayload.reason = rawReason;
-        }
+      if (wakeResult.decision === 'no_ready_tasks') {
+        skipPayload.reason = wakeResult.reason;
       }
       SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify(skipPayload));
       logger.info(`[PD:AutoConsumer] No task to consume: ${wakeResult.decision}`);

--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -25,9 +25,25 @@ export interface InternalizationAutoConsumerServiceShape {
   stop?: (ctx: OpenClawPluginServiceContext) => void;
 }
 
-let consumerTimeoutId: ReturnType<typeof setTimeout> | null = null;
-let consumerStopped = false;
-const startedWorkspaces = new Set<string>();
+interface WorkspaceConsumerState {
+  stopped: boolean;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+}
+
+const workspaceStates = new Map<string, WorkspaceConsumerState>();
+
+function getWorkspaceState(workspaceDir: string): WorkspaceConsumerState {
+  let state = workspaceStates.get(workspaceDir);
+  if (!state) {
+    state = { stopped: false, timeoutId: null };
+    workspaceStates.set(workspaceDir, state);
+  }
+  return state;
+}
+
+function formatRunOnceCommand(workspaceDir: string): string {
+  return `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`;
+}
 
 async function runConsumerCycle(
   workspaceDir: string,
@@ -41,8 +57,7 @@ async function runConsumerCycle(
   if (!flag.enabled) {
     const disabledInfo = JSON.stringify({
       reason: 'internalization_auto_consumer_disabled',
-      nextAction:
-        'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+      nextAction: formatRunOnceCommand(workspaceDir),
       flagSource: flag.source,
     });
     SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', disabledInfo);
@@ -111,12 +126,16 @@ async function runConsumerCycle(
     const wakeResult = await orchestrator.wakeOnce('dreamer');
 
     if (wakeResult.decision !== 'leased') {
-      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify({
+      const skipPayload: Record<string, unknown> = {
         decision: wakeResult.decision,
-        reason: wakeResult.decision === 'no_ready_tasks'
-          ? (wakeResult as { reason: string }).reason
-          : undefined,
-      }));
+      };
+      if (Object.hasOwn(wakeResult, 'reason')) {
+        const rawReason = (wakeResult as unknown as Record<string, unknown>).reason;
+        if (typeof rawReason === 'string') {
+          skipPayload.reason = rawReason;
+        }
+      }
+      SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify(skipPayload));
       logger.info(`[PD:AutoConsumer] No task to consume: ${wakeResult.decision}`);
       return;
     }
@@ -195,8 +214,9 @@ export const InternalizationAutoConsumerService: InternalizationAutoConsumerServ
     }
 
     const workspaceDir: string = maybeWorkspaceDir;
+    const state = getWorkspaceState(workspaceDir);
 
-    if (startedWorkspaces.has(workspaceDir)) {
+    if (!state.stopped && state.timeoutId !== null) {
       logger.info(`[PD:AutoConsumer] Already started for workspace: ${workspaceDir}`);
       return;
     }
@@ -209,8 +229,7 @@ export const InternalizationAutoConsumerService: InternalizationAutoConsumerServ
     if (!flag.enabled) {
       const disabledInfo = JSON.stringify({
         reason: 'internalization_auto_consumer_disabled',
-        nextAction:
-          'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+        nextAction: formatRunOnceCommand(workspaceDir),
         flagSource: flag.source,
       });
       SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_DISABLED', disabledInfo);
@@ -220,28 +239,31 @@ export const InternalizationAutoConsumerService: InternalizationAutoConsumerServ
       return;
     }
 
-    startedWorkspaces.add(workspaceDir);
-    consumerStopped = false;
+    state.stopped = false;
 
     const interval = INTERNALIZATION_AUTO_CONSUMER_INTERVAL_MS;
 
-    async function runCycle(): Promise<void> {
-      if (consumerStopped) return;
-      await runConsumerCycle(workspaceDir, logger);
-      if (consumerStopped) return;
-      consumerTimeoutId = setTimeout(runCycle, interval);
-      consumerTimeoutId.unref();
+    function scheduleNext(): void {
+      if (state.stopped) return;
+      state.timeoutId = setTimeout(runCycle, interval);
+      state.timeoutId?.unref();
     }
 
-    consumerTimeoutId = setTimeout(() => {
+    async function runCycle(): Promise<void> {
+      if (state.stopped) return;
+      await runConsumerCycle(workspaceDir, logger);
+      scheduleNext();
+    }
+
+    state.timeoutId = setTimeout(() => {
       void runCycle().catch((err: unknown) => {
         logger.error(`[PD:AutoConsumer] Startup cycle failed: ${String(err)}`);
-        if (consumerStopped) return;
-        consumerTimeoutId = setTimeout(runCycle, interval);
-        consumerTimeoutId.unref();
+        if (state.stopped) return;
+        state.timeoutId = setTimeout(runCycle, interval);
+        state.timeoutId?.unref();
       });
     }, INTERNALIZATION_AUTO_CONSUMER_INITIAL_DELAY_MS);
-    consumerTimeoutId.unref();
+    state.timeoutId?.unref();
 
     SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_STARTED', JSON.stringify({
       intervalMs: interval,
@@ -252,10 +274,23 @@ export const InternalizationAutoConsumerService: InternalizationAutoConsumerServ
     );
   },
 
-  stop(_ctx: OpenClawPluginServiceContext): void {
-    consumerStopped = true;
-    startedWorkspaces.clear();
-    if (consumerTimeoutId) clearTimeout(consumerTimeoutId);
-    consumerTimeoutId = null;
+  stop(ctx: OpenClawPluginServiceContext): void {
+    const workspaceDir = ctx?.workspaceDir;
+    if (workspaceDir) {
+      const state = workspaceStates.get(workspaceDir);
+      if (state) {
+        state.stopped = true;
+        if (state.timeoutId) clearTimeout(state.timeoutId);
+        state.timeoutId = null;
+      }
+      workspaceStates.delete(workspaceDir);
+    } else {
+      for (const [dir, state] of workspaceStates) {
+        state.stopped = true;
+        if (state.timeoutId) clearTimeout(state.timeoutId);
+        state.timeoutId = null;
+      }
+      workspaceStates.clear();
+    }
   },
 };

--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -9,6 +9,8 @@ import {
   resolveRuntimeConfigFromPdConfig,
   isRuntimeConfigError,
   computeConsumerDecision,
+  InternalizationQueueReadModel,
+  MVP_CORE_TASK_KINDS,
 } from '@principles/core/runtime-v2';
 import { loadPdConfigForPlugin, loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
 import { SystemLogger } from '../core/system-logger.js';
@@ -81,14 +83,22 @@ async function runConsumerCycle(
     handle = await createRuntimeStateHandle({ workspaceDir, readonly: false });
     const { stateManager } = handle;
 
+    const readModel = new InternalizationQueueReadModel(stateManager);
+    readModel.setPolicy({
+      enabledChannels: new Set(['prompt', 'code_tool_hook', 'defer_archive']),
+      actionableTaskKinds: new Set(MVP_CORE_TASK_KINDS),
+    });
+    const snapshot = await readModel.getSnapshot();
+
     const decision = computeConsumerDecision({
       autoConsumerEnabled: true,
-      readyTaskCount: 1,
+      readyTaskCount: snapshot.readyTasks.length,
     });
 
     if (!decision.shouldConsume) {
       SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify({
         reason: decision.reason,
+        readyTaskCount: snapshot.readyTasks.length,
       }));
       return;
     }
@@ -100,7 +110,7 @@ async function runConsumerCycle(
 
     const wakeResult = await orchestrator.wakeOnce('dreamer');
 
-    if (wakeResult.decision !== 'would_lease') {
+    if (wakeResult.decision !== 'leased') {
       SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify({
         decision: wakeResult.decision,
         reason: wakeResult.decision === 'no_ready_tasks'

--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -285,7 +285,7 @@ export const InternalizationAutoConsumerService: InternalizationAutoConsumerServ
       }
       workspaceStates.delete(workspaceDir);
     } else {
-      for (const [dir, state] of workspaceStates) {
+      for (const [, state] of workspaceStates) {
         state.stopped = true;
         if (state.timeoutId) clearTimeout(state.timeoutId);
         state.timeoutId = null;

--- a/packages/openclaw-plugin/tests/evolution-worker-slimming.test.ts
+++ b/packages/openclaw-plugin/tests/evolution-worker-slimming.test.ts
@@ -174,6 +174,8 @@ describe('PRI-294: Surface registry coverage audit', () => {
       'startup:workspace-init',
       'startup:evolution-worker',
       'startup:correction-observer',
+      'service:internalization-auto-consumer',  // PRI-381: bounded auto-consumer
+      'startup:internalization-auto-consumer',  // PRI-381: auto-consumer startup
     ];
     const allowedIds = new Set([...usedSet, ...additionallyRegistered]);
     const unaccounted = PLUGIN_SURFACE_REGISTRY

--- a/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
+++ b/packages/openclaw-plugin/tests/integration/mvp-surface-registry-guard.test.ts
@@ -244,6 +244,7 @@ describe('MVP Surface Registry Guard (PRI-289)', () => {
       const expectedIds = [
         'service:central-sync',
         'service:correction-observer',
+        'service:internalization-auto-consumer',
         'service:pd-task',
         'service:trajectory',
       ].sort();

--- a/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
+++ b/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
@@ -105,7 +105,7 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
   });
 
   describe('shouldStartInternalizationAutoConsumer', () => {
-    it('returns shouldStart=true with defaults (dogfood — enabled by default)', () => {
+    it('returns shouldStart=true with defaults (core flag — always enabled)', () => {
       const logger = createMockLogger();
       const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
       expect(result.shouldStart).toBe(true);
@@ -113,32 +113,24 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
       expect(result.disabledInfo).toBeNull();
     });
 
-    it('returns shouldStart=false when explicitly disabled in config', () => {
+    it('returns shouldStart=true even when config attempts to disable (core flag cannot be disabled)', () => {
       writeConfigYaml(workspaceDir, {
         internalization_auto_consumer: { category: 'core', enabled: false },
       });
       const logger = createMockLogger();
       const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
 
-      expect(result.shouldStart).toBe(false);
-      expect(result.flagSource).toBeDefined();
-      expect(result.disabledInfo).not.toBeNull();
+      expect(result.shouldStart).toBe(true);
+      expect(result.disabledInfo).toBeNull();
     });
 
-    it('disabled result has structured reason + nextAction (ERR-002)', () => {
+    it('returns shouldStart=true with explicit config enabling', () => {
       writeConfigYaml(workspaceDir, {
-        internalization_auto_consumer: { category: 'core', enabled: false },
+        internalization_auto_consumer: { category: 'core', enabled: true },
       });
       const logger = createMockLogger();
       const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
-
-      expect(result.disabledInfo).not.toBeNull();
-      const parsed = JSON.parse(result.disabledInfo!);
-      expect(parsed.reason).toBe('internalization_auto_consumer_disabled');
-      expect(parsed.nextAction).toContain('pd runtime internalization run-once');
-      expect(parsed.nextAction).toContain('--runner dreamer');
-      expect(parsed.featureFlag).toBe('internalization_auto_consumer');
-      expect(parsed.flagSource).toBeDefined();
+      expect(result.shouldStart).toBe(true);
     });
   });
 
@@ -150,13 +142,13 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
       expect(result.source).toBe('defaults');
     });
 
-    it('returns enabled=false when explicitly disabled', () => {
+    it('returns enabled=true even when config attempts to disable (core flag protection)', () => {
       writeConfigYaml(workspaceDir, {
         internalization_auto_consumer: { category: 'core', enabled: false },
       });
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'internalization_auto_consumer', logger);
-      expect(result.enabled).toBe(false);
+      expect(result.enabled).toBe(true);
     });
   });
 });

--- a/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
+++ b/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
@@ -101,7 +101,7 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
   afterEach(() => {
     try {
       fs.rmSync(workspaceDir, { recursive: true, force: true });
-    } catch {}
+    } catch { /* best-effort */ }
   });
 
   describe('shouldStartInternalizationAutoConsumer', () => {
@@ -122,7 +122,7 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
 
       expect(result.shouldStart).toBe(false);
       expect(result.disabledInfo).not.toBeNull();
-      const info = JSON.parse(result.disabledInfo!);
+      const info = JSON.parse(result.disabledInfo ?? '{}');
       expect(info.reason).toBe('internalization_auto_consumer_disabled');
       expect(info.nextAction).toContain('pd runtime internalization run-once');
       expect(info.flagSource).toBeDefined();

--- a/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
+++ b/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as yaml from 'js-yaml';
+
+vi.mock('../src/core/dictionary-service.js', () => ({
+  DictionaryService: { get: vi.fn(() => ({ flush: vi.fn() })) },
+}));
+
+vi.mock('../src/core/session-tracker.js', () => ({
+  initPersistence: vi.fn(),
+  flushAllSessions: vi.fn(),
+  listSessions: vi.fn(() => []),
+}));
+
+vi.mock('../src/core/workspace-context.js', () => {
+  const mockCtx = {
+    stateDir: '',
+    workspaceDir: '',
+    config: { get: vi.fn() },
+    eventLog: { recordHookExecution: vi.fn() },
+    dictionary: { flush: vi.fn() },
+    resolve: vi.fn((key: string) => `/mock/${key}`),
+    trajectory: null,
+  };
+  return {
+    WorkspaceContext: {
+      fromHookContext: vi.fn(() => mockCtx),
+      clearCache: vi.fn(),
+    },
+  };
+});
+
+import {
+  shouldStartInternalizationAutoConsumer,
+  loadFeatureFlagFromWorkspace,
+} from '../src/index.js';
+
+function createTempWorkspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-auto-consumer-'));
+  fs.mkdirSync(path.join(dir, '.pd'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.state'), { recursive: true });
+  return dir;
+}
+
+function writeConfigYaml(workspaceDir: string, featureOverrides: Record<string, unknown>): void {
+  const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
+  const defaultFeatures: Record<string, unknown> = {
+    prompt: { category: 'core', enabled: true },
+    code_tool_hook: { category: 'core', enabled: true },
+    defer_archive: { category: 'core', enabled: true },
+    correction_observer: { category: 'quiet', enabled: false },
+    empathy_observer: { category: 'quiet', enabled: false },
+    evolution_worker: { category: 'quiet', enabled: false },
+    internalization_auto_consumer: { category: 'core', enabled: true },
+    nocturnal: { category: 'gone', enabled: false },
+  };
+  const config = {
+    version: 1,
+    features: Object.assign({}, defaultFeatures, featureOverrides),
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+        philosopher: { enabled: false },
+        evaluator: { enabled: false },
+        rolloutReviewer: { enabled: false },
+        trainer: { enabled: false },
+        correctionObserver: { enabled: false },
+        empathyObserver: { enabled: false },
+      },
+    },
+  };
+  const content = yaml.dump(config, { schema: yaml.JSON_SCHEMA });
+  fs.writeFileSync(configPath, content, 'utf8');
+}
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('PRI-381: InternalizationAutoConsumer gate', () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = createTempWorkspace();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  describe('shouldStartInternalizationAutoConsumer', () => {
+    it('returns shouldStart=true with defaults (dogfood — enabled by default)', () => {
+      const logger = createMockLogger();
+      const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
+      expect(result.shouldStart).toBe(true);
+      expect(result.flagSource).toBeDefined();
+      expect(result.disabledInfo).toBeNull();
+    });
+
+    it('returns shouldStart=false when explicitly disabled in config', () => {
+      writeConfigYaml(workspaceDir, {
+        internalization_auto_consumer: { category: 'core', enabled: false },
+      });
+      const logger = createMockLogger();
+      const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
+
+      expect(result.shouldStart).toBe(false);
+      expect(result.flagSource).toBeDefined();
+      expect(result.disabledInfo).not.toBeNull();
+    });
+
+    it('disabled result has structured reason + nextAction (ERR-002)', () => {
+      writeConfigYaml(workspaceDir, {
+        internalization_auto_consumer: { category: 'core', enabled: false },
+      });
+      const logger = createMockLogger();
+      const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
+
+      expect(result.disabledInfo).not.toBeNull();
+      const parsed = JSON.parse(result.disabledInfo!);
+      expect(parsed.reason).toBe('internalization_auto_consumer_disabled');
+      expect(parsed.nextAction).toContain('pd runtime internalization run-once');
+      expect(parsed.nextAction).toContain('--runner dreamer');
+      expect(parsed.featureFlag).toBe('internalization_auto_consumer');
+      expect(parsed.flagSource).toBeDefined();
+    });
+  });
+
+  describe('loadFeatureFlagFromWorkspace for auto-consumer', () => {
+    it('returns enabled=true when no config.yaml exists (default)', () => {
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'internalization_auto_consumer', logger);
+      expect(result.enabled).toBe(true);
+      expect(result.source).toBe('defaults');
+    });
+
+    it('returns enabled=false when explicitly disabled', () => {
+      writeConfigYaml(workspaceDir, {
+        internalization_auto_consumer: { category: 'core', enabled: false },
+      });
+      const logger = createMockLogger();
+      const result = loadFeatureFlagFromWorkspace(workspaceDir, 'internalization_auto_consumer', logger);
+      expect(result.enabled).toBe(false);
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
+++ b/packages/openclaw-plugin/tests/internalization-auto-consumer-gate.test.ts
@@ -53,7 +53,7 @@ function writeConfigYaml(workspaceDir: string, featureOverrides: Record<string, 
     correction_observer: { category: 'quiet', enabled: false },
     empathy_observer: { category: 'quiet', enabled: false },
     evolution_worker: { category: 'quiet', enabled: false },
-    internalization_auto_consumer: { category: 'core', enabled: true },
+    internalization_auto_consumer: { category: 'quiet', enabled: true },
     nocturnal: { category: 'gone', enabled: false },
   };
   const config = {
@@ -105,7 +105,7 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
   });
 
   describe('shouldStartInternalizationAutoConsumer', () => {
-    it('returns shouldStart=true with defaults (core flag — always enabled)', () => {
+    it('returns shouldStart=true with defaults (quiet flag — default enabled)', () => {
       const logger = createMockLogger();
       const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
       expect(result.shouldStart).toBe(true);
@@ -113,20 +113,24 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
       expect(result.disabledInfo).toBeNull();
     });
 
-    it('returns shouldStart=true even when config attempts to disable (core flag cannot be disabled)', () => {
+    it('returns shouldStart=false when config disables the flag, with reason and nextAction', () => {
       writeConfigYaml(workspaceDir, {
-        internalization_auto_consumer: { category: 'core', enabled: false },
+        internalization_auto_consumer: { category: 'quiet', enabled: false },
       });
       const logger = createMockLogger();
       const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
 
-      expect(result.shouldStart).toBe(true);
-      expect(result.disabledInfo).toBeNull();
+      expect(result.shouldStart).toBe(false);
+      expect(result.disabledInfo).not.toBeNull();
+      const info = JSON.parse(result.disabledInfo!);
+      expect(info.reason).toBe('internalization_auto_consumer_disabled');
+      expect(info.nextAction).toContain('pd runtime internalization run-once');
+      expect(info.flagSource).toBeDefined();
     });
 
     it('returns shouldStart=true with explicit config enabling', () => {
       writeConfigYaml(workspaceDir, {
-        internalization_auto_consumer: { category: 'core', enabled: true },
+        internalization_auto_consumer: { category: 'quiet', enabled: true },
       });
       const logger = createMockLogger();
       const result = shouldStartInternalizationAutoConsumer(workspaceDir, logger);
@@ -142,13 +146,13 @@ describe('PRI-381: InternalizationAutoConsumer gate', () => {
       expect(result.source).toBe('defaults');
     });
 
-    it('returns enabled=true even when config attempts to disable (core flag protection)', () => {
+    it('returns enabled=false when config disables the flag (quiet flag can be disabled)', () => {
       writeConfigYaml(workspaceDir, {
-        internalization_auto_consumer: { category: 'core', enabled: false },
+        internalization_auto_consumer: { category: 'quiet', enabled: false },
       });
       const logger = createMockLogger();
       const result = loadFeatureFlagFromWorkspace(workspaceDir, 'internalization_auto_consumer', logger);
-      expect(result.enabled).toBe(true);
+      expect(result.enabled).toBe(false);
     });
   });
 });

--- a/packages/pd-cli/src/commands/runtime-internalization-queue.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-queue.ts
@@ -19,7 +19,7 @@ interface QueueOptions {
   json?: boolean;
 }
 
-function formatTextOutput(snap: InternalizationQueueSnapshot, workspaceDir: string): string {
+function formatTextOutput(snap: InternalizationQueueSnapshot, workspaceDir: string, autoConsumerEnabled: boolean): string {
   const lines: string[] = [];
   lines.push(`Internalization Queue Snapshot`);
   lines.push(`  pending: ${snap.pendingCount}  retry_wait: ${snap.retryWaitCount}`);
@@ -80,8 +80,13 @@ function formatTextOutput(snap: InternalizationQueueSnapshot, workspaceDir: stri
   }
 
   if (snap.readyTasks.length > 0) {
-    const nextAction = `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`;
-    lines.push(`  nextAction: ${nextAction}`);
+    if (autoConsumerEnabled) {
+      lines.push(`  consumerStatus: auto_consumer_enabled`);
+    } else {
+      const nextAction = `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`;
+      lines.push(`  consumerStatus: manual_action_required`);
+      lines.push(`  nextAction: ${nextAction}`);
+    }
   }
 
   return lines.join('\n');
@@ -119,7 +124,7 @@ export async function handleRuntimeInternalizationQueue(opts: QueueOptions): Pro
 
       console.log(JSON.stringify(output, null, 2));
     } else {
-      console.log(formatTextOutput(snapshot, workspaceDir));
+      console.log(formatTextOutput(snapshot, workspaceDir, autoConsumerEnabled));
     }
   } finally {
     await close();

--- a/packages/pd-cli/src/commands/runtime-internalization-queue.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-queue.ts
@@ -12,13 +12,14 @@ import { createInternalizationQueueReadModel } from '@principles/core/runtime-v2
 import type { InternalizationQueueSnapshot } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import { loadEffectiveFeatureFlags } from '../services/feature-flag-loader.js';
+import { loadPdConfig, computeFlagsFromLoadResult } from '../services/pd-config-loader.js';
 
 interface QueueOptions {
   workspace?: string;
   json?: boolean;
 }
 
-function formatTextOutput(snap: InternalizationQueueSnapshot): string {
+function formatTextOutput(snap: InternalizationQueueSnapshot, workspaceDir: string): string {
   const lines: string[] = [];
   lines.push(`Internalization Queue Snapshot`);
   lines.push(`  pending: ${snap.pendingCount}  retry_wait: ${snap.retryWaitCount}`);
@@ -78,6 +79,11 @@ function formatTextOutput(snap: InternalizationQueueSnapshot): string {
     }
   }
 
+  if (snap.readyTasks.length > 0) {
+    const nextAction = `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`;
+    lines.push(`  nextAction: ${nextAction}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -95,10 +101,25 @@ export async function handleRuntimeInternalizationQueue(opts: QueueOptions): Pro
   try {
     const snapshot = await readModel.getSnapshot();
 
+    const pdConfigResult = loadPdConfig(workspaceDir);
+    const pdFlags = computeFlagsFromLoadResult(pdConfigResult);
+    const autoConsumerEnabled = pdFlags.flags.internalization_auto_consumer?.enabled ?? false;
+
     if (opts.json) {
-      console.log(JSON.stringify(snapshot, null, 2));
+      const output: Record<string, unknown> = { ...snapshot };
+
+      if (snapshot.readyTasks.length > 0) {
+        if (autoConsumerEnabled) {
+          output.consumerStatus = 'auto_consumer_enabled';
+        } else {
+          output.nextAction = `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`;
+          output.consumerStatus = 'manual_action_required';
+        }
+      }
+
+      console.log(JSON.stringify(output, null, 2));
     } else {
-      console.log(formatTextOutput(snapshot));
+      console.log(formatTextOutput(snapshot, workspaceDir));
     }
   } finally {
     await close();

--- a/packages/pd-cli/src/commands/runtime-internalization-queue.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-queue.ts
@@ -107,6 +107,14 @@ export async function handleRuntimeInternalizationQueue(opts: QueueOptions): Pro
     const snapshot = await readModel.getSnapshot();
 
     const pdConfigResult = loadPdConfig(workspaceDir);
+    if (!pdConfigResult.ok) {
+      const configWarning = JSON.stringify({
+        level: 'warning',
+        source: 'pd_config',
+        errors: pdConfigResult.errors.map(e => ({ reason: e.reason, nextAction: e.nextAction })),
+      });
+      process.stderr.write(`${configWarning}\n`);
+    }
     const pdFlags = computeFlagsFromLoadResult(pdConfigResult);
     const autoConsumerEnabled = pdFlags.flags.internalization_auto_consumer?.enabled ?? false;
 

--- a/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
@@ -37,6 +37,16 @@ vi.mock('../../src/services/feature-flag-loader.js', () => ({
   }),
 }));
 
+const { mockLoadPdConfig, mockComputeFlagsFromLoadResult } = vi.hoisted(() => ({
+  mockLoadPdConfig: vi.fn(),
+  mockComputeFlagsFromLoadResult: vi.fn(),
+}));
+
+vi.mock('../../src/services/pd-config-loader.js', () => ({
+  loadPdConfig: mockLoadPdConfig,
+  computeFlagsFromLoadResult: mockComputeFlagsFromLoadResult,
+}));
+
 import { handleRuntimeInternalizationQueue } from '../../src/commands/runtime-internalization-queue.js';
 
 const WS = '/fake/workspace';
@@ -68,6 +78,12 @@ describe('handleRuntimeInternalizationQueue', () => {
     vi.clearAllMocks();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockLoadPdConfig.mockReturnValue({ ok: true, effective: {}, source: 'defaults' });
+    mockComputeFlagsFromLoadResult.mockReturnValue({
+      flags: {},
+      source: 'defaults',
+      errors: [],
+    });
   });
 
   afterEach(() => {
@@ -249,5 +265,81 @@ describe('handleRuntimeInternalizationQueue', () => {
     expect(output.countsByTaskKind.dreamer).toBe(2);
     expect(output.countsByTaskKind.scribe).toBe(1);
     expect(output.countsByChannel.prompt).toBe(3);
+  });
+
+  // ── nextAction / consumerStatus (PRI-381) ──────────────────────────────────
+
+  it('ready tasks + auto-consumer disabled → consumerStatus=manual_action_required + nextAction in JSON', async () => {
+    mockGetSnapshot.mockResolvedValue({
+      ...emptySnapshot(),
+      pendingCount: 3,
+      readyTasks: [
+        { taskId: 'task_dreamer_1', taskKind: 'dreamer', channel: 'prompt' },
+        { taskId: 'task_dreamer_2', taskKind: 'dreamer', channel: 'prompt' },
+      ],
+      noReadyTasks: null,
+    });
+    mockComputeFlagsFromLoadResult.mockReturnValue({
+      flags: {},
+      source: 'defaults',
+      errors: [],
+    });
+
+    await handleRuntimeInternalizationQueue({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.consumerStatus).toBe('manual_action_required');
+    expect(output.nextAction).toContain('pd runtime internalization run-once');
+    expect(output.nextAction).toContain('--runner dreamer');
+    expect(output.nextAction).toContain('--json');
+  });
+
+  it('ready tasks + auto-consumer enabled → consumerStatus=auto_consumer_enabled in JSON', async () => {
+    mockGetSnapshot.mockResolvedValue({
+      ...emptySnapshot(),
+      pendingCount: 3,
+      readyTasks: [
+        { taskId: 'task_dreamer_1', taskKind: 'dreamer', channel: 'prompt' },
+      ],
+      noReadyTasks: null,
+    });
+    mockComputeFlagsFromLoadResult.mockReturnValue({
+      flags: {
+        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'core' },
+      },
+      source: 'config',
+      errors: [],
+    });
+
+    await handleRuntimeInternalizationQueue({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.consumerStatus).toBe('auto_consumer_enabled');
+    expect(output.nextAction).toBeUndefined();
+  });
+
+  it('no ready tasks → no consumerStatus or nextAction in JSON', async () => {
+    mockGetSnapshot.mockResolvedValue(emptySnapshot());
+
+    await handleRuntimeInternalizationQueue({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.consumerStatus).toBeUndefined();
+    expect(output.nextAction).toBeUndefined();
+  });
+
+  it('ready tasks in text output show nextAction', async () => {
+    mockGetSnapshot.mockResolvedValue({
+      ...emptySnapshot(),
+      pendingCount: 1,
+      readyTasks: [{ taskId: 'task_003', taskKind: 'dreamer', channel: 'prompt' }],
+      noReadyTasks: null,
+    });
+
+    await handleRuntimeInternalizationQueue({ workspace: WS, json: false });
+
+    const text = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(text).toContain('nextAction:');
+    expect(text).toContain('pd runtime internalization run-once');
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
@@ -38,8 +38,14 @@ vi.mock('../../src/services/feature-flag-loader.js', () => ({
 }));
 
 const { mockLoadPdConfig, mockComputeFlagsFromLoadResult } = vi.hoisted(() => ({
-  mockLoadPdConfig: vi.fn(),
-  mockComputeFlagsFromLoadResult: vi.fn(),
+  mockLoadPdConfig: vi.fn().mockReturnValue({ config: {}, source: 'defaults' }),
+  mockComputeFlagsFromLoadResult: vi.fn().mockReturnValue({
+    flags: {
+      internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'core' },
+    },
+    source: 'defaults',
+    errors: [],
+  }),
 }));
 
 vi.mock('../../src/services/pd-config-loader.js', () => ({
@@ -80,7 +86,9 @@ describe('handleRuntimeInternalizationQueue', () => {
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockLoadPdConfig.mockReturnValue({ ok: true, effective: {}, source: 'defaults' });
     mockComputeFlagsFromLoadResult.mockReturnValue({
-      flags: {},
+      flags: {
+        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'core' },
+      },
       source: 'defaults',
       errors: [],
     });
@@ -269,7 +277,7 @@ describe('handleRuntimeInternalizationQueue', () => {
 
   // ── nextAction / consumerStatus (PRI-381) ──────────────────────────────────
 
-  it('ready tasks + auto-consumer disabled → consumerStatus=manual_action_required + nextAction in JSON', async () => {
+  it('ready tasks + auto-consumer (core flag default) → consumerStatus=auto_consumer_enabled in JSON', async () => {
     mockGetSnapshot.mockResolvedValue({
       ...emptySnapshot(),
       pendingCount: 3,
@@ -279,22 +287,15 @@ describe('handleRuntimeInternalizationQueue', () => {
       ],
       noReadyTasks: null,
     });
-    mockComputeFlagsFromLoadResult.mockReturnValue({
-      flags: {},
-      source: 'defaults',
-      errors: [],
-    });
 
     await handleRuntimeInternalizationQueue({ workspace: WS, json: true });
 
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
-    expect(output.consumerStatus).toBe('manual_action_required');
-    expect(output.nextAction).toContain('pd runtime internalization run-once');
-    expect(output.nextAction).toContain('--runner dreamer');
-    expect(output.nextAction).toContain('--json');
+    expect(output.consumerStatus).toBe('auto_consumer_enabled');
+    expect(output.nextAction).toBeUndefined();
   });
 
-  it('ready tasks + auto-consumer enabled → consumerStatus=auto_consumer_enabled in JSON', async () => {
+  it('ready tasks + auto-consumer enabled via config → consumerStatus=auto_consumer_enabled in JSON', async () => {
     mockGetSnapshot.mockResolvedValue({
       ...emptySnapshot(),
       pendingCount: 3,
@@ -328,7 +329,7 @@ describe('handleRuntimeInternalizationQueue', () => {
     expect(output.nextAction).toBeUndefined();
   });
 
-  it('ready tasks in text output show nextAction', async () => {
+  it('ready tasks in text output show auto_consumer status (not manual nextAction when enabled)', async () => {
     mockGetSnapshot.mockResolvedValue({
       ...emptySnapshot(),
       pendingCount: 1,
@@ -339,7 +340,7 @@ describe('handleRuntimeInternalizationQueue', () => {
     await handleRuntimeInternalizationQueue({ workspace: WS, json: false });
 
     const text = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    expect(text).toContain('nextAction:');
-    expect(text).toContain('pd runtime internalization run-once');
+    expect(text).toContain('auto_consumer_enabled');
+    expect(text).not.toContain('nextAction:');
   });
 });

--- a/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization-queue.test.ts
@@ -41,7 +41,7 @@ const { mockLoadPdConfig, mockComputeFlagsFromLoadResult } = vi.hoisted(() => ({
   mockLoadPdConfig: vi.fn().mockReturnValue({ config: {}, source: 'defaults' }),
   mockComputeFlagsFromLoadResult: vi.fn().mockReturnValue({
     flags: {
-      internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'core' },
+      internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'quiet' },
     },
     source: 'defaults',
     errors: [],
@@ -87,7 +87,7 @@ describe('handleRuntimeInternalizationQueue', () => {
     mockLoadPdConfig.mockReturnValue({ ok: true, effective: {}, source: 'defaults' });
     mockComputeFlagsFromLoadResult.mockReturnValue({
       flags: {
-        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'core' },
+        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'quiet' },
       },
       source: 'defaults',
       errors: [],
@@ -306,7 +306,7 @@ describe('handleRuntimeInternalizationQueue', () => {
     });
     mockComputeFlagsFromLoadResult.mockReturnValue({
       flags: {
-        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'core' },
+        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: true, category: 'quiet' },
       },
       source: 'config',
       errors: [],
@@ -317,6 +317,30 @@ describe('handleRuntimeInternalizationQueue', () => {
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
     expect(output.consumerStatus).toBe('auto_consumer_enabled');
     expect(output.nextAction).toBeUndefined();
+  });
+
+  it('ready tasks + auto-consumer disabled via config → consumerStatus=manual_action_required + nextAction in JSON', async () => {
+    mockGetSnapshot.mockResolvedValue({
+      ...emptySnapshot(),
+      pendingCount: 3,
+      readyTasks: [
+        { taskId: 'task_dreamer_1', taskKind: 'dreamer', channel: 'prompt' },
+      ],
+      noReadyTasks: null,
+    });
+    mockComputeFlagsFromLoadResult.mockReturnValue({
+      flags: {
+        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: false, category: 'quiet' },
+      },
+      source: 'config',
+      errors: [],
+    });
+
+    await handleRuntimeInternalizationQueue({ workspace: WS, json: true });
+
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(output.consumerStatus).toBe('manual_action_required');
+    expect(output.nextAction).toContain('pd runtime internalization run-once');
   });
 
   it('no ready tasks → no consumerStatus or nextAction in JSON', async () => {
@@ -342,5 +366,28 @@ describe('handleRuntimeInternalizationQueue', () => {
     const text = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
     expect(text).toContain('auto_consumer_enabled');
     expect(text).not.toContain('nextAction:');
+  });
+
+  it('ready tasks + auto-consumer disabled in text output shows manual_action_required + nextAction', async () => {
+    mockGetSnapshot.mockResolvedValue({
+      ...emptySnapshot(),
+      pendingCount: 1,
+      readyTasks: [{ taskId: 'task_003', taskKind: 'dreamer', channel: 'prompt' }],
+      noReadyTasks: null,
+    });
+    mockComputeFlagsFromLoadResult.mockReturnValue({
+      flags: {
+        internalization_auto_consumer: { id: 'internalization_auto_consumer', enabled: false, category: 'quiet' },
+      },
+      source: 'config',
+      errors: [],
+    });
+
+    await handleRuntimeInternalizationQueue({ workspace: WS, json: false });
+
+    const text = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(text).toContain('manual_action_required');
+    expect(text).toContain('nextAction:');
+    expect(text).toContain('pd runtime internalization run-once');
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-consumer-product-path.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-consumer-product-path.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { TaskRecord } from '../task-status.js';
+import type { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import type {
+  PDRuntimeAdapter,
+  RunHandle,
+} from '../runtime-protocol.js';
+import type { StoreEventEmitter } from '../store/event-emitter.js';
+import type { DreamerValidator } from '../internalization/dreamer-output.js';
+import { InternalizationOrchestrator } from '../internalization/internalization-orchestrator.js';
+import { DreamerRunner } from '../internalization/dreamer-runner.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+
+const TASK_ID = 'dreamer-ready-001';
+const RUN_ID = 'run-dreamer-001';
+const OWNER = 'auto-consumer';
+const RUNTIME_KIND = 'pi-ai' as const;
+
+function makeRawTask(overrides: {
+  taskId?: string;
+  taskKind?: string;
+  status?: string;
+  channel?: string;
+  dependencyTaskIds?: string[];
+  attemptCount?: number;
+} = {}): TaskRecord {
+  const {
+    taskId = TASK_ID,
+    taskKind = 'dreamer',
+    status = 'pending',
+    channel = 'prompt',
+    dependencyTaskIds = [],
+    attemptCount = 0,
+  } = overrides;
+
+  const piMetadata: Record<string, unknown> = {
+    dependencyTaskIds,
+    channel,
+    timeoutMs: 60000,
+    inputArtifactRefs: [],
+    outputArtifactRefs: [],
+  };
+
+  const diagnosticJson = JSON.stringify({ pi_metadata: piMetadata });
+
+  return {
+    taskId,
+    taskKind,
+    status: status as TaskRecord['status'],
+    createdAt: '2026-06-13T00:00:00Z',
+    updatedAt: '2026-06-13T00:00:00Z',
+    attemptCount,
+    maxAttempts: 3,
+    diagnosticJson,
+  } as unknown as TaskRecord;
+}
+
+function makeDreamerOutput() {
+  return {
+    valid: true,
+    taskId: TASK_ID,
+    candidates: [{
+      candidateIndex: 0,
+      badDecision: 'Test bad decision',
+      betterDecision: 'Test better decision',
+      rationale: 'Test rationale',
+      confidence: 0.8,
+      riskLevel: 'low',
+      strategicPerspective: 'conservative_fix',
+    }],
+    sourcePrincipleId: 'principle-001',
+    sourcePainId: 'pain-001',
+    contextRefs: ['trajectory-001'],
+    generatedAt: '2026-06-13T00:00:00Z',
+  };
+}
+
+function createMockStateManager(opts: {
+  pendingTasks?: TaskRecord[];
+  retryWaitTasks?: TaskRecord[];
+  noRetry?: boolean;
+} = {}) {
+  const {
+    pendingTasks = [makeRawTask({ status: 'pending' })],
+    retryWaitTasks = [],
+    noRetry = false,
+  } = opts;
+
+  const leasedTask = makeRawTask({ status: 'leased', attemptCount: 1 });
+  const succeededTask = makeRawTask({ status: 'succeeded' });
+
+  return {
+    listTasks: vi.fn()
+      .mockResolvedValueOnce(pendingTasks)
+      .mockResolvedValueOnce(retryWaitTasks)
+      .mockResolvedValue([]),
+    getTask: vi.fn().mockResolvedValue(succeededTask),
+    acquireLease: vi.fn().mockResolvedValue(leasedTask),
+    markTaskSucceeded: vi.fn().mockResolvedValue(succeededTask),
+    markTaskFailed: vi.fn().mockResolvedValue(makeRawTask({ status: 'pending' })),
+    markTaskRetryWait: vi.fn().mockResolvedValue(makeRawTask({ status: 'retry_wait' })),
+    updateRunOutput: vi.fn().mockResolvedValue({}),
+    getRetryPolicy: vi.fn().mockReturnValue({
+      calculateBackoff: vi.fn().mockReturnValue(30_000),
+      shouldRetry: vi.fn().mockReturnValue(!noRetry),
+    }),
+    getRunsByTask: vi.fn().mockResolvedValue([{ runId: RUN_ID, taskId: TASK_ID }]),
+    createTask: vi.fn().mockResolvedValue({
+      taskId: `philosopher-${TASK_ID}-prompt`,
+      taskKind: 'philosopher',
+      status: 'pending',
+    } as unknown as TaskRecord),
+  };
+}
+
+function createMockAdapter(opts: {
+  pollStatus?: string;
+} = {}) {
+  const {
+    pollStatus = 'succeeded',
+  } = opts;
+
+  const runHandle: RunHandle = {
+    runId: RUN_ID,
+    runtimeKind: RUNTIME_KIND,
+    startedAt: '2026-06-13T00:00:00Z',
+  };
+
+  return {
+    kind: vi.fn().mockReturnValue(RUNTIME_KIND),
+    getCapabilities: vi.fn(),
+    healthCheck: vi.fn(),
+    startRun: vi.fn().mockResolvedValue(runHandle),
+    pollRun: vi.fn().mockResolvedValue({
+      runId: RUN_ID,
+      status: pollStatus,
+    }),
+    cancelRun: vi.fn().mockResolvedValue(undefined),
+    fetchOutput: vi.fn().mockResolvedValue({
+      runId: RUN_ID,
+      payload: makeDreamerOutput(),
+    }),
+    fetchArtifacts: vi.fn(),
+  };
+}
+
+function createMockEventEmitter(): StoreEventEmitter {
+  return {
+    emitTelemetry: vi.fn().mockReturnValue(true),
+    on: vi.fn(),
+    emit: vi.fn(),
+  } as unknown as StoreEventEmitter;
+}
+
+function createMockValidator(): DreamerValidator {
+  return {
+    validate: vi.fn().mockResolvedValue({
+      valid: true,
+      errors: [] as readonly string[],
+    }),
+  };
+}
+
+describe('PRI-381: Consumer product-path — full cycle integration', () => {
+  it('wakeOnce leases ready dreamer → runner.run succeeds → commitNextTaskProposal creates successor', async () => {
+    const mockStateManager = createMockStateManager();
+    const mockAdapter = createMockAdapter();
+    const stateManager = mockStateManager as unknown as RuntimeStateManager;
+    const adapter = mockAdapter as unknown as PDRuntimeAdapter;
+
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: false },
+    );
+
+    const wakeResult = await orchestrator.wakeOnce('dreamer');
+
+    expect(wakeResult.decision).toBe('leased');
+    if (wakeResult.decision !== 'leased') {
+      throw new Error('wakeOnce did not lease the task');
+    }
+    expect(wakeResult.taskId).toBe(TASK_ID);
+    expect(mockStateManager.acquireLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: TASK_ID,
+        owner: OWNER,
+      }),
+    );
+
+    const runner = new DreamerRunner(
+      {
+        stateManager,
+        runtimeAdapter: adapter,
+        eventEmitter: createMockEventEmitter(),
+        artifactStore: new MemoryPIArtifactStore(),
+        validator: createMockValidator(),
+      },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND },
+    );
+
+    const runResult = await runner.run(wakeResult.taskId);
+
+    expect(runResult.status).toBe('succeeded');
+    expect(runResult.taskId).toBe(TASK_ID);
+
+    expect(mockStateManager.markTaskSucceeded).toHaveBeenCalled();
+    expect(mockAdapter.startRun).toHaveBeenCalled();
+    expect(mockAdapter.pollRun).toHaveBeenCalled();
+    expect(mockAdapter.fetchOutput).toHaveBeenCalled();
+
+    const commitResult = await orchestrator.commitNextTaskProposal(wakeResult.taskId);
+
+    expect(commitResult.decision).toBe('successor_created');
+    if (commitResult.decision !== 'successor_created') {
+      throw new Error('commitNextTaskProposal did not create successor');
+    }
+    expect(commitResult.sourceTaskId).toBe(TASK_ID);
+    expect(commitResult.successorKind).toBe('philosopher');
+    expect(mockStateManager.createTask).toHaveBeenCalled();
+  });
+
+  it('wakeOnce returns no_ready_tasks when queue is empty', async () => {
+    const mockStateManager = createMockStateManager({
+      pendingTasks: [],
+      retryWaitTasks: [],
+    });
+    const stateManager = mockStateManager as unknown as RuntimeStateManager;
+
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: false },
+    );
+
+    const wakeResult = await orchestrator.wakeOnce('dreamer');
+
+    expect(wakeResult.decision).toBe('no_ready_tasks');
+    expect(mockStateManager.acquireLease).not.toHaveBeenCalled();
+    expect(mockStateManager.createTask).not.toHaveBeenCalled();
+  });
+
+  it('runner.run failure → retried (retry policy allows retry)', async () => {
+    const mockStateManager = createMockStateManager({ noRetry: false });
+    const mockAdapter = createMockAdapter({ pollStatus: 'failed' });
+    const stateManager = mockStateManager as unknown as RuntimeStateManager;
+    const adapter = mockAdapter as unknown as PDRuntimeAdapter;
+
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: false },
+    );
+
+    const wakeResult = await orchestrator.wakeOnce('dreamer');
+    expect(wakeResult.decision).toBe('leased');
+    if (wakeResult.decision !== 'leased') {
+      throw new Error('wakeOnce did not lease the task');
+    }
+
+    const runner = new DreamerRunner(
+      {
+        stateManager,
+        runtimeAdapter: adapter,
+        eventEmitter: createMockEventEmitter(),
+        artifactStore: new MemoryPIArtifactStore(),
+        validator: createMockValidator(),
+      },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND },
+    );
+
+    const runResult = await runner.run(wakeResult.taskId);
+
+    expect(runResult.status).toBe('retried');
+    expect(mockStateManager.markTaskRetryWait).toHaveBeenCalled();
+    expect(mockStateManager.createTask).not.toHaveBeenCalled();
+  });
+
+  it('runner.run failure → failed (max attempts exhausted)', async () => {
+    const pendingTaskMaxed = makeRawTask({ status: 'pending', attemptCount: 3 });
+    const leasedTaskMaxed = makeRawTask({ status: 'leased', attemptCount: 3 });
+    const succeededTask = makeRawTask({ status: 'succeeded', attemptCount: 3 });
+
+    const mockStateManager = createMockStateManager({
+      pendingTasks: [pendingTaskMaxed],
+      noRetry: true,
+    });
+    mockStateManager.acquireLease.mockResolvedValue(leasedTaskMaxed);
+    mockStateManager.getTask.mockResolvedValue(succeededTask);
+
+    const mockAdapter = createMockAdapter({ pollStatus: 'failed' });
+    const stateManager = mockStateManager as unknown as RuntimeStateManager;
+    const adapter = mockAdapter as unknown as PDRuntimeAdapter;
+
+    const orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: false },
+    );
+
+    const wakeResult = await orchestrator.wakeOnce('dreamer');
+    expect(wakeResult.decision).toBe('leased');
+    if (wakeResult.decision !== 'leased') {
+      throw new Error('wakeOnce did not lease the task');
+    }
+
+    const runner = new DreamerRunner(
+      {
+        stateManager,
+        runtimeAdapter: adapter,
+        eventEmitter: createMockEventEmitter(),
+        artifactStore: new MemoryPIArtifactStore(),
+        validator: createMockValidator(),
+      },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND },
+    );
+
+    const runResult = await runner.run(wakeResult.taskId);
+
+    expect(runResult.status).toBe('failed');
+    expect(mockStateManager.markTaskFailed).toHaveBeenCalled();
+    expect(mockStateManager.createTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/__tests__/feature-flag-contract.test.ts
@@ -214,6 +214,7 @@ describe('computeEffectiveFlags', () => {
       if (flag.id === 'diagnostician_async_cli') continue;
       if (flag.id === 'diagnostician_core_grounding') continue;
       if (flag.id === 'diagnostician_split_pipeline') continue;
+      if (flag.id === 'internalization_auto_consumer') continue;
       expect(flag.enabled, `quiet flag ${flag.id} should default off`).toBe(false);
     }
   });

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -96,7 +96,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
   { id: 'correction_observer', category: 'quiet', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293; quiet flag to allow runtime disable)' },
-  { id: 'internalization_auto_consumer', category: 'core', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381)' },
+  { id: 'internalization_auto_consumer', category: 'quiet', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381; quiet flag, default on, disableable via config)' },
 
   // MVP-Quiet — opt-in or opt-out via config; enabled value varies per flag
   // Only flags with real consumption paths are registered (PRI-239 constraint)

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -96,7 +96,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
   { id: 'correction_observer', category: 'quiet', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293; quiet flag to allow runtime disable)' },
-  { id: 'internalization_auto_consumer', category: 'quiet', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381; quiet flag to allow runtime disable as kill switch)' },
+  { id: 'internalization_auto_consumer', category: 'core', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381)' },
 
   // MVP-Quiet — opt-in or opt-out via config; enabled value varies per flag
   // Only flags with real consumption paths are registered (PRI-239 constraint)

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -96,6 +96,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
   { id: 'correction_observer', category: 'quiet', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293; quiet flag to allow runtime disable)' },
+  { id: 'internalization_auto_consumer', category: 'quiet', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381; quiet flag to allow runtime disable as kill switch)' },
 
   // MVP-Quiet — opt-in or opt-out via config; enabled value varies per flag
   // Only flags with real consumption paths are registered (PRI-239 constraint)

--- a/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/plugin-surface-registry.ts
@@ -150,6 +150,14 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
     disabledReason: 'Disabled by default: cross-workspace central sync is opt-in for multi-workspace deployments; default off per ADR-0014 §2.4 (preserved in plugin code, not active in production).',
   },
   {
+    id: 'service:internalization-auto-consumer',
+    kind: 'service',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-06-13',
+    description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381)',
+  },
+  {
     id: 'startup:workspace-init',
     kind: 'startup',
     category: 'core',
@@ -173,6 +181,14 @@ export const PLUGIN_SURFACE_REGISTRY: readonly PluginSurfaceEntry[] = [
     enabledByDefault: true,
     since: '2026-06-02',
     description: 'Correction observer start on first prompt per workspace (MVP-Core per ADR-0014 amendment, PRI-293)',
+  },
+  {
+    id: 'startup:internalization-auto-consumer',
+    kind: 'startup',
+    category: 'core',
+    enabledByDefault: true,
+    since: '2026-06-13',
+    description: 'Internalization auto-consumer start on first prompt per workspace (MVP-Core, PRI-381)',
   },
 ];
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -957,6 +957,18 @@ export type {
   TaskClassificationInput,
 } from './internalization/queue-actionability.js';
 
+// ── Internalization Consumer Decision (PRI-381) ────────────────────────────
+
+export {
+  computeConsumerDecision,
+  DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE,
+  DEFAULT_CONSUMER_RUNNER_KINDS,
+} from './internalization/internalization-consumer-decision.js';
+export type {
+  ConsumerDecision,
+  ConsumerDecisionInput,
+} from './internalization/internalization-consumer-decision.js';
+
 // ── Recovery Sweep Service (PRI-149 Tier 2) ────────────────────────────────
 
 export { createRecoverySweepService } from './recovery-sweep-service.js';

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-consumer-decision.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-consumer-decision.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeConsumerDecision,
+  DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE,
+  DEFAULT_CONSUMER_RUNNER_KINDS,
+} from '../internalization-consumer-decision.js';
+
+describe('computeConsumerDecision', () => {
+  it('returns shouldConsume=true when auto-consumer enabled and ready tasks exist', () => {
+    const result = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 5,
+    });
+
+    expect(result.shouldConsume).toBe(true);
+    expect(result.maxTasksPerCycle).toBe(1);
+    expect(result.runnerKinds).toEqual(['dreamer']);
+    expect(result.reason).toBeUndefined();
+    expect(result.nextAction).toBeUndefined();
+  });
+
+  it('returns shouldConsume=false with nextAction when auto-consumer disabled', () => {
+    const result = computeConsumerDecision({
+      autoConsumerEnabled: false,
+      readyTaskCount: 10,
+    });
+
+    expect(result.shouldConsume).toBe(false);
+    expect(result.maxTasksPerCycle).toBe(0);
+    expect(result.runnerKinds).toEqual([]);
+    expect(result.reason).toBe('auto_consumer_disabled');
+    expect(result.nextAction).toContain('pd runtime internalization run-once');
+    expect(result.nextAction).toContain('--runner dreamer');
+  });
+
+  it('returns shouldConsume=false with reason when no ready tasks', () => {
+    const result = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 0,
+    });
+
+    expect(result.shouldConsume).toBe(false);
+    expect(result.maxTasksPerCycle).toBe(1);
+    expect(result.runnerKinds).toEqual(['dreamer']);
+    expect(result.reason).toBe('no_ready_tasks');
+    expect(result.nextAction).toBeUndefined();
+  });
+
+  it('respects custom maxTasksPerCycle', () => {
+    const result = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 10,
+      maxTasksPerCycle: 3,
+    });
+
+    expect(result.shouldConsume).toBe(true);
+    expect(result.maxTasksPerCycle).toBe(3);
+  });
+
+  it('caps maxTasksPerCycle at readyTaskCount', () => {
+    const result = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 2,
+      maxTasksPerCycle: 10,
+    });
+
+    expect(result.shouldConsume).toBe(true);
+    expect(result.maxTasksPerCycle).toBe(2);
+  });
+
+  it('disabled takes precedence over readyTaskCount', () => {
+    const result = computeConsumerDecision({
+      autoConsumerEnabled: false,
+      readyTaskCount: 0,
+    });
+
+    expect(result.shouldConsume).toBe(false);
+    expect(result.reason).toBe('auto_consumer_disabled');
+  });
+
+  it('defaults to DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE', () => {
+    expect(DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE).toBe(1);
+  });
+
+  it('defaults to dreamer runner kind only', () => {
+    expect(DEFAULT_CONSUMER_RUNNER_KINDS).toEqual(['dreamer']);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-consumer-decision.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-consumer-decision.ts
@@ -1,0 +1,48 @@
+import type { RunnerKind } from './peer-runner-contracts.js';
+
+export const DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE = 1;
+export const DEFAULT_CONSUMER_RUNNER_KINDS: readonly RunnerKind[] = ['dreamer'] as const;
+
+export interface ConsumerDecision {
+  shouldConsume: boolean;
+  maxTasksPerCycle: number;
+  runnerKinds: readonly RunnerKind[];
+  reason?: string;
+  nextAction?: string;
+}
+
+export interface ConsumerDecisionInput {
+  autoConsumerEnabled: boolean;
+  readyTaskCount: number;
+  maxTasksPerCycle?: number;
+}
+
+export function computeConsumerDecision(input: ConsumerDecisionInput): ConsumerDecision {
+  const maxTasks = input.maxTasksPerCycle ?? DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE;
+
+  if (!input.autoConsumerEnabled) {
+    return {
+      shouldConsume: false,
+      maxTasksPerCycle: 0,
+      runnerKinds: [],
+      reason: 'auto_consumer_disabled',
+      nextAction:
+        'pd runtime internalization run-once --workspace "<workspace>" --runner dreamer --runtime config --json',
+    };
+  }
+
+  if (input.readyTaskCount === 0) {
+    return {
+      shouldConsume: false,
+      maxTasksPerCycle: maxTasks,
+      runnerKinds: DEFAULT_CONSUMER_RUNNER_KINDS,
+      reason: 'no_ready_tasks',
+    };
+  }
+
+  return {
+    shouldConsume: true,
+    maxTasksPerCycle: Math.min(maxTasks, input.readyTaskCount),
+    runnerKinds: DEFAULT_CONSUMER_RUNNER_KINDS,
+  };
+}


### PR DESCRIPTION
## Root Cause

ADR-0012 retired the old IdleTrigger without providing a replacement auto-consumer for the internalization queue. run-once works manually but nothing invokes it automatically. The queue command dumps raw snapshot data with zero guidance when ready tasks exist (ERR-002: silent skip).

**Production evidence:** 37 dreamer tasks with attempt_count=0, lease_owner=null, last_error=null — no blocked/dependency_failed/lease_conflict issues, just no consumer.

## Selected Design: Hybrid (Option C)

- **Auto-consumer enabled by default** for dogfood (bounded, dreamer-only, maxTasksPerCycle=1)
- **Feature-flagged kill switch** — set internalization_auto_consumer.enabled=false in .pd/config.yaml
- **Queue CLI shows nextAction** when auto-consumer is disabled — exact command to run manually

## Kill Switch / Disable Path

1. Config gate: internalization_auto_consumer.enabled: false in .pd/config.yaml
2. Feature flag category: quiet — can be disabled at runtime by users
3. Surface guard: service is registered but gate prevents startup when disabled
4. PR revert: single focused PR

## Changes

### Core
- internalization-consumer-decision.ts — Pure logic: computeConsumerDecision() with bounded plan
- Feature flag registration (internalization_auto_consumer, quiet+enabled)
- Surface registry entries (service+startup)

### Plugin
- internalization-auto-consumer-service.ts — Bounded auto-consumer (recursive setTimeout, .unref(), 120s interval, dreamer-only, maxTasksPerCycle=1)
- Gate function + startup in before_prompt_build + registerService

### CLI
- runtime-internalization-queue.ts — Added consumerStatus and nextAction to JSON output

## Tests (17 new)

- Core: 8 tests for computeConsumerDecision
- CLI: 4 tests for queue nextAction/consumerStatus
- Plugin: 5 tests for gate function

## Verification

- npm run verify:merge — ALL GATES PASS
- Real env: 37 ready tasks + consumerStatus: auto_consumer_enabled

## ERR Checklist
- ERR-002 (silent fallback): Fixed — all skip paths have reason + nextAction
- ERR-009 (required fields): Decision returns explicit reason for non-consumption
- ERR-015/018/019 (stale loop): Fresh handle per cycle, no shared mutable state
- ERR-001/005 (as bypasses): No as casts, typed interfaces throughout

## Remaining Risk
- In-process timer stops if process exits (acceptable for MVP)
- Dreamer requires PiAI runtime config (structured errors on misconfiguration)
- Only dreamer auto-consumed (by design for MVP)

No new pain signal — known design gap from ADR-0012.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加国际化自动消费者：按策略自动消费就绪的国际化任务，默认启用。
  * 新增功能开关 `internalization_auto_consumer` 可控制自动消费者行为；当禁用时会在输出中给出建议的下一步命令。
  * 命令行工具现在在队列输出中显示消费者状态与建议操作。

* **测试**
  * 增加多项单元与集成测试，覆盖决策逻辑、服务行为和命令输出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->