### PR TITLE
fix(console): normalize sub-run task IDs in evidence chain (PRI-383)

### DIFF
--- a/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
+++ b/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
@@ -83,6 +83,51 @@ function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
+interface NormalizationResult {
+  success: boolean;
+  normalized?: string;
+  reason?: string;
+  nextAction?: string;
+}
+
+/**
+ * Normalize a diagnostician task ID to canonical "diagnosis_*" format.
+ * Supports:
+ * - diagnosis_manual_xxx
+ * - <stage>-diagnosis_manual_xxx (e.g. diag_router-diagnosis_manual_xxx)
+ * Fails loud if malformed.
+ */
+function normalizeDiagnosticianTaskId(taskId: string): NormalizationResult {
+  if (!taskId) {
+    return {
+      success: false,
+      reason: 'Diagnostician task ID is empty or missing.',
+      nextAction: 'Verify that the principle candidates table contains valid task IDs.',
+    };
+  }
+
+  // If it doesn't contain "diagnosis_", treat it as a non-standard canonical ID as-is (e.g. for testing)
+  if (!taskId.includes('diagnosis_')) {
+    return { success: true, normalized: taskId };
+  }
+
+  if (taskId.startsWith('diagnosis_')) {
+    return { success: true, normalized: taskId };
+  }
+
+  const idx = taskId.indexOf('diagnosis_');
+  if (idx > 0 && taskId[idx - 1] === '-') {
+    const normalized = taskId.slice(idx);
+    return { success: true, normalized };
+  }
+
+  return {
+    success: false,
+    reason: `Malformed diagnostician task ID: "${taskId}". Unable to normalize to canonical "diagnosis_*" format.`,
+    nextAction: 'Ensure task IDs follow the format "diagnosis_*" or "<stage>-diagnosis_*".',
+  };
+}
+
 /**
  * Runtime type guard: check if a value is a plain object (Record<string, unknown>).
  * Rejects null, arrays, primitives. Used instead of `as Record<string, unknown>`
@@ -736,26 +781,40 @@ export class EvidenceChainConsoleModel {
 
         for (const c of candidates) {
           const candidateId = isString(c.candidate_id) ? c.candidate_id : '';
-          const taskId = isString(c.task_id) ? c.task_id : '';
+          if (!candidateId) {
+            degradedReasons.push('Candidate record is missing candidate_id.');
+            degradedNextActions.push('Check principle_candidates table integrity.');
+            continue;
+          }
+
+          const rawTaskId = isString(c.task_id) ? c.task_id : '';
+          const normResult = normalizeDiagnosticianTaskId(rawTaskId);
+          if (!normResult.success || !normResult.normalized) {
+            degradedReasons.push(normResult.reason ?? 'Malformed candidate task ID.');
+            degradedNextActions.push(normResult.nextAction ?? 'Check principle_candidates table task IDs.');
+            continue;
+          }
+
+          const taskId = normResult.normalized;
+
           // PRI-380: Reverse-map candidate → painId via taskIdToPainId first,
           // then fall back to legacy taskId prefix stripping
           let painId = taskIdToPainId.get(taskId) ?? '';
           if (!painId && taskId.startsWith('diagnosis_')) {
             painId = taskId.slice('diagnosis_'.length);
           }
-          if (candidateId) {
-            const info: CandidateInfo = {
-              candidateId,
-              title: hasRichColumns ? readOwnString(c, 'title') : undefined,
-              description: hasRichColumns ? readOwnString(c, 'description') : undefined,
-              confidence: hasRichColumns && typeof c.confidence === 'number' && Number.isFinite(c.confidence)
-                ? c.confidence : undefined,
-              recommendationKind: hasRichColumns ? readOwnString(c, 'recommendation_kind') : undefined,
-            };
-            // candidateMap requires painId; candidateByTaskId only requires taskId
-            if (painId) candidateMap.set(painId, info);
-            if (taskId) candidateByTaskId.set(taskId, info);
-          }
+
+          const info: CandidateInfo = {
+            candidateId,
+            title: hasRichColumns ? readOwnString(c, 'title') : undefined,
+            description: hasRichColumns ? readOwnString(c, 'description') : undefined,
+            confidence: hasRichColumns && typeof c.confidence === 'number' && Number.isFinite(c.confidence)
+              ? c.confidence : undefined,
+            recommendationKind: hasRichColumns ? readOwnString(c, 'recommendation_kind') : undefined,
+          };
+          // candidateMap requires painId; candidateByTaskId only requires taskId
+          if (painId) candidateMap.set(painId, info);
+          if (taskId) candidateByTaskId.set(taskId, info);
         }
       } catch (err) {
         if (isMissingTableError(err)) {

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -440,6 +440,89 @@ describe('EvidenceChainConsoleModel — candidate generated', () => {
     expect(record!.linkedCandidateId).toBe('cand-001');
     expect(record!.state).toBe('candidate_generated');
   });
+
+  it('normalizes sub-run task IDs (e.g. diag_router-diagnosis_*) to canonical format', async () => {
+    const trajDb = createTrajectoryDb();
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Manual pain signal',
+      createdAt: '2026-06-07T10:00:00.000Z',
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: `diagnosis_pain_${rowId}`,
+      status: 'succeeded',
+    });
+    // Candidate generated with diag_router- prefixed task ID
+    insertCandidate(stateDb, {
+      candidateId: 'cand-002',
+      taskId: `diag_router-diagnosis_pain_${rowId}`,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const record = result.records.find(r => r.id === `pain_${rowId}`);
+    expect(record).toBeDefined();
+    expect(record!.linkedCandidateId).toBe('cand-002');
+    expect(record!.state).toBe('candidate_generated');
+  });
+
+  it('normalizes multi-segment prefixed task IDs to canonical format', async () => {
+    const trajDb = createTrajectoryDb();
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Manual pain signal',
+      createdAt: '2026-06-07T10:00:00.000Z',
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: `diagnosis_pain_${rowId}`,
+      status: 'succeeded',
+    });
+    // Candidate generated with multi-segment prefixed task ID
+    insertCandidate(stateDb, {
+      candidateId: 'cand-003',
+      taskId: `stage1-stage2-diagnosis_pain_${rowId}`,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const record = result.records.find(r => r.id === `pain_${rowId}`);
+    expect(record).toBeDefined();
+    expect(record!.linkedCandidateId).toBe('cand-003');
+    expect(record!.state).toBe('candidate_generated');
+  });
+
+  it('fails loud / degrades with reason when task ID is malformed', async () => {
+    const trajDb = createTrajectoryDb();
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Manual pain signal',
+      createdAt: '2026-06-07T10:00:00.000Z',
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: `diagnosis_pain_${rowId}`,
+      status: 'succeeded',
+    });
+    // Malformed task ID with invalid prefix separator
+    const malformedId = `diag_router_diagnosis_pain_${rowId}`;
+    insertCandidate(stateDb, {
+      candidateId: 'cand-004',
+      taskId: malformedId,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    expect(result.degradedReason).toContain('Malformed');
+    expect(result.degradedReason).toContain(malformedId);
+  });
 });
 
 // ── Sanitizer boundary ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Task ID Normalization Rules

We introduced `normalizeDiagnosticianTaskId` to clean and resolve candidate task IDs:
1. **Canonical format**: If the task ID starts with `diagnosis_`, it is returned as-is.
2. **Prefixed format**: If the task ID contains `diagnosis_` preceded by a hyphen (e.g. `diag_router-diagnosis_manual_xxx`), the runner/stage prefix is stripped, returning the canonical `diagnosis_*` ID.
3. **Non-standard format**: If the task ID does not contain `diagnosis_` at all (such as in-memory test IDs like `runtime_v2_task_xyz123`), it is allowed as-is to preserve test compatibility and flexibility.
4. **Malformed format**: If the task ID contains `diagnosis_` but does not start with it and is not preceded by a hyphen (e.g. `diag_router_diagnosis_...`), it is rejected as malformed. This triggers a loud degradation reason and next action, complying with Runtime Contract Rules.

## Avoidance of Error Recurrence (ERR Checklist)

- **[ERR-001] | `as string | undefined` type cast on untrusted JSON bypasses runtime validation**
  - Avoided by using strict `isString` runtime guards on SQLite columns and narrowing types safely rather than casting with `as`.
- **[ERR-005] | Invalid salvaged arrays bypass type contract in validate failure path**
  - Avoided by using element-wise types checks (`typeof` / `isString`) instead of raw array casts.
- **[ERR-009] | Validator silently skips missing/malformed required array fields instead of failing loud**
  - Avoided by pushing a structured degradation reason and next action to `degradedReasons`/`degradedNextActions` if a task ID is malformed, ensuring it is visible to the operator rather than silently skipped.

## Tests Run

- `npx vitest run packages/pd-console/tests/models/evidence-chain-console-model.test.ts` (all 43 tests pass, including new cases verifying normalization and malformed degradation)
- `npm run verify:merge` (repository hygiene, lint, typecheck, and build steps all pass successfully)

## Remaining Risk

- **Low Risk**: The normalization logic is focused entirely on the candidate task ID mapping. In the event of a malformed ID containing `diagnosis_` in an unexpected pattern, it will fail loudly and present a clear degradation reason on the Behavior Evidence console page, pointing the operator to check the database state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了诊断任务 ID 的验证机制，确保格式标准化处理。
  * 增强了候选项链路映射的稳定性，对异常情况提供明确的降级说明和后续操作指引。

* **Tests**
  * 新增测试用例覆盖任务 ID 规范化场景及异常处理流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->