### PR TITLE
refactor(bridge): dedup pain-signal-bridge result-shaping into pure function (PRI-456)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/pain-signal-bridge-result-shaping.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-signal-bridge-result-shaping.test.ts
@@ -1,0 +1,483 @@
+/**
+ * PRI-456: Characterization test for PainSignalBridge result-shaping.
+ *
+ * Pins the full PainSignalBridgeResult status matrix for both:
+ * - onDiagnosisComplete() (fresh diagnosis path)
+ * - buildExistingResult() (idempotent existing-task path)
+ *
+ * This test MUST remain green before and after the refactor that extracts
+ * a pure shapeBridgeResult() function. If any assertion changes, it is a
+ * behavior change — STOP.
+ *
+ * ERR gate:
+ * - ERR-007 / EP-02: single source for status decision (test proves both paths)
+ * - ERR-002 / EP-03: every degraded/failed branch keeps its structured message
+ * - ERR-004 / ERR-008 / EP-07: lineage fields come from the same source rows
+ */
+import { describe, it, expect } from 'vitest';
+import { PainSignalBridge } from '../pain-signal-bridge.js';
+import type { PainSignalBridgeResult } from '../pain-signal-bridge.js';
+import type { RuntimeStateManager, CandidateRecord } from '../store/runtime-state-manager.js';
+import type { CandidateIntakeService } from '../candidate-intake-service.js';
+import type { LedgerAdapter, LedgerPrincipleEntry } from '../candidate-intake.js';
+import type { DiagnosticianOutputV1 } from '../diagnostician-output.js';
+import type { PainProvenance } from '../admission-gate.js';
+import type { RunnerResult } from '../runner/runner-result.js';
+
+const PAIN_ID = 'pain-char-001';
+const TASK_ID = 'diagnosis_pain-char-001';
+const RUN_ID = 'run-char-1';
+
+// ── Factory helpers ──────────────────────────────────────────────────────────
+
+function makeCandidate(
+  id: string,
+  kind: CandidateRecord['recommendationKind'],
+  overrides: Partial<CandidateRecord> = {},
+): CandidateRecord {
+  return {
+    candidateId: id,
+    taskId: TASK_ID,
+    artifactId: `artifact-${id}`,
+    sourceRunId: `run-${id}`,
+    title: `Candidate ${id}`,
+    description: `Description for ${id}`,
+    confidence: 0.85,
+    sourceRecommendationJson: '{}',
+    recommendationKind: kind,
+    status: 'pending',
+    createdAt: '2026-06-24T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeLedgerEntry(candidateId: string): LedgerPrincipleEntry {
+  return {
+    id: `ledger-${candidateId}`,
+    status: 'probation',
+    createdAt: '2026-06-24T00:00:00.000Z',
+    text: `Principle text for ${candidateId}`,
+    sourceRef: `candidate://${candidateId}`,
+    title: `Principle ${candidateId}`,
+    evaluability: 'weak_heuristic',
+  };
+}
+
+function makeHighConfidenceOutput(): DiagnosticianOutputV1 {
+  return {
+    valid: true,
+    diagnosisId: 'diag-high',
+    summary: 'Valid diagnosis with sufficient evidence',
+    rootCause: 'Identified root cause from session trace',
+    violatedPrinciples: [],
+    evidence: [{ sourceRef: 'session-trace-1', note: 'Owner confirmed behavior' }],
+    recommendations: [{ kind: 'principle', description: 'Valid principle from evidence' }],
+    confidence: 0.85,
+  };
+}
+
+function makeLowConfidenceOutput(): DiagnosticianOutputV1 {
+  return {
+    valid: true,
+    diagnosisId: 'diag-low',
+    summary: 'Low confidence diagnosis',
+    rootCause: 'Insufficient evidence',
+    violatedPrinciples: [],
+    evidence: [],
+    recommendations: [{ kind: 'principle', description: 'Low confidence principle' }],
+    confidence: 0.3,
+  };
+}
+
+interface MockDeps {
+  stateManager: RuntimeStateManager;
+  intakeService: CandidateIntakeService;
+  ledgerAdapter: LedgerAdapter;
+  runner: { run: (taskId: string) => Promise<RunnerResult> };
+  telemetryEvents: Record<string, unknown>[];
+  createTaskCalls: Record<string, unknown>[];
+  updateCandidateStatusCalls: { candidateId: string; patch: Record<string, unknown> }[];
+}
+
+function makeMockDeps(overrides: {
+  candidates?: CandidateRecord[];
+  output?: DiagnosticianOutputV1;
+  ledgerEntries?: Map<string, LedgerPrincipleEntry>;
+  createTaskFn?: (input: Record<string, unknown>) => Promise<unknown>;
+  getTaskFn?: (taskId: string) => Promise<unknown>;
+  autoIntakeEnabled?: boolean;
+}): MockDeps {
+  const telemetryEvents: Record<string, unknown>[] = [];
+  const createTaskCalls: Record<string, unknown>[] = [];
+  const updateCandidateStatusCalls: { candidateId: string; patch: Record<string, unknown> }[] = [];
+
+  const createTaskMock = async (input: Record<string, unknown>) => {
+    createTaskCalls.push(input);
+    if (overrides.createTaskFn) return overrides.createTaskFn(input);
+    return { taskId: 'mock-task' };
+  };
+
+  const getTaskMock = overrides.getTaskFn ?? (async () => null);
+
+  const updateCandidateStatusMock = async (candidateId: string, patch: Record<string, unknown>) => {
+    updateCandidateStatusCalls.push({ candidateId, patch });
+  };
+
+  const stateManager = {
+    getTask: getTaskMock,
+    createTask: createTaskMock,
+    updateTask: async () => undefined,
+    getCandidatesByTaskId: async () => overrides.candidates ?? [],
+    getRunsByTask: async () => [{ runId: RUN_ID, taskId: TASK_ID, status: 'succeeded' }],
+    updateCandidateStatus: updateCandidateStatusMock,
+  } as unknown as RuntimeStateManager;
+
+  const intakeService = {
+    intake: async (candidateId: string) => ({ id: `ledger-${candidateId}` }),
+  } as unknown as CandidateIntakeService;
+
+  const ledgerEntries = overrides.ledgerEntries ?? new Map<string, LedgerPrincipleEntry>();
+  const ledgerAdapter = {
+    existsForCandidate: (candidateId: string) => ledgerEntries.get(candidateId) ?? null,
+  } as unknown as LedgerAdapter;
+
+  const runner = {
+    run: async (): Promise<RunnerResult> => ({
+      status: 'succeeded',
+      taskId: TASK_ID,
+      attemptCount: 1,
+      output: overrides.output ?? makeHighConfidenceOutput(),
+    }),
+  };
+
+  return {
+    stateManager,
+    intakeService,
+    ledgerAdapter,
+    runner,
+    telemetryEvents,
+    createTaskCalls,
+    updateCandidateStatusCalls,
+  };
+}
+
+function createBridge(deps: MockDeps, autoIntakeEnabled = true): PainSignalBridge {
+  return new PainSignalBridge({
+    stateManager: deps.stateManager,
+    runner: deps.runner,
+    intakeService: deps.intakeService,
+    ledgerAdapter: deps.ledgerAdapter,
+    autoIntakeEnabled,
+    eventEmitter: {
+      emitTelemetry: (event: { eventType: string; traceId: string; timestamp: string; payload: Record<string, unknown> }) => {
+        deps.telemetryEvents.push(event);
+      },
+    },
+  });
+}
+
+// Interface for accessing private buildExistingResult
+interface BridgeWithPrivate {
+  buildExistingResult(input: { painId: string; taskId: string }): Promise<PainSignalBridgeResult>;
+}
+
+const PROVENANCE: PainProvenance = 'openclaw_context_bound';
+
+// ── onDiagnosisComplete() characterization ───────────────────────────────────
+
+describe('PRI-456: onDiagnosisComplete result-shaping characterization', () => {
+  it('succeeded: 1 admitted candidate with ledger entry and successful dreamer seed', async () => {
+    const candidates = [makeCandidate('c1', 'principle')];
+    const deps = makeMockDeps({ candidates, output: makeHighConfidenceOutput() });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeHighConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(result.painId).toBe(PAIN_ID);
+    expect(result.taskId).toBe(TASK_ID);
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.artifactId).toBe('artifact-c1');
+    expect(result.candidateIds).toEqual(['c1']);
+    expect(result.ledgerEntryIds).toEqual(['ledger-c1']);
+    expect(result.admissionResults).toBeDefined();
+    expect(result.admissionResults).toHaveLength(1);
+    expect(result.admissionResults?.[0]?.admission.decision).toBe('admitted');
+    expect(result.message).toBeUndefined();
+  });
+
+  it('succeeded: autoIntakeEnabled=false — no ledger entries needed', async () => {
+    const candidates = [makeCandidate('c1', 'principle')];
+    const deps = makeMockDeps({ candidates, output: makeHighConfidenceOutput() });
+    const bridge = createBridge(deps, false);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeHighConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(result.candidateIds).toEqual(['c1']);
+    expect(result.ledgerEntryIds).toEqual([]);
+    expect(result.admissionResults).toBeDefined();
+    expect(result.admissionResults?.[0]?.admission.decision).toBe('admitted');
+    expect(result.message).toBeUndefined();
+  });
+
+  it('failed: no candidates — "Diagnostician succeeded but produced no principle candidates"', async () => {
+    const deps = makeMockDeps({ candidates: [], output: makeHighConfidenceOutput() });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeHighConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.painId).toBe(PAIN_ID);
+    expect(result.taskId).toBe(TASK_ID);
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.artifactId).toBeUndefined();
+    expect(result.candidateIds).toEqual([]);
+    expect(result.ledgerEntryIds).toEqual([]);
+    expect(result.admissionResults).toEqual([]);
+    expect(result.message).toBe('Diagnostician succeeded but produced no principle candidates');
+  });
+
+  it('degraded: all_candidates_gated — 1 candidate, low confidence, not admitted', async () => {
+    const candidates = [makeCandidate('c-gated', 'principle')];
+    const deps = makeMockDeps({ candidates, output: makeLowConfidenceOutput() });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeLowConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('degraded');
+    expect(result.candidateIds).toEqual(['c-gated']);
+    expect(result.ledgerEntryIds).toEqual([]);
+    expect(result.admissionResults).toBeDefined();
+    expect(result.admissionResults?.[0]?.admission.decision).toBe('needs_evidence');
+    expect(result.message).toContain('all_candidates_gated');
+    expect(result.message).toContain('c-gated=needs_evidence');
+  });
+
+  it('degraded: partial_admission — 2 candidates, 1 admitted, 1 deferred', async () => {
+    // To get partial admission, one candidate must be admitted (principle, high confidence)
+    // and one must be non-admitted (defer kind → always deferred regardless of confidence).
+    const candidatesPartial = [
+      makeCandidate('c-ok', 'principle'),
+      makeCandidate('c-defer', 'defer'),
+    ];
+    const deps = makeMockDeps({ candidates: candidatesPartial, output: makeHighConfidenceOutput() });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeHighConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('degraded');
+    expect(result.candidateIds).toEqual(['c-ok', 'c-defer']);
+    expect(result.ledgerEntryIds).toEqual(['ledger-c-ok']);
+    expect(result.admissionResults).toBeDefined();
+    expect(result.admissionResults).toHaveLength(2);
+    const admitted = result.admissionResults?.find((a) => a.candidateId === 'c-ok');
+    expect(admitted?.admission.decision).toBe('admitted');
+    const deferred = result.admissionResults?.find((a) => a.candidateId === 'c-defer');
+    expect(deferred?.admission.decision).toBe('deferred');
+    expect(result.message).toContain('partial_admission');
+    expect(result.message).toContain('1_admitted_1_gated');
+  });
+
+  it('degraded: dreamer_seed_failed — admitted candidate, ledger created, dreamer seed throws', async () => {
+    const candidates = [makeCandidate('c-fail', 'principle')];
+    const deps = makeMockDeps({
+      candidates,
+      output: makeHighConfidenceOutput(),
+      createTaskFn: async (input: Record<string, unknown>) => {
+        if (input.taskKind === 'dreamer') throw new Error('DB write failed');
+        return { taskId: input.taskId ?? 'mock-task' };
+      },
+    });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeHighConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('degraded');
+    expect(result.candidateIds).toEqual(['c-fail']);
+    expect(result.ledgerEntryIds).toEqual(['ledger-c-fail']);
+    expect(result.message).toContain('dreamer_seed_failed:c-fail');
+    // The candidate should still be consumed despite seed failure
+    const consumedCall = deps.updateCandidateStatusCalls.find((c) => c.candidateId === 'c-fail');
+    expect(consumedCall).toBeDefined();
+    expect(consumedCall?.patch).toEqual({ status: 'consumed' });
+  });
+
+  it('degraded: all_candidates_gated with seed failure note appended', async () => {
+    // When all candidates are gated AND a seed failure occurs (shouldn't normally happen
+    // since seed only runs for admitted candidates, but test the message format)
+    const candidates = [makeCandidate('c-gated', 'principle')];
+    const deps = makeMockDeps({
+      candidates,
+      output: makeLowConfidenceOutput(),
+    });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: makeLowConfidenceOutput(),
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    // All gated → degraded, no seed failure (no admitted candidates to seed)
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('all_candidates_gated');
+    expect(result.message).not.toContain('dreamer_seed_failed');
+  });
+
+  it('diagnosticianOutput=undefined: all candidates get needs_evidence → all_candidates_gated', async () => {
+    const candidates = [makeCandidate('c-undef', 'principle')];
+    const deps = makeMockDeps({ candidates });
+    const bridge = createBridge(deps);
+
+    const result = await bridge.onDiagnosisComplete({
+      taskId: TASK_ID,
+      diagnosticianOutput: undefined,
+      painId: PAIN_ID,
+      provenance: PROVENANCE,
+      inputEvidenceCount: 1,
+    });
+
+    expect(result.status).toBe('degraded');
+    expect(result.admissionResults).toBeDefined();
+    expect(result.admissionResults?.[0]?.admission.decision).toBe('needs_evidence');
+    expect(result.admissionResults?.[0]?.admission.reason).toBe('diagnostician_output_unavailable');
+    expect(result.message).toContain('all_candidates_gated');
+  });
+});
+
+// ── buildExistingResult() characterization ───────────────────────────────────
+
+describe('PRI-456: buildExistingResult result-shaping characterization', () => {
+  it('succeeded: existing task with candidates and ledger entries', async () => {
+    const candidates = [makeCandidate('c1', 'principle')];
+    const ledgerEntries = new Map<string, LedgerPrincipleEntry>([['c1', makeLedgerEntry('c1')]]);
+    const deps = makeMockDeps({ candidates, ledgerEntries });
+    const bridge = createBridge(deps);
+
+    const result = await (bridge as unknown as BridgeWithPrivate).buildExistingResult({
+      painId: PAIN_ID,
+      taskId: TASK_ID,
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(result.painId).toBe(PAIN_ID);
+    expect(result.taskId).toBe(TASK_ID);
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.artifactId).toBe('artifact-c1');
+    expect(result.candidateIds).toEqual(['c1']);
+    expect(result.ledgerEntryIds).toEqual(['ledger-c1']);
+    expect(result.message).toBe('Task already succeeded');
+  });
+
+  it('succeeded: autoIntakeEnabled=false — no ledger entries needed', async () => {
+    const candidates = [makeCandidate('c1', 'principle')];
+    const deps = makeMockDeps({ candidates, ledgerEntries: new Map() });
+    const bridge = createBridge(deps, false);
+
+    const result = await (bridge as unknown as BridgeWithPrivate).buildExistingResult({
+      painId: PAIN_ID,
+      taskId: TASK_ID,
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(result.candidateIds).toEqual(['c1']);
+    expect(result.ledgerEntryIds).toEqual([]);
+    expect(result.message).toBe('Task already succeeded');
+  });
+
+  it('failed: no candidates — "Task has no principle candidates — treating as failed"', async () => {
+    const deps = makeMockDeps({ candidates: [], ledgerEntries: new Map() });
+    const bridge = createBridge(deps);
+
+    const result = await (bridge as unknown as BridgeWithPrivate).buildExistingResult({
+      painId: PAIN_ID,
+      taskId: TASK_ID,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.painId).toBe(PAIN_ID);
+    expect(result.taskId).toBe(TASK_ID);
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.artifactId).toBeUndefined();
+    expect(result.candidateIds).toEqual([]);
+    expect(result.ledgerEntryIds).toEqual([]);
+    expect(result.message).toBe('Task has no principle candidates — treating as failed');
+  });
+
+  it('failed: no ledger entries with autoIntakeEnabled=true', async () => {
+    const candidates = [makeCandidate('c1', 'principle')];
+    const deps = makeMockDeps({ candidates, ledgerEntries: new Map() });
+    const bridge = createBridge(deps);
+
+    const result = await (bridge as unknown as BridgeWithPrivate).buildExistingResult({
+      painId: PAIN_ID,
+      taskId: TASK_ID,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.runId).toBe(RUN_ID);
+    expect(result.artifactId).toBe('artifact-c1');
+    expect(result.candidateIds).toEqual(['c1']);
+    expect(result.ledgerEntryIds).toEqual([]);
+    expect(result.message).toBe('Candidate intake did not produce a ledger entry — treating as failed');
+  });
+
+  it('multiple candidates with mixed ledger existence — only existing ledgers counted', async () => {
+    const candidates = [
+      makeCandidate('c1', 'principle'),
+      makeCandidate('c2', 'principle'),
+    ];
+    const ledgerEntries = new Map<string, LedgerPrincipleEntry>([['c1', makeLedgerEntry('c1')]]);
+    const deps = makeMockDeps({ candidates, ledgerEntries });
+    const bridge = createBridge(deps);
+
+    const result = await (bridge as unknown as BridgeWithPrivate).buildExistingResult({
+      painId: PAIN_ID,
+      taskId: TASK_ID,
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(result.candidateIds).toEqual(['c1', 'c2']);
+    expect(result.ledgerEntryIds).toEqual(['ledger-c1']);
+    expect(result.message).toBe('Task already succeeded');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/bridge-result-shaper.ts
+++ b/packages/principles-core/src/runtime-v2/bridge-result-shaper.ts
@@ -1,0 +1,174 @@
+/**
+ * PRI-456: Pure result-shaping function for PainSignalBridge.
+ *
+ * Extracts the duplicated status-decision tree from:
+ * - PainSignalBridge.onDiagnosisComplete() (fresh diagnosis path)
+ * - PainSignalBridge.buildExistingResult() (idempotent existing-task path)
+ *
+ * Both paths decide: no candidates → failed; admitted-but-no-ledger → failed;
+ * gated/partial → degraded; otherwise succeeded. But they differ in message
+ * strings and the fresh path has admission results + degraded states.
+ *
+ * This function is pure: zero I/O, zero side effects. Callers pass all
+ * computed values; the function never re-derives lineage fields.
+ *
+ * ERR gate:
+ * - ERR-007 / EP-02: single source for status decision — branches can't diverge
+ * - ERR-002 / EP-03: every degraded/failed branch keeps its structured message
+ * - ERR-004 / ERR-008 / EP-07: lineage fields are received, never re-derived
+ */
+import type { PainSignalBridgeResult } from './pain-signal-bridge.js';
+import type { CandidateAdmissionResult } from './admission-gate.js';
+
+/** Base fields shared by both fresh and existing paths. */
+interface ShapeBridgeResultBase {
+  painId: string;
+  taskId: string;
+  candidateIds: string[];
+  ledgerEntryIds: string[];
+  runId?: string;
+  artifactId?: string;
+  autoIntakeEnabled: boolean;
+}
+
+/** Fresh diagnosis path — has admission results and seed failure notes. */
+export interface ShapeBridgeResultFreshInput extends ShapeBridgeResultBase {
+  path: 'fresh';
+  admissionResults: CandidateAdmissionResult[];
+  /** Non-empty string when dreamer seed failed; empty string otherwise. */
+  seedFailureNote: string;
+}
+
+/** Existing-task idempotent path — ledger-existence-derived, no admissions. */
+export interface ShapeBridgeResultExistingInput extends ShapeBridgeResultBase {
+  path: 'existing';
+}
+
+export type ShapeBridgeResultInput =
+  | ShapeBridgeResultFreshInput
+  | ShapeBridgeResultExistingInput;
+
+/**
+ * Derive the final PainSignalBridgeResult from computed inputs.
+ *
+ * Byte-for-byte identical to the original inline logic in both call sites.
+ * The `path` discriminator selects the appropriate message strings and
+ * decision branches.
+ */
+export function shapeBridgeResult(input: ShapeBridgeResultInput): PainSignalBridgeResult {
+  const { painId, taskId, candidateIds, ledgerEntryIds, runId, artifactId, autoIntakeEnabled } = input;
+
+  // Common: no candidates → failed (message differs by path)
+  if (candidateIds.length === 0) {
+    if (input.path === 'fresh') {
+      return {
+        status: 'failed',
+        painId,
+        taskId,
+        runId,
+        candidateIds,
+        ledgerEntryIds,
+        admissionResults: input.admissionResults,
+        message: 'Diagnostician succeeded but produced no principle candidates',
+      };
+    }
+    return {
+      status: 'failed',
+      painId,
+      taskId,
+      runId,
+      candidateIds,
+      ledgerEntryIds,
+      message: 'Task has no principle candidates — treating as failed',
+    };
+  }
+
+  if (input.path === 'fresh') {
+    const { admissionResults, seedFailureNote } = input;
+    const admittedCount = admissionResults.filter((a) => a.admission.decision === 'admitted').length;
+    const nonAdmittedCount = admissionResults.length - admittedCount;
+
+    // Admitted candidates exist but intake produced no ledger entries
+    if (autoIntakeEnabled && admittedCount > 0 && ledgerEntryIds.length === 0) {
+      return {
+        status: 'failed',
+        painId,
+        taskId,
+        runId,
+        artifactId,
+        candidateIds,
+        ledgerEntryIds,
+        admissionResults,
+        message: 'Candidate intake did not produce a ledger entry',
+      };
+    }
+
+    // All candidates gated (none admitted)
+    if (nonAdmittedCount > 0 && admittedCount === 0) {
+      return {
+        status: 'degraded',
+        painId,
+        taskId,
+        runId,
+        artifactId,
+        candidateIds,
+        ledgerEntryIds,
+        admissionResults,
+        message: `all_candidates_gated:${admissionResults.map((a) => `${a.candidateId}=${a.admission.decision}`).join(',')}${seedFailureNote ? `; ${seedFailureNote}` : ''}`,
+      };
+    }
+
+    // Partial admission (some admitted, some gated)
+    if (nonAdmittedCount > 0 && admittedCount > 0) {
+      return {
+        status: 'degraded',
+        painId,
+        taskId,
+        runId,
+        artifactId,
+        candidateIds,
+        ledgerEntryIds,
+        admissionResults,
+        message: `partial_admission:${admittedCount}_admitted_${nonAdmittedCount}_gated${seedFailureNote ? `; ${seedFailureNote}` : ''}`,
+      };
+    }
+
+    // Success (or degraded if seed failure occurred)
+    return {
+      status: seedFailureNote ? 'degraded' : 'succeeded',
+      painId,
+      taskId,
+      runId,
+      artifactId,
+      candidateIds,
+      ledgerEntryIds,
+      admissionResults,
+      message: seedFailureNote || undefined,
+    };
+  }
+
+  // Existing path: no admission results, simpler decision tree
+  if (autoIntakeEnabled && ledgerEntryIds.length === 0) {
+    return {
+      status: 'failed',
+      painId,
+      taskId,
+      runId,
+      artifactId,
+      candidateIds,
+      ledgerEntryIds,
+      message: 'Candidate intake did not produce a ledger entry — treating as failed',
+    };
+  }
+
+  return {
+    status: 'succeeded',
+    painId,
+    taskId,
+    runId,
+    artifactId,
+    candidateIds,
+    ledgerEntryIds,
+    message: 'Task already succeeded',
+  };
+}

--- a/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-bridge.ts
@@ -8,6 +8,7 @@ import type { DiagnosticianOutputV1 } from './diagnostician-output.js';
 import { evaluateCandidateAdmissions } from './admission-gate.js';
 import { shouldShortCircuitEmptyEvidence } from './evidence-guards.js';
 import { buildDreamerSeedFromCandidate, ROUTE_CHANNEL_MAP, MVP_ENABLED_CHANNELS, CANDIDATE_KIND_TO_ROUTE } from './internalization/intake-to-internalization-bridge.js';
+import { shapeBridgeResult } from './bridge-result-shaper.js';
 
 export type { PainProvenance };
 
@@ -361,75 +362,18 @@ export class PainSignalBridge {
     const firstCandidate = candidates.at(0);
 
     const candidateIds = candidates.map((candidate) => candidate.candidateId);
-    if (candidateIds.length === 0) {
-      return {
-        status: 'failed',
-        painId,
-        taskId,
-        runId: latestRun?.runId,
-        candidateIds,
-        ledgerEntryIds,
-        admissionResults,
-        message: 'Diagnostician succeeded but produced no principle candidates',
-      };
-    }
-
-    const admittedCount = admissionResults.filter((a) => a.admission.decision === 'admitted').length;
-    const nonAdmittedCount = admissionResults.length - admittedCount;
-
-    if (this.autoIntakeEnabled && admittedCount > 0 && ledgerEntryIds.length === 0) {
-      return {
-        status: 'failed',
-        painId,
-        taskId,
-        runId: latestRun?.runId,
-        artifactId: firstCandidate?.artifactId,
-        candidateIds,
-        ledgerEntryIds,
-        admissionResults,
-        message: 'Candidate intake did not produce a ledger entry',
-      };
-    }
-
-    if (nonAdmittedCount > 0 && admittedCount === 0) {
-      return {
-        status: 'degraded',
-        painId,
-        taskId,
-        runId: latestRun?.runId,
-        artifactId: firstCandidate?.artifactId,
-        candidateIds,
-        ledgerEntryIds,
-        admissionResults,
-        message: `all_candidates_gated:${admissionResults.map((a) => `${a.candidateId}=${a.admission.decision}`).join(',')}${seedFailureNote ? `; ${seedFailureNote}` : ''}`,
-      };
-    }
-
-    if (nonAdmittedCount > 0 && admittedCount > 0) {
-      return {
-        status: 'degraded',
-        painId,
-        taskId,
-        runId: latestRun?.runId,
-        artifactId: firstCandidate?.artifactId,
-        candidateIds,
-        ledgerEntryIds,
-        admissionResults,
-        message: `partial_admission:${admittedCount}_admitted_${nonAdmittedCount}_gated${seedFailureNote ? `; ${seedFailureNote}` : ''}`,
-      };
-    }
-
-    return {
-      status: seedFailureNote ? 'degraded' : 'succeeded',
+    return shapeBridgeResult({
+      path: 'fresh',
       painId,
       taskId,
-      runId: latestRun?.runId,
-      artifactId: firstCandidate?.artifactId,
       candidateIds,
       ledgerEntryIds,
+      runId: latestRun?.runId,
+      artifactId: firstCandidate?.artifactId,
+      autoIntakeEnabled: this.autoIntakeEnabled,
       admissionResults,
-      message: seedFailureNote || undefined,
-    };
+      seedFailureNote,
+    });
   }
 
   private async buildExistingResult(input: { painId: string; taskId: string }): Promise<PainSignalBridgeResult> {
@@ -440,18 +384,6 @@ export class PainSignalBridge {
     const firstCandidate = candidates.at(0);
     const ledgerEntryIds: string[] = [];
 
-    if (candidateIds.length === 0) {
-      return {
-        status: 'failed',
-        painId: input.painId,
-        taskId: input.taskId,
-        runId: latestRun?.runId,
-        candidateIds: [],
-        ledgerEntryIds: [],
-        message: 'Task has no principle candidates — treating as failed',
-      };
-    }
-
     if (this.autoIntakeEnabled) {
       for (const candidate of candidates) {
         const ledgerEntry = this.ledgerAdapter.existsForCandidate(candidate.candidateId);
@@ -460,29 +392,17 @@ export class PainSignalBridge {
           await this.stateManager.updateCandidateStatus(candidate.candidateId, { status: 'consumed' });
         }
       }
-      if (ledgerEntryIds.length === 0) {
-        return {
-          status: 'failed',
-          painId: input.painId,
-          taskId: input.taskId,
-          runId: latestRun?.runId,
-          artifactId: firstCandidate?.artifactId,
-          candidateIds,
-          ledgerEntryIds: [],
-          message: 'Candidate intake did not produce a ledger entry — treating as failed',
-        };
-      }
     }
 
-    return {
-      status: 'succeeded',
+    return shapeBridgeResult({
+      path: 'existing',
       painId: input.painId,
       taskId: input.taskId,
-      runId: latestRun?.runId,
-      artifactId: firstCandidate?.artifactId,
       candidateIds,
       ledgerEntryIds,
-      message: 'Task already succeeded',
-    };
+      runId: latestRun?.runId,
+      artifactId: firstCandidate?.artifactId,
+      autoIntakeEnabled: this.autoIntakeEnabled,
+    });
   }
 }


### PR DESCRIPTION
## PRI-456: Dedup pain-signal-bridge result-shaping into one pure function

**Theme**: MVP-First complexity reduction (ADR-0014). Behavior-preserving refactor of the pain→principle bridge. No new feature, no MVP-Core behavior change.

### Problem

`pain-signal-bridge.ts` derived the final `PainSignalBridgeResult` status in **two** places that independently re-implemented the same decision tree:

- `onDiagnosisComplete()` (fresh diagnosis path)
- `buildExistingResult()` (idempotent "task already succeeded" path)

A fix to one branch silently missed the other (ERR-007/EP-02 class).

### Solution

Extracted a single pure function `shapeBridgeResult(input)` in [bridge-result-shaper.ts](packages/principles-core/src/runtime-v2/bridge-result-shaper.ts). Discriminated union input: `path='fresh'` (with admissionResults + seedFailureNote) vs `path='existing'` (ledger-existence-derived). Zero I/O, zero behavior change.

### Changes

| File | Change |
|------|--------|
| `bridge-result-shaper.ts` | **New** — pure function with discriminated union input |
| `pain-signal-bridge.ts` | `onDiagnosisComplete()` and `buildExistingResult()` call `shapeBridgeResult()` instead of inline decision trees (-94 lines, +14 lines) |
| `pain-signal-bridge-result-shaping.test.ts` | **New** — 13 characterization tests pinning full status matrix |

### ERR Gate

- **ERR-007 / EP-02 (Production Path Wiring)**: Single source for status decision — branches can't diverge. Both call sites use the same pure function.
- **ERR-002 / EP-03 (Fail Loud and Observable Degradation)**: Every `degraded`/`failed` branch keeps its structured `message`/reason; no silent collapse of a reason string.
- **ERR-004 / ERR-008 / EP-07 (Runtime State Source Alignment)**: Lineage fields (`painId`, `taskId`, `artifactId`, `runId`) are received as parameters, never re-derived by the helper.

### Safety Harness

1. **Characterization test FIRST**: 13 tests pinning the full status matrix committed and green BEFORE the refactor commit.
2. **Strangler steps**: Extract helper → switch call site 1 (onDiagnosisComplete) → green → switch call site 2 (buildExistingResult) → green.
3. **No flag needed** (pure, behavior-preserving) — diff does not alter any returned field.

### Tests Run

- `cd packages/principles-core && npm run build` — green
- `cd packages/principles-core && npm run test` — 5363 passed, 3 skipped, 3 todo
- `cd packages/principles-core && npm run lint` — green (0 errors in changed files)
- Architecture-regression test — 484 passed
- `npm run verify:merge` (pre-push hook) — green

### Iron Rules Verified

- Only `pain-signal-bridge.ts` modified (onDiagnosisComplete + buildExistingResult result shaping)
- No changes to PainToPrincipleService, createPainSignalBridge, asyncMode, bridge cache
- No changes to PainSignalBridgeResult fields or any returned value
- No changes to barrel exports, ALLOWED_EDGES, PEER_RUNNER_KINDS, or config defaults

### Remaining Risk

None. Pure refactor with characterization test proving byte-for-byte identical behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **重构**
  * 优化内部结果处理逻辑，统一诊断完成和既有任务的结果组装流程，提升代码可维护性。
  * 增强测试覆盖，确保结果状态矩阵和字段填充在多场景下的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->