### PR TITLE
feat(console): canonical pain identity linkage in evidence chain (PRI-406)

### DIFF
--- a/packages/openclaw-plugin/src/core/trajectory-types.ts
+++ b/packages/openclaw-plugin/src/core/trajectory-types.ts
@@ -68,6 +68,10 @@ export interface TrajectoryPainEventInput {
   confidence?: number | null;
   text?: string;
   createdAt?: string;
+  /** PRI-406: Canonical pain identity (e.g. manual_<ts>_<hash> or pain_<ts>_<hash>). */
+  canonicalPainId?: string;
+  /** PRI-406: Runtime V2 diagnostician task ID linked to this pain event. */
+  runtimeTaskId?: string;
 }
 
 export interface TrajectoryGateBlockInput {

--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -243,8 +243,9 @@ export class TrajectoryDatabase {
     this.withWrite(() => {
       const runResult = this.db.prepare(`
         INSERT INTO pain_events (
-          session_id, source, score, reason, severity, origin, confidence, text, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          session_id, source, score, reason, severity, origin, confidence, text, created_at,
+          canonical_pain_id, runtime_task_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         input.sessionId,
         input.source,
@@ -255,6 +256,8 @@ export class TrajectoryDatabase {
         input.confidence ?? null,
         input.text ?? null,
         input.createdAt ?? nowIso(),
+        input.canonicalPainId ?? null,
+        input.runtimeTaskId ?? null,
       );
       insertedId = runResult.lastInsertRowid as number;
     });
@@ -1331,6 +1334,28 @@ export class TrajectoryDatabase {
         throw err;
       }
     }
+
+    // PRI-406: Add canonical_pain_id and runtime_task_id columns to pain_events
+    for (const col of [
+      { name: 'canonical_pain_id', type: 'TEXT' },
+      { name: 'runtime_task_id', type: 'TEXT' },
+    ]) {
+      try {
+        this.db.exec(`ALTER TABLE pain_events ADD COLUMN ${col.name} ${col.type}`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+          throw err;
+        }
+      }
+    }
+
+    // PRI-406: Partial unique index on canonical_pain_id (non-null only) for dedup
+    this.db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
+      ON pain_events(canonical_pain_id)
+      WHERE canonical_pain_id IS NOT NULL
+    `);
 
     // Create FTS5 virtual table for pain_events text search (MEM-04)
     this.db.exec(`

--- a/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
+++ b/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
@@ -205,9 +205,23 @@ export class EvidenceChainConsoleModel {
       let trajDb: Database.Database | null = null;
       try {
         trajDb = new Database(trajectoryDbPath, { readonly: true });
-        painEvents = trajDb.prepare(
-          'SELECT id, session_id, source, score, reason, severity, origin, confidence, text, created_at, canonical_pain_id, runtime_task_id FROM pain_events ORDER BY created_at DESC LIMIT 100',
-        ).all();
+        // PRI-406: Try SELECT with canonical_pain_id and runtime_task_id columns.
+        // If the DB was created before the PRI-406 migration, these columns won't exist.
+        // Fall back to the legacy SELECT without them.
+        try {
+          painEvents = trajDb.prepare(
+            'SELECT id, session_id, source, score, reason, severity, origin, confidence, text, created_at, canonical_pain_id, runtime_task_id FROM pain_events ORDER BY created_at DESC LIMIT 100',
+          ).all();
+        } catch (colErr: unknown) {
+          const colMessage = colErr instanceof Error ? colErr.message : String(colErr);
+          if (colMessage.includes('no such column')) {
+            painEvents = trajDb.prepare(
+              'SELECT id, session_id, source, score, reason, severity, origin, confidence, text, created_at FROM pain_events ORDER BY created_at DESC LIMIT 100',
+            ).all();
+          } else {
+            throw colErr;
+          }
+        }
         trajectoryDbAvailable = true;
       } catch (err) {
         if (isMissingTableError(err)) {

--- a/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
+++ b/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
@@ -206,7 +206,7 @@ export class EvidenceChainConsoleModel {
       try {
         trajDb = new Database(trajectoryDbPath, { readonly: true });
         painEvents = trajDb.prepare(
-          'SELECT id, session_id, source, score, reason, severity, origin, confidence, text, created_at FROM pain_events ORDER BY created_at DESC LIMIT 100',
+          'SELECT id, session_id, source, score, reason, severity, origin, confidence, text, created_at, canonical_pain_id, runtime_task_id FROM pain_events ORDER BY created_at DESC LIMIT 100',
         ).all();
         trajectoryDbAvailable = true;
       } catch (err) {

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -1864,4 +1864,48 @@ describe('PRI-406: Canonical pain identity linkage', () => {
     expect(records[0].id).toBe(`pain_${rowId1}`);
     expect(records[0].linkMode).toBe('canonical');
   });
+
+  // (f) Regression: legacy DB without canonical_pain_id column → graceful fallback
+  it('(f) falls back to legacy SELECT when DB lacks canonical_pain_id column', async () => {
+    // Create a trajectory DB WITHOUT the new columns (simulating pre-PRI-406 DB)
+    const dbPath = path.join(workspaceDir, '.state', 'trajectory.db');
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS pain_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        score REAL NOT NULL DEFAULT 0,
+        reason TEXT,
+        severity TEXT,
+        origin TEXT,
+        confidence REAL,
+        text TEXT,
+        created_at TEXT NOT NULL
+      )
+    `);
+    db.prepare(
+      'INSERT INTO pain_events (session_id, source, score, reason, severity, text, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    ).run('session-001', 'manual', 0.8, 'Legacy DB pain', 'medium', 'Legacy DB pain', '2026-06-07T10:00:00.000Z');
+    db.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId: 'diagnosis_pain_1',
+      status: 'succeeded',
+      inputRef: '1',
+      createdAt: '2026-06-07T10:00:01.000Z',
+      diagnosticJson: JSON.stringify({ rootCause: 'Legacy DB test' }),
+    });
+    stateDb.close();
+
+    // Should not throw — gracefully falls back to legacy SELECT
+    const result = await model.getEvidenceChain();
+    expect(result.records.length).toBeGreaterThanOrEqual(1);
+    // Legacy rows won't have canonicalPainId or linkMode
+    const legacyRecord = result.records.find(r => r.id === 'pain_1');
+    expect(legacyRecord).toBeDefined();
+    expect(legacyRecord!.canonicalPainId).toBeUndefined();
+  });
 });

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -44,8 +44,17 @@ function createTrajectoryDb(): Database.Database {
       origin TEXT,
       confidence REAL,
       text TEXT,
-      created_at TEXT NOT NULL
+      created_at TEXT NOT NULL,
+      canonical_pain_id TEXT,
+      runtime_task_id TEXT
     )
+  `);
+
+  // PRI-406: Partial unique index for canonical_pain_id dedup
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
+    ON pain_events(canonical_pain_id)
+    WHERE canonical_pain_id IS NOT NULL
   `);
 
   return db;
@@ -97,9 +106,11 @@ function insertPainEvent(db: Database.Database, event: {
   severity?: string;
   text?: string;
   createdAt?: string;
+  canonicalPainId?: string;
+  runtimeTaskId?: string;
 }): number {
   const info = db.prepare(
-    'INSERT INTO pain_events (session_id, source, score, reason, severity, text, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO pain_events (session_id, source, score, reason, severity, text, created_at, canonical_pain_id, runtime_task_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
   ).run(
     event.sessionId ?? 'session-001',
     event.source,
@@ -108,6 +119,8 @@ function insertPainEvent(db: Database.Database, event: {
     event.severity ?? 'medium',
     event.text ?? 'Agent modified config without approval',
     event.createdAt ?? '2026-06-07T10:00:00.000Z',
+    event.canonicalPainId ?? null,
+    event.runtimeTaskId ?? null,
   );
   return Number(info.lastInsertRowid);
 }
@@ -1103,10 +1116,13 @@ describe('PRI-380: Evidence chain lineage join with Runtime V2 task IDs', () => 
 
   it('shows loud degradation with degradedReason when tasks exist but none link (ERR-002)', async () => {
     const trajDb = createTrajectoryDb();
+    // PRI-406: Use canonicalPainId so the "Could not link" banner is shown
+    // (legacy rows without canonicalPainId get the legacy-degraded label instead)
     const rowId = insertPainEvent(trajDb, {
       source: 'manual',
       text: 'Unlinked pain event',
       createdAt: '2026-06-07T10:00:00.000Z',
+      canonicalPainId: 'manual_1781409830758_unlinked1',
     });
     trajDb.close();
 
@@ -1135,13 +1151,15 @@ describe('PRI-380: Evidence chain lineage join with Runtime V2 task IDs', () => 
 
   it('aggregates multiple unmatched pain event warnings at response level and deduplicates nextAction (PRI-382)', async () => {
     const trajDb = createTrajectoryDb();
-    // Insert 5 unmatched pain events
+    // PRI-406: Insert 5 unmatched pain events WITH canonicalPainId
+    // (only canonical rows trigger the "Could not link" banner)
     const rowIds: number[] = [];
     for (let i = 0; i < 5; i++) {
       rowIds.push(insertPainEvent(trajDb, {
         source: 'manual',
         text: `Unlinked pain event ${i}`,
         createdAt: `2026-06-07T10:0${i}:00.000Z`,
+        canonicalPainId: `manual_1781409830758_unlinked_${i}`,
       }));
     }
     trajDb.close();
@@ -1616,5 +1634,234 @@ describe('EvidenceChainConsoleModel — PRI-388 dedupe', () => {
     const ids = result.records.map(r => r.id);
     expect(ids).toContain('pain_2'); // the Chinese recurrence is preserved
     expect(result.records.some(r => r.linkedTaskId === 'diagnosis_pain_1')).toBe(true);
+  });
+});
+
+// ── PRI-406: Canonical pain identity linkage golden fixtures ────────────────
+//
+// Five required scenarios (a–e):
+//   a) canonical painId → precise link to diagnostician task
+//   b) canonical painId → link to candidate/artifact chain
+//   c) legacy pain_N → fallback render with degraded label
+//   d) completely unlinked → reason + nextAction, no Error
+//   e) duplicate canonical_pain_id write → dedup (partial unique index)
+
+describe('PRI-406: Canonical pain identity linkage', () => {
+  // (a) canonical painId → precise link to diagnostician task
+  it('(a) links canonical painId to diagnostician task via precise join', async () => {
+    const canonicalId = 'manual_1781409830758_67f4cgg4';
+    const taskId = 'diag_rootcause-manual_1781409830758_67f4cgg4';
+
+    const trajDb = createTrajectoryDb();
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Agent modified config without approval',
+      createdAt: '2026-06-07T09:42:00.000Z',
+      canonicalPainId: canonicalId,
+      runtimeTaskId: taskId,
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId,
+      status: 'succeeded',
+      inputRef: canonicalId,
+      createdAt: '2026-06-07T09:42:01.000Z',
+      diagnosticJson: JSON.stringify({ rootCause: 'Config modification without approval' }),
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const record = result.records.find(r => r.id === `pain_${rowId}`);
+
+    expect(record).toBeDefined();
+    // Precise join: linked via canonical_pain_id, not timestamp heuristic
+    expect(record!.linkMode).toBe('canonical');
+    expect(record!.canonicalPainId).toBe(canonicalId);
+    expect(record!.runtimeTaskId).toBe(taskId);
+    expect(record!.linkedTaskId).toBe(taskId);
+    expect(record!.linkedTaskStatus).toBe('succeeded');
+    // No degradation — this is a clean canonical link
+    expect(record!.degradedReason).toBeUndefined();
+  });
+
+  // (b) canonical painId → link to candidate/artifact chain
+  it('(b) links canonical painId to candidate and principle chain', async () => {
+    const canonicalId = 'manual_1781409830758_67f4cgg4';
+    const taskId = 'diag_rootcause-manual_1781409830758_67f4cgg4';
+
+    const trajDb = createTrajectoryDb();
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Agent modified config without approval',
+      createdAt: '2026-06-07T09:42:00.000Z',
+      canonicalPainId: canonicalId,
+      runtimeTaskId: taskId,
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId,
+      status: 'succeeded',
+      inputRef: canonicalId,
+      createdAt: '2026-06-07T09:42:01.000Z',
+      diagnosticJson: JSON.stringify({ rootCause: 'Config modification without approval' }),
+    });
+    insertCandidate(stateDb, {
+      candidateId: 'cand-config-approval',
+      taskId,
+      title: 'Config modifications require explicit approval',
+      confidence: 0.92,
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const record = result.records.find(r => r.id === `pain_${rowId}`);
+
+    expect(record).toBeDefined();
+    expect(record!.linkMode).toBe('canonical');
+    expect(record!.linkedTaskId).toBe(taskId);
+    // Candidate chain is linked
+    expect(record!.linkedCandidateId).toBe('cand-config-approval');
+    expect(record!.candidateTitle).toBe('Config modifications require explicit approval');
+    expect(record!.confidence).toBe(0.92);
+  });
+
+  // (c) legacy pain_N → fallback render with degraded label
+  it('(c) marks legacy pain_N rows as legacy-degraded with linkMode=legacy', async () => {
+    const trajDb = createTrajectoryDb();
+    // Legacy row: no canonicalPainId, no runtimeTaskId
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Legacy pain event from before canonical identity',
+      createdAt: '2026-06-07T09:42:00.000Z',
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    // Task exists but won't match via legacy heuristic (far timestamp)
+    insertTask(stateDb, {
+      taskId: 'diagnosis_manual_9999_other',
+      status: 'succeeded',
+      inputRef: '999',
+      createdAt: '2026-06-07T20:00:00.000Z',
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const record = result.records.find(r => r.id === `pain_${rowId}`);
+
+    expect(record).toBeDefined();
+    // Legacy row: linkMode is 'legacy', not 'canonical'
+    expect(record!.linkMode).toBe('legacy');
+    // Legacy rows still get "Could not link" banner (ERR-002) — no silent fallback
+    expect(record!.degradedReason).toBeDefined();
+    expect(record!.degradedReason).toContain('Could not link');
+    expect(record!.nextAction).toBeDefined();
+    // Response-level degradation should also be present
+    expect(result.degradedReason).toBeDefined();
+  });
+
+  // (d) completely unlinked canonical row → reason + nextAction, no Error
+  it('(d) shows reason + nextAction for unlinked canonical row without throwing', async () => {
+    const canonicalId = 'manual_1781409830758_orphan1';
+
+    const trajDb = createTrajectoryDb();
+    const rowId = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'Canonical pain with no matching task',
+      createdAt: '2026-06-07T09:42:00.000Z',
+      canonicalPainId: canonicalId,
+    });
+    trajDb.close();
+
+    const stateDb = createStateDb();
+    // Task exists but doesn't match this canonical ID
+    insertTask(stateDb, {
+      taskId: 'diagnosis_other_task',
+      status: 'succeeded',
+      inputRef: 'manual_other_id',
+      createdAt: '2026-06-07T20:00:00.000Z',
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const record = result.records.find(r => r.id === `pain_${rowId}`);
+
+    expect(record).toBeDefined();
+    // Canonical row that can't link: this IS a real problem, show "Could not link"
+    expect(record!.canonicalPainId).toBe(canonicalId);
+    expect(record!.degradedReason).toContain('Could not link');
+    expect(record!.nextAction).toBeDefined();
+    expect(record!.nextAction).toContain('Runtime V2');
+    // Response-level degradation should be present
+    expect(result.degradedReason).toBeDefined();
+    // No error thrown — graceful degradation
+  });
+
+  // (e) duplicate canonical_pain_id write → dedup (partial unique index)
+  it('(e) deduplicates rows with same canonical_pain_id via partial unique index', async () => {
+    const canonicalId = 'manual_1781409830758_dedup1';
+    const taskId = 'diag_rootcause-manual_1781409830758_dedup1';
+
+    const trajDb = createTrajectoryDb();
+    // First write succeeds
+    const rowId1 = insertPainEvent(trajDb, {
+      source: 'manual',
+      text: 'First write of this pain',
+      createdAt: '2026-06-07T09:42:00.000Z',
+      canonicalPainId: canonicalId,
+      runtimeTaskId: taskId,
+    });
+
+    // Second write with same canonicalPainId should throw due to unique index
+    let duplicateThrew = false;
+    try {
+      insertPainEvent(trajDb, {
+        source: 'manual',
+        text: 'Duplicate write of same pain',
+        createdAt: '2026-06-07T09:42:01.000Z',
+        canonicalPainId: canonicalId,
+        runtimeTaskId: taskId,
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+        duplicateThrew = true;
+      }
+    }
+
+    // Verify the unique index prevented the duplicate at the DB level
+    expect(duplicateThrew).toBe(true);
+
+    // Verify only one row in the DB for this canonical pain ID
+    const rows = trajDb.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').all(canonicalId);
+    expect(rows).toHaveLength(1);
+
+    trajDb.close();
+
+    // Also verify by reading the file directly (same path the model uses)
+    const directDb = new Database(path.join(workspaceDir, '.state', 'trajectory.db'), { readonly: true });
+    const directRows = directDb.prepare('SELECT id, canonical_pain_id FROM pain_events WHERE canonical_pain_id = ?').all(canonicalId);
+    expect(directRows).toHaveLength(1);
+    directDb.close();
+
+    // Only one row exists for this canonical pain ID in the evidence chain
+    const stateDb = createStateDb();
+    insertTask(stateDb, {
+      taskId,
+      status: 'succeeded',
+      inputRef: canonicalId,
+      createdAt: '2026-06-07T09:42:01.000Z',
+      diagnosticJson: JSON.stringify({ rootCause: 'Dedup test' }),
+    });
+    stateDb.close();
+
+    const result = await model.getEvidenceChain();
+    const records = result.records.filter(r => r.canonicalPainId === canonicalId);
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe(`pain_${rowId1}`);
+    expect(records[0].linkMode).toBe('canonical');
   });
 });

--- a/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
@@ -23,6 +23,10 @@ export interface RecordPainSignalObservabilityOptions {
   workspaceDir: string;
   stateDir: string;
   data: PainDetectedData;
+  /** PRI-406: Canonical pain identity to write into pain_events.canonical_pain_id. */
+  canonicalPainId?: string;
+  /** PRI-406: Runtime V2 task ID to write into pain_events.runtime_task_id. */
+  runtimeTaskId?: string;
 }
 
 function nowIso(): string {
@@ -97,15 +101,42 @@ interface TrajectoryRecordOptions {
   data: PainDetectedData;
   timestamp: string;
   workspaceDir?: string;
+  /** PRI-406: Canonical pain identity to write into pain_events.canonical_pain_id. */
+  canonicalPainId?: string;
+  /** PRI-406: Runtime V2 task ID to write into pain_events.runtime_task_id. */
+  runtimeTaskId?: string;
 }
 
 function recordTrajectoryPainEvent(opts: TrajectoryRecordOptions): number | undefined {
-  const { stateDir, data, timestamp, workspaceDir } = opts;
+  const { stateDir, data, timestamp, workspaceDir, canonicalPainId, runtimeTaskId } = opts;
   const dbPath = nodePath.join(stateDir, 'trajectory.db');
   fs.mkdirSync(nodePath.dirname(dbPath), { recursive: true });
   const db = new Database(dbPath);
   try {
     ensurePainEventsSchema(db);
+
+    // PRI-406: Add canonical_pain_id and runtime_task_id columns if missing
+    for (const col of [
+      { name: 'canonical_pain_id', type: 'TEXT' },
+      { name: 'runtime_task_id', type: 'TEXT' },
+    ]) {
+      try {
+        db.exec(`ALTER TABLE pain_events ADD COLUMN ${col.name} ${col.type}`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+          throw err;
+        }
+      }
+    }
+
+    // PRI-406: Create partial unique index for canonical_pain_id dedup
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
+      ON pain_events(canonical_pain_id)
+      WHERE canonical_pain_id IS NOT NULL
+    `);
+
     const sessionId = data.sessionId ?? 'cli';
     const sessionColumns = getSessionsColumns(db);
     const hasMetadataJson = sessionColumns.includes('metadata_json');
@@ -126,8 +157,9 @@ function recordTrajectoryPainEvent(opts: TrajectoryRecordOptions): number | unde
 
     const result = db.prepare(`
       INSERT INTO pain_events (
-        session_id, source, score, reason, severity, origin, confidence, text, created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        session_id, source, score, reason, severity, origin, confidence, text, created_at,
+        canonical_pain_id, runtime_task_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       sessionId,
       data.source,
@@ -138,6 +170,8 @@ function recordTrajectoryPainEvent(opts: TrajectoryRecordOptions): number | unde
       1,
       sanitizeString(data.reason ?? '', workspaceDir),
       timestamp,
+      canonicalPainId ?? null,
+      runtimeTaskId ?? null,
     );
     return Number(result.lastInsertRowid);
   } finally {
@@ -208,7 +242,10 @@ export function recordPainSignalObservability(
   }
 
   try {
-    result.trajectoryPainEventId = recordTrajectoryPainEvent({ stateDir: opts.stateDir, data: opts.data, timestamp, workspaceDir: opts.workspaceDir });
+    result.trajectoryPainEventId = recordTrajectoryPainEvent({
+      stateDir: opts.stateDir, data: opts.data, timestamp, workspaceDir: opts.workspaceDir,
+      canonicalPainId: opts.canonicalPainId, runtimeTaskId: opts.runtimeTaskId,
+    });
   } catch (err) {
     warnings.push(`trajectory pain_events write failed: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -154,6 +154,8 @@ export class PainToPrincipleService {
             workspaceDir: this.opts.workspaceDir,
             stateDir: this.opts.stateDir,
             data: painData,
+            canonicalPainId: painId,
+            runtimeTaskId: taskIdResult.taskId,
           });
           observabilityWarnings = obs.warnings;
         }
@@ -190,6 +192,8 @@ export class PainToPrincipleService {
           workspaceDir: this.opts.workspaceDir,
           stateDir: this.opts.stateDir,
           data: painData,
+          canonicalPainId: painId,
+          runtimeTaskId: taskId,
         });
         observabilityWarnings = obs.warnings;
       }

--- a/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
+++ b/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
@@ -1033,17 +1033,13 @@ export function assembleEvidenceChain(params: {
           record.runtimeTaskId = eventRuntimeTaskId;
         }
 
-        // PRI-406: Distinguish canonical rows from legacy rows.
-        // Canonical rows that can't link: the precise join failed — this is a real problem.
-        // Legacy rows (no canonical_pain_id) that can't link: expected for pre-canonical data.
-        // Both get "Could not link" banner (ERR-002), but the reason differs.
+        // PRI-406: Both canonical and legacy unlinked rows get the same
+        // "Could not link" banner (ERR-002). The linkMode field distinguishes
+        // the linking strategy used; legacy rows additionally get linkMode='legacy'.
+        record.degradedReason = 'Could not link this pain event to a diagnostician task. The chain may be incomplete.';
+        record.nextAction = `Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.`;
         if (!eventCanonicalPainId) {
           record.linkMode = 'legacy';
-          record.degradedReason = 'Could not link this pain event to a diagnostician task. The chain may be incomplete.';
-          record.nextAction = `Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.`;
-        } else {
-          record.degradedReason = 'Could not link this pain event to a diagnostician task. The chain may be incomplete.';
-          record.nextAction = `Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.`;
         }
         degradedReasons.push(`Pain event ${painId} could not be linked to a diagnostician task.`);
         degradedNextActions.push('Check Runtime V2 pipeline status for unmatched pain ID formats.');

--- a/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
+++ b/packages/principles-core/src/runtime-v2/types/evidence-chain-contract.ts
@@ -70,6 +70,12 @@ export interface EvidenceChainRecord {
   recommendationKind?: string;
   internalizationTaskId?: string;
   dreamerTaskStatus?: string;
+  /** PRI-406: Canonical pain identity (e.g. manual_<ts>_<hash>). */
+  canonicalPainId?: string;
+  /** PRI-406: Runtime V2 diagnostician task ID. */
+  runtimeTaskId?: string;
+  /** PRI-406: How this record was linked — 'canonical' (precise via canonical_pain_id) or 'legacy' (timestamp/content heuristic). */
+  linkMode?: 'canonical' | 'legacy';
 }
 
 export const EvidenceChainRecordSchema = Type.Object({
@@ -94,6 +100,9 @@ export const EvidenceChainRecordSchema = Type.Object({
   recommendationKind: Type.Optional(Type.String()),
   internalizationTaskId: Type.Optional(Type.String()),
   dreamerTaskStatus: Type.Optional(Type.String()),
+  canonicalPainId: Type.Optional(Type.String()),
+  runtimeTaskId: Type.Optional(Type.String()),
+  linkMode: Type.Optional(Type.Union([Type.Literal('canonical'), Type.Literal('legacy')])),
 });
 
 export interface EvidenceChainResponse {
@@ -840,17 +849,49 @@ export function assembleEvidenceChain(params: {
     const text = readOwnString(event, 'text') ?? '';
     const createdAt = readOwnString(event, 'created_at') ?? '';
     const score = typeof event.score === 'number' ? event.score : 0;
+    // PRI-406: Read canonical_pain_id and runtime_task_id from pain_events
+    const canonicalPainId = readOwnString(event, 'canonical_pain_id');
+    const runtimeTaskId = readOwnString(event, 'runtime_task_id');
 
     const sourceKind = mapSourceKind(source);
     const painId = `pain_${eventId}`;
     painEventMeta.push({ painId, createdAt, source });
 
-    const linkedTask = taskMap.get(painId);
+    // PRI-406: Prefer precise join via canonical_pain_id → tasks.input_ref.
+    // When a pain event carries canonical_pain_id, look up the task by that ID
+    // first (the taskMap key is derived from input_ref, which equals canonical_pain_id).
+    // This is the authoritative join path — no timestamp/content heuristic needed.
+    let linkedTask = taskMap.get(painId);
+    let linkMode: 'canonical' | 'legacy' | undefined;
+
+    if (canonicalPainId) {
+      const canonicalTask = taskMap.get(canonicalPainId);
+      if (canonicalTask) {
+        linkedTask = canonicalTask;
+        linkMode = 'canonical';
+      } else if (runtimeTaskId) {
+        // Fallback: try to find task by runtimeTaskId in taskMap values
+        for (const [, entry] of taskMap.entries()) {
+          if (entry.taskId === runtimeTaskId) {
+            linkedTask = entry;
+            linkMode = 'canonical';
+            break;
+          }
+        }
+      }
+    }
+
     if (linkedTask) {
       directMatchedPainIds.add(painId);
+      if (!linkMode) {
+        linkMode = 'legacy';
+      }
     }
-    const linkedCandidate = candidateMap.get(painId);
-    const linkedPrincipleId = painToPrincipleMap.get(painId);
+    const linkedCandidate = candidateMap.get(painId)
+      || (canonicalPainId ? candidateMap.get(canonicalPainId) : undefined)
+      || (linkedTask ? candidateByTaskId.get(linkedTask.taskId) : undefined);
+    const linkedPrincipleId = painToPrincipleMap.get(painId)
+      || (canonicalPainId ? painToPrincipleMap.get(canonicalPainId) : undefined);
     const ledgerPrincipleStatus = linkedPrincipleId ? principleStatusMap.get(linkedPrincipleId) : undefined;
     const dreamerInfo = linkedCandidate ? dreamerMap.get(linkedCandidate.candidateId) : undefined;
 
@@ -878,6 +919,24 @@ export function assembleEvidenceChain(params: {
       summary: rawSummary,
       admissionDecision: inferAdmissionDecision(sourceKind),
     };
+
+    // PRI-406: Set canonical identity and link mode
+    if (canonicalPainId) {
+      record.canonicalPainId = canonicalPainId;
+    }
+    if (runtimeTaskId) {
+      record.runtimeTaskId = runtimeTaskId;
+    }
+    if (linkMode) {
+      record.linkMode = linkMode;
+    }
+
+    // PRI-406: When a pain event is linked via canonical_pain_id, also mark
+    // the canonical ID as covered so step 6 doesn't create a duplicate record
+    // for the same task.
+    if (canonicalPainId && linkedTask) {
+      directMatchedPainIds.add(canonicalPainId);
+    }
 
     if (linkedCandidate) {
       record.linkedCandidateId = linkedCandidate.candidateId;
@@ -914,6 +973,11 @@ export function assembleEvidenceChain(params: {
     record.nextAction = determineNextAction({ state, workspaceDir, recordId: painId, linkedTaskId: linkedTask?.taskId });
 
     if (!linkedTask && stateDbAvailable && taskMap.size > 0) {
+      // PRI-406: Rows without canonical_pain_id that have no linked task
+      // continue to get the "Could not link" banner (same as before).
+      // Rows WITH canonical_pain_id that have no linked task also get the
+      // banner — this is a real problem since the precise join should have worked.
+      // The linkMode field distinguishes the linking strategy used.
       continue;
     }
 
@@ -944,6 +1008,9 @@ export function assembleEvidenceChain(params: {
         const createdAt = readOwnString(event, 'created_at') ?? '';
         const score = typeof event.score === 'number' ? event.score : 0;
         const sourceKind = mapSourceKind(source);
+        // PRI-406: Read canonical fields
+        const eventCanonicalPainId = readOwnString(event, 'canonical_pain_id');
+        const eventRuntimeTaskId = readOwnString(event, 'runtime_task_id');
 
         // No linked task/candidate: state is admission-driven. tool_call/hook observations
         // are `evidence-only`; manual/review are `recorded-only`. (PRI-385 P1-2)
@@ -956,9 +1023,28 @@ export function assembleEvidenceChain(params: {
           state: unmatchedState,
           summary: text || reason || `Pain signal (source: ${source}, score: ${score})`,
           admissionDecision: inferAdmissionDecision(sourceKind),
-          degradedReason: 'Could not link this pain event to a diagnostician task. The chain may be incomplete.',
-          nextAction: `Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.`,
         };
+
+        // PRI-406: Set canonical identity fields
+        if (eventCanonicalPainId) {
+          record.canonicalPainId = eventCanonicalPainId;
+        }
+        if (eventRuntimeTaskId) {
+          record.runtimeTaskId = eventRuntimeTaskId;
+        }
+
+        // PRI-406: Distinguish canonical rows from legacy rows.
+        // Canonical rows that can't link: the precise join failed — this is a real problem.
+        // Legacy rows (no canonical_pain_id) that can't link: expected for pre-canonical data.
+        // Both get "Could not link" banner (ERR-002), but the reason differs.
+        if (!eventCanonicalPainId) {
+          record.linkMode = 'legacy';
+          record.degradedReason = 'Could not link this pain event to a diagnostician task. The chain may be incomplete.';
+          record.nextAction = `Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.`;
+        } else {
+          record.degradedReason = 'Could not link this pain event to a diagnostician task. The chain may be incomplete.';
+          record.nextAction = `Check Runtime V2 pipeline status. The diagnostician task may have a different pain ID format.`;
+        }
         degradedReasons.push(`Pain event ${painId} could not be linked to a diagnostician task.`);
         degradedNextActions.push('Check Runtime V2 pipeline status for unmatched pain ID formats.');
         records.push(record);
@@ -998,9 +1084,15 @@ export function assembleEvidenceChain(params: {
     const createdAt = readOwnString(event, 'created_at') ?? '';
     const score = typeof event.score === 'number' ? event.score : 0;
     const sourceKind = mapSourceKind(source);
+    // PRI-406: Read canonical fields for cross-ref records
+    const eventCanonicalPainId = readOwnString(event, 'canonical_pain_id');
+    const eventRuntimeTaskId = readOwnString(event, 'runtime_task_id');
 
-    const linkedCandidate = candidateMap.get(painId) || candidateByTaskId.get(crossRefTask.taskId);
-    const linkedPrincipleId = painToPrincipleMap.get(painId);
+    const linkedCandidate = candidateMap.get(painId)
+      || (eventCanonicalPainId ? candidateMap.get(eventCanonicalPainId) : undefined)
+      || candidateByTaskId.get(crossRefTask.taskId);
+    const linkedPrincipleId = painToPrincipleMap.get(painId)
+      || (eventCanonicalPainId ? painToPrincipleMap.get(eventCanonicalPainId) : undefined);
     const ledgerPrincipleStatus = linkedPrincipleId ? principleStatusMap.get(linkedPrincipleId) : undefined;
     const dreamerInfo = linkedCandidate ? dreamerMap.get(linkedCandidate.candidateId) : undefined;
 
@@ -1029,7 +1121,16 @@ export function assembleEvidenceChain(params: {
       admissionDecision: inferAdmissionDecision(sourceKind),
       linkedTaskId: crossRefTask.taskId,
       linkedTaskStatus: crossRefTask.status,
+      linkMode: 'legacy', // Cross-ref is always legacy (timestamp heuristic)
     };
+
+    // PRI-406: Set canonical identity fields
+    if (eventCanonicalPainId) {
+      record.canonicalPainId = eventCanonicalPainId;
+    }
+    if (eventRuntimeTaskId) {
+      record.runtimeTaskId = eventRuntimeTaskId;
+    }
 
     if (linkedCandidate) {
       record.linkedCandidateId = linkedCandidate.candidateId;
@@ -1067,6 +1168,13 @@ export function assembleEvidenceChain(params: {
 
   // 6. Include tasks that have no matching pain_event (e.g. CLI direct records)
   const coveredPainIds = new Set(records.map(r => r.id));
+  // PRI-406: Also consider canonicalPainId as covered to prevent step 6 from
+  // creating a duplicate record for the same task that step 5 already linked.
+  for (const r of records) {
+    if (r.canonicalPainId) {
+      coveredPainIds.add(r.canonicalPainId);
+    }
+  }
   // Only WEAK cross-refs (timestamp-only) block step 6 from creating a
   // task-id record. Strong-lineage cross-refs deferred in step 5b so the
   // canonical task-id form is shown. (PRI-388 reviewer P1.)
@@ -1108,6 +1216,10 @@ export function assembleEvidenceChain(params: {
       admissionDecision: 'store_signal',
       linkedTaskId: task.taskId,
       linkedTaskStatus: task.status,
+      // PRI-406: Task-only records from Runtime V2 are canonical-linked
+      // (their painId IS the canonical pain identity, e.g. manual_*)
+      canonicalPainId: painId.startsWith('pain_') ? undefined : painId,
+      linkMode: 'canonical',
     };
 
     if (linkedCandidate) {


### PR DESCRIPTION
## Summary

Fixes the P0 Console issue where pain events with canonical IDs (e.g. `manual_<ts>_<hash>`) showed "Could not link this pain event to a diagnostician task" because the evidence chain relied on timestamp/content heuristics instead of precise identity matching.

## Schema Changes (additive migration)

- `pain_events.canonical_pain_id TEXT NULL` — canonical pain identity
- `pain_events.runtime_task_id TEXT NULL` — linked Runtime V2 task ID
- Partial unique index: `idx_pain_events_canonical_pain_id ON pain_events(canonical_pain_id) WHERE canonical_pain_id IS NOT NULL`
- Migration uses `ALTER TABLE ADD COLUMN` with try/catch for idempotency (same pattern as existing `text` column migration)

## Changed Product Paths

**Write paths:**
- `TrajectoryDatabase.recordPainEvent()` — writes `canonical_pain_id` and `runtime_task_id`
- `recordTrajectoryPainEvent()` in `pain-signal-observability.ts` — writes canonical fields + creates partial unique index
- `PainToPrincipleService.recordPain()` — passes `painId` as `canonicalPainId` and `taskId` as `runtimeTaskId`

**Read paths:**
- `EvidenceChainConsoleModel` — reads `canonical_pain_id` and `runtime_task_id` from SQL
- `assembleEvidenceChain()` — uses `canonical_pain_id` for precise join via `taskMap.get(canonicalPainId)` before falling back to timestamp heuristic
- Step 6 dedup: `canonicalPainId` added to `coveredPainIds` to prevent duplicate records

## How Legacy Rows Are Handled

- Rows **with** `canonical_pain_id`: precise join → `linkMode: 'canonical'`
- Rows **without** `canonical_pain_id`: timestamp/content heuristic → `linkMode: 'legacy'`
- Both get "Could not link" banner when no task matches (ERR-002 compliance)
- The `linkMode` field distinguishes linking strategy in the API response

## Golden Fixtures Covered (a-e)

- **(a)** canonical painId → precise link to diagnostician task
- **(b)** canonical painId → link to candidate/artifact chain
- **(c)** legacy pain_N → fallback with `linkMode='legacy'`
- **(d)** unlinked canonical row → reason + nextAction
- **(e)** duplicate canonical_pain_id → dedup via partial unique index

## ERR Checklist

- **ERR-002**: Every degraded path includes reason + nextAction, never silent
- **ERR-004/008**: `canonical_pain_id` comes from same source as task `input_ref` (PainToPrincipleService)
- **ERR-025**: Tests use real canonical formats (`manual_<ts>_<hash>`), not just `pain_N`

## Tests Run

- `cd packages/principles-core && npm run build && npm run test` — 4678 passed (3 pre-existing failures in pruning-read-model, unrelated)
- `cd packages/openclaw-plugin && npm run test` — 1808 passed
- `cd packages/pd-console && npm run build && npm run test` — 57 passed (5 new PRI-406 tests)
- `npm run verify:merge` — passed

## Remaining Risk

- **trajectory.db migration on existing installs**: The `ALTER TABLE ADD COLUMN` migration is additive and idempotent. Existing rows will have `NULL` for the new columns and continue to work via the legacy heuristic path.
- **Hook paths not yet writing canonical_pain_id**: OpenClaw hook paths (`pain.ts`, `after-tool-call-helpers.ts`) still pre-write trajectory rows without `canonical_pain_id`. These rows will continue to use the legacy heuristic until the hook paths are updated (follow-up work).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增规范化疼痛身份追踪和诊断任务关联能力，实现更精确的事件链接和去重。

* **改进**
  * 增强数据完整性约束和数据库兼容性处理。
  * 确保在系统升级过程中对旧版数据的优雅降级支持。

* **测试**
  * 完善新增追踪功能的测试覆盖，包括典型场景和降级路径验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->