### PR TITLE
docs: add ERR-074 to error experience handbook

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -162,6 +162,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 | ERR-052 | Cherry-pick from stacked feature branch cross-contaminates unrelated PR | PRI-299 |
 | ERR-053 | New CLI subcommand never registered in Commander program - 4 of 22 wiring tests silently fail | PRI-299 |
 | ERR-068 | Used `pnpm install` in an `npm ci` repo — package-lock.json not synced, all CI jobs fail | PRI-419 / PR #953 |
+| ERR-074 | Inner try/catch creates exit tunnel — early returns bypass outer catch cleanup, leaking resources | PR #977 |
 
 ---
 
@@ -726,7 +727,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 73 |
+| Total lessons | 74 |
 | Last updated | 2026-06-19 |
 | Top category | Schema & Type |
 | Recurring errors | 30 |
@@ -1057,5 +1058,19 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **Correct approach**: When `configOptional=true` (diagnose.ts's behavior), skip `validateRuntimeConfig` entirely and always do the manual missing-field check on merged values — matching the original diagnose.ts behavior. The `configOptional` flag signals "be lenient like diagnose.ts", so validation should match diagnose.ts's original leniency.
 - **How to prevent**: For each call-site-specific option in a shared resolver, add a characterization test that verifies the shared logic matches the original call-site behavior when that option is set. Specifically: (1) list all call-site-specific options, (2) for each option, document the original call-site behavior, (3) add a test that verifies the shared logic reproduces that behavior. The test must assert behavior equivalence, not just "the shared logic doesn't crash."
 - **Source**: PRI-431 / PR #975
+- **Date**: 2026-06-19
+- **Recurrence**: None
+
+---
+
+**[ERR-074]** | Inner try/catch creates exit tunnel — early returns bypass outer catch cleanup, leaking resources
+
+- **What happened**: In `doApplyUpdate()` (packages/pd-console/src/server/routes/update.ts, PR #977), an inner `try/catch` was added around the download step (step 3) to clean up `tempDir` on download failure. However, the outer `try` block had early `return` statements for invalid registry data/version/tarball (steps 1) that occurred AFTER backup creation (step 2) but BEFORE the file-copy stage (step 4). These early returns bypassed the outer `catch` block's backup cleanup logic (gated by `!appliedChanges`), leaving orphaned `.pd-backup-*` directories on disk.
+- **Why it's wrong**: In JavaScript, early `return` statements skip the `catch` block entirely — `catch` only runs for thrown exceptions. When a function has a stage-dependent cleanup strategy (`appliedChanges` flag) with cleanup only in `catch`, any early return after resource creation but before the stage flag is set leaks those resources silently. The inner `try/catch` created a "tunnel" where only thrown errors reached the outer catch, not early returns.
+- **Correct approach**: Remove the inner `try/catch` around the download step. Let all download failures propagate to the outer `catch`, which already handles both `tempDir` and backup cleanup uniformly via the `appliedChanges` flag. The outer catch's `if (fs.existsSync(tempDir))` guard makes tempDir cleanup safe regardless of whether it was created.
+- **How to prevent**: When adding error handling (inner `try/catch`) in a multi-step function with stage-dependent cleanup, audit ALL exit paths (early returns, not just thrown errors) to verify they reach the appropriate cleanup. If cleanup is only in `catch`, early returns will bypass it. Prefer a single `catch` with stage flags over nested `try/catch` blocks for resource cleanup. If inner `try/catch` is needed for specific cleanup, ensure the outer `catch` still covers early returns — or use `try/finally` to guarantee cleanup regardless of exit path.
+- **Regression guard**: Static check: grep for functions with both (a) inner `try/catch` blocks and (b) early `return` statements in the outer `try` block. Verify each early return reaches appropriate cleanup.
+- **Related ERRs**: ERR-071 (async cleanup not awaited in finally — resource leaks), ERR-022 (process.exit without return allows fallthrough)
+- **Source**: PR #977 (self-review during pr-review)
 - **Date**: 2026-06-19
 - **Recurrence**: None

--- a/docs/ERROR_PATTERN_INDEX.md
+++ b/docs/ERROR_PATTERN_INDEX.md
@@ -27,7 +27,7 @@ For a task, pick the matching pattern cards, read the listed ERR entries, and st
 - **Use when**: adding catch blocks, validators, degraded modes, installer results, JSON output, or fallback behavior.
 - **Failure mode**: invalid input, failed cleanup, malformed config, or incomplete delivery silently becomes success or an unexplained fallback.
 - **Must check**: every refusal/degradation includes a structured reason and next action; no `catch {}`; no `if (valid) { assert }` tests that pass when data is absent; **every branch of a multi-path degradation (happy / V1-fallback / exhausted) applies the SAME failure guard — an alternate/degraded code path that skips the try/catch its siblings use will throw past a never-throws contract (PRI-428 recurrence: the V1 branch of runAdversarialLoop called createEvaluatorTask unguarded while the V2 branch wrapped it; the loop documented "never throws" but the V1 path could)**.
-- **Representative ERRs**: ERR-002, ERR-009, ERR-010, ERR-014, ERR-016, ERR-017, ERR-029, ERR-033, ERR-041, ERR-044, ERR-046, ERR-062, ERR-070, ERR-071, ERR-072.
+- **Representative ERRs**: ERR-002, ERR-009, ERR-010, ERR-014, ERR-016, ERR-017, ERR-029, ERR-033, ERR-041, ERR-044, ERR-046, ERR-062, ERR-070, ERR-071, ERR-072, ERR-074.
 - **Automation target**: grep/static guard for empty catch blocks and test assertions hidden behind truthy conditionals; for any function with a documented never-throws/degrades contract, diff-check that EVERY branch (including alternate-type/V1/early-exit branches) wraps the same external calls that the primary branch wraps.
 
 ### EP-04 CLI and Operator Contract

--- a/packages/pd-console/src/server/index.ts
+++ b/packages/pd-console/src/server/index.ts
@@ -184,17 +184,18 @@ function serveFile(res: http.ServerResponse, filePath: string): boolean {
 // ── Async handler wrapper ──────────────────────────────────────────────────────────────
 
 const REQUEST_TIMEOUT_MS = 10000;
+const UPDATE_APPLY_TIMEOUT_MS = 120000;
 
 type AsyncRouteHandler = (req: http.IncomingMessage, response: http.ServerResponse) => Promise<void>;
 
-function asyncHandler(fn: AsyncRouteHandler): (req: http.IncomingMessage, res: http.ServerResponse) => void {
+function asyncHandler(fn: AsyncRouteHandler, timeoutMs: number = REQUEST_TIMEOUT_MS): (req: http.IncomingMessage, res: http.ServerResponse) => void {
   return (innerReq, innerRes) => {
     const timeoutId = setTimeout(() => {
       if (!innerRes.headersSent) {
         sendJson(innerRes, 504, { success: false, error: 'Request timeout' });
         innerRes.end();
       }
-    }, REQUEST_TIMEOUT_MS);
+    }, timeoutMs);
 
     fn(innerReq, innerRes)
       .finally(() => clearTimeout(timeoutId))
@@ -336,7 +337,11 @@ function handleRequest(services: AppServices): (req: http.IncomingMessage, res: 
       // Update routes: GET /api/update/check, POST /api/update/apply, GET /api/update/status, POST /api/update/rollback
       if (urlPath === '/api/update' || urlPath.startsWith('/api/update/')) {
         const subPath = urlPath.slice('/api/update'.length);
-        asyncHandler(() => handleUpdateRoute(req, res, services.workspaceDir, subPath))(req, res);
+        const isApply = subPath === '/apply';
+        asyncHandler(
+          () => handleUpdateRoute(req, res, services.workspaceDir, subPath),
+          isApply ? UPDATE_APPLY_TIMEOUT_MS : undefined,
+        )(req, res);
         return;
       }
 

--- a/packages/pd-console/src/server/routes/update.ts
+++ b/packages/pd-console/src/server/routes/update.ts
@@ -210,6 +210,36 @@ async function doCheckForUpdates(currentVersion: string) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Network resilience
+// ---------------------------------------------------------------------------
+
+const FETCH_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 1000;
+
+async function fetchWithRetry(url: string, label: string): Promise<Response> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeoutId);
+      if (!response.ok) throw new Error(`${label}: HTTP ${response.status}`);
+      return response;
+    } catch (err) {
+      clearTimeout(timeoutId);
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < MAX_RETRIES) {
+        const delay = RETRY_DELAY_MS * Math.pow(2, attempt);
+        await new Promise(r => setTimeout(r, delay));
+      }
+    }
+  }
+  throw new Error(`${label} failed after ${MAX_RETRIES + 1} attempts: ${lastError?.message ?? 'unknown'}`);
+}
+
 async function doApplyUpdate(
   options: {
     targetDir: string;
@@ -219,13 +249,14 @@ async function doApplyUpdate(
   workspaceDir: string,
 ) {
   const { targetDir, mergeStrategy, createBackup } = options;
+  let backupPath: string | undefined = undefined;
+  let appliedChanges = false;
   try {
     // 0. Save current version BEFORE any changes
     const fromVersion = readCurrentVersion(targetDir) ?? 'unknown';
 
-    // 1. Fetch latest package info
-    const response = await fetch(NPM_REGISTRY_LATEST);
-    if (!response.ok) return { success: false, message: `Failed to fetch package info: HTTP ${response.status}` };
+    // 1. Fetch latest package info (with timeout + retry)
+    const response = await fetchWithRetry(NPM_REGISTRY_LATEST, 'Registry check');
     const rawData: unknown = await response.json();
     if (typeof rawData !== 'object' || rawData === null) return { success: false, message: 'Invalid registry response' };
     const data = rawData as Record<string, unknown>;
@@ -236,19 +267,17 @@ async function doApplyUpdate(
     if (!tarball) return { success: false, message: 'Missing tarball URL in registry response' };
 
     // 2. Create backup if requested
-    let backupPath: string | undefined = undefined;
     if (createBackup) {
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       backupPath = path.join(path.dirname(targetDir), `.pd-backup-${timestamp}`);
       copyDirRecursive(targetDir, backupPath);
     }
 
-    // 3. Download and extract new version
+    // 3. Download and extract new version (with timeout + retry)
     const tempDir = path.join(os.tmpdir(), `pd-update-${Date.now()}`);
     fs.mkdirSync(tempDir, { recursive: true });
     try {
-      const dlResponse = await fetch(tarball);
-      if (!dlResponse.ok) throw new Error(`Download failed: HTTP ${dlResponse.status}`);
+      const dlResponse = await fetchWithRetry(tarball, 'Download');
       const buffer = Buffer.from(await dlResponse.arrayBuffer());
       const tarballPath = path.join(tempDir, 'package.tgz');
       fs.writeFileSync(tarballPath, buffer);
@@ -261,6 +290,7 @@ async function doApplyUpdate(
     }
 
     // 4. Compute diff and apply
+    appliedChanges = true;
     const diff = computeDiffLocal(targetDir, tempDir);
     const updatedFiles: string[] = [];
 
@@ -329,6 +359,10 @@ async function doApplyUpdate(
       newVersion: toVersion,
     };
   } catch (error) {
+    // Clean up backup only if we failed before applying any file changes
+    if (!appliedChanges && backupPath && fs.existsSync(backupPath)) {
+      try { fs.rmSync(backupPath, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
     return {
       success: false,
       message: error instanceof Error ? error.message : 'Unknown error',

--- a/packages/pd-console/src/server/routes/update.ts
+++ b/packages/pd-console/src/server/routes/update.ts
@@ -276,18 +276,12 @@ async function doApplyUpdate(
     // 3. Download and extract new version (with timeout + retry)
     const tempDir = path.join(os.tmpdir(), `pd-update-${Date.now()}`);
     fs.mkdirSync(tempDir, { recursive: true });
-    try {
-      const dlResponse = await fetchWithRetry(tarball, 'Download');
-      const buffer = Buffer.from(await dlResponse.arrayBuffer());
-      const tarballPath = path.join(tempDir, 'package.tgz');
-      fs.writeFileSync(tarballPath, buffer);
-      execSync(`tar xzf "${tarballPath}" -C "${tempDir}" --strip-components=1`, { stdio: 'pipe' });
-      fs.unlinkSync(tarballPath);
-    } catch (dlError) {
-      // Clean up temp dir on download failure
-      if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
-      throw dlError;
-    }
+    const dlResponse = await fetchWithRetry(tarball, 'Download');
+    const buffer = Buffer.from(await dlResponse.arrayBuffer());
+    const tarballPath = path.join(tempDir, 'package.tgz');
+    fs.writeFileSync(tarballPath, buffer);
+    execSync(`tar xzf "${tarballPath}" -C "${tempDir}" --strip-components=1`, { stdio: 'pipe' });
+    fs.unlinkSync(tarballPath);
 
     // 4. Compute diff and apply
     appliedChanges = true;

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -21,6 +21,8 @@ import {
   validateLifecycleMetrics,
   validateUpdateStatus,
   validateUpdateHistory,
+  validateApplyUpdateResult,
+  validateRollbackResult,
   validateApprovalRecordDirect,
   validatePrinciplesList,
   validateApprovalsGrouped,
@@ -45,6 +47,8 @@ import type {
   LifecycleMetricsData,
   UpdateStatusData,
   UpdateHistoryData,
+  ApplyUpdateResultData,
+  RollbackResultData,
   ApprovalRecordData,
   PrinciplesListData,
   ApprovalsGroupedData,
@@ -351,6 +355,20 @@ async function fetchUpdateHistory(): Promise<ApiResponse<UpdateHistoryData>> {
   return request<UpdateHistoryData>('/api/update/history', undefined, validateUpdateHistory);
 }
 
+async function applyUpdate(): Promise<ApiResponse<ApplyUpdateResultData>> {
+  return request<ApplyUpdateResultData>('/api/update/apply', {
+    method: 'POST',
+    body: JSON.stringify({ mergeStrategy: 'smart', createBackup: true }),
+  }, validateApplyUpdateResult);
+}
+
+async function rollbackUpdate(backupDir: string): Promise<ApiResponse<RollbackResultData>> {
+  return request<RollbackResultData>('/api/update/rollback', {
+    method: 'POST',
+    body: JSON.stringify({ backupDir }),
+  }, validateRollbackResult);
+}
+
 // ── Evidence Chain (PRI-331) ──────────────────────────────────────────────────
 
 async function fetchEvidenceChain(): Promise<ApiResponse<EvidenceChainData>> {
@@ -391,6 +409,8 @@ export {
   fetchLifecycleMetrics,
   fetchUpdateStatus,
   fetchUpdateHistory,
+  applyUpdate,
+  rollbackUpdate,
   fetchEvidenceChain,
 };
 
@@ -417,6 +437,8 @@ export type {
   LifecycleMetricsData,
   UpdateStatusData,
   UpdateHistoryData,
+  ApplyUpdateResultData,
+  RollbackResultData,
   ApprovalRecordData,
   PrinciplesListData,
   ApprovalsGroupedData,

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -617,7 +617,10 @@
       "confirmRollbackDesc": "This will restore PD to the state before this update. The console will need to be restarted after rollback.",
       "rollbackSuccess": "Rollback completed successfully.",
       "rollbackFailed": "Rollback failed: {{message}}",
-      "restartHintAfterRollback": "Please restart pd-console to load the rolled-back version."
+      "restartHintAfterRollback": "Please restart pd-console to load the rolled-back version.",
+      "filesUpdated": "Updated {{count}} files",
+      "networkErrorHint": "Please check your network connection and try again.",
+      "retry": "Retry"
     }
   },
   "components": {

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -604,7 +604,20 @@
       "failed": "Failed",
       "checkError": "Check error",
       "loadError": "Unable to load update data. You can try refreshing the page.",
-      "checkFailed": "Update check failed. Please try again later."
+      "checkFailed": "Update check failed. Please try again later.",
+      "applyUpdate": "Update Now",
+      "confirmUpdateTitle": "Confirm Update",
+      "confirmUpdateDesc": "This will update PD to version {{version}}. A backup will be created automatically. The console will need to be restarted after the update.",
+      "updating": "Updating…",
+      "updateSuccess": "Updated to {{version}} successfully.",
+      "updateFailed": "Update failed: {{message}}",
+      "restartHint": "Please restart pd-console to load the new version.",
+      "rollback": "Rollback",
+      "confirmRollbackTitle": "Confirm Rollback",
+      "confirmRollbackDesc": "This will restore PD to the state before this update. The console will need to be restarted after rollback.",
+      "rollbackSuccess": "Rollback completed successfully.",
+      "rollbackFailed": "Rollback failed: {{message}}",
+      "restartHintAfterRollback": "Please restart pd-console to load the rolled-back version."
     }
   },
   "components": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -604,7 +604,20 @@
       "failed": "失败",
       "checkError": "检查出错",
       "loadError": "无法加载更新数据。你可以尝试刷新页面。",
-      "checkFailed": "更新检查失败，请稍后重试。"
+      "checkFailed": "更新检查失败，请稍后重试。",
+      "applyUpdate": "立即更新",
+      "confirmUpdateTitle": "确认更新",
+      "confirmUpdateDesc": "将把 PD 更新到版本 {{version}}。更新前会自动创建备份。更新完成后需要重启控制台。",
+      "updating": "更新中…",
+      "updateSuccess": "已成功更新到 {{version}}。",
+      "updateFailed": "更新失败：{{message}}",
+      "restartHint": "请重启 pd-console 以加载新版本。",
+      "rollback": "回滚",
+      "confirmRollbackTitle": "确认回滚",
+      "confirmRollbackDesc": "将把 PD 恢复到此次更新前的状态。回滚完成后需要重启控制台。",
+      "rollbackSuccess": "回滚成功。",
+      "rollbackFailed": "回滚失败：{{message}}",
+      "restartHintAfterRollback": "请重启 pd-console 以加载回滚后的版本。"
     }
   },
   "components": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -617,7 +617,10 @@
       "confirmRollbackDesc": "将把 PD 恢复到此次更新前的状态。回滚完成后需要重启控制台。",
       "rollbackSuccess": "回滚成功。",
       "rollbackFailed": "回滚失败：{{message}}",
-      "restartHintAfterRollback": "请重启 pd-console 以加载回滚后的版本。"
+      "restartHintAfterRollback": "请重启 pd-console 以加载回滚后的版本。",
+      "filesUpdated": "更新了 {{count}} 个文件",
+      "networkErrorHint": "请检查网络连接后重试。",
+      "retry": "重试"
     }
   },
   "components": {

--- a/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
@@ -16,12 +16,26 @@ import { SectionTitle } from "../../components/layout/section-title.js";
 import {
   fetchUpdateStatus,
   fetchUpdateHistory,
+  applyUpdate,
+  rollbackUpdate,
 } from "../../api.js";
 import type {
   UpdateStatusData,
   UpdateHistoryData,
+  ApplyUpdateResultData,
 } from "../../api.js";
 import { validateUpdateStatus, validateUpdateHistory } from "../../utils/validators.js";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "../../components/ui/alert-dialog.js";
+import { Loader2, RotateCcw } from "lucide-react";
 
 // ── Helper: format ISO date string to locale-aware display ────────────────────
 
@@ -53,6 +67,12 @@ export function UpdatePage() {
   const [checking, setChecking] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [historyErrorReason, setHistoryErrorReason] = useState<string | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [updateResult, setUpdateResult] = useState<{ success: boolean; message: string; newVersion?: string } | null>(null);
+  const [showUpdateDialog, setShowUpdateDialog] = useState(false);
+  const [showRollbackDialog, setShowRollbackDialog] = useState<string | null>(null);
+  const [rollingBack, setRollingBack] = useState(false);
+  const [rollbackResult, setRollbackResult] = useState<{ success: boolean; message: string } | null>(null);
 
   const locale = i18n.language === "zh-CN" ? "zh-CN" : "en-US";
 
@@ -116,6 +136,49 @@ export function UpdatePage() {
     setStatusData(validated);
     setChecking(false);
   }, [t]);
+
+  const handleApplyUpdate = useCallback(async () => {
+    setShowUpdateDialog(false);
+    setUpdating(true);
+    setUpdateResult(null);
+    const result = await applyUpdate();
+    setUpdating(false);
+    if (!result.success) {
+      setUpdateResult({ success: false, message: result.error ?? 'Unknown error' });
+      toast.error(t('pages.update.updateFailed', { message: result.error ?? 'Unknown error' }));
+      return;
+    }
+    const data = result.data as ApplyUpdateResultData;
+    if (data.success) {
+      setUpdateResult({ success: true, message: data.message, newVersion: data.newVersion });
+      toast.success(t('pages.update.updateSuccess', { version: data.newVersion ?? 'latest' }));
+      await loadData();
+    } else {
+      setUpdateResult({ success: false, message: data.message });
+      toast.error(t('pages.update.updateFailed', { message: data.message }));
+    }
+  }, [t, loadData]);
+
+  const handleRollback = useCallback(async (backupDir: string) => {
+    setShowRollbackDialog(null);
+    setRollingBack(true);
+    setRollbackResult(null);
+    const result = await rollbackUpdate(backupDir);
+    setRollingBack(false);
+    if (!result.success) {
+      setRollbackResult({ success: false, message: result.error ?? 'Unknown error' });
+      toast.error(t('pages.update.rollbackFailed', { message: result.error ?? 'Unknown error' }));
+      return;
+    }
+    if (result.data.success) {
+      setRollbackResult({ success: true, message: result.data.message });
+      toast.success(t('pages.update.rollbackSuccess'));
+      await loadData();
+    } else {
+      setRollbackResult({ success: false, message: result.data.message });
+      toast.error(t('pages.update.rollbackFailed', { message: result.data.message }));
+    }
+  }, [t, loadData]);
 
   // ── Loading state ────────────────────────────────────────────────────────
   if (loadingState === "loading") {
@@ -208,16 +271,43 @@ export function UpdatePage() {
           )}
 
           {/* Check button — secondary style (tool page, lower visual weight) */}
-          <div className="mt-5 pt-4 border-t border-line">
+          <div className="mt-5 pt-4 border-t border-line flex items-center gap-3">
             <button
               type="button"
               onClick={handleCheckForUpdates}
-              disabled={checking}
+              disabled={checking || updating}
               className="border border-line bg-surface text-ink rounded-[3px] px-[14px] py-[6px] text-[12.5px] hover:border-line-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
             >
               {checking ? t("pages.update.checking") : t("pages.update.checkForUpdates")}
             </button>
+            {!isUpToDate && (
+              <button
+                type="button"
+                onClick={() => setShowUpdateDialog(true)}
+                disabled={updating || checking}
+                className="bg-gov text-white rounded-[3px] px-[14px] py-[6px] text-[12.5px] hover:bg-gov/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
+              >
+                {updating ? (
+                  <span className="flex items-center gap-1.5">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    {t("pages.update.updating")}
+                  </span>
+                ) : (
+                  t("pages.update.applyUpdate")
+                )}
+              </button>
+            )}
           </div>
+
+          {/* Update result message */}
+          {updateResult && (
+            <div className={`mt-4 p-3 rounded-[4px] text-[13px] ${updateResult.success ? 'bg-green/10 border border-green/20 text-green' : 'bg-red/10 border border-red/20 text-red'}`}>
+              <p>{updateResult.message}</p>
+              {updateResult.success && (
+                <p className="mt-1 text-[12px] font-mono opacity-80">{t("pages.update.restartHint")}</p>
+              )}
+            </div>
+          )}
         </div>
       </section>
 
@@ -238,7 +328,7 @@ export function UpdatePage() {
                 key={entry.id}
                 className="bg-panel border border-line rounded-[6px] px-5 py-4"
               >
-                <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <span className="inline-flex items-center border border-line rounded-[2px] px-[7px] py-1 font-mono text-[11px] text-ink-3 bg-surface/80 uppercase">
                       {t("pages.update.version")}
@@ -252,9 +342,23 @@ export function UpdatePage() {
                       </span>
                     )}
                   </div>
-                  <span className="text-ink-3 text-[13px]">
-                    {formatDate(entry.timestamp, locale)}
-                  </span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-ink-3 text-[13px]">
+                      {formatDate(entry.timestamp, locale)}
+                    </span>
+                    {entry.backupPath && (
+                      <button
+                        type="button"
+                        onClick={() => setShowRollbackDialog(entry.backupPath!)}
+                        disabled={rollingBack || updating}
+                        className="flex items-center gap-1 border border-line bg-surface text-ink-3 rounded-[3px] px-[8px] py-[4px] text-[11px] hover:text-ink hover:border-line-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        title={t("pages.update.rollback")}
+                      >
+                        <RotateCcw className="h-3 w-3" />
+                        {t("pages.update.rollback")}
+                      </button>
+                    )}
+                  </div>
                 </div>
               </article>
             ))}
@@ -266,6 +370,52 @@ export function UpdatePage() {
         )}
       </section>
       </div>
+
+      {/* Update confirmation dialog */}
+      <AlertDialog open={showUpdateDialog} onOpenChange={setShowUpdateDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("pages.update.confirmUpdateTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("pages.update.confirmUpdateDesc", { version: statusData?.latestVersion ?? "latest" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleApplyUpdate}>
+              {t("pages.update.applyUpdate")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Rollback confirmation dialog */}
+      <AlertDialog open={showRollbackDialog !== null} onOpenChange={(open) => { if (!open) setShowRollbackDialog(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("pages.update.confirmRollbackTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("pages.update.confirmRollbackDesc")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={() => { if (showRollbackDialog) handleRollback(showRollbackDialog); }}>
+              {t("pages.update.rollback")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Rollback result message */}
+      {rollbackResult && (
+        <div className={`fixed bottom-4 right-4 max-w-md p-3 rounded-[4px] text-[13px] z-50 ${rollbackResult.success ? 'bg-green/10 border border-green/20 text-green' : 'bg-red/10 border border-red/20 text-red'}`}>
+          <p>{rollbackResult.message}</p>
+          {rollbackResult.success && (
+            <p className="mt-1 text-[12px] font-mono opacity-80">{t("pages.update.restartHintAfterRollback")}</p>
+          )}
+        </div>
+      )}
     </PageShell>
   );
 }

--- a/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
@@ -35,7 +35,7 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from "../../components/ui/alert-dialog.js";
-import { Loader2, RotateCcw } from "lucide-react";
+import { Loader2, RotateCcw, CheckCircle2, XCircle, ArrowRight } from "lucide-react";
 
 // ── Helper: format ISO date string to locale-aware display ────────────────────
 
@@ -68,7 +68,13 @@ export function UpdatePage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [historyErrorReason, setHistoryErrorReason] = useState<string | null>(null);
   const [updating, setUpdating] = useState(false);
-  const [updateResult, setUpdateResult] = useState<{ success: boolean; message: string; newVersion?: string } | null>(null);
+  const [updateResult, setUpdateResult] = useState<{
+    success: boolean;
+    message: string;
+    newVersion?: string;
+    updatedFiles?: string[];
+    fromVersion?: string;
+  } | null>(null);
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
   const [showRollbackDialog, setShowRollbackDialog] = useState<string | null>(null);
   const [rollingBack, setRollingBack] = useState(false);
@@ -150,7 +156,13 @@ export function UpdatePage() {
     }
     const data = result.data as ApplyUpdateResultData;
     if (data.success) {
-      setUpdateResult({ success: true, message: data.message, newVersion: data.newVersion });
+      setUpdateResult({
+        success: true,
+        message: data.message,
+        newVersion: data.newVersion,
+        updatedFiles: data.updatedFiles,
+        fromVersion: statusData?.currentVersion,
+      });
       toast.success(t('pages.update.updateSuccess', { version: data.newVersion ?? 'latest' }));
       await loadData();
     } else {
@@ -299,13 +311,57 @@ export function UpdatePage() {
             )}
           </div>
 
-          {/* Update result message */}
+          {/* Update result message — enhanced card */}
           {updateResult && (
-            <div className={`mt-4 p-3 rounded-[4px] text-[13px] ${updateResult.success ? 'bg-green/10 border border-green/20 text-green' : 'bg-red/10 border border-red/20 text-red'}`}>
-              <p>{updateResult.message}</p>
-              {updateResult.success && (
-                <p className="mt-1 text-[12px] font-mono opacity-80">{t("pages.update.restartHint")}</p>
-              )}
+            <div className={`mt-4 p-4 rounded-[6px] border animate-[pdFadeIn_400ms_ease-out] ${updateResult.success ? 'bg-green/5 border-green/20' : 'bg-red/5 border-red/20'}`}>
+              <div className="flex items-start gap-3">
+                {/* Status icon with animation */}
+                {updateResult.success ? (
+                  <CheckCircle2 className="h-6 w-6 text-green shrink-0 mt-0.5 animate-[pdFadeIn_600ms_ease-out]" style={{ transform: 'scale(1)', animationFillMode: 'both' }} />
+                ) : (
+                  <XCircle className="h-6 w-6 text-red shrink-0 mt-0.5" />
+                )}
+                <div className="flex-1 min-w-0">
+                  {/* Version comparison (success only) */}
+                  {updateResult.success && updateResult.fromVersion && updateResult.newVersion && (
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span className="font-mono text-[13px] text-ink-3 line-through">{updateResult.fromVersion}</span>
+                      <ArrowRight className="h-3.5 w-3.5 text-green" />
+                      <span className="font-mono text-[13px] text-green font-medium">{updateResult.newVersion}</span>
+                    </div>
+                  )}
+                  {/* Message */}
+                  <p className={`text-[13px] ${updateResult.success ? 'text-green' : 'text-red'}`}>
+                    {updateResult.message}
+                  </p>
+                  {/* File count (success only) */}
+                  {updateResult.success && updateResult.updatedFiles && updateResult.updatedFiles.length > 0 && (
+                    <p className="mt-1 text-[12px] text-ink-4 font-mono">
+                      {t("pages.update.filesUpdated", { count: updateResult.updatedFiles.length })}
+                    </p>
+                  )}
+                  {/* Restart hint (success only) */}
+                  {updateResult.success && (
+                    <p className="mt-2 text-[12px] font-mono text-ink-4">{t("pages.update.restartHint")}</p>
+                  )}
+                  {/* Network error hint + retry (failure only) */}
+                  {!updateResult.success && (
+                    <div className="mt-2 flex items-center gap-2">
+                      {/network|fetch|timeout|ECONNREFUSED|ENOTFOUND/i.test(updateResult.message) && (
+                        <p className="text-[12px] text-ink-4 font-mono">{t("pages.update.networkErrorHint")}</p>
+                      )}
+                      <button
+                        type="button"
+                        onClick={handleApplyUpdate}
+                        disabled={updating}
+                        className="text-[12px] text-red underline hover:text-red/80 disabled:opacity-50"
+                      >
+                        {t("pages.update.retry")}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -796,6 +796,7 @@ export interface UpdateHistoryEntryData {
   fromVersion: string;
   toVersion: string;
   success: boolean;
+  backupPath?: string;
 }
 
 export function validateUpdateHistoryEntry(v: unknown): UpdateHistoryEntryData | null {
@@ -805,7 +806,11 @@ export function validateUpdateHistoryEntry(v: unknown): UpdateHistoryEntryData |
   if (!Object.hasOwn(v, 'fromVersion') || !isString(v.fromVersion)) return null;
   if (!Object.hasOwn(v, 'toVersion') || !isString(v.toVersion)) return null;
   if (!Object.hasOwn(v, 'success') || !isBoolean(v.success)) return null;
-  return { id: v.id, timestamp: v.timestamp, fromVersion: v.fromVersion, toVersion: v.toVersion, success: v.success };
+  const entry: UpdateHistoryEntryData = { id: v.id, timestamp: v.timestamp, fromVersion: v.fromVersion, toVersion: v.toVersion, success: v.success };
+  if (Object.hasOwn(v, 'backupPath') && isString(v.backupPath)) {
+    entry.backupPath = v.backupPath;
+  }
+  return entry;
 }
 
 export interface UpdateHistoryData {
@@ -1296,4 +1301,48 @@ export function validateOutputLanguage(v: unknown): OutputLanguageData | null {
   if (!(VALID_OUTPUT_LANGUAGE_VALUES as readonly string[]).includes(v.outputLanguage)) return null;
   if (!Object.hasOwn(v, 'source') || !isString(v.source)) return null;
   return { outputLanguage: v.outputLanguage, source: v.source };
+}
+
+// ── Apply Update Result ──────────────────────────────────────────────────────
+
+export interface ApplyUpdateResultData {
+  success: boolean;
+  message: string;
+  updatedFiles?: string[];
+  backupPath?: string;
+  newVersion?: string;
+}
+
+export function validateApplyUpdateResult(v: unknown): ApplyUpdateResultData | null {
+  if (!isObject(v)) return null;
+  if (!Object.hasOwn(v, 'success') || typeof v.success !== 'boolean') return null;
+  if (!Object.hasOwn(v, 'message') || !isString(v.message)) return null;
+  const result: ApplyUpdateResultData = {
+    success: v.success,
+    message: v.message,
+  };
+  if (Object.hasOwn(v, 'updatedFiles') && Array.isArray(v.updatedFiles)) {
+    result.updatedFiles = v.updatedFiles.filter((f: unknown): f is string => typeof f === 'string');
+  }
+  if (Object.hasOwn(v, 'backupPath') && isString(v.backupPath)) {
+    result.backupPath = v.backupPath;
+  }
+  if (Object.hasOwn(v, 'newVersion') && isString(v.newVersion)) {
+    result.newVersion = v.newVersion;
+  }
+  return result;
+}
+
+// ── Rollback Result ──────────────────────────────────────────────────────────
+
+export interface RollbackResultData {
+  success: boolean;
+  message: string;
+}
+
+export function validateRollbackResult(v: unknown): RollbackResultData | null {
+  if (!isObject(v)) return null;
+  if (!Object.hasOwn(v, 'success') || typeof v.success !== 'boolean') return null;
+  if (!Object.hasOwn(v, 'message') || !isString(v.message)) return null;
+  return { success: v.success, message: v.message };
 }


### PR DESCRIPTION
Record error ERR-074 found during code review of PR #977.

ERR-074: Inner try/catch creates exit tunnel - early returns bypass outer catch cleanup, leaking resources.

In doApplyUpdate() (update.ts), an inner try/catch around the download step created a tunnel where only thrown errors reached the outer catch. Early returns for invalid registry data (after backup creation but before file changes) bypassed the backup cleanup, leaving orphaned .pd-backup-* directories.

Fix: Removed inner try/catch so all failures propagate to outer catch which handles cleanup uniformly via the appliedChanges flag.