### PR TITLE
docs: add ERR-075 to error experience handbook

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -163,6 +163,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 | ERR-053 | New CLI subcommand never registered in Commander program - 4 of 22 wiring tests silently fail | PRI-299 |
 | ERR-068 | Used `pnpm install` in an `npm ci` repo — package-lock.json not synced, all CI jobs fail | PRI-419 / PR #953 |
 | ERR-074 | Inner try/catch creates exit tunnel — early returns bypass outer catch cleanup, leaking resources | PR #977 |
+| ERR-075 | Hardcoded aria-label bypasses i18n — screen readers read in wrong language for non-English UI | PR #979 |
 
 ---
 
@@ -727,8 +728,8 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 74 |
-| Last updated | 2026-06-19 |
+| Total lessons | 75 |
+| Last updated | 2026-06-20 |
 | Top category | Schema & Type |
 | Recurring errors | 30 |
 
@@ -1073,4 +1074,20 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **Related ERRs**: ERR-071 (async cleanup not awaited in finally — resource leaks), ERR-022 (process.exit without return allows fallthrough)
 - **Source**: PR #977 (self-review during pr-review)
 - **Date**: 2026-06-19
+- **Recurrence**: None
+
+
+---
+
+**[ERR-075]** | Hardcoded aria-label bypasses i18n — screen readers read in wrong language for non-English UI
+
+- **What happened**: In `app-sidebar.tsx` (PR #979), the assistant added `aria-label={`${pendingCount} pending approvals`}` and `aria-label={`${degradedCount} degraded signals`}` as hardcoded English strings. The file already imported `useTranslation` and used `t()` for visible text (e.g., `t(item.labelKey)`), but the assistant failed to apply the same i18n convention to the new accessibility attributes.
+- **Why it is wrong**: In a bilingual (zh-CN/en) application, all user-facing strings — including accessibility attributes like `aria-label`, `title`, and `placeholder` — must go through the i18n translation function. Hardcoding English strings causes screen readers to read in English while the visual UI displays in Chinese, creating a mixed-language accessibility barrier for non-English users.
+- **Generalized failure mode**: When adding any user-facing string (visible text, aria-label, title, placeholder) in a component that already uses i18n, assistants must use `t()` for the new string, otherwise assistive technologies will read in the wrong language.
+- **Correct approach**: Use `t("components.sidebar.pendingApprovalsAria", { count: pendingCount })` and `t("components.sidebar.degradedSignalsAria", { count: degradedCount })`, with corresponding keys added to both `en.json` and `zh-CN.json`.
+- **How to prevent**: When adding any string attribute (aria-label, title, placeholder, alt) to a JSX element in a file that imports `useTranslation`/`t()`, verify the new string uses `t()` with a translation key. Grep for `aria-label={` and `aria-label="` in i18n-enabled components to find hardcoded strings.
+- **Regression guard**: Static check: grep for `aria-label=\{?\` or `aria-label="` in `.tsx` files under `packages/pd-console/src/ui/` that also import `useTranslation`. Any match that does not use `t(...)` is a finding.
+- **Related ERRs**: None
+- **Source**: PR #979 (CodeRabbit review)
+- **Date**: 2026-06-20
 - **Recurrence**: None

--- a/docs/ERROR_PATTERN_INDEX.md
+++ b/docs/ERROR_PATTERN_INDEX.md
@@ -86,6 +86,14 @@ For a task, pick the matching pattern cards, read the listed ERR entries, and st
 - **Representative ERRs**: ERR-006, ERR-012, ERR-027, ERR-032, ERR-052.
 - **Automation target**: PR pre-review checklist and `git log main..source-branch` before cherry-pick.
 
+### EP-11 i18n and Accessibility String Consistency
+
+- **Use when**: adding any user-facing string (visible text, `aria-label`, `title`, `placeholder`, `alt`) in a component that already uses an i18n translation function (`t()`, `useTranslation`, `i18next`).
+- **Failure mode**: new strings are hardcoded in the source language (usually English) while the rest of the component routes text through `t()`, causing screen readers, tooltips, and visible text to read in a different language than the active UI locale.
+- **Must check**: every new string attribute in an i18n-enabled component uses `t()` with a translation key; corresponding keys are added to all locale files (`en.json`, `zh-CN.json`, etc.); interpolation parameters (e.g., `{{count}}`) are passed through `t()` options.
+- **Representative ERRs**: ERR-075.
+- **Automation target**: grep for `aria-label={`, `aria-label="`, `title="`, `placeholder="` in `.tsx` files that import `useTranslation`/`t()`; any match not using `t(...)` is a finding.
+
 ## Maintenance Rules
 
 - Every ERR in a pattern card must exist in `docs/ERROR_EXPERIENCE_HANDBOOK.md`.


### PR DESCRIPTION
Record error ERR-075 found during code review of PR #979.

**Error**: Hardcoded aria-label bypasses i18n in app-sidebar.tsx — screen readers read in English while UI displays in zh-CN.

**Found by**: CodeRabbit review during pr-review of PR #979.

**Fix**: Replaced hardcoded English aria-label strings with t() calls using pendingApprovalsAria and degradedSignalsAria i18n keys.