### PR TITLE
fix(pri-453): remove gate-block-helper legacy recordPainEvent to eliminate double-write

### DIFF
--- a/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
+++ b/packages/openclaw-plugin/src/hooks/gate-block-helper.ts
@@ -110,15 +110,11 @@ export function recordGateBlockAndReturn(
   // so one mild block does not start a long diagnostician run.
   if (sessionId) {
     const GATE_BLOCK_PAIN_SCORE = 45; // Must be >= pain_trigger (40) so single gate block can trigger diagnosis (PRI-274)
-    // Record to trajectory (fire-and-forget, no .pain_flag file needed)
-    wctx.trajectory?.recordPainEvent?.({
-      sessionId,
-      source: 'gate_blocked',
-      score: GATE_BLOCK_PAIN_SCORE,
-      reason: `Gate blocked ${toolName} on ${filePath}: ${reason}`,
-      severity: 'mild',
-      origin: 'system_infer',
-    });
+    // PRI-453: Generate painId early. SDK observability path (emitPainDetectedEvent
+    // with default recordObservability: true) handles all writes: events_*.jsonl +
+    // evolution.jsonl + trajectory.db (with canonicalPainId for dedup). No separate
+    // legacy recordPainEvent call needed — avoids double-write to trajectory.db.
+    const gatePainId = `gate_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
     // PEAT-B1: Evidence triage (feature-flagged)
     let triageAdmitted = true;
@@ -175,7 +171,7 @@ export function recordGateBlockAndReturn(
           ts: new Date().toISOString(),
           type: 'pain_detected',
           data: {
-            painId: `gate_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+            painId: gatePainId,
             painType: 'user_frustration',
             source: 'gate_blocked',
             reason: `Gate blocked ${toolName} on ${filePath}: ${reason}`,

--- a/packages/openclaw-plugin/tests/hooks/gate-block-helper-profile.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/gate-block-helper-profile.test.ts
@@ -183,4 +183,27 @@ describe('Gate Block Helper — PROFILE Resilience', () => {
     expect(result).toBeDefined();
     expect(result.block).toBe(true);
   });
+
+  it('does NOT call recordPainEvent (SDK observability path handles trajectory.db)', async () => {
+    // PRI-453: Legacy recordPainEvent was removed to avoid double-write.
+    // SDK observability path (emitPainDetectedEvent with default recordObservability: true)
+    // handles all writes: events_*.jsonl + evolution.jsonl + trajectory.db.
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const { recordGateBlockAndReturn } = await import('../../src/hooks/gate-block-helper.js');
+    const wctx = makeTestWctx() as any;
+
+    recordGateBlockAndReturn(
+      wctx,
+      {
+        filePath: 'src/danger.ts',
+        reason: 'Test block',
+        toolName: 'write',
+        sessionId,
+      },
+      { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+    );
+
+    expect(wctx.trajectory.recordPainEvent).not.toHaveBeenCalled();
+  });
 });

--- a/packages/openclaw-plugin/tests/hooks/pain-emission-characterization.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/pain-emission-characterization.test.ts
@@ -58,7 +58,8 @@ function read(relativePath: string): string {
  * do not prematurely terminate the match (ERR-009 false-positive guard).
  */
 function extractGateBlockObject(source: string): string | null {
-  const marker = /painId:\s*`gate_[^`]+`/.exec(source);
+  // PRI-453: painId is now a variable reference (gatePainId), not inline template
+  const marker = /painId:\s*gatePainId/.exec(source);
   if (!marker) return null;
   const start = source.lastIndexOf('{', marker.index);
   if (start === -1) return null;
@@ -271,8 +272,11 @@ describe('PRI-433: PainAdmissionEmitter characterization (safety net)', () => {
   describe('gate-block-helper.ts emit site', () => {
     const source = read(GATE_BLOCK_HELPER);
 
-    it('uses painId format: gate_${Date.now()}_${random}', () => {
-      expect(source).toMatch(/painId:\s*`gate_\$\{Date\.now\(\)\}_\$\{Math\.random\(\)\.toString\(36\)\.slice\(2,\s*10\)\}`/);
+    it('uses painId format: gate_${Date.now()}_${random} via gatePainId variable', () => {
+      // PRI-453: painId is now generated early as `const gatePainId = `gate_...``
+      // and referenced as `painId: gatePainId` in the emit data block.
+      expect(source).toMatch(/const\s+gatePainId\s*=\s*`gate_\$\{Date\.now\(\)\}_\$\{Math\.random\(\)\.toString\(36\)\.slice\(2,\s*10\)\}`/);
+      expect(source).toMatch(/painId:\s*gatePainId/);
     });
 
     it('sets painType to "user_frustration"', () => {

--- a/packages/openclaw-plugin/tests/integration/pain-pipeline-roundtrip.test.ts
+++ b/packages/openclaw-plugin/tests/integration/pain-pipeline-roundtrip.test.ts
@@ -16,6 +16,8 @@
  * 5. `emitPainDetectedEvent` signature accepts optional options parameter.
  * 6. painId is generated before recordPainEvent (lineage consistency).
  * 7. Observer path uses same painId for recordPainEvent and emit (ERR-004/ERR-008).
+ * 8. gate-block-helper does NOT have a legacy recordPainEvent call
+ *    (SDK observability path handles all writes, avoiding double-write).
  *
  * ERR refs:
  * - ERR-004/ERR-008 (lineage consistency): same painId for trajectory + emit
@@ -141,6 +143,15 @@ describe('PRI-453: Pain pipeline round-trip invariants', () => {
       const source = read(LIFECYCLE);
       expect(source).not.toMatch(/recordObservability:\s*false/);
     });
+
+    it('gate-block-helper.ts generates painId before emitPainDetectedEvent', () => {
+      const source = read(GATE_BLOCK_HELPER);
+      const painIdLine = source.indexOf('const gatePainId = `gate_');
+      const emitLine = source.indexOf('void emitPainDetectedEvent(wctx, {');
+      expect(painIdLine).toBeGreaterThan(-1);
+      expect(emitLine).toBeGreaterThan(-1);
+      expect(painIdLine).toBeLessThan(emitLine);
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -208,6 +219,23 @@ describe('PRI-453: Pain pipeline round-trip invariants', () => {
       expect(source).toMatch(/painId:\s*observerPainId/);
       // There should be NO separate observerEmitPainId variable (lineage gap fixed)
       expect(source).not.toMatch(/observerEmitPainId/);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Invariant 8: gate-block-helper does NOT have legacy recordPainEvent
+  // (SDK observability path handles all writes, avoiding double-write)
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('gate-block-helper has no legacy recordPainEvent (no double-write)', () => {
+    it('gate-block-helper.ts does NOT call recordPainEvent directly', () => {
+      const source = read(GATE_BLOCK_HELPER);
+      expect(source).not.toMatch(/wctx\.trajectory\?\.recordPainEvent/);
+    });
+
+    it('gate-block-helper.ts uses gatePainId for emitted painId (SDK path writes canonicalPainId)', () => {
+      const source = read(GATE_BLOCK_HELPER);
+      expect(source).toMatch(/painId:\s*gatePainId/);
     });
   });
 });

--- a/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
@@ -2,15 +2,19 @@
  * Pain signal observability for Runtime v2 entry points.
  *
  * Design intent (PRI-453): This writer serves paths that do NOT have legacy
- * event-log/trajectory writers — specifically `pd pain record` CLI,
+ * event-log writers — specifically `pd pain record` CLI,
  * `gate-block-helper.ts`, and `lifecycle.ts`. Hook paths that already write
  * via legacy `recordPainSignal` + `recordPainEvent` pass
  * `recordObservability: false` to avoid triple-write.
  *
- * Automatic OpenClaw hook paths already record event-log and trajectory rows
- * before calling PainSignalBridge. `pd pain record` does not have a
- * WorkspaceContext, so it uses this small core writer to avoid an observability
- * gap while keeping `evolution_tasks` legacy queue disabled.
+ * `gate-block-helper.ts` has a legacy `recordGateBlock` call but no legacy
+ * `recordPainSignal` or `recordPainEvent` for pain events — it relies on
+ * this SDK writer for all pain observability (events_*.jsonl + evolution.jsonl
+ * + trajectory.db with canonicalPainId).
+ *
+ * `pd pain record` does not have a WorkspaceContext, so it uses this small
+ * core writer to avoid an observability gap while keeping `evolution_tasks`
+ * legacy queue disabled.
  */
 import Database from 'better-sqlite3';
 import * as fs from 'fs';


### PR DESCRIPTION
## Summary

Fixes the pre-existing `gate-block-helper.ts` trajectory.db double-write issue identified during PRI-453 review.

## Problem

`gate-block-helper.ts` had both a legacy `recordPainEvent` call (without `canonicalPainId`) and an `emitPainDetectedEvent` call (with default `recordObservability: true`). This caused the same pain event to be written to `trajectory.db` twice:
- Once by the legacy path (no `canonical_pain_id`)
- Once by the SDK observability path (with `canonical_painId`)

## Fix

- **Remove** the legacy `recordPainEvent` call at L114. The SDK observability path now handles all pain writes for gate-block-helper (`events_*.jsonl` + `evolution.jsonl` + `trajectory.db` with `canonicalPainId` via `gatePainId`).
- **Generate** `gatePainId` early and use it as the emitted event's `painId`, so the SDK path writes `canonicalPainId` to trajectory.db for dedup.
- **Update** `pain-signal-observability.ts` header comment to accurately describe gate-block-helper's writer setup.
- **Add** Invariant 8 to `pain-pipeline-roundtrip.test.ts` (no legacy `recordPainEvent` in gate-block-helper).
- **Add** runtime test in `gate-block-helper-profile.test.ts` verifying `recordPainEvent` is not called.
- **Update** `pain-emission-characterization.test.ts` for `gatePainId` variable reference pattern.

## Write Path (after fix)

| Call site | Track A (events) | Track B (trajectory) | SDK obs | evolution.jsonl |
|-----------|------------------|----------------------|---------|-----------------|
| gate-block-helper | none | none (removed) | default true | SDK |

## Tests

- `pain-pipeline-roundtrip.test.ts`: 21 passed (was 18, +3 new)
- `pain-emission-characterization.test.ts`: 56 passed
- `gate-block-helper-profile.test.ts`: 5 passed (was 4, +1 new)
- `npm run verify:merge`: all passed

Related: PRI-453
