### PR TITLE
fix(console): make principle detail approval actions honest

### DIFF
--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -336,7 +336,14 @@
         "viewActivation": "View activation status",
         "approveFailed": "Approval failed. Please try again later.",
         "partialFailure": "Decision applied, but {{failedCount}}/{{totalCount}} records failed. Please verify and retry.",
-        "rejectFailed": "Rejection failed. Please try again later."
+        "rejectFailed": "Rejection failed. Please try again later.",
+        "decisionTitle": "Decision Actions",
+        "parkUnavailable": "Park is not yet available",
+        "reasonDataUnavailable": "Data temporarily unavailable",
+        "reasonAlreadyHandled": "Already handled",
+        "reasonNoRecords": "No pending approval records",
+        "reasonUnsupportedChannel": "Not an MVP supported channel",
+        "unactionableReasonPrefix": "Unactionable reason: "
       }
     },
     "activation": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -336,7 +336,14 @@
         "viewActivation": "查看生效情况",
         "approveFailed": "批准失败，请稍后重试。",
         "partialFailure": "决策已执行，但 {{failedCount}}/{{totalCount}} 条记录失败。请检查后重试。",
-        "rejectFailed": "拒绝失败，请稍后重试。"
+        "rejectFailed": "拒绝失败，请稍后重试。",
+        "decisionTitle": "决策操作",
+        "parkUnavailable": "暂存尚未可用",
+        "reasonDataUnavailable": "数据暂不可用",
+        "reasonAlreadyHandled": "已处理",
+        "reasonNoRecords": "暂无待审批记录",
+        "reasonUnsupportedChannel": "不是 MVP 支持通道",
+        "unactionableReasonPrefix": "不可操作原因: "
       }
     },
     "activation": {

--- a/packages/pd-console/src/ui/pages/principles/PrincipleDetailPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrincipleDetailPage.tsx
@@ -131,6 +131,7 @@ export function PrincipleDetailPage() {
     if (!id) return;
     setLoading(true);
     setError(null);
+    setApprovalGroup(null); // Clear previous approval group to prevent stale actionability (P1)
     try {
       const [pResult, aResult, lResult] = await Promise.all([
         fetchPrincipleDetail(id),
@@ -154,12 +155,15 @@ export function PrincipleDetailPage() {
       if (aData) {
         const group = aData.groups.find((g) => g.principleId === id);
         setApprovalGroup(group ?? null);
+      } else {
+        setApprovalGroup(null);
       }
 
       const lData = lResult.success ? validateLifecycleMetrics(lResult.data) : null;
       setLifecycle(lData);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
+      setApprovalGroup(null);
     } finally {
       setLoading(false);
     }
@@ -170,7 +174,36 @@ export function PrincipleDetailPage() {
   }, [loadData]);
 
   // ── Actions ─────────────────────────────────────────────────────────────
-  const handleApprove = () => setShowConfirm(true);
+  // Actionable Approval Check (PRI-387)
+  let isActionable = false;
+  let reasonKey = "";
+  let defaultReason = "";
+
+  if (!approvalGroup) {
+    reasonKey = "principles.detail.reasonDataUnavailable";
+    defaultReason = "数据暂不可用";
+  } else if (approvalGroup.status !== "pending") {
+    reasonKey = "principles.detail.reasonAlreadyHandled";
+    defaultReason = "已处理";
+  } else if (approvalGroup.records.length === 0) {
+    reasonKey = "principles.detail.reasonNoRecords";
+    defaultReason = "暂无待审批记录";
+  } else {
+    const hasMvpChannel = approvalGroup.records.some(
+      (r) => r.channel === "prompt" || r.channel === "defer_archive"
+    );
+    if (!hasMvpChannel) {
+      reasonKey = "principles.detail.reasonUnsupportedChannel";
+      defaultReason = "不是 MVP 支持通道";
+    } else {
+      isActionable = true;
+    }
+  }
+
+  const handleApprove = () => {
+    if (!isActionable) return;
+    setShowConfirm(true);
+  };
   const cancelConfirm = () => setShowConfirm(false);
 
   // ── Apply decision to all records in the group ──────────────────────────
@@ -205,7 +238,7 @@ export function PrincipleDetailPage() {
   }
 
   const confirmApprove = async () => {
-    if (!approvalGroup || actionLoading) return;
+    if (!isActionable || !approvalGroup || actionLoading) return;
     setActionLoading(true);
     try {
       const { allSucceeded, failedCount, totalCount } = await applyDecisionToAllRecords("approve");
@@ -231,14 +264,17 @@ export function PrincipleDetailPage() {
     }
   };
 
-  const handleReject = () => setShowRejectInput(true);
+  const handleReject = () => {
+    if (!isActionable) return;
+    setShowRejectInput(true);
+  };
   const cancelReject = () => {
     setShowRejectInput(false);
     setRejectReason("");
   };
 
   const confirmReject = async () => {
-    if (!approvalGroup || !rejectReason.trim() || actionLoading) return;
+    if (!isActionable || !approvalGroup || !rejectReason.trim() || actionLoading) return;
     setActionLoading(true);
     try {
       const { allSucceeded, failedCount, totalCount } = await applyDecisionToAllRecords("reject", rejectReason.trim());
@@ -266,7 +302,7 @@ export function PrincipleDetailPage() {
   };
 
   const handlePark = () => {
-    toast.success(t("principles.detail.parked"));
+    // No-op: Park is disabled and not available in this version.
   };
 
   // ── Render ──────────────────────────────────────────────────────────────
@@ -458,78 +494,95 @@ export function PrincipleDetailPage() {
         </div>
       </details>
 
-      {/* ── Decision bar ────────────────────────────────────────────────── */}
-      {isPending && (
-        <div className="border-t border-line pt-6">
-          <div className="flex gap-3 flex-wrap">
-            <Button variant="default" onClick={handleApprove} disabled={actionLoading}>
-              {t("principles.detail.approve")}
-            </Button>
-            <Button variant="outline" onClick={handlePark} disabled={actionLoading}>
-              {t("principles.detail.park")}
-            </Button>
-            <Button variant="destructive" onClick={handleReject} disabled={actionLoading}>
-              {t("principles.detail.reject")}
-            </Button>
-          </div>
+      {/* ── Decision section (PRI-387) ────────────────────────────────────── */}
+      <div className="border-t border-line pt-6 mt-6">
+        <SectionTitle>{t("principles.detail.decisionTitle", { defaultValue: "决策操作" })}</SectionTitle>
+        
+        <div className="flex gap-3 flex-wrap items-center">
+          <Button
+            variant="default"
+            onClick={handleApprove}
+            disabled={!isActionable || actionLoading}
+          >
+            {t("principles.detail.approve")}
+          </Button>
+          
+          <Button
+            variant="outline"
+            onClick={handlePark}
+            disabled
+          >
+            {t("principles.detail.park")}
+          </Button>
+          
+          <Button
+            variant="destructive"
+            onClick={handleReject}
+            disabled={!isActionable || actionLoading}
+          >
+            {t("principles.detail.reject")}
+          </Button>
 
-          {/* Confirmation bar (J.1) */}
-          {showConfirm && (
-            <div className="mt-4 p-3 bg-gov/5 border border-gov/20 rounded-[var(--radius-md)]">
-              <p className="text-ink-2 text-[13px] mb-3">
-                {t("principles.detail.confirmApprove")}
-              </p>
-              <div className="flex gap-2">
-                <Button variant="default" size="sm" onClick={confirmApprove} disabled={actionLoading}>
-                  {t("principles.detail.confirm")}
-                </Button>
-                <Button variant="outline" size="sm" onClick={cancelConfirm}>
-                  {t("principles.detail.cancel")}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Rejection reason input (inline, not dialog) */}
-          {showRejectInput && (
-            <div className="mt-4 p-3 border border-danger/20 rounded-[var(--radius-md)]">
-              <label className="block font-mono text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-2">
-                {t("principles.detail.rejectReasonLabel", { defaultValue: "拒绝原因" })}
-              </label>
-              <textarea
-                value={rejectReason}
-                onChange={(e) => setRejectReason(e.target.value)}
-                placeholder={t("principles.detail.rejectReasonPlaceholder")}
-                className="w-full border border-line rounded-[var(--radius-md)] bg-surface text-ink px-3 py-2 text-[13px] min-h-[80px] resize-y focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gov"
-                aria-label={t("principles.detail.rejectReasonPlaceholder")}
-              />
-              <div className="flex gap-2 mt-2">
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={confirmReject}
-                  disabled={!rejectReason.trim() || actionLoading}
-                >
-                  {t("principles.detail.confirmReject")}
-                </Button>
-                <Button variant="outline" size="sm" onClick={cancelReject}>
-                  {t("principles.detail.cancel")}
-                </Button>
-              </div>
-            </div>
-          )}
+          {/* Park unavailable note */}
+          <span className="text-ink-4 text-[13px]">
+            ({t("principles.detail.parkUnavailable", { defaultValue: "暂存尚未可用" })})
+          </span>
         </div>
-      )}
 
-      {/* Already decided state */}
-      {!isPending && approvalGroup && (
-        <div className="border-t border-line pt-6">
-          <p className="text-ink-3 text-[13px]">
-            {approvalGroup.status === "approved" && t("principles.detail.alreadyApproved", { defaultValue: "此原则已批准。" })}
-            {approvalGroup.status === "rejected" && t("principles.detail.alreadyRejected", { defaultValue: "此原则已拒绝。" })}
+        {/* Actionable or non-actionable status messages */}
+        {!isActionable && (
+          <p className="text-danger text-[13px] mt-3 font-mono">
+            {t("principles.detail.unactionableReasonPrefix", { defaultValue: "不可操作原因: " })}
+            {t(reasonKey, { defaultValue: defaultReason })}
           </p>
-        </div>
-      )}
+        )}
+
+        {/* Confirmation bar (J.1) */}
+        {isActionable && showConfirm && (
+          <div className="mt-4 p-3 bg-gov/5 border border-gov/20 rounded-[var(--radius-md)]">
+            <p className="text-ink-2 text-[13px] mb-3">
+              {t("principles.detail.confirmApprove")}
+            </p>
+            <div className="flex gap-2">
+              <Button variant="default" size="sm" onClick={confirmApprove} disabled={actionLoading}>
+                {t("principles.detail.confirm")}
+              </Button>
+              <Button variant="outline" size="sm" onClick={cancelConfirm}>
+                {t("principles.detail.cancel")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Rejection reason input (inline, not dialog) */}
+        {isActionable && showRejectInput && (
+          <div className="mt-4 p-3 border border-danger/20 rounded-[var(--radius-md)]">
+            <label className="block font-mono text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-2">
+              {t("principles.detail.rejectReasonLabel", { defaultValue: "拒绝原因" })}
+            </label>
+            <textarea
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              placeholder={t("principles.detail.rejectReasonPlaceholder")}
+              className="w-full border border-line rounded-[var(--radius-md)] bg-surface text-ink px-3 py-2 text-[13px] min-h-[80px] resize-y focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gov"
+              aria-label={t("principles.detail.rejectReasonPlaceholder")}
+            />
+            <div className="flex gap-2 mt-2">
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={confirmReject}
+                disabled={!rejectReason.trim() || actionLoading}
+              >
+                {t("principles.detail.confirmReject")}
+              </Button>
+              <Button variant="outline" size="sm" onClick={cancelReject}>
+                {t("principles.detail.cancel")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/tests/ui/principle-review.test.ts
+++ b/packages/pd-console/tests/ui/principle-review.test.ts
@@ -673,3 +673,62 @@ describe("PRI-332: Backend contract validators", () => {
     expect(validatorsSrc).toMatch(/readabilityWarningCode.*return null/);
   });
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// 17. PRI-387: Principle Detail Action Honesty
+// ════════════════════════════════════════════════════════════════════════════
+describe("PRI-387: Principle Detail Action Honesty", () => {
+  it("detail page checks if any record is in an MVP-supported channel", () => {
+    expect(principleDetailSrc).toMatch(/channel === "prompt" \|\| r\.channel === "defer_archive"/);
+  });
+
+  it("detail page checks for data unavailable reason", () => {
+    expect(principleDetailSrc).toMatch(/reasonDataUnavailable|reasonKey = "principles\.detail\.reasonDataUnavailable"/);
+    expect(getPagesKey("principles.detail.reasonDataUnavailable")).toBeTruthy();
+    expect(getPagesKeyZh("principles.detail.reasonDataUnavailable")).toBeTruthy();
+  });
+
+  it("detail page checks for already handled reason", () => {
+    expect(principleDetailSrc).toMatch(/reasonAlreadyHandled|reasonKey = "principles\.detail\.reasonAlreadyHandled"/);
+    expect(getPagesKey("principles.detail.reasonAlreadyHandled")).toBeTruthy();
+    expect(getPagesKeyZh("principles.detail.reasonAlreadyHandled")).toBeTruthy();
+  });
+
+  it("detail page checks for no records reason", () => {
+    expect(principleDetailSrc).toMatch(/reasonNoRecords|reasonKey = "principles\.detail\.reasonNoRecords"/);
+    expect(getPagesKey("principles.detail.reasonNoRecords")).toBeTruthy();
+    expect(getPagesKeyZh("principles.detail.reasonNoRecords")).toBeTruthy();
+  });
+
+  it("detail page checks for unsupported channel reason", () => {
+    expect(principleDetailSrc).toMatch(/reasonUnsupportedChannel|reasonKey = "principles\.detail\.reasonUnsupportedChannel"/);
+    expect(getPagesKey("principles.detail.reasonUnsupportedChannel")).toBeTruthy();
+    expect(getPagesKeyZh("principles.detail.reasonUnsupportedChannel")).toBeTruthy();
+  });
+
+  it("Park action is disabled and has unavailable message", () => {
+    expect(principleDetailSrc).toMatch(/onClick=\{handlePark\}\s+disabled/);
+    expect(principleDetailSrc).toMatch(/parkUnavailable/);
+    expect(getPagesKey("principles.detail.parkUnavailable")).toBeTruthy();
+    expect(getPagesKeyZh("principles.detail.parkUnavailable")).toBeTruthy();
+  });
+
+  it("handlePark does not trigger toast or claim persistence", () => {
+    const parkFunc = principleDetailSrc.substring(
+      principleDetailSrc.indexOf("const handlePark = () =>"),
+      principleDetailSrc.indexOf("const handlePark = () =>") + 150
+    );
+    expect(parkFunc).not.toMatch(/toast\.success/);
+    expect(parkFunc).not.toMatch(/toast\.error/);
+  });
+
+  it("confirmApprove and confirmReject are guarded by isActionable check", () => {
+    expect(principleDetailSrc).toMatch(/confirmApprove = async \(\) => \{\s*if \(!isActionable/);
+    expect(principleDetailSrc).toMatch(/confirmReject = async \(\) => \{\s*if \(!isActionable/);
+  });
+
+  it("only status pending allows approve/reject actionability (fail-closed check)", () => {
+    expect(principleDetailSrc).toMatch(/status !== "pending"/);
+    expect(principleDetailSrc).not.toMatch(/status === "approved" \|\| approvalGroup\.status === "rejected"/);
+  });
+});


### PR DESCRIPTION
# fix(console): make principle detail approval actions honest

Make all owner actions on the Principle Detail page honest:
1. **Park Action**: Disabled the button and removed the fake success toast, making it a no-op. Rendered the warning label `(暂存尚未可用)` next to the button.
2. **Actionability & Honesty**: Approve/Reject buttons are now disabled unless there is a pending approval record with an MVP-supported channel (`prompt` or `defer_archive`).
3. **Clear Reasons**: Displayed the exact reason for the un-actionable state below the buttons:
   - Data temporarily unavailable (数据暂不可用)
   - Already handled (已处理)
   - No pending approval records (暂无待审批记录)
   - Not an MVP supported channel (不是 MVP 支持通道)
4. **Safety Guards**: Both `confirmApprove` and `confirmReject` now check for actionability before firing, preventing programmatic bypass.

## Constraints & Gates Met
- **Linear Ticket**: PRI-387
- **F.4 Channel display honesty**: Checked and adhered to.
- **EP-03 Fail Loud & ERR-002**: Avoided silent fallback/fake success toast.
- **EP-01 Trust Boundary & ERR-009**: Handled all invalid state checks loudly.
- **EP-09 Test Reality Gap & ERR-025**: Added source-code contract tests verifying the new honest logic.

## Verification
- Run `pnpm --filter @principles/pd-console test` -> 970 passed.
- Run `npm run verify:merge` -> Successfully passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增"决策操作"区块，在批准/拒绝操作不可用时，显示具体原因（如数据不可用、已处理、无待处理记录、不支持的通道）。
  * 增强了多语言文案支持，优化了用户提示体验。

* **功能改进**
  * 优化批准和拒绝操作的可用性校验逻辑。
  * "暂存"按钮现已禁用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->