### PR TITLE
feat(rulehost): make SQLite the sole RuleHost source and delete filesystem compatibility (PRI-436)

### DIFF
--- a/packages/openclaw-plugin/src/core/code-implementation-storage.ts
+++ b/packages/openclaw-plugin/src/core/code-implementation-storage.ts
@@ -105,20 +105,6 @@ export function getImplementationAssetRoot(stateDir: string, implId: string): st
 }
 
 /**
- * Load manifest from disk. Returns null if not found (does not throw).
- */
-export function loadManifest(stateDir: string, implId: string): CodeImplementationManifest | null {
-  validateImplId(implId);
-  const manifestPath = path.join(getImplementationAssetRoot(stateDir, implId), MANIFEST_FILENAME);
-  if (!fs.existsSync(manifestPath)) return null;
-  try {
-    return JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as CodeImplementationManifest;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Write manifest atomically using withLock.
  */
 export function writeManifest(
@@ -161,23 +147,6 @@ export function deleteImplementationAssetDir(stateDir: string, implId: string): 
   withLock(assetRoot, () => {
     fs.rmSync(assetRoot, { recursive: true, force: true });
   });
-}
-
-/**
- * Load the entry source code from disk.
- * Returns null if manifest doesn't exist or entry file is missing.
- */
-export function loadEntrySource(stateDir: string, implId: string): string | null {
-  validateImplId(implId);
-  const manifest = loadManifest(stateDir, implId);
-  if (!manifest) return null;
-  const entryPath = path.join(getImplementationAssetRoot(stateDir, implId), manifest.entryFile);
-  if (!fs.existsSync(entryPath)) return null;
-  try {
-    return fs.readFileSync(entryPath, 'utf-8');
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/packages/openclaw-plugin/src/core/principle-tree-ledger.ts
+++ b/packages/openclaw-plugin/src/core/principle-tree-ledger.ts
@@ -702,19 +702,6 @@ export function transitionImplementationState(
 }
 
 /**
- * Get all implementations for a specific lifecycle state across all rules.
- */
-export function listImplementationsByLifecycleState(
-  stateDir: string,
-  state: ImplementationLifecycleState
-): Implementation[] {
-  const ledger = loadLedger(stateDir);
-  return Object.values(ledger.tree.implementations).filter(
-    (impl) => impl.lifecycleState === state
-  );
-}
-
-/**
  * Get implementations in a specific lifecycle state for a given rule.
  */
 export function listRuleImplementationsByState(

--- a/packages/openclaw-plugin/src/core/rule-host.ts
+++ b/packages/openclaw-plugin/src/core/rule-host.ts
@@ -1,13 +1,15 @@
 /**
  * Rule Host — Constrained execution layer for active code implementations
  *
- * PURPOSE: Load active code implementations from the principle-tree ledger
- * AND from the activations table (code_tool_hook channel), execute them in a
- * constrained node:vm context, and merge their decisions.
+ * PURPOSE: Load active code implementations from the SQLite activations table
+ * (code_tool_hook channel), execute them in a constrained node:vm context,
+ * and merge their decisions.
  *
- * ARCHITECTURE:
- *   - Constructor takes stateDir to access the principle-tree ledger
- *   - Optional workspaceDir enables reading code_tool_hook activations from SQLite
+ * ARCHITECTURE (PRI-436):
+ *   - SQLite is the SOLE production source of active RuleCode
+ *   - No filesystem ledger or implementation asset reads occur during evaluation
+ *   - Constructor takes stateDir for API compatibility (no longer used for impl loading)
+ *   - workspaceDir enables reading code_tool_hook activations from SQLite
  *   - evaluate(input) loads active code implementations and runs them
  *   - Each implementation executes in an isolated vm context with minimal helpers
  *   - Decision merge: block short-circuits, requireApproval collects, allow is implicit
@@ -22,11 +24,6 @@
  *   - Never throw, never bypass downstream gates (Progressive Gate, Edit Verification)
  */
 
-import * as fs from 'fs';
-import {
-  listImplementationsByLifecycleState,
-} from './principle-tree-ledger.js';
-import { loadEntrySource } from './code-implementation-storage.js';
 import { createRuleHostHelpers } from '@principles/core/runtime-v2';
 import { mergeDecisions } from '@principles/core/runtime-v2';
 import { SqliteConnection } from '@principles/core/runtime-v2';
@@ -37,13 +34,12 @@ import type {
   RuleHostMeta,
   LoadedImplementation,
 } from '@principles/core/runtime-v2';
-import type { Implementation } from '../types/principle-tree-schema.js';
 
 import type { RuleHostLogger } from '@principles/core/runtime-v2';
 export type { RuleHostLogger } from '@principles/core/runtime-v2';
 
 export interface RuleHostOptions {
-  /** Workspace directory for SQLite access. When provided, RuleHost also loads code_tool_hook activations from the activations table. */
+  /** Workspace directory for SQLite access. Required for RuleHost to load active code_tool_hook activations. */
   workspaceDir?: string;
 }
 
@@ -84,7 +80,6 @@ export class RuleHost {
    *   - { decision: 'block', ... } when any implementation returns block (short-circuits)
    *   - { decision: 'requireApproval', ... } when any implementation returns requireApproval
    */
-     
   evaluate(input: RuleHostInput): RuleHostResult | undefined {
     try {
       const activeImpls = this._loadActiveCodeImplementations();
@@ -99,70 +94,28 @@ export class RuleHost {
   }
 
   /**
-   * Load active code implementations from the ledger AND the activations table.
+   * Load active code implementations from the SQLite activations table.
    *
-   * Sources (merged, deduplicated by implId):
-   *   1. principle-tree-ledger.json: implementations with lifecycleState='active' and type='code'
-   *   2. activations table: code_tool_hook channel activations (when workspaceDir is provided)
+   * PRI-436: SQLite is the SOLE production source. The filesystem ledger
+   * (principle-tree-ledger) and implementation asset paths have been deleted.
+   * No fallback, no dual-source, no deprecated adapter.
    *
-   * This bridges the gap between RuleHostWriter (which records activation metadata in SQLite)
-   * and RuleHost enforcement (which previously only read from the ledger JSON file).
-   * See BUG-001 / ERR-011 / ERR-035.
+   * Source: activations table (code_tool_hook channel, deactivated_at IS NULL)
+   *   → JOIN pi_artifacts for content_json → extract implementationCode → compile
    */
   private _loadActiveCodeImplementations(): LoadedImplementation[] {
-    const loaded: LoadedImplementation[] = [];
-    const seenImplIds = new Set<string>();
+    if (!this.workspaceDir) {
+      return [];
+    }
 
-    // Source 1: principle-tree-ledger.json (existing path)
     try {
-      const activeAllTypes = listImplementationsByLifecycleState(
-        this.stateDir,
-        'active'
-      );
-
-      // Filter to code-type implementations only
-      const codeImpls = activeAllTypes.filter((impl) => impl.type === 'code');
-
-      for (const impl of codeImpls) {
-        try {
-          const loadedImpl = this._loadSingleImplementation(impl);
-          if (loadedImpl && !seenImplIds.has(loadedImpl.implId)) {
-            loaded.push(loadedImpl);
-            seenImplIds.add(loadedImpl.implId);
-          }
-        } catch (loadError: unknown) {
-          // Individual load failure: log and skip
-          this.logger.warn?.(
-            `[RuleHost] Failed to load implementation ${impl.id}: ${String(loadError)}`
-          );
-        }
-      }
-    } catch (ledgerError: unknown) {
-      // Ledger access failure: log and continue to activations table
+      return this._loadFromActivationsTable(this.workspaceDir);
+    } catch (activationError: unknown) {
       this.logger.warn?.(
-        `[RuleHost] Failed to access ledger: ${String(ledgerError)}`
+        `[RuleHost] Failed to load code_tool_hook activations: ${String(activationError)}`
       );
+      return [];
     }
-
-    // Source 2: activations table (code_tool_hook channel) — bridges BUG-001
-    if (this.workspaceDir) {
-      try {
-        const activationImpls = this._loadFromActivationsTable(this.workspaceDir);
-        for (const impl of activationImpls) {
-          if (!seenImplIds.has(impl.implId)) {
-            loaded.push(impl);
-            seenImplIds.add(impl.implId);
-          }
-        }
-      } catch (activationError: unknown) {
-        // Activations table access failure: log and continue with ledger-only results
-        this.logger.warn?.(
-          `[RuleHost] Failed to load code_tool_hook activations: ${String(activationError)}`
-        );
-      }
-    }
-
-    return loaded;
   }
 
   /**
@@ -170,10 +123,15 @@ export class RuleHost {
    *
    * For each activation record:
    *   1. Query the pi_artifacts table for the artifact content
-   *   2. Parse content_json to extract implementationCode
-   *   3. Compile via loadRuleImplementationModule (same vm isolation as ledger path)
+   *   2. Parse content_json to extract implementationCode (treated as unknown, EP-01)
+   *   3. Compile via loadRuleImplementationModule (isolated vm context)
    *
-   * This mirrors the PromptActivationReader pattern for SQLite access.
+   * PRI-436 invariant: at most one active activation per rule (target_ref).
+   * Duplicate active activations for the same target_ref are ALL skipped
+   * (zero executions) and emit structured unhealthy evidence via logger.warn
+   * (Runtime Contract Rule 9: graceful degradation includes a reason).
+   *
+   * All data from SQLite is treated as unknown and validated before use.
    */
   private _loadFromActivationsTable(workspaceDir: string): LoadedImplementation[] {
     const sqliteConn = new SqliteConnection(workspaceDir);
@@ -195,13 +153,58 @@ export class RuleHost {
         return [];
       }
 
-      const loaded: LoadedImplementation[] = [];
-
+      // PRI-436: Group active rows by target_ref to detect duplicates.
+      // At most one active activation per rule (target_ref) is allowed.
+      // Duplicate groups are skipped entirely (zero executions) and emit
+      // structured unhealthy evidence. Non-duplicate rows proceed to compilation.
+      const rowsByTargetRef = new Map<string, Record<string, unknown>[]>();
       for (const row of rows) {
         if (!row || typeof row !== 'object') {
           continue;
         }
         const r = row as Record<string, unknown>;
+        const targetRef = typeof r['target_ref'] === 'string' ? r['target_ref'] : '';
+        const activationId = typeof r['activation_id'] === 'string' ? r['activation_id'] : '';
+        if (!targetRef) {
+          this.logger.warn?.(
+            `[RuleHost] Activation ${activationId}: missing target_ref, skipping`
+          );
+          continue;
+        }
+        const group = rowsByTargetRef.get(targetRef);
+        if (group) {
+          group.push(r);
+        } else {
+          rowsByTargetRef.set(targetRef, [r]);
+        }
+      }
+
+      // Emit structured unhealthy evidence for duplicate groups; collect valid (non-duplicate) rows.
+      const validRows: Record<string, unknown>[] = [];
+      for (const [targetRef, group] of rowsByTargetRef) {
+        if (group.length > 1) {
+          const activationIds: string[] = [];
+          const artifactIds: string[] = [];
+          for (const r of group) {
+            if (typeof r['activation_id'] === 'string') activationIds.push(r['activation_id']);
+            if (typeof r['artifact_id'] === 'string') artifactIds.push(r['artifact_id']);
+          }
+          this.logger.warn?.(
+            `[RuleHost] Duplicate active activations detected — skipping all executions for this rule. ` +
+            `targetRef=${targetRef} count=${group.length} ` +
+            `activationIds=[${activationIds.join(', ')}] ` +
+            `artifactIds=[${artifactIds.join(', ')}] ` +
+            `reason=at most one active activation per rule is allowed ` +
+            `nextAction=deactivate all but one activation for this target_ref`
+          );
+        } else {
+          validRows.push(group[0]);
+        }
+      }
+
+      const loaded: LoadedImplementation[] = [];
+
+      for (const r of validRows) {
         const activationId = typeof r['activation_id'] === 'string' ? r['activation_id'] : '';
         const artifactId = typeof r['artifact_id'] === 'string' ? r['artifact_id'] : '';
         const contentJson = typeof r['content_json'] === 'string' ? r['content_json'] : '';
@@ -288,85 +291,6 @@ export class RuleHost {
       } catch {
         // best-effort cleanup
       }
-    }
-  }
-
-  /**
-   * Load and compile a single implementation from its code asset path.
-   *
-   * The implementation file is expected to export:
-   *   - meta: { name, version, ruleId, coversCondition }
-   *   - evaluate(input: RuleHostInput): RuleHostResult
-   *
-   * Uses the shared isolated runtime loader so candidate code does not execute
-   * in the host global realm.
-   */
-     
-  private _loadSingleImplementation(
-    impl: Implementation
-  ): LoadedImplementation | null {
-    let sourceCode = loadEntrySource(this.stateDir, impl.id);
-    if (!sourceCode) {
-      const assetPath = impl.path;
-      if (!assetPath || !fs.existsSync(assetPath)) {
-        return null;
-      }
-
-      try {
-        sourceCode = fs.readFileSync(assetPath, 'utf-8');
-      } catch {
-        return null;
-      }
-    }
-
-    try {
-      const moduleExports = loadRuleImplementationModule(sourceCode, impl.id);
-
-      if (!moduleExports || typeof moduleExports.evaluate !== 'function') {
-        return null;
-      }
-
-      const fallbackMeta: RuleHostMeta = {
-        name: impl.id,
-        version: impl.version,
-        ruleId: impl.ruleId,
-        coversCondition: impl.coversCondition,
-      };
-      const meta: RuleHostMeta =
-        moduleExports.meta && typeof moduleExports.meta === 'object'
-          ? (moduleExports.meta as RuleHostMeta)
-          : fallbackMeta;
-
-      // Return a loaded implementation that wraps the compiled evaluate
-      // with the actual helpers from the input at evaluation time
-       
-      const rawEvaluate = moduleExports.evaluate as (
-        _input: RuleHostInput,
-        _helpers: ReturnType<typeof createRuleHostHelpers>
-      ) => RuleHostResult;
-       
-
-      return {
-        implId: impl.id,
-        ruleId: impl.ruleId,
-        meta,
-        evaluate: (input: RuleHostInput): RuleHostResult => {
-          const frozenHelpers = createRuleHostHelpers(input);
-          const result = rawEvaluate(input, frozenHelpers);
-          // C: Enrich result with rule/principle IDs for observability
-          if (result.matched && (result.decision === 'block' || result.decision === 'requireApproval')) {
-            result.ruleId = impl.ruleId;
-            result.principleId = meta.ruleId ?? impl.ruleId;
-          }
-          return result;
-        },
-      };
-    } catch (compileError: unknown) {
-      // Compilation failure: log and skip
-      this.logger.warn?.(
-        `[RuleHost] Failed to compile implementation ${impl.id}: ${String(compileError)}`
-      );
-      return null;
     }
   }
 }

--- a/packages/openclaw-plugin/tests/core/code-implementation-storage.test.ts
+++ b/packages/openclaw-plugin/tests/core/code-implementation-storage.test.ts
@@ -5,9 +5,7 @@ import * as path from 'path';
 import {
   deleteImplementationAssetDir,
   getImplementationAssetRoot,
-  loadManifest,
   writeManifest,
-  loadEntrySource,
   createImplementationAssetDir,
   writeEntrySource,
   type CodeImplementationManifest,
@@ -60,47 +58,6 @@ describe('CodeImplementationStorage', () => {
       expect(() => getImplementationAssetRoot(stateDir, '')).toThrow(
         'Implementation ID must not be empty',
       );
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // loadManifest
-  // -------------------------------------------------------------------------
-
-  describe('loadManifest', () => {
-    it('returns null when no manifest file exists', () => {
-      const result = loadManifest(stateDir, 'nonexistent');
-      expect(result).toBeNull();
-    });
-
-    it('returns parsed manifest when manifest file exists', () => {
-      const implId = 'IMPL_002';
-      const manifest: CodeImplementationManifest = {
-        version: '1.0.0',
-        entryFile: 'entry.js',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        replaySampleRefs: [],
-        lastEvalReportRef: null,
-      };
-
-      // Write directly (bypass writeManifest to test load independently)
-      const assetRoot = getImplementationAssetRoot(stateDir, implId);
-      fs.mkdirSync(assetRoot, { recursive: true });
-      fs.writeFileSync(path.join(assetRoot, 'manifest.json'), JSON.stringify(manifest), 'utf-8');
-
-      const result = loadManifest(stateDir, implId);
-      expect(result).toEqual(manifest);
-    });
-
-    it('returns null for corrupted manifest JSON', () => {
-      const implId = 'IMPL_003';
-      const assetRoot = getImplementationAssetRoot(stateDir, implId);
-      fs.mkdirSync(assetRoot, { recursive: true });
-      fs.writeFileSync(path.join(assetRoot, 'manifest.json'), 'not-valid-json{{{', 'utf-8');
-
-      const result = loadManifest(stateDir, implId);
-      expect(result).toBeNull();
     });
   });
 
@@ -178,67 +135,6 @@ describe('CodeImplementationStorage', () => {
   });
 
   // -------------------------------------------------------------------------
-  // loadEntrySource
-  // -------------------------------------------------------------------------
-
-  describe('loadEntrySource', () => {
-    it('returns null when no manifest exists', () => {
-      const result = loadEntrySource(stateDir, 'nonexistent');
-      expect(result).toBeNull();
-    });
-
-    it('returns null when manifest exists but entry file does not', () => {
-      const implId = 'IMPL_007';
-      const assetRoot = getImplementationAssetRoot(stateDir, implId);
-      fs.mkdirSync(assetRoot, { recursive: true });
-
-      // Write manifest pointing to a non-existent entry file
-      const manifest: CodeImplementationManifest = {
-        version: '1.0.0',
-        entryFile: 'nonexistent.js',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        replaySampleRefs: [],
-        lastEvalReportRef: null,
-      };
-      fs.writeFileSync(
-        path.join(assetRoot, 'manifest.json'),
-        JSON.stringify(manifest),
-        'utf-8',
-      );
-
-      const result = loadEntrySource(stateDir, implId);
-      expect(result).toBeNull();
-    });
-
-    it('returns file content when entry file exists', () => {
-      const implId = 'IMPL_008';
-      const assetRoot = getImplementationAssetRoot(stateDir, implId);
-      fs.mkdirSync(assetRoot, { recursive: true });
-
-      const entryContent = 'export function evaluate() { return true; }';
-      fs.writeFileSync(path.join(assetRoot, 'entry.js'), entryContent, 'utf-8');
-
-      const manifest: CodeImplementationManifest = {
-        version: '1.0.0',
-        entryFile: 'entry.js',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        replaySampleRefs: [],
-        lastEvalReportRef: null,
-      };
-      fs.writeFileSync(
-        path.join(assetRoot, 'manifest.json'),
-        JSON.stringify(manifest),
-        'utf-8',
-      );
-
-      const result = loadEntrySource(stateDir, implId);
-      expect(result).toBe(entryContent);
-    });
-  });
-
-  // -------------------------------------------------------------------------
   // createImplementationAssetDir
   // -------------------------------------------------------------------------
 
@@ -300,7 +196,9 @@ describe('CodeImplementationStorage', () => {
         artificerArtifactId: 'artifact-1',
       });
 
-      const loaded = loadManifest(stateDir, implId);
+      // Verify persisted manifest contains lineage
+      const assetRoot = getImplementationAssetRoot(stateDir, implId);
+      const loaded = JSON.parse(fs.readFileSync(path.join(assetRoot, 'manifest.json'), 'utf-8'));
       expect(loaded?.lineage).toMatchObject({
         sourcePainIds: ['pain:gate:1'],
         sourceGateBlockIds: ['gate:write:1'],
@@ -344,22 +242,23 @@ describe('CodeImplementationStorage', () => {
       expect(fs.existsSync(reportPath)).toBe(true);
     });
 
-    it('manifest is loadable via loadManifest after creation', () => {
+    it('manifest is persisted with correct version after creation', () => {
       const implId = 'IMPL_014';
       createImplementationAssetDir(stateDir, implId, '4.0.0');
 
-      const loaded = loadManifest(stateDir, implId);
+      const assetRoot = getImplementationAssetRoot(stateDir, implId);
+      const loaded = JSON.parse(fs.readFileSync(path.join(assetRoot, 'manifest.json'), 'utf-8'));
       expect(loaded).not.toBeNull();
-      expect(loaded!.version).toBe('4.0.0');
-      expect(loaded!.entryFile).toBe('entry.js');
+      expect(loaded.version).toBe('4.0.0');
+      expect(loaded.entryFile).toBe('entry.js');
     });
 
-    it('entry source is loadable via loadEntrySource after creation', () => {
+    it('entry source is persisted after creation', () => {
       const implId = 'IMPL_015';
       createImplementationAssetDir(stateDir, implId, '1.0.0');
 
-      const source = loadEntrySource(stateDir, implId);
-      expect(source).not.toBeNull();
+      const assetRoot = getImplementationAssetRoot(stateDir, implId);
+      const source = fs.readFileSync(path.join(assetRoot, 'entry.js'), 'utf-8');
       expect(source).toContain('export const meta');
       expect(source).toContain('export function evaluate');
     });
@@ -370,7 +269,8 @@ describe('CodeImplementationStorage', () => {
         entrySource: 'export const meta = { name: "x", version: "1", ruleId: "R", coversCondition: "c" }; export function evaluate() { return { decision: "allow", matched: false, reason: "ok" }; }',
       });
 
-      const source = loadEntrySource(stateDir, implId);
+      const assetRoot = getImplementationAssetRoot(stateDir, implId);
+      const source = fs.readFileSync(path.join(assetRoot, 'entry.js'), 'utf-8');
       expect(source).toContain('export const meta');
       expect(source).not.toContain('placeholder');
     });
@@ -383,7 +283,9 @@ describe('CodeImplementationStorage', () => {
 
       writeEntrySource(stateDir, implId, 'export const meta = { name: "updated", version: "1", ruleId: "R", coversCondition: "c" }; export function evaluate() { return { decision: "allow", matched: false, reason: "updated" }; }');
 
-      expect(loadEntrySource(stateDir, implId)).toContain('updated');
+      const assetRoot = getImplementationAssetRoot(stateDir, implId);
+      const source = fs.readFileSync(path.join(assetRoot, 'entry.js'), 'utf-8');
+      expect(source).toContain('updated');
     });
 
     it('removes the asset directory through deleteImplementationAssetDir', () => {

--- a/packages/openclaw-plugin/tests/core/rule-host-sqlite-source.test.ts
+++ b/packages/openclaw-plugin/tests/core/rule-host-sqlite-source.test.ts
@@ -1,0 +1,720 @@
+/**
+ * PRI-436: SQLite is the sole RuleHost source — TDD vertical slices
+ *
+ * Tests verify through public interfaces:
+ *   - Real SQLite store (SqliteConnection + SqliteActivationStateStore)
+ *   - Real RuleHost.evaluate()
+ *   - No mocking of private internals
+ *
+ * ERR risk mitigation:
+ *   - ERR-024/ERR-048: tests exercise the production RuleHost.evaluate() → SQLite read chain
+ *   - ERR-073: tests verify call-site behavior equivalence, not just reader happy path
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SqliteConnection, SqliteActivationStateStore } from '@principles/core/runtime-v2';
+import type { RuleHostInput } from '@principles/core/runtime-v2';
+import { RuleHost } from '../../src/core/rule-host.js';
+
+// ── Test helpers ───────────────────────────────────────────────────────────
+
+const RULE_ID = 'R_TEST_SQLITE_001';
+const ARTIFACT_ID = 'art-rule-sqlite-001';
+const ACTIVATION_ID = `act_code_${RULE_ID}`;
+
+const BLOCKING_CODE = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'Blocked: system directory' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'test-sqlite-rule', version: '1', ruleId: '${RULE_ID}', coversCondition: 'all' };
+`;
+
+let tempWorkspaceDir: string;
+let tempStateDir: string;
+let sqliteConn: SqliteConnection;
+
+function setupTempDirs(): void {
+  const baseTmp = os.tmpdir();
+  tempWorkspaceDir = fs.mkdtempSync(path.join(baseTmp, 'pd-rulehost-sqlite-'));
+  tempStateDir = path.join(tempWorkspaceDir, '.principles');
+  fs.mkdirSync(tempStateDir, { recursive: true });
+}
+
+function insertRuleArtifact(overrides?: {
+  artifactId?: string;
+  ruleId?: string;
+  contentJson?: string;
+  validationStatus?: string;
+  sourceTaskId?: string;
+}): void {
+  const artifactId = overrides?.artifactId ?? ARTIFACT_ID;
+  const ruleId = overrides?.ruleId ?? RULE_ID;
+  const validationStatus = overrides?.validationStatus ?? 'validated';
+  const sourceTaskId = overrides?.sourceTaskId ?? 'task-test-001';
+  const db = sqliteConn.getDb();
+  const now = new Date().toISOString();
+
+  const contentJson = overrides?.contentJson ?? JSON.stringify({
+    principleId: 'P_TEST_001',
+    ruleId,
+    implementationCode: BLOCKING_CODE,
+    goldenTrace: {
+      traceId: 'trace-test-001',
+      cases: [
+        { caseId: 'case-neg-1', kind: 'negative', toolName: 'write_file', params: { path: '/etc/passwd' }, expectedDecision: 'block' },
+        { caseId: 'case-pos-1', kind: 'positive', toolName: 'write_file', params: { path: '/safe/file.txt' }, expectedDecision: 'allow' },
+      ],
+      createdAt: now,
+      version: 1,
+    },
+    ruleHostGateDecision: 'accepted_shadow',
+    affectedTools: ['write_file'],
+    painReasonSummary: 'Test: prevent writing to system directories',
+  });
+
+  db.prepare(`
+    INSERT INTO pi_artifacts (artifact_id, artifact_kind, source_task_id, source_principle_id, source_rule_id, lineage_artifact_ids, validation_status, content_json, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    artifactId,
+    'rule',
+    sourceTaskId,
+    'P_TEST_001',
+    ruleId,
+    '[]',
+    validationStatus,
+    contentJson,
+    now,
+    now,
+  );
+}
+
+async function insertCodeToolHookActivation(overrides?: {
+  activationId?: string;
+  artifactId?: string;
+  ruleId?: string;
+  deactivatedAt?: string | null;
+}): Promise<void> {
+  const activationId = overrides?.activationId ?? ACTIVATION_ID;
+  const artifactId = overrides?.artifactId ?? ARTIFACT_ID;
+  const ruleId = overrides?.ruleId ?? RULE_ID;
+  const store = new SqliteActivationStateStore(sqliteConn);
+  const now = new Date().toISOString();
+
+  await store.recordActivation({
+    activationId,
+    idempotencyKey: `${artifactId}::code_tool_hook`,
+    artifactId,
+    channel: 'code_tool_hook',
+    action: 'code_tool_hook_shadow_activate',
+    targetRef: `impl://${ruleId}`,
+    activatedAt: now,
+    deactivatedAt: overrides?.deactivatedAt ?? null,
+  });
+}
+
+function makeInput(normalizedPath: string): RuleHostInput {
+  return {
+    action: {
+      toolName: 'write_file',
+      normalizedPath,
+      paramsSummary: { path: normalizedPath },
+    },
+    workspace: {
+      isRiskPath: false,
+      planStatus: 'NONE',
+      hasPlanFile: false,
+    },
+    session: {
+      sessionId: 'test-session',
+      currentGfi: 0,
+      recentThinking: false,
+    },
+    evolution: {
+      epTier: 1,
+    },
+    derived: {
+      estimatedLineChanges: 1,
+      bashRisk: 'safe' as const,
+    },
+  };
+}
+
+// ── Setup / Teardown ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  setupTempDirs();
+  sqliteConn = new SqliteConnection(tempWorkspaceDir);
+  sqliteConn.getDb();
+});
+
+afterEach(() => {
+  try { sqliteConn?.close(); } catch { /* best-effort */ }
+  try { fs.rmSync(tempWorkspaceDir, { recursive: true, force: true }); } catch { /* Windows */ }
+});
+
+// ── Slice 1: SQLite-only RuleHost executes exactly once ────────────────────
+
+describe('PRI-436 Slice 1: SQLite-only RuleHost executes exactly once', () => {
+  it('single SQLite activation produces block for matching path', async () => {
+    insertRuleArtifact();
+    await insertCodeToolHookActivation();
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    expect(result).toBeDefined();
+    expect(result?.decision).toBe('block');
+    expect(result?.matched).toBe(true);
+    expect(result?.ruleId).toBe(RULE_ID);
+  });
+
+  it('single SQLite activation allows non-matching path', async () => {
+    insertRuleArtifact();
+    await insertCodeToolHookActivation();
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/safe/project/file.txt'));
+
+    // No match → undefined (no opinion) or allow
+    expect(result?.decision ?? 'allow').toBe('allow');
+  });
+
+  it('no SQLite activation → no opinion (undefined)', async () => {
+    // Artifact exists but no activation
+    insertRuleArtifact();
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    expect(result).toBeUndefined();
+  });
+
+  it('deactivated SQLite activation → no opinion (undefined)', async () => {
+    insertRuleArtifact();
+    await insertCodeToolHookActivation({ deactivatedAt: new Date().toISOString() });
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    expect(result).toBeUndefined();
+  });
+});
+
+// ── Slice 2: Legacy filesystem file exists but is never read/compiled ──────
+
+const LEGACY_RULE_ID = 'R_TEST_DUAL_001';
+const LEGACY_IMPL_ID = 'impl_legacy_001';
+const SQLITE_RULE_ID = 'R_TEST_DUAL_001';
+const SQLITE_ARTIFACT_ID = 'art-rule-dual-001';
+const SQLITE_ACTIVATION_ID = 'act_code_R_TEST_DUAL_001';
+
+const LEGACY_BLOCK_CODE = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'LEGACY_BLOCK' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'legacy-rule', version: '1', ruleId: '${LEGACY_RULE_ID}', coversCondition: 'all' };
+`;
+
+const SQLITE_BLOCK_CODE = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'SQLITE_BLOCK' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'sqlite-rule', version: '2', ruleId: '${SQLITE_RULE_ID}', coversCondition: 'all' };
+`;
+
+/**
+ * Write a filesystem ledger (principle_training_state.json) with an active
+ * code implementation. Also writes the implementation source file to disk.
+ */
+function writeLegacyFilesystemLedger(stateDir: string): void {
+  const ledgerPath = path.join(stateDir, 'principle_training_state.json');
+  const implSourcePath = path.join(stateDir, 'principles', 'implementations', LEGACY_IMPL_ID, 'entry.js');
+
+  // Write the implementation source file
+  fs.mkdirSync(path.dirname(implSourcePath), { recursive: true });
+  fs.writeFileSync(implSourcePath, LEGACY_BLOCK_CODE, 'utf-8');
+
+  // Write the manifest
+  const manifestPath = path.join(stateDir, 'principles', 'implementations', LEGACY_IMPL_ID, 'manifest.json');
+  fs.writeFileSync(manifestPath, JSON.stringify({
+    implId: LEGACY_IMPL_ID,
+    entryFile: 'entry.js',
+    version: '1',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }), 'utf-8');
+
+  // Write the ledger
+  const now = new Date().toISOString();
+  const ledger = {
+    _tree: {
+      principles: {},
+      rules: {},
+      implementations: {
+        [LEGACY_IMPL_ID]: {
+          id: LEGACY_IMPL_ID,
+          ruleId: LEGACY_RULE_ID,
+          type: 'code',
+          path: implSourcePath,
+          version: '1',
+          coversCondition: 'all',
+          coveragePercentage: 100,
+          lifecycleState: 'active',
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      metrics: {},
+      lastUpdated: now,
+    },
+  };
+  fs.writeFileSync(ledgerPath, JSON.stringify(ledger, null, 2), 'utf-8');
+}
+
+describe('PRI-436 Slice 2: Legacy filesystem file is never read/compiled', () => {
+  it('conflicting legacy ledger exists → SQLite version wins (filesystem never read)', async () => {
+    // Create conflicting filesystem ledger with LEGACY_BLOCK code
+    writeLegacyFilesystemLedger(tempStateDir);
+
+    // Create SQLite activation with SQLITE_BLOCK code
+    insertRuleArtifact({
+      artifactId: SQLITE_ARTIFACT_ID,
+      ruleId: SQLITE_RULE_ID,
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_DUAL_001',
+        ruleId: SQLITE_RULE_ID,
+        implementationCode: SQLITE_BLOCK_CODE,
+        goldenTrace: {
+          traceId: 'trace-dual-001',
+          cases: [
+            { caseId: 'case-neg-1', kind: 'negative', toolName: 'write_file', params: { path: '/etc/passwd' }, expectedDecision: 'block' },
+            { caseId: 'case-pos-1', kind: 'positive', toolName: 'write_file', params: { path: '/safe/file.txt' }, expectedDecision: 'allow' },
+          ],
+          createdAt: new Date().toISOString(),
+          version: 1,
+        },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: prevent writing to system directories',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: SQLITE_ACTIVATION_ID,
+      artifactId: SQLITE_ARTIFACT_ID,
+      ruleId: SQLITE_RULE_ID,
+    });
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    expect(result).toBeDefined();
+    expect(result?.decision).toBe('block');
+    expect(result?.matched).toBe(true);
+    // SQLite version must win — filesystem legacy code must NOT be read
+    expect(result?.reason).toBe('SQLITE_BLOCK');
+    expect(result?.reason).not.toBe('LEGACY_BLOCK');
+  });
+
+  it('legacy ledger exists but no SQLite activation → no opinion (undefined)', async () => {
+    // Filesystem ledger exists but RuleHost should not read it
+    writeLegacyFilesystemLedger(tempStateDir);
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    // No SQLite activation → no opinion, even though filesystem ledger has an active impl
+    expect(result).toBeUndefined();
+  });
+});
+
+// ── Slice 3: Duplicate active DB rows execute zero times + structured unhealthy evidence ───
+
+const DUP_RULE_ID = 'R_TEST_DUP_001';
+const DUP_ARTIFACT_ID_A = 'art-dup-a-001';
+const DUP_ARTIFACT_ID_B = 'art-dup-b-001';
+const DUP_ACTIVATION_ID_A = 'act_code_dup_a_001';
+const DUP_ACTIVATION_ID_B = 'act_code_dup_b_001';
+
+const DUP_BLOCK_CODE_A = `
+function evaluate(input, helpers) {
+  return { decision: 'block', matched: true, reason: 'DUP_BLOCK_A' };
+}
+var meta = { name: 'dup-rule-a', version: '1', ruleId: '${DUP_RULE_ID}', coversCondition: 'all' };
+`;
+
+const DUP_BLOCK_CODE_B = `
+function evaluate(input, helpers) {
+  return { decision: 'block', matched: true, reason: 'DUP_BLOCK_B' };
+}
+var meta = { name: 'dup-rule-b', version: '2', ruleId: '${DUP_RULE_ID}', coversCondition: 'all' };
+`;
+
+describe('PRI-436 Slice 3: Duplicate active DB rows execute zero times + structured unhealthy evidence', () => {
+  it('two active activations for the same rule → zero executions (undefined) + structured warn', async () => {
+    // Insert two artifacts for the same rule (different artifactIds, different code)
+    insertRuleArtifact({
+      artifactId: DUP_ARTIFACT_ID_A,
+      ruleId: DUP_RULE_ID,
+      sourceTaskId: 'task-dup-a-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_DUP_001',
+        ruleId: DUP_RULE_ID,
+        implementationCode: DUP_BLOCK_CODE_A,
+        goldenTrace: { traceId: 'trace-dup-a', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: duplicate A',
+      }),
+    });
+    insertRuleArtifact({
+      artifactId: DUP_ARTIFACT_ID_B,
+      ruleId: DUP_RULE_ID,
+      sourceTaskId: 'task-dup-b-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_DUP_001',
+        ruleId: DUP_RULE_ID,
+        implementationCode: DUP_BLOCK_CODE_B,
+        goldenTrace: { traceId: 'trace-dup-b', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: duplicate B',
+      }),
+    });
+
+    // Insert two active activations targeting the same rule (same target_ref)
+    await insertCodeToolHookActivation({
+      activationId: DUP_ACTIVATION_ID_A,
+      artifactId: DUP_ARTIFACT_ID_A,
+      ruleId: DUP_RULE_ID,
+    });
+    await insertCodeToolHookActivation({
+      activationId: DUP_ACTIVATION_ID_B,
+      artifactId: DUP_ARTIFACT_ID_B,
+      ruleId: DUP_RULE_ID,
+    });
+
+    // Spy logger to capture structured warn evidence
+    const warnCalls: string[] = [];
+    const spyLogger: { warn: (_message: string) => void } = {
+      warn: (message: string) => { warnCalls.push(message); },
+    };
+
+    const ruleHost = new RuleHost(tempStateDir, spyLogger, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    // Zero executions for the duplicate rule → no opinion (undefined)
+    expect(result).toBeUndefined();
+
+    // Structured unhealthy evidence emitted via logger.warn
+    expect(warnCalls.length).toBeGreaterThan(0);
+    const dupWarn = warnCalls.find(m => m.toLowerCase().includes('duplicate'));
+    expect(dupWarn).toBeDefined();
+    // Evidence must identify the conflicting rule and activations
+    expect(dupWarn).toContain(DUP_RULE_ID);
+    expect(dupWarn).toContain(DUP_ACTIVATION_ID_A);
+    expect(dupWarn).toContain(DUP_ACTIVATION_ID_B);
+  });
+
+  it('non-duplicate rule still executes when another rule has duplicates', async () => {
+    // Rule with duplicate activations (should be skipped)
+    insertRuleArtifact({
+      artifactId: DUP_ARTIFACT_ID_A,
+      ruleId: DUP_RULE_ID,
+      sourceTaskId: 'task-dup-a-002',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_DUP_001',
+        ruleId: DUP_RULE_ID,
+        implementationCode: DUP_BLOCK_CODE_A,
+        goldenTrace: { traceId: 'trace-dup-a', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: duplicate A',
+      }),
+    });
+    insertRuleArtifact({
+      artifactId: DUP_ARTIFACT_ID_B,
+      ruleId: DUP_RULE_ID,
+      sourceTaskId: 'task-dup-b-002',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_DUP_001',
+        ruleId: DUP_RULE_ID,
+        implementationCode: DUP_BLOCK_CODE_B,
+        goldenTrace: { traceId: 'trace-dup-b', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: duplicate B',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: DUP_ACTIVATION_ID_A,
+      artifactId: DUP_ARTIFACT_ID_A,
+      ruleId: DUP_RULE_ID,
+    });
+    await insertCodeToolHookActivation({
+      activationId: DUP_ACTIVATION_ID_B,
+      artifactId: DUP_ARTIFACT_ID_B,
+      ruleId: DUP_RULE_ID,
+    });
+
+    // Non-duplicate rule (should execute normally)
+    const OTHER_RULE_ID = 'R_TEST_OTHER_001';
+    const OTHER_ARTIFACT_ID = 'art-other-001';
+    const OTHER_ACTIVATION_ID = 'act_code_other_001';
+    const OTHER_BLOCK_CODE = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'OTHER_BLOCK' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'other-rule', version: '1', ruleId: '${OTHER_RULE_ID}', coversCondition: 'all' };
+`;
+    insertRuleArtifact({
+      artifactId: OTHER_ARTIFACT_ID,
+      ruleId: OTHER_RULE_ID,
+      sourceTaskId: 'task-other-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_OTHER_001',
+        ruleId: OTHER_RULE_ID,
+        implementationCode: OTHER_BLOCK_CODE,
+        goldenTrace: { traceId: 'trace-other', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: other rule',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: OTHER_ACTIVATION_ID,
+      artifactId: OTHER_ARTIFACT_ID,
+      ruleId: OTHER_RULE_ID,
+    });
+
+    const warnCalls: string[] = [];
+    const spyLogger: { warn: (_message: string) => void } = {
+      warn: (message: string) => { warnCalls.push(message); },
+    };
+
+    const ruleHost = new RuleHost(tempStateDir, spyLogger, { workspaceDir: tempWorkspaceDir });
+    const result = ruleHost.evaluate(makeInput('/etc/passwd'));
+
+    // Non-duplicate rule still executes and blocks
+    expect(result).toBeDefined();
+    expect(result?.decision).toBe('block');
+    expect(result?.matched).toBe(true);
+    expect(result?.reason).toBe('OTHER_BLOCK');
+    expect(result?.ruleId).toBe(OTHER_RULE_ID);
+
+    // Duplicate rule evidence still emitted
+    const dupWarn = warnCalls.find(m => m.toLowerCase().includes('duplicate'));
+    expect(dupWarn).toBeDefined();
+    expect(dupWarn).toContain(DUP_RULE_ID);
+  });
+});
+
+// ── Slice 4: edit/reactivate selects only new version; deactivate removes effect immediately ─
+
+const EDIT_RULE_ID = 'R_TEST_EDIT_001';
+const EDIT_ARTIFACT_ID_V1 = 'art-edit-v1-001';
+const EDIT_ARTIFACT_ID_V2 = 'art-edit-v2-001';
+const EDIT_ACTIVATION_ID_V1 = 'act_code_edit_v1_001';
+const EDIT_ACTIVATION_ID_V2 = 'act_code_edit_v2_001';
+
+const EDIT_BLOCK_CODE_V1 = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'EDIT_V1_BLOCK' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'edit-rule-v1', version: '1', ruleId: '${EDIT_RULE_ID}', coversCondition: 'all' };
+`;
+
+const EDIT_BLOCK_CODE_V2 = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'EDIT_V2_BLOCK' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'edit-rule-v2', version: '2', ruleId: '${EDIT_RULE_ID}', coversCondition: 'all' };
+`;
+
+describe('PRI-436 Slice 4: edit/reactivate selects only new version; deactivate removes effect immediately', () => {
+  it('edit: old version deactivated + new version active → only new version executes', async () => {
+    // v1: insert artifact + activate
+    insertRuleArtifact({
+      artifactId: EDIT_ARTIFACT_ID_V1,
+      ruleId: EDIT_RULE_ID,
+      sourceTaskId: 'task-edit-v1-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_EDIT_001',
+        ruleId: EDIT_RULE_ID,
+        implementationCode: EDIT_BLOCK_CODE_V1,
+        goldenTrace: { traceId: 'trace-edit-v1', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: edit v1',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: EDIT_ACTIVATION_ID_V1,
+      artifactId: EDIT_ARTIFACT_ID_V1,
+      ruleId: EDIT_RULE_ID,
+    });
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+
+    // v1 is active → v1 executes
+    const resultV1 = ruleHost.evaluate(makeInput('/etc/passwd'));
+    expect(resultV1?.decision).toBe('block');
+    expect(resultV1?.reason).toBe('EDIT_V1_BLOCK');
+
+    // Edit: deactivate v1, insert v2, activate v2
+    const store = new SqliteActivationStateStore(sqliteConn);
+    await store.deactivateActivation(EDIT_ACTIVATION_ID_V1, new Date().toISOString());
+
+    insertRuleArtifact({
+      artifactId: EDIT_ARTIFACT_ID_V2,
+      ruleId: EDIT_RULE_ID,
+      sourceTaskId: 'task-edit-v2-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_EDIT_001',
+        ruleId: EDIT_RULE_ID,
+        implementationCode: EDIT_BLOCK_CODE_V2,
+        goldenTrace: { traceId: 'trace-edit-v2', cases: [], createdAt: new Date().toISOString(), version: 2 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: edit v2',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: EDIT_ACTIVATION_ID_V2,
+      artifactId: EDIT_ARTIFACT_ID_V2,
+      ruleId: EDIT_RULE_ID,
+    });
+
+    // Only v2 should execute (v1 is deactivated)
+    const resultV2 = ruleHost.evaluate(makeInput('/etc/passwd'));
+    expect(resultV2?.decision).toBe('block');
+    expect(resultV2?.reason).toBe('EDIT_V2_BLOCK');
+    expect(resultV2?.reason).not.toBe('EDIT_V1_BLOCK');
+  });
+
+  it('deactivate removes effect immediately (same RuleHost instance, no restart)', async () => {
+    insertRuleArtifact({
+      artifactId: EDIT_ARTIFACT_ID_V1,
+      ruleId: EDIT_RULE_ID,
+      sourceTaskId: 'task-deact-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_EDIT_001',
+        ruleId: EDIT_RULE_ID,
+        implementationCode: EDIT_BLOCK_CODE_V1,
+        goldenTrace: { traceId: 'trace-deact', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: deactivate',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: EDIT_ACTIVATION_ID_V1,
+      artifactId: EDIT_ARTIFACT_ID_V1,
+      ruleId: EDIT_RULE_ID,
+    });
+
+    const ruleHost = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+
+    // Rule is active → blocks
+    const resultBefore = ruleHost.evaluate(makeInput('/etc/passwd'));
+    expect(resultBefore?.decision).toBe('block');
+    expect(resultBefore?.reason).toBe('EDIT_V1_BLOCK');
+
+    // Deactivate
+    const store = new SqliteActivationStateStore(sqliteConn);
+    await store.deactivateActivation(EDIT_ACTIVATION_ID_V1, new Date().toISOString());
+
+    // Same RuleHost instance → no effect immediately (no restart needed)
+    const resultAfter = ruleHost.evaluate(makeInput('/etc/passwd'));
+    expect(resultAfter).toBeUndefined();
+  });
+});
+
+// ── Slice 5: Restart preserves the one active version ──────────────────────
+
+const RESTART_RULE_ID = 'R_TEST_RESTART_001';
+const RESTART_ARTIFACT_ID = 'art-restart-001';
+const RESTART_ACTIVATION_ID = 'act_code_restart_001';
+
+const RESTART_BLOCK_CODE = `
+function evaluate(input, helpers) {
+  var p = input.action.normalizedPath || '';
+  if (p.startsWith('/etc')) {
+    return { decision: 'block', matched: true, reason: 'RESTART_BLOCK' };
+  }
+  return { decision: 'allow', matched: false, reason: 'Not matched' };
+}
+var meta = { name: 'restart-rule', version: '1', ruleId: '${RESTART_RULE_ID}', coversCondition: 'all' };
+`;
+
+describe('PRI-436 Slice 5: Restart preserves the one active version', () => {
+  it('new RuleHost instance (simulated restart) loads the same active version from SQLite', async () => {
+    insertRuleArtifact({
+      artifactId: RESTART_ARTIFACT_ID,
+      ruleId: RESTART_RULE_ID,
+      sourceTaskId: 'task-restart-001',
+      contentJson: JSON.stringify({
+        principleId: 'P_TEST_RESTART_001',
+        ruleId: RESTART_RULE_ID,
+        implementationCode: RESTART_BLOCK_CODE,
+        goldenTrace: { traceId: 'trace-restart', cases: [], createdAt: new Date().toISOString(), version: 1 },
+        ruleHostGateDecision: 'accepted_shadow',
+        affectedTools: ['write_file'],
+        painReasonSummary: 'Test: restart persistence',
+      }),
+    });
+    await insertCodeToolHookActivation({
+      activationId: RESTART_ACTIVATION_ID,
+      artifactId: RESTART_ARTIFACT_ID,
+      ruleId: RESTART_RULE_ID,
+    });
+
+    // Instance 1 (original process)
+    const ruleHost1 = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result1 = ruleHost1.evaluate(makeInput('/etc/passwd'));
+    expect(result1?.decision).toBe('block');
+    expect(result1?.reason).toBe('RESTART_BLOCK');
+    expect(result1?.ruleId).toBe(RESTART_RULE_ID);
+
+    // Instance 2 (simulated restart — new RuleHost, same SQLite state)
+    const ruleHost2 = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result2 = ruleHost2.evaluate(makeInput('/etc/passwd'));
+    expect(result2?.decision).toBe('block');
+    expect(result2?.reason).toBe('RESTART_BLOCK');
+    expect(result2?.ruleId).toBe(RESTART_RULE_ID);
+
+    // Deactivate, then instance 3 (restart after deactivation)
+    const store = new SqliteActivationStateStore(sqliteConn);
+    await store.deactivateActivation(RESTART_ACTIVATION_ID, new Date().toISOString());
+
+    const ruleHost3 = new RuleHost(tempStateDir, console, { workspaceDir: tempWorkspaceDir });
+    const result3 = ruleHost3.evaluate(makeInput('/etc/passwd'));
+    expect(result3).toBeUndefined();
+  });
+});

--- a/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-auto-correct-shadow.test.ts
@@ -52,7 +52,6 @@ vi.mock('../../src/core/rule-host.js', () => ({
 
 vi.mock('../../src/core/principle-tree-ledger.js', () => ({
   loadLedger: vi.fn(),
-  listImplementationsByLifecycleState: vi.fn(() => []),
 }));
 
 vi.mock('../../src/hooks/gate-block-helper.js', () => ({

--- a/packages/openclaw-plugin/tests/hooks/gate-auto-correct.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-auto-correct.test.ts
@@ -55,7 +55,6 @@ vi.mock('../../src/core/rule-host.js', () => ({
 
 vi.mock('../../src/core/principle-tree-ledger.js', () => ({
   loadLedger: vi.fn(),
-  listImplementationsByLifecycleState: vi.fn(() => []),
 }));
 
 vi.mock('../../src/hooks/gate-block-helper.js', () => ({

--- a/packages/openclaw-plugin/tests/hooks/gate-no-path-write-tool.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-no-path-write-tool.test.ts
@@ -54,7 +54,6 @@ vi.mock('../../src/core/rule-host.js', () => ({
 
 vi.mock('../../src/core/principle-tree-ledger.js', () => ({
   loadLedger: vi.fn(),
-  listImplementationsByLifecycleState: vi.fn(() => []),
 }));
 
 // Mock WorkspaceContext to return a controlled instance with our mockEventLog.

--- a/packages/openclaw-plugin/tests/hooks/gate-rule-host-pipeline.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-rule-host-pipeline.test.ts
@@ -53,7 +53,6 @@ vi.mock('../../src/core/rule-host.js', () => ({
 
 vi.mock('../../src/core/principle-tree-ledger.js', () => ({
   loadLedger: vi.fn(),
-  listImplementationsByLifecycleState: vi.fn(() => []),
 }));
 
 describe('Gate Rule Host Only Pipeline', () => {

--- a/packages/openclaw-plugin/tests/integration/pain-id-chain-e2e.test.ts
+++ b/packages/openclaw-plugin/tests/integration/pain-id-chain-e2e.test.ts
@@ -26,8 +26,8 @@ import { RuleHost } from '../../src/core/rule-host.js';
 import { EvolutionReducerImpl } from '../../src/core/evolution-reducer.js';
 import {
   loadLedger,
-  transitionImplementationState,
 } from '../../src/core/principle-tree-ledger.js';
+import { SqliteConnection, SqliteActivationStateStore } from '@principles/core/runtime-v2';
 import { safeRmDir } from '../test-utils.js';
 import type { RuleHostInput } from '../../src/core/rule-host-types.js';
 
@@ -56,6 +56,60 @@ function createTestWorkspace(): TestWorkspace {
 function disposeTestWorkspace(ws: TestWorkspace): void {
   ws.trajectory.dispose();
   safeRmDir(ws.workspaceDir);
+}
+
+/**
+ * PRI-436: Insert compiled rule code as a pi_artifacts row + activations row
+ * so RuleHost can load it from SQLite (the sole production source).
+ */
+function activateCompiledRule(
+  workspaceDir: string,
+  ruleId: string,
+  implementationCode: string,
+  principleId: string,
+): void {
+  const sqliteConn = new SqliteConnection(workspaceDir);
+  try {
+    const db = sqliteConn.getDb();
+    const now = new Date().toISOString();
+    const artifactId = `art-${ruleId}`;
+
+    const contentJson = JSON.stringify({
+      principleId,
+      ruleId,
+      implementationCode,
+    });
+
+    db.prepare(`
+      INSERT INTO pi_artifacts (artifact_id, artifact_kind, source_task_id, source_principle_id, source_rule_id, lineage_artifact_ids, validation_status, content_json, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      artifactId,
+      'rule',
+      `task-${ruleId}`,
+      principleId,
+      ruleId,
+      '[]',
+      'validated',
+      contentJson,
+      now,
+      now,
+    );
+
+    const store = new SqliteActivationStateStore(sqliteConn);
+    store.recordActivation({
+      activationId: `act_code_${ruleId}`,
+      idempotencyKey: `${artifactId}::code_tool_hook`,
+      artifactId,
+      channel: 'code_tool_hook',
+      action: 'code_tool_hook_shadow_activate',
+      targetRef: `impl://${ruleId}`,
+      activatedAt: now,
+      deactivatedAt: null,
+    });
+  } finally {
+    try { sqliteConn.close(); } catch { /* best-effort */ }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -134,16 +188,16 @@ describe('Pain ID Chain E2E: pain event → principle → compile → RuleHost',
     expect(compileResult.ruleId).toBeDefined();
     expect(compileResult.implementationId).toBeDefined();
 
-    // Verify implementation is candidate (not active — must be promoted before enforcing)
+    // Verify implementation is candidate (not active — must be activated before enforcing)
     const updatedLedger = loadLedger(ws.stateDir);
     const impl = updatedLedger.tree.implementations[compileResult.implementationId!];
     expect(impl.lifecycleState).toBe('candidate');
 
-    // ── Step 5: Promote to active so RuleHost will enforce ──
-    transitionImplementationState(ws.stateDir, compileResult.implementationId!, 'active');
+    // ── Step 5: Activate via SQLite (PRI-436: sole production source) ──
+    activateCompiledRule(ws.workspaceDir, compileResult.ruleId!, compileResult.code!, principleId!);
 
     // ── Step 6: RuleHost.evaluate(matching input) → block ──
-    const host = new RuleHost(ws.stateDir, { warn: () => {} });
+    const host = new RuleHost(ws.stateDir, { warn: () => {} }, { workspaceDir: ws.workspaceDir });
 
     const matchingInput: RuleHostInput = {
       action: {

--- a/packages/openclaw-plugin/tests/integration/principle-compiler-e2e.test.ts
+++ b/packages/openclaw-plugin/tests/integration/principle-compiler-e2e.test.ts
@@ -21,8 +21,8 @@ import { RuleHost } from '../../src/core/rule-host.js';
 import {
   loadLedger,
   saveLedger,
-  transitionImplementationState,
 } from '../../src/core/principle-tree-ledger.js';
+import { SqliteConnection, SqliteActivationStateStore } from '@principles/core/runtime-v2';
 import type { RuleHostInput } from '../../src/core/rule-host-types.js';
 
 // ---------------------------------------------------------------------------
@@ -48,6 +48,60 @@ function createTestWorkspace(): TestWorkspace {
 function disposeTestWorkspace(ws: TestWorkspace): void {
   ws.trajectory.dispose();
   fs.rmSync(ws.workspaceDir, { recursive: true, force: true });
+}
+
+/**
+ * PRI-436: Insert compiled rule code as a pi_artifacts row + activations row
+ * so RuleHost can load it from SQLite (the sole production source).
+ */
+function activateCompiledRule(
+  workspaceDir: string,
+  ruleId: string,
+  implementationCode: string,
+  principleId: string,
+): void {
+  const sqliteConn = new SqliteConnection(workspaceDir);
+  try {
+    const db = sqliteConn.getDb();
+    const now = new Date().toISOString();
+    const artifactId = `art-${ruleId}`;
+
+    const contentJson = JSON.stringify({
+      principleId,
+      ruleId,
+      implementationCode,
+    });
+
+    db.prepare(`
+      INSERT INTO pi_artifacts (artifact_id, artifact_kind, source_task_id, source_principle_id, source_rule_id, lineage_artifact_ids, validation_status, content_json, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      artifactId,
+      'rule',
+      `task-${ruleId}`,
+      principleId,
+      ruleId,
+      '[]',
+      'validated',
+      contentJson,
+      now,
+      now,
+    );
+
+    const store = new SqliteActivationStateStore(sqliteConn);
+    store.recordActivation({
+      activationId: `act_code_${ruleId}`,
+      idempotencyKey: `${artifactId}::code_tool_hook`,
+      artifactId,
+      channel: 'code_tool_hook',
+      action: 'code_tool_hook_shadow_activate',
+      targetRef: `impl://${ruleId}`,
+      activatedAt: now,
+      deactivatedAt: null,
+    });
+  } finally {
+    try { sqliteConn.close(); } catch { /* best-effort */ }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -168,21 +222,16 @@ describe('Principle Compiler E2E: compile → promote → RuleHost blocks', () =
       },
     };
 
-    // ── Step 4: RuleHost should NOT block yet (candidate not loaded) ──
-    const hostBeforePromote = new RuleHost(ws.stateDir, { warn: () => {} });
+    // ── Step 4: RuleHost should NOT block yet (no SQLite activation yet) ──
+    const hostBeforePromote = new RuleHost(ws.stateDir, { warn: () => {} }, { workspaceDir: ws.workspaceDir });
     const noBlockResult = hostBeforePromote.evaluate(matchingInput);
-    expect(noBlockResult).toBeUndefined(); // candidate not loaded → no block
+    expect(noBlockResult).toBeUndefined(); // no activation → no block
 
-    // ── Step 5: Promote to 'active' so RuleHost will enforce ──
-    transitionImplementationState(ws.stateDir, implId, 'active');
-
-    // Verify promotion
-    const ledgerAfterPromote = loadLedger(ws.stateDir);
-    const implAfterPromote = ledgerAfterPromote.tree.implementations[implId];
-    expect(implAfterPromote.lifecycleState).toBe('active');
+    // ── Step 5: Activate via SQLite (PRI-436: sole production source) ──
+    activateCompiledRule(ws.workspaceDir, result.ruleId!, result.code!, principleId);
 
     // ── Step 6: Create RuleHost and evaluate with matching input ──
-    const host = new RuleHost(ws.stateDir, { warn: () => {} });
+    const host = new RuleHost(ws.stateDir, { warn: () => {} }, { workspaceDir: ws.workspaceDir });
 
     // Matching input: bash tool with a heartbeat command (defined in Step 4)
     const blockResult = host.evaluate(matchingInput);
@@ -224,7 +273,7 @@ describe('Principle Compiler E2E: compile → promote → RuleHost blocks', () =
   });
 
   it('should return undefined when no active implementations exist', () => {
-    const host = new RuleHost(ws.stateDir, { warn: () => {} });
+    const host = new RuleHost(ws.stateDir, { warn: () => {} }, { workspaceDir: ws.workspaceDir });
 
     const input: RuleHostInput = {
       action: {

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -681,6 +681,24 @@ describe('PRI-42 internalization boundary', () => {
     expect(src).not.toContain("from './rule-host-types.js'");
   });
 
+  it('PRI-436: plugin rule-host.ts does NOT import filesystem ledger or implementation storage', async () => {
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const ruleHostPath = resolve(
+      __dirname,
+      '../../../../openclaw-plugin/src/core/rule-host.ts',
+    );
+    expect(existsSync(ruleHostPath)).toBe(true);
+    const src = readFileSync(ruleHostPath, 'utf-8');
+
+    // PRI-436: SQLite is the sole RuleHost source. No filesystem imports allowed.
+    expect(src).not.toContain("from './principle-tree-ledger.js'");
+    expect(src).not.toContain("from './code-implementation-storage.js'");
+    expect(src).not.toContain('listImplementationsByLifecycleState');
+    expect(src).not.toContain('loadEntrySource');
+    expect(src).not.toContain("import * as fs from 'fs'");
+  });
+
   it('plugin gate.ts imports RuleHostInput from core barrel', async () => {
     const { existsSync, readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');


### PR DESCRIPTION
## Summary

PRI-436: Make SQLite the sole RuleHost source and delete filesystem compatibility.

## Changes

### Production code
- **`rule-host.ts`**: Deleted filesystem ledger/implementation asset read path. SQLite `activations` table is now the sole production source of active RuleCode. Added duplicate active activation detection by `target_ref` — at most one active per rule, duplicate groups are skipped (zero executions) with structured unhealthy evidence via `logger.warn`.
- **`principle-tree-ledger.ts`**: Deleted `listImplementationsByLifecycleState()` (zero remaining production callers).
- **`code-implementation-storage.ts`**: Deleted `loadManifest()` and `loadEntrySource()` (zero remaining production callers).

### Tests
- **`rule-host-sqlite-source.test.ts`** (new): 11 TDD vertical slice tests covering SQLite-only execution, duplicate detection, edit/reactivate/deactivate, and restart persistence. All tests use real SQLite store + real `RuleHost.evaluate()`.
- **`architecture-regression.test.ts`**: Added guard preventing filesystem imports in `rule-host.ts`.
- **`principle-compiler-e2e.test.ts`** + **`pain-id-chain-e2e.test.ts`**: Updated to use SQLite activation path (`SqliteActivationStateStore.recordActivation()`) instead of legacy `transitionImplementationState()`.
- **`code-implementation-storage.test.ts`**: Removed tests for deleted functions.
- **4 gate test files**: Removed dead `listImplementationsByLifecycleState` mock entries.

## TDD Vertical Slices

1. **Slice 1**: SQLite-only RuleHost executes exactly once (4 tests)
2. **Slice 2**: Legacy filesystem file is never read/compiled (2 tests)
3. **Slice 3**: Duplicate active DB rows execute zero times + structured unhealthy evidence (2 tests)
4. **Slice 4**: edit/reactivate selects only new version; deactivate removes effect immediately (2 tests)
5. **Slice 5**: Restart preserves the one active version (1 test)

## ERR Checklist

| ERR | Title | How avoided |
|-----|-------|-------------|
| ERR-012 | Stale-main rollback | Branch tracks `origin/main`; no rollback of merged code |
| ERR-024 | RuleHost dual-source ambiguity | SQLite is now the sole source; filesystem path deleted |
| ERR-035 | Static guard misses legacy paths | Architecture regression guard added for `rule-host.ts` |
| ERR-048 | Silent fallback on corrupt data | Duplicate groups emit structured `logger.warn` with reason + nextAction |
| ERR-073 | Characterization tests miss call-site behavior | E2E tests updated to verify SQLite activation → RuleHost block chain |

## Runtime Contract Rules

1. ✅ SQLite rows treated as `unknown`, validated with `typeof` before use
2. ✅ No `as` bypass — type guards used for `Record<string, unknown>` narrowing
3. ✅ Missing `target_ref` fails loud (skip + warn)
4. ✅ Array elements validated with `typeof` checks
5. ✅ `Object.hasOwn()` not needed (using `typeof r['key']` pattern)
6. ✅ N/A — no lineage fields in this change
7. ✅ N/A — no retry/repair loops
8. ✅ `logger.warn` messages are bounded strings, no raw `JSON.stringify` on unknowns
9. ✅ Duplicate detection emits reason + nextAction (no silent fallback)

## CLI/Operator Gate

N/A — no CLI command changes in this PR.

## Tests Run

| Suite | Result |
|-------|--------|
| `packages/openclaw-plugin` | 1871 passed, 0 failed, 29 skipped ✅ |
| `packages/pd-cli` | 1001 passed, 1 pre-existing failure (PRI-393), 2 skipped ✅ |
| `npm run lint` | ✅ passed |
| `npm run verify:merge` | ✅ passed |
| `npm run check:error-handbook` | ✅ passed (pre-existing warnings) |

**Pre-existing failures** (verified via `git stash` on clean main):
- `pd-cli/tests/commands/runtime.test.ts > PRI-393: env var missing` — unrelated to PRI-436

## Remaining Risk

- `transitionImplementationState()` is still used by legacy CLI commands (`promote-impl`, `rollback-impl`, `disable-impl`, `archive-impl`) but no longer affects RuleHost enforcement. These commands update the filesystem ledger only. The production activation path is via `ActivationDispatcher.dispatch()` → `SqliteActivationStateStore.recordActivation()`. A follow-up issue should address whether these legacy commands need to be updated or deprecated.

Closes PRI-436
