### PR TITLE
docs(pri-457): trace live MVP runner chain per activation channel + pinning test

### DIFF
--- a/docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md
+++ b/docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md
@@ -64,13 +64,13 @@ by evidence of what actually fires today.
 
 ### `MVP_ENABLED_CHANNELS` (intake-to-internalization-bridge.ts)
 
-```
+```javascript
 Set { 'prompt', 'code_tool_hook', 'defer_archive' }
 ```
 
 ### `MVP_CORE_TASK_KINDS` (queue-actionability.ts)
 
-```
+```javascript
 ['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator']
 ```
 
@@ -78,7 +78,7 @@ Set { 'prompt', 'code_tool_hook', 'defer_archive' }
 
 ### `DEFAULT_CONSUMER_RUNNER_KINDS` (internalization-consumer-decision.ts)
 
-```
+```javascript
 ['dreamer']
 ```
 
@@ -103,7 +103,7 @@ through the peer runner chain).
 
 ## ALLOWED_EDGES (Job Graph Topology)
 
-```
+```text
 dreamer → philosopher → scribe → artificer → evaluator → rollout_reviewer
 ```
 
@@ -189,7 +189,7 @@ only calls `wakeOnce('dreamer')`. This is a runtime behavior, not a config gate.
 When a dreamer task succeeds and `commitNextTaskProposal` is called, the
 successor chain created in the store is:
 
-```
+```text
 dreamer (succeeded) → philosopher (pending) → scribe (pending) → artificer (pending) → evaluator (pending) → rollout_reviewer (pending)
 ```
 

--- a/docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md
+++ b/docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md
@@ -1,0 +1,219 @@
+# C2-P0: Live MVP Runner Chain Trace
+
+**Issue**: PRI-457
+**Date**: 2026-06-24
+**Type**: Read-only spike — no production code changed
+
+## Purpose
+
+Pin the exact set of peer runners that actually execute for each MVP activation
+channel under default shipped production config. This is the prerequisite for
+C2-P2 (de-surface Quiet runners) — any runner removal or hiding must be backed
+by evidence of what actually fires today.
+
+## ERR Gate
+
+- **ERR-004 / ERR-008 / EP-07**: successor task kinds are read from the real
+  store after `commitNextTaskProposal`, not inferred from `ALLOWED_EDGES` on
+  paper. The pinning test (`c2-live-runner-chain.test.ts`) seeds real tasks
+  through the real seeding path and asserts real successor records.
+- **EP-09**: the pinning test exercises the real `InternalizationOrchestrator`
+  + `RuntimeStateManager` (SQLite), not a hand-written expected-edge list.
+
+## Sources Read
+
+| File | Role |
+|------|------|
+| `internalization-job-graph.ts` | `ALLOWED_EDGES`, `getAllowedSuccessors`, `validateEdge` |
+| `internalization-state-machine.ts` | `createNextTaskProposal` (successor proposal logic) |
+| `internalization-orchestrator.ts` | `proposeNextTask`, `commitNextTaskProposal` (real seeding path) |
+| `intake-to-internalization-bridge.ts` | `computeBridgeDecision`, `ROUTE_CHANNEL_MAP`, `MVP_ENABLED_CHANNELS` |
+| `internalization-route.ts` | `decideInternalizationRoute` (recommendation kind → route) |
+| `peer-runner-contracts.ts` | `PEER_RUNNER_KINDS`, `InternalizationChannel` type |
+| `queue-actionability.ts` | `MVP_CORE_TASK_KINDS` |
+| `internalization-consumer-decision.ts` | `DEFAULT_CONSUMER_RUNNER_KINDS` |
+| `pd-config-defaults.ts` | `DEFAULT_AGENT_ENABLED` |
+| `feature-flag-contract.ts` | `DEFAULT_FEATURE_FLAGS` |
+| `internalization-auto-consumer-service.ts` (plugin) | Auto-consumer: only calls `wakeOnce('dreamer')` |
+| `runtime-internalization-run-once.ts` (pd-cli) | CLI: accepts `--runner`, does NOT check config enabled |
+
+## Config Defaults Relied On
+
+### `DEFAULT_AGENT_ENABLED` (pd-config-defaults.ts)
+
+| Agent | enabled | Classification |
+|-------|---------|----------------|
+| diagnostician | true | Core (pre-pipeline) |
+| dreamer | true | **Core** |
+| philosopher | false | **Quiet** |
+| scribe | true | **Core** |
+| artificer | true | **Core** |
+| evaluator | false | **Quiet** |
+| rolloutReviewer | false | **Quiet** |
+| correctionObserver | false | Quiet (observer, not peer runner) |
+| empathyObserver | false | Quiet (observer, not peer runner) |
+
+### Feature flags (feature-flag-contract.ts)
+
+| Flag | category | enabled | Effect |
+|------|----------|---------|--------|
+| `internalization_auto_consumer` | quiet | true | Auto-consumer runs dreamer tasks every 120s |
+| `code_rule_capability` | core | true | RuleHost pipeline (artificer↔evaluator) for code_tool_hook |
+| `l2_dreamer` | quiet | false | L2 agent loop for dreamer (off by default) |
+| `internalization_core_grounding` | quiet | true | Core principle grounding in dreamer/philosopher/scribe prompts |
+
+### `MVP_ENABLED_CHANNELS` (intake-to-internalization-bridge.ts)
+
+```
+Set { 'prompt', 'code_tool_hook', 'defer_archive' }
+```
+
+### `MVP_CORE_TASK_KINDS` (queue-actionability.ts)
+
+```
+['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator']
+```
+
+`rollout_reviewer` is **excluded** — not operator-actionable in MVP.
+
+### `DEFAULT_CONSUMER_RUNNER_KINDS` (internalization-consumer-decision.ts)
+
+```
+['dreamer']
+```
+
+The auto-consumer only picks up dreamer tasks.
+
+## Route → Channel Mapping
+
+| Recommendation kind | Route | Channel | MVP-enabled? |
+|---------------------|-------|---------|--------------|
+| `principle` | `principle-ledger` | `prompt` | Yes |
+| `rule` | `rule-candidate` | `code_tool_hook` | Yes |
+| `implementation` | `implementation-candidate` | `skill` | **No** (rejected at bridge) |
+| `prompt` | `prompt-injection-candidate` | `prompt` | Yes |
+| `defer` | `deferred` | — | **No** (returns `not_internalizable`) |
+
+**Critical finding**: `defer_archive` is in `MVP_ENABLED_CHANNELS` but **no route
+maps to it**. The `ROUTE_CHANNEL_MAP` has no `defer_archive` entry. `defer`
+recommendations return `not_internalizable` at the intake bridge. The
+`defer_archive` channel is an **activation** channel (how an approved principle
+is applied), not an **internalization** channel (how a principle is generated
+through the peer runner chain).
+
+## ALLOWED_EDGES (Job Graph Topology)
+
+```
+dreamer → philosopher → scribe → artificer → evaluator → rollout_reviewer
+```
+
+`validateEdge(from, to, _channel)` — the `_channel` parameter is **unused**.
+All edges are valid for all channels. The job graph does NOT filter by channel.
+
+## Live Runner Chain Per Channel
+
+### Channel: `prompt` (principle-ledger route)
+
+| Step | Runner | Fires by default? | Skip mechanism |
+|------|--------|-------------------|----------------|
+| 1 | dreamer | **Yes** | Auto-consumer calls `wakeOnce('dreamer')` every 120s |
+| 2 | philosopher | **No** | Auto-consumer only runs dreamer; config `philosopher.enabled=false` (not enforced in execution path, but reflects intent) |
+| 3 | scribe | **No** (auto) | Auto-consumer only runs dreamer; config `scribe.enabled=true` but no auto-dispatch |
+| 4 | artificer | **No** (auto) | Auto-consumer only runs dreamer; config `artificer.enabled=true` but no auto-dispatch |
+| 5 | evaluator | **No** | Auto-consumer only runs dreamer; config `evaluator.enabled=false` |
+| 6 | rollout_reviewer | **No** | Auto-consumer only runs dreamer; config `rolloutReviewer.enabled=false`; excluded from `MVP_CORE_TASK_KINDS` |
+
+**Actual live chain (default config)**: dreamer only (auto-consumer).
+After dreamer succeeds, `commitNextTaskProposal` creates a philosopher successor
+task in `pending` state, but no worker picks it up automatically.
+
+**Manual path**: operator can run `pd runtime internalization run-once --runner <kind>`
+to execute any runner. The CLI does NOT check `internalAgents.{name}.enabled`.
+
+### Channel: `code_tool_hook` (rule-candidate route)
+
+| Step | Runner | Fires by default? | Skip mechanism |
+|------|--------|-------------------|----------------|
+| 1 | dreamer | **Yes** | Auto-consumer calls `wakeOnce('dreamer')` every 120s |
+| 2 | philosopher | **No** | Same as prompt channel |
+| 3 | scribe | **No** (auto) | Same as prompt channel |
+| 4 | artificer | **No** (auto) | Same as prompt channel; additionally, `run-rulehost` CLI checks `artificer.enabled` |
+| 5 | evaluator | **No** | Same as prompt channel; additionally, `run-rulehost` CLI checks `evaluator.enabled` |
+| 6 | rollout_reviewer | **No** | Same as prompt channel |
+
+**Actual live chain (default config)**: dreamer only (auto-consumer).
+Same as prompt channel — the auto-consumer does not differentiate by channel.
+
+**RuleHost path**: `pd runtime internalization run-rulehost` runs the
+artificer↔evaluator adversarial loop for code-rule candidates. This CLI DOES
+check `artificer.enabled` and `evaluator.enabled` — if either is false,
+`CodeRuleCapability.enabled=false` with a disabled reason.
+
+### Channel: `defer_archive`
+
+**No runners run.** No route maps to the `defer_archive` internalization channel.
+`defer` recommendations return `not_internalizable` at the intake bridge
+(`computeBridgeDecision`). No dreamer task is seeded.
+
+The `defer_archive` activation channel is a separate concept: it is how an
+already-approved principle is applied (archived/deferred), not how a principle
+is generated through the peer runner chain.
+
+## Core/Quiet Classification Summary
+
+| Runner | Config default | Auto-consumer picks up? | In MVP_CORE_TASK_KINDS? | Classification |
+|--------|---------------|------------------------|------------------------|----------------|
+| dreamer | enabled=true | Yes | Yes | **Core** |
+| philosopher | enabled=false | No | Yes | **Quiet** |
+| scribe | enabled=true | No | Yes | **Core** (config on, but no auto-dispatch) |
+| artificer | enabled=true | No | Yes | **Core** (config on, but no auto-dispatch) |
+| evaluator | enabled=false | No | Yes | **Quiet** |
+| rollout_reviewer | enabled=false | No | No | **Quiet** (also excluded from actionable queue) |
+
+### Key finding: config `enabled` is NOT enforced in the main execution path
+
+The `internalAgents.{name}.enabled` config flag is **not checked** by:
+- `InternalizationOrchestrator.wakeOnce()` — leases any pending task regardless of config
+- `InternalizationOrchestrator.commitNextTaskProposal()` — creates successors regardless of config
+- `pd runtime internalization run-once` CLI — runs any runner specified via `--runner`
+
+The only places `enabled` is checked:
+- `run-rulehost` CLI: checks `artificer.enabled` and `evaluator.enabled` for the code-rule capability
+- `pd-config-loader.ts`: checks `correctionObserver.enabled` and `empathyObserver.enabled` for observer services
+
+The **actual skip mechanism** for non-dreamer runners is that the auto-consumer
+only calls `wakeOnce('dreamer')`. This is a runtime behavior, not a config gate.
+
+## Successor Chain (from real store — verified by pinning test)
+
+When a dreamer task succeeds and `commitNextTaskProposal` is called, the
+successor chain created in the store is:
+
+```
+dreamer (succeeded) → philosopher (pending) → scribe (pending) → artificer (pending) → evaluator (pending) → rollout_reviewer (pending)
+```
+
+Each successor is created with:
+- `taskKind`: the next runner from `getAllowedSuccessors`
+- `channel`: inherited from the parent task
+- `dependencyTaskIds`: `[parentTaskId]`
+- `status`: `pending`
+
+The pinning test (`c2-live-runner-chain.test.ts`) verifies this by:
+1. Seeding a dreamer task through the real intake bridge
+2. Marking it succeeded
+3. Calling `commitNextTaskProposal` iteratively
+4. Reading the actual successor task from the store
+5. Asserting the `taskKind` matches the expected chain
+
+## Implications for C2-P2 (De-surface Quiet runners)
+
+1. **philosopher**: default-off config + not auto-dispatched → safe to de-surface
+2. **evaluator**: default-off config + not auto-dispatched → safe to de-surface
+3. **rollout_reviewer**: default-off + excluded from MVP_CORE_TASK_KINDS → safe to de-surface
+4. **scribe, artificer**: config on but not auto-dispatched → de-surface with care
+   (they are Core by config intent, just not auto-run by the consumer)
+5. **dreamer**: Core, auto-dispatched → do NOT de-surface
+
+The config `enabled` flag is a hint, not a gate. C2-P2 must not rely on it alone
+for de-surfacing — the pinning test is the safety net.

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts
@@ -1,0 +1,368 @@
+/**
+ * C2-P0 Pinning Test: Live MVP Runner Chain (PRI-457)
+ *
+ * Asserts the actual successor task chain created in the real store matches
+ * the documented live runner chain for each MVP activation channel.
+ *
+ * ERR Gate:
+ *   - ERR-004 / ERR-008 / EP-07: successor task kinds are read from the real
+ *     store after commitNextTaskProposal, not inferred from ALLOWED_EDGES.
+ *   - EP-09: uses real InternalizationOrchestrator + RuntimeStateManager (SQLite),
+ *     not a hand-written expected-edge list.
+ *
+ * This test is the regression guard for C2-P2 (de-surface Quiet runners).
+ * If the live chain ever diverges from the documented MVP chain, CI fails.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { RuntimeStateManager } from '../../store/runtime-state-manager.js';
+import { InternalizationOrchestrator } from '../internalization-orchestrator.js';
+import {
+  buildDreamerTaskSeed,
+  computeBridgeDecision,
+  type IntakeToInternalizationBridgeInput,
+} from '../intake-to-internalization-bridge.js';
+import type { InternalizationChannel, PeerRunnerKind } from '../peer-runner-contracts.js';
+
+// ── Test constants ───────────────────────────────────────────────────────────
+
+const OWNER = 'test-c2-p0';
+const RUNTIME_KIND = 'test-double';
+
+/**
+ * The expected live runner chain under default config, per channel.
+ *
+ * This is the ASSERTION target — the test verifies that the real store
+ * contains these successor task kinds after each commitNextTaskProposal call.
+ *
+ * Source: docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md
+ */
+const EXPECTED_CHAIN: PeerRunnerKind[] = [
+  'dreamer',
+  'philosopher',
+  'scribe',
+  'artificer',
+  'evaluator',
+  'rollout_reviewer',
+];
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+/** Options for seeding a dreamer task through the real intake bridge path. */
+interface SeedDreamerOptions {
+  candidateId: string;
+  channel: InternalizationChannel;
+  sourceTaskId?: string;
+}
+
+/**
+ * Seed a dreamer task through the real intake bridge path.
+ *
+ * Uses buildDreamerTaskSeed (the same function the production intake bridge
+ * calls) to generate the diagnosticJson, then creates the task in the real
+ * store. This is the real seeding path — not a hand-built task record.
+ */
+async function seedDreamerTask(
+  stateManager: RuntimeStateManager,
+  options: SeedDreamerOptions,
+): Promise<string> {
+  const { candidateId, channel, sourceTaskId } = options;
+  const bridgeInput: IntakeToInternalizationBridgeInput = {
+    candidateId,
+    recommendationKind: channel === 'code_tool_hook' ? 'rule' : 'principle',
+    route: channel === 'code_tool_hook' ? 'rule-candidate' : 'principle-ledger',
+    ready: true,
+    sourceTaskId,
+    sourceArtifactId: sourceTaskId ? `art-${sourceTaskId}` : undefined,
+    sourceRunId: sourceTaskId ? `run-${sourceTaskId}` : undefined,
+  };
+
+  const seed = buildDreamerTaskSeed(bridgeInput);
+  if ('decision' in seed) {
+    // BridgeDecision has 4 variants; only not_internalizable/invalid_candidate carry reason.
+    const reason = 'reason' in seed ? seed.reason : seed.decision;
+    throw new Error(`Failed to seed dreamer task: ${reason}`);
+  }
+
+  await stateManager.createTask({
+    taskId: seed.taskId,
+    taskKind: seed.taskKind,
+    status: seed.status,
+    attemptCount: seed.attemptCount,
+    maxAttempts: seed.maxAttempts,
+    diagnosticJson: seed.diagnosticJson,
+    inputRef: undefined,
+    resultRef: undefined,
+    lastError: undefined,
+    leaseOwner: undefined,
+    leaseExpiresAt: undefined,
+  });
+
+  return seed.taskId;
+}
+
+/**
+ * Transition a task from pending → leased → succeeded.
+ *
+ * This simulates what the auto-consumer / CLI does when a runner completes
+ * successfully. The orchestrator's commitNextTaskProposal requires the source
+ * task to be in 'succeeded' status.
+ */
+async function simulateTaskSuccess(
+  stateManager: RuntimeStateManager,
+  taskId: string,
+): Promise<void> {
+  await stateManager.acquireLease({
+    taskId,
+    owner: OWNER,
+    runtimeKind: RUNTIME_KIND,
+  });
+  await stateManager.markTaskSucceeded(taskId);
+}
+
+/**
+ * Read the actual successor task from the store after commitNextTaskProposal.
+ *
+ * EP-07 compliance: reads the REAL successor record from the store, not a
+ * hand-written expected value. The assertion compares the actual taskKind
+ * from the store against the expected chain.
+ */
+async function readActualSuccessor(
+  stateManager: RuntimeStateManager,
+  successorTaskId: string,
+): Promise<{ taskId: string; taskKind: string; status: string }> {
+  const task = await stateManager.getTask(successorTaskId);
+  if (!task) {
+    throw new Error(`Successor task ${successorTaskId} not found in store`);
+  }
+  return {
+    taskId: task.taskId,
+    taskKind: task.taskKind,
+    status: task.status,
+  };
+}
+
+/**
+ * Walk the full successor chain from a seeded dreamer task, returning the
+ * actual task kinds observed in the store.
+ *
+ * EP-07: every successor is read from the real store via readActualSuccessor.
+ */
+async function walkFullChain(
+  stateManager: RuntimeStateManager,
+  orchestrator: InternalizationOrchestrator,
+  dreamerTaskId: string,
+): Promise<string[]> {
+  let currentTaskId = dreamerTaskId;
+  const actualChain: string[] = ['dreamer'];
+
+  for (let i = 0; i < EXPECTED_CHAIN.length - 1; i++) {
+    const expectedNextKind = EXPECTED_CHAIN[i + 1];
+    if (!expectedNextKind) {
+      throw new Error(`EXPECTED_CHAIN[${i + 1}] is undefined`);
+    }
+
+    await simulateTaskSuccess(stateManager, currentTaskId);
+    const commitResult = await orchestrator.commitNextTaskProposal(currentTaskId);
+
+    if (commitResult.decision !== 'successor_created') {
+      throw new Error(`Expected successor_created at chain step ${i}, got ${commitResult.decision}`);
+    }
+    expect(commitResult.successorKind).toBe(expectedNextKind);
+
+    const actualSuccessor = await readActualSuccessor(stateManager, commitResult.successorTaskId);
+    expect(actualSuccessor.taskKind).toBe(expectedNextKind);
+    expect(actualSuccessor.status).toBe('pending');
+
+    actualChain.push(actualSuccessor.taskKind);
+    currentTaskId = commitResult.successorTaskId;
+  }
+
+  // Terminal runner has no successor
+  await simulateTaskSuccess(stateManager, currentTaskId);
+  const terminalCommit = await orchestrator.commitNextTaskProposal(currentTaskId);
+  expect(terminalCommit.decision).toBe('no_successor');
+
+  return actualChain;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PRI-457 C2-P0: Live MVP runner chain pinning test', () => {
+  let tmpDir: string;
+  let stateManager: RuntimeStateManager;
+  let orchestrator: InternalizationOrchestrator;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-c2-p0-chain-'));
+    stateManager = new RuntimeStateManager({ workspaceDir: tmpDir });
+    await stateManager.initialize();
+    orchestrator = new InternalizationOrchestrator(
+      { stateManager },
+      { owner: OWNER, runtimeKind: RUNTIME_KIND, dryRun: true },
+    );
+  });
+
+  afterEach(async () => {
+    await stateManager.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Channel: prompt ──────────────────────────────────────────────────────
+
+  it('prompt channel: full successor chain dreamer→philosopher→scribe→artificer→evaluator→rollout_reviewer', async () => {
+    const dreamerTaskId = await seedDreamerTask(stateManager, {
+      candidateId: `cand-prompt-${Date.now()}`,
+      channel: 'prompt',
+    });
+
+    const dreamerTask = await stateManager.getTask(dreamerTaskId);
+    expect(dreamerTask).not.toBeNull();
+    if (!dreamerTask) {
+      throw new Error('Dreamer task not found after seeding');
+    }
+    expect(dreamerTask.taskKind).toBe('dreamer');
+
+    const actualChain = await walkFullChain(stateManager, orchestrator, dreamerTaskId);
+    expect(actualChain).toEqual(EXPECTED_CHAIN);
+  });
+
+  // ── Channel: code_tool_hook ──────────────────────────────────────────────
+
+  it('code_tool_hook channel: full successor chain dreamer→philosopher→scribe→artificer→evaluator→rollout_reviewer', async () => {
+    const dreamerTaskId = await seedDreamerTask(stateManager, {
+      candidateId: `cand-hook-${Date.now()}`,
+      channel: 'code_tool_hook',
+    });
+
+    const dreamerTask = await stateManager.getTask(dreamerTaskId);
+    expect(dreamerTask).not.toBeNull();
+    if (!dreamerTask) {
+      throw new Error('Dreamer task not found after seeding');
+    }
+    expect(dreamerTask.taskKind).toBe('dreamer');
+
+    const actualChain = await walkFullChain(stateManager, orchestrator, dreamerTaskId);
+    expect(actualChain).toEqual(EXPECTED_CHAIN);
+  });
+
+  // ── Channel: defer_archive ───────────────────────────────────────────────
+
+  it('defer_archive channel: no route maps to defer_archive — no dreamer task seeded', async () => {
+    // The intake bridge has NO route that maps to the defer_archive channel.
+    // defer recommendations return 'not_internalizable' at computeBridgeDecision.
+    const bridgeInput: IntakeToInternalizationBridgeInput = {
+      candidateId: `cand-defer-${Date.now()}`,
+      recommendationKind: 'defer',
+      route: 'deferred',
+      ready: false,
+    };
+
+    const decision = computeBridgeDecision(bridgeInput);
+    expect(decision.decision).toBe('not_internalizable');
+
+    // No dreamer task is seeded — no runners run for defer_archive
+    // through the internalization pipeline.
+  });
+
+  // ── Cross-channel: successor inherits channel from parent ─────────────────
+
+  it('successor tasks inherit the channel from the parent task', async () => {
+    for (const channel of ['prompt', 'code_tool_hook'] as InternalizationChannel[]) {
+      const dreamerTaskId = await seedDreamerTask(stateManager, {
+        candidateId: `cand-${channel}-inherit-${Date.now()}`,
+        channel,
+      });
+
+      await simulateTaskSuccess(stateManager, dreamerTaskId);
+      const commitResult = await orchestrator.commitNextTaskProposal(dreamerTaskId);
+
+      if (commitResult.decision !== 'successor_created') {
+        throw new Error(`Expected successor_created, got ${commitResult.decision}`);
+      }
+      expect(commitResult.successorKind).toBe('philosopher');
+
+      // Read the actual successor and verify its channel via hydrated metadata
+      const successorTask = await stateManager.getTask(commitResult.successorTaskId);
+      expect(successorTask).not.toBeNull();
+      if (!successorTask) {
+        throw new Error(`Successor task ${commitResult.successorTaskId} not found`);
+      }
+      expect(successorTask.diagnosticJson).toBeDefined();
+
+      // Parse the PI metadata to verify channel inheritance
+      const diagJson = successorTask.diagnosticJson;
+      if (!diagJson) {
+        throw new Error('Successor task diagnosticJson is empty');
+      }
+      const parsed = JSON.parse(diagJson) as Record<string, unknown>;
+      const piMeta = parsed.pi_metadata as Record<string, unknown> | undefined;
+      expect(piMeta).toBeDefined();
+      if (!piMeta) {
+        throw new Error('pi_metadata not found in successor diagnosticJson');
+      }
+      expect(piMeta.channel).toBe(channel);
+    }
+  });
+
+  // ── Edge validation: validateEdge does not filter by channel ──────────────
+
+  it('validateEdge returns true for all peer runner edges regardless of channel', async () => {
+    // This documents that the job graph does NOT filter by channel.
+    // The _channel parameter in validateEdge is unused.
+    // This is a key finding for C2-P2: channel-based runner skipping does NOT
+    // happen at the job graph level.
+    const { validateEdge } = await import('../internalization-job-graph.js');
+
+    const edges: [PeerRunnerKind, PeerRunnerKind][] = [
+      ['dreamer', 'philosopher'],
+      ['philosopher', 'scribe'],
+      ['scribe', 'artificer'],
+      ['artificer', 'evaluator'],
+      ['evaluator', 'rollout_reviewer'],
+    ];
+
+    for (const [from, to] of edges) {
+      expect(validateEdge(from, to, 'prompt')).toBe(true);
+      expect(validateEdge(from, to, 'code_tool_hook')).toBe(true);
+      expect(validateEdge(from, to, 'defer_archive')).toBe(true);
+    }
+  });
+
+  // ── Config defaults: document the DEFAULT_AGENT_ENABLED values ────────────
+
+  it('DEFAULT_AGENT_ENABLED: dreamer+scribe+artificer on; philosopher+evaluator+rolloutReviewer off', async () => {
+    // This pins the config defaults that the trace doc relies on.
+    // If these defaults change, the Core/Quiet classification must be re-evaluated.
+    const { getDefaultInternalAgents } = await import('../../config/pd-config-defaults.js');
+    const agents = getDefaultInternalAgents();
+
+    expect(agents.agents.dreamer.enabled).toBe(true);
+    expect(agents.agents.philosopher.enabled).toBe(false);
+    expect(agents.agents.scribe.enabled).toBe(true);
+    expect(agents.agents.artificer.enabled).toBe(true);
+    expect(agents.agents.evaluator.enabled).toBe(false);
+    expect(agents.agents.rolloutReviewer.enabled).toBe(false);
+  });
+
+  // ── MVP_CORE_TASK_KINDS excludes rollout_reviewer ─────────────────────────
+
+  it('MVP_CORE_TASK_KINDS excludes rollout_reviewer', async () => {
+    const { MVP_CORE_TASK_KINDS } = await import('../queue-actionability.js');
+    expect(MVP_CORE_TASK_KINDS).toContain('dreamer');
+    expect(MVP_CORE_TASK_KINDS).toContain('philosopher');
+    expect(MVP_CORE_TASK_KINDS).toContain('scribe');
+    expect(MVP_CORE_TASK_KINDS).toContain('artificer');
+    expect(MVP_CORE_TASK_KINDS).toContain('evaluator');
+    expect(MVP_CORE_TASK_KINDS).not.toContain('rollout_reviewer');
+  });
+
+  // ── DEFAULT_CONSUMER_RUNNER_KINDS is dreamer-only ────────────────────────
+
+  it('DEFAULT_CONSUMER_RUNNER_KINDS is dreamer-only', async () => {
+    const { DEFAULT_CONSUMER_RUNNER_KINDS } = await import('../internalization-consumer-decision.js');
+    expect(DEFAULT_CONSUMER_RUNNER_KINDS).toEqual(['dreamer']);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts
@@ -253,15 +253,22 @@ describe('PRI-457 C2-P0: Live MVP runner chain pinning test', () => {
   it('defer_archive channel: no route maps to defer_archive — no dreamer task seeded', async () => {
     // The intake bridge has NO route that maps to the defer_archive channel.
     // defer recommendations return 'not_internalizable' at computeBridgeDecision.
+    // Use ready: true so the code reaches the route check (not the !ready early exit).
     const bridgeInput: IntakeToInternalizationBridgeInput = {
       candidateId: `cand-defer-${Date.now()}`,
       recommendationKind: 'defer',
       route: 'deferred',
-      ready: false,
+      ready: true,
     };
 
     const decision = computeBridgeDecision(bridgeInput);
     expect(decision.decision).toBe('not_internalizable');
+    // Verify the rejection is specifically because the route is deferred,
+    // not because of a missing ready flag or unknown route.
+    if (!('reason' in decision)) {
+      throw new Error('Expected not_internalizable decision to have a reason field');
+    }
+    expect(decision.reason).toContain('deferred');
 
     // No dreamer task is seeded — no runners run for defer_archive
     // through the internalization pipeline.
@@ -293,17 +300,27 @@ describe('PRI-457 C2-P0: Live MVP runner chain pinning test', () => {
       expect(successorTask.diagnosticJson).toBeDefined();
 
       // Parse the PI metadata to verify channel inheritance
+      // Runtime Contract #2/#5: no `as` on untrusted data; use typeof + Object.hasOwn
       const diagJson = successorTask.diagnosticJson;
       if (!diagJson) {
         throw new Error('Successor task diagnosticJson is empty');
       }
-      const parsed = JSON.parse(diagJson) as Record<string, unknown>;
-      const piMeta = parsed.pi_metadata as Record<string, unknown> | undefined;
-      expect(piMeta).toBeDefined();
-      if (!piMeta) {
-        throw new Error('pi_metadata not found in successor diagnosticJson');
+      const parsed: unknown = JSON.parse(diagJson);
+      if (typeof parsed !== 'object' || parsed === null) {
+        throw new Error('diagnosticJson is not an object');
       }
-      expect(piMeta.channel).toBe(channel);
+      if (!Object.hasOwn(parsed, 'pi_metadata')) {
+        throw new Error('pi_metadata key not found in successor diagnosticJson');
+      }
+      const piMeta = (parsed as Record<string, unknown>).pi_metadata;
+      if (typeof piMeta !== 'object' || piMeta === null) {
+        throw new Error('pi_metadata is not an object');
+      }
+      if (!Object.hasOwn(piMeta, 'channel')) {
+        throw new Error('pi_metadata.channel is missing');
+      }
+      const channelValue = (piMeta as Record<string, unknown>).channel;
+      expect(channelValue).toBe(channel);
     }
   });
 


### PR DESCRIPTION
## PRI-457: C2-P0 — Trace Live MVP Runner Chain Per Activation Channel

### Summary

Read-only spike that traces the actual successor task chain seeded by each MVP activation channel (`prompt`, `code_tool_hook`, `defer_archive`) under default production config, and adds a pinning test as the regression guard for C2-P2.

### Deliverables

1. **Trace document**: `docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md`
   - Channel → ordered runner table
   - Skip mechanism per runner (config `enabled:false` / flag / edge logic)
   - Core/Quiet classification
   - Config defaults the classification depends on

2. **Pinning test**: `packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts`
   - Uses real `InternalizationOrchestrator` + `RuntimeStateManager` (SQLite)
   - Asserts actual successor task kinds read from the store (EP-07 compliant)
   - Uses real seeding path via `buildDreamerTaskSeed` (EP-09 compliant)

### Key Findings

1. **Config `enabled:false` is NOT enforced in the main execution path.** The actual skip mechanism for non-dreamer runners is that `internalization-auto-consumer-service` only calls `wakeOnce('dreamer')`. The `DEFAULT_CONSUMER_RUNNER_KINDS` is `['dreamer']` — no other runner is ever woken by the auto-consumer.

2. **`defer_archive` has NO route mapping** in `ROUTE_CHANNEL_MAP`. It is an activation channel (archive-on-defer), not an internalization channel. `defer` recommendations return `not_internalizable` at `computeBridgeDecision`.

3. **`validateEdge` does NOT filter by channel.** The `_channel` parameter is unused. Channel-based runner skipping does NOT happen at the job graph level.

4. **`MVP_CORE_TASK_KINDS` excludes `rollout_reviewer`** — the terminal runner is not in the MVP core set.

5. **`DEFAULT_AGENT_ENABLED`**: dreamer=true, philosopher=false, scribe=true, artificer=true, evaluator=false, rolloutReviewer=false. But this config is only checked in `run-rulehost` CLI (for artificer/evaluator) and `pd-config-loader` (for observers) — NOT in the auto-consumer path.

### ERR Checklist

| ERR | Title | How this PR avoids recurrence |
|-----|-------|-------------------------------|
| ERR-004 | Lineage fields must be internally consistent | Successor tasks inherit channel from parent via `diagnosticJson` — verified by cross-channel inheritance test |
| ERR-008 | Lineage and evidence fields must come from the same source | Test reads actual successor records from the store, not inferred from ALLOWED_EDGES |
| EP-07 | Runtime state source alignment | `readActualSuccessor` reads the REAL successor record from the store after `commitNextTaskProposal` |
| EP-09 | Test reality gap | Uses real `InternalizationOrchestrator` + `RuntimeStateManager` (SQLite) + real `buildDreamerTaskSeed` seeding path, not a hand-written expected-edge list |

### Iron Rule Compliance

No runner code, `ALLOWED_EDGES`, `PEER_RUNNER_KINDS`, barrel exports, or config defaults were modified. This is a read-only spike + test addition.

### Tests Run

- `cd packages/principles-core && npm run build` — green
- `cd packages/principles-core && npm run test` — 234 passed, 4 skipped (5350 tests)
- `npm run lint` — 0 errors, 1 pre-existing warning (unrelated file)

### Remaining Risk

- The pinning test uses `dryRun: true` in the orchestrator options. This means the orchestrator does not execute runners — it only creates successor task proposals. The test verifies the task chain topology, not runner execution. This is intentional for a C2-P0 pinning test.
- The trace document reflects the state as of commit `e933d395`. If config defaults or `ALLOWED_EDGES` change, the doc + test must be updated.

### Linear

Closes PRI-457.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 新增 MVP 激活执行链路的详细文档，说明默认生产配置下 runner 任务的实际执行行为和依赖配置

* **测试**
  * 新增端到端回归测试套件，验证 MVP Runner 链在不同场景下的任务继任逻辑与预期一致

<!-- end of auto-generated comment: release notes by coderabbit.ai -->