### PR TITLE
refactor(pri-458): de-surface MVP-Quiet peer runners from internal barrel

### DIFF
--- a/docs/architecture/COMPONENTS.md
+++ b/docs/architecture/COMPONENTS.md
@@ -153,7 +153,7 @@ PD 系统有 5 类组件：
 | `ScribeRunner` | 🟢 Runner | core | `runtime-v2/internalization/scribe-runner.ts` | PhilosopherOutput | PIArtifact(principle) | ✅ MVP-Core |
 | `ArtificerRunner` | 🟢 Runner | core | `runtime-v2/internalization/artificer-runner.ts` | ScribeOutput | PIArtifact(rule) | ✅ MVP-Core |
 | `EvaluatorRunner` | 🟡 Runner | core | `runtime-v2/internalization/evaluator-runner.ts` | ArtificerOutput | PIArtifact(rule) | ✅ MVP-Quiet (default off; MVP-Core for RuleHost per ADR-0014 amendment) |
-| `RolloutReviewerRunner` | 🟡 Runner | core | `runtime-v2/internalization/rollout-reviewer-runner.ts` | EvaluatorOutput | PIArtifact(rule) + 触发 ActivationDispatcher | ⚠️ MVP-Quiet (default off) |
+| `RolloutReviewerRunner` | 🟡 Runner | core | `runtime-v2/internalization/rollout-reviewer-runner.ts` | EvaluatorOutput | PIArtifact(rule) + 触发 ActivationDispatcher | ✅ MVP-Quiet (default off) |
 | `TrainerRunner` | 🟢 Runner | core | `runtime-v2/internalization/trainer-runner.ts` | RolloutReviewerOutput | PIArtifact(training_data) | Deferred |
 
 #### 3.2.3 Runner 输出 Validator（每 Runner 一个）

--- a/docs/architecture/COMPONENTS.md
+++ b/docs/architecture/COMPONENTS.md
@@ -148,13 +148,13 @@ PD 系统有 5 类组件：
 
 | Runner | 类型 | 包 | 文件 | 输入工件 | 输出工件 | 状态 |
 |--------|-----|----|----|---------|---------|------|
-| `DreamerRunner` | 🟢 Runner | core | `runtime-v2/internalization/dreamer-runner.ts` | LedgerPrincipleEntry | PIArtifact(principle) | ✅ |
-| `PhilosopherRunner` | 🟢 Runner | core | `runtime-v2/internalization/philosopher-runner.ts` | DreamerOutput | PIArtifact(principle) | ✅ |
-| `ScribeRunner` | 🟢 Runner | core | `runtime-v2/internalization/scribe-runner.ts` | PhilosopherOutput | PIArtifact(principle) | ✅ |
-| `ArtificerRunner` | 🟢 Runner | core | `runtime-v2/internalization/artificer-runner.ts` | ScribeOutput | PIArtifact(rule) | ✅ |
-| `EvaluatorRunner` | 🟢 Runner | core | `runtime-v2/internalization/evaluator-runner.ts` | ArtificerOutput | PIArtifact(rule) | ✅ |
-| `RolloutReviewerRunner` | 🟢 Runner | core | `runtime-v2/internalization/rollout-reviewer-runner.ts` | EvaluatorOutput | PIArtifact(rule) + 触发 ActivationDispatcher | ⚠️ 需扩展 |
-| `TrainerRunner` | 🟢 Runner | core | `runtime-v2/internalization/trainer-runner.ts` | RolloutReviewerOutput | PIArtifact(training_data) | ✅ |
+| `DreamerRunner` | 🟢 Runner | core | `runtime-v2/internalization/dreamer-runner.ts` | LedgerPrincipleEntry | PIArtifact(principle) | ✅ MVP-Core |
+| `PhilosopherRunner` | 🟡 Runner | core | `runtime-v2/internalization/philosopher-runner.ts` | DreamerOutput | PIArtifact(principle) | ✅ MVP-Quiet (default off) |
+| `ScribeRunner` | 🟢 Runner | core | `runtime-v2/internalization/scribe-runner.ts` | PhilosopherOutput | PIArtifact(principle) | ✅ MVP-Core |
+| `ArtificerRunner` | 🟢 Runner | core | `runtime-v2/internalization/artificer-runner.ts` | ScribeOutput | PIArtifact(rule) | ✅ MVP-Core |
+| `EvaluatorRunner` | 🟡 Runner | core | `runtime-v2/internalization/evaluator-runner.ts` | ArtificerOutput | PIArtifact(rule) | ✅ MVP-Quiet (default off; MVP-Core for RuleHost per ADR-0014 amendment) |
+| `RolloutReviewerRunner` | 🟡 Runner | core | `runtime-v2/internalization/rollout-reviewer-runner.ts` | EvaluatorOutput | PIArtifact(rule) + 触发 ActivationDispatcher | ⚠️ MVP-Quiet (default off) |
+| `TrainerRunner` | 🟢 Runner | core | `runtime-v2/internalization/trainer-runner.ts` | RolloutReviewerOutput | PIArtifact(training_data) | Deferred |
 
 #### 3.2.3 Runner 输出 Validator（每 Runner 一个）
 

--- a/docs/architecture/INTERNALIZATION_PIPELINE.md
+++ b/docs/architecture/INTERNALIZATION_PIPELINE.md
@@ -812,13 +812,13 @@ routing_policy:
 | IntakeToInternalizationBridge | ✅ | 已解决断点 ①：probation/candidate → root dreamer task |
 | RoutingPolicy | ✅ | 可能需要扩展 channel mapping |
 | InternalizationOrchestrator | ✅ | |
-| DreamerRunner | ✅ | |
-| PhilosopherRunner | ✅ | |
-| ScribeRunner | ✅ | |
-| ArtificerRunner | ✅ | |
-| EvaluatorRunner | ✅ | |
-| RolloutReviewerRunner | ✅ | 增加 ActivationDispatcher 调用 |
-| TrainerRunner | ✅ | 仅 model_training 通道 |
+| DreamerRunner | ✅ MVP-Core | |
+| PhilosopherRunner | ✅ MVP-Quiet | default off; not auto-dispatched |
+| ScribeRunner | ✅ MVP-Core | |
+| ArtificerRunner | ✅ MVP-Core | |
+| EvaluatorRunner | ✅ MVP-Quiet | default off; MVP-Core for RuleHost per ADR-0014 amendment |
+| RolloutReviewerRunner | ✅ MVP-Quiet | default off; excluded from MVP_CORE_TASK_KINDS |
+| TrainerRunner | Deferred | 仅 model_training 通道 |
 | **触发** | | |
 | IdleTrigger | ⚠️ Deprecated | 现存 core 策略为退役对象；不得建立 plugin 宿主适配，改由 PD-owned explicit scheduling |
 | **Stage 3 (Activation)** | | |

--- a/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-once.ts
@@ -38,6 +38,9 @@ interface RunOnceOptions {
 const OWNER = 'pd-cli-internalization-run-once';
 const RUNTIME_KIND = 'local-worker';
 
+// PRI-458: philosopher, evaluator, rollout_reviewer are MVP-Quiet (default off).
+// They remain supported via --runner for manual operation but are not auto-dispatched.
+// See docs/plans/2026-06-mvp-slimming-candidates-1-2/c2-live-runner-chain.md
 const SUPPORTED_RUNNERS = new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator', 'rollout_reviewer']);
 
 interface RunOnceOutput {

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -2131,14 +2131,9 @@ describe('PRI-EVAL EvaluatorRunner boundary', () => {
     expect(src).not.toContain('node:cron');
   });
 
-  it('BARREL_EXPORTS: internalization/index.ts exports EvaluatorRunner and EvaluatorOutput', async () => {
-    const { readFileSync } = await import('node:fs');
-    const { resolve } = await import('node:path');
-    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
-    expect(src).toContain('EvaluatorRunner');
-    expect(src).toContain('EvaluatorOutput');
-    expect(src).toContain('DefaultEvaluatorValidator');
-  });
+  // PRI-458: BARREL_EXPORTS assertion for EvaluatorRunner removed — de-surfaced from
+  // internalization/index.ts (MVP-Quiet). The runner remains in runtime-v2/index.ts
+  // (public barrel) because rulehost-pipeline-runner.ts imports it (EP-02 exception).
 
   it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers evaluator-output-v1 schema', async () => {
     const { readFileSync } = await import('node:fs');
@@ -2195,14 +2190,10 @@ describe('PRI-RR RolloutReviewerRunner boundary', () => {
     expect(src).not.toContain('node:cron');
   });
 
-  it('BARREL_EXPORTS: internalization/index.ts exports RolloutReviewerRunner and RolloutReviewerOutput', async () => {
-    const { readFileSync } = await import('node:fs');
-    const { resolve } = await import('node:path');
-    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
-    expect(src).toContain('RolloutReviewerRunner');
-    expect(src).toContain('RolloutReviewerOutput');
-    expect(src).toContain('DefaultRolloutReviewerValidator');
-  });
+  // PRI-458: BARREL_EXPORTS assertion for RolloutReviewerRunner removed — de-surfaced from
+  // internalization/index.ts (MVP-Quiet). The runner remains in runtime-v2/index.ts
+  // (public barrel) because runtime-internalization-run-once.ts imports it and
+  // package.json has no deep import path available.
 
   it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers rollout-reviewer-output-v1 schema', async () => {
     const { readFileSync } = await import('node:fs');
@@ -2499,12 +2490,14 @@ describe('PRI-117 Nocturnal god-class freeze', () => {
     }
   });
 
-  it('RUNTIME_V2_USES_PEER_RUNNERS: DreamerRunner/PhilosopherRunner/ScribeRunner are the canonical entry points', async () => {
+  it('RUNTIME_V2_USES_PEER_RUNNERS: DreamerRunner/ScribeRunner/ArtificerRunner are the canonical MVP-Core entry points', async () => {
+    // PRI-458: narrowed to MVP-Core runners only. PhilosopherRunner (MVP-Quiet)
+    // remains in runtime-v2/index.ts for rulehost-pipeline-runner.ts compatibility
+    // but is no longer asserted as a canonical entry point.
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');
     expect(src).toContain('DreamerRunner');
-    expect(src).toContain('PhilosopherRunner');
     expect(src).toContain('ScribeRunner');
     expect(src).toContain('ArtificerRunner');
   });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -2085,6 +2085,21 @@ describe('PRI-111 ArtificerRunner boundary', () => {
   });
 });
 
+// ── PRI-458: PhilosopherRunner barrel boundary (MVP-Quiet) ─────────────────────
+
+describe('PRI-458 PhilosopherRunner barrel boundary', () => {
+  it('BARREL_EXPORTS: internalization/index.ts does NOT export PhilosopherRunner (PRI-458 MVP-Quiet)', async () => {
+    // PRI-458: PhilosopherRunner is de-surfaced from the internal barrel (MVP-Quiet).
+    // It remains in runtime-v2/index.ts (public barrel) because rulehost-pipeline-runner.ts
+    // imports it from there (EP-02 exception).
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).not.toContain("from './philosopher-runner.js'");
+    expect(src).not.toContain("from './philosopher-output.js'");
+  });
+});
+
 // ── PRI-EVAL: EvaluatorRunner boundary guards ──────────────────────────────────
 
 describe('PRI-EVAL EvaluatorRunner boundary', () => {
@@ -2131,9 +2146,18 @@ describe('PRI-EVAL EvaluatorRunner boundary', () => {
     expect(src).not.toContain('node:cron');
   });
 
-  // PRI-458: BARREL_EXPORTS assertion for EvaluatorRunner removed — de-surfaced from
-  // internalization/index.ts (MVP-Quiet). The runner remains in runtime-v2/index.ts
-  // (public barrel) because rulehost-pipeline-runner.ts imports it (EP-02 exception).
+  it('BARREL_EXPORTS: internalization/index.ts does NOT export EvaluatorRunner (PRI-458 MVP-Quiet)', async () => {
+    // PRI-458: EvaluatorRunner is de-surfaced from the internal barrel (MVP-Quiet).
+    // It remains in runtime-v2/index.ts (public barrel) because rulehost-pipeline-runner.ts
+    // imports it from there (EP-02 exception). These negative assertions lock the boundary:
+    // if someone re-aggregates the evaluator exports into this barrel, the test will fail.
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).not.toContain("from './evaluator-runner.js'");
+    expect(src).not.toContain("from './evaluator-output.js'");
+    expect(src).not.toContain("from './evaluator-prompt-builder.js'");
+  });
 
   it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers evaluator-output-v1 schema', async () => {
     const { readFileSync } = await import('node:fs');
@@ -2190,10 +2214,17 @@ describe('PRI-RR RolloutReviewerRunner boundary', () => {
     expect(src).not.toContain('node:cron');
   });
 
-  // PRI-458: BARREL_EXPORTS assertion for RolloutReviewerRunner removed — de-surfaced from
-  // internalization/index.ts (MVP-Quiet). The runner remains in runtime-v2/index.ts
-  // (public barrel) because runtime-internalization-run-once.ts imports it and
-  // package.json has no deep import path available.
+  it('BARREL_EXPORTS: internalization/index.ts does NOT export RolloutReviewerRunner (PRI-458 MVP-Quiet)', async () => {
+    // PRI-458: RolloutReviewerRunner is de-surfaced from the internal barrel (MVP-Quiet).
+    // It remains in runtime-v2/index.ts (public barrel) because runtime-internalization-run-once.ts
+    // imports it from there and package.json has no deep import path available (EP-02 exception).
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '..', 'internalization', 'index.ts'), 'utf-8');
+    expect(src).not.toContain("from './rollout-reviewer-runner.js'");
+    expect(src).not.toContain("from './rollout-reviewer-output.js'");
+    expect(src).not.toContain("from './rollout-reviewer-prompt-builder.js'");
+  });
 
   it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers rollout-reviewer-output-v1 schema', async () => {
     const { readFileSync } = await import('node:fs');

--- a/packages/principles-core/src/runtime-v2/internalization/index.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/index.ts
@@ -191,32 +191,9 @@ export {
 
 export { DreamerRunner } from './dreamer-runner.js';
 
-// ── Philosopher Runner (PRI-90) ────────────────────────────────────────────────
-
-export type {
-  PhilosopherOutputV1,
-  PhilosopherPrincipleCandidate,
-  PhilosopherValidationResult,
-  PhilosopherValidator,
-} from './philosopher-output.js';
-
-export {
-  DefaultPhilosopherValidator,
-} from './philosopher-output.js';
-
-export type {
-  PhilosopherRunnerResultStatus,
-  PhilosopherRunnerResult,
-  PhilosopherRunnerOptions,
-  ResolvedPhilosopherRunnerOptions,
-  PhilosopherRunnerDeps,
-} from './philosopher-runner.js';
-
-export {
-  PhilosopherRunner,
-  resolvePhilosopherRunnerOptions,
-  DEFAULT_PHILOSOPHER_RUNNER_OPTIONS,
-} from './philosopher-runner.js';
+// ── Philosopher Runner (PRI-90) — MVP-Quiet: de-surfaced from internal barrel (PRI-458) ──
+// Types/classes remain in philosopher-output.ts and philosopher-runner.ts.
+// Import directly from those source files if needed (not from this barrel).
 
 // ── Scribe Runner (PRI-109) ────────────────────────────────────────────────────
 
@@ -276,100 +253,13 @@ export {
   DEFAULT_ARTIFICER_RUNNER_OPTIONS,
 } from './artificer-runner.js';
 
-// ── Evaluator Runner (PRI-EVAL) ────────────────────────────────────────────────
+// ── Evaluator Runner (PRI-EVAL) — MVP-Quiet: de-surfaced from internal barrel (PRI-458) ──
+// Types/classes remain in evaluator-output.ts, evaluator-runner.ts, and evaluator-prompt-builder.ts.
+// Import directly from those source files if needed (not from this barrel).
 
-export type {
-  EvaluatorEvaluation,
-  EvaluatorSourceTrace,
-  EvaluatorOutputV1,
-  EvaluatorOutputV2,
-  EvaluatorValidationResult,
-  EvaluatorValidator,
-  EvaluatorCodeReview,
-  EvaluatorAdversarialResult,
-  AdversarialCase,
-  AdversarialFailedCase,
-  AdversarialAttackType,
-} from './evaluator-output.js';
-
-export {
-  DefaultEvaluatorValidator,
-  EvaluatorOutputV1Schema,
-  EvaluatorEvaluationSchema,
-  EvaluatorSourceTraceSchema,
-  EVALUATOR_DECISIONS,
-  isEvaluatorOutputV2,
-} from './evaluator-output.js';
-
-export type {
-  EvaluatorRunnerResultStatus,
-  EvaluatorRunnerResult,
-  EvaluatorRunnerOptions,
-  ResolvedEvaluatorRunnerOptions,
-  EvaluatorRunnerDeps,
-} from './evaluator-runner.js';
-
-export {
-  EvaluatorRunner,
-  resolveEvaluatorRunnerOptions,
-  DEFAULT_EVALUATOR_RUNNER_OPTIONS,
-} from './evaluator-runner.js';
-
-export {
-  EvaluatorPromptBuilder,
-  EVALUATOR_PROTOCOL_INSTRUCTION,
-  EVALUATOR_PROMPT_CONTRACT_VERSION,
-} from './evaluator-prompt-builder.js';
-
-export type {
-  EvaluatorPromptBuilderInput,
-  EvaluatorPromptInput,
-  EvaluatorPromptBuildResult,
-} from './evaluator-prompt-builder.js';
-
-// ── Rollout Reviewer Runner (PRI-RR) ────────────────────────────────────────
-
-export type {
-  RolloutReviewerReview,
-  RolloutReviewerSourceTrace,
-  RolloutReviewerOutputV1,
-  RolloutReviewerValidationResult,
-  RolloutReviewerValidator,
-} from './rollout-reviewer-output.js';
-
-export {
-  DefaultRolloutReviewerValidator,
-  RolloutReviewerOutputV1Schema,
-  RolloutReviewerReviewSchema,
-  RolloutReviewerSourceTraceSchema,
-  ROLLOUT_REVIEWER_DECISIONS,
-} from './rollout-reviewer-output.js';
-
-export type {
-  RolloutReviewerRunnerResultStatus,
-  RolloutReviewerRunnerResult,
-  RolloutReviewerRunnerOptions,
-  ResolvedRolloutReviewerRunnerOptions,
-  RolloutReviewerRunnerDeps,
-} from './rollout-reviewer-runner.js';
-
-export {
-  RolloutReviewerRunner,
-  resolveRolloutReviewerRunnerOptions,
-  DEFAULT_ROLLOUT_REVIEWER_RUNNER_OPTIONS,
-} from './rollout-reviewer-runner.js';
-
-export {
-  RolloutReviewerPromptBuilder,
-  ROLLOUT_REVIEWER_PROTOCOL_INSTRUCTION,
-  ROLLOUT_REVIEWER_PROMPT_CONTRACT_VERSION,
-} from './rollout-reviewer-prompt-builder.js';
-
-export type {
-  RolloutReviewerPromptBuilderInput,
-  RolloutReviewerPromptInput,
-  RolloutReviewerPromptBuildResult,
-} from './rollout-reviewer-prompt-builder.js';
+// ── Rollout Reviewer Runner (PRI-RR) — MVP-Quiet: de-surfaced from internal barrel (PRI-458) ──
+// Types/classes remain in rollout-reviewer-output.ts, rollout-reviewer-runner.ts, and rollout-reviewer-prompt-builder.ts.
+// Import directly from those source files if needed (not from this barrel).
 
 // ── Internalization Orchestrator (PRI-68) ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes PRI-458. De-surfaces MVP-Quiet peer runners (philosopher / evaluator / rollout_reviewer) from owner-facing surfaces, per PRI-457's `c2-live-runner-chain.md` Quiet classification.

**Iron rules honored:**
- No runner file or test deleted.
- `ALLOWED_EDGES` / `PEER_RUNNER_KINDS` / config defaults unchanged.
- PRI-457 pinning test (`c2-live-runner-chain.test.ts`) stays green before and after — no channel's actual triggered runner changed.

## Changes

### 1. `internalization/index.ts` — internal barrel narrowing
Removed `PhilosopherRunner` / `EvaluatorRunner` / `RolloutReviewerRunner` exports from the internal barrel. Types/classes remain in their source files (`philosopher-runner.ts`, `evaluator-runner.ts`, `rollout-reviewer-runner.ts`).

**EP-02 importer analysis (production path wiring):**
- Grep'd all importers of the three Quiet runner exports from `internalization/index.ts` — zero importers found.
- `runtime-v2/index.ts` (public barrel) imports directly from source files (e.g., `from './internalization/philosopher-runner.js'`), NOT from `internalization/index.ts`.
- `rulehost-pipeline-runner.ts` (MVP-Core `code_tool_hook` path) imports `PhilosopherRunner` + `EvaluatorRunner` from `@principles/core/runtime-v2` (public barrel). Since `package.json` only exposes `./runtime-v2` (no deep imports), removing these from the public barrel would break the pd-cli build. **Therefore only the internal barrel was narrowed.**

### 2. `architecture-regression.test.ts` — assertion narrowing
- Removed `BARREL_EXPORTS: internalization/index.ts exports EvaluatorRunner...` assertion.
- Removed `BARREL_EXPORTS: internalization/index.ts exports RolloutReviewerRunner...` assertion.
- Narrowed `RUNTIME_V2_USES_PEER_RUNNERS` to assert only MVP-Core runners (Dreamer / Scribe / Artificer).
- Core-no-I/O, schema registry, forbidden imports, and base-class invariants unchanged.

### 3. Owner docs / CLI help cleanup
- `COMPONENTS.md`: marked philosopher / evaluator / rollout_reviewer as 🟡 MVP-Quiet (default off) in runner status table.
- `INTERNALIZATION_PIPELINE.md`: added MVP-Quiet markers to runner status table.
- `runtime-internalization-run-once.ts`: added comment noting the three runners are MVP-Quiet but remain supported via `--runner` for manual operation.

## ERR Checklist

| ERR / EP | Title | How avoided |
|----------|-------|-------------|
| ERR-012 / EP-10 | Stale-main rollback | `git diff origin/main --name-only` confirms only 5 intended files changed; no rollback of merged code. |
| EP-02 | Production path wiring | Grep'd all importers before removing barrel exports; `rulehost-pipeline-runner.ts` imports from public barrel, not internal barrel, so removal is safe. |
| ERR-002 / EP-03 | Fail loud / observable degradation | No behavior or observability removed for runners that still run; only barrel re-export and doc presentation changed. |

## Tests

- `npm run build` — green
- `npm run test` (principles-core) — 5361 passed | 3 skipped | 3 todo (235 files)
- `npm run lint` — 0 errors (1 pre-existing warning in unrelated `validate-live-path.ts`)
- `npm run verify:merge` — green (pre-push hook)
- `check:runtime-contract` — 0 new violations

## Diff scope

```
docs/architecture/COMPONENTS.md
docs/architecture/INTERNALIZATION_PIPELINE.md
packages/pd-cli/src/commands/runtime-internalization-run-once.ts
packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
packages/principles-core/src/runtime-v2/internalization/index.ts
```

## Remaining risk

- The public barrel (`runtime-v2/index.ts`) still exports the three Quiet runners because `rulehost-pipeline-runner.ts` depends on them. This is intentional per EP-02 — removing them would require refactoring `rulehost-pipeline-runner.ts` first, which is out of scope for this issue.
- No feature flag added: this commit only changes barrel exports and docs, not runtime behavior, so there is no runtime path to disable. The runners themselves remain flag-gated by their existing config defaults (off).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 更新了架构与内部化相关说明，明确各组件的当前阶段、默认启用状态和适用范围。
* **Bug Fixes**
  * 调整了相关运行项的可见入口与说明，减少误用默认自动调度的可能性。
  * 修正了部分测试断言，使其与当前对外可用范围保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->