### PR TITLE
fix(installer): remove shell '> nul' redirect that creates real files on Windows Git Bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ debug_*.txt
 *_debug.txt
 test_log_*.txt
 full_test_report*.txt
+# Windows Git Bash creates actual files instead of redirecting to NUL device
+nul
+NUL
 temp/
 tmp/
 

--- a/packages/openclaw-plugin/scripts/sync-plugin.mjs
+++ b/packages/openclaw-plugin/scripts/sync-plugin.mjs
@@ -1083,7 +1083,7 @@ function restartGatewayWindows() {
                         execSync(`wmic process where "ProcessId=${pidTrim}" call terminate`, { stdio: 'ignore' });
                     } catch { /* ignore individual failures */ }
                 }
-                execSync('timeout /t 3 /nobreak > nul', { shell: true, stdio: 'ignore' });
+                execSync('timeout /t 3 /nobreak', { shell: true, stdio: 'ignore' });
             }
         } catch { /* no existing processes */ }
 
@@ -1147,7 +1147,7 @@ function restartGatewayWindows() {
                 }
             } catch { /* port not listening yet */ }
             try {
-                execSync('timeout /t 1 /nobreak > nul', { shell: true, stdio: 'ignore' });
+                execSync('timeout /t 1 /nobreak', { shell: true, stdio: 'ignore' });
             } catch { /* ignore */ }
         }
 


### PR DESCRIPTION
## Bug

`sync-plugin.mjs` 中有两行 `timeout /t 3 /nobreak > nul` 和 `timeout /t 1 /nobreak > nul`，在 Windows Git Bash (MINGW/MSYS) 环境下会**创建真实的 `nul`/`NUL` 文件**到项目根目录（各 72 字节），而不是重定向到 Windows NUL 设备。

## Root Cause

`execSync` 的 `{ shell: true, stdio: ignore }` 已经丢弃了所有子进程输出，`> nul` 是完全多余的 shell 级重定向。但 MINGW/MSYS 对 `nul` 的设备映射在 Anaconda cygpath 污染 PATH 时会失效——MSYS 把 `nul` 当作普通文件名处理，创建了真实文件。

生成的 `nul` 文件内容为：
```
ls: cannot access 'D:Codeprinciplespackages': No such file or directory
```
路径分隔符丢失是典型的 Anaconda `cygpath` 破坏症状。

## Fix

- 移除 `> nul` 重定向（`stdio: 'ignore'` 已足够）
- 添加 `nul`/`NUL` 到 `.gitignore` 作为安全网
