### PR TITLE
feat(pri-461): add RuleHost readiness resolver with three explicit statuses

### DIFF
--- a/packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts
@@ -111,6 +111,7 @@ function resolvePiAiAgentAdapter(
 function resolveRunRuleHostRuntime(
   workspaceDir: string,
   timeoutMs: number | undefined,
+  readiness: RuleHostReadinessResult,
 ): ResolvedRunRuleHostRuntime {
   const { configLoadResult } = resolveRuntimeFromPdConfig(workspaceDir);
 
@@ -128,6 +129,14 @@ function resolveRunRuleHostRuntime(
     philosopher: philosopher.profileId,
     scribe: scribe.profileId,
   };
+  if (readiness.status === 'text_principle_only') {
+    return {
+      agentAdapters: { dreamer: dreamer.adapter, philosopher: philosopher.adapter, scribe: scribe.adapter, evaluator: scribe.adapter },
+      agentRuntimeProfiles,
+      capability: { enabled: false, disabledReason: readiness.reason },
+      capabilityStatus: `code_rule_capability: OFF (${readiness.reason})`,
+    };
+  }
   const featureFlags = computeFeatureFlagsFromConfig(effective);
   if (!isFeatureEnabled(featureFlags, 'code_rule_capability')) {
     return {
@@ -353,7 +362,7 @@ export async function handleRunRuleHost(opts: RunRuleHostOptions): Promise<void>
   // ── Resolve each executed agent from canonical config ──
   let resolvedRuntime: ResolvedRunRuleHostRuntime;
   try {
-    resolvedRuntime = resolveRunRuleHostRuntime(workspaceDir, opts.timeoutMs);
+    resolvedRuntime = resolveRunRuleHostRuntime(workspaceDir, opts.timeoutMs, readiness);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (opts.json) {
@@ -375,7 +384,8 @@ export async function handleRunRuleHost(opts: RunRuleHostOptions): Promise<void>
         painId: opts.painId,
         workspace: workspaceDir,
         channel,
-        readiness: readiness.status,
+        readiness,
+        readinessStatus: readiness.status,
         capabilityStatus: resolvedRuntime.capabilityStatus,
         agentRuntimeProfiles: resolvedRuntime.agentRuntimeProfiles,
         codeRuleCapability: { enabled: resolvedRuntime.capability.enabled, disabledReason: resolvedRuntime.capability.disabledReason },

--- a/packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts
@@ -38,6 +38,8 @@ import {
 } from '@principles/core/runtime-v2';
 import type { EffectivePdConfig, InternalAgentName, PDRuntimeAdapter } from '@principles/core/runtime-v2';
 import { resolveRuntimeFromPdConfig } from '../services/resolve-runtime-from-pd-config.js';
+import { resolveRuleHostReadiness } from '../services/rulehost-readiness.js';
+import type { RuleHostReadinessResult } from '../services/rulehost-readiness.js';
 
 export interface RunRuleHostOptions {
   workspace?: string;
@@ -234,16 +236,35 @@ function formatTextOutput(result: RuleHostPipelineResult): string {
   return lines.join('\n');
 }
 
-function formatDryRunOutput(opts: RunRuleHostOptions, capabilityStatus: string, workspaceDir: string): string {
+interface DryRunFormatInput {
+  readonly opts: RunRuleHostOptions;
+  readonly capabilityStatus: string;
+  readonly workspaceDir: string;
+  readonly readiness: RuleHostReadinessResult;
+}
+
+function formatDryRunOutput(input: DryRunFormatInput): string {
+  const { opts, capabilityStatus, workspaceDir, readiness } = input;
   const lines: string[] = [];
   lines.push('RuleHost Pipeline (PRI-429) — DRY RUN');
   lines.push(`pain: ${opts.painId}`);
   lines.push(`workspace: ${workspaceDir}`);
   lines.push(`channel: ${opts.channel ?? 'code_tool_hook'}`);
+  lines.push(`readiness: ${readiness.status.toUpperCase()}`);
+  if (readiness.status !== 'ready') {
+    lines.push(`  reason: ${readiness.reason}`);
+    lines.push(`  nextAction: ${readiness.nextAction}`);
+  }
   lines.push(capabilityStatus);
   lines.push('');
   lines.push('No tasks created, no LLM calls made, no artifacts written.');
-  lines.push('Next: pass --confirm to actually run the pipeline.');
+  if (readiness.status === 'ready') {
+    lines.push('Next: pass --confirm to actually run the pipeline.');
+  } else if (readiness.status === 'text_principle_only') {
+    lines.push('Next: pass --confirm to run in text-principle-only mode, or fix the issues above to enable full pipeline.');
+  } else {
+    lines.push('Next: fix the readiness issues above before running the pipeline.');
+  }
   return lines.join('\n');
 }
 
@@ -303,6 +324,32 @@ export async function handleRunRuleHost(opts: RunRuleHostOptions): Promise<void>
 
   const workspaceDir = resolveWorkspace(opts);
 
+  // ── Readiness check (PRI-461) ──
+  // Check all preconditions BEFORE constructing adapters. This produces a
+  // structured ready/text_principle_only/refused status instead of an opaque
+  // agent_runtime_resolution_failed error.
+  const readiness = resolveRuleHostReadiness(workspaceDir);
+
+  // If refused, emit structured error and exit (CLI gate rule 2 + rule 5).
+  // Refused means the pipeline cannot run at all — do NOT attempt adapter
+  // construction or pipeline execution.
+  if (readiness.status === 'refused') {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({
+        status: 'refused',
+        reason: readiness.reason,
+        nextAction: readiness.nextAction,
+        readiness,
+      }) + '\n');
+    } else {
+      console.error(`RuleHost readiness: REFUSED`);
+      console.error(`  reason: ${readiness.reason}`);
+      console.error(`  nextAction: ${readiness.nextAction}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
   // ── Resolve each executed agent from canonical config ──
   let resolvedRuntime: ResolvedRunRuleHostRuntime;
   try {
@@ -310,7 +357,7 @@ export async function handleRunRuleHost(opts: RunRuleHostOptions): Promise<void>
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (opts.json) {
-      process.stdout.write(JSON.stringify({ status: 'failed', reason: 'agent_runtime_resolution_failed', message, nextAction: 'check internalAgents and runtimeProfiles in .pd/config.yaml; run pd config doctor' }) + '\n');
+      process.stdout.write(JSON.stringify({ status: 'failed', reason: 'agent_runtime_resolution_failed', message, nextAction: 'check internalAgents and runtimeProfiles in .pd/config.yaml; run pd config doctor', readiness }) + '\n');
     } else {
       console.error(`Error: ${message}`);
     }
@@ -328,13 +375,18 @@ export async function handleRunRuleHost(opts: RunRuleHostOptions): Promise<void>
         painId: opts.painId,
         workspace: workspaceDir,
         channel,
+        readiness: readiness.status,
         capabilityStatus: resolvedRuntime.capabilityStatus,
         agentRuntimeProfiles: resolvedRuntime.agentRuntimeProfiles,
         codeRuleCapability: { enabled: resolvedRuntime.capability.enabled, disabledReason: resolvedRuntime.capability.disabledReason },
-        nextAction: 'pass --confirm to actually run the pipeline',
+        nextAction: readiness.status === 'ready'
+          ? 'pass --confirm to run the full pipeline'
+          : readiness.status === 'text_principle_only'
+            ? 'pass --confirm to run in text-principle-only mode (code-rule capability OFF), or fix the issues above to enable full pipeline'
+            : 'fix the readiness issues above before running the pipeline',
       }) + '\n');
     } else {
-      process.stdout.write(formatDryRunOutput(opts, resolvedRuntime.capabilityStatus, workspaceDir) + '\n');
+      process.stdout.write(formatDryRunOutput({ opts, capabilityStatus: resolvedRuntime.capabilityStatus, workspaceDir, readiness }) + '\n');
     }
     return;
   }

--- a/packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts
+++ b/packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Unit tests for RuleHost readiness resolver (PRI-461).
+ *
+ * Tests the three readiness statuses (ready / text_principle_only / refused)
+ * against various config combinations, including the default installed config
+ * pattern from create-principles-disciple.
+ *
+ * ERR refs:
+ *   - EP-02 / ERR-024, ERR-025: tests exercise the real config resolution path
+ *   - EP-03: refused/text_principle_only include reason + nextAction
+ *   - EP-07: readiness uses the same config source as the pipeline
+ *   - EP-09: tests cover the default installed config, not just hand-written happy paths
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as yaml from 'js-yaml';
+import { resolveRuleHostReadiness } from '../rulehost-readiness.js';
+
+// ── workspace helpers ─────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-readiness-'));
+}
+
+interface ConfigOptions {
+  /** Override agent enabled flags. Defaults: all pi-ai agents enabled. */
+  readonly agentEnabled?: Partial<Record<'dreamer' | 'philosopher' | 'scribe' | 'artificer' | 'evaluator', boolean>>;
+  /** Override runtime profile type. Default: 'pi-ai'. */
+  readonly profileType?: 'pi-ai' | 'openclaw';
+  /** Override API key env var name. Default: 'TEST_API_KEY'. */
+  readonly apiKeyEnv?: string;
+  /** Override code_rule_capability feature flag. Default: true. */
+  readonly codeRuleCapabilityEnabled?: boolean;
+  /** Override profile fields. */
+  readonly profileProvider?: string;
+  readonly profileModel?: string;
+}
+
+function writeConfig(workspaceDir: string, opts: ConfigOptions = {}): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+
+  const profileType = opts.profileType ?? 'pi-ai';
+  const apiKeyEnv = opts.apiKeyEnv ?? 'TEST_API_KEY';
+  const profileId = profileType === 'pi-ai' ? 'pi-ai.default' : 'openclaw.default';
+
+  const profile: Record<string, unknown> = profileType === 'pi-ai'
+    ? {
+        type: 'pi-ai',
+        provider: opts.profileProvider ?? 'anthropic',
+        model: opts.profileModel ?? 'claude-sonnet',
+        apiKeyEnv,
+      }
+    : {
+        type: 'openclaw',
+        source: 'default',
+      };
+
+  const defaultEnabled: Record<string, boolean> = {
+    dreamer: true,
+    philosopher: true,
+    scribe: true,
+    artificer: true,
+    evaluator: true,
+  };
+  const agentEnabled = { ...defaultEnabled, ...opts.agentEnabled };
+
+  const cfg = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      code_rule_capability: { category: 'core', enabled: opts.codeRuleCapabilityEnabled ?? true },
+    },
+    runtimeProfiles: {
+      [profileId]: profile,
+    },
+    internalAgents: {
+      defaultRuntime: profileId,
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: profileId },
+        dreamer: { enabled: agentEnabled.dreamer, runtimeProfile: profileId },
+        philosopher: { enabled: agentEnabled.philosopher, runtimeProfile: profileId },
+        scribe: { enabled: agentEnabled.scribe, runtimeProfile: profileId },
+        artificer: { enabled: agentEnabled.artificer, runtimeProfile: profileId },
+        evaluator: { enabled: agentEnabled.evaluator, runtimeProfile: profileId },
+        rolloutReviewer: { enabled: false, runtimeProfile: profileId },
+        correctionObserver: { enabled: false, runtimeProfile: profileId },
+        empathyObserver: { enabled: false, runtimeProfile: profileId },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  };
+
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+}
+
+/**
+ * Write the default installed config pattern from create-principles-disciple.
+ * This uses openclaw profiles and has philosopher/evaluator disabled.
+ */
+function writeDefaultInstalledConfig(workspaceDir: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+
+  const cfg = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      code_rule_capability: { category: 'core', enabled: true },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: 'openclaw.default' },
+        dreamer: { enabled: true, runtimeProfile: 'openclaw.default' },
+        philosopher: { enabled: false, runtimeProfile: 'openclaw.default' },
+        scribe: { enabled: true, runtimeProfile: 'openclaw.default' },
+        artificer: { enabled: true, runtimeProfile: 'openclaw.default' },
+        evaluator: { enabled: false, runtimeProfile: 'openclaw.default' },
+        rolloutReviewer: { enabled: false, runtimeProfile: 'openclaw.default' },
+        correctionObserver: { enabled: false, runtimeProfile: 'openclaw.default' },
+        empathyObserver: { enabled: false, runtimeProfile: 'openclaw.default' },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  };
+
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+}
+
+function writeMalformedConfig(workspaceDir: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), 'this: is: not: valid: yaml: [', 'utf8');
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe('resolveRuleHostReadiness', () => {
+  let workspaceDir: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    workspaceDir = mkTmpDir();
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+    try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  // ── refused: config malformed ───────────────────────────────────────────
+
+  it('returns refused when config is malformed', () => {
+    writeMalformedConfig(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/config/i);
+    expect(result.nextAction).toBeDefined();
+    expect(result.nextAction.length).toBeGreaterThan(0);
+  });
+
+  // ── refused: required agent issues ──────────────────────────────────────
+
+  it('returns refused when dreamer is disabled', () => {
+    writeConfig(workspaceDir, { agentEnabled: { dreamer: false } });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/dreamer/i);
+    expect(result.nextAction).toBeDefined();
+  });
+
+  it('returns refused when philosopher is disabled', () => {
+    writeConfig(workspaceDir, { agentEnabled: { philosopher: false } });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/philosopher/i);
+    expect(result.nextAction).toBeDefined();
+  });
+
+  it('returns refused when scribe is disabled', () => {
+    writeConfig(workspaceDir, { agentEnabled: { scribe: false } });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/scribe/i);
+    expect(result.nextAction).toBeDefined();
+  });
+
+  it('returns refused when dreamer uses openclaw profile (not pi-ai)', () => {
+    writeConfig(workspaceDir, { profileType: 'openclaw' });
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/pi-ai|openclaw|profile/i);
+    expect(result.nextAction).toBeDefined();
+  });
+
+  it('returns refused when API key env var is not set', () => {
+    writeConfig(workspaceDir, { apiKeyEnv: 'MISSING_API_KEY' });
+    // Do NOT set MISSING_API_KEY in env
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/API key|apiKeyEnv|MISSING_API_KEY/i);
+    expect(result.nextAction).toBeDefined();
+  });
+
+  it('returns refused when API key env var is set but empty', () => {
+    writeConfig(workspaceDir, { apiKeyEnv: 'EMPTY_API_KEY' });
+    process.env.EMPTY_API_KEY = '';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toMatch(/API key|apiKeyEnv|EMPTY_API_KEY/i);
+    expect(result.nextAction).toBeDefined();
+  });
+
+  // ── text_principle_only: code-rule capability off ───────────────────────
+
+  it('returns text_principle_only when code_rule_capability flag is OFF', () => {
+    writeConfig(workspaceDir, { codeRuleCapabilityEnabled: false });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('text_principle_only');
+    expect(result.reason).toMatch(/code_rule_capability|feature flag/i);
+    expect(result.nextAction).toBeDefined();
+    expect(result.codeRuleCapability.enabled).toBe(false);
+  });
+
+  it('returns text_principle_only when evaluator is disabled', () => {
+    writeConfig(workspaceDir, { agentEnabled: { evaluator: false } });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('text_principle_only');
+    expect(result.reason).toMatch(/evaluator/i);
+    expect(result.nextAction).toBeDefined();
+    expect(result.codeRuleCapability.enabled).toBe(false);
+  });
+
+  it('returns text_principle_only when artificer is disabled', () => {
+    writeConfig(workspaceDir, { agentEnabled: { artificer: false } });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('text_principle_only');
+    expect(result.reason).toMatch(/artificer/i);
+    expect(result.nextAction).toBeDefined();
+    expect(result.codeRuleCapability.enabled).toBe(false);
+  });
+
+  it('returns text_principle_only when artificer API key is missing', () => {
+    // Use a config where artificer has a different profile with a missing API key
+    const configDir = path.join(workspaceDir, '.pd');
+    fs.mkdirSync(configDir, { recursive: true });
+    const cfg = {
+      version: 1,
+      features: {
+        prompt: { category: 'core', enabled: true },
+        code_tool_hook: { category: 'core', enabled: true },
+        defer_archive: { category: 'core', enabled: true },
+        code_rule_capability: { category: 'core', enabled: true },
+      },
+      runtimeProfiles: {
+        'pi-ai.main': { type: 'pi-ai', provider: 'anthropic', model: 'claude-sonnet', apiKeyEnv: 'MAIN_API_KEY' },
+        'pi-ai.artificer': { type: 'pi-ai', provider: 'openrouter', model: 'gpt-4', apiKeyEnv: 'ARTIFICER_API_KEY' },
+      },
+      internalAgents: {
+        defaultRuntime: 'pi-ai.main',
+        agents: {
+          diagnostician: { enabled: true, runtimeProfile: 'pi-ai.main' },
+          dreamer: { enabled: true, runtimeProfile: 'pi-ai.main' },
+          philosopher: { enabled: true, runtimeProfile: 'pi-ai.main' },
+          scribe: { enabled: true, runtimeProfile: 'pi-ai.main' },
+          artificer: { enabled: true, runtimeProfile: 'pi-ai.artificer' },
+          evaluator: { enabled: true, runtimeProfile: 'pi-ai.main' },
+          rolloutReviewer: { enabled: false, runtimeProfile: 'pi-ai.main' },
+          correctionObserver: { enabled: false, runtimeProfile: 'pi-ai.main' },
+          empathyObserver: { enabled: false, runtimeProfile: 'pi-ai.main' },
+        },
+      },
+      ui: { diagnostics: { mode: 'simple' } },
+    };
+    fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+
+    process.env.MAIN_API_KEY = 'sk-main';
+    // Do NOT set ARTIFICER_API_KEY
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('text_principle_only');
+    expect(result.reason).toMatch(/artificer|ARTIFICER_API_KEY/i);
+    expect(result.nextAction).toBeDefined();
+    expect(result.codeRuleCapability.enabled).toBe(false);
+  });
+
+  // ── ready: all conditions met ───────────────────────────────────────────
+
+  it('returns ready when all agents enabled with pi-ai profiles and API keys set', () => {
+    writeConfig(workspaceDir, {});
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.status).toBe('ready');
+    expect(result.codeRuleCapability.enabled).toBe(true);
+  });
+
+  // ── default installed config (EP-09) ────────────────────────────────────
+
+  it('returns refused for the default installed config (openclaw profiles, philosopher/evaluator disabled)', () => {
+    writeDefaultInstalledConfig(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir);
+    // Default config uses openclaw profiles — dreamer/scribe can't get pi-ai adapters.
+    // Philosopher is also disabled. So the status is refused.
+    expect(result.status).toBe('refused');
+    expect(result.reason).toBeDefined();
+    expect(result.reason.length).toBeGreaterThan(0);
+    expect(result.nextAction).toBeDefined();
+    expect(result.nextAction.length).toBeGreaterThan(0);
+  });
+
+  // ── result structure ────────────────────────────────────────────────────
+
+  it('includes per-agent statuses in the result', () => {
+    writeConfig(workspaceDir, {});
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.agentStatuses).toBeDefined();
+    expect(result.agentStatuses.dreamer).toBeDefined();
+    expect(result.agentStatuses.philosopher).toBeDefined();
+    expect(result.agentStatuses.scribe).toBeDefined();
+    expect(result.agentStatuses.artificer).toBeDefined();
+    expect(result.agentStatuses.evaluator).toBeDefined();
+  });
+
+  it('includes codeRuleCapability in the result', () => {
+    writeConfig(workspaceDir, { codeRuleCapabilityEnabled: false });
+    process.env.TEST_API_KEY = 'sk-test';
+    const result = resolveRuleHostReadiness(workspaceDir);
+    expect(result.codeRuleCapability).toBeDefined();
+    expect(result.codeRuleCapability.enabled).toBe(false);
+    expect(result.codeRuleCapability.disabledReason).toBeDefined();
+  });
+
+  // ── env var injection ───────────────────────────────────────────────────
+
+  it('uses injected getEnvVar callback instead of process.env', () => {
+    writeConfig(workspaceDir, { apiKeyEnv: 'INJECTED_KEY' });
+    // Do NOT set INJECTED_KEY in process.env
+    const result = resolveRuleHostReadiness(workspaceDir, (name) => {
+      if (name === 'INJECTED_KEY') return 'sk-injected';
+      return undefined;
+    });
+    expect(result.status).toBe('ready');
+  });
+});

--- a/packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts
+++ b/packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts
@@ -143,19 +143,20 @@ function writeMalformedConfig(workspaceDir: string): void {
   fs.writeFileSync(path.join(configDir, 'config.yaml'), 'this: is: not: valid: yaml: [', 'utf8');
 }
 
+function envLookup(env: Record<string, string | undefined>): (name: string) => string | undefined {
+  return (name) => env[name];
+}
+
 // ── tests ─────────────────────────────────────────────────────────────────
 
 describe('resolveRuleHostReadiness', () => {
   let workspaceDir: string;
-  let savedEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
     workspaceDir = mkTmpDir();
-    savedEnv = { ...process.env };
   });
 
   afterEach(() => {
-    process.env = savedEnv;
     try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
@@ -163,7 +164,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused when config is malformed', () => {
     writeMalformedConfig(workspaceDir);
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({}));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/config/i);
     expect(result.nextAction).toBeDefined();
@@ -174,8 +175,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused when dreamer is disabled', () => {
     writeConfig(workspaceDir, { agentEnabled: { dreamer: false } });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/dreamer/i);
     expect(result.nextAction).toBeDefined();
@@ -183,8 +183,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused when philosopher is disabled', () => {
     writeConfig(workspaceDir, { agentEnabled: { philosopher: false } });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/philosopher/i);
     expect(result.nextAction).toBeDefined();
@@ -192,8 +191,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused when scribe is disabled', () => {
     writeConfig(workspaceDir, { agentEnabled: { scribe: false } });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/scribe/i);
     expect(result.nextAction).toBeDefined();
@@ -201,7 +199,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused when dreamer uses openclaw profile (not pi-ai)', () => {
     writeConfig(workspaceDir, { profileType: 'openclaw' });
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({}));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/pi-ai|openclaw|profile/i);
     expect(result.nextAction).toBeDefined();
@@ -210,7 +208,7 @@ describe('resolveRuleHostReadiness', () => {
   it('returns refused when API key env var is not set', () => {
     writeConfig(workspaceDir, { apiKeyEnv: 'MISSING_API_KEY' });
     // Do NOT set MISSING_API_KEY in env
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({}));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/API key|apiKeyEnv|MISSING_API_KEY/i);
     expect(result.nextAction).toBeDefined();
@@ -218,8 +216,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused when API key env var is set but empty', () => {
     writeConfig(workspaceDir, { apiKeyEnv: 'EMPTY_API_KEY' });
-    process.env.EMPTY_API_KEY = '';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ EMPTY_API_KEY: '' }));
     expect(result.status).toBe('refused');
     expect(result.reason).toMatch(/API key|apiKeyEnv|EMPTY_API_KEY/i);
     expect(result.nextAction).toBeDefined();
@@ -229,8 +226,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns text_principle_only when code_rule_capability flag is OFF', () => {
     writeConfig(workspaceDir, { codeRuleCapabilityEnabled: false });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('text_principle_only');
     expect(result.reason).toMatch(/code_rule_capability|feature flag/i);
     expect(result.nextAction).toBeDefined();
@@ -239,8 +235,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns text_principle_only when evaluator is disabled', () => {
     writeConfig(workspaceDir, { agentEnabled: { evaluator: false } });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('text_principle_only');
     expect(result.reason).toMatch(/evaluator/i);
     expect(result.nextAction).toBeDefined();
@@ -249,8 +244,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns text_principle_only when artificer is disabled', () => {
     writeConfig(workspaceDir, { agentEnabled: { artificer: false } });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('text_principle_only');
     expect(result.reason).toMatch(/artificer/i);
     expect(result.nextAction).toBeDefined();
@@ -291,9 +285,8 @@ describe('resolveRuleHostReadiness', () => {
     };
     fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
 
-    process.env.MAIN_API_KEY = 'sk-main';
     // Do NOT set ARTIFICER_API_KEY
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ MAIN_API_KEY: 'sk-main' }));
     expect(result.status).toBe('text_principle_only');
     expect(result.reason).toMatch(/artificer|ARTIFICER_API_KEY/i);
     expect(result.nextAction).toBeDefined();
@@ -304,8 +297,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns ready when all agents enabled with pi-ai profiles and API keys set', () => {
     writeConfig(workspaceDir, {});
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.status).toBe('ready');
     expect(result.codeRuleCapability.enabled).toBe(true);
   });
@@ -314,7 +306,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('returns refused for the default installed config (openclaw profiles, philosopher/evaluator disabled)', () => {
     writeDefaultInstalledConfig(workspaceDir);
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({}));
     // Default config uses openclaw profiles — dreamer/scribe can't get pi-ai adapters.
     // Philosopher is also disabled. So the status is refused.
     expect(result.status).toBe('refused');
@@ -328,8 +320,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('includes per-agent statuses in the result', () => {
     writeConfig(workspaceDir, {});
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.agentStatuses).toBeDefined();
     expect(result.agentStatuses.dreamer).toBeDefined();
     expect(result.agentStatuses.philosopher).toBeDefined();
@@ -340,8 +331,7 @@ describe('resolveRuleHostReadiness', () => {
 
   it('includes codeRuleCapability in the result', () => {
     writeConfig(workspaceDir, { codeRuleCapabilityEnabled: false });
-    process.env.TEST_API_KEY = 'sk-test';
-    const result = resolveRuleHostReadiness(workspaceDir);
+    const result = resolveRuleHostReadiness(workspaceDir, envLookup({ TEST_API_KEY: 'sk-test' }));
     expect(result.codeRuleCapability).toBeDefined();
     expect(result.codeRuleCapability.enabled).toBe(false);
     expect(result.codeRuleCapability.disabledReason).toBeDefined();

--- a/packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts
+++ b/packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts
@@ -358,4 +358,19 @@ describe('resolveRuleHostReadiness', () => {
     });
     expect(result.status).toBe('ready');
   });
+
+  // ── Runtime Contract #9: graceful degradation with reason ────────────────
+
+  it('returns refused when getEnvVar throws (Runtime Contract #9: never throws)', () => {
+    writeConfig(workspaceDir, { apiKeyEnv: 'TEST_KEY' });
+    const throwingGetEnv = (): string => {
+      throw new Error('env access failed');
+    };
+    const result = resolveRuleHostReadiness(workspaceDir, throwingGetEnv);
+    expect(result.status).toBe('refused');
+    expect(result.reason).toContain('readiness_resolution_failed');
+    expect(result.reason).toContain('env access failed');
+    expect(result.nextAction).toBeDefined();
+    expect(result.codeRuleCapability.enabled).toBe(false);
+  });
 });

--- a/packages/pd-cli/src/services/rulehost-readiness.ts
+++ b/packages/pd-cli/src/services/rulehost-readiness.ts
@@ -216,7 +216,15 @@ export function resolveRuleHostReadiness(
   const { effective } = configLoadResult;
 
   // ── Step 2: Check required agents (dreamer, philosopher, scribe) ──
-  const agentStatuses: Record<string, AgentReadiness> = {};
+  // Build agentStatuses with all 5 keys from the start to avoid `as` casts.
+  const unchecked: AgentReadiness = { status: 'not_ready', reason: 'not checked' };
+  const agentStatuses: RuleHostReadinessResult['agentStatuses'] = {
+    dreamer: unchecked,
+    philosopher: unchecked,
+    scribe: unchecked,
+    artificer: unchecked,
+    evaluator: unchecked,
+  };
   const requiredFailures: string[] = [];
 
   for (const agentName of REQUIRED_AGENTS) {
@@ -231,7 +239,7 @@ export function resolveRuleHostReadiness(
     const reason = `required_agents_not_ready: ${requiredFailures.join('; ')}`;
     const nextAction = `Fix the following agent issues in .pd/config.yaml: ${requiredFailures.join('; ')}. RuleHost requires dreamer, philosopher, and scribe agents to be enabled with pi-ai runtime profiles and valid API keys.`;
     return buildRefusedResult(reason, nextAction, {
-      agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+      agentStatuses,
       codeRuleCapability: { enabled: false, disabledReason: 'required_agents_not_ready' },
     });
   }
@@ -246,7 +254,7 @@ export function resolveRuleHostReadiness(
       agentStatuses[agentName] = checkAgentReadiness(effective, agentName, getEnvVar);
     }
     return buildTextPrincipleOnlyResult(reason, nextAction, {
-      agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+      agentStatuses,
       codeRuleCapability: { enabled: false, disabledReason: reason },
     });
   }
@@ -266,7 +274,7 @@ export function resolveRuleHostReadiness(
     const reason = `code_rule_agents_not_ready: ${codeRuleFailures.join('; ')}`;
     const nextAction = `Fix the following agent issues to enable code-rule capability: ${codeRuleFailures.join('; ')}. Text-principle-only mode is available with the current configuration.`;
     return buildTextPrincipleOnlyResult(reason, nextAction, {
-      agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+      agentStatuses,
       codeRuleCapability: { enabled: false, disabledReason: reason },
     });
   }
@@ -276,7 +284,7 @@ export function resolveRuleHostReadiness(
     status: 'ready',
     reason: 'All agents ready with pi-ai profiles and valid API keys. Code-rule capability is ON.',
     nextAction: 'Pass --confirm to run the full pipeline.',
-    agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+    agentStatuses,
     codeRuleCapability: { enabled: true },
   };
 }

--- a/packages/pd-cli/src/services/rulehost-readiness.ts
+++ b/packages/pd-cli/src/services/rulehost-readiness.ts
@@ -1,0 +1,282 @@
+/**
+ * RuleHost Readiness Resolver — PRI-461
+ *
+ * Checks all preconditions for `run-rulehost` BEFORE constructing adapters,
+ * returning one of three user-visible statuses:
+ *   - `ready`: all agents enabled with pi-ai profiles and API keys; code-rule capability ON
+ *   - `text_principle_only`: dreamer/philosopher/scribe ready, but code-rule capability OFF
+ *     (flag disabled, or artificer/evaluator not ready)
+ *   - `refused`: dreamer/philosopher/scribe chain broken (disabled, wrong profile, missing API key,
+ *     or config malformed)
+ *
+ * This module NEVER throws. It always returns a structured result with reason + nextAction,
+ * so the CLI handler can emit a clear status instead of an opaque adapter-resolution failure.
+ *
+ * ERR refs:
+ *   - EP-02 / ERR-024, ERR-025: wired into the production handler path (runtime-internalization-run-rulehost.ts)
+ *   - EP-03: refused/text_principle_only include reason + nextAction
+ *   - EP-07: uses the same config source as the pipeline (resolveRuntimeFromPdConfig)
+ *   - EP-09: tests cover the default installed config pattern
+ */
+
+import {
+  resolveAgentRuntimeBinding,
+  checkAgentRuntimeReadiness,
+  computeFeatureFlagsFromConfig,
+  isFeatureEnabled,
+} from '@principles/core/runtime-v2';
+import type {
+  EffectivePdConfig,
+  InternalAgentName,
+  RuntimeProfile,
+} from '@principles/core/runtime-v2';
+import { resolveRuntimeFromPdConfig } from './resolve-runtime-from-pd-config.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type RuleHostReadinessStatus = 'ready' | 'text_principle_only' | 'refused';
+
+export interface AgentReadiness {
+  readonly status: 'ready' | 'disabled' | 'not_ready' | 'needs_setup' | 'wrong_profile_type';
+  readonly reason?: string;
+  readonly nextAction?: string;
+  readonly profileId?: string;
+  readonly profileType?: string;
+}
+
+export interface CodeRuleCapabilityReadiness {
+  readonly enabled: boolean;
+  readonly disabledReason?: string;
+}
+
+export interface RuleHostReadinessResult {
+  readonly status: RuleHostReadinessStatus;
+  readonly reason: string;
+  readonly nextAction: string;
+  readonly agentStatuses: {
+    readonly dreamer: AgentReadiness;
+    readonly philosopher: AgentReadiness;
+    readonly scribe: AgentReadiness;
+    readonly artificer: AgentReadiness;
+    readonly evaluator: AgentReadiness;
+  };
+  readonly codeRuleCapability: CodeRuleCapabilityReadiness;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * Agents required for the text-principle path (dreamer → philosopher → scribe).
+ * If any of these is not ready, the pipeline cannot produce even text principles.
+ */
+const REQUIRED_AGENTS: readonly InternalAgentName[] = ['dreamer', 'philosopher', 'scribe'];
+
+/**
+ * Agents required for the code-rule capability (artificer + evaluator).
+ * Both must be ready for the adversarial loop to run.
+ */
+const CODE_RULE_AGENTS: readonly InternalAgentName[] = ['artificer', 'evaluator'];
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+/**
+ * Check a single agent's readiness for the RuleHost pipeline.
+ *
+ * Checks (in order):
+ *   1. Agent enabled (via resolveAgentRuntimeBinding)
+ *   2. Profile exists (via resolveAgentRuntimeBinding)
+ *   3. Profile type is 'pi-ai' (RuleHost needs PiAiRuntimeAdapter)
+ *   4. Profile is ready (via checkAgentRuntimeReadiness — provider/model/apiKeyEnv set, env var exists)
+ *
+ * Returns a structured AgentReadiness result. Never throws.
+ */
+function checkAgentReadiness(
+  effective: EffectivePdConfig,
+  agentName: InternalAgentName,
+  getEnvVar: (name: string) => string | undefined,
+): AgentReadiness {
+  const binding = resolveAgentRuntimeBinding(effective, agentName);
+
+  if (!binding.ok) {
+    return {
+      status: binding.readiness === 'disabled' ? 'disabled' : binding.readiness === 'needs_setup' ? 'needs_setup' : 'not_ready',
+      reason: binding.reason,
+      nextAction: binding.nextAction,
+    };
+  }
+
+  const profile: RuntimeProfile = binding.profile;
+  const profileType = profile.type;
+
+  // RuleHost pipeline constructs PiAiRuntimeAdapter instances, so the profile
+  // must be pi-ai. OpenClaw profiles delegate to OpenClaw's own runtime, which
+  // is not available in the RuleHost pipeline context.
+  if (profileType !== 'pi-ai') {
+    return {
+      status: 'wrong_profile_type',
+      reason: `Agent '${agentName}' uses profile '${binding.profileId}' with type '${profileType}', but RuleHost requires pi-ai profile type`,
+      nextAction: `Add a pi-ai runtime profile to .pd/config.yaml and assign it to ${agentName} via internalAgents.agents.${agentName}.runtimeProfile`,
+      profileId: binding.profileId,
+      profileType,
+    };
+  }
+
+  const readiness = checkAgentRuntimeReadiness(profile, getEnvVar);
+  if (readiness.readiness !== 'ready') {
+    return {
+      status: readiness.readiness === 'needs_setup' ? 'needs_setup' : 'not_ready',
+      reason: readiness.reason,
+      nextAction: readiness.nextAction,
+      profileId: binding.profileId,
+      profileType,
+    };
+  }
+
+  return {
+    status: 'ready',
+    profileId: binding.profileId,
+    profileType,
+  };
+}
+
+// ── Helpers (defined before public function to satisfy no-use-before-define) ──
+
+interface ReadinessResultParts {
+  readonly agentStatuses: RuleHostReadinessResult['agentStatuses'];
+  readonly codeRuleCapability: CodeRuleCapabilityReadiness;
+}
+
+function emptyAgentStatuses(): RuleHostReadinessResult['agentStatuses'] {
+  const empty: AgentReadiness = { status: 'not_ready', reason: 'not checked' };
+  return {
+    dreamer: empty,
+    philosopher: empty,
+    scribe: empty,
+    artificer: empty,
+    evaluator: empty,
+  };
+}
+
+function buildRefusedResult(
+  reason: string,
+  nextAction: string,
+  parts: ReadinessResultParts,
+): RuleHostReadinessResult {
+  return {
+    status: 'refused',
+    reason,
+    nextAction,
+    agentStatuses: parts.agentStatuses,
+    codeRuleCapability: parts.codeRuleCapability,
+  };
+}
+
+function buildTextPrincipleOnlyResult(
+  reason: string,
+  nextAction: string,
+  parts: ReadinessResultParts,
+): RuleHostReadinessResult {
+  return {
+    status: 'text_principle_only',
+    reason,
+    nextAction,
+    agentStatuses: parts.agentStatuses,
+    codeRuleCapability: parts.codeRuleCapability,
+  };
+}
+
+/**
+ * Resolve RuleHost readiness from the workspace's .pd/config.yaml.
+ *
+ * This is the production entry point called by the `run-rulehost` handler
+ * BEFORE constructing any adapters. It returns a structured result so the
+ * handler can emit a clear status instead of an opaque adapter-resolution failure.
+ *
+ * @param workspaceDir - The workspace directory containing .pd/config.yaml
+ * @param getEnvVar - Env var accessor, defaults to process.env. Injected for testability.
+ * @returns Structured readiness result. Never throws.
+ */
+export function resolveRuleHostReadiness(
+  workspaceDir: string,
+  getEnvVar: (name: string) => string | undefined = (name) => process.env[name],
+): RuleHostReadinessResult {
+  // ── Step 1: Load config ──
+  const { configLoadResult } = resolveRuntimeFromPdConfig(workspaceDir, getEnvVar);
+
+  if (!configLoadResult.ok) {
+    const [firstError] = configLoadResult.errors;
+    const reason = `config_malformed: ${firstError?.reason ?? 'unknown config error'}`;
+    const nextAction = firstError?.nextAction ?? 'Fix .pd/config.yaml syntax and retry';
+    return buildRefusedResult(reason, nextAction, {
+      agentStatuses: emptyAgentStatuses(),
+      codeRuleCapability: { enabled: false, disabledReason: 'config_malformed' },
+    });
+  }
+
+  const { effective } = configLoadResult;
+
+  // ── Step 2: Check required agents (dreamer, philosopher, scribe) ──
+  const agentStatuses: Record<string, AgentReadiness> = {};
+  const requiredFailures: string[] = [];
+
+  for (const agentName of REQUIRED_AGENTS) {
+    const readiness = checkAgentReadiness(effective, agentName, getEnvVar);
+    agentStatuses[agentName] = readiness;
+    if (readiness.status !== 'ready') {
+      requiredFailures.push(`${agentName}: ${readiness.reason ?? readiness.status}`);
+    }
+  }
+
+  if (requiredFailures.length > 0) {
+    const reason = `required_agents_not_ready: ${requiredFailures.join('; ')}`;
+    const nextAction = `Fix the following agent issues in .pd/config.yaml: ${requiredFailures.join('; ')}. RuleHost requires dreamer, philosopher, and scribe agents to be enabled with pi-ai runtime profiles and valid API keys.`;
+    return buildRefusedResult(reason, nextAction, {
+      agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+      codeRuleCapability: { enabled: false, disabledReason: 'required_agents_not_ready' },
+    });
+  }
+
+  // ── Step 3: Check code_rule_capability feature flag ──
+  const featureFlags = computeFeatureFlagsFromConfig(effective);
+  if (!isFeatureEnabled(featureFlags, 'code_rule_capability')) {
+    const reason = 'code_rule_capability feature flag is disabled';
+    const nextAction = "Enable code_rule_capability in .pd/config.yaml features.code_rule_capability.enabled to run the full adversarial pipeline. Text-principle-only mode is available.";
+    // Still check artificer/evaluator for reporting, but they don't affect the status
+    for (const agentName of CODE_RULE_AGENTS) {
+      agentStatuses[agentName] = checkAgentReadiness(effective, agentName, getEnvVar);
+    }
+    return buildTextPrincipleOnlyResult(reason, nextAction, {
+      agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+      codeRuleCapability: { enabled: false, disabledReason: reason },
+    });
+  }
+
+  // ── Step 4: Check code-rule agents (artificer, evaluator) ──
+  const codeRuleFailures: string[] = [];
+
+  for (const agentName of CODE_RULE_AGENTS) {
+    const readiness = checkAgentReadiness(effective, agentName, getEnvVar);
+    agentStatuses[agentName] = readiness;
+    if (readiness.status !== 'ready') {
+      codeRuleFailures.push(`${agentName}: ${readiness.reason ?? readiness.status}`);
+    }
+  }
+
+  if (codeRuleFailures.length > 0) {
+    const reason = `code_rule_agents_not_ready: ${codeRuleFailures.join('; ')}`;
+    const nextAction = `Fix the following agent issues to enable code-rule capability: ${codeRuleFailures.join('; ')}. Text-principle-only mode is available with the current configuration.`;
+    return buildTextPrincipleOnlyResult(reason, nextAction, {
+      agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+      codeRuleCapability: { enabled: false, disabledReason: reason },
+    });
+  }
+
+  // ── Step 5: All checks pass → ready ──
+  return {
+    status: 'ready',
+    reason: 'All agents ready with pi-ai profiles and valid API keys. Code-rule capability is ON.',
+    nextAction: 'Pass --confirm to run the full pipeline.',
+    agentStatuses: agentStatuses as RuleHostReadinessResult['agentStatuses'],
+    codeRuleCapability: { enabled: true },
+  };
+}

--- a/packages/pd-cli/src/services/rulehost-readiness.ts
+++ b/packages/pd-cli/src/services/rulehost-readiness.ts
@@ -233,15 +233,8 @@ export function resolveRuleHostReadiness(
   const { effective } = configLoadResult;
 
   // ── Step 2: Check required agents (dreamer, philosopher, scribe) ──
-  // Build agentStatuses with all 5 keys from the start to avoid `as` casts.
-  const unchecked: AgentReadiness = { status: 'not_ready', reason: 'not checked' };
-  const agentStatuses: AgentStatusesMap = {
-    dreamer: unchecked,
-    philosopher: unchecked,
-    scribe: unchecked,
-    artificer: unchecked,
-    evaluator: unchecked,
-  };
+  // Start with all 5 keys set to 'not checked'; updated as each agent is checked.
+  const agentStatuses: AgentStatusesMap = emptyAgentStatuses();
   const requiredFailures: string[] = [];
 
   for (const agentName of REQUIRED_AGENTS) {

--- a/packages/pd-cli/src/services/rulehost-readiness.ts
+++ b/packages/pd-cli/src/services/rulehost-readiness.ts
@@ -202,20 +202,9 @@ function buildTextPrincipleOnlyResult(
   };
 }
 
-/**
- * Resolve RuleHost readiness from the workspace's .pd/config.yaml.
- *
- * This is the production entry point called by the `run-rulehost` handler
- * BEFORE constructing any adapters. It returns a structured result so the
- * handler can emit a clear status instead of an opaque adapter-resolution failure.
- *
- * @param workspaceDir - The workspace directory containing .pd/config.yaml
- * @param getEnvVar - Env var accessor, defaults to process.env. Injected for testability.
- * @returns Structured readiness result. Never throws.
- */
-export function resolveRuleHostReadiness(
+function resolveRuleHostReadinessUnchecked(
   workspaceDir: string,
-  getEnvVar: (name: string) => string | undefined = (name) => process.env[name],
+  getEnvVar: (name: string) => string | undefined,
 ): RuleHostReadinessResult {
   // ── Step 1: Load config ──
   const { configLoadResult } = resolveRuntimeFromPdConfig(workspaceDir, getEnvVar);
@@ -297,4 +286,41 @@ export function resolveRuleHostReadiness(
     agentStatuses,
     codeRuleCapability: { enabled: true },
   };
+}
+
+/**
+ * Resolve RuleHost readiness from the workspace's .pd/config.yaml.
+ *
+ * This is the production entry point called by the `run-rulehost` handler
+ * BEFORE constructing any adapters. It returns a structured result so the
+ * handler can emit a clear status instead of an opaque adapter-resolution failure.
+ *
+ * This function NEVER throws. Any unexpected exception from config loading,
+ * feature-flag computation, agent checks, or getEnvVar is caught and converted
+ * to a `refused` result with reason + nextAction (Runtime Contract #9).
+ *
+ * @param workspaceDir - The workspace directory containing .pd/config.yaml
+ * @param getEnvVar - Env var accessor, defaults to process.env. Injected for testability.
+ * @returns Structured readiness result. Never throws.
+ */
+export function resolveRuleHostReadiness(
+  workspaceDir: string,
+  getEnvVar: (name: string) => string | undefined = (name) => process.env[name],
+): RuleHostReadinessResult {
+  try {
+    return resolveRuleHostReadinessUnchecked(workspaceDir, getEnvVar);
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error && error.message.length > 0
+        ? error.message
+        : 'unknown readiness resolution error';
+    return buildRefusedResult(
+      `readiness_resolution_failed: ${message}`,
+      'Fix the readiness resolution error and retry. Run `pd config doctor` for diagnostics.',
+      {
+        agentStatuses: emptyAgentStatuses(),
+        codeRuleCapability: { enabled: false, disabledReason: 'readiness_resolution_failed' },
+      },
+    );
+  }
 }

--- a/packages/pd-cli/src/services/rulehost-readiness.ts
+++ b/packages/pd-cli/src/services/rulehost-readiness.ts
@@ -27,7 +27,6 @@ import {
 } from '@principles/core/runtime-v2';
 import type {
   EffectivePdConfig,
-  InternalAgentName,
   RuntimeProfile,
 } from '@principles/core/runtime-v2';
 import { resolveRuntimeFromPdConfig } from './resolve-runtime-from-pd-config.js';
@@ -63,19 +62,37 @@ export interface RuleHostReadinessResult {
   readonly codeRuleCapability: CodeRuleCapabilityReadiness;
 }
 
+/**
+ * The 5 internal agents that RuleHost readiness checks.
+ * Narrowed from InternalAgentName so array iteration indexes a known-shape map.
+ */
+type RuleHostAgentName = 'dreamer' | 'philosopher' | 'scribe' | 'artificer' | 'evaluator';
+
+/**
+ * Mutable builder type for agentStatuses during construction.
+ * The readonly RuleHostReadinessResult['agentStatuses'] is assigned from this.
+ */
+interface AgentStatusesMap {
+  dreamer: AgentReadiness;
+  philosopher: AgentReadiness;
+  scribe: AgentReadiness;
+  artificer: AgentReadiness;
+  evaluator: AgentReadiness;
+}
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /**
  * Agents required for the text-principle path (dreamer → philosopher → scribe).
  * If any of these is not ready, the pipeline cannot produce even text principles.
  */
-const REQUIRED_AGENTS: readonly InternalAgentName[] = ['dreamer', 'philosopher', 'scribe'];
+const REQUIRED_AGENTS: readonly RuleHostAgentName[] = ['dreamer', 'philosopher', 'scribe'];
 
 /**
  * Agents required for the code-rule capability (artificer + evaluator).
  * Both must be ready for the adversarial loop to run.
  */
-const CODE_RULE_AGENTS: readonly InternalAgentName[] = ['artificer', 'evaluator'];
+const CODE_RULE_AGENTS: readonly RuleHostAgentName[] = ['artificer', 'evaluator'];
 
 // ── Implementation ────────────────────────────────────────────────────────────
 
@@ -92,7 +109,7 @@ const CODE_RULE_AGENTS: readonly InternalAgentName[] = ['artificer', 'evaluator'
  */
 function checkAgentReadiness(
   effective: EffectivePdConfig,
-  agentName: InternalAgentName,
+  agentName: RuleHostAgentName,
   getEnvVar: (name: string) => string | undefined,
 ): AgentReadiness {
   const binding = resolveAgentRuntimeBinding(effective, agentName);
@@ -142,11 +159,11 @@ function checkAgentReadiness(
 // ── Helpers (defined before public function to satisfy no-use-before-define) ──
 
 interface ReadinessResultParts {
-  readonly agentStatuses: RuleHostReadinessResult['agentStatuses'];
+  readonly agentStatuses: AgentStatusesMap;
   readonly codeRuleCapability: CodeRuleCapabilityReadiness;
 }
 
-function emptyAgentStatuses(): RuleHostReadinessResult['agentStatuses'] {
+function emptyAgentStatuses(): AgentStatusesMap {
   const empty: AgentReadiness = { status: 'not_ready', reason: 'not checked' };
   return {
     dreamer: empty,
@@ -218,7 +235,7 @@ export function resolveRuleHostReadiness(
   // ── Step 2: Check required agents (dreamer, philosopher, scribe) ──
   // Build agentStatuses with all 5 keys from the start to avoid `as` casts.
   const unchecked: AgentReadiness = { status: 'not_ready', reason: 'not checked' };
-  const agentStatuses: RuleHostReadinessResult['agentStatuses'] = {
+  const agentStatuses: AgentStatusesMap = {
     dreamer: unchecked,
     philosopher: unchecked,
     scribe: unchecked,

--- a/packages/pd-cli/tests/commands/run-rulehost-handler.test.ts
+++ b/packages/pd-cli/tests/commands/run-rulehost-handler.test.ts
@@ -71,6 +71,11 @@ function parseJsonObject(text: string): Record<string, unknown> {
   return parsed;
 }
 
+/** Type guard: narrows `unknown` to `Record<string, unknown>` without `as`. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function captureStdio(fn: () => Promise<void>): Promise<StdIoState> {
   return new Promise((resolve, reject) => {
     const origExitCode = process.exitCode;
@@ -437,7 +442,11 @@ describe('handleRunRuleHost — PRI-461 readiness integration', () => {
     );
     const payload = parseJsonObject(stdout.trim());
     expect(payload.readiness).toBeDefined();
-    const readiness = payload.readiness as Record<string, unknown>;
+    const readiness = payload.readiness;
+    expect(isRecord(readiness)).toBe(true);
+    if (!isRecord(readiness)) {
+      throw new Error('readiness is not a record');
+    }
     expect(readiness.status).toBe('refused');
     expect(readiness.agentStatuses).toBeDefined();
   });

--- a/packages/pd-cli/tests/commands/run-rulehost-handler.test.ts
+++ b/packages/pd-cli/tests/commands/run-rulehost-handler.test.ts
@@ -251,3 +251,209 @@ describe('handleRunRuleHost — dry-run mode output shape (with minimal pd-confi
     }
   });
 });
+
+// ── PRI-461: readiness integration tests ──────────────────────────────────
+//
+// Verifies the handler emits the three readiness statuses (ready /
+// text_principle_only / refused) with the correct exit codes and JSON shape.
+// These tests exercise the full path: config → resolveRuleHostReadiness →
+// handler output, ensuring the readiness gate is wired into production code
+// (EP-02) and that refused statuses fail loud with reason + nextAction (EP-03).
+
+function writeFullReadyConfig(workspaceDir: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  const cfg = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      code_rule_capability: { category: 'core', enabled: true },
+    },
+    workspace: { default: workspaceDir },
+    runtimeProfiles: {
+      'pi-ai.default': { type: 'pi-ai', provider: 'anthropic', model: 'claude-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+    },
+    internalAgents: {
+      defaultRuntime: 'pi-ai.default',
+      agents: {
+        dreamer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        philosopher: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        scribe: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        artificer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        evaluator: { enabled: true, runtimeProfile: 'pi-ai.default' },
+      },
+    },
+  };
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+}
+
+function writeTextPrincipleOnlyConfig(workspaceDir: string): void {
+  // code_rule_capability explicitly OFF → text_principle_only
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  const cfg = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      code_rule_capability: { category: 'core', enabled: false },
+    },
+    workspace: { default: workspaceDir },
+    runtimeProfiles: {
+      'pi-ai.default': { type: 'pi-ai', provider: 'anthropic', model: 'claude-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+    },
+    internalAgents: {
+      defaultRuntime: 'pi-ai.default',
+      agents: {
+        dreamer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        philosopher: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        scribe: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        artificer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        evaluator: { enabled: true, runtimeProfile: 'pi-ai.default' },
+      },
+    },
+  };
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+}
+
+function writeRefusedConfig(workspaceDir: string): void {
+  // dreamer disabled → required agent missing → refused
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  const cfg = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      code_rule_capability: { category: 'core', enabled: true },
+    },
+    workspace: { default: workspaceDir },
+    runtimeProfiles: {
+      'pi-ai.default': { type: 'pi-ai', provider: 'anthropic', model: 'claude-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+    },
+    internalAgents: {
+      defaultRuntime: 'pi-ai.default',
+      agents: {
+        dreamer: { enabled: false, runtimeProfile: 'pi-ai.default' },
+        philosopher: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        scribe: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        artificer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        evaluator: { enabled: true, runtimeProfile: 'pi-ai.default' },
+      },
+    },
+  };
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+}
+
+describe('handleRunRuleHost — PRI-461 readiness integration', () => {
+  let workspaceDir: string;
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    workspaceDir = mkTmpDir();
+    savedEnv = { ...process.env };
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+    try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  // ── ready ───────────────────────────────────────────────────────────────
+
+  it('emits readiness=ready in --json dry-run when all agents and code-rule capability are ON', async () => {
+    writeFullReadyConfig(workspaceDir);
+    const { stdout, exitCode } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, json: true, workspace: workspaceDir }),
+    );
+    const payload = parseJsonObject(stdout.trim());
+    expect(payload.status).toBe('dry_run');
+    expect(payload.readiness).toBe('ready');
+    expect(exitCode).toBeUndefined();
+  });
+
+  it('emits readiness=ready in plain-text dry-run output', async () => {
+    writeFullReadyConfig(workspaceDir);
+    const { stdout } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, workspace: workspaceDir }),
+    );
+    expect(stdout).toMatch(/readiness:\s*READY/i);
+  });
+
+  // ── text_principle_only ─────────────────────────────────────────────────
+
+  it('emits readiness=text_principle_only in --json dry-run when code_rule_capability is OFF', async () => {
+    writeTextPrincipleOnlyConfig(workspaceDir);
+    const { stdout, exitCode } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, json: true, workspace: workspaceDir }),
+    );
+    const payload = parseJsonObject(stdout.trim());
+    expect(payload.status).toBe('dry_run');
+    expect(payload.readiness).toBe('text_principle_only');
+    expect(exitCode).toBeUndefined();
+  });
+
+  it('emits readiness=text_principle_only in plain-text dry-run output', async () => {
+    writeTextPrincipleOnlyConfig(workspaceDir);
+    const { stdout } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, workspace: workspaceDir }),
+    );
+    expect(stdout).toMatch(/readiness:\s*TEXT_PRINCIPLE_ONLY/i);
+  });
+
+  // ── refused ─────────────────────────────────────────────────────────────
+
+  it('exits with code=1 and emits status=refused in --json when dreamer is disabled', async () => {
+    writeRefusedConfig(workspaceDir);
+    const { stdout, exitCode } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, json: true, workspace: workspaceDir }),
+    );
+    const payload = parseJsonObject(stdout.trim());
+    expect(payload.status).toBe('refused');
+    expect(typeof payload.reason).toBe('string');
+    expect(typeof payload.nextAction).toBe('string');
+    expect(exitCode).toBe(1);
+  });
+
+  it('exits with code=1 and emits REFUSED in plain-text when dreamer is disabled', async () => {
+    writeRefusedConfig(workspaceDir);
+    const { stderr, exitCode } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, workspace: workspaceDir }),
+    );
+    expect(stderr).toMatch(/REFUSED/i);
+    expect(stderr).toMatch(/dreamer/i);
+    expect(exitCode).toBe(1);
+  });
+
+  it('refused status includes the full readiness object in --json output', async () => {
+    writeRefusedConfig(workspaceDir);
+    const { stdout } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, json: true, workspace: workspaceDir }),
+    );
+    const payload = parseJsonObject(stdout.trim());
+    expect(payload.readiness).toBeDefined();
+    const readiness = payload.readiness as Record<string, unknown>;
+    expect(readiness.status).toBe('refused');
+    expect(readiness.agentStatuses).toBeDefined();
+  });
+
+  it('refused status does NOT attempt pipeline execution or adapter construction', async () => {
+    // If the handler tried to construct adapters with a disabled dreamer,
+    // resolveRunRuleHostRuntime would throw. The readiness gate must prevent
+    // that by exiting before resolveRunRuleHostRuntime is called.
+    writeRefusedConfig(workspaceDir);
+    const { stdout, exitCode } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, json: true, workspace: workspaceDir }),
+    );
+    const payload = parseJsonObject(stdout.trim());
+    // Must be 'refused', NOT 'failed' with 'agent_runtime_resolution_failed'
+    expect(payload.status).toBe('refused');
+    expect(payload.reason).not.toMatch(/agent_runtime_resolution_failed/);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/packages/pd-cli/tests/commands/run-rulehost-handler.test.ts
+++ b/packages/pd-cli/tests/commands/run-rulehost-handler.test.ts
@@ -324,6 +324,35 @@ function writeTextPrincipleOnlyConfig(workspaceDir: string): void {
   fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
 }
 
+function writeEvaluatorDisabledConfig(workspaceDir: string): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  const cfg = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      code_rule_capability: { category: 'core', enabled: true },
+    },
+    workspace: { default: workspaceDir },
+    runtimeProfiles: {
+      'pi-ai.default': { type: 'pi-ai', provider: 'anthropic', model: 'claude-sonnet', apiKeyEnv: 'ANTHROPIC_API_KEY' },
+    },
+    internalAgents: {
+      defaultRuntime: 'pi-ai.default',
+      agents: {
+        dreamer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        philosopher: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        scribe: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        artificer: { enabled: true, runtimeProfile: 'pi-ai.default' },
+        evaluator: { enabled: false, runtimeProfile: 'pi-ai.default' },
+      },
+    },
+  };
+  fs.writeFileSync(path.join(configDir, 'config.yaml'), yaml.dump(cfg), 'utf8');
+}
+
 function writeRefusedConfig(workspaceDir: string): void {
   // dreamer disabled → required agent missing → refused
   const configDir = path.join(workspaceDir, '.pd');
@@ -378,7 +407,13 @@ describe('handleRunRuleHost — PRI-461 readiness integration', () => {
     );
     const payload = parseJsonObject(stdout.trim());
     expect(payload.status).toBe('dry_run');
-    expect(payload.readiness).toBe('ready');
+    expect(payload.readinessStatus).toBe('ready');
+    const readiness = payload.readiness;
+    expect(isRecord(readiness)).toBe(true);
+    if (!isRecord(readiness)) {
+      throw new Error('readiness is not a record');
+    }
+    expect(readiness.status).toBe('ready');
     expect(exitCode).toBeUndefined();
   });
 
@@ -399,7 +434,34 @@ describe('handleRunRuleHost — PRI-461 readiness integration', () => {
     );
     const payload = parseJsonObject(stdout.trim());
     expect(payload.status).toBe('dry_run');
-    expect(payload.readiness).toBe('text_principle_only');
+    expect(payload.readinessStatus).toBe('text_principle_only');
+    const readiness = payload.readiness;
+    expect(isRecord(readiness)).toBe(true);
+    if (!isRecord(readiness)) {
+      throw new Error('readiness is not a record');
+    }
+    expect(readiness.status).toBe('text_principle_only');
+    expect(typeof readiness.reason).toBe('string');
+    expect(typeof readiness.nextAction).toBe('string');
+    expect(exitCode).toBeUndefined();
+  });
+
+  it('does not reclassify evaluator-disabled text_principle_only as runtime resolution failure', async () => {
+    writeEvaluatorDisabledConfig(workspaceDir);
+    const { stdout, exitCode } = await captureStdio(() =>
+      handleRunRuleHost({ painId: 'pain-1', dryRun: true, json: true, workspace: workspaceDir }),
+    );
+    const payload = parseJsonObject(stdout.trim());
+    expect(payload.status).toBe('dry_run');
+    expect(payload.readinessStatus).toBe('text_principle_only');
+    const readiness = payload.readiness;
+    expect(isRecord(readiness)).toBe(true);
+    if (!isRecord(readiness)) {
+      throw new Error('readiness is not a record');
+    }
+    expect(readiness.status).toBe('text_principle_only');
+    expect(String(readiness.reason)).toContain('evaluator');
+    expect(String(payload.capabilityStatus)).toContain('evaluator');
     expect(exitCode).toBeUndefined();
   });
 

--- a/packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts
+++ b/packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts
@@ -52,6 +52,18 @@ function writeConfig(workspaceDir: string, content: object): void {
   );
 }
 
+/** Type guard: narrows `unknown` to `Record<string, unknown>` without `as`. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${label} is not a record`);
+  }
+  return value;
+}
+
 /** Config with both artificer+evaluator enabled, pi-ai profile, API key env set. */
 function makeCapabilityOnConfig(workspaceDir: string): object {
   return {
@@ -90,17 +102,19 @@ function makeCapabilityOnConfig(workspaceDir: string): object {
 
 /** Config with artificer disabled (capability must be OFF). */
 function makeArtificerDisabledConfig(workspaceDir: string): object {
-  const cfg = makeCapabilityOnConfig(workspaceDir) as Record<string, unknown>;
-  const internalAgents = cfg.internalAgents as { agents: Record<string, { enabled: boolean; runtimeProfile?: string }> };
-  internalAgents.agents.artificer = { enabled: false };
+  const cfg = makeCapabilityOnConfig(workspaceDir);
+  const internalAgents = requireRecord(Reflect.get(cfg, 'internalAgents'), 'internalAgents');
+  const agents = requireRecord(Reflect.get(internalAgents, 'agents'), 'internalAgents.agents');
+  Reflect.set(agents, 'artificer', { enabled: false });
   return cfg;
 }
 
 /** Config with evaluator disabled (capability must be OFF). */
 function makeEvaluatorDisabledConfig(workspaceDir: string): object {
-  const cfg = makeCapabilityOnConfig(workspaceDir) as Record<string, unknown>;
-  const internalAgents = cfg.internalAgents as { agents: Record<string, { enabled: boolean; runtimeProfile?: string }> };
-  internalAgents.agents.evaluator = { enabled: false };
+  const cfg = makeCapabilityOnConfig(workspaceDir);
+  const internalAgents = requireRecord(Reflect.get(cfg, 'internalAgents'), 'internalAgents');
+  const agents = requireRecord(Reflect.get(internalAgents, 'agents'), 'internalAgents.agents');
+  Reflect.set(agents, 'evaluator', { enabled: false });
   return cfg;
 }
 
@@ -158,15 +172,11 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
   }
 
   /** Extract the single JSON object written to stdout. Fails if not exactly one write. */
-  function parseJsonOutput(): unknown {
+  function parseJsonOutput(): Record<string, unknown> {
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const raw = stdoutSpy.mock.calls[0][0] as string;
-    return JSON.parse(raw);
-  }
-
-  /** Type guard: narrows `unknown` to `Record<string, unknown>` without `as`. */
-  function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
+    const parsed: unknown = JSON.parse(raw);
+    return requireRecord(parsed, 'stdout JSON');
   }
 
   // ── Capability ON: both agents enabled, API key set ──────────────────────
@@ -183,14 +193,11 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    expect(typeof output).toBe('object');
-    expect(output).not.toBeNull();
-    const obj = output as { status: string; codeRuleCapability?: { enabled: boolean; disabledReason?: string }; capabilityStatus?: string };
-    expect(obj.status).toBe('dry_run');
-    expect(obj.codeRuleCapability).toBeDefined();
-    expect(obj.codeRuleCapability?.enabled).toBe(true);
-    expect(obj.codeRuleCapability?.disabledReason).toBeUndefined();
-    expect(obj.capabilityStatus).toContain('ON');
+    const codeRuleCapability = requireRecord(output.codeRuleCapability, 'codeRuleCapability');
+    expect(output.status).toBe('dry_run');
+    expect(codeRuleCapability.enabled).toBe(true);
+    expect(codeRuleCapability.disabledReason).toBeUndefined();
+    expect(String(output.capabilityStatus)).toContain('ON');
     // exitCode must NOT be set for dry_run success
     expect(process.exitCode).toBeUndefined();
   });
@@ -208,16 +215,13 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     await handleRunRuleHost({ workspace, painId: 'pain-flag-default', dryRun: true, json: true });
 
     const output = parseJsonOutput();
-    // PRI-435 (CodeRabbit P3): narrow unknown before property access
-    expect(typeof output).toBe('object');
-    expect(output).not.toBeNull();
-    const obj = output as { status: string; codeRuleCapability?: { enabled: boolean; disabledReason?: string }; capabilityStatus?: string };
-    expect(obj.status).toBe('dry_run');
+    const codeRuleCapability = requireRecord(output.codeRuleCapability, 'codeRuleCapability');
+    expect(output.status).toBe('dry_run');
     // PRI-435: code_rule_capability is now a core flag — defaults ON even when omitted from config.
     // It cannot be disabled by config. The capability is ON when artificer+evaluator are configured.
-    expect(obj.codeRuleCapability).toEqual(expect.objectContaining({ enabled: true }));
-    expect(obj.codeRuleCapability?.disabledReason).toBeUndefined();
-    expect(String(obj.capabilityStatus)).toContain('ON');
+    expect(codeRuleCapability).toEqual(expect.objectContaining({ enabled: true }));
+    expect(codeRuleCapability.disabledReason).toBeUndefined();
+    expect(String(output.capabilityStatus)).toContain('ON');
   });
 
   it('PRI-435: explicit emergency disable via code_rule_capability.enabled=false is observable', async () => {
@@ -234,16 +238,13 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     await handleRunRuleHost({ workspace, painId: 'pain-emergency-disable', dryRun: true, json: true });
 
     const output = parseJsonOutput();
-    // PRI-435 (CodeRabbit P3): narrow unknown before property access
-    expect(typeof output).toBe('object');
-    expect(output).not.toBeNull();
-    const obj = output as { status: string; codeRuleCapability?: { enabled: boolean; disabledReason?: string }; capabilityStatus?: string };
-    expect(obj.status).toBe('dry_run');
+    const codeRuleCapability = requireRecord(output.codeRuleCapability, 'codeRuleCapability');
+    expect(output.status).toBe('dry_run');
     // PRI-435: Emergency disable via code_rule_capability.enabled=false is preserved.
     // The capability is OFF with a structured reason.
-    expect(obj.codeRuleCapability).toEqual(expect.objectContaining({ enabled: false }));
-    expect(String(obj.codeRuleCapability?.disabledReason)).toContain('feature flag');
-    expect(String(obj.capabilityStatus)).toContain('OFF');
+    expect(codeRuleCapability).toEqual(expect.objectContaining({ enabled: false }));
+    expect(String(codeRuleCapability.disabledReason)).toContain('feature flag');
+    expect(String(output.capabilityStatus)).toContain('OFF');
   });
 
   it('reports the resolved runtime profile for every executed agent', async () => {
@@ -320,10 +321,10 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string; codeRuleCapability: { enabled: boolean; disabledReason?: string } };
-    expect(obj.status).toBe('dry_run');
-    expect(obj.codeRuleCapability.enabled).toBe(false);
-    expect(obj.codeRuleCapability.disabledReason).toContain('artificer');
+    const codeRuleCapability = requireRecord(output.codeRuleCapability, 'codeRuleCapability');
+    expect(output.status).toBe('dry_run');
+    expect(codeRuleCapability.enabled).toBe(false);
+    expect(String(codeRuleCapability.disabledReason)).toContain('artificer');
   });
 
   // ── Capability OFF: evaluator disabled ───────────────────────────────────
@@ -340,10 +341,10 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string; codeRuleCapability: { enabled: boolean; disabledReason?: string } };
-    expect(obj.status).toBe('dry_run');
-    expect(obj.codeRuleCapability.enabled).toBe(false);
-    expect(obj.codeRuleCapability.disabledReason).toContain('evaluator');
+    const codeRuleCapability = requireRecord(output.codeRuleCapability, 'codeRuleCapability');
+    expect(output.status).toBe('dry_run');
+    expect(codeRuleCapability.enabled).toBe(false);
+    expect(String(codeRuleCapability.disabledReason)).toContain('evaluator');
   });
 
   // ── Capability OFF: API key not set ──────────────────────────────────────
@@ -405,10 +406,11 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string; codeRuleCapability: { enabled: boolean; disabledReason?: string } };
-    expect(obj.status).toBe('dry_run');
-    expect(obj.codeRuleCapability.enabled).toBe(false);
-    expect(obj.codeRuleCapability.disabledReason).toContain('apiKeyEnv');
+    const codeRuleCapability = requireRecord(output.codeRuleCapability, 'codeRuleCapability');
+    expect(output.status).toBe('dry_run');
+    expect(codeRuleCapability.enabled).toBe(false);
+    expect(String(codeRuleCapability.disabledReason)).toContain('TEST_RULEHOST_ARTIFICER_KEY');
+    expect(String(codeRuleCapability.disabledReason)).toContain('not set');
   });
 
   // ── CLI gate: mutual exclusivity ─────────────────────────────────────────
@@ -426,10 +428,9 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string; reason: string; nextAction: string };
-    expect(obj.status).toBe('failed');
-    expect(obj.reason).toContain('mutually exclusive');
-    expect(obj.nextAction).toBeTruthy();
+    expect(output.status).toBe('failed');
+    expect(String(output.reason)).toContain('mutually exclusive');
+    expect(output.nextAction).toBeTruthy();
     expect(process.exitCode).toBe(1);
   });
 
@@ -447,10 +448,9 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string; reason: string; nextAction: string };
-    expect(obj.status).toBe('failed');
-    expect(obj.reason).toContain('painId');
-    expect(obj.nextAction).toBeTruthy();
+    expect(output.status).toBe('failed');
+    expect(String(output.reason)).toContain('painId');
+    expect(output.nextAction).toBeTruthy();
     expect(process.exitCode).toBe(1);
   });
 
@@ -492,8 +492,7 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string };
-    expect(obj.status).toBe('dry_run');
+    expect(output.status).toBe('dry_run');
     // Must NOT set exitCode for dry_run
     expect(process.exitCode).toBeUndefined();
   });
@@ -513,10 +512,9 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     });
 
     const output = parseJsonOutput();
-    const obj = output as { status: string; reason: string; nextAction: string };
-    expect(obj.status).toBe('failed');
-    expect(obj.reason).toContain('unsupported channel');
-    expect(obj.nextAction).toBeTruthy();
+    expect(output.status).toBe('failed');
+    expect(String(output.reason)).toContain('unsupported channel');
+    expect(output.nextAction).toBeTruthy();
     expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts
+++ b/packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts
@@ -164,6 +164,11 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     return JSON.parse(raw);
   }
 
+  /** Type guard: narrows `unknown` to `Record<string, unknown>` without `as`. */
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
   // ── Capability ON: both agents enabled, API key set ──────────────────────
 
   it('dry-run reports code_rule_capability: ON when artificer+evaluator enabled and API key set', async () => {
@@ -275,6 +280,10 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
     // construction, returning status='refused' with a structured reason instead
     // of the old opaque 'agent_runtime_resolution_failed' error.
     const output = parseJsonOutput();
+    expect(isRecord(output)).toBe(true);
+    if (!isRecord(output)) {
+      throw new Error('output is not a record');
+    }
     expect(output.status).toBe('refused');
     expect(String(output.reason)).toContain('philosopher');
     expect(typeof output.nextAction).toBe('string');

--- a/packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts
+++ b/packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts
@@ -271,10 +271,13 @@ describe('runRuleHost production-wiring (PRI-429) — deterministic, no LLM', ()
 
     await handleRunRuleHost({ workspace, painId: 'pain-disabled-philosopher', confirm: true, json: true });
 
+    // PRI-461: readiness gate catches disabled required agents BEFORE adapter
+    // construction, returning status='refused' with a structured reason instead
+    // of the old opaque 'agent_runtime_resolution_failed' error.
     const output = parseJsonOutput();
-    expect(output.status).toBe('failed');
-    expect(output.reason).toBe('agent_runtime_resolution_failed');
-    expect(String(output.message)).toContain('philosopher');
+    expect(output.status).toBe('refused');
+    expect(String(output.reason)).toContain('philosopher');
+    expect(typeof output.nextAction).toBe('string');
     expect(process.exitCode).toBe(1);
     expect(fs.existsSync(path.join(workspace, '.state', 'runtime-v2.sqlite'))).toBe(false);
   });


### PR DESCRIPTION
## PRI-461: RuleHost Readiness Resolver

Closes #PRI-461

### Problem

The `pd runtime internalization run-rulehost` handler threw opaque `agent_runtime_resolution_failed` errors when preconditions weren't met (disabled agents, wrong profile type, missing API keys). Users had no way to distinguish "can run fully" from "can only produce text principles" from "cannot run at all".

### Solution

Add `resolveRuleHostReadiness()` pre-gate that checks all pipeline preconditions BEFORE constructing adapters, returning one of three user-visible statuses:

| Status | Meaning | Exit Code |
|--------|---------|-----------|
| `ready` | All agents enabled with pi-ai profiles + API keys; code-rule capability ON | 0 (dry-run) |
| `text_principle_only` | Required agents (dreamer/philosopher/scribe) ready, but code-rule capability OFF | 0 (dry-run) |
| `refused` | Required agents chain broken (disabled, wrong profile, missing key, malformed config) | 1 |

Each non-ready status includes a structured `reason` and `nextAction` so users know exactly what to fix.

### Changes

- **New**: `packages/pd-cli/src/services/rulehost-readiness.ts` — Readiness resolver module
- **New**: `packages/pd-cli/src/services/__tests__/rulehost-readiness.test.ts` — 16 unit tests
- **Modified**: `packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts` — Integrate readiness gate before adapter construction
- **Modified**: `packages/pd-cli/tests/commands/run-rulehost-handler.test.ts` — 8 handler integration tests
- **Modified**: `packages/pd-cli/tests/services/rulehost-pipeline-e2e.test.ts` — Update philosopher-disabled test to expect `refused` instead of `failed/agent_runtime_resolution_failed`

### ERR Compliance

- **EP-02 / ERR-024, ERR-025**: Readiness gate is wired into the production handler path, not just tests
- **EP-03**: `refused` and `text_principle_only` include `reason` + `nextAction` (fail loud, no silent fallback)
- **EP-07**: Uses the same config source (`resolveRuntimeFromPdConfig`) as the pipeline itself
- **EP-09**: Tests cover the default installed config pattern from `create-principles-disciple`, not just hand-written happy paths

### CLI Gate Compliance

- **Rule 1** (JSON strict): `--json` output is exactly one parseable JSON object
- **Rule 2** (exit paths stop): `refused` status sets `process.exitCode = 1` and returns immediately
- **Rule 5** (failure paths don't mutate): `refused` exits before any adapter construction or pipeline execution — no state mutation
- **Rule 6** (operator output needs next action): every `refused` result includes structured `reason` and `nextAction`

### Tests

- `pd-cli`: 1145 passed, 2 skipped (73 test files)
- `principles-core`: 5424 passed, 3 skipped, 3 todo (238 test files)
- `lint`: 0 errors (1 pre-existing warning unrelated to this PR)
- `verify:merge`: passed (all pre-push hooks green)

### TDD Workflow

1. **Red phase**: Wrote 16 unit tests covering all three statuses + edge cases (malformed config, disabled agents, wrong profile type, missing/empty API keys, code_rule_capability OFF, default installed config)
2. **Green phase**: Implemented `resolveRuleHostReadiness()` to make all tests pass
3. **Integration**: Added 8 handler-level tests verifying the readiness gate is wired into production code
4. **Regression**: Updated 1 E2E test that expected the old opaque error message

### Runtime Contract Checklist

| # | Rule | Status |
|---|------|--------|
| 1 | Treat parsed JSON/config as `unknown` | N/A — uses typed `EffectivePdConfig` from validated config loader |
| 2 | No `as` to bypass validation | ✅ — uses `resolveAgentRuntimeBinding` and `checkAgentRuntimeReadiness` type guards |
| 3 | Required fields fail loud | ✅ — missing config/agents/profiles return `refused` with reason |
| 4 | Validate array element types | N/A — no array processing |
| 5 | Use `Object.hasOwn()` | ✅ — delegated to `resolveAgentRuntimeBinding` which uses `Object.hasOwn` |
| 6 | Lineage/evidence consistency | N/A — no lineage fields |
| 7 | Retry/repair loop state | N/A — no retry loops |
| 8 | Bounded preview/telemetry | N/A — no preview paths |
| 9 | Graceful degradation includes reason | ✅ — all non-ready statuses include `reason` + `nextAction` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增运行前就绪性检查，提前识别可用、仅文本模式或拒绝状态，并输出更明确的下一步建议。
  * 干运行输出增强，JSON 与文本模式都会返回更完整的就绪状态信息。

* **修复**
  * 当就绪性不满足时，命令会直接停止并返回错误码，避免继续执行后续流程。
  * 运行失败时，错误输出现在会携带更详细的状态信息。

* **测试**
  * 新增并更新多项测试，覆盖不同配置下的就绪状态与输出行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->