### PR TITLE
fix(pd-console): keep update check response shape stable on registry failure

### DIFF
--- a/packages/pd-console/src/server/routes/update.ts
+++ b/packages/pd-console/src/server/routes/update.ts
@@ -205,6 +205,11 @@ async function doCheckForUpdates(currentVersion: string) {
     return {
       hasUpdate: false,
       currentVersion,
+      // Contract with the UI (UpdatePage.tsx) requires latestVersion to be a
+      // string. When the registry check fails we don't know the latest version,
+      // so emit an empty string to keep the response shape stable and let the
+      // UI surface `error` instead of crashing the whole page.
+      latestVersion: '',
       error: error instanceof Error ? error.message : 'Unknown error',
     };
   }

--- a/packages/pd-console/tests/server/routes/update.test.ts
+++ b/packages/pd-console/tests/server/routes/update.test.ts
@@ -476,10 +476,14 @@ describe('handleUpdateRoute', () => {
 
       // doCheckForUpdates catches the error and returns hasUpdate:false with error message
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
-      const body = parseResponseBody<{ success: boolean; data: { hasUpdate: boolean; error: string } }>(res);
+      const body = parseResponseBody<{ success: boolean; data: { hasUpdate: boolean; latestVersion: string; error: string } }>(res);
       expect(body.success).toBe(true);
       expect(body.data.hasUpdate).toBe(false);
       expect(body.data.error).toContain('Network timeout');
+      // Regression guard: latestVersion must always be present as a string so
+      // the UI's validateUpdateStatus doesn't reject the response shape and
+      // crash the whole page on registry/network failures.
+      expect(typeof body.data.latestVersion).toBe('string');
     });
 
     it('POST /apply should return failure when fetch returns non-ok status', async () => {


### PR DESCRIPTION
## Summary

Fix the PD web console update page (`/#/update`) crashing with `Response validation failed: unexpected data shape from server` whenever the npm registry check fails.

## Root cause

`GET /api/update/check`'s `doCheckForUpdates` had two return paths with inconsistent shapes:

- **Success path**: `{ hasUpdate, currentVersion, latestVersion }`
- **Error path** (catch block): `{ hasUpdate, currentVersion, error }` — **missing `latestVersion`**

The UI's `validateUpdateStatus` ([validators.ts:776](packages/pd-console/src/ui/utils/validators.ts#L776)) requires `latestVersion` to be a string. When the registry request timed out or failed (common from networks with poor npmjs.org reachability), the validator returned `null`, and [api.ts:159-163](packages/pd-console/src/ui/api.ts#L159) converted that into `"Response validation failed: unexpected data shape from server"`, taking down the entire page.

## Fix

Add `latestVersion: ''` to the error path so the response shape always matches the contract documented in [UpdatePage.tsx:5](packages/pd-console/src/ui/pages/settings/UpdatePage.tsx#L5). The UI already has a `statusData?.error` notice block ([UpdatePage.tsx:279-283](packages/pd-console/src/ui/pages/settings/UpdatePage.tsx#L279)) that surfaces the failure reason gracefully — it just never got the chance because the page crashed before reaching it.

## Changes

- `packages/pd-console/src/server/routes/update.ts` — error path of `doCheckForUpdates` now emits `latestVersion: ''`
- `packages/pd-console/tests/server/routes/update.test.ts` — strengthened the existing "handle fetch rejection gracefully" test with a regression assertion that `latestVersion` is always a string

## ERR checklist (Runtime Contract Rules)

- **ERR-001 / Rule 1 (treat untrusted data as unknown)**: N/A — this change fixes the server-side producer of the data shape, not a consumer of untrusted data. The server constructs the response object itself.
- **ERR-009 / Rule 3 (required fields must fail loud)**: Directly addressed. The bug was a required field (`latestVersion`) silently absent in an error path. The fix makes all return paths of `doCheckForUpdates` satisfy the documented contract.
- **ERR-002 / Rule 9 (graceful degradation must include a reason)**: The error path already included an `error` string with the failure reason. The fix preserves that and additionally keeps the shape stable so the UI can render the degradation notice instead of crashing.

Remaining Runtime Contract rules (2, 4, 5, 6, 7, 8): N/A — no parsed JSON / LLM output / DB data / retry loops / preview serialization involved in this change.

## CLI / Operator Gate

N/A — no changes to `pd-cli` commands or operator workflows.

## Tests

- `cd packages/pd-console && npx vitest run tests/server/routes/update.test.ts` → **38 passed**
- Pre-push `verify:merge` hook → **green** (lint, build, typecheck:openclaw-plugin, typecheck:pd-console all passed)

## PR comments handled

N/A — new PR, no review comments yet.

## Remaining risk

- The fix is backend-only. The currently running web console process still serves the old compiled response; it needs a `pd-console` rebuild + restart for the fix to take effect at runtime.
- `latestVersion: ''` is a sentinel meaning "unknown". The UI renders `—` for empty `latestVersion` (via `statusData?.latestVersion ?? "—"`), which is the intended degraded display. No UI change required.
