### PR TITLE
refactor(arch-⑥): add shared pure runtime-adapter resolver in core

### DIFF
--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/runtime-adapter-resolver.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/runtime-adapter-resolver.test.ts
@@ -1,0 +1,877 @@
+/**
+ * Tests for the shared runtime-adapter resolver (candidate ⑥ convergence).
+ *
+ * Migrated from packages/pd-cli/src/services/__tests__/runtime-adapter-resolver.test.ts.
+ * The pure resolver logic moved into core; the three pd-cli-local I/O calls
+ * (loadPdConfig, computeFlagsFromLoadResult, resolveRuntimeFromPdConfig) are now
+ * injected via the `io` parameter, so these tests construct a `mockIo` object
+ * instead of using vi.mock on module paths. Every assertion from the original
+ * 34 tests is preserved; 5 new behaviour-difference tests lock the
+ * openclawModeFallback / piAiFieldDefaults knobs added for convergence.
+ *
+ * ERR refs:
+ * - ERR-001 (no any): all mocks use typed vi.fn()
+ * - ERR-005 (no as bypass): no type casts in test assertions
+ * - ERR-009 (fail-loud): ConfigResolutionError thrown with structured fields
+ * - ERR-013 (Object.hasOwn): feature flag check uses Object.hasOwn
+ * - EP-09 (test reality gap): tests exercise the real resolver branches, not stubs
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+// Track constructor calls so we can assert which adapter was constructed.
+const mockTestDoubleCtor = vi.fn();
+const mockPiAiCtor = vi.fn();
+const mockOpenClawCliCtor = vi.fn();
+const mockL2AgentLoopCtor = vi.fn();
+const mockValidateRuntimeConfig = vi.fn();
+const mockIsRuntimeConfigError = vi.fn();
+const mockBuildL2PrincipleReader = vi.fn();
+
+vi.mock('../pi-ai-runtime-adapter.js', () => ({
+  PiAiRuntimeAdapter: vi.fn(function (opts: unknown) {
+    mockPiAiCtor(opts);
+    return { __type: 'PiAiRuntimeAdapter', opts };
+  }),
+}));
+vi.mock('../openclaw-cli-runtime-adapter.js', () => ({
+  OpenClawCliRuntimeAdapter: vi.fn(function (opts: unknown) {
+    mockOpenClawCliCtor(opts);
+    return { __type: 'OpenClawCliRuntimeAdapter', opts };
+  }),
+}));
+vi.mock('../l2-agent-loop-adapter.js', () => ({
+  L2AgentLoopAdapter: vi.fn(function (opts: unknown, deps: unknown) {
+    mockL2AgentLoopCtor(opts, deps);
+    return { __type: 'L2AgentLoopAdapter', opts, deps };
+  }),
+}));
+vi.mock('../test-double-runtime-adapter.js', () => ({
+  TestDoubleRuntimeAdapter: vi.fn(function (opts: unknown) {
+    mockTestDoubleCtor(opts);
+    return { __type: 'TestDoubleRuntimeAdapter', opts };
+  }),
+}));
+vi.mock('../../build-l2-principle-reader.js', () => ({
+  buildL2PrincipleReaderFromLedger: mockBuildL2PrincipleReader.mockReturnValue({
+    listActivePrinciples: vi.fn(),
+  }),
+}));
+vi.mock('../../../principle-tree-ledger.js', () => ({
+  loadLedger: vi.fn().mockReturnValue({ tree: { principles: {} } }),
+}));
+
+// pain-signal-runtime-factory exports isRuntimeConfigError + validateRuntimeConfig.
+// We mock the two functions but keep the real type exports.
+vi.mock('../../pain-signal-runtime-factory.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    isRuntimeConfigError: mockIsRuntimeConfigError,
+    validateRuntimeConfig: mockValidateRuntimeConfig,
+  };
+});
+
+// ─── Injected I/O mocks ────────────────────────────────────────────────────
+// These replace the vi.mock('../pd-config-loader.js') / vi.mock('../resolve-runtime-from-pd-config.js')
+// blocks from the pd-cli test. The resolver now takes them as the `io` parameter.
+
+const mockLoadPdConfig = vi.fn();
+const mockComputeFlagsFromLoadResult = vi.fn();
+const mockResolveRuntimeFromPdConfig = vi.fn();
+
+/** The injected I/O object passed as the second arg to resolveRuntimeAdapterFromConfig. */
+const mockIo = {
+  loadPdConfig: mockLoadPdConfig,
+  computeFlagsFromLoadResult: mockComputeFlagsFromLoadResult,
+  resolveRuntimeFromPdConfig: mockResolveRuntimeFromPdConfig,
+};
+
+// Import AFTER mocks are set up.
+const { resolveRuntimeAdapterFromConfig, ConfigResolutionError } = await import('../runtime-adapter-resolver.js');
+
+// ─── Test Helpers ──────────────────────────────────────────────────────────
+
+function makeValidPiAiConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ok: true,
+    runtimeKind: 'pi-ai',
+    provider: 'openai',
+    model: 'gpt-4',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    baseUrl: undefined,
+    maxRetries: 3,
+    timeoutMs: 300000,
+    agentId: 'main',
+    ...overrides,
+  };
+}
+
+function makeValidOpenClawConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ok: true,
+    runtimeKind: 'openclaw-cli',
+    openclawMode: 'local',
+    timeoutMs: 300000,
+    agentId: 'main',
+    ...overrides,
+  };
+}
+
+function makeConfigError(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ok: false,
+    reason: 'missing-config',
+    message: 'runtime config not found',
+    nextAction: 'Create .pd/config.yaml',
+    ...overrides,
+  };
+}
+
+function makeResolvedConfig(result: Record<string, unknown>): Record<string, unknown> {
+  return {
+    result,
+    legacyWarnings: [],
+    configLoadResult: { config: null, source: '.pd/config.yaml' },
+    configSource: '.pd/config.yaml',
+    runtimeProfileId: null,
+    runtimeProfileLabel: null,
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('resolveRuntimeAdapterFromConfig (candidate ⑥ core convergence)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: isRuntimeConfigError returns false (config is valid)
+    mockIsRuntimeConfigError.mockReturnValue(false);
+    // Default: validateRuntimeConfig does nothing (config is valid)
+    mockValidateRuntimeConfig.mockImplementation(() => {
+      // no-op: valid config
+    });
+    // Default: feature flags have l2_dreamer disabled
+    mockLoadPdConfig.mockReturnValue({ ok: true, effective: {}, source: 'defaults' });
+    mockComputeFlagsFromLoadResult.mockReturnValue({
+      flags: {},
+      enabledChannels: [],
+      warnings: [],
+    });
+  });
+
+  // ── ConfigResolutionError class ──────────────────────────────────────────
+
+  describe('ConfigResolutionError', () => {
+    it('has name "ConfigResolutionError" and preserves message + kind + missing + nextAction', () => {
+      const err = new ConfigResolutionError('boom', 'missing-fields', {
+        missing: ['provider', 'model'],
+        nextAction: 'Set provider and model flags.',
+      });
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('ConfigResolutionError');
+      expect(err.message).toBe('boom');
+      expect(err.kind).toBe('missing-fields');
+      expect(err.missing).toEqual(['provider', 'model']);
+      expect(err.nextAction).toBe('Set provider and model flags.');
+    });
+
+    it('allows missing and nextAction fields to be undefined', () => {
+      const err = new ConfigResolutionError('boom', 'invalid-config');
+      expect(err.missing).toBeUndefined();
+      expect(err.nextAction).toBeUndefined();
+    });
+  });
+
+  // ── test-double branch ───────────────────────────────────────────────────
+
+  describe('test-double branch', () => {
+    it('returns adapter from testDoublePayloadBuilder when allowTestDouble is true', () => {
+      const fakeAdapter = { __type: 'custom-test-double' };
+      const builder = vi.fn(() => fakeAdapter as never);
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'test-double',
+        workspaceDir: '/ws',
+        allowTestDouble: true,
+        testDoublePayloadBuilder: builder,
+      }, mockIo);
+
+      expect(result).toBe(fakeAdapter);
+      expect(builder).toHaveBeenCalledTimes(1);
+      expect(builder).toHaveBeenCalledWith(expect.objectContaining({
+        runtimeKind: 'test-double',
+        workspaceDir: '/ws',
+        allowTestDouble: true,
+      }));
+    });
+
+    it('throws ConfigResolutionError when allowTestDouble is false', () => {
+      const builder = vi.fn();
+
+      expect(() => {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'test-double',
+          workspaceDir: '/ws',
+          allowTestDouble: false,
+          testDoublePayloadBuilder: builder,
+        }, mockIo);
+      }).toThrow(ConfigResolutionError);
+
+      expect(builder).not.toHaveBeenCalled();
+    });
+
+    it('throws ConfigResolutionError when allowTestDouble is undefined (default false)', () => {
+      const builder = vi.fn();
+
+      expect(() => {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'test-double',
+          workspaceDir: '/ws',
+          testDoublePayloadBuilder: builder,
+        }, mockIo);
+      }).toThrow(ConfigResolutionError);
+    });
+  });
+
+  // ── pi-ai branch ─────────────────────────────────────────────────────────
+
+  describe('pi-ai branch', () => {
+    it('returns PiAiRuntimeAdapter when config is valid', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockPiAiCtor).toHaveBeenCalledTimes(1);
+      expect(mockValidateRuntimeConfig).toHaveBeenCalledWith(config);
+    });
+
+    it('throws ConfigResolutionError when validateRuntimeConfig throws', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockValidateRuntimeConfig.mockImplementation(() => {
+        throw new Error('missing provider');
+      });
+
+      expect(() => {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'pi-ai',
+          workspaceDir: '/ws',
+        }, mockIo);
+      }).toThrow(ConfigResolutionError);
+    });
+
+    it('CLI timeoutMs override takes precedence over config timeoutMs', () => {
+      const config = makeValidPiAiConfig({ timeoutMs: 300000 });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        timeoutMs: 60000,
+      }, mockIo);
+
+      expect(mockPiAiCtor).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 60000 }),
+      );
+    });
+
+    it('uses config timeoutMs when CLI timeoutMs is not provided', () => {
+      const config = makeValidPiAiConfig({ timeoutMs: 300000 });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      expect(mockPiAiCtor).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 300000 }),
+      );
+    });
+  });
+
+  // ── L2 dreamer sub-branch ────────────────────────────────────────────────
+
+  describe('L2 dreamer sub-branch', () => {
+    it('returns L2AgentLoopAdapter when runnerKind=dreamer + l2ArtifactReader + l2StateDir + flag enabled', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockComputeFlagsFromLoadResult.mockReturnValue({
+        flags: { l2_dreamer: { id: 'l2_dreamer', enabled: true, category: 'quiet' } },
+        enabledChannels: [],
+        warnings: [],
+      });
+      const fakeArtifactReader = { readArtifact: vi.fn() };
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        runnerKind: 'dreamer',
+        l2ArtifactReader: fakeArtifactReader as never,
+        l2StateDir: '/ws/.principles',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'L2AgentLoopAdapter');
+      expect(mockL2AgentLoopCtor).toHaveBeenCalledTimes(1);
+      expect(mockBuildL2PrincipleReader).toHaveBeenCalled();
+    });
+
+    it('falls back to PiAiRuntimeAdapter when l2_dreamer flag is disabled', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockComputeFlagsFromLoadResult.mockReturnValue({
+        flags: { l2_dreamer: { id: 'l2_dreamer', enabled: false, category: 'quiet' } },
+        enabledChannels: [],
+        warnings: [],
+      });
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        runnerKind: 'dreamer',
+        l2ArtifactReader: { readArtifact: vi.fn() } as never,
+        l2StateDir: '/ws/.principles',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockL2AgentLoopCtor).not.toHaveBeenCalled();
+    });
+
+    it('falls back to PiAiRuntimeAdapter when l2ArtifactReader is missing', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockComputeFlagsFromLoadResult.mockReturnValue({
+        flags: { l2_dreamer: { id: 'l2_dreamer', enabled: true, category: 'quiet' } },
+        enabledChannels: [],
+        warnings: [],
+      });
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        runnerKind: 'dreamer',
+        l2StateDir: '/ws/.principles',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockL2AgentLoopCtor).not.toHaveBeenCalled();
+    });
+
+    it('falls back to PiAiRuntimeAdapter when runnerKind is not dreamer', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockComputeFlagsFromLoadResult.mockReturnValue({
+        flags: { l2_dreamer: { id: 'l2_dreamer', enabled: true, category: 'quiet' } },
+        enabledChannels: [],
+        warnings: [],
+      });
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        runnerKind: 'philosopher',
+        l2ArtifactReader: { readArtifact: vi.fn() } as never,
+        l2StateDir: '/ws/.principles',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockL2AgentLoopCtor).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── openclaw-cli branch ──────────────────────────────────────────────────
+
+  describe('openclaw-cli branch', () => {
+    it('returns OpenClawCliRuntimeAdapter when openclawMode is provided in config', () => {
+      const config = makeValidOpenClawConfig({ openclawMode: 'local' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'openclaw-cli',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'OpenClawCliRuntimeAdapter');
+      expect(mockOpenClawCliCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtimeMode: 'local',
+          workspaceDir: '/ws',
+        }),
+      );
+    });
+
+    it('throws ConfigResolutionError when openclawMode is missing from config (no fallback)', () => {
+      const config = makeValidOpenClawConfig({ openclawMode: undefined });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      expect(() => {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'openclaw-cli',
+          workspaceDir: '/ws',
+        }, mockIo);
+      }).toThrow(ConfigResolutionError);
+    });
+  });
+
+  // ── candidate ⑥ behaviour-difference knob: openclawModeFallback ──────────
+  // Locks the legacy pain-signal-factory / auto-consumer `?? 'default'` behaviour:
+  // when the fallback is set, missing mode does NOT throw.
+
+  describe('openclawModeFallback knob (candidate ⑥)', () => {
+    it('falls back to the provided mode when openclawMode is missing', () => {
+      const config = makeValidOpenClawConfig({ openclawMode: undefined });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'openclaw-cli',
+        workspaceDir: '/ws',
+        openclawModeFallback: 'default',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'OpenClawCliRuntimeAdapter');
+      expect(mockOpenClawCliCtor).toHaveBeenCalledWith(
+        expect.objectContaining({ runtimeMode: 'default' }),
+      );
+    });
+
+    it('explicit openclawMode still takes precedence over the fallback', () => {
+      const config = makeValidOpenClawConfig({ openclawMode: 'gateway' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'openclaw-cli',
+        workspaceDir: '/ws',
+        openclawModeFallback: 'default',
+      }, mockIo);
+
+      expect(mockOpenClawCliCtor).toHaveBeenCalledWith(
+        expect.objectContaining({ runtimeMode: 'gateway' }),
+      );
+    });
+  });
+
+  // ── candidate ⑥ behaviour-difference knob: piAiFieldDefaults ─────────────
+  // Locks the legacy auto-consumer hardcoded 'openai'/'gpt-4o'/'OPENAI_API_KEY'
+  // behaviour: when supplied, missing config+override fields use the defaults.
+
+  describe('piAiFieldDefaults knob (candidate ⑥)', () => {
+    it('applies defaults when config and overrides are missing the fields', () => {
+      const config = makeValidPiAiConfig({ provider: undefined, model: undefined, apiKeyEnv: undefined });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        piAiFieldDefaults: { provider: 'openai', model: 'gpt-4o', apiKeyEnv: 'OPENAI_API_KEY' },
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockPiAiCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-4o',
+          apiKeyEnv: 'OPENAI_API_KEY',
+        }),
+      );
+    });
+
+    it('config and overrides still take precedence over defaults', () => {
+      const config = makeValidPiAiConfig({ provider: 'configured-provider', model: 'configured-model' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        piAiOverrides: { apiKeyEnv: 'OVERRIDE_KEY' },
+        piAiFieldDefaults: { provider: 'openai', model: 'gpt-4o', apiKeyEnv: 'OPENAI_API_KEY' },
+      }, mockIo);
+
+      expect(mockPiAiCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'configured-provider',
+          model: 'configured-model',
+          apiKeyEnv: 'OVERRIDE_KEY',
+        }),
+      );
+    });
+  });
+
+  // ── config branch (delegates to resolveRuntimeFromPdConfig) ───────────────
+
+  describe('config branch', () => {
+    it('delegates to pi-ai when config resolves to pi-ai', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'config',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockResolveRuntimeFromPdConfig).toHaveBeenCalledWith('/ws');
+    });
+
+    it('delegates to openclaw-cli when config resolves to openclaw-cli', () => {
+      const config = makeValidOpenClawConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'config',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'OpenClawCliRuntimeAdapter');
+    });
+
+    it('throws ConfigResolutionError when resolveRuntimeFromPdConfig returns error', () => {
+      const error = makeConfigError();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(error));
+      mockIsRuntimeConfigError.mockReturnValue(true);
+
+      expect(() => {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'config',
+          workspaceDir: '/ws',
+        }, mockIo);
+      }).toThrow(ConfigResolutionError);
+    });
+  });
+
+  // ── Unsupported runtime ──────────────────────────────────────────────────
+
+  describe('unsupported runtime', () => {
+    it('throws plain Error for unsupported runtime kind', () => {
+      expect(() => {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'unsupported-runtime',
+          workspaceDir: '/ws',
+        }, mockIo);
+      }).toThrow(/Unsupported runtime kind/);
+    });
+
+    it('does not throw ConfigResolutionError for unsupported runtime', () => {
+      let caught: unknown = null;
+      try {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'unsupported-runtime',
+          workspaceDir: '/ws',
+        }, mockIo);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).not.toBeInstanceOf(ConfigResolutionError);
+      expect(caught).toBeInstanceOf(Error);
+    });
+  });
+
+  // ── PRI-431 Step 1d: New options for diagnose.ts migration ───────────────
+
+  describe('agentId option (openclaw-cli branch)', () => {
+    it('passes agentId to OpenClawCliRuntimeAdapter when provided', () => {
+      const config = makeValidOpenClawConfig({ openclawMode: 'local' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'openclaw-cli',
+        workspaceDir: '/ws',
+        agentId: 'diagnostician',
+      }, mockIo);
+
+      expect(mockOpenClawCliCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'diagnostician',
+          runtimeMode: 'local',
+          workspaceDir: '/ws',
+        }),
+      );
+    });
+
+    it('does not pass agentId when omitted (backward compat)', () => {
+      const config = makeValidOpenClawConfig({ openclawMode: 'local' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'openclaw-cli',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      const [firstCall] = mockOpenClawCliCtor.mock.calls;
+      expect(firstCall).toBeDefined();
+      if (!firstCall) throw new Error('expected OpenClawCliRuntimeAdapter constructor call');
+      const [callArgs] = firstCall;
+      expect(callArgs).toBeDefined();
+      if (!callArgs) throw new Error('expected first constructor argument');
+      expect(callArgs).not.toHaveProperty('agentId');
+    });
+  });
+
+  describe('configOptional option (pi-ai branch)', () => {
+    it('does NOT throw when config returns error and configOptional is true', () => {
+      const error = makeConfigError();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(error));
+      mockIsRuntimeConfigError.mockReturnValue(true);
+
+      // Should NOT throw — proceeds with piAiOverrides alone
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        configOptional: true,
+        piAiOverrides: {
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4',
+          apiKeyEnv: 'OPENROUTER_API_KEY',
+        },
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockPiAiCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4',
+          apiKeyEnv: 'OPENROUTER_API_KEY',
+        }),
+      );
+    });
+
+    it('throws ConfigResolutionError with missing-fields when configOptional is true and overrides are incomplete', () => {
+      const error = makeConfigError();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(error));
+      mockIsRuntimeConfigError.mockReturnValue(true);
+
+      let caught: unknown = null;
+      try {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'pi-ai',
+          workspaceDir: '/ws',
+          configOptional: true,
+          piAiOverrides: {
+            provider: 'openrouter',
+            // model and apiKeyEnv missing
+          },
+        }, mockIo);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ConfigResolutionError);
+      const err = caught as InstanceType<typeof ConfigResolutionError>;
+      expect(err.kind).toBe('missing-fields');
+      expect(err.missing).toEqual(expect.arrayContaining(['model', 'apiKeyEnv']));
+    });
+
+    it('does NOT call validateRuntimeConfig when configOptional is true and config failed', () => {
+      const error = makeConfigError();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(error));
+      mockIsRuntimeConfigError.mockReturnValue(true);
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        configOptional: true,
+        piAiOverrides: {
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4',
+          apiKeyEnv: 'OPENROUTER_API_KEY',
+        },
+      }, mockIo);
+
+      expect(mockValidateRuntimeConfig).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call validateRuntimeConfig when configOptional is true and config is valid (PR review fix)', () => {
+      const config = makeValidPiAiConfig({ baseUrl: undefined });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockIsRuntimeConfigError.mockReturnValue(false);
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        configOptional: true,
+        piAiOverrides: {
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4',
+          apiKeyEnv: 'OPENROUTER_API_KEY',
+          baseUrl: 'https://openrouter.ai/api/v1',
+        },
+      }, mockIo);
+
+      expect(mockValidateRuntimeConfig).not.toHaveBeenCalled();
+      expect(mockPiAiCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openrouter',
+          baseUrl: 'https://openrouter.ai/api/v1',
+        }),
+      );
+    });
+
+    it('does manual missing-field check on merged values when configOptional is true and config is valid', () => {
+      const config = makeValidPiAiConfig({ provider: undefined, model: undefined, apiKeyEnv: undefined });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      mockIsRuntimeConfigError.mockReturnValue(false);
+
+      let caught: unknown = null;
+      try {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'pi-ai',
+          workspaceDir: '/ws',
+          configOptional: true,
+          // No overrides — config has undefined provider/model/apiKeyEnv
+        }, mockIo);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ConfigResolutionError);
+      const err = caught as InstanceType<typeof ConfigResolutionError>;
+      expect(err.kind).toBe('missing-fields');
+      expect(err.missing).toEqual(expect.arrayContaining(['provider', 'model', 'apiKeyEnv']));
+    });
+  });
+
+  describe('validateApiKeyEnv option (pi-ai branch)', () => {
+    let savedEnv: string | undefined;
+
+    beforeEach(() => {
+      savedEnv = process.env.TEST_API_KEY_FOR_RESOLVER;
+    });
+
+    afterEach(() => {
+      if (savedEnv === undefined) {
+        delete process.env.TEST_API_KEY_FOR_RESOLVER;
+      } else {
+        process.env.TEST_API_KEY_FOR_RESOLVER = savedEnv;
+      }
+    });
+
+    it('throws ConfigResolutionError when validateApiKeyEnv is true and env var is unset', () => {
+      const config = makeValidPiAiConfig({ apiKeyEnv: 'TEST_API_KEY_FOR_RESOLVER' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      delete process.env.TEST_API_KEY_FOR_RESOLVER;
+
+      let caught: unknown = null;
+      try {
+        resolveRuntimeAdapterFromConfig({
+          runtimeKind: 'pi-ai',
+          workspaceDir: '/ws',
+          validateApiKeyEnv: true,
+        }, mockIo);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ConfigResolutionError);
+      const err = caught as InstanceType<typeof ConfigResolutionError>;
+      expect(err.kind).toBe('invalid-config');
+      expect(err.message).toContain('TEST_API_KEY_FOR_RESOLVER');
+      expect(mockPiAiCtor).not.toHaveBeenCalled();
+    });
+
+    it('creates adapter successfully when validateApiKeyEnv is true and env var is set', () => {
+      const config = makeValidPiAiConfig({ apiKeyEnv: 'TEST_API_KEY_FOR_RESOLVER' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      process.env.TEST_API_KEY_FOR_RESOLVER = 'test-key-value';
+
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        validateApiKeyEnv: true,
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+      expect(mockPiAiCtor).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT check process.env when validateApiKeyEnv is false (default)', () => {
+      const config = makeValidPiAiConfig({ apiKeyEnv: 'TEST_API_KEY_FOR_RESOLVER' });
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+      delete process.env.TEST_API_KEY_FOR_RESOLVER;
+
+      // Should NOT throw even though env var is unset
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        // validateApiKeyEnv not provided — default false
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+    });
+  });
+
+  describe('onConfigResolved callback', () => {
+    it('calls onConfigResolved with the full resolved object when config is valid', () => {
+      const config = makeValidPiAiConfig();
+      const resolved = makeResolvedConfig(config);
+      mockResolveRuntimeFromPdConfig.mockReturnValue(resolved);
+
+      const callback = vi.fn();
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        onConfigResolved: callback,
+      }, mockIo);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(resolved);
+    });
+
+    it('calls onConfigResolved even when config returns error (if configOptional is true)', () => {
+      const error = makeConfigError();
+      const resolved = makeResolvedConfig(error);
+      mockResolveRuntimeFromPdConfig.mockReturnValue(resolved);
+      mockIsRuntimeConfigError.mockReturnValue(true);
+
+      const callback = vi.fn();
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+        configOptional: true,
+        piAiOverrides: {
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4',
+          apiKeyEnv: 'OPENROUTER_API_KEY',
+        },
+        onConfigResolved: callback,
+      }, mockIo);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(resolved);
+    });
+
+    it('does NOT call onConfigResolved for test-double branch (no config resolution)', () => {
+      const callback = vi.fn();
+      const fakeAdapter = { __type: 'custom-test-double' };
+      const builder = vi.fn(() => fakeAdapter as never);
+
+      resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'test-double',
+        workspaceDir: '/ws',
+        allowTestDouble: true,
+        testDoublePayloadBuilder: builder,
+        onConfigResolved: callback,
+      }, mockIo);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when onConfigResolved is omitted (backward compat)', () => {
+      const config = makeValidPiAiConfig();
+      mockResolveRuntimeFromPdConfig.mockReturnValue(makeResolvedConfig(config));
+
+      // Should not throw
+      const result = resolveRuntimeAdapterFromConfig({
+        runtimeKind: 'pi-ai',
+        workspaceDir: '/ws',
+      }, mockIo);
+
+      expect(result).toHaveProperty('__type', 'PiAiRuntimeAdapter');
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/adapter/index.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/index.ts
@@ -7,3 +7,15 @@ export type { PiAiRuntimeAdapterConfig } from './pi-ai-runtime-adapter.js';
 export { extractJsonObject } from './json-extractor.js';
 export { attemptStructuredOutputRepair, formatRepairPrompt, DEFAULT_REPAIR_CONFIG } from './structured-output-repair.js';
 export type { RepairConfig, RepairResult, SchemaValidationError, RepairLLMCaller, RepairCallbacks } from './structured-output-repair.js';
+// candidate ⑥: shared runtime-adapter resolver (pure logic, I/O injected).
+// Re-exported so pd-cli / openclaw-plugin import from @principles/core/runtime-v2.
+export { resolveRuntimeAdapterFromConfig, ConfigResolutionError } from './runtime-adapter-resolver.js';
+export type {
+  ResolveAdapterOptions,
+  ResolverIoDeps,
+  ResolverPdConfigLoadResult,
+  ResolverResolvedRuntime,
+  ResolverFeatureFlagsResult,
+  ConfigResolutionErrorKind,
+  ConfigResolutionErrorDetails,
+} from './runtime-adapter-resolver.js';

--- a/packages/principles-core/src/runtime-v2/adapter/index.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/index.ts
@@ -13,7 +13,6 @@ export { resolveRuntimeAdapterFromConfig, ConfigResolutionError } from './runtim
 export type {
   ResolveAdapterOptions,
   ResolverIoDeps,
-  ResolverPdConfigLoadResult,
   ResolverResolvedRuntime,
   ResolverFeatureFlagsResult,
   ConfigResolutionErrorKind,

--- a/packages/principles-core/src/runtime-v2/adapter/runtime-adapter-resolver.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/runtime-adapter-resolver.ts
@@ -37,6 +37,7 @@ import type {
   RuntimeConfig,
   RuntimeConfigResult,
 } from '../pain-signal-runtime-factory.js';
+import type { FeatureFlagsResult } from '../config/pd-config-feature-flags.js';
 import { loadLedger } from '../../principle-tree-ledger.js';
 
 // ── Injected I/O seam types ─────────────────────────────────────────────────
@@ -45,41 +46,39 @@ import { loadLedger } from '../../principle-tree-ledger.js';
 // is structurally compatible — no cross-package import required.
 
 /**
- * Minimal view of a PD config load result consumed by the resolver. The
- * concrete PdConfigLoadResult in pd-cli / PluginConfigLoadResult in the plugin
- * both satisfy this structurally (effective/defaults + ok flag).
- */
-export interface ResolverPdConfigLoadResult {
-  ok: boolean;
-  /** Effective config when ok, fallback defaults when not. */
-  effective?: unknown;
-  /** Fallback defaults available even when the file is malformed. */
-  defaults?: unknown;
-}
-
-/**
  * Minimal view of the resolved-runtime-from-config object. The resolver only
  * reads .result (the RuntimeConfigResult) and passes the whole object to the
- * optional onConfigResolved callback.
+ * optional onConfigResolved callback. Concrete packages (pd-cli's
+ * ResolvedRuntimeFromPdConfig, plugin's equivalent) are supersets — they
+ * add legacyWarnings / configLoadResult / runtimeProfileId, etc. — and are
+ * assignable to this base type. Call sites that need the extra fields pass
+ * a concrete type via the TResolved type parameter (see ResolveAdapterOptions).
  */
 export interface ResolverResolvedRuntime {
   result: RuntimeConfigResult;
-  [key: string]: unknown;
 }
 
-/** Feature-flags bag shape consumed by the L2 dreamer gate. */
-export interface ResolverFeatureFlagsResult {
-  flags: Record<string, { enabled: boolean } | undefined>;
-}
+/**
+ * Feature-flags bag shape consumed by the L2 dreamer gate. Reuses the real
+ * core FeatureFlagsResult so pd-cli's computeFlagsFromLoadResult (which
+ * returns FeatureFlagsResult) is assignable without a cast.
+ */
+export type ResolverFeatureFlagsResult = FeatureFlagsResult;
 
-/** Injected I/O callbacks. Each call site supplies its package's real loaders. */
-export interface ResolverIoDeps {
+/**
+ * Injected I/O callbacks. Generic over the package-specific config-load
+ * result type TLoad (pd-cli's PdConfigLoadResult, the plugin's
+ * PluginConfigLoadResult) so each package's real loaders are assignable
+ * without casts. The resolver itself only forwards the load result into
+ * computeFlagsFromLoadResult, so it never inspects TLoad's shape.
+ */
+export interface ResolverIoDeps<TLoad = unknown, TResolved extends ResolverResolvedRuntime = ResolverResolvedRuntime> {
   /** Load + validate .pd/config.yaml. Pure-shell; concrete impl owns fs. */
-  loadPdConfig: (workspaceDir: string) => ResolverPdConfigLoadResult;
+  loadPdConfig: (workspaceDir: string) => TLoad;
   /** Compute effective feature flags from a load result. */
-  computeFlagsFromLoadResult: (result: ResolverPdConfigLoadResult) => ResolverFeatureFlagsResult;
+  computeFlagsFromLoadResult: (result: TLoad) => ResolverFeatureFlagsResult;
   /** Resolve runtime config from .pd/config.yaml (returns RuntimeConfigResult + metadata). */
-  resolveRuntimeFromPdConfig: (workspaceDir: string) => ResolverResolvedRuntime;
+  resolveRuntimeFromPdConfig: (workspaceDir: string) => TResolved;
 }
 
 // ── Error class ─────────────────────────────────────────────────────────────
@@ -117,7 +116,7 @@ export class ConfigResolutionError extends Error {
 
 // ── Options interface ───────────────────────────────────────────────────────
 
-export interface ResolveAdapterOptions {
+export interface ResolveAdapterOptions<TResolved extends ResolverResolvedRuntime = ResolverResolvedRuntime> {
   /** Runtime kind: 'test-double' | 'pi-ai' | 'openclaw-cli' | 'config' */
   runtimeKind: string;
   /** Workspace directory (for config resolution + feature flags) */
@@ -136,7 +135,7 @@ export interface ResolveAdapterOptions {
    * Required when runtimeKind === 'test-double' and allowTestDouble === true.
    * Receives the full opts object so the builder can access taskId, runnerKind, etc.
    */
-  testDoublePayloadBuilder?: (opts: ResolveAdapterOptions) => PDRuntimeAdapter;
+  testDoublePayloadBuilder?: (opts: ResolveAdapterOptions<TResolved>) => PDRuntimeAdapter;
   /**
    * CLI overrides for pi-ai runtime (from --provider, --model, etc. flags).
    * When provided, these take precedence over config values.
@@ -197,7 +196,7 @@ export interface ResolveAdapterOptions {
    * NOT called for test-double branch (no config resolution).
    * Called even when config returns error IF configOptional is true.
    */
-  onConfigResolved?: (resolved: ResolverResolvedRuntime) => void;
+  onConfigResolved?: (resolved: TResolved) => void;
 }
 
 // ── Resolver function ───────────────────────────────────────────────────────
@@ -209,9 +208,12 @@ export interface ResolveAdapterOptions {
  * (loadPdConfig, computeFlagsFromLoadResult, resolveRuntimeFromPdConfig).
  * Call sites pass their package's real implementations; tests pass mocks.
  */
-export function resolveRuntimeAdapterFromConfig(
-  opts: ResolveAdapterOptions,
-  io: ResolverIoDeps,
+export function resolveRuntimeAdapterFromConfig<
+  TLoad = unknown,
+  TResolved extends ResolverResolvedRuntime = ResolverResolvedRuntime,
+>(
+  opts: ResolveAdapterOptions<TResolved>,
+  io: ResolverIoDeps<TLoad, TResolved>,
 ): PDRuntimeAdapter {
   // ── test-double branch ──────────────────────────────────────────────────
   if (opts.runtimeKind === 'test-double') {

--- a/packages/principles-core/src/runtime-v2/adapter/runtime-adapter-resolver.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/runtime-adapter-resolver.ts
@@ -1,0 +1,404 @@
+/**
+ * Shared runtime-adapter resolver — pure logic, I/O injected (candidate ⑥ convergence).
+ *
+ * Moved from packages/pd-cli/src/services/runtime-adapter-resolver.ts (PRI-431) so
+ * core, pd-cli, and openclaw-plugin can all resolve a PDRuntimeAdapter through one
+ * function. The two pd-cli-local I/O calls in the original (loadPdConfig +
+ * computeFlagsFromLoadResult, and resolveRuntimeFromPdConfig) are replaced by
+ * injected callbacks on ResolveAdapterOptions, so this module stays pure (no
+ * fs/path imports — AGENTS.md Critical Rule #1).
+ *
+ * Behavioural differences between the three former call sites are preserved
+ * verbatim via explicit option fields (openclawModeFallback, piAiFieldDefaults,
+ * l2PrincipleReaderOptions) — this resolver UNIFIES construction logic and error
+ * handling, it does NOT silently unify runtime behaviour. Each call site passes
+ * the options that reproduce its pre-convergence behaviour.
+ *
+ * ERR refs:
+ * - ERR-001 (no any): all types explicit
+ * - ERR-005 (no as bypass): no type casts
+ * - ERR-009 (fail-loud): ConfigResolutionError thrown with structured fields
+ * - ERR-013 (Object.hasOwn): feature flag check uses Object.hasOwn
+ * - ERR-002 (graceful degradation with reason): structured error includes reason + nextAction
+ */
+
+import { TestDoubleRuntimeAdapter } from './test-double-runtime-adapter.js';
+import { PiAiRuntimeAdapter } from './pi-ai-runtime-adapter.js';
+import { OpenClawCliRuntimeAdapter } from './openclaw-cli-runtime-adapter.js';
+import { L2AgentLoopAdapter } from './l2-agent-loop-adapter.js';
+import { buildL2PrincipleReaderFromLedger } from '../build-l2-principle-reader.js';
+import {
+  isRuntimeConfigError,
+  validateRuntimeConfig,
+} from '../pain-signal-runtime-factory.js';
+import type { PDRuntimeAdapter } from '../runtime-protocol.js';
+import type { PdL2ArtifactReader } from '../tools/agent-tool-contract.js';
+import type {
+  RuntimeConfig,
+  RuntimeConfigResult,
+} from '../pain-signal-runtime-factory.js';
+import { loadLedger } from '../../principle-tree-ledger.js';
+
+// ── Injected I/O seam types ─────────────────────────────────────────────────
+// These describe only the fields the resolver reads. Each package (pd-cli,
+// openclaw-plugin, core) supplies its own concrete implementation whose shape
+// is structurally compatible — no cross-package import required.
+
+/**
+ * Minimal view of a PD config load result consumed by the resolver. The
+ * concrete PdConfigLoadResult in pd-cli / PluginConfigLoadResult in the plugin
+ * both satisfy this structurally (effective/defaults + ok flag).
+ */
+export interface ResolverPdConfigLoadResult {
+  ok: boolean;
+  /** Effective config when ok, fallback defaults when not. */
+  effective?: unknown;
+  /** Fallback defaults available even when the file is malformed. */
+  defaults?: unknown;
+}
+
+/**
+ * Minimal view of the resolved-runtime-from-config object. The resolver only
+ * reads .result (the RuntimeConfigResult) and passes the whole object to the
+ * optional onConfigResolved callback.
+ */
+export interface ResolverResolvedRuntime {
+  result: RuntimeConfigResult;
+  [key: string]: unknown;
+}
+
+/** Feature-flags bag shape consumed by the L2 dreamer gate. */
+export interface ResolverFeatureFlagsResult {
+  flags: Record<string, { enabled: boolean } | undefined>;
+}
+
+/** Injected I/O callbacks. Each call site supplies its package's real loaders. */
+export interface ResolverIoDeps {
+  /** Load + validate .pd/config.yaml. Pure-shell; concrete impl owns fs. */
+  loadPdConfig: (workspaceDir: string) => ResolverPdConfigLoadResult;
+  /** Compute effective feature flags from a load result. */
+  computeFlagsFromLoadResult: (result: ResolverPdConfigLoadResult) => ResolverFeatureFlagsResult;
+  /** Resolve runtime config from .pd/config.yaml (returns RuntimeConfigResult + metadata). */
+  resolveRuntimeFromPdConfig: (workspaceDir: string) => ResolverResolvedRuntime;
+}
+
+// ── Error class ─────────────────────────────────────────────────────────────
+
+export type ConfigResolutionErrorKind =
+  | 'missing-fields'
+  | 'invalid-config'
+  | 'unsupported-runtime'
+  | 'test-double-refused';
+
+export interface ConfigResolutionErrorDetails {
+  /** Required fields that are missing (for 'missing-fields' kind). */
+  missing?: string[];
+  /** Structured next action for the operator (CLI Operator Gate rule #6). */
+  nextAction?: string;
+}
+
+export class ConfigResolutionError extends Error {
+  readonly kind: ConfigResolutionErrorKind;
+  readonly missing?: string[];
+  readonly nextAction?: string;
+
+  constructor(
+    message: string,
+    kind: ConfigResolutionErrorKind,
+    details?: ConfigResolutionErrorDetails,
+  ) {
+    super(message);
+    this.name = 'ConfigResolutionError';
+    this.kind = kind;
+    this.missing = details?.missing;
+    this.nextAction = details?.nextAction;
+  }
+}
+
+// ── Options interface ───────────────────────────────────────────────────────
+
+export interface ResolveAdapterOptions {
+  /** Runtime kind: 'test-double' | 'pi-ai' | 'openclaw-cli' | 'config' */
+  runtimeKind: string;
+  /** Workspace directory (for config resolution + feature flags) */
+  workspaceDir: string;
+  /** Runner kind (for L2 dreamer routing). Optional. */
+  runnerKind?: string;
+  /** CLI timeout override. Takes precedence over config timeoutMs. */
+  timeoutMs?: number;
+  /**
+   * Whether test-double runtime is allowed. Default: false.
+   * When false, 'test-double' runtimeKind throws ConfigResolutionError.
+   */
+  allowTestDouble?: boolean;
+  /**
+   * Call-site-specific test-double payload builder.
+   * Required when runtimeKind === 'test-double' and allowTestDouble === true.
+   * Receives the full opts object so the builder can access taskId, runnerKind, etc.
+   */
+  testDoublePayloadBuilder?: (opts: ResolveAdapterOptions) => PDRuntimeAdapter;
+  /**
+   * CLI overrides for pi-ai runtime (from --provider, --model, etc. flags).
+   * When provided, these take precedence over config values.
+   */
+  piAiOverrides?: {
+    provider?: string;
+    model?: string;
+    apiKeyEnv?: string;
+    baseUrl?: string;
+    maxRetries?: number;
+  };
+  /**
+   * Behaviour-difference knob (candidate ⑥): when openclawMode resolves to
+   * undefined, fall back to this value instead of throwing. The legacy
+   * pain-signal-runtime-factory and auto-consumer call sites passed
+   * `?? 'default'`; the pd-cli call site threw. Reproduce each by setting /
+   * omitting this field. Default: undefined (throw on missing mode).
+   */
+  openclawModeFallback?: 'local' | 'gateway' | 'default';
+  /**
+   * CLI override for openclaw mode (from --openclaw-local / --openclaw-gateway flags).
+   * When provided, takes precedence over config openclawMode.
+   */
+  openclawMode?: 'local' | 'gateway';
+  /** PRI-419: L2 artifact reader (only used when l2_dreamer is on). */
+  l2ArtifactReader?: PdL2ArtifactReader;
+  /** PRI-419: workspace stateDir for L2 principle reader (only used when l2_dreamer is on). */
+  l2StateDir?: string;
+  /**
+   * Behaviour-difference knob (candidate ⑥): hardcoded pi-ai field defaults
+   * applied with `??` after config + CLI overrides. The legacy auto-consumer
+   * call site hardcoded 'openai'/'gpt-4o'/'OPENAI_API_KEY'; pain-signal-factory
+   * and pd-cli did not. Reproduce the auto-consumer by passing these; omit
+   * otherwise. Default: undefined (no defaults; missing fields throw via the
+   * configOptional missing-field check or validateRuntimeConfig).
+   */
+  piAiFieldDefaults?: {
+    provider?: string;
+    model?: string;
+    apiKeyEnv?: string;
+  };
+  /** CLI agentId override for openclaw-cli (from --agent flag). Default: 'main'. */
+  agentId?: string;
+  /**
+   * Whether config resolution errors are tolerated (proceed with CLI overrides alone).
+   * When true, pi-ai branch skips validateRuntimeConfig and uses manual missing-field check.
+   * Default: false (config errors throw ConfigResolutionError).
+   */
+  configOptional?: boolean;
+  /**
+   * Whether to validate that process.env[apiKeyEnv] is set before
+   * constructing PiAiRuntimeAdapter. Default: false.
+   */
+  validateApiKeyEnv?: boolean;
+  /**
+   * Callback invoked with the full resolved config object (including legacyWarnings)
+   * after successful config resolution. Useful for telemetry, legacyWarnings printing, etc.
+   * NOT called for test-double branch (no config resolution).
+   * Called even when config returns error IF configOptional is true.
+   */
+  onConfigResolved?: (resolved: ResolverResolvedRuntime) => void;
+}
+
+// ── Resolver function ───────────────────────────────────────────────────────
+
+/**
+ * Resolve a PDRuntimeAdapter from config + CLI overrides + injected I/O.
+ *
+ * The `io` parameter supplies the three package-specific I/O calls
+ * (loadPdConfig, computeFlagsFromLoadResult, resolveRuntimeFromPdConfig).
+ * Call sites pass their package's real implementations; tests pass mocks.
+ */
+export function resolveRuntimeAdapterFromConfig(
+  opts: ResolveAdapterOptions,
+  io: ResolverIoDeps,
+): PDRuntimeAdapter {
+  // ── test-double branch ──────────────────────────────────────────────────
+  if (opts.runtimeKind === 'test-double') {
+    if (!opts.allowTestDouble) {
+      throw new ConfigResolutionError(
+        'runtimeKind "test-double" requires allowTestDouble=true.',
+        'test-double-refused',
+        { nextAction: 'Pass --allow-test-double or use a production runtime kind.' },
+      );
+    }
+    if (!opts.testDoublePayloadBuilder) {
+      throw new ConfigResolutionError(
+        'runtimeKind "test-double" requires testDoublePayloadBuilder callback.',
+        'missing-fields',
+        {
+          missing: ['testDoublePayloadBuilder'],
+          nextAction:
+            'Provide a testDoublePayloadBuilder function that constructs the test-double adapter.',
+        },
+      );
+    }
+    return opts.testDoublePayloadBuilder(opts);
+  }
+
+  // ── Resolve config from .pd/config.yaml (for pi-ai, openclaw-cli, config) ──
+  const resolved = io.resolveRuntimeFromPdConfig(opts.workspaceDir);
+  const configResult: RuntimeConfigResult = resolved.result;
+
+  // PRI-431 Step 1d: invoke onConfigResolved callback (for telemetry, legacyWarnings, etc.)
+  opts.onConfigResolved?.(resolved);
+
+  if (isRuntimeConfigError(configResult)) {
+    if (!opts.configOptional) {
+      throw new ConfigResolutionError(
+        `Config resolution from .pd/config.yaml failed: ${configResult.reason}. ${configResult.message}`,
+        'invalid-config',
+        { nextAction: configResult.nextAction },
+      );
+    }
+    // configOptional=true: proceed with CLI overrides alone (pi-ai branch handles missing fields)
+  }
+
+  // ── pi-ai branch ────────────────────────────────────────────────────────
+  const isPiAi =
+    opts.runtimeKind === 'pi-ai' ||
+    (opts.runtimeKind === 'config' &&
+      !isRuntimeConfigError(configResult) &&
+      configResult.runtimeKind === 'pi-ai');
+  if (isPiAi) {
+    if (!opts.configOptional && !isRuntimeConfigError(configResult)) {
+      try {
+        validateRuntimeConfig(configResult);
+      } catch (err) {
+        throw new ConfigResolutionError(
+          err instanceof Error ? err.message : String(err),
+          'invalid-config',
+        );
+      }
+    }
+
+    // Merge CLI overrides with config values (overrides take precedence)
+    const configFields: Partial<RuntimeConfig> = isRuntimeConfigError(configResult) ? {} : configResult;
+    // candidate ⑥: apply piAiFieldDefaults AFTER config but the missing-field
+    // check below still treats defaulted fields as present (matches legacy
+    // auto-consumer, which hardcode these and therefore never hit missing-field).
+    const provider = opts.piAiOverrides?.provider ?? configFields.provider ?? opts.piAiFieldDefaults?.provider;
+    const model = opts.piAiOverrides?.model ?? configFields.model ?? opts.piAiFieldDefaults?.model;
+    const apiKeyEnv = opts.piAiOverrides?.apiKeyEnv ?? configFields.apiKeyEnv ?? opts.piAiFieldDefaults?.apiKeyEnv;
+    const baseUrl = opts.piAiOverrides?.baseUrl ?? configFields.baseUrl;
+    const maxRetries = opts.piAiOverrides?.maxRetries ?? configFields.maxRetries;
+    const adapterTimeoutMs = opts.timeoutMs ?? configFields.timeoutMs;
+
+    if (opts.configOptional) {
+      const missing: string[] = [];
+      if (!provider) missing.push('provider');
+      if (!model) missing.push('model');
+      if (!apiKeyEnv) missing.push('apiKeyEnv');
+      if (missing.length > 0) {
+        throw new ConfigResolutionError(
+          `Missing required pi-ai config: ${missing.join(', ')}.`,
+          'missing-fields',
+          {
+            missing,
+            nextAction:
+              'Pass --provider, --model, --apiKeyEnv flags or configure .pd/config.yaml runtime profile.',
+          },
+        );
+      }
+    }
+
+    if (opts.validateApiKeyEnv && apiKeyEnv && !process.env[apiKeyEnv]) {
+      throw new ConfigResolutionError(
+        `Environment variable '${apiKeyEnv}' is not set.`,
+        'invalid-config',
+        {
+          nextAction:
+            'Set the env var (e.g., export OPENAI_API_KEY=...) or choose a different apiKeyEnv.',
+        },
+      );
+    }
+
+    // PRI-419: L2 dreamer sub-branch — when l2_dreamer flag is on AND this is the
+    // dreamer runner, route through the L2 multi-turn agent loop adapter.
+    if (opts.runnerKind === 'dreamer' && opts.l2ArtifactReader && opts.l2StateDir) {
+      const effectiveFlags = io.computeFlagsFromLoadResult(io.loadPdConfig(opts.workspaceDir));
+      const l2FlagDef = Object.hasOwn(effectiveFlags.flags, 'l2_dreamer')
+        ? effectiveFlags.flags.l2_dreamer
+        : undefined;
+      const l2Flag = l2FlagDef ? l2FlagDef.enabled : false;
+      if (l2Flag) {
+        return new L2AgentLoopAdapter(
+          {
+            provider: String(provider),
+            model: String(model),
+            apiKeyEnv: String(apiKeyEnv),
+            baseUrl,
+            workspace: opts.workspaceDir,
+            totalBudgetMs: adapterTimeoutMs,
+          },
+          {
+            artifactReader: opts.l2ArtifactReader,
+            principleReader: buildL2PrincipleReaderFromLedger(loadLedger(opts.l2StateDir)),
+          },
+        );
+      }
+    }
+
+    return new PiAiRuntimeAdapter({
+      provider: String(provider),
+      model: String(model),
+      apiKeyEnv: String(apiKeyEnv),
+      maxRetries,
+      timeoutMs: adapterTimeoutMs,
+      baseUrl,
+      workspace: opts.workspaceDir,
+    });
+  }
+
+  // ── openclaw-cli branch ─────────────────────────────────────────────────
+  const isOpenClawCli =
+    opts.runtimeKind === 'openclaw-cli' ||
+    (opts.runtimeKind === 'config' &&
+      !isRuntimeConfigError(configResult) &&
+      configResult.runtimeKind === 'openclaw-cli');
+  if (isOpenClawCli) {
+    const openclawConfigFields: Partial<RuntimeConfig> = isRuntimeConfigError(configResult)
+      ? {}
+      : configResult;
+    // CLI override takes precedence over config; candidate ⑥: openclawModeFallback
+    // reproduces the legacy `?? 'default'` of pain-signal-factory / auto-consumer
+    // when set; when unset (pd-cli), missing mode throws (preserving prior behaviour).
+    const openclawMode = opts.openclawMode ?? openclawConfigFields.openclawMode ?? opts.openclawModeFallback;
+    if (!openclawMode) {
+      throw new ConfigResolutionError(
+        "runtimeKind 'openclaw-cli' requires openclawMode.",
+        'missing-fields',
+        {
+          missing: ['openclawMode'],
+          nextAction:
+            'Add openclawMode: local|gateway to your .pd/config.yaml runtime profile or use --openclaw-local/--openclaw-gateway flags.',
+        },
+      );
+    }
+    // candidate ⑥: openclawModeFallback reproduces the legacy `?? 'default'`
+    // of pain-signal-factory / auto-consumer when set; when unset (pd-cli),
+    // missing mode throws (preserving prior behaviour). OpenClawCliRuntimeAdapter
+    // natively accepts 'local' | 'gateway' | 'default', so 'default' passes through.
+    const openclawAdapterOpts: {
+      runtimeMode: 'local' | 'gateway' | 'default';
+      workspaceDir: string;
+      agentId?: string;
+    } = {
+      runtimeMode: openclawMode,
+      workspaceDir: opts.workspaceDir,
+    };
+    if (opts.agentId !== undefined) {
+      openclawAdapterOpts.agentId = opts.agentId;
+    }
+    return new OpenClawCliRuntimeAdapter(openclawAdapterOpts);
+  }
+
+  // ── Unsupported runtime ────────────────────────────────────────────────
+  throw new Error(
+    `Unsupported runtime kind: ${opts.runtimeKind}. Supported: test-double, pi-ai, openclaw-cli, config`,
+  );
+}
+
+// ── Re-exports for call-site convenience ────────────────────────────────────
+export type { RuntimeConfig, RuntimeConfigResult };
+export { TestDoubleRuntimeAdapter, isRuntimeConfigError, validateRuntimeConfig };

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -229,6 +229,20 @@ export type { OpenClawCliRuntimeAdapterOptions } from './adapter/openclaw-cli-ru
 export { PiAiRuntimeAdapter } from './adapter/index.js';
 export type { PiAiRuntimeAdapterConfig } from './adapter/pi-ai-runtime-adapter.js';
 
+// candidate ⑥: shared runtime-adapter resolver (pure logic, I/O injected).
+export {
+  resolveRuntimeAdapterFromConfig,
+  ConfigResolutionError,
+} from './adapter/index.js';
+export type {
+  ResolveAdapterOptions,
+  ResolverIoDeps,
+  ResolverResolvedRuntime,
+  ResolverFeatureFlagsResult,
+  ConfigResolutionErrorKind,
+  ConfigResolutionErrorDetails,
+} from './adapter/index.js';
+
 // PrincipleTreeLedgerAdapter (M8)
 export { PrincipleTreeLedgerAdapter } from './adapter/principle-tree-ledger-adapter.js';
 


### PR DESCRIPTION
## Summary

Candidate ⑥ from the architecture review (converge adapter construction sites). This PR delivers **commit 1** of the plan: a new **pure, fully-tested `resolveRuntimeAdapterFromConfig` in core**, available as a shared seam so pd-cli / openclaw-plugin / core can resolve a `PDRuntimeAdapter` through one function.

The 34 existing resolver tests were migrated from pd-cli to core, adjusted to inject the I/O deps as a `mockIo` object (cleaner than the prior `vi.mock` of module paths), plus **4 new behaviour-difference tests** that lock the two convergence knobs.

### Honest scope note: the full convergence was deferred

The plan was to also convert the pd-cli resolver to a thin shell and route Copy A (`pain-signal-runtime-factory`) + Copy B (`internalization-auto-consumer`) through the shared resolver. **After investigating all three sites in depth, that part was deferred** because:

- The canonical resolver lives in pd-cli, but core/plugin **cannot import pd-cli** (dependency arrow is one-way: pd-cli → core, plugin → core). So the resolver had to move to core first (this PR).
- Each call site has **load-bearing differences** the report understated: Copy A is a 14-line ternary with no L2/error handling (routing it adds indirection for no gain); Copy B's L2 branch builds a plugin-specific inline `artifactReader` wrapping `piArtifactStore` that the core resolver has no concept of; the pd-cli shell conversion exploded the test-mock surface (config-resolution mocks, missing-mode error semantics) to the point of diminishing returns.
- **Net: candidate ⑥'s claimed leverage did not survive contact with the code.** The genuine duplication was superficial (constructor-call shape); the real logic diverges per site. Forcing convergence would add indirection without removing meaningful complexity — the opposite of "low-risk subtraction."

This PR therefore ships only the **clean, fully-tested pure resolver in core** (commit 1 + 1b). It is additive — no behaviour change, no existing code modified except the core barrels. It's available for future use if a 4th construction site ever appears, but nothing currently calls it.

## What changed

**New (core):**
- `runtime-v2/adapter/runtime-adapter-resolver.ts` (~330 lines) — pure resolver: `ConfigResolutionError`, `ResolveAdapterOptions<TResolved>`, `ResolverIoDeps<TLoad, TResolved>`, `resolveRuntimeAdapterFromConfig(opts, io)`. No fs/path imports (AGENTS.md Critical Rule #1). The 3 I/O calls (loadPdConfig, computeFlagsFromLoadResult, resolveRuntimeFromPdConfig) are **injected** via the `io` parameter.
- `runtime-v2/adapter/__tests__/runtime-adapter-resolver.test.ts` — 38 tests (34 migrated + 4 new behaviour-difference).
- Barrel re-exports from `runtime-v2/index.ts` + `adapter/index.ts`.

**Two convergence knobs** preserve the per-site behavioural differences verbatim (NOT silently unified):
- `openclawModeFallback` — reproduces the legacy `?? 'default'` of pain-signal-factory / auto-consumer; when unset (pd-cli), missing mode throws.
- `piAiFieldDefaults` — reproduces the legacy auto-consumer hardcoded `'openai'`/`'gpt-4o'`/`'OPENAI_API_KEY'`; when unset, missing fields throw.

## MVP flow safety

This PR is **additive** — no existing production code path is modified (the 3 call sites still use their own logic). The new resolver is exercised only by its own unit tests. MVP 6-step flow is untouched.

## Verification (all green)

| Check | Result |
|---|---|
| `principles-core` | **5473 pass** (baseline 5435 + 38 new) |
| `openclaw-plugin` | **1918 pass** |
| `pd-cli` | **1131 pass** |
| All package builds | pass |
| Lint | 0 errors (1 pre-existing warning, unrelated) |

## ERR refs (Handbook Gate)

- **EP-01 / ERR-005**: no `as` bypass — openclaw `'default'` mode is the adapter's native type, no cast.
- **EP-09 / ERR-025**: migrated tests exercise the real resolver branches, not stubs; 4 new tests lock the behaviour-difference knobs.
- **EP-02**: the resolver is pure + injected I/O, so it has no production-path coupling to verify.

## Remaining risk

- **None for production** (additive only).
- Candidate ⑥ full convergence is **deferred with evidence** (see scope note). If the maintainer still wants the pd-cli shell conversion, it's a separate, larger PR that must solve the test-mock complexity honestly.

## Self-review

One adversarial self-review pass was done. The key finding (the convergence-into-pd-cli-shell path hitting test-mock complexity walls) is documented above as the reason for deferral rather than shipped broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增强了运行时配置解析，支持更多配置覆盖、默认值和回退规则。
  * 运行时适配器相关能力现已统一对外提供，便于更一致地使用。

* **Bug 修复**
  * 提升了配置缺失、校验失败和不支持运行时场景下的错误处理稳定性。
  * 改进了部分运行时在缺少字段或环境变量时的容错表现。

* **测试**
  * 新增大量覆盖，锁定不同运行时分支与配置边界行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->