### PR TITLE
fix(console): aggregate unmatched pain warnings at response level (PRI-382)

### DIFF
--- a/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
+++ b/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
@@ -1152,8 +1152,38 @@ export class EvidenceChainConsoleModel {
     };
 
     if (degradedReasons.length > 0) {
-      response.degradedReason = degradedReasons.join('; ');
-      response.nextAction = degradedNextActions.join(' ');
+      // Group unmatched pain event warnings to prevent flooding the global degradedReason (PRI-382)
+      const unmatchedPainIds: string[] = [];
+      const otherReasons: string[] = [];
+      const unmatchedPainRegex = /^Pain event (.*) could not be linked to a diagnostician task\.$/;
+
+      for (const reason of degradedReasons) {
+        const match = unmatchedPainRegex.exec(reason);
+        if (match) {
+          unmatchedPainIds.push(match[1]);
+        } else {
+          otherReasons.push(reason);
+        }
+      }
+
+      const finalReasons: string[] = [];
+      if (unmatchedPainIds.length > 0) {
+        if (unmatchedPainIds.length === 1) {
+          finalReasons.push(`Pain event ${unmatchedPainIds[0]} could not be linked to a diagnostician task.`);
+        } else {
+          finalReasons.push(`${unmatchedPainIds.length} evidence records could not be linked to diagnostician tasks. Showing per-record details below.`);
+        }
+      }
+
+      // Keep other unique degradation reasons
+      const uniqueOtherReasons = Array.from(new Set(otherReasons));
+      finalReasons.push(...uniqueOtherReasons);
+
+      response.degradedReason = finalReasons.join('; ');
+
+      // Deduplicate next actions so we don't repeat the same action multiple times
+      const uniqueNextActions = Array.from(new Set(degradedNextActions));
+      response.nextAction = uniqueNextActions.join(' ');
     }
 
     // Note when evidence-only sources exist but no pain signals

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -1129,6 +1129,46 @@ describe('PRI-380: Evidence chain lineage join with Runtime V2 task IDs', () => 
     expect(result.degradedReason).toBeDefined();
     expect(result.nextAction).toBeDefined();
   });
+
+  it('aggregates multiple unmatched pain event warnings at response level and deduplicates nextAction (PRI-382)', async () => {
+    const trajDb = createTrajectoryDb();
+    // Insert 5 unmatched pain events
+    const rowIds: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      rowIds.push(insertPainEvent(trajDb, {
+        source: 'manual',
+        text: `Unlinked pain event ${i}`,
+        createdAt: `2026-06-07T10:0${i}:00.000Z`,
+      }));
+    }
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    // Task exists but won't match any of these (different ID and far in future)
+    insertTask(stateDb, {
+      taskId: 'diagnosis_manual_9999_other',
+      status: 'succeeded',
+      inputRef: '999',
+      createdAt: '2026-06-07T20:00:00.000Z',
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // 1. Assert each record still has its own details (Requirement 1)
+    for (const rowId of rowIds) {
+      const record = result.records.find(r => r.id === `pain_${rowId}`);
+      expect(record).toBeDefined();
+      expect(record!.degradedReason).toBe('Could not link this pain event to a diagnostician task. The chain may be incomplete.');
+      expect(record!.nextAction).toBe('Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.');
+    }
+
+    // 2. Assert response-level degradedReason is aggregated (Requirement 2)
+    expect(result.degradedReason).toBe('5 evidence records could not be linked to diagnostician tasks. Showing per-record details below.');
+
+    // 3. Assert response-level nextAction is deduplicated (Requirement 3)
+    expect(result.nextAction).toBe('Check Runtime V2 pipeline status for unmatched pain ID formats.');
+  });
 });
 
 // ── PRI-380: crossReferenceByTimestamp unit tests ─────────────────────────────


### PR DESCRIPTION
## Degradation Aggregation Rules

We introduced aggregation and deduplication of degradation warnings at the response level in `EvidenceChainConsoleModel.ts`:

1. **Unmatched Pain Event Reasons**:
   - Parses the list of `degradedReasons` using regex `/^Pain event (.*) could not be linked to a diagnostician task\.$/`.
   - **Collapsing**:
     - If exactly **1** unmatched pain event exists: reports `"Pain event <painId> could not be linked to a diagnostician task."`.
     - If **multiple** unmatched pain events exist: collapses them into a single summary string: `"${count} evidence records could not be linked to diagnostician tasks. Showing per-record details below."`.
2. **Other Degradation Reasons**:
   - Keeps all other types of degradation reasons (e.g. state database not found, candidates table missing, malformed ledger JSON, etc.) in the list, but deduplicates them to prevent repetition.
3. **Next Actions Deduplication**:
   - Deduplicates all nextAction instructions (e.g. "Check Runtime V2 pipeline status for unmatched pain ID formats.") so they are only displayed once in the global yellow banner.

**Note**: Individual record-level `degradedReason` and `nextAction` are untouched and remain visible within each card's technical details.

## Avoidance of Error Recurrence (ERR Checklist)

- **[ERR-002] | Catch-and-degrade pattern silently swallows failure reasons**
  - Avoided by keeping all granular degradation details on the records intact (`record.degradedReason` / `record.nextAction`) while consolidating the global page-level warning.
- **[ERR-009] | Validator silently skips missing/malformed required array fields instead of failing loud**
  - Avoided by ensuring all unmatched records are strictly counted and accounted for in the aggregated summary.

## Tests Run

- `npx vitest run packages/pd-console/tests/models/evidence-chain-console-model.test.ts` (all 44 tests pass successfully, including the new aggregation test)
- `npm run verify:merge` (repository hygiene, lint, typecheck, and build steps all pass successfully)
