### PR TITLE
fix(rulehost): align prompt template with unified ArtificerRuleOutput

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -1018,7 +1018,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
   - When implementing a `PDRuntimeAdapter`, read `RunHandleSchema` / `RunStatusSchema` from `runtime-protocol.ts` and copy field names verbatim — do not rely on memory. The two objects differ only by `status`, which is easy to conflate.
   - Treat every output-emitting path (happy, degraded, fallback, retry-exhausted) as a trust boundary: each must emit only objects that passed validation. Degradation is a *content* transformation (strip code fields), not a *trust* escape hatch.
   - Prefer `throw PDRuntimeError` over returning a contradictory state object on total failure — it surfaces in `handlePostLeaseError` with a structured reason, rather than relying on the caller to cross-check handle vs pollRun.
-- **Recurrence**: First occurrence (EP-01 Trust Boundary + EP-02 Production Path Wiring). Found in self-review before external handoff; both fixed in commit c396ed92 before any PR.
+- **Recurrence**: 2026-06-21 PR #993 — the production Artificer prompt requested the retired `implementationPlan` field while the validator required `implementationSummary`, again coding against a remembered output contract instead of the canonical schema. Fixed by aligning the prompt and schema reference on V2 and adding negative assertions for the retired V1 field. Original occurrence was found in self-review before external handoff and fixed in commit c396ed92.
 
 **[ERR-070]** | New public types/classes not exported from barrel `index.ts` — module consumers cannot import the new API surface
 

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -2063,11 +2063,12 @@ describe('PRI-111 ArtificerRunner boundary', () => {
     expect(src).toContain('DefaultArtificerValidator');
   });
 
-  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers artificer-rule-output-v1 schema', async () => {
+  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers unified artificer-rule-output-v2 schema', async () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
-    expect(src).toContain('artificer-rule-output-v1');
+    expect(src).toContain('artificer-rule-output-v2');
+    expect(src).not.toContain('artificer-rule-output-v1');
     expect(src).toContain('ArtificerRuleOutputSchema');
   });
 });
@@ -3624,4 +3625,3 @@ describe('PRI-416: barrel cap guards', () => {
     expect(exportLines.length).toBeLessThanOrEqual(BARREL_MAX_EXPORT_LINES);
   });
 });
-

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -333,7 +333,7 @@ const OUTPUT_SCHEMA_REGISTRY = new Map<string, TSchema>([
   ['dreamer-output-v1', DreamerOutputV1Schema],
   ['philosopher-output-v1', PhilosopherOutputV1Schema],
   ['scribe-output-v1', ScribeOutputV1Schema],
-  ['artificer-rule-output-v1', ArtificerRuleOutputSchema],
+  ['artificer-rule-output-v2', ArtificerRuleOutputSchema],
   ['evaluator-output-v1', EvaluatorOutputV1Schema],
   ['rollout-reviewer-output-v1', RolloutReviewerOutputV1Schema],
   ['trainer-output-v1', TrainerOutputV1Schema],

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
@@ -54,6 +54,7 @@ describe('ArtificerPromptBuilder', () => {
 
   it('instruction requires implementationSummary as a non-empty string', () => {
     expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('implementationSummary MUST be a non-empty string');
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).not.toContain('"implementationPlan"');
   });
 
   it('message is valid JSON containing promptInput', () => {

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
@@ -52,8 +52,8 @@ describe('ArtificerPromptBuilder', () => {
     expect(ARTIFICER_PROMPT_CONTRACT_VERSION).toBe('artificer-output-v2.prompt.v1');
   });
 
-  it('confidence instruction says number not string/percentage', () => {
-    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('NOT a string, NOT a percentage');
+  it('instruction requires implementationSummary as a non-empty string', () => {
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('implementationSummary MUST be a non-empty string');
   });
 
   it('message is valid JSON containing promptInput', () => {

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
@@ -29,27 +29,20 @@ export interface ArtificerPromptBuildResult {
   readonly promptInput: ArtificerPromptInput;
 }
 
-export const ARTIFICER_PROTOCOL_INSTRUCTION = `You are an Artificer agent in a principle internalization pipeline. Your role is to transform the Scribe's formal principle draft into an implementation-oriented plan with concrete changes, tests, and rollout notes.
+export const ARTIFICER_PROTOCOL_INSTRUCTION = `You are an Artificer agent in a principle internalization pipeline. Your role is to transform the Scribe's formal principle draft into executable RuleHost code with a concise implementation summary, tests, and rollout notes.
 
 PROTOCOL:
 1. Review the scribeArtifact to understand the formal principle draft
-2. Transform the principle draft into an implementation plan and executable RuleHost code
+2. Transform the principle draft into executable RuleHost code and a brief implementation summary
 3. Preserve the lineage trace from scribe, philosopher, and dreamer artifacts
 4. Identify risks associated with implementing this principle
-5. The implementation plan should be concrete enough to guide code changes, not just philosophical
+5. The implementation summary should clearly describe what the code does and why
 
 OUTPUT FORMAT (pure JSON, no markdown):
 {
   "taskId": "<from input>",
   "sourceScribeArtifactId": "<copy exactly from input.sourceScribeArtifactId>",
-  "implementationPlan": {
-    "summary": "<concise summary of the implementation approach>",
-    "targetSurface": "<specific code/module/surface area to modify>",
-    "changes": ["<specific change 1>", "<specific change 2>"],
-    "tests": ["<test requirement 1>", "<test requirement 2>"],
-    "rolloutNotes": ["<rollout consideration 1>", "<rollout consideration 2>"],
-    "confidence": 0.8
-  },
+  "implementationSummary": "<concise summary of what the code does and the implementation approach>",
   "sourceTrace": {
     "scribeArtifactId": "<copy exactly from input.sourceScribeArtifactId>",
     "philosopherArtifactId": "<from scribe artifact if available, or omit>",
@@ -67,12 +60,7 @@ OUTPUT FORMAT (pure JSON, no markdown):
 
 CONSTRAINTS:
 - Output ONLY valid JSON (no markdown, no explanatory text, no code fences)
-- implementationPlan.summary MUST be a non-empty string
-- implementationPlan.targetSurface MUST be a non-empty string
-- implementationPlan.changes MUST be an array of strings
-- implementationPlan.tests MUST be an array of strings
-- implementationPlan.rolloutNotes MUST be an array of strings
-- implementationPlan.confidence MUST be a number between 0.0 and 1.0 (NOT a string, NOT a percentage)
+- implementationSummary MUST be a non-empty string describing what the code does and the implementation approach
 - sourceScribeArtifactId MUST be copied exactly from input.sourceScribeArtifactId (non-empty string)
 - sourceTrace.scribeArtifactId MUST be copied exactly from input.sourceScribeArtifactId
 - sourceTrace.philosopherArtifactId is optional — include only if available from scribe artifact

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-runner.ts
@@ -22,7 +22,7 @@
  *   1. acquireLease — isolated try/catch, lease_conflict is non-mutating
  *   2. resolve Scribe dependency from dependencyTaskIds
  *   3. fetch Scribe artifact via PIArtifactStore
- *   4. startRun with outputSchemaRef: 'artificer-rule-output-v1'
+ *   4. startRun with outputSchemaRef: 'artificer-rule-output-v2'
  *   5. pollUntilTerminal (inherited)
  *   6. fetchOutput → validate as unknown → cast to ArtificerRuleOutput
  *   7. checkLineageIntegrity (sourceScribeArtifactId consistency, ERR-008)
@@ -228,7 +228,7 @@ export class ArtificerRunner extends BasePeerRunner<ArtificerContext, ArtificerR
       taskRef: { taskId },
       inputPayload: message,
       contextItems: [],
-      outputSchemaRef: 'artificer-rule-output-v1',
+      outputSchemaRef: 'artificer-rule-output-v2',
       timeoutMs: this.resolvedOptions.timeoutMs,
     });
   }

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -62,7 +62,7 @@ interface EvaluatorContext {
    * Scribe principle artifact contentJson (RuleHost MVP Activation, PRD Decision 12).
    * Loaded so the evaluator LLM can judge code intentConsistency/scopePrecision
    * against the original principle text. Null when no scribe artifact is resolvable
-   * (V1 artificer output, or scribeArtifactId missing/malformed).
+   * (scribeArtifactId missing/malformed or upstream artifact unavailable).
    */
   readonly scribeArtifact: string | null;
   readonly sourceScribeArtifactId: string | null;


### PR DESCRIPTION
## Summary

Fixes prompt-validator mismatch discovered after PRI-439 merge (PR #992).

### Problem
The Artificer prompt template (`ARTIFICER_PROTOCOL_INSTRUCTION`) was asking the LLM to output the V1 `implementationPlan` object field, which was removed when `ArtificerRuleOutput` was unified in PRI-439. Meanwhile, the validator (`DefaultArtificerValidator`) requires a mandatory `implementationSummary` string field that was not mentioned in the prompt.

This mismatch would cause the one-shot Artificer path to always fail validation with:
```
'implementationSummary is required'
```

### Changes
1. **artificer-prompt-builder.ts**: Replace `implementationPlan` object with `implementationSummary` string in OUTPUT FORMAT and update CONSTRAINTS accordingly
2. **artificer-prompt-builder.test.ts**: Update test assertion from checking "NOT a string, NOT a percentage" (stale confidence constraint) to checking "implementationSummary MUST be a non-empty string"
3. **evaluator-runner.ts**: Remove obsolete "(V1 artificer output, ...)" comment and update to "(scribeArtifactId missing/malformed or upstream artifact unavailable)"

### Verification
- All prompt builder tests pass (11/11)
- All internalization tests pass (515/515)
- Lint checks pass
- Pre-commit hooks pass

<!-- Linear: N/A (follow-up cleanup for PRI-439) -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  - 更新了提示生成器的测试断言

* **优化改进**
  - 简化了协议指令的输出格式约束
  - 更新了文档注释以准确反映系统行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->