### PR TITLE
fix: harden LLM output contract — artificer return shape + generatedAt unification + stripFabricatedIds + shared extractJsonObject

### DIFF
--- a/packages/pd-console/src/server/models/PrincipleTrajectoryModel.ts
+++ b/packages/pd-console/src/server/models/PrincipleTrajectoryModel.ts
@@ -117,14 +117,14 @@ function readLedgerPrinciple(workspaceDir: string, principleId: string): LedgerP
   if (!isRecord(parsed)) return null;
 
   const treeValue: unknown = Object.hasOwn(parsed, '_tree')
-    ? parsed['_tree']
+    ? parsed._tree
     : Object.hasOwn(parsed, 'tree')
-      ? parsed['tree']
+      ? parsed.tree
       : parsed;
 
   if (!isRecord(treeValue)) return null;
 
-  const principlesValue = treeValue['principles'];
+  const principlesValue = treeValue.principles;
   if (!isRecord(principlesValue)) return null;
 
   const entry = principlesValue[principleId];
@@ -198,13 +198,13 @@ export class PrincipleTrajectoryModel {
     let candidateRecord: unknown = null;
 
     if (stateDbAvailable && db && principle.derivedFromPainIds.length > 0) {
-      const candidateId = principle.derivedFromPainIds[0];
+      const [candidateId] = principle.derivedFromPainIds;
       try {
         const rows = db.prepare(
           'SELECT candidate_id, task_id, recommendation_kind, status, title, abstracted_principle, confidence FROM principle_candidates WHERE candidate_id = ?'
         ).all(candidateId);
         if (rows.length > 0) {
-          candidateRecord = rows[0];
+          [candidateRecord] = rows;
           taskId = getOwnString(rows[0], 'task_id') ?? null;
         }
       } catch (err) {
@@ -228,7 +228,7 @@ export class PrincipleTrajectoryModel {
           'SELECT task_id, task_kind, status, created_at FROM tasks WHERE task_id = ?'
         ).all(taskId);
         if (taskRows.length > 0) {
-          taskRecord = taskRows[0];
+          [taskRecord] = taskRows;
         }
       } catch (err) {
         if (!isMissingTableError(err) && !isMissingColumnError(err)) {
@@ -241,7 +241,7 @@ export class PrincipleTrajectoryModel {
           "SELECT artifact_id, artifact_kind, created_at FROM artifacts WHERE task_id = ? AND artifact_kind = 'diagnostician_output' LIMIT 1"
         ).all(taskId);
         if (artRows.length > 0) {
-          diagnosticArtifact = artRows[0];
+          [diagnosticArtifact] = artRows;
         }
       } catch (err) {
         if (!isMissingTableError(err) && !isMissingColumnError(err)) {
@@ -333,6 +333,7 @@ export class PrincipleTrajectoryModel {
 
   // ── Stage assemblers ─────────────────────────────────────────────────────
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private assembleEvidenceStage(
     principle: LedgerPrinciple,
     candidateRecord: unknown,
@@ -365,6 +366,7 @@ export class PrincipleTrajectoryModel {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private assembleDiagnosisStage(
     taskRecord: unknown,
     diagnosticArtifact: unknown,
@@ -397,6 +399,7 @@ export class PrincipleTrajectoryModel {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private assembleProposalStage(candidateRecord: unknown): TrajectoryStage {
     if (!candidateRecord) {
       return {
@@ -426,6 +429,7 @@ export class PrincipleTrajectoryModel {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private assembleReviewStage(
     approvalRecords: unknown[],
     piArtifactCount: number,
@@ -477,6 +481,7 @@ export class PrincipleTrajectoryModel {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private assembleDeployStage(
     activationRecords: unknown[],
     piArtifactCount: number,
@@ -527,6 +532,7 @@ export class PrincipleTrajectoryModel {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private assembleBehaviorStage(
     principle: LedgerPrinciple,
     activationRecords: unknown[],
@@ -561,6 +567,7 @@ export class PrincipleTrajectoryModel {
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private createAllUnavailable(reason: string): TrajectoryStage[] {
     const keys: TrajectoryStage['key'][] = ['evidence', 'diagnosis', 'proposal', 'review', 'deploy', 'behavior'];
     return keys.map(key => ({

--- a/packages/pd-console/src/ui/App.tsx
+++ b/packages/pd-console/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { LoginForm } from "./components/auth/login-form.js";
 import { ErrorBoundary } from "./components/error-boundary.js";
 import { checkAuth, getToken } from "./api.js";
 import { NotificationProvider } from "./components/notifications/NotificationProvider.js";
+import { Toaster } from "./components/ui/sonner.js";
 
 // New page imports (CR2 directory structure)
 import { FocusPage } from "./pages/focus/FocusPage.js";
@@ -197,6 +198,7 @@ export function App() {
         <HashRouter>
           <AuthRoutes />
         </HashRouter>
+        <Toaster />
       </I18nextProvider>
     </ThemeProvider>
   );

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -55,7 +55,6 @@ import type {
   ApprovalsGroupedData,
   EvidenceChainData,
   TrajectoryData,
-  TrajectoryStageData,
 } from "./utils/validators.js";
 
 // ── Auth ──────────────────────────────────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -524,6 +524,8 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     'renderPrinciplesToDirectives',
     // PRI-431
     'buildL2PrincipleReaderFromLedger',
+    // LLM output hardening — shared utility
+    'stripFabricatedCorePrincipleIds',
   ];
 
   for (const name of REQUIRED_EXPORTS) {

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -509,6 +509,7 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     // PRI-44
     'generateFromTemplate',
     'checkForbiddenPatterns',
+    'checkReturnStatementsMissingFields',
     // PRI-45
     'mergeDecisions',
     // PRI-149 Tier 2

--- a/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/attack-e2e-pipeline-smoke.test.ts
@@ -50,12 +50,22 @@ import { validateCorrectionProposal } from '../internalization/correction-propos
 import { PDRuntimeError } from '../error-categories.js';
 import type { TaskRecord } from '../task-status.js';
 import { SqliteConnection } from '../store/sqlite-connection.js';
+import type { RetryPolicy } from '../store/lifecycle/retry-policy.js';
 
 vi.mock('@mariozechner/pi-ai', () => ({
   getModel: vi.fn(),
   getProviders: vi.fn(() => ['openrouter', 'anthropic', 'openai']),
   complete: vi.fn(),
 }));
+
+// Fast retry policy for tests — production DefaultRetryPolicy uses 30s base delay
+// which causes test timeouts when sub-runners return 'retried'
+const fastRetryPolicy: RetryPolicy = {
+  calculateBackoff: () => 10, // 10ms — instant for tests
+  shouldRetry: (task) => task.attemptCount < task.maxAttempts,
+  markRetryWait: vi.fn(),
+  markFailed: vi.fn(),
+};
 
 class InMemoryLedgerAdapter implements LedgerAdapter {
   private readonly entries = new Map<string, LedgerPrincipleEntry>();
@@ -270,6 +280,7 @@ function makeSplitRunner(
     stateManager,
     committer,
     perStageTimeoutMs: options.timeoutMs ?? 5000,
+    retryPolicy: fastRetryPolicy,
   });
 }
 

--- a/packages/principles-core/src/runtime-v2/__tests__/principle-compiler-core.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/principle-compiler-core.test.ts
@@ -148,6 +148,88 @@ export function evaluate() { return { matched: false, reason: 'ok' }; }
   });
 });
 
+// ── Return statement field check ─────────────────────────────────────────────
+
+describe('checkReturnStatementsMissingFields', () => {
+  async function getModule() {
+    return import('../internalization/rule-code-validator.js');
+  }
+
+  it('returns empty array for code with all three fields in every return', async () => {
+    const { checkReturnStatementsMissingFields } = await getModule();
+    const code = `
+function evaluate(input, helpers) {
+  if (input.action.toolName === 'write') {
+    return { decision: 'block', matched: true, reason: 'blocked' };
+  }
+  return { decision: 'allow', matched: false, reason: 'safe' };
+}
+`;
+    expect(checkReturnStatementsMissingFields(code)).toEqual([]);
+  });
+
+  it('detects return missing decision and reason', async () => {
+    const { checkReturnStatementsMissingFields } = await getModule();
+    const code = `
+function evaluate(input, helpers) {
+  return { matched: false };
+}
+`;
+    const violations = checkReturnStatementsMissingFields(code);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('decision');
+    expect(violations[0]).toContain('reason');
+  });
+
+  it('detects return missing only reason', async () => {
+    const { checkReturnStatementsMissingFields } = await getModule();
+    const code = `
+function evaluate(input, helpers) {
+  return { decision: 'allow', matched: true };
+}
+`;
+    const violations = checkReturnStatementsMissingFields(code);
+    expect(violations).toHaveLength(1);
+    // The "missing required field(s): reason" part should only list 'reason'
+    const [missingPart] = violations[0].split('—');
+    expect(missingPart).toContain('reason');
+    expect(missingPart).not.toContain('decision');
+  });
+
+  it('detects multiple violations across multiple returns', async () => {
+    const { checkReturnStatementsMissingFields } = await getModule();
+    const code = `
+function evaluate(input, helpers) {
+  if (input.x) {
+    return { matched: true };
+  }
+  if (input.y) {
+    return { decision: 'block', matched: true };
+  }
+  return { decision: 'allow', matched: false, reason: 'ok' };
+}
+`;
+    const violations = checkReturnStatementsMissingFields(code);
+    expect(violations).toHaveLength(2);
+  });
+
+  it('skips complex returns with nested braces (no false positives)', async () => {
+    const { checkReturnStatementsMissingFields } = await getModule();
+    const code = `
+function evaluate(input, helpers) {
+  return { decision: 'propose_correction', matched: true, reason: 'fix', correctionProposal: { params: { a: 1 } } };
+}
+`;
+    expect(checkReturnStatementsMissingFields(code)).toEqual([]);
+  });
+
+  it('returns empty for code with no return statements', async () => {
+    const { checkReturnStatementsMissingFields } = await getModule();
+    const code = `const x = 1;`;
+    expect(checkReturnStatementsMissingFields(code)).toEqual([]);
+  });
+});
+
 // ── Type exports via barrel ──────────────────────────────────────────────────
 
 describe('PRI-44 barrel exports', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/principle-compiler-core.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/principle-compiler-core.test.ts
@@ -191,7 +191,11 @@ function evaluate(input, helpers) {
     const violations = checkReturnStatementsMissingFields(code);
     expect(violations).toHaveLength(1);
     // The "missing required field(s): reason" part should only list 'reason'
-    const [missingPart] = violations[0].split('—');
+    const [firstViolation] = violations;
+    if (firstViolation === undefined) {
+      throw new Error('expected violation to exist');
+    }
+    const [missingPart] = firstViolation.split('—');
     expect(missingPart).toContain('reason');
     expect(missingPart).not.toContain('decision');
   });

--- a/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pruning-read-model.test.ts
@@ -11,6 +11,12 @@ import type { LedgerPrinciple } from '../../principle-tree-ledger.js';
 
 const WORKSPACE = '/tmp/ws';
 
+// Relative date helpers — tests must not use hardcoded dates that age out
+const MS_PER_DAY = 86_400_000;
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * MS_PER_DAY).toISOString();
+}
+
 interface LedgerStore {
   tree: {
     principles: Record<string, LedgerPrinciple>;
@@ -44,8 +50,8 @@ const LEDGER_MIXED: LedgerStore = {
       old_watch: {
         id: 'old_watch',
         status: 'active',
-        createdAt: '2026-03-18T00:00:00.000Z',
-        updatedAt: '2025-12-01T00:00:00.000Z',
+        createdAt: daysAgo(45),
+        updatedAt: daysAgo(180),
         derivedFromPainIds: [],
         ruleIds: [],
         conflictsWithPrincipleIds: [],
@@ -63,8 +69,8 @@ const LEDGER_MIXED: LedgerStore = {
       old_review: {
         id: 'old_review',
         status: 'active',
-        createdAt: '2026-01-02T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
+        createdAt: daysAgo(120),
+        updatedAt: daysAgo(500),
         derivedFromPainIds: [],
         ruleIds: [],
         conflictsWithPrincipleIds: [],
@@ -506,8 +512,8 @@ describe('PruningReadModel', () => {
           mid_age: {
             id: 'mid_age',
             status: 'active',
-            createdAt: '2026-03-18T00:00:00.000Z',
-            updatedAt: '2025-12-01T00:00:00.000Z',
+            createdAt: daysAgo(45),
+            updatedAt: daysAgo(180),
             derivedFromPainIds: [],
             ruleIds: [],
             conflictsWithPrincipleIds: [],

--- a/packages/principles-core/src/runtime-v2/activation/production-gate-deps.ts
+++ b/packages/principles-core/src/runtime-v2/activation/production-gate-deps.ts
@@ -30,7 +30,7 @@ import type {
 } from '../internalization/refiner-rulehost-gate.js';
 import type { RefinerSandboxResult, RefinerSandboxOptions } from '../internalization/refiner-sandbox-wrapper.js';
 import { evaluateInRefinerSandbox } from '../internalization/refiner-sandbox-wrapper.js';
-import { checkForbiddenPatterns } from '../internalization/rule-code-validator.js';
+import { checkForbiddenPatterns, checkReturnStatementsMissingFields } from '../internalization/rule-code-validator.js';
 import { validateCorrectionProposal } from '../internalization/correction-proposal.js';
 import { safeStringifyPreview } from '../feedback/safe-stringify.js';
 
@@ -188,6 +188,24 @@ export function createProductionGateDeps(): RefinerRuleHostGateDeps {
           failedCases: [],
           executionTimeMs: Date.now() - startTime,
           forbiddenPatternViolations: forbiddenViolations,
+        };
+      }
+
+      // Static check: catch return statements missing required RuleHostResult
+      // fields (decision, matched, reason) before VM execution. This catches
+      // the most common LLM mistake (e.g. `return { matched: false }`) and
+      // feeds a specific error message back into the write-test-fix loop.
+      const returnShapeViolations = checkReturnStatementsMissingFields(code);
+      if (returnShapeViolations.length > 0) {
+        return {
+          success: false,
+          failedCases: returnShapeViolations.map((msg) => ({
+            caseId: '__return_shape__',
+            errorType: 'validation_failed' as const,
+            message: msg,
+          })),
+          executionTimeMs: Date.now() - startTime,
+          forbiddenPatternViolations: [],
         };
       }
 

--- a/packages/principles-core/src/runtime-v2/adapter/artificer-l2-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/artificer-l2-adapter.ts
@@ -54,6 +54,7 @@ import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { safeStringifyPreview, truncatePreview } from './output-repair-contract.js';
 import { resolveL2Model } from './l2-agent-loop-adapter.js';
+import { extractJsonObject } from './json-extractor.js';
 
 /**
  * Mockable LLM call. Receives the assembled prompt (initial prompt + optional
@@ -77,37 +78,6 @@ export type ArtificerL2GenerateCodeFn = (prompt: string) => Promise<unknown>;
  *   - ERR-001: returned value is `unknown` — caller must validate
  *   - ERR-014: response content is safely extracted (no raw JSON.stringify on unknown)
  */
-/**
- * Extract the first JSON object from a text string. Mirrors the pattern in
- * l2-agent-loop-adapter.ts. Returns null if no JSON object is found.
- */
-function extractJsonObject(text: string): unknown | null {
-  const start = text.indexOf('{');
-  if (start === -1) return null;
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-  for (let i = start; i < text.length; i += 1) {
-    const ch = text[i];
-    if (escape) { escape = false; continue; }
-    if (ch === '\\') { escape = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
-    if (ch === '{') depth += 1;
-    else if (ch === '}') {
-      depth -= 1;
-      if (depth === 0) {
-        const candidate = text.slice(start, i + 1);
-        try {
-          return JSON.parse(candidate);
-        } catch {
-          return null;
-        }
-      }
-    }
-  }
-  return null;
-}
 
 export function buildArtificerL2GenerateCode(config: {
   readonly provider: string;

--- a/packages/principles-core/src/runtime-v2/core-principles/__tests__/strip-fabricated-ids.test.ts
+++ b/packages/principles-core/src/runtime-v2/core-principles/__tests__/strip-fabricated-ids.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { stripFabricatedCorePrincipleIds } from '../strip-fabricated-ids.js';
+
+describe('stripFabricatedCorePrincipleIds', () => {
+  it('strips fabricated sourcePrincipleId (pri-unknown)', () => {
+    const output = { sourcePrincipleId: 'pri-unknown', other: 'value' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(Object.hasOwn(output, 'sourcePrincipleId')).toBe(false);
+    expect(output.other).toBe('value');
+  });
+
+  it('strips fabricated sourcePrincipleId (pri-000)', () => {
+    const output = { sourcePrincipleId: 'pri-000' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(Object.hasOwn(output, 'sourcePrincipleId')).toBe(false);
+  });
+
+  it('strips fabricated sourcePrincipleId (pri-999)', () => {
+    const output = { sourcePrincipleId: 'pri-999' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(Object.hasOwn(output, 'sourcePrincipleId')).toBe(false);
+  });
+
+  it('strips fabricated sourcePrincipleId (T-99 — format-valid but not in registry)', () => {
+    const output = { sourcePrincipleId: 'T-99' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(Object.hasOwn(output, 'sourcePrincipleId')).toBe(false);
+  });
+
+  it('preserves valid sourcePrincipleId (T-01)', () => {
+    const output = { sourcePrincipleId: 'T-01', other: 'value' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(output.sourcePrincipleId).toBe('T-01');
+  });
+
+  it('preserves valid sourcePrincipleId (T-10)', () => {
+    const output = { sourcePrincipleId: 'T-10' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(output.sourcePrincipleId).toBe('T-10');
+  });
+
+  it('does nothing when sourcePrincipleId is absent', () => {
+    const output = { other: 'value' };
+    stripFabricatedCorePrincipleIds(output);
+    expect(Object.hasOwn(output, 'sourcePrincipleId')).toBe(false);
+    expect(output.other).toBe('value');
+  });
+
+  it('does not strip non-string sourcePrincipleId (lets validation handle it)', () => {
+    const output = { sourcePrincipleId: 123 };
+    stripFabricatedCorePrincipleIds(output);
+    // Non-string values are left for validation to reject (Runtime Contract Rule 3)
+    expect(output.sourcePrincipleId).toBe(123);
+  });
+
+  it('strips empty string sourcePrincipleId (not in registry)', () => {
+    const output = { sourcePrincipleId: '' };
+    stripFabricatedCorePrincipleIds(output);
+    // Empty string is not a valid core principle ID — stripped so validation
+    // can detect the missing field and fail loud (Runtime Contract Rule 3)
+    expect(Object.hasOwn(output, 'sourcePrincipleId')).toBe(false);
+  });
+
+  it('is a no-op for null', () => {
+    expect(() => stripFabricatedCorePrincipleIds(null)).not.toThrow();
+  });
+
+  it('is a no-op for undefined', () => {
+    expect(() => stripFabricatedCorePrincipleIds(undefined)).not.toThrow();
+  });
+
+  it('is a no-op for primitives', () => {
+    expect(() => stripFabricatedCorePrincipleIds('string')).not.toThrow();
+    expect(() => stripFabricatedCorePrincipleIds(42)).not.toThrow();
+    expect(() => stripFabricatedCorePrincipleIds(true)).not.toThrow();
+  });
+
+  it('is a no-op for arrays', () => {
+    const arr = [{ sourcePrincipleId: 'pri-unknown' }];
+    stripFabricatedCorePrincipleIds(arr);
+    // Arrays are not LLM output objects — skip
+    expect(arr[0]?.sourcePrincipleId).toBe('pri-unknown');
+  });
+
+  it('handles object with no own properties (prototype)', () => {
+    const obj = Object.create({ sourcePrincipleId: 'pri-unknown' });
+    stripFabricatedCorePrincipleIds(obj);
+    // Object.hasOwn returns false for inherited properties — no stripping
+    expect(Object.hasOwn(obj, 'sourcePrincipleId')).toBe(false);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/core-principles/index.ts
+++ b/packages/principles-core/src/runtime-v2/core-principles/index.ts
@@ -14,3 +14,5 @@ export {
 } from './core-axiom-block.js';
 
 export type { CoreAxiomBlockOptions } from './core-axiom-block.js';
+
+export { stripFabricatedCorePrincipleIds } from './strip-fabricated-ids.js';

--- a/packages/principles-core/src/runtime-v2/core-principles/strip-fabricated-ids.ts
+++ b/packages/principles-core/src/runtime-v2/core-principles/strip-fabricated-ids.ts
@@ -1,0 +1,29 @@
+import { isCorePrincipleId } from './core-principle-registry.js';
+
+/**
+ * Strip fabricated core principle IDs from an untrusted LLM output object.
+ *
+ * LLMs sometimes invent placeholder IDs like "pri-unknown", "pri-000", "pri-999"
+ * when they don't know the correct value. This function removes those fabricated
+ * values so downstream validation can detect the missing field and fail loud
+ * (Runtime Contract Rule 3).
+ *
+ * Currently strips:
+ * - `sourcePrincipleId`: single string field, deleted if not a valid core principle ID
+ *
+ * @param untrustedOutput - The LLM output object to mutate in-place
+ */
+export function stripFabricatedCorePrincipleIds(untrustedOutput: unknown): void {
+  if (typeof untrustedOutput !== 'object' || untrustedOutput === null || Array.isArray(untrustedOutput)) {
+    return;
+  }
+
+  // Strip fabricated sourcePrincipleId — LLM invents placeholders like pri-unknown, pri-000, pri-999
+  if (Object.hasOwn(untrustedOutput, 'sourcePrincipleId')) {
+    const val = Reflect.get(untrustedOutput, 'sourcePrincipleId');
+    // Use registry membership check — format-only regex would accept T-99 etc.
+    if (typeof val === 'string' && !isCorePrincipleId(val)) {
+      Reflect.deleteProperty(untrustedOutput, 'sourcePrincipleId');
+    }
+  }
+}

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -350,6 +350,7 @@ export {
   isCorePrincipleId,
   getCorePrinciple,
   CorePrincipleSchema,
+  stripFabricatedCorePrincipleIds,
 } from './core-principles/index.js';
 
 export type { CorePrinciple } from './core-principles/index.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -446,7 +446,7 @@ export { decideInternalizationRoute } from './internalization/internalization-ro
 export type { PainPattern } from './internalization/template-generator.js';
 export { generateFromTemplate } from './internalization/template-generator.js';
 export type { ValidationResult } from './internalization/rule-code-validator.js';
-export { checkForbiddenPatterns } from './internalization/rule-code-validator.js';
+export { checkForbiddenPatterns, checkReturnStatementsMissingFields } from './internalization/rule-code-validator.js';
 export type { CompileResult } from './internalization/compile-result.js';
 
 // Pruning mask — builds masked principle set from review log (PRI-48)

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
@@ -80,6 +80,12 @@ CONSTRAINTS:
 - risks MUST be an array of strings (can be empty if no risks identified)
 - generatedAt MUST be the current ISO-8601 timestamp (use the actual current time, NOT a placeholder)
 - implementationCode MUST define exactly function evaluate(input, helpers) and return { decision, matched, reason }
+- EVERY return statement inside evaluate() MUST include ALL three fields: decision, matched, reason
+- Do NOT return partial objects — missing fields will fail sandbox validation and block activation
+- GOOD: return { decision: 'allow', matched: false, reason: 'path is within workspace, no risk' }
+- GOOD: return { decision: 'block', matched: true, reason: 'write to system path outside workspace' }
+- BAD:  return { matched: false } — missing decision and reason, will be rejected
+- BAD:  return { decision: 'allow', matched: true } — missing reason, will be rejected
 - input.action contains toolName, normalizedPath, and paramsSummary; inspect only these RuleHost inputs
 - implementationCode MUST be deterministic and self-contained: no imports, require, eval, Function, I/O, network, timers, Date.now, or randomness
 - goldenTraceCases MUST contain 2-10 cases with at least one positive allow case and one negative block/propose_correction case

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-runner.ts
@@ -375,18 +375,12 @@ export class ArtificerRunner extends BasePeerRunner<ArtificerContext, ArtificerO
    * Only fill when absent via Object.hasOwn — present-but-falsy values
    * must reach validation and fail loud (Runtime Contract Rule 3).
    *
-   * Also overrides generatedAt with the actual current timestamp (LLM may
-   * echo the prompt's example date).
+   * generatedAt override is handled by the base class — subclasses must call
+   * super.postFetchTransform() to inherit it.
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown, _context: ArtificerContext): void {
+    super.postFetchTransform(taskId, untrustedOutput, _context);
     injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
-
-    if (typeof untrustedOutput === 'object' && untrustedOutput !== null) {
-      const record = untrustedOutput as Record<string, unknown>;
-      // Override generatedAt with actual timestamp — LLM may echo prompt example date
-      record.generatedAt = new Date().toISOString();
-    }
   }
 
   protected override emitSuccessTelemetry(taskId: string, output: ArtificerOutputV1): void {

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -311,19 +311,15 @@ export class DreamerRunner extends BasePeerRunner<DreamerContext, DreamerOutput>
    * Only fill when absent via Object.hasOwn — present-but-falsy values
    * must reach validation and fail loud (Runtime Contract Rule 3).
    *
-   * Also overrides generatedAt with the actual current timestamp (LLM may
-   * echo the prompt's example date) and strips fabricated sourcePrincipleId
-   * values (LLM invents placeholders like "pri-unknown", "pri-000", etc.).
+   * Also strips fabricated sourcePrincipleId values (LLM invents placeholders
+   * like "pri-unknown", "pri-000", etc.). The generatedAt override is handled
+   * by the base class via super.postFetchTransform().
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown, _context: DreamerContext): void {
+    super.postFetchTransform(taskId, untrustedOutput, _context);
     injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
 
     if (typeof untrustedOutput === 'object' && untrustedOutput !== null && !Array.isArray(untrustedOutput)) {
-      // Override generatedAt with actual timestamp — LLM may echo prompt example date
-      if (Object.hasOwn(untrustedOutput, 'generatedAt')) {
-        Reflect.set(untrustedOutput, 'generatedAt', new Date().toISOString());
-      }
       // Strip fabricated sourcePrincipleId — LLM invents placeholders like pri-unknown, pri-000, pri-999
       if (Object.hasOwn(untrustedOutput, 'sourcePrincipleId') && typeof (untrustedOutput as Record<string, unknown>).sourcePrincipleId === 'string') {
         const val = (untrustedOutput as Record<string, unknown>).sourcePrincipleId as string;

--- a/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/dreamer-runner.ts
@@ -21,7 +21,7 @@ import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
 import { DreamerPromptBuilder } from './dreamer-prompt-builder.js';
 import { injectRunnerLineageIfAbsent } from './peer-runner-contracts.js';
-import { isCorePrincipleId } from '../core-principles/index.js';
+import { stripFabricatedCorePrincipleIds } from '../core-principles/index.js';
 import { BasePeerRunner } from '../runner/base-peer-runner.js';
 import type {
   PeerRunnerOptions,
@@ -311,24 +311,14 @@ export class DreamerRunner extends BasePeerRunner<DreamerContext, DreamerOutput>
    * Only fill when absent via Object.hasOwn — present-but-falsy values
    * must reach validation and fail loud (Runtime Contract Rule 3).
    *
-   * Also strips fabricated sourcePrincipleId values (LLM invents placeholders
-   * like "pri-unknown", "pri-000", etc.). The generatedAt override is handled
-   * by the base class via super.postFetchTransform().
+   * Also strips fabricated sourcePrincipleId values via the shared
+   * stripFabricatedCorePrincipleIds utility. The generatedAt override is
+   * handled by the base class via super.postFetchTransform().
    */
   protected override postFetchTransform(taskId: string, untrustedOutput: unknown, _context: DreamerContext): void {
     super.postFetchTransform(taskId, untrustedOutput, _context);
     injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
-
-    if (typeof untrustedOutput === 'object' && untrustedOutput !== null && !Array.isArray(untrustedOutput)) {
-      // Strip fabricated sourcePrincipleId — LLM invents placeholders like pri-unknown, pri-000, pri-999
-      if (Object.hasOwn(untrustedOutput, 'sourcePrincipleId') && typeof (untrustedOutput as Record<string, unknown>).sourcePrincipleId === 'string') {
-        const val = (untrustedOutput as Record<string, unknown>).sourcePrincipleId as string;
-        // Use registry membership check — format-only regex would accept T-99 etc.
-        if (!isCorePrincipleId(val)) {
-          Reflect.deleteProperty(untrustedOutput, 'sourcePrincipleId');
-        }
-      }
-    }
+    stripFabricatedCorePrincipleIds(untrustedOutput);
   }
 
   protected override emitSuccessTelemetry(taskId: string, output: DreamerOutput): void {

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -550,18 +550,12 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
    * Only fill when absent via Object.hasOwn — present-but-falsy values
    * must reach validation and fail loud (Runtime Contract Rule 3).
    *
-   * Also overrides generatedAt with the actual current timestamp (LLM may
-   * echo the prompt's example date).
+   * generatedAt override is handled by the base class — subclasses must call
+   * super.postFetchTransform() to inherit it.
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown, _context: EvaluatorContext): void {
+    super.postFetchTransform(taskId, untrustedOutput, _context);
     injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
-
-    if (typeof untrustedOutput === 'object' && untrustedOutput !== null) {
-      const record = untrustedOutput as Record<string, unknown>;
-      // Override generatedAt with actual timestamp — LLM may echo prompt example date
-      record.generatedAt = new Date().toISOString();
-    }
   }
 
   protected override emitSuccessTelemetry(taskId: string, output: EvaluatorOutputV1): void {

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -29,7 +29,7 @@ export { generateFromTemplate } from './template-generator.js';
 
 // Code validation (PRI-44)
 export type { ValidationResult } from './rule-code-validator.js';
-export { checkForbiddenPatterns } from './rule-code-validator.js';
+export { checkForbiddenPatterns, checkReturnStatementsMissingFields } from './rule-code-validator.js';
 
 // Compile result (PRI-44)
 export type { CompileResult } from './compile-result.js';

--- a/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/philosopher-runner.ts
@@ -341,19 +341,12 @@ export class PhilosopherRunner extends BasePeerRunner<PhilosopherContext, Philos
    * Only fill when absent via Object.hasOwn — present-but-falsy values
    * must reach validation and fail loud (Runtime Contract Rule 3).
    *
-   * Also overrides generatedAt with the actual current timestamp (LLM may
-   * echo the prompt's example date).
+   * The generatedAt override is handled by the base class via
+   * super.postFetchTransform().
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown, _context: PhilosopherContext): void {
+    super.postFetchTransform(taskId, untrustedOutput, _context);
     injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
-
-    if (typeof untrustedOutput === 'object' && untrustedOutput !== null && !Array.isArray(untrustedOutput)) {
-      // Override generatedAt with actual timestamp — LLM may echo prompt example date
-      if (Object.hasOwn(untrustedOutput, 'generatedAt')) {
-        Reflect.set(untrustedOutput, 'generatedAt', new Date().toISOString());
-      }
-    }
   }
 
   protected override emitSuccessTelemetry(taskId: string, output: PhilosopherOutputV1): void {

--- a/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/refiner-sandbox-wrapper.ts
@@ -1,7 +1,7 @@
 import type { GoldenTrace, GoldenTraceCase } from '../golden-trace.js';
 import type { ReplayEvaluateFn } from '../golden-trace-replay-validator.js';
 import { diffParams } from '../golden-trace-replay-validator.js';
-import { checkForbiddenPatterns } from './rule-code-validator.js';
+import { checkForbiddenPatterns, checkReturnStatementsMissingFields } from './rule-code-validator.js';
 import { createSyntheticRuleHostInput } from '../golden-trace.js';
 import type { RuleHostHelpers } from './rule-host-helpers.js';
 import type { RuleHostResult } from './rule-host-contracts.js';
@@ -211,6 +211,22 @@ export function evaluateInRefinerSandbox(
       failedCases: [],
       executionTimeMs: Date.now() - startTime,
       forbiddenPatternViolations: forbiddenViolations,
+    };
+  }
+
+  // Static check: catch return statements missing required RuleHostResult
+  // fields before execution. Mirrors the check in production-gate-deps.ts.
+  const returnShapeViolations = checkReturnStatementsMissingFields(code);
+  if (returnShapeViolations.length > 0) {
+    return {
+      success: false,
+      failedCases: returnShapeViolations.map((msg) => ({
+        caseId: '__return_shape__',
+        errorType: 'validation_failed' as const,
+        message: msg,
+      })),
+      executionTimeMs: Date.now() - startTime,
+      forbiddenPatternViolations: [],
     };
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/rule-code-validator.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-code-validator.ts
@@ -47,3 +47,40 @@ export function checkForbiddenPatterns(code: string): string[] {
   }
   return labels;
 }
+
+/**
+ * Best-effort static check: find `return { ... }` statements in rule code that
+ * are missing required RuleHostResult fields (decision, matched, reason).
+ *
+ * Only matches simple return objects without nested braces. Complex returns
+ * (with nested objects like correctionProposal) are skipped — no false positives.
+ * The sandbox's runtime type guard (isValidRuleHostResult) is the authoritative
+ * check; this is an early-warning static layer that catches the most common
+ * LLM mistake pattern (e.g. `return { matched: false }`) before VM execution.
+ *
+ * Returns an array of violation messages (empty if no violations found).
+ */
+export function checkReturnStatementsMissingFields(code: string): string[] {
+  const violations: string[] = [];
+  // Match `return { ... }` blocks without nested braces (multiline).
+  // [^{}] ensures we only match simple objects — complex returns with nested
+  // objects (e.g. correctionProposal) are skipped to avoid false positives.
+  const returnPattern = /return\s*\{([^{}]+)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = returnPattern.exec(code)) !== null) {
+    const content = match[1] ?? '';
+    const hasDecision = /\bdecision\s*:/.test(content);
+    const hasMatched = /\bmatched\s*:/.test(content);
+    const hasReason = /\breason\s*:/.test(content);
+    const missing: string[] = [];
+    if (!hasDecision) missing.push('decision');
+    if (!hasMatched) missing.push('matched');
+    if (!hasReason) missing.push('reason');
+    if (missing.length > 0) {
+      violations.push(
+        `return statement missing required field(s): ${missing.join(', ')} — found: return { ${content.trim()} }`,
+      );
+    }
+  }
+  return violations;
+}

--- a/packages/principles-core/src/runtime-v2/internalization/scribe-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/scribe-runner.ts
@@ -347,19 +347,12 @@ export class ScribeRunner extends BasePeerRunner<ScribeContext, ScribeOutputV1> 
    * Only fill when absent via Object.hasOwn — present-but-falsy values
    * must reach validation and fail loud (Runtime Contract Rule 3).
    *
-   * Also overrides generatedAt with the actual current timestamp (LLM may
-   * echo the prompt's example date).
+   * The generatedAt override is handled by the base class via
+   * super.postFetchTransform().
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected override postFetchTransform(taskId: string, untrustedOutput: unknown): void {
+  protected override postFetchTransform(taskId: string, untrustedOutput: unknown, _context: ScribeContext): void {
+    super.postFetchTransform(taskId, untrustedOutput, _context);
     injectRunnerLineageIfAbsent(untrustedOutput, 'taskId', taskId);
-
-    if (typeof untrustedOutput === 'object' && untrustedOutput !== null && !Array.isArray(untrustedOutput)) {
-      // Override generatedAt with actual timestamp — LLM may echo prompt example date
-      if (Object.hasOwn(untrustedOutput, 'generatedAt')) {
-        Reflect.set(untrustedOutput, 'generatedAt', new Date().toISOString());
-      }
-    }
   }
 
   protected override emitSuccessTelemetry(taskId: string, output: ScribeOutputV1): void {

--- a/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
@@ -160,14 +160,15 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
    *
    * Base implementation overrides `generatedAt` with the actual current timestamp,
    * because LLM may echo the prompt's example date instead of generating the real time.
+   * Unconditionally sets `generatedAt` — if the LLM omitted it, we add it; if the LLM
+   * echoed a stale date, we replace it. Subclasses should call `super.postFetchTransform()`
+   * to inherit this behavior instead of duplicating the override.
    */
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   protected postFetchTransform(_taskId: string, untrustedOutput: unknown, _context: TContext): void {
     // Override generatedAt with actual timestamp — LLM may echo prompt example date
     if (typeof untrustedOutput === 'object' && untrustedOutput !== null && !Array.isArray(untrustedOutput)) {
-      if (Object.hasOwn(untrustedOutput, 'generatedAt')) {
-        Reflect.set(untrustedOutput, 'generatedAt', new Date().toISOString());
-      }
+      Reflect.set(untrustedOutput, 'generatedAt', new Date().toISOString());
     }
   }
 


### PR DESCRIPTION
## Summary

Systematic hardening of the LLM output validation chain, addressing the root cause identified via 5-Why analysis: the validation chain relies on isolated ad-hoc patches rather than a systematic defense-in-depth framework.

This PR eliminates 3 classes of ad-hoc patch points from the 17 identified across 4 layers.

### Commit 1: fix(artificer) — strengthen prompt + static check for return shape
- Added EVERY return constraint with GOOD/BAD examples to artificer prompt
- Added checkReturnStatementsMissingFields() static analysis function (regex-based)
- Wired into both production gate and refiner sandbox wrapper
- 6 new tests for the static check

### Commit 2: fix(pd-console) — mount Toaster component
- Added Toaster to App.tsx so toast notifications actually render

### Commit 3: refactor(runner) — unify generatedAt override via super.postFetchTransform() (A)
- Base class postFetchTransform() now unconditionally sets generatedAt on object outputs
- 5 internalization runners call super.postFetchTransform() instead of reimplementing
- Removed as Record<string, unknown> casts from artificer/evaluator runners
- Removed unused eslint-disable directives

### Commit 4: refactor(core-principles) — extract stripFabricatedCorePrincipleIds utility (B)
- New shared utility function in core-principles/strip-fabricated-ids.ts
- Uses Reflect.get instead of as type assertions (Runtime Contract Rule 2)
- Dreamer runner now calls the shared utility instead of inline logic
- 14 new tests covering valid/invalid IDs, edge cases, inherited properties

### Commit 5: refactor(artificer-l2-adapter) — use shared extractJsonObject (E)
- Deleted private extractJsonObject duplicate (27 lines)
- Imported shared one from json-extractor.ts
- Behavior enhancement: now supports code-fenced JSON

## ERR Checklist

| ERR | How avoided |
|-----|-------------|
| ERR-001 (as bypasses validation) | Replaced as Record<string, unknown> with Reflect.get + typeof guards |
| ERR-005 (array element types) | N/A - no array handling in changed code |
| ERR-009 (required fields fail loud) | N/A - generatedAt is system-injected, not a required field |
| ERR-013 (Object.hasOwn vs in) | All untrusted key checks use Object.hasOwn |
| ERR-014 (safe serialization) | Shared extractJsonObject validates return type (object only) |

## Tests Run

- 761 relevant tests pass across 12 test files
- npm run lint clean on changed files
- 8 pre-existing failures (attack-e2e timeouts + pruning-read-model) verified unrelated

## Remaining Risk

- Pre-existing lint errors in PrincipleTrajectoryModel.ts and api.ts block npm run verify:merge
- Pre-existing test failures in attack-e2e-pipeline-smoke.test.ts and pruning-read-model.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added return statement validation to ensure rule implementations include required fields (`decision`, `matched`, `reason`).
  * Added detection and removal of fabricated core principle IDs to prevent spurious data injection.
  * Integrated toast notification system into the console application.

* **Bug Fixes**
  * Improved error handling in production gate validation with clearer field validation failure reporting.
  * Refactored runner data processing to properly delegate timestamp and context handling to base classes.

* **Tests**
  * Expanded test coverage for return statement validation and core principle ID handling.
  * Updated test fixtures to use relative timestamps for better maintainability.
  * Added fast retry policy for e2e smoke testing scenarios.

* **Chores**
  * Refactored trajectory model row extraction for improved code clarity.
  * Optimized imports and consolidated related validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->