### PR TITLE
fix(runtime): split-stage taskId re-injection + test-double split schema (PRI-401)

### DIFF
--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/test-double-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/test-double-runtime-adapter.test.ts
@@ -78,6 +78,102 @@ describe('TestDoubleRuntimeAdapter', () => {
     });
   });
 
+  // ── BUG-008: Stage-aware dispatch tests (PRI-401) ───────────────────────────
+
+  describe('stage-aware dispatch (BUG-008)', () => {
+    it('dispatches DiagRootCauseOutputV1 for diag_rootcause taskId', async () => {
+      const adapter = new TestDoubleRuntimeAdapter();
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'test', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 5000,
+        taskRef: { taskId: 'diag_rootcause-diagnosis_pain-001' },
+      });
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output).not.toBeNull();
+      if (!output) throw new Error('output is null');
+      const payload = output.payload as Record<string, unknown>;
+      expect(payload.valid).toBe(true);
+      expect(payload.taskId).toBe('diag_rootcause-diagnosis_pain-001');
+      expect(payload.rootCauseCategory).toBe('Design');
+      expect(Array.isArray(payload.causalChain)).toBe(true);
+      expect((payload.causalChain as unknown[]).length).toBeGreaterThan(0);
+    });
+
+    it('dispatches DiagDistillerOutputV1 for diag_distiller taskId', async () => {
+      const adapter = new TestDoubleRuntimeAdapter();
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'test', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 5000,
+        taskRef: { taskId: 'diag_distiller-diagnosis_pain-001' },
+      });
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output).not.toBeNull();
+      if (!output) throw new Error('output is null');
+      const payload = output.payload as Record<string, unknown>;
+      expect(payload.valid).toBe(true);
+      expect(payload.taskId).toBe('diag_distiller-diagnosis_pain-001');
+      expect(payload.abstractedPrinciple).toBeTruthy();
+      expect(payload.sourceRootCauseArtifactId).toBeTruthy();
+    });
+
+    it('dispatches DiagnosticianOutputV1 for diag_router taskId', async () => {
+      const adapter = new TestDoubleRuntimeAdapter();
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'test', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 5000,
+        taskRef: { taskId: 'diag_router-diagnosis_pain-001' },
+      });
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output).not.toBeNull();
+      if (!output) throw new Error('output is null');
+      const payload = output.payload as Record<string, unknown>;
+      expect(payload.valid).toBe(true);
+      expect(payload.summary).toBeTruthy();
+      expect(payload.rootCause).toBeTruthy();
+      expect(Array.isArray(payload.recommendations)).toBe(true);
+    });
+
+    it('falls back to monolithic DiagnosticianOutputV1 for non-split taskId', async () => {
+      const adapter = new TestDoubleRuntimeAdapter({}, 'my-task');
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'test', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 5000,
+        taskRef: { taskId: 'diagnosis_pain-001' },
+      });
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output).not.toBeNull();
+      if (!output) throw new Error('output is null');
+      const payload = output.payload as Record<string, unknown>;
+      expect(payload.valid).toBe(true);
+      expect(payload.taskId).toBe('my-task');
+      // Monolithic output should NOT have rootCauseCategory
+      expect(payload.rootCauseCategory).toBeUndefined();
+    });
+
+    it('falls back to defaultTaskId when no taskRef provided', async () => {
+      const adapter = new TestDoubleRuntimeAdapter({}, 'fallback-task');
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'test', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 5000,
+      });
+      const output = await adapter.fetchOutput(handle.runId);
+      expect(output).not.toBeNull();
+      if (!output) throw new Error('output is null');
+      const payload = output.payload as Record<string, unknown>;
+      expect(payload.taskId).toBe('fallback-task');
+    });
+  });
+
   describe('behavior overrides', () => {
     it('onStartRun callback overrides default startRun behavior', async () => {
       const overrides: TestDoubleBehaviorOverrides = {

--- a/packages/principles-core/src/runtime-v2/adapter/test-double-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/test-double-runtime-adapter.ts
@@ -4,6 +4,11 @@
  * First real implementation of the M1 PDRuntimeAdapter interface.
  * Default behavior: succeed-on-first-poll with valid DiagnosticianOutputV1.
  * All methods overridable via TestDoubleBehaviorOverrides callbacks.
+ *
+ * BUG-008: Default fetchOutput dispatches stage-aware mock outputs based on
+ * taskId prefix (diag_rootcause/diag_distiller/diag_router), reusing fixtures
+ * from split-pipeline-mock-outputs.ts. Non-split taskIds fall back to the
+ * original monolithic DiagnosticianOutputV1 shape (backward-compatible).
  */
 import type {
   PDRuntimeAdapter,
@@ -17,6 +22,7 @@ import type {
   RuntimeArtifactRef,
   ContextItem,
 } from '../runtime-protocol.js';
+import { MOCK_ROOT_CAUSE_OUTPUTS, MOCK_DISTILLER_OUTPUTS, MOCK_ROUTER_OUTPUTS } from '../internalization/__tests__/__fixtures__/split-pipeline-mock-outputs.js';
 
 /** Optional callbacks to override default TestDoubleRuntimeAdapter behavior. */
 export interface TestDoubleBehaviorOverrides {
@@ -34,6 +40,8 @@ export class TestDoubleRuntimeAdapter implements PDRuntimeAdapter {
   private readonly overrides: TestDoubleBehaviorOverrides;
   private readonly defaultTaskId: string;
   private runCounter = 0;
+  /** BUG-008: Map runId → taskId so fetchOutput can dispatch by stage prefix. */
+  private readonly runIdToTaskId = new Map<string, string>();
 
   constructor(overrides?: TestDoubleBehaviorOverrides, defaultTaskId?: string) {
     this.overrides = overrides ?? {};
@@ -79,8 +87,14 @@ export class TestDoubleRuntimeAdapter implements PDRuntimeAdapter {
       return this.overrides.onStartRun(input);
     }
     this.runCounter += 1;
+    const runId = `td-${this.runCounter}`;
+    // BUG-008: Store taskId from taskRef so fetchOutput can dispatch by stage prefix
+    const taskId = input.taskRef?.taskId;
+    if (typeof taskId === 'string') {
+      this.runIdToTaskId.set(runId, taskId);
+    }
     return {
-      runId: `td-${this.runCounter}`,
+      runId,
       runtimeKind: 'test-double',
       startedAt: new Date().toISOString(),
     };
@@ -104,6 +118,41 @@ export class TestDoubleRuntimeAdapter implements PDRuntimeAdapter {
     if (this.overrides.onFetchOutput) {
       return this.overrides.onFetchOutput(runId);
     }
+
+    // BUG-008: Dispatch stage-aware mock outputs based on taskId prefix.
+    // Reuse fixtures from split-pipeline-mock-outputs.ts (R6).
+    const taskId = this.runIdToTaskId.get(runId) ?? this.defaultTaskId;
+
+    if (taskId.includes('diag_rootcause')) {
+      return {
+        runId,
+        payload: {
+          ...MOCK_ROOT_CAUSE_OUTPUTS.R6,
+          taskId,
+        },
+      };
+    }
+
+    if (taskId.includes('diag_distiller')) {
+      return {
+        runId,
+        payload: {
+          ...MOCK_DISTILLER_OUTPUTS.R6,
+          taskId,
+        },
+      };
+    }
+
+    if (taskId.includes('diag_router')) {
+      return {
+        runId,
+        payload: {
+          ...MOCK_ROUTER_OUTPUTS.R6,
+        },
+      };
+    }
+
+    // Backward-compatible: monolithic DiagnosticianOutputV1 for non-split taskIds
     return {
       runId,
       payload: {

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diag-rootcause-output.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diag-rootcause-output.test.ts
@@ -61,4 +61,43 @@ describe('DiagRootCauseOutputV1Schema', () => {
     const result = await validator.validate(output, 'task-001');
     expect(result.valid).toBe(true);
   });
+
+  // ── BUG-007c: taskId re-injection tests (PRI-401) ───────────────────────────
+
+  it('re-injects taskId when LLM outputs parent task ID (BUG-007c)', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = { ...validOutput, taskId: 'diagnosis_manual_xxx' };
+    const expectedTaskId = 'diag_rootcause-diagnosis_manual_xxx';
+    const result = await validator.validate(output, expectedTaskId);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings?.length).toBeGreaterThan(0);
+    expect(result.warnings?.[0]).toContain('re-injected');
+    // Verify the output was mutated to have the correct taskId
+    expect(output.taskId).toBe(expectedTaskId);
+  });
+
+  it('re-injection value comes from caller expectedTaskId, not LLM output (ERR-008)', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = { ...validOutput, taskId: 'diagnosis_manual_xxx' };
+    const expectedTaskId = 'diag_rootcause-diagnosis_manual_xxx';
+    await validator.validate(output, expectedTaskId);
+    // The re-injected value must be the caller's expectedTaskId
+    expect(output.taskId).toBe(expectedTaskId);
+  });
+
+  it('still errors on truly mismatched taskId (not parent/child relationship)', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = { ...validOutput, taskId: 'completely-different-task' };
+    const result = await validator.validate(output, 'diag_rootcause-diagnosis_manual_xxx');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('taskId mismatch'))).toBe(true);
+  });
+
+  it('still errors when taskId matches but other fields are invalid', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = { ...validOutput, taskId: 'task-001', rootCauseCategory: 'InvalidCategory' };
+    const result = await validator.validate(output, 'task-001');
+    expect(result.valid).toBe(false);
+  });
 });

--- a/packages/principles-core/src/runtime-v2/diagnostician/diag-rootcause-output.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/diag-rootcause-output.ts
@@ -108,7 +108,7 @@ export interface DiagRootCauseValidator {
    * @param taskId - Expected taskId for lineage verification (ERR-008)
    * @returns Validation result with valid flag, errors, and optional error category
    */
-  validate(output: unknown, taskId: string): Promise<{ valid: boolean; errors: string[]; errorCategory?: string }>;
+  validate(output: unknown, taskId: string): Promise<{ valid: boolean; errors: string[]; errorCategory?: string; warnings?: string[] }>;
 }
 
 /**
@@ -127,8 +127,9 @@ export class DefaultDiagRootCauseValidator implements DiagRootCauseValidator {
   async validate(
     output: unknown,
     taskId: string,
-  ): Promise<{ valid: boolean; errors: string[]; errorCategory?: string }> {
+  ): Promise<{ valid: boolean; errors: string[]; errorCategory?: string; warnings?: string[] }> {
     const errors: string[] = [];
+    const warnings: string[] = [];
 
     // ── Step 1: Object guard ────────────────────────────────────────────────
     if (typeof output !== 'object' || output === null) {
@@ -139,8 +140,24 @@ export class DefaultDiagRootCauseValidator implements DiagRootCauseValidator {
     const record = output as Record<string, unknown>;
 
     // ── Step 2: taskId lineage check (ERR-008) ──────────────────────────────
+    // BUG-007c: If LLM outputs the parent task ID (without diag_rootcause- prefix),
+    // re-inject the expected taskId from the caller (trusted source) instead of
+    // treating it as a hard error. The re-injection value MUST come from the
+    // caller's `taskId` parameter, never from LLM output (ERR-008).
     if (typeof record.taskId !== 'string' || record.taskId !== taskId) {
-      errors.push(`taskId mismatch: expected ${taskId}, got ${String(record.taskId)}`);
+      const DIAG_ROOTCAUSE_PREFIX = 'diag_rootcause-';
+      if (
+        typeof record.taskId === 'string'
+        && taskId.startsWith(DIAG_ROOTCAUSE_PREFIX)
+        && record.taskId === taskId.slice(DIAG_ROOTCAUSE_PREFIX.length)
+      ) {
+        // LLM output the parent task ID — re-inject the expected stage taskId
+        const parentTaskId = record.taskId;
+        record.taskId = taskId;
+        warnings.push(`taskId re-injected: LLM output parent ID "${parentTaskId}", corrected to "${taskId}" (ERR-008)`);
+      } else {
+        errors.push(`taskId mismatch: expected ${taskId}, got ${String(record.taskId)}`);
+      }
     }
 
     // ── Step 3: valid flag must be true ─────────────────────────────────────
@@ -212,9 +229,9 @@ export class DefaultDiagRootCauseValidator implements DiagRootCauseValidator {
     }
 
     if (errors.length > 0) {
-      return { valid: false, errors, errorCategory: 'output_invalid' };
+      return { valid: false, errors, errorCategory: 'output_invalid', warnings };
     }
 
-    return { valid: true, errors: [] };
+    return { valid: true, errors: [], warnings };
   }
 }


### PR DESCRIPTION
## Summary

Fixes two independent issues blocking the split diagnostician pipeline (Stage A→B→C) from completing in test environments.

### BUG-007c: taskId re-injection (diag-rootcause-output.ts)

`DefaultDiagRootCauseValidator.validate()` Step 2 previously only reported an error when `output.taskId` didn't match `expectedTaskId`. The schema comment promised "re-injected if stripped" (ERR-008), but the code never implemented re-injection.

**Fix**: When `output.taskId` equals the parent task ID (i.e., `expectedTaskId` without the `diag_rootcause-` prefix), the validator now:
1. Re-injects `expectedTaskId` into `output.taskId` (value from caller — trusted source, ERR-008)
2. Records a warning instead of an error
3. Continues validation of remaining fields

The error message `taskId mismatch: expected diag_rootcause-..., got diagnosis_manual_...` no longer appears for the parent-ID case.

### BUG-008: test-double stage dispatch (test-double-runtime-adapter.ts)

`TestDoubleRuntimeAdapter.fetchOutput()` always returned a monolithic `DiagnosticianOutputV1` (no `rootCauseCategory`, no `causalChain`, wrong taskId). Split pipeline stages would immediately fail schema validation with `output_invalid`.

**Fix**: `fetchOutput` now dispatches stage-aware mock outputs based on taskId prefix:
- `diag_rootcause-*` → `DiagRootCauseOutputV1` (R6 fixture with `rootCauseCategory`, `causalChain`)
- `diag_distiller-*` → `DiagDistillerOutputV1` (R6 fixture with `abstractedPrinciple`, `groundedOnCorePrincipleIds`)
- `diag_router-*` → `DiagnosticianOutputV1` (R6 fixture with `violatedPrinciples`, `recommendations`)
- Other → original monolithic shape (backward-compatible)

Fixtures are reused from `split-pipeline-mock-outputs.ts` — no hand-crafted test data.

### ERR-008: How avoided

The re-injection value comes **exclusively** from the caller's `expectedTaskId` parameter (trusted source), never from the LLM output. The LLM's `output.taskId` is only used to *detect* the parent-ID pattern, not to *set* the corrected value.

### Tests run

- `npx vitest run "diag-rootcause"` — 22 passed (11 in diag-rootcause-output.test.ts, 11 in diag-rootcause-runner.test.ts)
- `npx vitest run "test-double-runtime-adapter"` — 17 passed (5 new stage-dispatch tests)
- `npx vitest run "diag-chain-e2e"` — 15 passed (existing split pipeline tests)
- `npm run verify:merge` — passed (build + lint + typecheck + artifact check + error handbook check)

### Remaining risk

- The `DiagDistillerValidator` has the same taskId mismatch pattern (Step 2) but without re-injection. If LLM outputs a parent ID for distiller stage, it will still fail. This is a separate fix (not in scope for BUG-007c which is rootcause-specific).
- Pre-existing test failures in `pruning-read-model.test.ts` (2 tests) are unrelated to this PR.

Closes: PRI-401
