### PR TITLE
feat(pd-console): skeleton loading + crossfade animations across all pages

### DIFF
--- a/packages/pd-console/src/ui/components/layout/app-sidebar.tsx
+++ b/packages/pd-console/src/ui/components/layout/app-sidebar.tsx
@@ -101,10 +101,10 @@ export function AppSidebar() {
                 to={item.href}
                 data-testid={`nav-${item.id}`}
                 className={cn(
-                  "flex items-center gap-3 px-3 py-2 rounded-[var(--radius-sm)] text-[13px] transition-colors",
+                  "flex items-center gap-3 px-3 py-2 rounded-[var(--radius-sm)] text-[13px] transition-all duration-150",
                   active
                     ? "border-l-2 border-l-gov bg-paper-2 text-ink"
-                    : "text-ink-3 hover:text-ink hover:bg-paper-2"
+                    : "border-l-2 border-l-transparent text-ink-3 hover:text-ink hover:bg-paper-2"
                 )}
               >
                 <Icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
@@ -134,10 +134,10 @@ export function AppSidebar() {
                   to={item.href}
                   data-testid={`nav-${item.id}`}
                   className={cn(
-                    "flex items-center gap-3 px-3 py-1.5 rounded-[var(--radius-sm)] text-[12px] transition-colors",
+                    "flex items-center gap-3 px-3 py-1.5 rounded-[var(--radius-sm)] text-[12px] transition-all duration-150",
                     active
                       ? "border-l-2 border-l-gov bg-paper-2 text-ink"
-                      : "text-ink-4 hover:text-ink-3 hover:bg-paper-2"
+                      : "border-l-2 border-l-transparent text-ink-4 hover:text-ink-3 hover:bg-paper-2"
                   )}
                 >
                   <Icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />

--- a/packages/pd-console/src/ui/components/layout/page-loading.tsx
+++ b/packages/pd-console/src/ui/components/layout/page-loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "../ui/skeleton.js";
+
+/**
+ * Reusable loading skeleton for full-page loading states.
+ * Shows a title skeleton + N card skeletons with a subtle fade-in.
+ * Replaces plain "Loading…" text across all pages for consistent perceived performance.
+ */
+export function PageLoading({ cardCount = 3 }: { cardCount?: number }) {
+  return (
+    <div className="animate-[pdFadeIn_200ms_ease-out]">
+      {/* Title skeleton */}
+      <Skeleton className="h-8 w-[60%] rounded-[4px] mb-3" />
+      <Skeleton className="h-4 w-[80%] rounded-sm mb-2" />
+      <Skeleton className="h-4 w-[50%] rounded-sm mb-8" />
+
+      {/* Card skeletons */}
+      <div className="space-y-4">
+        {Array.from({ length: cardCount }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-panel border border-line rounded-[var(--radius-md)] p-4"
+          >
+            <div className="flex items-center gap-2 mb-3">
+              <Skeleton className="h-5 w-20 rounded-[2px]" />
+              <Skeleton className="h-5 w-16 rounded-[2px]" />
+            </div>
+            <Skeleton className="h-4 w-full rounded-sm mb-2" />
+            <Skeleton className="h-4 w-[75%] rounded-sm mb-4" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3.5 w-24 rounded-sm" />
+              <Skeleton className="h-3.5 w-20 rounded-sm" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/pd-console/src/ui/components/layout/page-loading.tsx
+++ b/packages/pd-console/src/ui/components/layout/page-loading.tsx
@@ -4,10 +4,25 @@ import { Skeleton } from "../ui/skeleton.js";
  * Reusable loading skeleton for full-page loading states.
  * Shows a title skeleton + N card skeletons with a subtle fade-in.
  * Replaces plain "Loading…" text across all pages for consistent perceived performance.
+ *
+ * Accessibility: the root container is a live region (role="status" aria-live="polite")
+ * with a localized aria-label, so screen readers announce the loading state.
+ * Callers MUST pass a localized `label` (e.g. t("common.loading")).
  */
-export function PageLoading({ cardCount = 3 }: { cardCount?: number }) {
+export function PageLoading({
+  cardCount = 3,
+  label,
+}: {
+  cardCount?: number;
+  label: string;
+}) {
   return (
-    <div className="animate-[pdFadeIn_200ms_ease-out]">
+    <div
+      className="animate-[pdFadeIn_200ms_ease-out]"
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+    >
       {/* Title skeleton */}
       <Skeleton className="h-8 w-[60%] rounded-[4px] mb-3" />
       <Skeleton className="h-4 w-[80%] rounded-sm mb-2" />

--- a/packages/pd-console/src/ui/components/layout/page-shell.tsx
+++ b/packages/pd-console/src/ui/components/layout/page-shell.tsx
@@ -9,11 +9,15 @@ interface PageShellProps extends React.HTMLAttributes<HTMLDivElement> {
  * 712px centered container — the "slow thinking" physical layout.
  * Blueprint grid background is on body (globals.css), this adds
  * the centered content column with generous whitespace.
+ * Includes a subtle fade-in on mount for page transitions.
  */
 export function PageShell({ children, className, ...props }: PageShellProps) {
   return (
     <div
-      className={cn("mx-auto max-w-[712px] px-6 py-8", className)}
+      className={cn(
+        "mx-auto max-w-[712px] px-6 py-8 animate-[pdFadeIn_200ms_ease-out]",
+        className
+      )}
       {...props}
     >
       {children}

--- a/packages/pd-console/src/ui/components/layout/section-title.tsx
+++ b/packages/pd-console/src/ui/components/layout/section-title.tsx
@@ -13,7 +13,7 @@ export function SectionTitle({ children, className, ...props }: SectionTitleProp
   return (
     <h2
       className={cn(
-        "font-mono text-[11px] uppercase tracking-[0.1em] text-ink-3",
+        "font-mono text-[11px] uppercase tracking-[var(--tracking-wide)] text-ink-3",
         "border-b border-line pb-2 mb-4",
         className
       )}

--- a/packages/pd-console/src/ui/components/ui/badge.tsx
+++ b/packages/pd-console/src/ui/components/ui/badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../lib/utils.js";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-[2px] px-2 py-0.5 font-mono text-[11px] tracking-[0.02em] font-medium transition-colors",
+  "inline-flex items-center rounded-[2px] px-2 py-0.5 font-mono text-[11px] tracking-[var(--tracking-wide)] font-medium transition-colors",
   {
     variants: {
       variant: {

--- a/packages/pd-console/src/ui/components/ui/button.tsx
+++ b/packages/pd-console/src/ui/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../lib/utils.js";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-sm)] text-[12.5px] font-medium transition-[border-color,background,color] duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gov disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-sm)] text-[12.5px] font-medium transition-[border-color,background,color,transform] duration-150 active:scale-[0.98] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gov disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/packages/pd-console/src/ui/components/ui/card.tsx
+++ b/packages/pd-console/src/ui/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-[var(--radius-md)] border border-line bg-surface text-ink shadow-card transition-[border-color,box-shadow] duration-150 hover:border-line-2 hover:shadow-[0_24px_56px_rgba(31,41,51,.12)]",
+      "rounded-[var(--radius-md)] border border-line bg-surface text-ink shadow-card transition-[border-color,box-shadow,transform] duration-200 hover:border-line-2 hover:-translate-y-px hover:shadow-[0_24px_56px_rgba(31,41,51,.12)]",
       className
     )}
     {...props}

--- a/packages/pd-console/src/ui/components/ui/input.tsx
+++ b/packages/pd-console/src/ui/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-[border-color,box-shadow] duration-150 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-gov focus-visible:shadow-[var(--shadow-ring)] disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/packages/pd-console/src/ui/pages/activation/ActivationPage.tsx
+++ b/packages/pd-console/src/ui/pages/activation/ActivationPage.tsx
@@ -352,7 +352,7 @@ export function ActivationPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <PageLoading cardCount={4} />
+        <PageLoading cardCount={4} label={t("common.loading")} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/pages/activation/ActivationPage.tsx
+++ b/packages/pd-console/src/ui/pages/activation/ActivationPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import {
   fetchAllActivations,
@@ -351,9 +352,7 @@ export function ActivationPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <div className="text-ink-3 text-sm" role="status" aria-live="polite">
-          {t("common.loading")}…
-        </div>
+        <PageLoading cardCount={4} />
       </PageShell>
     );
   }
@@ -386,6 +385,7 @@ export function ActivationPage() {
 
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Layer 1: Conclusion — eyebrow + title + subtitle */}
       <div className="font-mono text-[12px] tracking-[0.14em] text-ink-3 uppercase mb-3">
         {t("pages.activation.eyebrow")}
@@ -507,6 +507,7 @@ export function ActivationPage() {
       <footer className="mt-12 pt-6 border-t border-line text-ink-3 text-[13px]">
         {t("pages.activation.footer")}
       </footer>
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import {
   fetchConfigSummary,
@@ -787,9 +788,7 @@ export function ControlCenterPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <div className="text-ink-3 text-sm" role="status" aria-live="polite">
-          {t("common.loading")}…
-        </div>
+        <PageLoading cardCount={3} />
       </PageShell>
     );
   }
@@ -851,6 +850,7 @@ export function ControlCenterPage() {
 
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Layer 1: Conclusion — eyebrow + title + subtitle */}
       <div className="font-mono text-[12px] tracking-[0.14em] text-ink-3 uppercase mb-3">
         {t("pages.controlCenter.eyebrow")}
@@ -912,6 +912,7 @@ export function ControlCenterPage() {
       <section className="mt-8" aria-labelledby="section-diagnostics">
         <AdvancedDiagnostics config={configData} />
       </section>
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
@@ -788,7 +788,7 @@ export function ControlCenterPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <PageLoading cardCount={3} />
+        <PageLoading cardCount={3} label={t("common.loading")} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/pages/focus/FocusPage.tsx
+++ b/packages/pd-console/src/ui/pages/focus/FocusPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import { DailyThoughtCard } from "../../components/focus/daily-thought-card.js";
 import {
@@ -671,9 +672,7 @@ export function FocusPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <div className="text-ink-3 text-sm" role="status" aria-live="polite">
-          {t("common.loading")}…
-        </div>
+        <PageLoading cardCount={3} />
       </PageShell>
     );
   }
@@ -719,6 +718,7 @@ export function FocusPage() {
 
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Layer 1: Conclusion — eyebrow + title + subtitle */}
       <div className="font-mono text-[12px] tracking-[0.14em] text-ink-3 uppercase mb-3">
         {t("pages.focus.eyebrow")}
@@ -887,6 +887,7 @@ export function FocusPage() {
       <footer className="mt-12 pt-6 border-t border-line text-ink-3 text-[13px]">
         {t("pages.focus.footer")}
       </footer>
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/focus/FocusPage.tsx
+++ b/packages/pd-console/src/ui/pages/focus/FocusPage.tsx
@@ -672,7 +672,7 @@ export function FocusPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <PageLoading cardCount={3} />
+        <PageLoading cardCount={3} label={t("common.loading")} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/pages/pain/PainPage.tsx
+++ b/packages/pd-console/src/ui/pages/pain/PainPage.tsx
@@ -12,6 +12,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PageShell } from '../../components/layout/page-shell.js';
+import { PageLoading } from '../../components/layout/page-loading.js';
 import { Badge } from '../../components/ui/badge.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.js';
 import { Button } from '../../components/ui/button.js';
@@ -123,7 +124,7 @@ export function PainPage() {
 
       {/* Content area */}
       {state.status === 'loading' && (
-        <div className="text-ink-3 text-sm py-8">{t('common.loading')}…</div>
+        <PageLoading cardCount={4} />
       )}
 
       {state.status === 'error' && (
@@ -138,13 +139,15 @@ export function PainPage() {
       )}
 
       {state.status === 'loaded' && (
-        <LoadedContent
-          data={state.data}
-          expandedIds={expandedIds}
-          onToggle={toggleExpanded}
-          onRefresh={loadData}
-          t={t}
-        />
+        <div className="animate-[pdFadeIn_400ms_ease-out]">
+          <LoadedContent
+            data={state.data}
+            expandedIds={expandedIds}
+            onToggle={toggleExpanded}
+            onRefresh={loadData}
+            t={t}
+          />
+        </div>
       )}
     </PageShell>
   );

--- a/packages/pd-console/src/ui/pages/pain/PainPage.tsx
+++ b/packages/pd-console/src/ui/pages/pain/PainPage.tsx
@@ -124,7 +124,7 @@ export function PainPage() {
 
       {/* Content area */}
       {state.status === 'loading' && (
-        <PageLoading cardCount={4} />
+        <PageLoading cardCount={4} label={t('common.loading')} />
       )}
 
       {state.status === 'error' && (

--- a/packages/pd-console/src/ui/pages/principles/PrincipleDetailPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrincipleDetailPage.tsx
@@ -314,7 +314,7 @@ export function PrincipleDetailPage() {
   if (loading) {
     return (
       <PageShell>
-        <PageLoading cardCount={1} />
+        <PageLoading cardCount={1} label={t("principles.loading", { defaultValue: "Loading…" })} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/pages/principles/PrincipleDetailPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrincipleDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import { Button } from "../../components/ui/button.js";
 import {
@@ -313,7 +314,7 @@ export function PrincipleDetailPage() {
   if (loading) {
     return (
       <PageShell>
-        <p className="text-ink-3 text-sm">{t("principles.loading", { defaultValue: "Loading…" })}</p>
+        <PageLoading cardCount={1} />
       </PageShell>
     );
   }
@@ -339,6 +340,7 @@ export function PrincipleDetailPage() {
 
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Back link */}
       <Button variant="ghost" onClick={() => navigate("/principles")} className="mb-4 -ml-2">
         ← {t("principles.detail.backToList")}
@@ -645,6 +647,7 @@ export function PrincipleDetailPage() {
             </div>
           </div>
         )}
+      </div>
       </div>
     </PageShell>
   );

--- a/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
@@ -332,7 +332,12 @@ export function PrinciplesPage() {
 
       {/* Content */}
       {loading && (
-        <div className="grid gap-3 animate-[pdFadeIn_200ms_ease-out]">
+        <div
+          className="grid gap-3 animate-[pdFadeIn_200ms_ease-out]"
+          role="status"
+          aria-live="polite"
+          aria-label={t("principles.loading", { defaultValue: "Loading…" })}
+        >
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}

--- a/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
+++ b/packages/pd-console/src/ui/pages/principles/PrinciplesPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { PageShell } from "../../components/layout/page-shell.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import { Button } from "../../components/ui/button.js";
+import { Skeleton } from "../../components/ui/skeleton.js";
 import {
   fetchPrinciples,
   fetchApprovalsGrouped,
@@ -331,7 +332,25 @@ export function PrinciplesPage() {
 
       {/* Content */}
       {loading && (
-        <p className="text-ink-3 text-sm">{t("principles.loading", { defaultValue: "Loading…" })}</p>
+        <div className="grid gap-3 animate-[pdFadeIn_200ms_ease-out]">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-panel border border-line rounded-[var(--radius-md)] p-4 border-l-[3px] border-l-transparent"
+            >
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <Skeleton className="h-5 w-[55%] rounded-sm" />
+                <Skeleton className="h-5 w-16 rounded-[2px]" />
+              </div>
+              <Skeleton className="h-4 w-full rounded-sm mb-2" />
+              <Skeleton className="h-4 w-[80%] rounded-sm mb-4" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-3.5 w-20 rounded-sm" />
+                <Skeleton className="h-3.5 w-24 rounded-sm" />
+              </div>
+            </div>
+          ))}
+        </div>
       )}
 
       {error && (
@@ -373,7 +392,7 @@ export function PrinciplesPage() {
       )}
 
       {!loading && !error && filtered.length > 0 && (
-        <div className="grid gap-3">
+        <div className="grid gap-3 animate-[pdFadeIn_400ms_ease-out]">
           {filtered.map((card) => (
             <article
               key={card.principleId}
@@ -382,8 +401,8 @@ export function PrinciplesPage() {
                 "bg-panel border border-line rounded-[var(--radius-md)] p-4 cursor-pointer " +
                 "border-l-[3px] " +
                 STATUS_BORDER[card.status] + " " +
-                "transition-[border-color,background] duration-150 " +
-                "hover:border-line-2 hover:bg-surface " +
+                "transition-[border-color,background,transform] duration-150 " +
+                "hover:border-line-2 hover:bg-surface hover:-translate-y-px " +
                 "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gov"
               }
               tabIndex={0}

--- a/packages/pd-console/src/ui/pages/report-problem/ReportProblemPage.tsx
+++ b/packages/pd-console/src/ui/pages/report-problem/ReportProblemPage.tsx
@@ -474,7 +474,7 @@ export function ReportProblemPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <PageLoading cardCount={3} />
+        <PageLoading cardCount={3} label={t("common.loading")} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/pages/report-problem/ReportProblemPage.tsx
+++ b/packages/pd-console/src/ui/pages/report-problem/ReportProblemPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import {
   createFeedbackReport,
@@ -473,9 +474,7 @@ export function ReportProblemPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <div className="text-ink-3 text-sm" role="status" aria-live="polite">
-          {t("common.loading")}…
-        </div>
+        <PageLoading cardCount={3} />
       </PageShell>
     );
   }
@@ -503,6 +502,7 @@ export function ReportProblemPage() {
   // ── Loaded state ─────────────────────────────────────────────────────────
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Layer 1: Conclusion — eyebrow + title + subtitle */}
       <div className="font-mono text-[12px] tracking-[0.14em] text-ink-3 uppercase mb-3">
         {t("pages.reportProblem.eyebrow")}
@@ -715,6 +715,7 @@ export function ReportProblemPage() {
       <footer className="mt-12 pt-6 border-t border-line text-ink-3 text-[13px]">
         {t("pages.reportProblem.privacy.guarantee")}
       </footer>
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
@@ -255,7 +255,7 @@ export function SettingsPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <PageLoading cardCount={3} />
+        <PageLoading cardCount={3} label={t("common.loading")} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import {
   getToken,
@@ -254,9 +255,7 @@ export function SettingsPage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <div className="text-ink-3 text-sm" role="status" aria-live="polite">
-          {t("common.loading")}…
-        </div>
+        <PageLoading cardCount={3} />
       </PageShell>
     );
   }
@@ -288,6 +287,7 @@ export function SettingsPage() {
 
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Layer 1: Conclusion — eyebrow + title + subtitle */}
       <div className="font-mono text-[12px] tracking-[0.14em] text-ink-3 uppercase mb-3">
         {t("pages.settings.eyebrow")}
@@ -485,6 +485,7 @@ export function SettingsPage() {
           </div>
         </div>
       </section>
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
+import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
 import {
   fetchUpdateStatus,
@@ -120,9 +121,7 @@ export function UpdatePage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <div className="text-ink-3 text-sm" role="status" aria-live="polite">
-          {t("common.loading")}…
-        </div>
+        <PageLoading cardCount={2} />
       </PageShell>
     );
   }
@@ -152,6 +151,7 @@ export function UpdatePage() {
 
   return (
     <PageShell>
+      <div className="animate-[pdFadeIn_400ms_ease-out]">
       {/* Layer 1: Conclusion — eyebrow + title + subtitle */}
       <div className="font-mono text-[12px] tracking-[0.14em] text-ink-3 uppercase mb-3">
         {t("pages.update.eyebrow")}
@@ -265,6 +265,7 @@ export function UpdatePage() {
           </div>
         )}
       </section>
+      </div>
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
@@ -121,7 +121,7 @@ export function UpdatePage() {
   if (loadingState === "loading") {
     return (
       <PageShell>
-        <PageLoading cardCount={2} />
+        <PageLoading cardCount={2} label={t("common.loading")} />
       </PageShell>
     );
   }

--- a/packages/pd-console/src/ui/styles/globals.css
+++ b/packages/pd-console/src/ui/styles/globals.css
@@ -60,12 +60,18 @@
   --radius-lg: 8px;
   --radius-xl: 12px;
 
-  /* Font families (B.3) */
+  /* Font families (B.3) — JetBrains Mono loaded via @fontsource in main.tsx */
   --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "SFMono-Regular", "Cascadia Mono", "JetBrains Mono", Consolas, monospace;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", "Cascadia Mono", Consolas, monospace;
+
+  /* Tracking tokens — 3 levels, replaces 6+ ad-hoc values */
+  --tracking-tight: -0.011em;   /* large headings */
+  --tracking-normal: 0em;        /* body */
+  --tracking-wide: 0.08em;       /* mono eyebrow / labels */
 
   /* Shadows (B.2) */
   --shadow-card: 0 18px 48px rgba(31, 41, 51, .08);
+  --shadow-ring: 0 0 0 3px color-mix(in srgb, var(--color-gov) 18%, transparent);
 }
 
 /* Dark mode tokens (B.1.1) — via [data-theme="dark"], NOT .dark class */
@@ -132,9 +138,22 @@
       linear-gradient(color-mix(in srgb, var(--color-gov) 3.5%, transparent) 1px, transparent 1px),
       linear-gradient(90deg, color-mix(in srgb, var(--color-gov) 3.5%, transparent) 1px, transparent 1px);
     background-size: 32px 32px;
-    /* Tabular nums (B.3) */
-    font-variant-numeric: tabular-nums;
+    /* Tabular nums + lining figures (B.3) */
+    font-variant-numeric: tabular-nums lining-nums;
+    /* Inter stylistic sets: cv01 (l/1/I), cv11 (single-story a), ss01 (alt 6/9) */
+    font-feature-settings: "cv01", "cv11", "ss01";
+    letter-spacing: var(--tracking-normal);
   }
+  /* Headings use tight tracking */
+  h1, h2, h3, h4, h5, h6 {
+    letter-spacing: var(--tracking-tight);
+  }
+}
+
+/* Page transition + content fade-in animations (B.2 / K.4) */
+@keyframes pdFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* Reduced motion (B.2 / K.4) */

--- a/packages/pd-console/tests/server/routes/update.test.ts
+++ b/packages/pd-console/tests/server/routes/update.test.ts
@@ -71,6 +71,7 @@ function parseResponseBody<T>(res: ServerResponse): T {
 let workspaceDir: string;
 let pluginDir: string;
 let tmpDir: string;
+let savedOpenclawHome: string | undefined;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -85,9 +86,19 @@ beforeEach(() => {
 
   const packageJson = { name: 'principles-disciple', version: '1.0.0' };
   fs.writeFileSync(path.join(extensionsDir, 'package.json'), JSON.stringify(packageJson));
+
+  // Inject OPENCLAW_HOME so resolvePluginDir() finds the test's tmpDir/extensions
+  // instead of the real ~/.openclaw/extensions/principles-disciple installation.
+  // Without this, tests would hit (and damage) the real PD install.
+  savedOpenclawHome = process.env.OPENCLAW_HOME;
+  process.env.OPENCLAW_HOME = tmpDir;
 });
 
 afterEach(() => {
+  // Restore OPENCLAW_HOME
+  if (savedOpenclawHome === undefined) delete process.env.OPENCLAW_HOME;
+  else process.env.OPENCLAW_HOME = savedOpenclawHome;
+
   // Cleanup temp dir
   if (tmpDir && fs.existsSync(tmpDir)) {
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -156,16 +167,24 @@ describe('handleUpdateRoute', () => {
       const emptyWorkspace = path.join(emptyTmpDir, 'workspace');
       fs.mkdirSync(emptyWorkspace, { recursive: true });
 
-      const req = createMockRequest('GET');
-      const res = createMockResponse();
+      // Point OPENCLAW_HOME to a dir with no extensions/principles-disciple,
+      // so resolvePluginDir() returns a non-existent path → version undefined.
+      const savedHome = process.env.OPENCLAW_HOME;
+      process.env.OPENCLAW_HOME = emptyTmpDir;
 
-      await handleUpdateRoute(req, res, emptyWorkspace, '/check');
+      try {
+        const req = createMockRequest('GET');
+        const res = createMockResponse();
 
-      expect(res.writeHead).toHaveBeenCalledWith(500, expect.any(Object));
-      const body = parseResponseBody<{ success: boolean; error: string }>(res);
-      expect(body.error).toBe('version_not_found');
+        await handleUpdateRoute(req, res, emptyWorkspace, '/check');
 
-      fs.rmSync(emptyTmpDir, { recursive: true, force: true });
+        expect(res.writeHead).toHaveBeenCalledWith(500, expect.any(Object));
+        const body = parseResponseBody<{ success: boolean; error: string }>(res);
+        expect(body.error).toBe('version_not_found');
+      } finally {
+        process.env.OPENCLAW_HOME = savedHome;
+        fs.rmSync(emptyTmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/pd-console/tests/ui/loading-a11y.test.ts
+++ b/packages/pd-console/tests/ui/loading-a11y.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Accessibility regression test for loading states (PR #965 review feedback).
+ *
+ * The vitest config uses 'node' environment (no jsdom), so we cannot mount
+ * React components. Instead we verify the source-code contract: every page
+ * loading branch must expose a live region (role="status" aria-live="polite")
+ * with a localized aria-label, so screen readers announce the loading state.
+ *
+ * This guards against accidentally removing these attributes in future edits.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// __dirname = packages/pd-console/tests/ui
+// SRC_ROOT  = packages/pd-console/src/ui
+const SRC_ROOT = join(__dirname, "..", "..", "src", "ui");
+
+function readSrc(relPath: string): string {
+  return readFileSync(join(SRC_ROOT, relPath), "utf-8");
+}
+
+describe("PageLoading component: live-region contract", () => {
+  const source = readSrc("components/layout/page-loading.tsx");
+
+  it("declares role=\"status\" on the root container", () => {
+    expect(source).toContain('role="status"');
+  });
+
+  it("declares aria-live=\"polite\" on the root container", () => {
+    expect(source).toContain('aria-live="polite"');
+  });
+
+  it("requires a localized label prop (not a hardcoded string)", () => {
+    // The label must be a prop, not a hardcoded literal, so callers pass
+    // i18n-translated text.
+    expect(source).toMatch(/label:\s*string/);
+    expect(source).toContain("aria-label={label}");
+  });
+});
+
+describe("Pages using PageLoading: pass a localized label", () => {
+  // Pages that import PageLoading must pass label={...} — not call it bare.
+  const PAGES_USING_PAGE_LOADING = [
+    "pages/activation/ActivationPage.tsx",
+    "pages/control-center/ControlCenterPage.tsx",
+    "pages/focus/FocusPage.tsx",
+    "pages/pain/PainPage.tsx",
+    "pages/principles/PrincipleDetailPage.tsx",
+    "pages/report-problem/ReportProblemPage.tsx",
+    "pages/settings/SettingsPage.tsx",
+    "pages/settings/UpdatePage.tsx",
+  ];
+
+  for (const relPath of PAGES_USING_PAGE_LOADING) {
+    it(`${relPath} passes label={...} to every PageLoading usage`, () => {
+      const source = readSrc(relPath);
+      // Every occurrence of <PageLoading must be followed (within the same tag)
+      // by label={...}. A bare <PageLoading ... /> without label is a regression.
+      const usages = source.match(/<PageLoading\b[^>]*\/>/g) ?? [];
+      expect(usages.length, "expected at least one PageLoading usage").toBeGreaterThan(0);
+      for (const usage of usages) {
+        expect(usage, `missing label prop in: ${usage}`).toMatch(/label=\{/);
+      }
+    });
+  }
+});
+
+describe("PrinciplesPage inline skeleton: live-region contract", () => {
+  // PrinciplesPage uses an inline skeleton (different card shape) instead of
+  // PageLoading, so we verify the live-region attributes directly.
+  const source = readSrc("pages/principles/PrinciplesPage.tsx");
+
+  it("the inline loading block declares role=\"status\"", () => {
+    expect(source).toContain('role="status"');
+  });
+
+  it("the inline loading block declares aria-live=\"polite\"", () => {
+    expect(source).toContain('aria-live="polite"');
+  });
+
+  it("the inline loading block has a localized aria-label", () => {
+    // Must use t(...) for the label, not a hardcoded English string.
+    expect(source).toMatch(/aria-label=\{t\(/);
+  });
+});

--- a/packages/pd-console/tests/ui/principle-review.test.ts
+++ b/packages/pd-console/tests/ui/principle-review.test.ts
@@ -616,9 +616,10 @@ describe("PRI-332: Principle Review readability", () => {
   it("PrinciplesPage never shows raw i18n key for unknown channels", () => {
     // Old pattern: t("principles." + (CHANNEL_LABELS[ch] ?? ch))
     // This would show "principles.model_training" as raw key for unknown channels
-    // New pattern: CHANNEL_LABELS[ch] ? t(...) : ch
+    // Current pattern: enumLabel('channel', ch, t) — centralized 3-tier fallback
+    // (i18n → local map → raw value) that never exposes a raw i18n key.
     expect(principlesPageSrc).not.toMatch(/CHANNEL_LABELS\[ch\] \?\? ch/);
-    expect(principlesPageSrc).toMatch(/CHANNEL_LABELS\[ch\]/);
+    expect(principlesPageSrc).toMatch(/enumLabel\(['"]channel['"]/);
   });
 
   it("language hint i18n keys exist in both languages", () => {


### PR DESCRIPTION
## Summary

Replace plain Loading… text with a reusable PageLoading skeleton component across all pages, and add crossfade fade-in animation to loaded content for smoother perceived performance.

### Changes

**New component**
- PageLoading — reusable skeleton with title + N card placeholders, animated with pdFadeIn 200ms`n
**Skeleton loading applied to 9 pages**
- Principles (list + detail), Pain, Focus, Activation, ControlCenter, Settings, Update, ReportProblem

**Crossfade animation on loaded content**
- All pages now wrap loaded content with nimate-[pdFadeIn_400ms_ease-out]`n- Consistent 400ms duration (snappy but visible)

**Micro-interactions (from earlier session, kept)**
- Button press feedback: ctive:scale-[0.98]`n- Card hover lift: hover:-translate-y-px`n- Sidebar nav highlight transition
- Page shell fade-in on mount

**Cleanup**
- Removed unused pdStaggerIn keyframe and .animate-stagger-in class

### ERR Checklist
- ERR-001: No ny types, no s bypass — N/A (pure CSS/JSX changes)
- ERR-002: Loading states still show meaningful skeleton, not silent fallback — OK
- ERR-014/016: No telemetry/preview paths touched — N/A

### Tests
- 
pm run build — passed
- 
pm run test — 12 pre-existing failures (same on base branch, not caused by this PR)
- Pre-push erify:merge gate — passed (lint, build, typecheck all green)

### Base branch
Rebased on top of eat/rulehost-mvp-activation (PR #963) per request.