### PR TITLE
Add comprehensive tests for resolve-runtime-from-pd-config

### DIFF
--- a/packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts
+++ b/packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for resolve-runtime-from-pd-config.ts — PRI-393, PRI-402
+ *
+ * Covers:
+ *   - buildProfileLabel: pi-ai and openclaw profile label formatting
+ *   - resolveRuntimeFromPdConfig: successful config loading, malformed config, legacy warnings
+ *   - resolveRuntimeWithOverrides: CLI flag overrides on top of config values
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as yaml from 'js-yaml';
+import { isRuntimeConfigError } from '@principles/core/runtime-v2';
+import {
+  resolveRuntimeFromPdConfig,
+  resolveRuntimeWithOverrides,
+} from '../../src/services/resolve-runtime-from-pd-config.js';
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-resolve-runtime-test-'));
+}
+
+function rmTmpDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function writeConfig(workspaceDir: string, content: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), content, 'utf8');
+}
+
+const mockEnvWithKeys = (name: string): string | undefined => {
+  if (name === 'ANTHROPIC_API_KEY') return 'sk-ant-test-key';
+  if (name === 'OPENROUTER_API_KEY') return 'sk-or-test-key';
+  if (name === 'TEST_API_KEY') return 'sk-test-key';
+  return undefined;
+};
+
+function makeValidOpenClawConfigYaml(workspaceDir: string): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+    },
+    workspace: {
+      default: workspaceDir,
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+      'openclaw.model.lmstudio.qwen3': { type: 'openclaw', provider: 'lmstudio', model: 'qwen3.6-27b-mtp' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: 'openclaw.model.lmstudio.qwen3' },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+      },
+    },
+  });
+}
+
+function makeValidPiAiConfigYaml(workspaceDir: string): string {
+  return yaml.dump({
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+    },
+    workspace: {
+      default: workspaceDir,
+    },
+    runtimeProfiles: {
+      'pd.anthropic-sonnet': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 300000, maxRetries: 3 },
+    },
+    internalAgents: {
+      defaultRuntime: 'pd.anthropic-sonnet',
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: 'pd.anthropic-sonnet' },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+        artificer: { enabled: true },
+      },
+    },
+  });
+}
+
+describe('buildProfileLabel', () => {
+  it('formats pi-ai profile with provider and model', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'pi-ai.test': { type: 'pi-ai', provider: 'openrouter', model: 'anthropic/claude-sonnet-4', apiKeyEnv: 'OPENROUTER_API_KEY' },
+      },
+      internalAgents: {
+        defaultRuntime: 'pi-ai.test',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.test' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp, mockEnvWithKeys);
+      expect(result.runtimeProfileId).toBe('pi-ai.test');
+      expect(result.runtimeProfileLabel).toBe('pi-ai: openrouter/anthropic/claude-sonnet-4');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns null profile info when pi-ai profile is missing required provider/model', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'pi-ai.missing': { type: 'pi-ai', apiKeyEnv: 'TEST_API_KEY' },
+      },
+      internalAgents: {
+        defaultRuntime: 'pi-ai.missing',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.missing' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp, mockEnvWithKeys);
+      expect(result.runtimeProfileId).toBe(null);
+      expect(result.runtimeProfileLabel).toBe(null);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('formats openclaw profile with provider and model', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'openclaw.model.lmstudio.qwen3': { type: 'openclaw', provider: 'lmstudio', model: 'qwen3.6-27b-mtp' },
+      },
+      internalAgents: {
+        defaultRuntime: 'openclaw.model.lmstudio.qwen3',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'openclaw.model.lmstudio.qwen3' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(result.runtimeProfileId).toBe('openclaw.model.lmstudio.qwen3');
+      expect(result.runtimeProfileLabel).toBe('openclaw: lmstudio: qwen3.6-27b-mtp');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('formats openclaw profile with source when no provider/model', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'openclaw.default': { type: 'openclaw', source: 'default' },
+      },
+      internalAgents: {
+        defaultRuntime: 'openclaw.default',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'openclaw.default' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(result.runtimeProfileId).toBe('openclaw.default');
+      expect(result.runtimeProfileLabel).toBe('openclaw: default');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+describe('resolveRuntimeFromPdConfig', () => {
+  it('returns resolved runtime config from valid openclaw config.yaml', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidOpenClawConfigYaml(tmp));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(isRuntimeConfigError(result.result)).toBe(false);
+      expect(result.configSource).toBe('.pd/config.yaml');
+      expect(result.legacyWarnings).toEqual([]);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns resolved runtime config from valid pi-ai config.yaml with env vars', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidPiAiConfigYaml(tmp));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp, mockEnvWithKeys);
+      expect(isRuntimeConfigError(result.result)).toBe(false);
+      expect(result.configSource).toBe('.pd/config.yaml');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns legacy warnings when legacy files detected', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidOpenClawConfigYaml(tmp));
+    const stateDir = path.join(tmp, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'workflows.yaml'), 'version: 1\n', 'utf8');
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(result.legacyWarnings.length).toBeGreaterThan(0);
+      expect(result.legacyWarnings[0]).toContain('Legacy config files detected');
+      expect(result.legacyWarnings[0]).toContain('workflows.yaml');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns error result when config.yaml is malformed', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(isRuntimeConfigError(result.result)).toBe(true);
+      expect((result.result as { ok: false }).reason).toContain('config_malformed');
+      expect(result.runtimeProfileId).toBe(null);
+      expect(result.runtimeProfileLabel).toBe(null);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns error result when config.yaml validation fails', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({ version: 99, features: {}, runtimeProfiles: {}, internalAgents: { defaultRuntime: 'x', agents: {} } }));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(isRuntimeConfigError(result.result)).toBe(true);
+      expect((result.result as { ok: false }).reason).toContain('config_malformed');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns defaults and profile info when config.yaml is missing', () => {
+    const tmp = mkTmpDir();
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(isRuntimeConfigError(result.result)).toBe(false);
+      expect(result.configSource).toBe('.pd/config.yaml');
+      expect(result.runtimeProfileId).toBe('openclaw.default');
+      expect(typeof result.runtimeProfileLabel).toBe('string');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('includes legacy warnings even when config is malformed', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    const stateDir = path.join(tmp, '.state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'workflows.yaml'), 'version: 1\n', 'utf8');
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp);
+      expect(isRuntimeConfigError(result.result)).toBe(true);
+      expect(result.legacyWarnings.length).toBeGreaterThan(0);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns not_ready error when pi-ai config is valid but apiKeyEnv not set', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidPiAiConfigYaml(tmp));
+    try {
+      const result = resolveRuntimeFromPdConfig(tmp, () => undefined);
+      expect(isRuntimeConfigError(result.result)).toBe(true);
+      expect((result.result as { ok: false }).reason).toBe('not_ready');
+    } finally { rmTmpDir(tmp); }
+  });
+});
+
+describe('resolveRuntimeWithOverrides', () => {
+  it('returns merged config with CLI overrides applied', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, makeValidPiAiConfigYaml(tmp));
+    try {
+      const result = resolveRuntimeWithOverrides(tmp, {
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4',
+        apiKeyEnv: 'OPENROUTER_API_KEY',
+      }, mockEnvWithKeys);
+      expect(result.mergedConfig).not.toBeNull();
+      if (!result.mergedConfig) throw new Error('Expected mergedConfig');
+      expect(result.mergedConfig.provider).toBe('openrouter');
+      expect(result.mergedConfig.model).toBe('anthropic/claude-sonnet-4');
+      expect(result.mergedConfig.apiKeyEnv).toBe('OPENROUTER_API_KEY');
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('partial CLI overrides merge with config values', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'pi-ai.test': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 300000, maxRetries: 3 },
+      },
+      internalAgents: {
+        defaultRuntime: 'pi-ai.test',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.test' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeWithOverrides(tmp, {
+        model: 'claude-3-opus',
+      }, mockEnvWithKeys);
+      expect(result.mergedConfig).not.toBeNull();
+      if (!result.mergedConfig) throw new Error('Expected mergedConfig');
+      expect(result.mergedConfig.provider).toBe('anthropic');
+      expect(result.mergedConfig.model).toBe('claude-3-opus');
+      expect(result.mergedConfig.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
+      expect(result.mergedConfig.timeoutMs).toBe(300000);
+      expect(result.mergedConfig.maxRetries).toBe(3);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns mergedConfig as null when config resolution fails', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, 'version: [unterminated');
+    try {
+      const result = resolveRuntimeWithOverrides(tmp, { provider: 'openrouter' });
+      expect(isRuntimeConfigError(result.result)).toBe(true);
+      expect(result.mergedConfig).toBe(null);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('merges maxRetries and timeoutMs with nullish coalescing', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'pi-ai.test': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY', timeoutMs: 300000, maxRetries: 3 },
+      },
+      internalAgents: {
+        defaultRuntime: 'pi-ai.test',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.test' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeWithOverrides(tmp, {
+        maxRetries: 0,
+        timeoutMs: 0,
+      }, mockEnvWithKeys);
+      expect(result.mergedConfig).not.toBeNull();
+      if (!result.mergedConfig) throw new Error('Expected mergedConfig');
+      expect(result.mergedConfig.maxRetries).toBe(0);
+      expect(result.mergedConfig.timeoutMs).toBe(0);
+    } finally { rmTmpDir(tmp); }
+  });
+
+  it('returns profile info from config even when CLI overrides are provided', () => {
+    const tmp = mkTmpDir();
+    writeConfig(tmp, yaml.dump({
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+      },
+      workspace: { default: tmp },
+      runtimeProfiles: {
+        'pi-ai.test': { type: 'pi-ai', provider: 'anthropic', model: 'claude-3-5-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+      },
+      internalAgents: {
+        defaultRuntime: 'pi-ai.test',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.test' },
+        },
+      },
+    }));
+    try {
+      const result = resolveRuntimeWithOverrides(tmp, {
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4',
+      }, mockEnvWithKeys);
+      expect(result.runtimeProfileId).toBe('pi-ai.test');
+      expect(result.runtimeProfileLabel).toBe('pi-ai: anthropic/claude-3-5-sonnet');
+    } finally { rmTmpDir(tmp); }
+  });
+});

--- a/packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts
+++ b/packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts
@@ -244,7 +244,8 @@ describe('resolveRuntimeFromPdConfig', () => {
     try {
       const result = resolveRuntimeFromPdConfig(tmp);
       expect(isRuntimeConfigError(result.result)).toBe(true);
-      expect((result.result as { ok: false }).reason).toContain('config_malformed');
+      if (!isRuntimeConfigError(result.result)) throw new Error('Expected RuntimeConfigError');
+      expect(result.result.reason).toContain('config_malformed');
       expect(result.runtimeProfileId).toBe(null);
       expect(result.runtimeProfileLabel).toBe(null);
     } finally { rmTmpDir(tmp); }
@@ -256,7 +257,8 @@ describe('resolveRuntimeFromPdConfig', () => {
     try {
       const result = resolveRuntimeFromPdConfig(tmp);
       expect(isRuntimeConfigError(result.result)).toBe(true);
-      expect((result.result as { ok: false }).reason).toContain('config_malformed');
+      if (!isRuntimeConfigError(result.result)) throw new Error('Expected RuntimeConfigError');
+      expect(result.result.reason).toContain('config_malformed');
     } finally { rmTmpDir(tmp); }
   });
 
@@ -290,7 +292,8 @@ describe('resolveRuntimeFromPdConfig', () => {
     try {
       const result = resolveRuntimeFromPdConfig(tmp, () => undefined);
       expect(isRuntimeConfigError(result.result)).toBe(true);
-      expect((result.result as { ok: false }).reason).toBe('not_ready');
+      if (!isRuntimeConfigError(result.result)) throw new Error('Expected RuntimeConfigError');
+      expect(result.result.reason).toBe('not_ready');
     } finally { rmTmpDir(tmp); }
   });
 });

--- a/packages/principles-core/src/runtime-v2/config/pd-config-agent-binding.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-agent-binding.ts
@@ -59,6 +59,7 @@ export interface PiAiAdapterConfigResult {
   apiKeyEnv: string;
   baseUrl?: string;
   timeoutMs?: number;
+  maxRetries?: number;
   workspace: string;
 }
 
@@ -264,6 +265,9 @@ export function createAdapterConfigFromProfile(
     }
     if (profile.timeoutMs) {
       result.timeoutMs = profile.timeoutMs;
+    }
+    if (profile.maxRetries !== undefined) {
+      result.maxRetries = profile.maxRetries;
     }
     return result;
   }

--- a/packages/principles-core/src/runtime-v2/config/pd-config-types.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-types.ts
@@ -54,6 +54,8 @@ export interface PdLocalRuntimeProfile {
   baseUrl?: string;
   /** Optional timeout in milliseconds */
   timeoutMs?: number;
+  /** Optional maximum number of retries */
+  maxRetries?: number;
 }
 
 export type RuntimeProfile = OpenClawRuntimeProfile | PdLocalRuntimeProfile;

--- a/packages/principles-core/src/runtime-v2/config/pd-config-validate.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-validate.ts
@@ -199,6 +199,14 @@ function validatePdLocalProfile(
     errors.push(err(`${path}.timeoutMs`, `profile '${profileId}' timeoutMs must be positive, got ${timeoutMs}`, `Set timeoutMs in profile '${profileId}' to a positive number`));
   }
 
+  const maxRetries = readOwn(raw, 'maxRetries');
+  if (maxRetries !== undefined && !isNumber(maxRetries)) {
+    errors.push(err(`${path}.maxRetries`, `profile '${profileId}' maxRetries must be a finite number, got ${safePreview(maxRetries)}`, `Fix maxRetries in profile '${profileId}'`));
+  }
+  if (isNumber(maxRetries) && maxRetries < 0) {
+    errors.push(err(`${path}.maxRetries`, `profile '${profileId}' maxRetries must be non-negative, got ${maxRetries}`, `Set maxRetries in profile '${profileId}' to a non-negative number`));
+  }
+
   // Reject raw secret values
   const forbiddenValueKeys = ['apiKey', 'api_key', 'token', 'gatewayToken', 'gateway_token', 'secret', 'password', 'auth'];
   for (const fk of forbiddenValueKeys) {
@@ -219,6 +227,7 @@ function validatePdLocalProfile(
   };
   if (isString(baseUrl)) result.baseUrl = baseUrl;
   if (isNumber(timeoutMs)) result.timeoutMs = timeoutMs;
+  if (isNumber(maxRetries)) result.maxRetries = maxRetries;
   return { ok: true, value: result };
 }
 

--- a/packages/principles-core/src/runtime-v2/config/pd-config-validate.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-validate.ts
@@ -204,7 +204,10 @@ function validatePdLocalProfile(
     errors.push(err(`${path}.maxRetries`, `profile '${profileId}' maxRetries must be a finite number, got ${safePreview(maxRetries)}`, `Fix maxRetries in profile '${profileId}'`));
   }
   if (isNumber(maxRetries) && maxRetries < 0) {
-    errors.push(err(`${path}.maxRetries`, `profile '${profileId}' maxRetries must be non-negative, got ${maxRetries}`, `Set maxRetries in profile '${profileId}' to a non-negative number`));
+    errors.push(err(`${path}.maxRetries`, `profile '${profileId}' maxRetries must be non-negative, got ${maxRetries}`, `Set maxRetries in profile '${profileId}' to a non-negative integer`));
+  }
+  if (isNumber(maxRetries) && !Number.isInteger(maxRetries)) {
+    errors.push(err(`${path}.maxRetries`, `profile '${profileId}' maxRetries must be an integer, got ${maxRetries}`, `Set maxRetries in profile '${profileId}' to a non-negative integer`));
   }
 
   // Reject raw secret values

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -335,6 +335,7 @@ export function resolveRuntimeConfigFromPdConfig(
       apiKeyEnv: adapterConfig.apiKeyEnv,
       baseUrl: adapterConfig.baseUrl,
       timeoutMs: adapterConfig.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxRetries: adapterConfig.maxRetries,
       agentId: 'main',
     };
   }


### PR DESCRIPTION
This PR adds:

**Tests:**
- 17 new tests in `packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts`
- Coverage for `buildProfileLabel` formatting (pi-ai and openclaw)
- Coverage for `resolveRuntimeFromPdConfig` (valid/invalid/malformed configs)
- Coverage for `resolveRuntimeWithOverrides` (CLI flag merging)

**Bug Fix:**
- Added `maxRetries` support to the pd-config resolution pipeline
- The field was missing from validation, adapter config creation, and final resolution
- Ensures `maxRetries` configured in `.pd/config.yaml` is properly passed to the runtime adapter

**Files Changed:**
- `packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts` (new)
- `packages/principles-core/src/runtime-v2/config/pd-config-types.ts`
- `packages/principles-core/src/runtime-v2/config/pd-config-agent-binding.ts`
- `packages/principles-core/src/runtime-v2/config/pd-config-validate.ts`
- `packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * pi-ai 运行时配置现已支持 `maxRetries` 字段，用于自定义请求重试次数上限。

* **改进**
  * 在合并 CLI 覆盖项时，空字符串将被正确保留，不再被错误地回退到配置值。

* **测试**
  * 新增并完善运行时配置解析、校验、告警处理及覆盖合并的测试用例覆盖面。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->