### PR TITLE
fix: post-commit bugfix — canonical_pain_id UNIQUE constraint + Linux rm + empty-string config guards

### DIFF
--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -276,8 +276,13 @@ export class TrajectoryDatabase {
           SET runtime_task_id = COALESCE(?, runtime_task_id)
           WHERE canonical_pain_id = ?
         `).run(input.runtimeTaskId ?? null, input.canonicalPainId);
-        const row = this.db.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').get(input.canonicalPainId) as { id: number } | undefined;
-        insertedId = row?.id ?? -1;
+        const rawRow = this.db.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').get(input.canonicalPainId);
+        // Runtime Contract #1/#2: validate DB row instead of `as` cast
+        if (rawRow && typeof rawRow === 'object' && Object.hasOwn(rawRow, 'id') && typeof (rawRow as Record<string, unknown>).id === 'number') {
+          insertedId = (rawRow as { id: number }).id;
+        } else {
+          insertedId = -1;
+        }
       } else {
         throw insertErr;
       }

--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -241,6 +241,10 @@ export class TrajectoryDatabase {
     this.recordSession({ sessionId: input.sessionId, startedAt: input.createdAt });
     let insertedId = -1;
     this.withWrite(() => {
+    // Try INSERT; on UNIQUE constraint violation for canonical_pain_id, do UPDATE instead.
+    // SQLite UPSERT (ON CONFLICT) does not support partial unique indexes, so we
+    // handle the conflict manually.
+    try {
       const runResult = this.db.prepare(`
         INSERT INTO pain_events (
           session_id, source, score, reason, severity, origin, confidence, text, created_at,
@@ -259,7 +263,25 @@ export class TrajectoryDatabase {
         input.canonicalPainId ?? null,
         input.runtimeTaskId ?? null,
       );
-      insertedId = runResult.lastInsertRowid as number;
+      insertedId = Number(runResult.lastInsertRowid);
+    } catch (insertErr: unknown) {
+      if (
+        input.canonicalPainId &&
+        insertErr instanceof Error &&
+        insertErr.message.includes('UNIQUE constraint failed') &&
+        insertErr.message.includes('canonical_pain_id')
+      ) {
+        this.db.prepare(`
+          UPDATE pain_events
+          SET runtime_task_id = COALESCE(?, runtime_task_id)
+          WHERE canonical_pain_id = ?
+        `).run(input.runtimeTaskId ?? null, input.canonicalPainId);
+        const row = this.db.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').get(input.canonicalPainId) as { id: number } | undefined;
+        insertedId = row?.id ?? -1;
+      } else {
+        throw insertErr;
+      }
+    }
     });
     // FTS indexing is best-effort — run outside the transaction so it cannot
     // roll back the committed pain event row (MEM-03, MEM-04).

--- a/packages/pd-cli/src/services/pd-config-loader.ts
+++ b/packages/pd-cli/src/services/pd-config-loader.ts
@@ -91,7 +91,7 @@ function detectLegacyFiles(workspaceDir: string): string[] {
 /** PRI-404: Generate nextAction suggestions for removing legacy files. */
 function buildLegacyFileNextActions(legacyFiles: string[]): string[] {
   return legacyFiles.map(f => {
-    return `Run 'Remove-Item ${f} -Force' to remove legacy config`;
+    return `Run 'rm ${f}' to remove legacy config`;
   });
 }
 

--- a/packages/pd-cli/src/services/resolve-runtime-from-pd-config.ts
+++ b/packages/pd-cli/src/services/resolve-runtime-from-pd-config.ts
@@ -169,22 +169,24 @@ export function resolveRuntimeWithOverrides(
 
   const config = base.result;
   // CLI flags override config values
+  // Use ?? (not ||) so empty-string overrides are preserved until the guard below
   const merged: RuntimeConfig = {
     ...config,
-    provider: overrides.provider || config.provider,
-    model: overrides.model || config.model,
-    apiKeyEnv: overrides.apiKeyEnv || config.apiKeyEnv,
-    baseUrl: overrides.baseUrl || config.baseUrl,
+    provider: overrides.provider ?? config.provider,
+    model: overrides.model ?? config.model,
+    apiKeyEnv: overrides.apiKeyEnv ?? config.apiKeyEnv,
+    baseUrl: overrides.baseUrl ?? config.baseUrl,
     maxRetries: overrides.maxRetries ?? config.maxRetries,
     timeoutMs: overrides.timeoutMs ?? config.timeoutMs,
   };
 
-  // Guard: empty-string provider/model/apiKeyEnv after merge means the user
+  // Guard: empty-string provider/model/apiKeyEnv/baseUrl after merge means the user
   // explicitly passed '' or the config has a blank value. Normalise to
   // undefined so downstream validation (handlePiAiProbe) can catch it.
   if (!merged.provider) merged.provider = undefined;
   if (!merged.model) merged.model = undefined;
   if (!merged.apiKeyEnv) merged.apiKeyEnv = undefined;
+  if (!merged.baseUrl) merged.baseUrl = undefined;
 
   return { ...base, mergedConfig: merged };
 }

--- a/packages/pd-cli/src/services/resolve-runtime-from-pd-config.ts
+++ b/packages/pd-cli/src/services/resolve-runtime-from-pd-config.ts
@@ -179,5 +179,12 @@ export function resolveRuntimeWithOverrides(
     timeoutMs: overrides.timeoutMs ?? config.timeoutMs,
   };
 
+  // Guard: empty-string provider/model/apiKeyEnv after merge means the user
+  // explicitly passed '' or the config has a blank value. Normalise to
+  // undefined so downstream validation (handlePiAiProbe) can catch it.
+  if (!merged.provider) merged.provider = undefined;
+  if (!merged.model) merged.model = undefined;
+  if (!merged.apiKeyEnv) merged.apiKeyEnv = undefined;
+
   return { ...base, mergedConfig: merged };
 }

--- a/packages/pd-cli/tests/commands/config-doctor.test.ts
+++ b/packages/pd-cli/tests/commands/config-doctor.test.ts
@@ -240,7 +240,7 @@ describe('Legacy file detection', () => {
     } finally { rmTmpDir(tmp); }
   });
 
-  it('PRI-404: legacyFileNextActions contains Remove-Item commands and does not pollute nextActions', async () => {
+  it('PRI-404: legacyFileNextActions contains rm commands and does not pollute nextActions', async () => {
     const tmp = mkTmpDir();
     const stateDir = path.join(tmp, '.state');
     fs.mkdirSync(stateDir, { recursive: true });
@@ -248,10 +248,10 @@ describe('Legacy file detection', () => {
     try {
       const output = await buildDoctorOutput({ workspaceDir: tmp });
       expect(output.legacyFileNextActions.length).toBeGreaterThan(0);
-      expect(output.legacyFileNextActions[0]).toContain('Remove-Item');
+      expect(output.legacyFileNextActions[0]).toContain('rm ');
       expect(output.legacyFileNextActions[0]).toContain('workflows.yaml');
       // Regression: legacyFileNextActions must NOT appear in general nextActions
-      expect(output.nextActions.some(na => na.includes('Remove-Item') && na.includes('workflows.yaml'))).toBe(false);
+      expect(output.nextActions.some(na => na.includes('rm ') && na.includes('workflows.yaml'))).toBe(false);
     } finally { rmTmpDir(tmp); }
   });
 });

--- a/packages/pd-cli/tests/services/pd-config-loader.test.ts
+++ b/packages/pd-cli/tests/services/pd-config-loader.test.ts
@@ -446,7 +446,7 @@ describe('Legacy file detection', () => {
     } finally { rmTmpDir(tmp); }
   });
 
-  it('PRI-404: includes legacyFileNextActions with Remove-Item command when legacy files detected', () => {
+  it('PRI-404: includes legacyFileNextActions with rm command when legacy files detected', () => {
     const tmp = mkTmpDir();
     const stateDir = path.join(tmp, '.state');
     fs.mkdirSync(stateDir, { recursive: true });
@@ -454,7 +454,7 @@ describe('Legacy file detection', () => {
     try {
       const result = loadPdConfig(tmp);
       expect(result.legacyFileNextActions.length).toBeGreaterThan(0);
-      expect(result.legacyFileNextActions[0]).toContain('Remove-Item');
+      expect(result.legacyFileNextActions[0]).toContain('rm ');
       expect(result.legacyFileNextActions[0]).toContain('workflows.yaml');
     } finally { rmTmpDir(tmp); }
   });

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-signal-observability.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-signal-observability.test.ts
@@ -195,4 +195,62 @@ describe('recordPainSignalObservability', () => {
     expect(parsed.data.reason).toContain('___REDACTED___');
     expect(parsed.data.reason).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz0123456789');
   });
+
+  it('handles UNIQUE constraint violation on canonical_pain_id via upsert', () => {
+    const { workspaceDir, stateDir } = makeWorkspace();
+    const canonicalPainId = 'manual_duplicate_test_001';
+
+    // First insert — should succeed
+    const result1 = recordPainSignalObservability({
+      workspaceDir,
+      stateDir,
+      data: {
+        painId: canonicalPainId,
+        taskId: 'diagnosis_duplicate_001',
+        painType: 'user_frustration',
+        source: 'manual',
+        reason: 'first insert',
+        score: 80,
+        sessionId: 'cli',
+        agentId: 'pd-cli',
+      },
+      canonicalPainId,
+      runtimeTaskId: 'task_001',
+    });
+    expect(result1.trajectoryPainEventId).toBeGreaterThan(0);
+    expect(result1.warnings).toEqual([]);
+
+    // Second insert with same canonicalPainId — should NOT throw, should upsert
+    const result2 = recordPainSignalObservability({
+      workspaceDir,
+      stateDir,
+      data: {
+        painId: canonicalPainId,
+        taskId: 'diagnosis_duplicate_002',
+        painType: 'user_frustration',
+        source: 'manual',
+        reason: 'second insert (should upsert)',
+        score: 90,
+        sessionId: 'cli',
+        agentId: 'pd-cli',
+      },
+      canonicalPainId,
+      runtimeTaskId: 'task_002',
+    });
+    // Should succeed without UNIQUE constraint error
+    expect(result2.warnings).toEqual([]);
+
+    // Verify only one row exists for this canonicalPainId
+    const db = new Database(join(stateDir, 'trajectory.db'), { readonly: true });
+    try {
+      const rows = db.prepare(
+        'SELECT canonical_pain_id, runtime_task_id FROM pain_events WHERE canonical_pain_id = ?'
+      ).all(canonicalPainId) as { canonical_pain_id: string; runtime_task_id: string | null }[];
+      expect(rows.length).toBe(1);
+      // runtime_task_id should be updated to the new value
+      expect(rows[0]!.runtime_task_id).toBe('task_002');
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
@@ -191,8 +191,12 @@ function recordTrajectoryPainEvent(opts: TrajectoryRecordOptions): number | unde
           SET runtime_task_id = COALESCE(?, runtime_task_id)
           WHERE canonical_pain_id = ?
         `).run(runtimeTaskId ?? null, canonicalPainId);
-        const row = db.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').get(canonicalPainId) as { id: number } | undefined;
-        return row?.id;
+        const rawRow = db.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').get(canonicalPainId);
+        // Runtime Contract #1/#2: validate DB row instead of `as` cast
+        if (rawRow && typeof rawRow === 'object' && Object.hasOwn(rawRow, 'id') && typeof (rawRow as Record<string, unknown>).id === 'number') {
+          return (rawRow as { id: number }).id;
+        }
+        return undefined;
       }
       throw insertErr;
     }

--- a/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
@@ -155,25 +155,47 @@ function recordTrajectoryPainEvent(opts: TrajectoryRecordOptions): number | unde
       `).run(sessionId, timestamp, timestamp);
     }
 
-    const result = db.prepare(`
-      INSERT INTO pain_events (
-        session_id, source, score, reason, severity, origin, confidence, text, created_at,
-        canonical_pain_id, runtime_task_id
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      sessionId,
-      data.source,
-      data.score ?? 80,
-      sanitizeString(data.reason ?? '', workspaceDir),
-      severityFromScore(data.score ?? 80),
-      data.source === 'manual' ? 'user_manual' : 'system_infer',
-      1,
-      sanitizeString(data.reason ?? '', workspaceDir),
-      timestamp,
-      canonicalPainId ?? null,
-      runtimeTaskId ?? null,
-    );
-    return Number(result.lastInsertRowid);
+    // Try INSERT; on UNIQUE constraint violation for canonical_pain_id, do UPDATE instead.
+    // SQLite UPSERT (ON CONFLICT) does not support partial unique indexes, so we
+    // handle the conflict manually.
+    try {
+      const result = db.prepare(`
+        INSERT INTO pain_events (
+          session_id, source, score, reason, severity, origin, confidence, text, created_at,
+          canonical_pain_id, runtime_task_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        sessionId,
+        data.source,
+        data.score ?? 80,
+        sanitizeString(data.reason ?? '', workspaceDir),
+        severityFromScore(data.score ?? 80),
+        data.source === 'manual' ? 'user_manual' : 'system_infer',
+        1,
+        sanitizeString(data.reason ?? '', workspaceDir),
+        timestamp,
+        canonicalPainId ?? null,
+        runtimeTaskId ?? null,
+      );
+      return Number(result.lastInsertRowid);
+    } catch (insertErr: unknown) {
+      // If UNIQUE constraint violation on canonical_pain_id, upsert manually
+      if (
+        canonicalPainId &&
+        insertErr instanceof Error &&
+        insertErr.message.includes('UNIQUE constraint failed') &&
+        insertErr.message.includes('canonical_pain_id')
+      ) {
+        db.prepare(`
+          UPDATE pain_events
+          SET runtime_task_id = COALESCE(?, runtime_task_id)
+          WHERE canonical_pain_id = ?
+        `).run(runtimeTaskId ?? null, canonicalPainId);
+        const row = db.prepare('SELECT id FROM pain_events WHERE canonical_pain_id = ?').get(canonicalPainId) as { id: number } | undefined;
+        return row?.id;
+      }
+      throw insertErr;
+    }
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Post-Commit Correctness Check — Bug Fixes

Three bugs found and fixed from analyzing recent commits:

### Bug 1 (CRITICAL): UNIQUE constraint violation on canonical_pain_id
**Files**: pain-signal-observability.ts, trajectory.ts

Two separate INSERT paths into pain_events can insert the same canonical_pain_id, causing an unhandled SQLite constraint error. The partial unique index WHERE canonical_pain_id IS NOT NULL was correctly created, but the fix using ON CONFLICT(canonical_pain_id) DO UPDATE does not work because SQLite UPSERT does not support partial unique indexes as conflict targets.

**Fix**: Replaced ON CONFLICT with try/catch — attempt INSERT, catch UNIQUE constraint failed on canonical_pain_id, then do a manual UPDATE instead.

### Bug 2 (MEDIUM): PowerShell commands on Linux
**File**: pd-config-loader.ts

buildLegacyFileNextActions generated Remove-Item ... -Force (PowerShell) on Linux systems.

**Fix**: Changed to rm.

### Bug 3 (MEDIUM): Empty-string config values bypass validation
**File**: resolve-runtime-from-pd-config.ts

Empty string provider/model/apiKeyEnv bypasses the !provider check in downstream validation because empty string || fallback falls through when fallback is also empty.

**Fix**: Normalise empty strings to undefined after merge.

## Test Coverage
- Added test for canonical_pain_id upsert behavior in pain-signal-observability.test.ts
- Updated existing tests for rm command in pd-config-loader.test.ts and config-doctor.test.ts
- All 58 relevant tests pass
- Lint: 0 errors
- Build: all 3 packages compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进痛点信号记录的去重与冲突处理：当出现唯一性冲突时会更新已存在记录的任务标识，避免重复写入。
  * 加强异常场景下的结果返回一致性，确保不会因冲突导致异常中断。
  * 提升配置参数合并容错性：对空值进行归一化处理，以便后续校验按“未提供”理解。
* **Tests**
  * 增补唯一约束冲突的覆盖用例，并验证写入结果仅保留一条记录且任务标识被更新。
  * 更新遗留配置清理相关的测试断言为跨平台命令风格。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->