### PR TITLE
fix(internalization): persist failures with reason in auto-consumer and base-peer-runner

### DIFF
--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -45,6 +45,28 @@ function formatRunOnceCommand(workspaceDir: string): string {
   return `pd runtime internalization run-once --workspace "${workspaceDir}" --runner dreamer --runtime config --json`;
 }
 
+function getNextActionForError(category?: string): string {
+  if (category === 'lease_conflict') {
+    return 'Retry later or check for concurrent worker processes.';
+  }
+  if (category === 'timeout') {
+    return 'Check model provider service status/latency, or increase timeout settings in workflows.yaml.';
+  }
+  if (category === 'cancelled') {
+    return 'Re-enqueue or restart the task if it was cancelled by mistake.';
+  }
+  if (category === 'output_invalid') {
+    return 'Verify if model outputs conform to expected schema and adjust prompt or validation templates if needed.';
+  }
+  if (category === 'input_invalid') {
+    return 'Check predecessor task outputs and database integrity for malformed input references.';
+  }
+  if (category === 'max_attempts_exceeded') {
+    return 'Investigate persistent failures, correct the root issue, and clear last_error or reset attempt count.';
+  }
+  return 'Run: pd runtime internalization run-once --runner dreamer --runtime config --json to isolate the failure.';
+}
+
 async function runConsumerCycle(
   workspaceDir: string,
   logger: PluginLogger,
@@ -105,6 +127,10 @@ async function runConsumerCycle(
     });
     const snapshot = await readModel.getSnapshot();
 
+    if (snapshot.readyTasks.length > 5) {
+      logger.warn(`[PD:AutoConsumer] Backlog detected: ${snapshot.readyTasks.length} tasks ready. Processing only one task.`);
+    }
+
     const decision = computeConsumerDecision({
       autoConsumerEnabled: true,
       readyTaskCount: snapshot.readyTasks.length,
@@ -120,12 +146,12 @@ async function runConsumerCycle(
 
     const orchestrator = new InternalizationOrchestrator(
       { stateManager },
-      { owner: 'auto-consumer', runtimeKind: 'config', dryRun: false },
+      { owner: 'auto-consumer', runtimeKind: 'config', dryRun: true },
     );
 
     const wakeResult = await orchestrator.wakeOnce('dreamer');
 
-    if (wakeResult.decision !== 'leased') {
+    if (wakeResult.decision !== 'would_lease') {
       const skipPayload: Record<string, unknown> = {
         decision: wakeResult.decision,
       };
@@ -182,11 +208,19 @@ async function runConsumerCycle(
         `[PD:AutoConsumer] Task ${taskId} succeeded. Successor: ${commitResult.decision}`,
       );
     } else {
+      const errorCategory = runResult.errorCategory;
+      const failureReason = runResult.failureReason;
+      const nextAction = getNextActionForError(errorCategory);
       SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_TASK_FAILED', JSON.stringify({
         taskId,
         status: runResult.status,
+        errorCategory,
+        failureReason,
+        nextAction,
       }));
-      logger.warn(`[PD:AutoConsumer] Task ${taskId} status: ${runResult.status}`);
+      logger.warn(
+        `[PD:AutoConsumer] Task ${taskId} status: ${runResult.status}. Category: ${errorCategory}. Reason: ${failureReason}. Next Action: ${nextAction}`
+      );
     }
   } catch (err) {
     SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_ERROR', String(err));

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-consumer-product-path.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-consumer-product-path.test.ts
@@ -269,7 +269,11 @@ describe('PRI-381: Consumer product-path — full cycle integration', () => {
     const runResult = await runner.run(wakeResult.taskId);
 
     expect(runResult.status).toBe('retried');
-    expect(mockStateManager.markTaskRetryWait).toHaveBeenCalled();
+    expect(mockStateManager.markTaskRetryWait).toHaveBeenCalledWith(
+      wakeResult.taskId,
+      'execution_failed',
+      expect.stringContaining('Runtime execution ended with status: failed'),
+    );
     expect(mockStateManager.createTask).not.toHaveBeenCalled();
   });
 
@@ -314,7 +318,11 @@ describe('PRI-381: Consumer product-path — full cycle integration', () => {
     const runResult = await runner.run(wakeResult.taskId);
 
     expect(runResult.status).toBe('failed');
-    expect(mockStateManager.markTaskFailed).toHaveBeenCalled();
+    expect(mockStateManager.markTaskFailed).toHaveBeenCalledWith(
+      wakeResult.taskId,
+      'max_attempts_exceeded',
+      expect.stringContaining('Max attempts exceeded: Runtime execution ended with status: failed'),
+    );
     expect(mockStateManager.createTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/internalization-failure-persistence.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/internalization-failure-persistence.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { RuntimeStateManager } from '../store/runtime-state-manager.js';
+import { DreamerRunner } from '../internalization/dreamer-runner.js';
+import { MemoryPIArtifactStore } from '../internalization/pi-artifact-store.js';
+import { StoreEventEmitter } from '../store/event-emitter.js';
+import type { PDRuntimeAdapter } from '../runtime-protocol.js';
+import { DefaultDreamerValidator } from '../internalization/dreamer-output.js';
+
+describe('PRI-384: Failure reason persistence to runs table', () => {
+  let tmpDir: string;
+  let stateManager: RuntimeStateManager;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-failure-persist-'));
+    stateManager = new RuntimeStateManager({ workspaceDir: tmpDir });
+    await stateManager.initialize();
+  });
+
+  afterEach(async () => {
+    await stateManager.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('markTaskFailed persists detailed reason to SQLite runs table', async () => {
+    const taskId = 'task-failed-001';
+    await stateManager.taskStore.createTask({
+      taskId,
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+    });
+
+    // Acquire lease to start a run
+    await stateManager.acquireLease({
+      taskId,
+      owner: 'test-agent',
+      runtimeKind: 'pi-ai',
+    });
+
+    const detailedReason = 'Validation failed: candidate index 0 is missing badDecision';
+    await stateManager.markTaskFailed(taskId, 'output_invalid', detailedReason);
+
+    // Verify task state
+    const task = await stateManager.taskStore.getTask(taskId);
+    expect(task?.status).toBe('failed');
+    expect(task?.lastError).toBe('output_invalid');
+
+    // Verify run record
+    const runs = await stateManager.runStore.listRunsByTask(taskId);
+    expect(runs).toHaveLength(1);
+    const [run] = runs;
+    expect(run?.executionStatus).toBe('failed');
+    expect(run?.reason).toBe(detailedReason);
+    expect(run?.errorCategory).toBe('output_invalid');
+  });
+
+  it('markTaskRetryWait persists detailed reason to SQLite runs table', async () => {
+    const taskId = 'task-retry-001';
+    await stateManager.taskStore.createTask({
+      taskId,
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+    });
+
+    // Acquire lease to start a run
+    await stateManager.acquireLease({
+      taskId,
+      owner: 'test-agent',
+      runtimeKind: 'pi-ai',
+    });
+
+    const detailedReason = 'API request failed with status code 503 Service Unavailable';
+    await stateManager.markTaskRetryWait(taskId, 'execution_failed', detailedReason);
+
+    // Verify task state
+    const task = await stateManager.taskStore.getTask(taskId);
+    expect(task?.status).toBe('retry_wait');
+    expect(task?.lastError).toBe('execution_failed');
+
+    // Verify run record
+    const runs = await stateManager.runStore.listRunsByTask(taskId);
+    expect(runs).toHaveLength(1);
+    const [run] = runs;
+    expect(run?.executionStatus).toBe('failed');
+    expect(run?.reason).toBe(detailedReason);
+    expect(run?.errorCategory).toBe('execution_failed');
+  });
+
+  it('BasePeerRunner failure propagates reason to SQLite runs table', async () => {
+    const taskId = 'task-runner-fail-001';
+    const diagnosticJson = JSON.stringify({
+      pi_metadata: {
+        dependencyTaskIds: [],
+        channel: 'prompt',
+      },
+    });
+    await stateManager.taskStore.createTask({
+      taskId,
+      taskKind: 'dreamer',
+      status: 'pending',
+      attemptCount: 0,
+      maxAttempts: 3,
+      diagnosticJson,
+    });
+
+    // Mock an adapter that fails on startRun
+    const mockAdapter: PDRuntimeAdapter = {
+      kind() { return 'pi-ai'; },
+      async getCapabilities() {
+        return {
+          supportsStructuredJsonOutput: true,
+          supportsToolUse: false,
+          supportsWorkingDirectory: false,
+          supportsModelSelection: false,
+          supportsLongRunningSessions: false,
+          supportsCancellation: false,
+          supportsArtifactWriteBack: false,
+          supportsConcurrentRuns: false,
+          supportsStreaming: false,
+        };
+      },
+      async healthCheck() {
+        return {
+          healthy: true,
+          degraded: false,
+          warnings: [],
+          lastCheckedAt: new Date().toISOString(),
+        };
+      },
+      async startRun() {
+        throw new Error('LLM provider error');
+      },
+      async pollRun() {
+        return { runId: 'run-1', status: 'failed', reason: 'Aborted' };
+      },
+      async cancelRun() {
+        // Mock cancel
+      },
+      async fetchOutput() {
+        return { runId: 'run-1', payload: {} };
+      },
+      async fetchArtifacts() { return []; },
+    };
+
+    const runner = new DreamerRunner(
+      {
+        stateManager,
+        runtimeAdapter: mockAdapter,
+        eventEmitter: new StoreEventEmitter(),
+        artifactStore: new MemoryPIArtifactStore(),
+        validator: new DefaultDreamerValidator(),
+      },
+      { owner: 'test-agent', runtimeKind: 'pi-ai' },
+    );
+
+    const result = await runner.run(taskId);
+    expect(result.status).toBe('retried');
+    expect(result.failureReason).toBe('LLM provider error');
+
+    // Verify run record has the failure reason
+    const runs = await stateManager.runStore.listRunsByTask(taskId);
+    expect(runs).toHaveLength(1);
+    const [run] = runs;
+    expect(run?.executionStatus).toBe('failed');
+    expect(run?.reason).toBe('LLM provider error');
+    expect(run?.errorCategory).toBe('execution_failed');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
@@ -497,7 +497,9 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
       taskId,
       task,
       errorCategory,
-      failureReason: `Runtime execution ended with status: ${runStatus.status}`,
+      failureReason: runStatus.reason
+        ? `Runtime execution ended with status: ${runStatus.status}. Reason: ${runStatus.reason}`
+        : `Runtime execution ended with status: ${runStatus.status}`,
     });
   }
 
@@ -535,7 +537,7 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
     // Permanent errors — never retry
     if (this.permanentErrorCategories.has(ctx.errorCategory)) {
       try {
-        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory);
+        await this.stateManager.markTaskFailed(ctx.taskId, ctx.errorCategory, ctx.failureReason);
       } catch (stateErr) {
         this.emitEvent('mark_failed_error', ctx.taskId, {
           errorCategory: 'storage_unavailable',
@@ -569,7 +571,7 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
     const shouldRetry = this.stateManager.getRetryPolicy().shouldRetry(ctx.task);
     if (shouldRetry) {
       try {
-        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory);
+        await this.stateManager.markTaskRetryWait(ctx.taskId, ctx.errorCategory, ctx.failureReason);
       } catch (stateErr) {
         this.emitEvent('mark_retry_error', ctx.taskId, {
           errorCategory: 'storage_unavailable',
@@ -600,7 +602,11 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
 
     // Max attempts exceeded
     try {
-      await this.stateManager.markTaskFailed(ctx.taskId, 'max_attempts_exceeded');
+      await this.stateManager.markTaskFailed(
+        ctx.taskId,
+        'max_attempts_exceeded',
+        `Max attempts exceeded: ${ctx.failureReason}`,
+      );
     } catch (stateErr) {
       this.emitEvent('mark_failed_error', ctx.taskId, {
         errorCategory: 'storage_unavailable',

--- a/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
+++ b/packages/principles-core/src/runtime-v2/store/runtime-state-manager.ts
@@ -270,7 +270,11 @@ export class RuntimeStateManager {
   }
 
   /** Mark a task as failed and emit task_failed event. */
-  async markTaskFailed(taskId: string, lastError: PDErrorCategory): Promise<TaskRecord> {
+  async markTaskFailed(
+    taskId: string,
+    lastError: PDErrorCategory,
+    failureReason?: string,
+  ): Promise<TaskRecord> {
     this.assertInitialized();
     const now = new Date().toISOString();
 
@@ -288,7 +292,7 @@ export class RuntimeStateManager {
       await this._runStore.updateRun(latestRun.runId, {
         executionStatus: 'failed',
         endedAt: now,
-        reason: 'task_failed',
+        reason: failureReason ?? 'task_failed',
         errorCategory: lastError,
       });
     }
@@ -307,7 +311,11 @@ export class RuntimeStateManager {
   /** Mark a task as retry_wait and emit task_retried event. Per D-03: retry with backoff.
    *  Sets leaseExpiresAt to now + backoffMs so that canRetryNow() gates correctly.
    */
-  async markTaskRetryWait(taskId: string, errorCategory: PDErrorCategory): Promise<TaskRecord> {
+  async markTaskRetryWait(
+    taskId: string,
+    errorCategory: PDErrorCategory,
+    failureReason?: string,
+  ): Promise<TaskRecord> {
     this.assertInitialized();
     const now = new Date().toISOString();
 
@@ -331,7 +339,7 @@ export class RuntimeStateManager {
       await this._runStore.updateRun(latestRun.runId, {
         executionStatus: 'failed',
         endedAt: now,
-        reason: 'task_retry',
+        reason: failureReason ?? 'task_retry',
         errorCategory,
       });
     }


### PR DESCRIPTION
# PRI-384 — Internalization auto-consumer should persist failures with reasons and match CLI run-once behavior

## Root Cause

1. **Lease Conflict in Auto-Consumer**:
   - `InternalizationAutoConsumerService` was instantiating `InternalizationOrchestrator` with `dryRun: false` and calling `wakeOnce()`, which immediately leased the task in the SQLite database (changing status to `leased`).
   - Immediately after, it invoked `runner.run(taskId)`. The base runner in `BasePeerRunner.ts` always calls `stateManager.acquireLease` at the start of its run. Because the task was already leased, `acquireLease` threw a `lease_conflict` error, causing the task to fail immediately.
   - The integration test in `internalization-consumer-product-path.test.ts` used a mocked `acquireLease` that returned the leased task record without checking the database state, hiding this bug.
   - CLI `run-once` worked because it instantiated `InternalizationOrchestrator` with `dryRun: true`, getting a task ID via `would_lease` and delegating the actual lease operation to the runner.

2. **Opaque Failure Reasons**:
   - In `BasePeerRunner.retryOrFail`, calls to `stateManager.markTaskFailed` and `markTaskRetryWait` did not propagate `ctx.failureReason` (the detailed string error message). As a result, the SQLite `runs` table updated the `reason` column with a hardcoded `'task_failed'` or `'task_retry'` string, discarding the error details.
   - The auto-consumer failure logging only serialized `runResult.status`, outputting a generic `INTERNALIZATION_CONSUMER_TASK_FAILED` message without the error category or detailed reason.

## Fixes

1. **Auto-Consumer Alignment**:
   - Configured `InternalizationOrchestrator` in `InternalizationAutoConsumerService` to use `dryRun: true`.
   - Updated the decision check from `leased` to `would_lease`, delegating the actual lease to the runner just like the CLI `run-once` command.

2. **Failure Reason Persistence**:
   - Updated `markTaskFailed` and `markTaskRetryWait` in `RuntimeStateManager` to accept an optional `failureReason?: string` parameter and save it to the run record's `reason` column.
   - Passed `ctx.failureReason` from `BasePeerRunner.ts` error handlers to these state manager transitions.
   - Updated the auto-consumer's `SystemLogger.log` and warning logs to output `errorCategory`, `failureReason`, and `nextAction` (mapped from errorCategory).
   - Added a backlog warning warning log if more than 5 ready tasks accumulate in a cycle.

## Pain Signal

Recorded developing pain signal:
- **Pain ID**: `manual_1781338301370_gr9vdibx`
- **Reason**: 单元测试 Mock 了 stateManager.acquireLease，导致没有发现 wakeOnce (dryRun: false) 提前租赁了任务、使得 runner.run 再次租赁时发生 lease_conflict 的严重 Bug。

## Avoidance of Error Recurrence (ERR Checklist)

- **[ERR-002] | Catch-and-degrade pattern silently swallows failure reasons**
  - Avoided by logging and persisting full, structured failure reasons and next actions instead of silences.
- **[ERR-015] | Stale loop state during retry/repair**
  - Avoided by preserving attempt-specific failure reasons in the database run records for every execution attempt.

## Verification & Tests

1. **New Integration Tests**:
   - Added `packages/principles-core/src/runtime-v2/__tests__/internalization-failure-persistence.test.ts` verifying that `markTaskFailed` / `markTaskRetryWait` and `BasePeerRunner` failure paths correctly persist failure reasons to SQLite `runs` table.
2. **Updated Integration Tests**:
   - Enhanced assertions in `internalization-consumer-product-path.test.ts` to verify mock stateManager is called with the detailed failure reasons.
3. **Execution**:
   - All tests pass: `npx vitest run packages/principles-core/src/runtime-v2/__tests__/`
   - Repo validation passes: `npm run verify:merge`
