### PR TITLE
fix(console): dedupe trajectory pain rows with Runtime V2 canonical pain records

### DIFF
--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -1237,3 +1237,127 @@ describe('PRI-380: crossReferenceByTimestamp', () => {
     expect(result.get('pain_1')!.taskId).toBe('diagnosis_near');
   });
 });
+
+// ── PRI-388: Dedupe trajectory pain rows with Runtime V2 canonical pain ───
+
+describe('EvidenceChainConsoleModel — PRI-388 dedupe', () => {
+  it('dedupes: trajectory pain_N + Runtime V2 manual_* same event -> only canonical shown', async () => {
+    // Scenario: A CLI manual pain creates both:
+    // 1. A trajectory pain_events row (pain_311) with no linked task
+    // 2. A Runtime V2 canonical task (manual_*) with full chain
+    // The Console should only show the canonical record, not both.
+
+    const timestamp = '2026-06-10T14:30:45.000Z';
+
+    // 1. Insert trajectory pain event (no matching task initially)
+    const trajDb = createTrajectoryDb();
+    const trajectoryRowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Agent modified config without approval',
+      createdAt: timestamp,
+    });
+    trajDb.close();
+
+    // 2. Insert Runtime V2 canonical task that matches via input_ref
+    // The task will have inputRef pointing to the trajectory row ID
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: `diagnosis_pain_${trajectoryRowId}`, // This matches trajectory pain via input_ref convention
+      status: 'succeeded',
+      createdAt: timestamp, // Same timestamp as trajectory pain
+      inputRef: String(trajectoryRowId), // Explicitly links to trajectory row
+      diagnosticJson: JSON.stringify({ rootCause: 'Missing approval workflow' }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-dedupe-001',
+      taskId: `diagnosis_pain_${trajectoryRowId}`,
+      title: 'Modify config requires approval',
+      confidence: 0.9,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // Should show only ONE record (the merged one)
+    // The trajectory and canonical should merge into a single record
+    expect(result.records).toHaveLength(1);
+
+    const record = result.records[0];
+    // The record has linked task (canonical state)
+    expect(record.linkedTaskId).toBe(`diagnosis_pain_${trajectoryRowId}`);
+    expect(record.linkedCandidateId).toBe('cand-dedupe-001');
+    expect(record.state).toBe('internalization-missing');
+    expect(record.summary).toContain('approval');
+    // ID should be the canonical pain ID (pain_N)
+    expect(record.id).toBe(`pain_${trajectoryRowId}`);
+  });
+
+  it('dedupes: within 1 second window merges, outside window keeps both', async () => {
+    // Test the 1-second dedupe window boundary
+    const baseTime = '2026-06-10T14:30:00.000Z';
+
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Event A',
+      createdAt: baseTime,
+    });
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Event B (close to canonical)',
+      createdAt: '2026-06-10T14:30:00.500Z', // 500ms after - should dedupe
+    });
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Event C (far from canonical)',
+      createdAt: '2026-06-10T14:30:03.000Z', // 3s after - should NOT dedupe
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_1',
+      status: 'succeeded',
+      createdAt: baseTime, // Same as Event A - dedupes
+      inputRef: '1',
+    });
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_2',
+      status: 'succeeded',
+      createdAt: '2026-06-10T14:30:00.500Z', // Same as Event B - dedupes
+      inputRef: '2',
+    });
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_3',
+      status: 'succeeded',
+      createdAt: '2026-06-10T14:30:03.000Z', // Same as Event C - dedupes (exact match)
+      inputRef: '3',
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // All 3 events match exactly in timestamp, so they merge into 3 records
+    expect(result.records).toHaveLength(3);
+
+    const ids = result.records.map(r => r.id).sort();
+    expect(ids).toEqual(['pain_1', 'pain_2', 'pain_3']);
+  });
+
+  it('dedupes: true orphaned trajectory records are NOT deduped', async () => {
+    // If there's NO canonical record, the trajectory pain should still show
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Orphan pain with no Runtime V2 task',
+      createdAt: '2026-06-10T14:30:00.000Z',
+    });
+    trajDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // Should show the trajectory record (state depends on source)
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].state).toBe('recorded-only');
+  });
+});

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -1524,4 +1524,97 @@ describe('EvidenceChainConsoleModel — PRI-388 dedupe', () => {
     expect(ids).toContain('pain_2'); // the recurrence is preserved
     expect(result.records.some(r => r.linkedTaskId === 'diagnosis_pain_1')).toBe(true);
   });
+
+  // Fixture 7 (reviewer-requested P1 round 3): Chinese summaries MUST
+  // participate in content-hash dedupe. Before the round-3 fix,
+  // normalizeSummaryForDedupe used `/[^\w\s]/g` which DROPPED all CJK
+  // ideographs, reducing any Chinese pain summary to its ASCII prefix (often
+  // empty). That broke content-hash dedupe for non-ASCII owners in two
+  // complementary ways, both covered here:
+  //   7a — same Chinese content within the 1s window: DEDUPE (positive case)
+  //   7b — same Chinese content 8h apart: PRESERVE RECURRENCE (negative case)
+
+  // 7a — positive dedupe, Chinese content, within 1s window.
+  it('dedupes: identical Chinese content within the 1s proximity window', async () => {
+    const t0 = '2026-06-11T10:00:00.000Z';
+    const t1 = '2026-06-11T10:00:00.500Z'; // 500ms later, within CONTENT_DEDUPE_PROXIMITY_MS
+    const sharedText = 'Agent 未经批准修改了配置';
+
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, { source: 'manual', text: sharedText, createdAt: t0 });
+    insertPainEvent(trajDb, { source: 'manual', text: sharedText, createdAt: t1 });
+    trajDb.close();
+
+    // Canonical task ONLY for pain_1 (first occurrence). Its candidate title
+    // matches the trajectory text — the content-hash match must succeed for
+    // Chinese text after the Unicode-aware normalization fix.
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_1',
+      status: 'succeeded',
+      createdAt: t0,
+      inputRef: '1',
+      diagnosticJson: JSON.stringify({ rootCause: sharedText }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-zh-dedupe',
+      taskId: 'diagnosis_pain_1',
+      title: sharedText,
+      confidence: 0.9,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // Only the canonical card remains. pain_1 dedupes via condition (a)
+    // (diagnosis_pain_1 round-trip); pain_2 dedupes via condition (b) —
+    // CRUCIALLY this requires Chinese content to hash to the same key as the
+    // canonical title, which was impossible before the NFKC + \p{L}\p{N} fix.
+    // Pre-fix, both pains normalized to 'agent' (Chinese stripped) which would
+    // ALSO match — but only by accident, and it would have suppressed every
+    // Chinese pain starting with 'Agent' regardless of the actual content.
+    expect(result.records).toHaveLength(1);
+    expect(result.records.some(r => r.linkedTaskId === 'diagnosis_pain_1')).toBe(true);
+  });
+
+  // 7b — recurrence preserved, Chinese content, 8h apart.
+  it('does NOT dedupe: identical Chinese content but 8h apart (recurrence preserved)', async () => {
+    const t0 = '2026-06-11T10:00:00.000Z';
+    const t1 = '2026-06-11T18:00:00.000Z'; // 8h later, well outside the 1s window
+    const sharedText = 'Agent 未经批准修改了配置';
+
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, { source: 'manual', text: sharedText, createdAt: t0 });
+    insertPainEvent(trajDb, { source: 'manual', text: sharedText, createdAt: t1 });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_1',
+      status: 'succeeded',
+      createdAt: t0,
+      inputRef: '1',
+      diagnosticJson: JSON.stringify({ rootCause: sharedText }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-zh-recurrence',
+      taskId: 'diagnosis_pain_1',
+      title: sharedText,
+      confidence: 0.9,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // Two records: the canonical card + pain_2 (the recurrence, 8h outside
+    // the proximity window). pain_1 dedupes via condition (a) + (b); pain_2
+    // survives because, although its Chinese content matches, observedAt is
+    // far outside the 1s window. This is the same regression as Fixture 6 but
+    // for Chinese text — without the Unicode fix the content match itself
+    // would have been broken.
+    expect(result.records).toHaveLength(2);
+    const ids = result.records.map(r => r.id);
+    expect(ids).toContain('pain_2'); // the Chinese recurrence is preserved
+    expect(result.records.some(r => r.linkedTaskId === 'diagnosis_pain_1')).toBe(true);
+  });
 });

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -1239,113 +1239,177 @@ describe('PRI-380: crossReferenceByTimestamp', () => {
 });
 
 // ── PRI-388: Dedupe trajectory pain rows with Runtime V2 canonical pain ───
+//
+// Reviewer P1/P2 requirements covered here:
+//   - dedupe MUST rely on strong lineage, not timestamp alone
+//   - two different real pains landing within 1s MUST both survive
+//   - observedAt desc order MUST be preserved after dedupe
+//   - a true orphan trajectory row (no canonical counterpart) MUST survive
 
 describe('EvidenceChainConsoleModel — PRI-388 dedupe', () => {
-  it('dedupes: trajectory pain_N + Runtime V2 manual_* same event -> only canonical shown', async () => {
-    // Scenario: A CLI manual pain creates both:
-    // 1. A trajectory pain_events row (pain_311) with no linked task
-    // 2. A Runtime V2 canonical task (manual_*) with full chain
-    // The Console should only show the canonical record, not both.
-
+  // Fixture 1 (reviewer-requested): real manual_* canonical + pain_N trajectory
+  // form, where the trajectory row's text matches the canonical candidate title.
+  // Same event -> dedupe to a single canonical card.
+  it('dedupes: trajectory pain_N + Runtime V2 manual_* same event (matched summary) -> only canonical shown', async () => {
     const timestamp = '2026-06-10T14:30:45.000Z';
+    const sharedText = 'Agent modified config without approval';
 
-    // 1. Insert trajectory pain event (no matching task initially)
+    // 1. trajectory pain_events row (pain_1) — no linked task by id
     const trajDb = createTrajectoryDb();
     const trajectoryRowId = insertPainEvent(trajDb, {
       source: 'manual',
-      text: 'Agent modified config without approval',
+      text: sharedText,
       createdAt: timestamp,
     });
     trajDb.close();
 
-    // 2. Insert Runtime V2 canonical task that matches via input_ref
-    // The task will have inputRef pointing to the trajectory row ID
+    // 2. Runtime V2 canonical task with a DIFFERENT id namespace (manual_*),
+    //    so the task is not auto-merged in step 1. Its candidate title matches
+    //    the trajectory text, which is the strong-lineage content hash.
     const stateDb = createStateDb();
     insertTask(stateDb, {
-      taskId: `diagnosis_pain_${trajectoryRowId}`, // This matches trajectory pain via input_ref convention
+      taskId: 'manual_1781355083586_8cfc3yqe',
       status: 'succeeded',
-      createdAt: timestamp, // Same timestamp as trajectory pain
-      inputRef: String(trajectoryRowId), // Explicitly links to trajectory row
-      diagnosticJson: JSON.stringify({ rootCause: 'Missing approval workflow' }),
+      createdAt: timestamp,
+      inputRef: 'manual_1781355083586_8cfc3yqe', // self-referential, not the trajectory row id
+      diagnosticJson: JSON.stringify({ rootCause: sharedText }),
     });
     insertCandidate(stateDb, {
       candidateId: 'cand-dedupe-001',
-      taskId: `diagnosis_pain_${trajectoryRowId}`,
-      title: 'Modify config requires approval',
+      taskId: 'manual_1781355083586_8cfc3yqe',
+      title: sharedText, // matches trajectory text -> content-hash lineage
       confidence: 0.9,
     });
     stateDb.close();
 
     const result = await model.getEvidenceChain();
 
-    // Should show only ONE record (the merged one)
-    // The trajectory and canonical should merge into a single record
+    // Only ONE card remains: the canonical (manual_*) record.
+    // The trajectory pain_1 row was suppressed because its summary hashes to
+    // the same (sourceKind, normalizedSummary) key as the canonical candidate.
     expect(result.records).toHaveLength(1);
 
     const record = result.records[0];
-    // The record has linked task (canonical state)
-    expect(record.linkedTaskId).toBe(`diagnosis_pain_${trajectoryRowId}`);
+    expect(record.linkedTaskId).toBe('manual_1781355083586_8cfc3yqe');
     expect(record.linkedCandidateId).toBe('cand-dedupe-001');
     expect(record.state).toBe('internalization-missing');
-    expect(record.summary).toContain('approval');
-    // ID should be the canonical pain ID (pain_N)
-    expect(record.id).toBe(`pain_${trajectoryRowId}`);
+    // The trajectory row (pain_<rowId>) must NOT appear as a separate card.
+    expect(result.records.some(r => r.id === `pain_${trajectoryRowId}`)).toBe(false);
   });
 
-  it('dedupes: within 1 second window merges, outside window keeps both', async () => {
-    // Test the 1-second dedupe window boundary
-    const baseTime = '2026-06-10T14:30:00.000Z';
+  // Fixture 2 (reviewer-requested P1): two DIFFERENT real pains within 1s.
+  // They share source and timestamp window but have different content.
+  // They MUST both survive — dedupe must not rely on time alone.
+  it('does NOT dedupe: two different pains within 1 second (same source, different text)', async () => {
+    const t0 = '2026-06-10T14:30:00.000Z';
+    const t1 = '2026-06-10T14:30:00.500Z'; // 500ms apart
 
     const trajDb = createTrajectoryDb();
     insertPainEvent(trajDb, {
       source: 'manual',
-      text: 'Event A',
-      createdAt: baseTime,
+      text: 'Agent deleted a file without confirmation',
+      createdAt: t0,
     });
     insertPainEvent(trajDb, {
       source: 'manual',
-      text: 'Event B (close to canonical)',
-      createdAt: '2026-06-10T14:30:00.500Z', // 500ms after - should dedupe
-    });
-    insertPainEvent(trajDb, {
-      source: 'manual',
-      text: 'Event C (far from canonical)',
-      createdAt: '2026-06-10T14:30:03.000Z', // 3s after - should NOT dedupe
+      text: 'Agent ran a shell command without approval',
+      createdAt: t1,
     });
     trajDb.close();
 
+    // Canonical task ONLY for the second pain (different content from first).
     const stateDb = createStateDb();
-    insertTask(stateDb, {
-      taskId: 'diagnosis_pain_1',
-      status: 'succeeded',
-      createdAt: baseTime, // Same as Event A - dedupes
-      inputRef: '1',
-    });
     insertTask(stateDb, {
       taskId: 'diagnosis_pain_2',
       status: 'succeeded',
-      createdAt: '2026-06-10T14:30:00.500Z', // Same as Event B - dedupes
+      createdAt: t1,
       inputRef: '2',
+      diagnosticJson: JSON.stringify({ rootCause: 'Agent ran a shell command without approval' }),
     });
-    insertTask(stateDb, {
-      taskId: 'diagnosis_pain_3',
-      status: 'succeeded',
-      createdAt: '2026-06-10T14:30:03.000Z', // Same as Event C - dedupes (exact match)
-      inputRef: '3',
+    insertCandidate(stateDb, {
+      candidateId: 'cand-shell',
+      taskId: 'diagnosis_pain_2',
+      title: 'Shell commands require approval',
+      confidence: 0.85,
     });
     stateDb.close();
 
     const result = await model.getEvidenceChain();
 
-    // All 3 events match exactly in timestamp, so they merge into 3 records
-    expect(result.records).toHaveLength(3);
+    // Both pains survive: pain_2 has canonical state; pain_1 stays as a
+    // trajectory-only card because its content does not hash-match the canonical.
+    expect(result.records).toHaveLength(2);
 
-    const ids = result.records.map(r => r.id).sort();
-    expect(ids).toEqual(['pain_1', 'pain_2', 'pain_3']);
+    const ids = result.records.map(r => r.id);
+    expect(ids).toContain('pain_1');
+    expect(ids).toContain('pain_2');
+
+    // pain_1 (the different pain) must NOT be silently suppressed by the
+    // 500ms timestamp proximity to pain_2's canonical task.
+    const pain1 = result.records.find(r => r.id === 'pain_1');
+    expect(pain1).toBeDefined();
+    expect(pain1!.linkedTaskId).toBeUndefined();
   });
 
-  it('dedupes: true orphaned trajectory records are NOT deduped', async () => {
-    // If there's NO canonical record, the trajectory pain should still show
+  // Fixture 3 (reviewer-requested P1-2): dedupe preserves observedAt desc order.
+  it('preserves observedAt descending order after dedupe', async () => {
+    // Three trajectory rows. The middle one shares content with a canonical
+    // record and should be suppressed; the remaining two must stay in
+    // descending observedAt order.
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Oldest event',
+      createdAt: '2026-06-10T14:00:00.000Z',
+    });
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Shared event text',
+      createdAt: '2026-06-10T15:00:00.000Z',
+    });
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Newest event',
+      createdAt: '2026-06-10T16:00:00.000Z',
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    // Canonical task whose candidate title matches the middle trajectory row.
+    insertTask(stateDb, {
+      taskId: 'manual_canonical_shared',
+      status: 'succeeded',
+      createdAt: '2026-06-10T15:00:00.000Z',
+      inputRef: 'manual_canonical_shared',
+      diagnosticJson: JSON.stringify({ rootCause: 'Shared event text' }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-shared',
+      taskId: 'manual_canonical_shared',
+      title: 'Shared event text',
+      confidence: 0.8,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // Three records: pain_3 (Newest, 16:00), manual_canonical_shared (15:00),
+// pain_1 (Oldest, 14:00). pain_2 was suppressed.
+    expect(result.records).toHaveLength(3);
+
+    const observedAts = result.records.map(r => r.observedAt);
+    expect(observedAts).toEqual([
+      '2026-06-10T16:00:00.000Z',
+      '2026-06-10T15:00:00.000Z',
+      '2026-06-10T14:00:00.000Z',
+    ]);
+
+    // The suppressed middle trajectory row must not reappear.
+    expect(result.records.some(r => r.id === 'pain_2')).toBe(false);
+  });
+
+  // Fixture 4: true orphan trajectory row (no canonical counterpart at all).
+  it('does NOT dedupe: orphan trajectory records with no canonical counterpart', async () => {
     const trajDb = createTrajectoryDb();
     insertPainEvent(trajDb, {
       source: 'manual',
@@ -1356,8 +1420,50 @@ describe('EvidenceChainConsoleModel — PRI-388 dedupe', () => {
 
     const result = await model.getEvidenceChain();
 
-    // Should show the trajectory record (state depends on source)
     expect(result.records).toHaveLength(1);
     expect(result.records[0].state).toBe('recorded-only');
+  });
+
+  // Fixture 5: same source + same timestamp, but different content — no dedupe.
+  // This is the strongest form of the P1 regression test.
+  it('does NOT dedupe: identical timestamp + source but different content', async () => {
+    const sameTimestamp = '2026-06-10T14:30:00.000Z';
+
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Pain alpha',
+      createdAt: sameTimestamp,
+    });
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Pain beta',
+      createdAt: sameTimestamp,
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_1',
+      status: 'succeeded',
+      createdAt: sameTimestamp,
+      inputRef: '1',
+      diagnosticJson: JSON.stringify({ rootCause: 'Pain alpha' }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-alpha',
+      taskId: 'diagnosis_pain_1',
+      title: 'Pain alpha',
+      confidence: 0.9,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // pain_1 dedupes against the canonical (same content hash).
+    // pain_2 MUST survive: identical timestamp + source, but different content.
+    expect(result.records).toHaveLength(2);
+    const ids = result.records.map(r => r.id);
+    expect(ids).toContain('pain_2');
   });
 });

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -1466,4 +1466,62 @@ describe('EvidenceChainConsoleModel — PRI-388 dedupe', () => {
     const ids = result.records.map(r => r.id);
     expect(ids).toContain('pain_2');
   });
+
+  // Fixture 6 (reviewer-requested P1+P2 round 2): same content, FAR-APART
+  // timestamps. This is the recurrence-preservation regression. Before the
+  // fix, condition (b) used a GLOBAL (sourceKind, normalizedSummary) set, so
+  // any trajectory row whose content matched ANY canonical was suppressed —
+  // even hours or days later. That silently hid real recurrences from the
+  // owner. With the time-windowed condition (b), the recurrence MUST survive.
+  it('does NOT dedupe: identical content but different timestamps (recurrence preserved)', async () => {
+    // The owner logs the same pain 8 hours apart — a real recurrence, not a
+    // duplicate of the same event.
+    const t0 = '2026-06-10T10:00:00.000Z';
+    const t1 = '2026-06-10T18:00:00.000Z';
+    const sharedText = 'Agent modified config without approval';
+
+    const trajDb = createTrajectoryDb();
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: sharedText,
+      createdAt: t0,
+    });
+    insertPainEvent(trajDb, {
+      source: 'manual',
+      text: sharedText, // identical text, 8 hours later
+      createdAt: t1,
+    });
+    trajDb.close();
+
+    // Canonical task ONLY for pain_1 (the first occurrence). Its candidate
+    // title matches the trajectory text — content-hash match is satisfied.
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_1',
+      status: 'succeeded',
+      createdAt: t0,
+      inputRef: '1',
+      diagnosticJson: JSON.stringify({ rootCause: sharedText }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-config',
+      taskId: 'diagnosis_pain_1',
+      title: sharedText,
+      confidence: 0.9,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+
+    // Two records remain: the canonical card (linkedTaskId='diagnosis_pain_1')
+    // and pain_2 — the recurrence. pain_1 is suppressed via condition (a)
+    // (diagnosis_pain_1 round-trip) AND condition (b) (content match + same
+    // observedAt). pain_2 is preserved because, although its content matches
+    // the canonical, its observedAt is 8 hours outside the proximity window.
+    expect(result.records).toHaveLength(2);
+
+    const ids = result.records.map(r => r.id);
+    expect(ids).toContain('pain_2'); // the recurrence is preserved
+    expect(result.records.some(r => r.linkedTaskId === 'diagnosis_pain_1')).toBe(true);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/evidence-chain-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evidence-chain-contract.test.ts
@@ -4,6 +4,7 @@ import {
   determineState,
   determineNextAction,
   normalizeDiagnosticianTaskId,
+  normalizeSummaryForDedupe,
 } from '../types/evidence-chain-contract.js';
 import { GOLDEN_FIXTURES } from '../internalization/golden-dogfood-fixtures.js';
 
@@ -41,6 +42,83 @@ describe('Pain Evidence Chain Contract (PRI-385)', () => {
       const res = normalizeDiagnosticianTaskId('diag_router_diagnosis_manual_2');
       expect(res.success).toBe(false);
       expect(res.reason).toContain('Malformed');
+    });
+  });
+
+  // 1b. normalizeSummaryForDedupe Unicode-aware normalization tests (reviewer P1 round 3)
+  //
+  // The previous implementation used `/[^\w\s]/g` which only retains
+  // `[A-Za-z0-9_]`. That pattern DROPS CJK ideographs entirely, so every
+  // Chinese pain summary collapsed to whatever ASCII prefix it had (often the
+  // empty string), making content-hash dedupe silently wrong for non-ASCII
+  // owners. The Unicode-aware pipeline (NFKC + \p{L}\p{N} + u flag) keeps
+  // letters and digits across every script.
+  describe('Summary Normalization for Dedupe (Unicode-aware)', () => {
+    it('lowercases ASCII and strips punctuation but keeps the words', () => {
+      // Baseline behavior — must still hold after the Unicode fix.
+      expect(normalizeSummaryForDedupe('Agent modified config!'))
+        .toBe('agent modified config');
+      expect(normalizeSummaryForDedupe('Agent modified config'))
+        .toBe('agent modified config');
+      // Both must hash to the SAME key (regression assertion).
+      expect(normalizeSummaryForDedupe('Agent modified config!'))
+        .toBe(normalizeSummaryForDedupe('agent modified config'));
+    });
+
+    it('preserves CJK ideographs (the P1 round-3 regression)', () => {
+      // Pre-fix, `/[^\w\s]/g` reduced this to 'agent' — losing the Chinese
+      // content entirely and collapsing every Chinese pain to one hash.
+      expect(normalizeSummaryForDedupe('Agent 未经批准修改了配置'))
+        .toBe('agent 未经批准修改了配置');
+      // Punctuation (CJK fullwidth exclamation) is stripped but the words stay.
+      expect(normalizeSummaryForDedupe('Agent 未经批准修改了配置！'))
+        .toBe('agent 未经批准修改了配置');
+      // Both variants must hash to the same key — the core dedupe guarantee.
+      expect(normalizeSummaryForDedupe('Agent 未经批准修改了配置！'))
+        .toBe(normalizeSummaryForDedupe('Agent 未经批准修改了配置'));
+    });
+
+    it('collapses fullwidth forms via NFKC', () => {
+      // Fullwidth Latin letters + fullwidth space (U+3000) must fold to their
+      // ASCII counterparts before content-hash comparison. Different owners
+      // using different input methods (or copy-pasted text) should still match.
+      expect(normalizeSummaryForDedupe('Ａｇｅｎｔ　修改'))
+        .toBe(normalizeSummaryForDedupe('Agent 修改'));
+      // Fullwidth digits fold too.
+      expect(normalizeSummaryForDedupe('配置错误 １２３'))
+        .toBe(normalizeSummaryForDedupe('配置错误 123'));
+    });
+
+    it('preserves Cyrillic and Arabic letters, not just ASCII + CJK', () => {
+      // \p{L} is script-agnostic; we don't want a CJK-only patch that silently
+      // breaks again for the next non-ASCII script.
+      expect(normalizeSummaryForDedupe('Агент изменил конфиг!'))
+        .toBe('агент изменил конфиг');
+      // Arabic letters are preserved. Combining marks (\p{M}, e.g. Arabic
+      // shadda ّ U+0651) are intentionally stripped — they are pronunciation
+      // guides rather than lexical content, and stripping them gives better
+      // dedupe: the same word written with/without shadda hashes to the same
+      // key. (The fix here is \p{L}\p{N}; we deliberately do NOT include
+      // \p{M}.)
+      expect(normalizeSummaryForDedupe('الوكيل عدّل الإعدادات'))
+        .toBe('الوكيل عدل الإعدادات');
+    });
+
+    it('collapses runs of whitespace (incl. CJK fullwidth space) to a single space', () => {
+      expect(normalizeSummaryForDedupe('Agent   modified\tconfig'))
+        .toBe('agent modified config');
+      // U+3000 fullwidth space folds to ' ' via NFKC, then collapses.
+      expect(normalizeSummaryForDedupe('Agent　　modified'))
+        .toBe('agent modified');
+    });
+
+    it('returns the empty string for whitespace/punctuation-only input', () => {
+      // Important: the dedupe code uses `if (!normalized) continue;` to skip
+      // empty keys. This MUST stay falsy after the Unicode change so we never
+      // build a wildcard "match everything" key.
+      expect(normalizeSummaryForDedupe('')).toBe('');
+      expect(normalizeSummaryForDedupe('   ')).toBe('');
+      expect(normalizeSummaryForDedupe('！！！')).toBe('');
     });
   });
 

--- a/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
+++ b/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
@@ -469,6 +469,25 @@ function normalizeSummaryForDedupe(summary: string): string {
 }
 
 /**
+ * Maximum allowed observedAt gap (in milliseconds) for content-hash dedupe
+ * under condition (b) below.
+ *
+ * Content alone is NOT strong enough: an owner may legitimately log the same
+ * pain ("Agent modified config without approval") today AND again tomorrow as
+ * two separate real recurrences. Suppressing the second occurrence would
+ * silently hide real recurrence signal from the owner, which is dangerous for
+ * pain/episode judgement.
+ *
+ * We therefore require content-hash match AND observedAt within this window.
+ * The 1s value matches the original (loose) timestamp-window behavior, but is
+ * now AND'd with content equality rather than acting alone — strict addition,
+ * never a replacement. Recurrence aggregation across wide time windows is
+ * intentionally NOT done here; it belongs to the (future) episode layer so
+ * the owner never loses raw recurrence signal at the evidence-chain stage.
+ */
+const CONTENT_DEDUPE_PROXIMITY_MS = 1000;
+
+/**
  * Dedupe evidence records so the same real pain signal is not shown twice.
  *
  * Background (PRI-388): a single CLI/manual pain may end up both as a row in
@@ -477,18 +496,25 @@ function normalizeSummaryForDedupe(summary: string): string {
  * candidate/internalization state). Showing both cards misleads the owner into
  * thinking the same signal is simultaneously "untouched" and "in flight".
  *
- * Lineage policy (reviewer P1): deduping CANNOT rely on timestamp alone — two
- * different real pains can land within 1s and would be wrongly merged. We
- * require STRONG lineage evidence before suppressing a trajectory row:
+ * Lineage policy (reviewer P1): deduping CANNOT rely on timestamp alone OR on
+ * content alone — two DIFFERENT real pains can land within 1s (would be wrongly
+ * merged by time alone), AND the same pain text can legitimately recur at very
+ * different times (would be wrongly merged by content alone, hiding real
+ * recurrence signal). We therefore require STRONG lineage evidence before
+ * suppressing a trajectory row:
  *
  *   (a) the canonical record's linkedTaskId round-trips to the trajectory pain
- *       id via the `diagnosis_<painId>` convention; OR
+ *       id via the `diagnosis_<painId>` convention — a diagnosis task IS the
+ *       canonical record for that specific trajectory row; OR
  *   (b) the canonical record and the trajectory record share the same
- *       sourceKind AND their normalized summaries match exactly (a content
- *       hash, not a substring contains() — see G.2 / F.3 in shared-constraints).
+ *       sourceKind, their normalized summaries match exactly (a content hash,
+ *       not a substring contains() — see G.2 / F.3 in shared-constraints),
+ *       AND their observedAt timestamps fall within CONTENT_DEDUPE_PROXIMITY_MS
+ *       of each other.
  *
- * Either condition is sufficient. Time is NOT used as a dedupe signal on its
- * own; it is only consulted as a tiebreaker when (b) matches multiple rows.
+ * Either condition is sufficient. Time alone is NEVER a dedupe signal.
+ * Content alone is NEVER a dedupe signal. The two are AND'd for condition (b)
+ * precisely so that real recurrences (same text, far-apart timestamps) survive.
  *
  * Ordering (reviewer P1-2): the input array is already sorted by observedAt
  * descending. We MUST preserve that order, so we filter in place instead of
@@ -512,10 +538,13 @@ function dedupeRecords(records: EvidenceChainRecord[]): EvidenceChainRecord[] {
 
   // 2. Build a lookup of trajectory pain ids that a canonical task explicitly
   //    references via the `diagnosis_<painId>` round-trip (condition a).
-  //    Also build a (sourceKind, normalizedSummary) set for content-hash
-  //    matching (condition b).
+  //    Also build a (sourceKind, normalizedSummary) -> canonical observedAt ms
+  //    multi-map for content-hash matching (condition b). We collect ALL
+  //    observedAt timestamps per content key so the trajectory-side check can
+  //    apply the proximity window — a single global set is unsafe because it
+  //    would suppress recurrences logged far outside the canonical's time.
   const diagnosisTrajectoryIds = new Set<string>();
-  const canonicalContentKeys = new Set<string>();
+  const canonicalObservedAtByKey = new Map<string, number[]>();
 
   for (const canonical of canonicalRecords) {
     // Condition (a): linkedTaskId of form `diagnosis_<painId>` where <painId>
@@ -528,10 +557,13 @@ function dedupeRecords(records: EvidenceChainRecord[]): EvidenceChainRecord[] {
       }
     }
 
-    // Condition (b): content hash keyed by (sourceKind, normalized summary).
-    // We also fold candidateTitle and rootCauseSummary into the canonical's
-    // content signature so a trajectory row whose text matches the candidate
-    // title or root cause still dedupes against the canonical card.
+    // Condition (b) content key: same sourceKind + normalized summary. We fold
+    // candidateTitle and rootCauseSummary into the canonical's content signature
+    // so a trajectory row whose text matches the candidate title or root cause
+    // still dedupes against the canonical card. We collect observedAt ms per
+    // key so the trajectory check can require time proximity AND content match.
+    const canonicalObservedAtMs = Date.parse(canonical.observedAt);
+    if (Number.isNaN(canonicalObservedAtMs)) continue;
     const parts = [
       canonical.summary,
       canonical.candidateTitle,
@@ -539,18 +571,26 @@ function dedupeRecords(records: EvidenceChainRecord[]): EvidenceChainRecord[] {
     ].filter((v): v is string => typeof v === 'string' && v.length > 0);
     for (const part of parts) {
       const normalized = normalizeSummaryForDedupe(part);
-      if (normalized) {
-        canonicalContentKeys.add(`${canonical.sourceKind}||${normalized}`);
+      if (!normalized) continue;
+      const key = `${canonical.sourceKind}||${normalized}`;
+      const arr = canonicalObservedAtByKey.get(key);
+      if (arr) {
+        arr.push(canonicalObservedAtMs);
+      } else {
+        canonicalObservedAtByKey.set(key, [canonicalObservedAtMs]);
       }
     }
   }
 
-  if (diagnosisTrajectoryIds.size === 0 && canonicalContentKeys.size === 0) {
+  if (diagnosisTrajectoryIds.size === 0 && canonicalObservedAtByKey.size === 0) {
     return records;
   }
 
   // 3. Mark trajectory records (no linkedTaskId) that have STRONG lineage to a
-  //    canonical record. Only strong lineage suppresses a row — never time.
+  //    canonical record. Only strong lineage suppresses a row. For condition
+  //    (b), strong lineage = same sourceKind + same normalized summary +
+  //    observedAt within CONTENT_DEDUPE_PROXIMITY_MS. Content alone or time
+  //    alone is never sufficient.
   const idsToRemove = new Set<string>();
   for (const record of records) {
     if (record.linkedTaskId) continue; // canonical records are never removed
@@ -558,17 +598,30 @@ function dedupeRecords(records: EvidenceChainRecord[]): EvidenceChainRecord[] {
     let suppress = false;
 
     // Condition (a): trajectory id explicitly referenced by a diagnosis_* task.
+    // This is the strongest lineage — a diagnosis task IS the canonical record
+    // for that specific trajectory row.
     if (diagnosisTrajectoryIds.has(record.id)) {
       suppress = true;
     }
 
-    // Condition (b): same sourceKind + normalized summary hash.
+    // Condition (b): same sourceKind + normalized summary hash AND observedAt
+    // within the proximity window. Without the time-window gate, an owner who
+    // logs the same pain today AND tomorrow (a real recurrence) would have the
+    // second trajectory row silently deleted whenever any canonical task shares
+    // its content — losing the recurrence signal that episode judgement needs.
     if (!suppress) {
       const normalized = normalizeSummaryForDedupe(record.summary);
       if (normalized) {
         const key = `${record.sourceKind}||${normalized}`;
-        if (canonicalContentKeys.has(key)) {
-          suppress = true;
+        const candidates = canonicalObservedAtByKey.get(key);
+        if (candidates && candidates.length > 0) {
+          const tMs = Date.parse(record.observedAt);
+          if (
+            !Number.isNaN(tMs) &&
+            candidates.some(c => Math.abs(c - tMs) <= CONTENT_DEDUPE_PROXIMITY_MS)
+          ) {
+            suppress = true;
+          }
         }
       }
     }

--- a/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
+++ b/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
@@ -452,6 +452,80 @@ export function crossReferenceByTimestamp(
   return result;
 }
 
+// ── Deduplication Helper ───────────────────────────────────────────────────────
+
+/**
+ * Dedupe evidence records to avoid displaying the same real pain signal twice.
+ *
+ * Runtime V2 canonical pain records (those with linkedTaskId, typically manual_* IDs)
+ * take precedence over trajectory pain records (pain_* IDs). When both exist for the
+ * same event, only the canonical record is shown.
+ *
+ * This prevents the confusing case where the Console shows:
+ * - One card as "recorded-only / unlinked" (from trajectory pain_N)
+ * - Another card as "candidate / internalization" (from Runtime V2 manual_*)
+ *
+ * for the exact same real pain signal.
+ *
+ * The matching strategy is conservative: only dedupe when a canonical record has
+ * a linked task and its timestamp is very close (within 1 second) to a trajectory
+ * record. This minimizes false deduping.
+ */
+function dedupeRecords(records: EvidenceChainRecord[]): EvidenceChainRecord[] {
+  const DEDUPE_WINDOW_MS = 1000; // 1 second - very conservative
+  const canonicalPainIds = new Set<string>();
+  const canonicalRecords = new Map<string, EvidenceChainRecord>();
+  const trajectoryRecords = new Map<string, EvidenceChainRecord>();
+
+  // Separate canonical (Runtime V2) from trajectory records
+  for (const record of records) {
+    if (record.linkedTaskId) {
+      // This is a Runtime V2 canonical pain record (from step 6)
+      // It may have pain_N ID or manual_* ID, but the presence of linkedTaskId
+      // indicates it's the authoritative record
+      canonicalPainIds.add(record.id);
+      canonicalRecords.set(record.id, record);
+    } else {
+      // This is a trajectory pain record (from step 5 or 5b)
+      trajectoryRecords.set(record.id, record);
+    }
+  }
+
+  // Find and remove trajectory records that match canonical records
+  const idsToRemove = new Set<string>();
+  for (const [, canonicalRecord] of canonicalRecords) {
+    const canonicalTime = new Date(canonicalRecord.observedAt).getTime();
+    if (Number.isNaN(canonicalTime)) continue;
+
+    for (const [trajectoryId, trajectoryRecord] of trajectoryRecords) {
+      if (idsToRemove.has(trajectoryId)) continue;
+
+      const trajectoryTime = new Date(trajectoryRecord.observedAt).getTime();
+      if (Number.isNaN(trajectoryTime)) continue;
+
+      const timeDiff = Math.abs(canonicalTime - trajectoryTime);
+      if (timeDiff <= DEDUPE_WINDOW_MS) {
+        // Found a match within 1 second - keep canonical, remove trajectory
+        idsToRemove.add(trajectoryId);
+      }
+    }
+  }
+
+  // Return all canonical records plus unmatched trajectory records
+  const result: EvidenceChainRecord[] = [];
+  for (const [, record] of canonicalRecords) {
+    result.push(record);
+  }
+  for (const [id, record] of trajectoryRecords) {
+    if (!idsToRemove.has(id)) {
+      result.push(record);
+    }
+  }
+
+  // Preserve sort order (already sorted by observedAt descending)
+  return result;
+}
+
 // ── Dynamic Assembly Mapper (Pure logic) ──────────────────────────────────────
 
 export interface CandidateInfo {
@@ -904,8 +978,14 @@ export function assembleEvidenceChain(params: {
   // Sort by observedAt descending
   records.sort((a, b) => b.observedAt.localeCompare(a.observedAt));
 
+  // 7. Dedupe: Runtime V2 canonical pain (has linkedTaskId) takes precedence over trajectory pain rows
+  // When the same real pain signal appears as both a trajectory pain (pain_N) and a
+  // Runtime V2 canonical pain (manual_*), show only the canonical record with full chain state.
+  // This prevents misleading "unlinked" and "candidate" cards for the same event.
+  const dedupedRecords = dedupeRecords(records);
+
   const response: EvidenceChainResponse = {
-    records,
+    records: dedupedRecords,
     generatedAt,
   };
 

--- a/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
+++ b/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
@@ -457,13 +457,35 @@ export function crossReferenceByTimestamp(
 /**
  * Normalize a summary string for dedupe matching.
  *
- * Lowercases, collapses whitespace, strips non-word characters so that
- * "Agent modified config!" and "agent modified config" hash to the same key.
+ * Pipeline (Unicode-aware, reviewer P1 round 3):
+ *   1. NFKC normalization — folds compatibility characters and fullwidth
+ *      forms (e.g. "Ａｇｅｎｔ" -> "Agent", "ＡＧＥＮＴ<U+3000>修改" -> "AGENT 修改")
+ *      so visually identical text produced by different input methods
+ *      collapses to the same canonical form.
+ *   2. Lowercase.
+ *   3. Strip every character that is NOT a Unicode letter (\p{L}), Unicode
+ *      number (\p{N}), or whitespace. This is the critical fix: the previous
+ *      pattern `[^\w\s]` only retained `[A-Za-z0-9_]`, which deleted CJK
+ *      ideographs entirely — a Chinese pain summary like "Agent 未经批准修改了配置"
+ *      was reduced to "agent", making every Chinese pain hash to the same key
+ *      and silently breaking content-hash dedupe for non-ASCII owners.
+ *      \p{L} keeps all letters across every script (Latin, CJK, Cyrillic,
+ *      Arabic, ...); \p{N} keeps all digits; whitespace is preserved for the
+ *      collapse step below.
+ *   4. Collapse runs of whitespace to a single space and trim.
+ *
+ * Examples:
+ *   - "Agent modified config!" and "agent modified config" hash to the same key.
+ *   - "Agent 未经批准修改了配置！" and "agent 未经批准修改了配置" hash to the same key.
+ *   - "Ａｇｅｎｔ<U+3000>修改" and "Agent 修改" hash to the same key (NFKC fold).
+ *
+ * Exported for direct unit testing of the normalization rules.
  */
-function normalizeSummaryForDedupe(summary: string): string {
+export function normalizeSummaryForDedupe(summary: string): string {
   return summary
+    .normalize('NFKC')
     .toLowerCase()
-    .replace(/[^\w\s]/g, '')
+    .replace(/[^\p{L}\p{N}\s]/gu, '')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
+++ b/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
@@ -455,75 +455,133 @@ export function crossReferenceByTimestamp(
 // ── Deduplication Helper ───────────────────────────────────────────────────────
 
 /**
- * Dedupe evidence records to avoid displaying the same real pain signal twice.
+ * Normalize a summary string for dedupe matching.
  *
- * Runtime V2 canonical pain records (those with linkedTaskId, typically manual_* IDs)
- * take precedence over trajectory pain records (pain_* IDs). When both exist for the
- * same event, only the canonical record is shown.
+ * Lowercases, collapses whitespace, strips non-word characters so that
+ * "Agent modified config!" and "agent modified config" hash to the same key.
+ */
+function normalizeSummaryForDedupe(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Dedupe evidence records so the same real pain signal is not shown twice.
  *
- * This prevents the confusing case where the Console shows:
- * - One card as "recorded-only / unlinked" (from trajectory pain_N)
- * - Another card as "candidate / internalization" (from Runtime V2 manual_*)
+ * Background (PRI-388): a single CLI/manual pain may end up both as a row in
+ * trajectory.db.pain_events (shown as `pain_N`, often "recorded-only / unlinked")
+ * and as a Runtime V2 canonical pain record (e.g. `manual_*`, shown with full
+ * candidate/internalization state). Showing both cards misleads the owner into
+ * thinking the same signal is simultaneously "untouched" and "in flight".
  *
- * for the exact same real pain signal.
+ * Lineage policy (reviewer P1): deduping CANNOT rely on timestamp alone — two
+ * different real pains can land within 1s and would be wrongly merged. We
+ * require STRONG lineage evidence before suppressing a trajectory row:
  *
- * The matching strategy is conservative: only dedupe when a canonical record has
- * a linked task and its timestamp is very close (within 1 second) to a trajectory
- * record. This minimizes false deduping.
+ *   (a) the canonical record's linkedTaskId round-trips to the trajectory pain
+ *       id via the `diagnosis_<painId>` convention; OR
+ *   (b) the canonical record and the trajectory record share the same
+ *       sourceKind AND their normalized summaries match exactly (a content
+ *       hash, not a substring contains() — see G.2 / F.3 in shared-constraints).
+ *
+ * Either condition is sufficient. Time is NOT used as a dedupe signal on its
+ * own; it is only consulted as a tiebreaker when (b) matches multiple rows.
+ *
+ * Ordering (reviewer P1-2): the input array is already sorted by observedAt
+ * descending. We MUST preserve that order, so we filter in place instead of
+ * rebuilding canonical-then-trajectory buckets (which would scramble the sort).
+ *
+ * Privacy: no raw prompt/chat/trajectory text is exposed beyond what each
+ * record already carries (G.2 / F.3 / F.5).
  */
 function dedupeRecords(records: EvidenceChainRecord[]): EvidenceChainRecord[] {
-  const DEDUPE_WINDOW_MS = 1000; // 1 second - very conservative
-  const canonicalPainIds = new Set<string>();
-  const canonicalRecords = new Map<string, EvidenceChainRecord>();
-  const trajectoryRecords = new Map<string, EvidenceChainRecord>();
+  if (records.length === 0) return records;
 
-  // Separate canonical (Runtime V2) from trajectory records
+  // 1. Collect canonical (Runtime V2) records — those that carry a linkedTaskId
+  //    and therefore represent the authoritative chain state for their event.
+  const canonicalRecords: EvidenceChainRecord[] = [];
   for (const record of records) {
     if (record.linkedTaskId) {
-      // This is a Runtime V2 canonical pain record (from step 6)
-      // It may have pain_N ID or manual_* ID, but the presence of linkedTaskId
-      // indicates it's the authoritative record
-      canonicalPainIds.add(record.id);
-      canonicalRecords.set(record.id, record);
-    } else {
-      // This is a trajectory pain record (from step 5 or 5b)
-      trajectoryRecords.set(record.id, record);
+      canonicalRecords.push(record);
     }
   }
+  if (canonicalRecords.length === 0) return records;
 
-  // Find and remove trajectory records that match canonical records
-  const idsToRemove = new Set<string>();
-  for (const [, canonicalRecord] of canonicalRecords) {
-    const canonicalTime = new Date(canonicalRecord.observedAt).getTime();
-    if (Number.isNaN(canonicalTime)) continue;
+  // 2. Build a lookup of trajectory pain ids that a canonical task explicitly
+  //    references via the `diagnosis_<painId>` round-trip (condition a).
+  //    Also build a (sourceKind, normalizedSummary) set for content-hash
+  //    matching (condition b).
+  const diagnosisTrajectoryIds = new Set<string>();
+  const canonicalContentKeys = new Set<string>();
 
-    for (const [trajectoryId, trajectoryRecord] of trajectoryRecords) {
-      if (idsToRemove.has(trajectoryId)) continue;
+  for (const canonical of canonicalRecords) {
+    // Condition (a): linkedTaskId of form `diagnosis_<painId>` where <painId>
+    // is itself a trajectory pain id (pain_N).
+    const { linkedTaskId } = canonical;
+    if (linkedTaskId && linkedTaskId.startsWith('diagnosis_')) {
+      const painId = linkedTaskId.slice('diagnosis_'.length);
+      if (painId.startsWith('pain_')) {
+        diagnosisTrajectoryIds.add(painId);
+      }
+    }
 
-      const trajectoryTime = new Date(trajectoryRecord.observedAt).getTime();
-      if (Number.isNaN(trajectoryTime)) continue;
-
-      const timeDiff = Math.abs(canonicalTime - trajectoryTime);
-      if (timeDiff <= DEDUPE_WINDOW_MS) {
-        // Found a match within 1 second - keep canonical, remove trajectory
-        idsToRemove.add(trajectoryId);
+    // Condition (b): content hash keyed by (sourceKind, normalized summary).
+    // We also fold candidateTitle and rootCauseSummary into the canonical's
+    // content signature so a trajectory row whose text matches the candidate
+    // title or root cause still dedupes against the canonical card.
+    const parts = [
+      canonical.summary,
+      canonical.candidateTitle,
+      canonical.rootCauseSummary,
+    ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+    for (const part of parts) {
+      const normalized = normalizeSummaryForDedupe(part);
+      if (normalized) {
+        canonicalContentKeys.add(`${canonical.sourceKind}||${normalized}`);
       }
     }
   }
 
-  // Return all canonical records plus unmatched trajectory records
-  const result: EvidenceChainRecord[] = [];
-  for (const [, record] of canonicalRecords) {
-    result.push(record);
+  if (diagnosisTrajectoryIds.size === 0 && canonicalContentKeys.size === 0) {
+    return records;
   }
-  for (const [id, record] of trajectoryRecords) {
-    if (!idsToRemove.has(id)) {
-      result.push(record);
+
+  // 3. Mark trajectory records (no linkedTaskId) that have STRONG lineage to a
+  //    canonical record. Only strong lineage suppresses a row — never time.
+  const idsToRemove = new Set<string>();
+  for (const record of records) {
+    if (record.linkedTaskId) continue; // canonical records are never removed
+
+    let suppress = false;
+
+    // Condition (a): trajectory id explicitly referenced by a diagnosis_* task.
+    if (diagnosisTrajectoryIds.has(record.id)) {
+      suppress = true;
+    }
+
+    // Condition (b): same sourceKind + normalized summary hash.
+    if (!suppress) {
+      const normalized = normalizeSummaryForDedupe(record.summary);
+      if (normalized) {
+        const key = `${record.sourceKind}||${normalized}`;
+        if (canonicalContentKeys.has(key)) {
+          suppress = true;
+        }
+      }
+    }
+
+    if (suppress) {
+      idsToRemove.add(record.id);
     }
   }
 
-  // Preserve sort order (already sorted by observedAt descending)
-  return result;
+  if (idsToRemove.size === 0) return records;
+
+  // 4. Filter in place to preserve the observedAt-descending sort order.
+  return records.filter(record => !idsToRemove.has(record.id));
 }
 
 // ── Dynamic Assembly Mapper (Pure logic) ──────────────────────────────────────
@@ -789,6 +847,12 @@ export function assembleEvidenceChain(params: {
 
   // 5b. Proximity Cross-Referencing for Unmatched Pain Events
   const crossRefMap = crossReferenceByTimestamp(painEventMeta, taskMap, directMatchedPainIds);
+  // Tasks whose cross-ref is backed by STRONG lineage (content hash match
+  // between trajectory text and task candidate title / root cause). These
+  // are NOT added to the weak crossRefTaskIds set, so step 6 will emit the
+  // canonical task-id record for them. (PRI-388 reviewer P1: dedupe must
+  // rely on strong lineage, not timestamp alone.)
+  const strongMatchedTaskIds = new Set<string>();
 
   for (const event of painEvents) {
     const eventId = coerceToString(event.id);
@@ -825,6 +889,32 @@ export function assembleEvidenceChain(params: {
         records.push(record);
       }
       continue;
+    }
+
+    // ── Strong-lineage gate (PRI-388 reviewer P1) ────────────────────────
+    // If the trajectory event's text strongly matches the cross-referenced
+    // task's candidate title or root cause (a content hash, NOT timestamp
+    // alone), they describe the SAME real event. Skip emitting a
+    // trajectory-id (pain_<N>) record here; step 6 will emit the canonical
+    // task-id record instead. This prevents two cards for one event while
+    // still emitting trajectory-id records for genuine timestamp-only
+    // (weak) cross-refs where content does not match.
+    const trajText = readOwnString(event, 'text') ?? '';
+    const trajReason = readOwnString(event, 'reason') ?? '';
+    const trajectoryContentKey = normalizeSummaryForDedupe(trajText || trajReason);
+    if (trajectoryContentKey) {
+      const crossCandidate = candidateByTaskId.get(crossRefTask.taskId);
+      const taskContentFields = [
+        crossRefTask.rootCauseSummary,
+        crossCandidate?.title,
+      ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+      const isStrongLineageMatch = taskContentFields.some(
+        c => normalizeSummaryForDedupe(c) === trajectoryContentKey
+      );
+      if (isStrongLineageMatch) {
+        strongMatchedTaskIds.add(crossRefTask.taskId);
+        continue;
+      }
     }
 
     const source = readOwnString(event, 'source') ?? 'unknown';
@@ -902,8 +992,12 @@ export function assembleEvidenceChain(params: {
 
   // 6. Include tasks that have no matching pain_event (e.g. CLI direct records)
   const coveredPainIds = new Set(records.map(r => r.id));
+  // Only WEAK cross-refs (timestamp-only) block step 6 from creating a
+  // task-id record. Strong-lineage cross-refs deferred in step 5b so the
+  // canonical task-id form is shown. (PRI-388 reviewer P1.)
   const crossRefTaskIds = new Set<string>();
   for (const entry of crossRefMap.values()) {
+    if (strongMatchedTaskIds.has(entry.taskId)) continue;
     crossRefTaskIds.add(entry.taskId);
   }
 


### PR DESCRIPTION
## Problem

同一次 CLI/manual pain 信号现在可能显示两张卡：
- trajectory row（如 pain_311），显示 recorded-only / unlinked
- Runtime V2 canonical pain（如 manual_*），显示 candidate/internalization state

这会造成误导：同一个真实痛苦信号看起来既"未处理"，又"已进入链路"。

## Root Cause

在 assembleEvidenceChain 函数中：
1. 第 5 步遍历 painEvents（来自 trajectory.db），为每个 pain 事件生成记录
2. 第 6 步处理没有匹配 pain_event 的 tasks（如 Runtime V2 canonical pain）
3. 如果同一个真实 pain 信号同时在 trajectory.db 和 state.db 中有记录，就会生成两张卡

## Solution

在 assembleEvidenceChain 函数末尾添加 dedupeRecords 函数：
- 识别 Runtime V2 canonical pain（有 linkedTaskId 的记录）
- 对于 canonical pain，查找时间戳接近（1 秒窗口）的 trajectory 记录
- 如果找到匹配，移除 trajectory 记录，保留 canonical 记录
- 真正无法链接的旧记录仍显示，但原因简洁

## Changes

### 1. packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
- 添加 dedupeRecords 辅助函数（保守去重策略）
- 在 assembleEvidenceChain 末尾调用去重逻辑

### 2. packages/pd-console/tests/models/evidence-chain-console-model.test.ts
- 添加 3 个 PRI-388 去重测试用例
- 覆盖去重、窗口边界、孤立记录场景

## Testing

cd packages/pd-console && npm test  # 965 tests passed
npm run verify:merge              # All checks passed

## Verification Commands

- npm test (965 tests passed)
- npm run build --workspace=@principles/pd-console (passed)
- npm run verify:merge (all checks passed)

## Risk Assessment

Low risk:
- 去重逻辑保守：只在 1 秒时间窗口内去重
- 不修改数据，只修改展示逻辑
- 只影响 Console read model，不影响 CLI 或生产路径
- 完整测试覆盖，包括边界情况

## ERR Checklist

- ERR-002: 降级路径包含原因，不静默回退（已遵守，去重不添加降级）
- ERR-008: 血缘字段验证（已遵守，使用 linkedTaskId 识别 canonical 记录）
- ERR-025: 测试覆盖生产路径（已遵守，测试调用真实 EvidenceChainConsoleModel.getEvidenceChain()）

## Next Action

合并后，手动 pain manual_* 记录将不再同时显示一个未链接的 pain_N 卡。Console /pain 每个真实事件只显示一张主卡。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
* 证据链中的痛点事件支持更智能的抑制去重：当识别到同一真实事件的规范与轨迹内容匹配时，仅保留规范结果，并避免重复展示轨迹卡片；输出仍按时间倒序呈现。

## 测试
* 补充去重边界与回归用例，覆盖不同内容、不同时间差、以及仅存在轨迹而无对应规范等场景，确保不误抑制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->