### PR TITLE
docs: add ERR-080 to error experience handbook

### DIFF
--- a/docs/ERROR_EXPERIENCE_HANDBOOK.md
+++ b/docs/ERROR_EXPERIENCE_HANDBOOK.md
@@ -149,6 +149,7 @@ Errors where AI assistants introduced security risks or bypassed safety checks.
 | ERR-058 | Inconsistent forbidden-key lists across validation paths — gateway_token passes pi-ai profile validation | PRI-304 |
 | ERR-059 | Nullish coalescing dead code — always-defined default shadows user override in effective config merge | PRI-304 |
 | ERR-079 | Concurrency-primitive hardening gaps (age-based lock eviction, busy-spin retry) silently re-open the data-loss class the primitive was added to prevent | PRI-459 / PR #1045 |
+| ERR-080 | Size bound applied to raw input then content escaped — escaped output exceeds budget due to entity expansion | PRI-467 / PR #1059 |
 
 ---
 
@@ -732,7 +733,7 @@ Errors in how AI assistants approached the task — not reading context, not fol
 
 | Metric | Value |
 |--------|-------|
-| Total lessons | 79 |
+| Total lessons | 80 |
 | Last updated | 2026-06-25 |
 | Top category | Schema & Type |
 | Recurring errors | 35 |
@@ -1155,5 +1156,20 @@ Errors in how AI assistants approached the task — not reading context, not fol
 - **Regression guard**: `tests/principle-tree-ledger.lock.test.ts` — "a second writer fails LOUD while the lock is held by another owner" (live PID, tight retries, expects `LockAcquisitionError`) and "a live PID whose lock age exceeds lockStaleMs is NOT reclaimed as stale" (backdated mtime + live PID, still throws).
 - **Related ERRs**: ERR-069 P2 (degradation path written as afterthought skips the happy-path's rigor — same pattern group applied to concurrency), ERR-001 (`as`-bypass on the lock's caught-unknown error, fixed in the same review), ERR-009 (silent overwrite sibling in the same PR)
 - **Source**: PRI-459 / PR #1045
+- **Date**: 2026-06-25
+- **Recurrence**: None
+
+---
+
+**[ERR-080]** | Size bound applied to raw input then content escaped — escaped output exceeds budget due to entity expansion
+
+- **What happened**: In `buildIntentFrictionBlock()` (`packages/principles-core/src/runtime-v2/intent/intent-friction-block.ts`), the `INTENT_INJECT_MAX_CHARS` bound (4000 chars) was applied to the RAW intent content via `slice()`, and then `escapeXml()` was called on the already-bounded slice. Because XML entity expansion is length-increasing (`&` → `&amp;` = 5x, `<` → `&lt;` = 4x), the escaped output could exceed the budget. A 4000-char raw string of `&` would be bounded to 4000 chars, then escaped to ~20000 chars of `&amp;` — 5x over the budget. The prompt hook's 9000-char `truncateInjectionToBudget` size guard provided a hard upper bound, but the `INTENT_INJECT_MAX_CHARS` contract was silently violated.
+- **Why it's wrong**: The bound exists to limit how much untrusted INTENT.md content is injected into the prompt (a prompt-budget / trust-boundary control). Applying the bound to the pre-transformation input defeats the bound because a length-increasing transformation happens after the check. This is the same class as ERR-056 (redaction/truncation applied at the wrong point in the pipeline) and ERR-024 (security validator exists but is not wired into the real enforcement path) — the control exists but is applied at the wrong layer, so it does not protect the actual emitted output.
+- **Generalized failure mode**: When bounding text that undergoes a length-increasing transformation (XML/HTML escaping, URL percent-encoding, JSON stringification with escaping, base64 encoding), assistants must bound the POST-transformation output, not the pre-transformation input. Otherwise the transformed output can exceed the budget by the expansion factor (up to 5x for XML escaping of `&`, 3x for URL encoding of some chars).
+- **Correct approach**: Escape FIRST, then bound the escaped content to `INTENT_INJECT_MAX_CHARS` (minus the truncation marker length). Append the truncation marker after the budget cut. The marker is short (~60 chars), contains no XML special chars, and the prompt hook's 9000-char size guard provides a hard upper bound on the total block.
+- **How to prevent**: During PR review of any size-bounding logic on content that is subsequently transformed (escaped, encoded, stringified): check that the bound is applied to the FINAL output form, not an intermediate form. Ask: "does any transformation between the bound check and the output expand the content?" If yes, move the bound after the transformation. Add a regression test using expandable chars (e.g., 5000 `&` chars) to verify the escaped output respects the budget.
+- **Regression guard**: `packages/principles-core/src/runtime-v2/intent/__tests__/intent-friction-block.test.ts` — "bounds the ESCAPED content to INTENT_INJECT_MAX_CHARS even with expandable chars" (5000 `&` chars → escaped output must be ≤ `INTENT_INJECT_MAX_CHARS + 2`, must contain truncation marker, must not contain raw unescaped `&`).
+- **Related ERRs**: ERR-056 (security transformation applied at wrong point in pipeline), ERR-024 (security validator not wired into real enforcement path), ERR-014 (bounding asymmetry across code paths), ERR-017 (unsafe serialization on unknown values)
+- **Source**: PRI-467 / PR #1059 (CodeRabbit review)
 - **Date**: 2026-06-25
 - **Recurrence**: None

--- a/docs/ERROR_PATTERN_INDEX.md
+++ b/docs/ERROR_PATTERN_INDEX.md
@@ -66,9 +66,9 @@ For a task, pick the matching pattern cards, read the listed ERR entries, and st
 
 - **Use when**: adding redaction, command blocking, path handling, shell execution, or security validators.
 - **Failure mode**: a security control is placed at the wrong layer, matches the wrong scope, or is bypassed by interpolation/substrings.
-- **Must check**: enforcement input is not prematurely redacted; persistence output is redacted; shell arguments are passed as argv; path checks use segment boundaries.
-- **Representative ERRs**: ERR-003, ERR-024, ERR-030, ERR-045, ERR-051, ERR-055, ERR-056, ERR-058.
-- **Automation target**: tests for composite sensitive keys, value-based redaction, raw enforcement input, and sibling path false positives.
+- **Must check**: enforcement input is not prematurely redacted; persistence output is redacted; shell arguments are passed as argv; path checks use segment boundaries; **size bounds on content that undergoes a length-increasing transformation (XML/HTML escaping, URL encoding, base64) are applied to the POST-transformation output, not the pre-transformation input (ERR-080: bounding raw content then escaping it lets entity expansion `&`→`&amp;` 5x blow the budget)**.
+- **Representative ERRs**: ERR-003, ERR-024, ERR-030, ERR-045, ERR-051, ERR-055, ERR-056, ERR-058, ERR-080.
+- **Automation target**: tests for composite sensitive keys, value-based redaction, raw enforcement input, and sibling path false positives; regression test with expandable chars (`&`.repeat(N)) for any escape-then-bound pipeline.
 
 ### EP-09 Test Reality Gap
 


### PR DESCRIPTION
Record error ERR-080 found during code review of PRI-467 / PR #1059.

**ERR-080**: Size bound applied to raw input then content escaped — escaped output exceeds budget due to entity expansion.

Root cause: in buildIntentFrictionBlock(), the INTENT_INJECT_MAX_CHARS bound was applied to raw content, then escapeXml() was called on the bounded slice. XML entity expansion (and -> andamp; = 5x) caused escaped output to exceed the 4000-char budget. Fix: escape FIRST, then bound the escaped content.

Classified as Category 5 (Security and Safety) — the bound is a prompt-budget / trust-boundary control applied at the wrong layer. Added to EP-08 (Security Boundary Placement) in ERROR_PATTERN_INDEX.md.

Changes:
- docs/ERROR_EXPERIENCE_HANDBOOK.md: add ERR-080 detailed entry + Category 5 table row + statistics (79 -> 80)
- docs/ERROR_PATTERN_INDEX.md: add ERR-080 to EP-08 representative ERRs + must-check note

check:error-handbook: OK (80 entries consistent).

Do NOT merge — user merges manually.