### PR TITLE
fix(config): expose provider/model in config doctor output for pi-ai profiles

### DIFF
--- a/packages/pd-cli/src/services/config-doctor.ts
+++ b/packages/pd-cli/src/services/config-doctor.ts
@@ -320,8 +320,8 @@ function diagnoseInternalAgent(
         runtimeProfileId: agent.runtimeProfileId,
         runtimeProfileLabel: agent.runtimeProfileLabel,
         readiness: 'needs_setup',
-        provider: null,
-        model: null,
+        provider: profile.provider ?? null,
+        model: profile.model ?? null,
         apiKeyEnv: null,
         apiKeyPresent: false,
         reason: `pi-ai profile '${profile.id}' missing apiKeyEnv`,
@@ -336,8 +336,8 @@ function diagnoseInternalAgent(
         runtimeProfileId: agent.runtimeProfileId,
         runtimeProfileLabel: agent.runtimeProfileLabel,
         readiness: 'needs_setup',
-        provider: null,
-        model: null,
+        provider: profile.provider ?? null,
+        model: profile.model ?? null,
         apiKeyEnv,
         apiKeyPresent: false,
         reason: `Environment variable '${apiKeyEnv}' is not set or empty`,
@@ -352,8 +352,8 @@ function diagnoseInternalAgent(
       runtimeProfileId: agent.runtimeProfileId,
       runtimeProfileLabel: agent.runtimeProfileLabel,
       readiness: 'not_ready', // runtime availability unknown without actual probe
-      provider: null,
-      model: null,
+      provider: profile.provider ?? null,
+      model: profile.model ?? null,
       apiKeyEnv,
       apiKeyPresent: true,
       reason: `pi-ai profile configured with apiKeyEnv='${apiKeyEnv}' (key present); runtime availability unknown`,
@@ -465,8 +465,8 @@ export async function buildDoctorOutput(input: BuildDoctorInput): Promise<Doctor
       ? 'config_missing'
       : 'needs_probe';
     providerHealth.push({
-      provider: null,
-      model: null,
+      provider: agent.provider,
+      model: agent.model,
       apiKeyEnv: agent.apiKeyEnv,
       apiKeyPresent: agent.apiKeyPresent,
       classification,

--- a/packages/pd-console/src/ui/utils/control-center-helpers.ts
+++ b/packages/pd-console/src/ui/utils/control-center-helpers.ts
@@ -22,6 +22,8 @@ export interface RedactedRuntimeProfileSummary {
   type: string;
   label: string;
   apiKeyEnv?: string;
+  provider?: string;
+  model?: string;
   readiness: ReadinessStatus;
 }
 

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -276,6 +276,8 @@ export interface RedactedRuntimeProfileSummaryData {
   type: string;
   label: string;
   apiKeyEnv?: string;
+  provider?: string;
+  model?: string;
   readiness: ReadinessStatus;
 }
 
@@ -285,12 +287,16 @@ function validateRuntimeProfileSummary(v: unknown): RedactedRuntimeProfileSummar
   if (!Object.hasOwn(v, 'type') || !isString(v.type)) return null;
   if (!Object.hasOwn(v, 'label') || !isString(v.label)) return null;
   if (Object.hasOwn(v, 'apiKeyEnv') && !isString(v.apiKeyEnv)) return null;
+  if (Object.hasOwn(v, 'provider') && !isString(v.provider)) return null;
+  if (Object.hasOwn(v, 'model') && !isString(v.model)) return null;
   if (!Object.hasOwn(v, 'readiness')) return null;
   const readiness = validateReadinessStatus(v.readiness);
   if (readiness === null) return null;
   return {
     id: v.id, type: v.type, label: v.label,
     ...(Object.hasOwn(v, 'apiKeyEnv') && isString(v.apiKeyEnv) ? { apiKeyEnv: v.apiKeyEnv } : {}),
+    ...(Object.hasOwn(v, 'provider') && isString(v.provider) ? { provider: v.provider } : {}),
+    ...(Object.hasOwn(v, 'model') && isString(v.model) ? { model: v.model } : {}),
     readiness,
   };
 }

--- a/packages/principles-core/src/runtime-v2/config/pd-config-redaction.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-redaction.ts
@@ -137,6 +137,12 @@ export function redactPdConfig(effective: EffectivePdConfig): RedactedPdConfigSu
     if (profile.type === 'pi-ai') {
       const pd = profile;
       summary.apiKeyEnv = pd.apiKeyEnv;
+      summary.provider = pd.provider;
+      summary.model = pd.model;
+    } else if (profile.type === 'openclaw') {
+      const oc = profile;
+      if (oc.provider) summary.provider = oc.provider;
+      if (oc.model) summary.model = oc.model;
     }
 
     runtimeProfiles.push(summary);

--- a/packages/principles-core/src/runtime-v2/config/pd-config-types.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-types.ts
@@ -181,6 +181,10 @@ export interface RedactedRuntimeProfileSummary {
   label: string;
   /** For pi-ai profiles: the env var name, never the value */
   apiKeyEnv?: string;
+  /** Provider name (e.g. "lmstudio") — not sensitive, safe to expose */
+  provider?: string;
+  /** Model ID (e.g. "qwen3.6-27b-mtp") — not sensitive, safe to expose */
+  model?: string;
   /** Whether the profile appears ready (has required fields) */
   readiness: 'ready' | 'not_ready' | 'needs_setup' | 'disabled' | 'unknown';
 }


### PR DESCRIPTION
## Summary

Fix config doctor display bug where `provider` and `model` fields showed `null` for pi-ai runtime profiles, despite the values being correctly configured in `.pd/config.yaml`.

## Root Cause

`RedactedRuntimeProfileSummary` in `pd-config-types.ts` did not include `provider` or `model` fields. During config redaction, these non-sensitive fields were stripped along with actual secrets. The `config-doctor.ts` service then hardcoded `provider: null, model: null` because the redacted type didn't carry them.

## Changes (5 files)

1. **`packages/principles-core/src/runtime-v2/config/pd-config-types.ts`**: Added optional `provider?: string` and `model?: string` to `RedactedRuntimeProfileSummary`
2. **`packages/principles-core/src/runtime-v2/config/pd-config-redaction.ts`**: Populate `provider` and `model` during redaction for both pi-ai and openclaw profiles
3. **`packages/pd-cli/src/services/config-doctor.ts`**: Use `profile.provider ?? null` and `profile.model ?? null` instead of hardcoded `null` in `diagnoseInternalAgent()` and `buildDoctorOutput()`
4. **`packages/pd-console/src/ui/utils/validators.ts`**: Updated console validator to accept new optional fields
5. **`packages/pd-console/src/ui/utils/control-center-helpers.ts`**: Updated console helper type to include new optional fields

## Before / After

**Before** (`pd config doctor --json`):
```json
"internalAgents": [{ "name": "diagnostician", "provider": null, "model": null }]
"providerHealth": [{ "provider": null, "model": null }]
```

**After**:
```json
"internalAgents": [{ "name": "diagnostician", "provider": "lmstudio", "model": "qwen3.6-27b-mtp" }]
"providerHealth": [{ "provider": "lmstudio", "model": "qwen3.6-27b-mtp" }]
```

## Related

- Found during PRI-399 ops readiness verification
- This is a **display bug** — does NOT affect runtime behavior
- `provider` and `model` are not sensitive data and are safe to expose in redacted summaries

## ERR Checklist

- ERR-001 (untrusted data): N/A — reading from config.yaml, not external input
- ERR-005 (as bypasses validation): N/A — no type assertions added
- ERR-009 (fail loud): N/A — this is a display enhancement, not validation
