### PR TITLE
feat(PRI-468): Stage A optional intentTension + Stage C additive passthrough

### DIFF
--- a/packages/openclaw-plugin/src/commands/pain.ts
+++ b/packages/openclaw-plugin/src/commands/pain.ts
@@ -8,6 +8,7 @@ import type { EvolutionLoopEvent } from '../core/evolution-types.js';
 import { computeHash } from '../utils/hashing.js';
 import { PainToPrincipleService, PrincipleTreeLedgerAdapter } from '@principles/core/runtime-v2';
 import { loadPdConfigForPlugin } from '../core/pd-config-loader.js';
+import { createIntentDocReader } from '../core/intent-doc-reader-adapter.js';
 
 /**
  * Creates a visual progress bar (e.g., [██████░░░░])
@@ -321,6 +322,7 @@ export async function handlePainReportCommand(ctx: PluginCommandContext): Promis
       autoIntakeEnabled: true,
       effectiveConfig: configResult.effective,
       getEnvVar: (name: string) => process.env[name],
+      intentDocReader: createIntentDocReader(wctx.workspaceDir),
     });
 
     const result = await service.recordPain({

--- a/packages/openclaw-plugin/src/core/intent-doc-reader-adapter.ts
+++ b/packages/openclaw-plugin/src/core/intent-doc-reader-adapter.ts
@@ -1,0 +1,65 @@
+/**
+ * PRI-468 — Plugin adapter implementing the core `IntentDocReader` port.
+ *
+ * Bridges the plugin-owned `safeReadIntentDoc()` I/O function to the
+ * core-owned `IntentDocReader` interface so Stage A (in core) can read
+ * INTENT.md without core performing any filesystem I/O.
+ *
+ * This adapter only MAPS types — it adds no new I/O, no new flag checks,
+ * and no new telemetry. The underlying `safeReadIntentDoc()` already
+ * performs the flag-first check (SPEC §12), TTL+mtime cache, and size cap.
+ *
+ * ERR checklist:
+ *   EP-01 / ERR-001: never `as` — field-by-field mapping with typeof checks
+ *   EP-02 / ERR-025: plugin I/O file, whitelisted in architecture-regression
+ *   EP-03 / ERR-002: every degraded path flows through with reason + nextAction
+ *
+ * Architecture: this file is I/O (delegates to fs-reading safeReadIntentDoc).
+ * It will be added to KNOWN_PLUGIN_CORE_FILES in architecture-regression.test.ts.
+ */
+
+import { safeReadIntentDoc } from './intent-doc-reader.js';
+import type {
+  IntentDocReader,
+  IntentDocReadResult,
+  IntentDocReference,
+} from '@principles/core/runtime-v2';
+
+/**
+ * Create an IntentDocReader bound to a specific workspace.
+ *
+ * The returned reader is stateless beyond the workspace binding — each
+ * `readIntentDoc()` call delegates to `safeReadIntentDoc()`, which owns
+ * the TTL+mtime cache.
+ */
+export function createIntentDocReader(workspaceDir: string): IntentDocReader {
+  return {
+    readIntentDoc(): IntentDocReadResult {
+      const result = safeReadIntentDoc(workspaceDir);
+
+      if (result.ok && result.doc) {
+        const doc = result.doc;
+        const reference: IntentDocReference = {
+          raw: typeof doc.raw === 'string' ? doc.raw : '',
+          contentHash: typeof doc.contentHash === 'string' ? doc.contentHash : '',
+          path: typeof doc.path === 'string' ? doc.path : '',
+        };
+        return {
+          ok: true,
+          found: true,
+          flagEnabled: true,
+          doc: reference,
+        };
+      }
+
+      // Degraded path — preserve structured reason + nextAction (EP-03 / ERR-002)
+      return {
+        ok: false,
+        found: result.found,
+        flagEnabled: result.flagEnabled,
+        reason: result.reason,
+        nextAction: result.nextAction,
+      };
+    },
+  };
+}

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -28,6 +28,7 @@ import { resolveWorkspaceDirForRuntimeV2 } from '../utils/workspace-resolver.js'
 import { PainToPrincipleService, PrincipleTreeLedgerAdapter, type PainDetectedData } from '@principles/core/runtime-v2';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 import { loadPdConfigForPlugin, loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
+import { createIntentDocReader } from '../core/intent-doc-reader-adapter.js';
 import { evaluateTriggerController } from '@principles/core/runtime-v2';
 import { isSharedCooldownActive, markSharedEpisodeAsDiagnosed } from './trigger-cooldown-tracker.js';
 import { buildManualPainObservation, resolveSourceKind } from './raw-observation-adapter.js';
@@ -60,6 +61,10 @@ function createPainToPrincipleService(wctx: WorkspaceContext): PainToPrincipleSe
     autoIntakeEnabled: true,
     effectiveConfig: configResult.effective,
     getEnvVar: (name: string) => process.env[name],
+    // PRI-468: wire INTENT.md reader so Stage A can produce intentTension
+    // when intent_engineering flag is on. Adapter performs no I/O beyond
+    // delegating to safeReadIntentDoc (which owns the flag-first check).
+    intentDocReader: createIntentDocReader(wctx.workspaceDir),
   });
 }
 

--- a/packages/openclaw-plugin/tests/core-anti-growth.test.ts
+++ b/packages/openclaw-plugin/tests/core-anti-growth.test.ts
@@ -110,6 +110,9 @@ describe('PRI-212 plugin core anti-growth guard', () => {
     // PRI-467: Plugin I/O boundary — reads .principles/INTENT.md with TTL+mtime
     // cache, delegates parsing/validation/hashing to @principles/core. Never throws.
     'intent-doc-reader.ts',
+    // PRI-468: Plugin adapter implementing core IntentDocReader port — pure type
+    // mapping from safeReadIntentDoc result to core IntentDocReadResult. No new I/O.
+    'intent-doc-reader-adapter.ts',
   ] as const;
 
   // Category 6: Test files

--- a/packages/openclaw-plugin/tests/core/intent-doc-reader-adapter.test.ts
+++ b/packages/openclaw-plugin/tests/core/intent-doc-reader-adapter.test.ts
@@ -1,0 +1,143 @@
+/**
+ * PRI-468 — Plugin adapter test: createIntentDocReader.
+ *
+ * Verifies the adapter maps safeReadIntentDoc() results to the core
+ * IntentDocReader port interface correctly:
+ *   - ok path → IntentDocReference with raw/contentHash/path
+ *   - flag_disabled → ok=false with reason
+ *   - not_found → ok=false with reason
+ *   - oversized → ok=false with reason
+ *
+ * Uses real fs writes in temp dirs (EP-09).
+ *
+ * ERR checklist:
+ *   EP-01 / ERR-001: no `as` — typeof checks on mapped fields
+ *   EP-03 / ERR-002: degraded paths preserve reason + nextAction
+ *   EP-09: real fs operations in os.tmpdir()
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as yaml from 'js-yaml';
+import { createIntentDocReader } from '../../src/core/intent-doc-reader-adapter.js';
+import { resetIntentDocCacheForTest } from '../../src/core/intent-doc-reader.js';
+
+// Helper to write a valid .pd/config.yaml enabling intent_engineering.
+// Mirrors the structure in intent-doc-reader.test.ts (full config, js-yaml dump).
+function writeConfigEnablingIntent(workspaceDir: string, enabled: boolean): void {
+  const configDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(configDir, { recursive: true });
+  const config = {
+    version: 1,
+    features: {
+      prompt: { category: 'core', enabled: true },
+      code_tool_hook: { category: 'core', enabled: true },
+      defer_archive: { category: 'core', enabled: true },
+      intent_engineering: { category: 'quiet', enabled },
+    },
+    runtimeProfiles: {
+      'openclaw.default': { type: 'openclaw', source: 'default' },
+    },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  };
+  fs.writeFileSync(
+    path.join(configDir, 'config.yaml'),
+    yaml.dump(config),
+    'utf8',
+  );
+}
+
+function writeIntentMd(workspaceDir: string, content: string): void {
+  const intentDir = path.join(workspaceDir, '.principles');
+  fs.mkdirSync(intentDir, { recursive: true });
+  fs.writeFileSync(path.join(intentDir, 'INTENT.md'), content, 'utf8');
+}
+
+describe('createIntentDocReader (PRI-468 adapter)', () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-intent-adapter-'));
+    resetIntentDocCacheForTest();
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    resetIntentDocCacheForTest();
+  });
+
+  it('returns ok=true with IntentDocReference when flag on + file exists', () => {
+    writeConfigEnablingIntent(workspaceDir, true);
+    const content = '# Why\nValidate the loop\n';
+    writeIntentMd(workspaceDir, content);
+
+    const reader = createIntentDocReader(workspaceDir);
+    const result = reader.readIntentDoc();
+
+    expect(result.ok).toBe(true);
+    expect(result.found).toBe(true);
+    expect(result.flagEnabled).toBe(true);
+    expect(result.doc).toBeDefined();
+    expect(typeof result.doc?.raw).toBe('string');
+    expect(result.doc?.raw).toBe(content);
+    expect(typeof result.doc?.contentHash).toBe('string');
+    expect(result.doc?.contentHash.length).toBeGreaterThan(0);
+    expect(typeof result.doc?.path).toBe('string');
+    expect(result.doc?.path).toContain('INTENT.md');
+  });
+
+  it('returns ok=false with reason=flag_disabled when flag off (no fs access)', () => {
+    writeConfigEnablingIntent(workspaceDir, false);
+    // Even with a file present, flag off → flag_disabled
+    writeIntentMd(workspaceDir, '# Why\nx\n');
+
+    const reader = createIntentDocReader(workspaceDir);
+    const result = reader.readIntentDoc();
+
+    expect(result.ok).toBe(false);
+    expect(result.found).toBe(false);
+    expect(result.flagEnabled).toBe(false);
+    expect(result.reason).toBe('flag_disabled');
+    expect(typeof result.nextAction).toBe('string');
+    expect(result.doc).toBeUndefined();
+  });
+
+  it('returns ok=false with reason=not_found when flag on but file missing', () => {
+    writeConfigEnablingIntent(workspaceDir, true);
+    // No INTENT.md written
+
+    const reader = createIntentDocReader(workspaceDir);
+    const result = reader.readIntentDoc();
+
+    expect(result.ok).toBe(false);
+    expect(result.found).toBe(false);
+    expect(result.flagEnabled).toBe(true);
+    expect(result.reason).toBe('not_found');
+    expect(typeof result.nextAction).toBe('string');
+    expect(result.doc).toBeUndefined();
+  });
+
+  it('returns ok=false with reason=oversized when file exceeds cap', () => {
+    writeConfigEnablingIntent(workspaceDir, true);
+    // 33KB content — exceeds 32KB cap
+    const big = '# Why\n' + 'a'.repeat(33 * 1024);
+    writeIntentMd(workspaceDir, big);
+
+    const reader = createIntentDocReader(workspaceDir);
+    const result = reader.readIntentDoc();
+
+    expect(result.ok).toBe(false);
+    expect(result.found).toBe(true);
+    expect(result.flagEnabled).toBe(true);
+    expect(result.reason).toBe('oversized');
+    expect(typeof result.nextAction).toBe('string');
+    expect(result.doc).toBeUndefined();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -336,6 +336,10 @@ const KNOWN_PLUGIN_CORE_FILES = new Set([
   // PRI-467: Plugin I/O boundary — reads .principles/INTENT.md with TTL+mtime cache,
   // delegates parsing/validation/hashing to @principles/core. Never throws.
   'intent-doc-reader.ts',
+  // PRI-468: Plugin adapter implementing core IntentDocReader port — pure type
+  // mapping from safeReadIntentDoc result to the core-owned IntentDocReadResult.
+  // No new I/O; delegates to intent-doc-reader.ts above.
+  'intent-doc-reader-adapter.ts',
 
   // ── Test Files ──────────────────────────────────────────────────────────
   '__tests__/focus-history.test.ts',
@@ -400,7 +404,9 @@ describe('PRI-212 plugin core anti-growth guard', () => {
     // in plugin src/core/ and own I/O side effects, so they stay classified.
     // PRI-467: Added intent-doc-reader.ts (92 → 93) — plugin I/O boundary for
     // reading .principles/INTENT.md with TTL+mtime cache for prompt injection.
-    expect(KNOWN_PLUGIN_CORE_FILES.size).toBe(93);
+    // PRI-468: Added intent-doc-reader-adapter.ts (93 → 94) — plugin adapter
+    // implementing core IntentDocReader port (pure type mapping, no new I/O).
+    expect(KNOWN_PLUGIN_CORE_FILES.size).toBe(94);
   });
 });
 

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/__snapshots__/schema-prompt-adapter.test.ts.snap
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/__snapshots__/schema-prompt-adapter.test.ts.snap
@@ -67,5 +67,6 @@ exports[`generateConstraints() > generateConstraints matches snapshot 1`] = `
     Conditional: "rule" kind → triggerPattern and action are required
     Conditional: "principle" kind → abstractedPrinciple is required
   confidence: number {description: A number between 0.0 and 1.0 (NOT a string, NOT a percentage), min: 0, max: 1} (required)
-  ambiguityNotes: string[] (optional)"
+  ambiguityNotes: string[] (optional)
+  intentTension: object (optional)"
 `;

--- a/packages/principles-core/src/runtime-v2/diagnostician-output.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-output.ts
@@ -9,6 +9,7 @@
  */
 import { Type, type Static } from '@sinclair/typebox';
 import type { DiagnosticianContextPayload } from './context-payload.js';
+import { IntentTensionSchema } from './diagnostician/diag-rootcause-output.js';
 
 // ── Diagnostician Output V1 ──
 
@@ -57,6 +58,21 @@ export const DiagnosticianOutputV1Schema = Type.Object({
   recommendations: Type.Array(DiagnosticianRecommendationSchema),
   confidence: Type.Number({ minimum: 0, maximum: 1, description: 'A number between 0.0 and 1.0 (NOT a string, NOT a percentage)' }),
   ambiguityNotes: Type.Optional(Type.Array(Type.String())),
+  /**
+   * PRI-468: Optional intent tension passed through from Stage A.
+   *
+   * Present only when:
+   *   1. The `intent_engineering` flag is on, AND
+   *   2. Stage A emitted an intentTension, AND
+   *   3. Stage C additive passthrough copied it here.
+   *
+   * Stage C MUST NOT generate intentTension when Stage A omitted it
+   * (SPEC §18.2 — additive only, never generates).
+   *
+   * This field is additive — existing consumers that don't know about
+   * intentTension will ignore it (SPEC §18.3 — don't break downstream).
+   */
+  intentTension: Type.Optional(IntentTensionSchema),
 });
  
 export type DiagnosticianOutputV1 = Static<typeof DiagnosticianOutputV1Schema>;

--- a/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician-prompt-builder.ts
@@ -26,6 +26,22 @@ export interface BuildPromptOptions {
   outputLanguage?: OutputLanguage;
   /** T-E (PRI-371): Inject core axiom grounding as PHASE 3.5 (default: false) */
   coreGrounding?: boolean;
+  /** PRI-468: Inject intent tension check as PHASE 3.6 (default: false) */
+  intentGrounding?: boolean;
+  /**
+   * PRI-468: INTENT.md reference to include in the prompt payload.
+   *
+   * When provided (along with `intentGrounding: true`), the `raw` content
+   * is included in the prompt as `intentDoc.raw` so the LLM can reference
+   * it. The `contentHash` is the lineage link for `intentTension.intentDocHash`.
+   *
+   * When absent, the prompt is byte-identical to the pre-PRI-468 prompt.
+   */
+  intentDoc?: {
+    readonly raw: string;
+    readonly contentHash: string;
+    readonly path: string;
+  };
 }
 
 /**
@@ -63,6 +79,22 @@ export interface PromptInput {
   diagnosticInstruction: string;
   /** Warnings added during truncation (e.g., conversationWindow entries removed) */
   truncationWarnings?: string[];
+  /**
+   * PRI-468: Optional INTENT.md reference for Stage A intent tension check.
+   *
+   * Present only when `intent_engineering` flag is on AND INTENT.md was
+   * successfully read. The `raw` content is included verbatim (unescaped)
+   * so the LLM can use it as a stable reference for judging intent tension.
+   * The `contentHash` is the lineage link for `intentTension.intentDocHash`.
+   *
+   * When absent (flag off or read failed), the prompt is byte-identical to
+   * the pre-PRI-468 prompt (EP-03: no silent fallback).
+   */
+  intentDoc?: {
+    readonly raw: string;
+    readonly contentHash: string;
+    readonly path: string;
+  };
 }
 
 /** Size limits for buildPrompt() to prevent token overflow. */

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diag-rootcause-output.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/diag-rootcause-output.test.ts
@@ -1,24 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import { Value } from '@sinclair/typebox/value';
 import { DiagRootCauseOutputV1Schema, DefaultDiagRootCauseValidator } from '../diag-rootcause-output.js';
+import type { IntentTension } from '../diag-rootcause-output.js';
+
+// Module-scope fixture so all describe blocks can share it.
+const validOutput = {
+  valid: true,
+  diagnosisId: 'diag-001',
+  taskId: 'task-001',
+  summary: 'Test summary',
+  causalChain: [
+    { why: 1, statement: 'First why', evidenceRefs: ['ref1'] },
+    { why: 2, statement: 'Second why', evidenceRefs: ['ref1'] },
+  ],
+  rootCause: 'Design: Poor error handling',
+  rootCauseCategory: 'Design',
+  evidence: [{ sourceRef: 'src1', note: 'note1' }],
+  confidence: 0.8,
+  ambiguityNotes: ['note1'],
+};
 
 describe('DiagRootCauseOutputV1Schema', () => {
-  const validOutput = {
-    valid: true,
-    diagnosisId: 'diag-001',
-    taskId: 'task-001',
-    summary: 'Test summary',
-    causalChain: [
-      { why: 1, statement: 'First why', evidenceRefs: ['ref1'] },
-      { why: 2, statement: 'Second why', evidenceRefs: ['ref1'] },
-    ],
-    rootCause: 'Design: Poor error handling',
-    rootCauseCategory: 'Design',
-    evidence: [{ sourceRef: 'src1', note: 'note1' }],
-    confidence: 0.8,
-    ambiguityNotes: ['note1'],
-  };
-
   it('valid root cause output passes Value.Check', () => {
     expect(Value.Check(DiagRootCauseOutputV1Schema, validOutput)).toBe(true);
   });
@@ -272,5 +274,142 @@ describe('DiagRootCauseOutputV1Schema', () => {
     const result = await validator.validate(output, 'task-001');
     expect(result.valid).toBe(false);
     expect(result.errors.some((e: string) => e.includes('People|Design|Assumption|Tooling'))).toBe(true);
+  });
+});
+
+// ── PRI-468: intentTension on DiagRootCauseOutputV1Schema ────────────────────
+
+describe('DiagRootCauseOutputV1Schema — intentTension (PRI-468)', () => {
+  const validIntentTension: IntentTension = {
+    source: 'action_drift',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['current_strategic_focus', 'non_negotiables'],
+    evidence: [
+      'INTENT says current focus is validating the smallest Pain → Principle loop.',
+      'Agent designed a heavy dashboard.',
+      'Owner correction says the result increased review burden.',
+    ],
+    explanation:
+      'The work may be useful later, but it optimized presentation completeness before validating the current learning loop.',
+    suggestedOwnerAction: 'confirm_drift',
+    intentDocHash: 'sha256:abc123',
+  };
+
+  it('accepts output without intentTension (optional)', () => {
+    expect(Value.Check(DiagRootCauseOutputV1Schema, validOutput)).toBe(true);
+  });
+
+  it('accepts output with valid intentTension', () => {
+    const output = { ...validOutput, intentTension: validIntentTension };
+    expect(Value.Check(DiagRootCauseOutputV1Schema, output)).toBe(true);
+  });
+
+  it('Value.Clean strips intentTension.confidence from nested object', () => {
+    const output = {
+      ...validOutput,
+      intentTension: { ...validIntentTension, confidence: 0.8 },
+    };
+    const cleaned = Value.Clean(DiagRootCauseOutputV1Schema, output) as Record<string, unknown>;
+    const cleanedTension = cleaned.intentTension as Record<string, unknown> | undefined;
+    expect(cleanedTension).toBeDefined();
+    expect(Object.hasOwn(cleanedTension as Record<string, unknown>, 'confidence')).toBe(false);
+  });
+
+  it('rejects output with intentTension.confidence (additionalProperties: false)', () => {
+    const output = {
+      ...validOutput,
+      intentTension: { ...validIntentTension, confidence: 0.8 },
+    };
+    expect(Value.Check(DiagRootCauseOutputV1Schema, output)).toBe(false);
+  });
+
+  it('rejects output with intentTension.source = invalid', () => {
+    const output = {
+      ...validOutput,
+      intentTension: { ...validIntentTension, source: 'definitely_drift' },
+    };
+    expect(Value.Check(DiagRootCauseOutputV1Schema, output)).toBe(false);
+  });
+
+  it('rejects output with intentTension.evidence > 3 items', () => {
+    const output = {
+      ...validOutput,
+      intentTension: {
+        ...validIntentTension,
+        evidence: ['one', 'two', 'three', 'four'],
+      },
+    };
+    expect(Value.Check(DiagRootCauseOutputV1Schema, output)).toBe(false);
+  });
+});
+
+// ── PRI-468: DefaultDiagRootCauseValidator with intentTension ───────────────
+
+describe('DefaultDiagRootCauseValidator — intentTension (PRI-468)', () => {
+  const validIntentTension: IntentTension = {
+    source: 'action_drift',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['current_strategic_focus'],
+    evidence: ['Agent added a dashboard.', 'Owner said focus was the loop.'],
+    explanation: 'Action optimized presentation over the current learning loop.',
+    suggestedOwnerAction: 'confirm_drift',
+    intentDocHash: 'sha256:abc123',
+  };
+
+  it('accepts valid output with intentTension', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = { ...validOutput, intentTension: validIntentTension };
+    const result = await validator.validate(output, 'task-001');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects intentTension with confidence field', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = {
+      ...validOutput,
+      intentTension: { ...validIntentTension, confidence: 0.8 },
+    };
+    const result = await validator.validate(output, 'task-001');
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e: string) => e.includes('intentTension') || e.includes('confidence') || e.includes('Additional')),
+    ).toBe(true);
+  });
+
+  it('rejects intentTension with invalid source', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = {
+      ...validOutput,
+      intentTension: { ...validIntentTension, source: 'definitely_drift' },
+    };
+    const result = await validator.validate(output, 'task-001');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects intentTension with evidence > 3 items', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = {
+      ...validOutput,
+      intentTension: {
+        ...validIntentTension,
+        evidence: ['one', 'two', 'three', 'four'],
+      },
+    };
+    const result = await validator.validate(output, 'task-001');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects intentTension that is not an object', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const output = { ...validOutput, intentTension: 'not an object' };
+    const result = await validator.validate(output, 'task-001');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('intentTension'))).toBe(true);
+  });
+
+  it('still accepts output without intentTension (backward compat)', async () => {
+    const validator = new DefaultDiagRootCauseValidator();
+    const result = await validator.validate(validOutput, 'task-001');
+    expect(result.valid).toBe(true);
   });
 });

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/intent-tension-schema.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/intent-tension-schema.test.ts
@@ -1,0 +1,314 @@
+/**
+ * PRI-468 — IntentTensionSchema unit tests (SPEC §23.3).
+ *
+ * Validates the TypeBox schema for the optional `intentTension` field added
+ * to DiagRootCauseOutputV1Schema. The schema must:
+ *   - accept all four `source` enum values (SPEC §16.5)
+ *   - accept all three `evidenceStrength` values
+ *   - accept all five `relatedIntentFields` values
+ *   - accept all six `suggestedOwnerAction` values (SPEC §21)
+ *   - cap `evidence` at 3 items (SPEC §16.4)
+ *   - reject `confidence` (SPEC §16.3 — intentTension.confidence is forbidden;
+ *     existing rootCause-level confidence is untouched)
+ *   - treat `intentDocHash` as optional (SPEC §16.2)
+ *
+ * TDD: this test is written BEFORE the schema exists. Run to confirm RED.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  IntentTensionSchema,
+  IntentTensionSourceSchema,
+  EvidenceStrengthSchema,
+  IntentRelatedFieldSchema,
+  SuggestedOwnerActionSchema,
+  type IntentTension,
+} from '../diag-rootcause-output.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const validIntentTension: IntentTension = {
+  source: 'action_drift',
+  evidenceStrength: 'moderate',
+  relatedIntentFields: ['current_strategic_focus', 'non_negotiables'],
+  evidence: [
+    'INTENT says current focus is validating the smallest Pain → Principle loop.',
+    'Agent designed a heavy dashboard.',
+    'Owner correction says the result increased review burden.',
+  ],
+  explanation:
+    'The work may be useful later, but it optimized presentation completeness before validating the current learning loop.',
+  suggestedOwnerAction: 'confirm_drift',
+  intentDocHash: 'sha256:abc123',
+};
+
+// ── Schema existence ─────────────────────────────────────────────────────────
+
+describe('IntentTensionSchema — existence', () => {
+  it('exports IntentTensionSchema', () => {
+    expect(IntentTensionSchema).toBeDefined();
+  });
+
+  it('exports sub-literal schemas', () => {
+    expect(IntentTensionSourceSchema).toBeDefined();
+    expect(EvidenceStrengthSchema).toBeDefined();
+    expect(IntentRelatedFieldSchema).toBeDefined();
+    expect(SuggestedOwnerActionSchema).toBeDefined();
+  });
+});
+
+// ── §23.3.1 — source enum validity ──────────────────────────────────────────
+
+describe('IntentTensionSchema — source enum (SPEC §16.5)', () => {
+  const SOURCES = ['none', 'action_drift', 'intent_suspect', 'healthy_tension'] as const;
+
+  for (const source of SOURCES) {
+    it(`accepts source="${source}"`, () => {
+      const obj = { ...validIntentTension, source };
+      expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+    });
+  }
+
+  it('rejects unknown source value', () => {
+    const obj = { ...validIntentTension, source: 'definitely_drift' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects missing source', () => {
+    const { source: _source, ...obj } = validIntentTension;
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── §23.3.2 — evidenceStrength enum validity ────────────────────────────────
+
+describe('IntentTensionSchema — evidenceStrength enum', () => {
+  const STRENGTHS = ['weak', 'moderate', 'strong'] as const;
+
+  for (const evidenceStrength of STRENGTHS) {
+    it(`accepts evidenceStrength="${evidenceStrength}"`, () => {
+      const obj = { ...validIntentTension, evidenceStrength };
+      expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+    });
+  }
+
+  it('rejects unknown evidenceStrength value', () => {
+    const obj = { ...validIntentTension, evidenceStrength: 'very_strong' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects numeric evidenceStrength', () => {
+    const obj = { ...validIntentTension, evidenceStrength: 0.8 };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── §23.3.3 — relatedIntentFields enum validity ─────────────────────────────
+
+describe('IntentTensionSchema — relatedIntentFields enum', () => {
+  const FIELDS = [
+    'why',
+    'desired_outcome',
+    'non_negotiables',
+    'stop_escalation',
+    'current_strategic_focus',
+  ] as const;
+
+  for (const field of FIELDS) {
+    it(`accepts relatedIntentFields=["${field}"]`, () => {
+      const obj = { ...validIntentTension, relatedIntentFields: [field] };
+      expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+    });
+  }
+
+  it('accepts multiple relatedIntentFields', () => {
+    const obj = { ...validIntentTension, relatedIntentFields: [...FIELDS] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('accepts empty relatedIntentFields array', () => {
+    const obj = { ...validIntentTension, relatedIntentFields: [] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('rejects unknown relatedIntentFields value', () => {
+    const obj = { ...validIntentTension, relatedIntentFields: ['unknown_field'] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects non-array relatedIntentFields', () => {
+    const obj = { ...validIntentTension, relatedIntentFields: 'current_strategic_focus' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── §23.3.4 — suggestedOwnerAction enum validity ────────────────────────────
+
+describe('IntentTensionSchema — suggestedOwnerAction enum (SPEC §21)', () => {
+  const ACTIONS = [
+    'confirm_drift',
+    'revise_intent',
+    'observe',
+    'dismiss',
+    'promote_to_principle',
+    'promote_to_rulehost',
+  ] as const;
+
+  for (const suggestedOwnerAction of ACTIONS) {
+    it(`accepts suggestedOwnerAction="${suggestedOwnerAction}"`, () => {
+      const obj = { ...validIntentTension, suggestedOwnerAction };
+      expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+    });
+  }
+
+  it('rejects unknown suggestedOwnerAction value', () => {
+    const obj = { ...validIntentTension, suggestedOwnerAction: 'ignore' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── §23.3.5 — evidence max 3 items (SPEC §16.4) ─────────────────────────────
+
+describe('IntentTensionSchema — evidence maxItems: 3 (SPEC §16.4)', () => {
+  it('accepts evidence with 0 items', () => {
+    const obj = { ...validIntentTension, evidence: [] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('accepts evidence with 1 item', () => {
+    const obj = { ...validIntentTension, evidence: ['one'] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('accepts evidence with exactly 3 items', () => {
+    const obj = { ...validIntentTension, evidence: ['one', 'two', 'three'] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('rejects evidence with 4 items', () => {
+    const obj = { ...validIntentTension, evidence: ['one', 'two', 'three', 'four'] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects evidence with 10 items', () => {
+    const obj = { ...validIntentTension, evidence: Array.from({ length: 10 }, (_, i) => `evidence-${i}`) };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects non-array evidence', () => {
+    const obj = { ...validIntentTension, evidence: 'single string' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects evidence array with non-string elements', () => {
+    const obj = { ...validIntentTension, evidence: ['ok', 42, 'bad'] };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── §23.3.6 — confidence is rejected (SPEC §16.3) ───────────────────────────
+
+describe('IntentTensionSchema — confidence forbidden (SPEC §16.3)', () => {
+  it('rejects intentTension.confidence: number', () => {
+    const obj = { ...validIntentTension, confidence: 0.8 };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects intentTension.confidence: 0', () => {
+    const obj = { ...validIntentTension, confidence: 0 };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects intentTension.confidence: 1', () => {
+    const obj = { ...validIntentTension, confidence: 1 };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('Value.Clean strips confidence from intentTension', () => {
+    const obj = { ...validIntentTension, confidence: 0.8 };
+    const cleaned = Value.Clean(IntentTensionSchema, obj) as Record<string, unknown>;
+    expect(Object.hasOwn(cleaned, 'confidence')).toBe(false);
+  });
+
+  it('Value.Errors reports confidence as additional property', () => {
+    const obj = { ...validIntentTension, confidence: 0.8 };
+    const errors = [...Value.Errors(IntentTensionSchema, obj)];
+    expect(errors.some((e) => e.path.includes('confidence') || e.message.includes('Additional'))).toBe(true);
+  });
+});
+
+// ── §23.3.7 — intentDocHash is optional (SPEC §16.2) ────────────────────────
+
+describe('IntentTensionSchema — intentDocHash optional', () => {
+  it('accepts intentTension with intentDocHash', () => {
+    const obj = { ...validIntentTension, intentDocHash: 'sha256:abc123' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('accepts intentTension without intentDocHash', () => {
+    const { intentDocHash: _hash, ...obj } = validIntentTension;
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('accepts intentTension with empty intentDocHash', () => {
+    const obj = { ...validIntentTension, intentDocHash: '' };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(true);
+  });
+
+  it('rejects non-string intentDocHash', () => {
+    const obj = { ...validIntentTension, intentDocHash: 123 };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── §16.4 — explanation is required non-empty string ────────────────────────
+
+describe('IntentTensionSchema — explanation required', () => {
+  it('rejects missing explanation', () => {
+    const { explanation: _exp, ...obj } = validIntentTension;
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+
+  it('rejects non-string explanation', () => {
+    const obj = { ...validIntentTension, explanation: 42 };
+    expect(Value.Check(IntentTensionSchema, obj)).toBe(false);
+  });
+});
+
+// ── Full valid object ────────────────────────────────────────────────────────
+
+describe('IntentTensionSchema — full valid object', () => {
+  it('accepts the canonical valid intentTension', () => {
+    expect(Value.Check(IntentTensionSchema, validIntentTension)).toBe(true);
+  });
+
+  it('Value.Clean returns a clean object with all valid fields', () => {
+    const withExtra = { ...validIntentTension, extraField: 'should be removed' };
+    const cleaned = Value.Clean(IntentTensionSchema, withExtra) as Record<string, unknown>;
+    expect(Object.hasOwn(cleaned, 'extraField')).toBe(false);
+    expect(Object.hasOwn(cleaned, 'source')).toBe(true);
+    expect(Object.hasOwn(cleaned, 'evidenceStrength')).toBe(true);
+    expect(Object.hasOwn(cleaned, 'relatedIntentFields')).toBe(true);
+    expect(Object.hasOwn(cleaned, 'evidence')).toBe(true);
+    expect(Object.hasOwn(cleaned, 'explanation')).toBe(true);
+    expect(Object.hasOwn(cleaned, 'suggestedOwnerAction')).toBe(true);
+    expect(Object.hasOwn(cleaned, 'intentDocHash')).toBe(true);
+  });
+
+  it('rejects empty object', () => {
+    expect(Value.Check(IntentTensionSchema, {})).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(Value.Check(IntentTensionSchema, null)).toBe(false);
+  });
+
+  it('rejects array', () => {
+    expect(Value.Check(IntentTensionSchema, [])).toBe(false);
+  });
+
+  it('rejects string', () => {
+    expect(Value.Check(IntentTensionSchema, 'not an object')).toBe(false);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/diagnostician/__tests__/rootcause-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/__tests__/rootcause-prompt-builder.test.ts
@@ -36,3 +36,85 @@ describe('RootCausePromptBuilder', () => {
     expect(phase35Index).toBeGreaterThan(phase3Index);
   });
 });
+
+// ── PRI-468: PHASE 3.6 — Intent Tension Check ───────────────────────────────
+
+describe('RootCausePromptBuilder — PHASE 3.6 Intent Tension Check (PRI-468)', () => {
+  it('intentGrounding=false does NOT include PHASE 3.6', () => {
+    const instruction = buildRootCauseProtocolInstruction({
+      coreGrounding: false,
+      intentGrounding: false,
+    });
+    expect(instruction).not.toContain('PHASE 3.6');
+    expect(instruction).not.toContain('Intent Tension Check');
+  });
+
+  it('intentGrounding=undefined does NOT include PHASE 3.6 (default off)', () => {
+    const instruction = buildRootCauseProtocolInstruction({ coreGrounding: false });
+    expect(instruction).not.toContain('PHASE 3.6');
+  });
+
+  it('intentGrounding=true injects PHASE 3.6', () => {
+    const instruction = buildRootCauseProtocolInstruction({
+      coreGrounding: false,
+      intentGrounding: true,
+    });
+    expect(instruction).toContain('PHASE 3.6');
+    expect(instruction).toContain('Intent Tension Check');
+  });
+
+  it('PHASE 3.6 contains SPEC §17 required text', () => {
+    const instruction = buildRootCauseProtocolInstruction({
+      coreGrounding: false,
+      intentGrounding: true,
+    });
+    expect(instruction).toContain('Owner-owned INTENT.md');
+    expect(instruction).toContain('Do not assume every failure is intent drift');
+    expect(instruction).toContain('Do not treat INTENT.md as a hard rule system');
+    expect(instruction).toContain("source='none'");
+    expect(instruction).toContain("evidenceStrength='weak'");
+    expect(instruction).toContain('intent_suspect');
+    expect(instruction).toContain('Return intentTension as an optional additive field');
+    expect(instruction).toContain('PD surfaces tension');
+    expect(instruction).toContain('Owner decides value');
+  });
+
+  it('PHASE 3.6 appears after PHASE 3.5 when both are enabled', () => {
+    const instruction = buildRootCauseProtocolInstruction({
+      coreGrounding: true,
+      intentGrounding: true,
+    });
+    const phase35Index = instruction.indexOf('PHASE 3.5');
+    const phase36Index = instruction.indexOf('PHASE 3.6');
+    expect(phase36Index).toBeGreaterThan(phase35Index);
+  });
+
+  it('PHASE 3.6 appears after PHASE 3 when only 3.6 is enabled', () => {
+    const instruction = buildRootCauseProtocolInstruction({
+      coreGrounding: false,
+      intentGrounding: true,
+    });
+    const phase3Index = instruction.indexOf('PHASE 3 —');
+    const phase36Index = instruction.indexOf('PHASE 3.6');
+    expect(phase36Index).toBeGreaterThan(phase3Index);
+  });
+
+  // EP-03: no silent fallback — byte-identical output when flag off
+  it('intentGrounding=false produces byte-identical output to pre-change prompt', () => {
+    const before = buildRootCauseProtocolInstruction({ coreGrounding: false });
+    const after = buildRootCauseProtocolInstruction({
+      coreGrounding: false,
+      intentGrounding: false,
+    });
+    expect(after).toBe(before);
+  });
+
+  it('intentGrounding=false + coreGrounding=true produces byte-identical output to coreGrounding-only', () => {
+    const before = buildRootCauseProtocolInstruction({ coreGrounding: true });
+    const after = buildRootCauseProtocolInstruction({
+      coreGrounding: true,
+      intentGrounding: false,
+    });
+    expect(after).toBe(before);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/diagnostician/diag-rootcause-output.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/diag-rootcause-output.ts
@@ -59,6 +59,112 @@ export const DiagRootCauseEvidenceSchema = Type.Object({
 /** Evidence entry linking a source reference to an explanatory note. */
 export type DiagRootCauseEvidence = Static<typeof DiagRootCauseEvidenceSchema>;
 
+// ── Intent Tension sub-schemas (PRI-468, SPEC §16) ──────────────────────────
+
+/**
+ * Intent tension source enum (SPEC §16.5).
+ *
+ * - `none` — no tension detected
+ * - `action_drift` — Agent's action appears to drift from INTENT
+ * - `intent_suspect` — INTENT itself may be stale, ambiguous, or contradictory
+ * - `healthy_tension` — genuine strategic trade-off, no drift
+ */
+export const IntentTensionSourceSchema = Type.Union([
+  Type.Literal('none'),
+  Type.Literal('action_drift'),
+  Type.Literal('intent_suspect'),
+  Type.Literal('healthy_tension'),
+]);
+
+/** Intent tension source: none | action_drift | intent_suspect | healthy_tension */
+export type IntentTensionSource = Static<typeof IntentTensionSourceSchema>;
+
+/**
+ * Evidence strength enum (SPEC §16.6).
+ *
+ * Coarse three-level scale; intentionally NOT a numeric confidence
+ * (SPEC §16.3 forbids `intentTension.confidence`).
+ */
+export const EvidenceStrengthSchema = Type.Union([
+  Type.Literal('weak'),
+  Type.Literal('moderate'),
+  Type.Literal('strong'),
+]);
+
+/** Evidence strength: weak | moderate | strong */
+export type EvidenceStrength = Static<typeof EvidenceStrengthSchema>;
+
+/**
+ * Related INTENT.md field enum (SPEC §16.7).
+ *
+ * Snake_case keys mirror the INTENT.md section identifiers used in the
+ * prompt block. The LLM picks one or more fields that the tension
+ * relates to.
+ */
+export const IntentRelatedFieldSchema = Type.Union([
+  Type.Literal('why'),
+  Type.Literal('desired_outcome'),
+  Type.Literal('non_negotiables'),
+  Type.Literal('stop_escalation'),
+  Type.Literal('current_strategic_focus'),
+]);
+
+/** Related INTENT field: why | desired_outcome | non_negotiables | stop_escalation | current_strategic_focus */
+export type IntentRelatedField = Static<typeof IntentRelatedFieldSchema>;
+
+/**
+ * Suggested Owner action enum (SPEC §21).
+ *
+ * PD surfaces tension; the Owner decides value. This field is a
+ * SUGGESTION — never auto-applied. The Owner must record a
+ * IntentDecisionRecord (PRI-470) before any follow-up action executes.
+ */
+export const SuggestedOwnerActionSchema = Type.Union([
+  Type.Literal('confirm_drift'),
+  Type.Literal('revise_intent'),
+  Type.Literal('observe'),
+  Type.Literal('dismiss'),
+  Type.Literal('promote_to_principle'),
+  Type.Literal('promote_to_rulehost'),
+]);
+
+/** Suggested Owner action: confirm_drift | revise_intent | observe | dismiss | promote_to_principle | promote_to_rulehost */
+export type SuggestedOwnerAction = Static<typeof SuggestedOwnerActionSchema>;
+
+/**
+ * IntentTension schema (SPEC §16.2).
+ *
+ * Optional object produced by Stage A when the Agent detects a tension
+ * between its action and the Owner-authored INTENT.md.
+ *
+ * CRITICAL (SPEC §16.3): this object MUST NOT carry a `confidence`
+ * field. The Stage A `confidence` (rootCause-level) is the only
+ * diagnostician confidence. To enforce this, `additionalProperties: false`
+ * is set so any extra property (including `confidence`) is rejected by
+ * `Value.Check`.
+ *
+ * Lineage (SPEC §16.2): `intentDocHash` is optional but, when present,
+ * MUST match the hash of the INTENT.md that was injected into the
+ * prompt. The Stage A runner enforces this invariant (PRI-468).
+ */
+export const IntentTensionSchema = Type.Object({
+  source: IntentTensionSourceSchema,
+  evidenceStrength: EvidenceStrengthSchema,
+  relatedIntentFields: Type.Array(IntentRelatedFieldSchema),
+  evidence: Type.Array(Type.String(), { maxItems: 3 }),
+  explanation: Type.String({ minLength: 1 }),
+  suggestedOwnerAction: SuggestedOwnerActionSchema,
+  intentDocHash: Type.Optional(Type.String()),
+}, { additionalProperties: false });
+
+/**
+ * IntentTension — optional Stage A output describing a tension between
+ * the Agent's action and the Owner-authored INTENT.md.
+ *
+ * `confidence` is forbidden on this object (SPEC §16.3).
+ */
+export type IntentTension = Static<typeof IntentTensionSchema>;
+
 // ── Main output schema ───────────────────────────────────────────────────────
 
 /**
@@ -84,6 +190,16 @@ export const DiagRootCauseOutputV1Schema = Type.Object({
   evidence: Type.Array(DiagRootCauseEvidenceSchema),
   confidence: Type.Number({ minimum: 0, maximum: 1 }),
   ambiguityNotes: Type.Optional(Type.Array(Type.String())),
+  /**
+   * Optional intent tension (PRI-468, SPEC §16). Present only when:
+   *   1. The `intent_engineering` flag is on, AND
+   *   2. The Stage A prompt was built with the INTENT context injected, AND
+   *   3. The LLM chose to emit a tension.
+   *
+   * When absent (flag off or LLM omitted), Stage C passthrough must NOT
+   * synthesize one (SPEC §18 — additive only, never generates).
+   */
+  intentTension: Type.Optional(IntentTensionSchema),
 });
 
 /** Typed output of the Root Cause stage (Stage A). */
@@ -217,6 +333,24 @@ export class DefaultDiagRootCauseValidator implements DiagRootCauseValidator {
         }
         if (typeof ev.note !== 'string' || ev.note.trim() === '') {
           errors.push(`evidence[${i}].note must be a non-empty string`);
+        }
+      }
+    }
+
+    // ── Step 6b: intentTension element-level checks (PRI-468, SPEC §16) ─────
+    // Provide clearer error messages than the TypeBox fallback for the most
+    // critical SPEC §16.3 violation (forbidden `confidence` field) and for
+    // non-object intentTension. The TypeBox schema (with additionalProperties:
+    // false) catches these as well, but the explicit check produces a
+    // human-readable message that references the SPEC clause.
+    if (Object.hasOwn(record, 'intentTension')) {
+      const tension = record.intentTension;
+      if (tension === null || typeof tension !== 'object') {
+        errors.push('intentTension must be an object when present');
+      } else {
+        const tensionRecord = tension as Record<string, unknown>;
+        if (Object.hasOwn(tensionRecord, 'confidence')) {
+          errors.push('intentTension.confidence is forbidden (SPEC §16.3); use rootCause-level confidence instead');
         }
       }
     }

--- a/packages/principles-core/src/runtime-v2/diagnostician/rootcause-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/rootcause-prompt-builder.ts
@@ -40,6 +40,58 @@ import type { PromptInput } from '../diagnostician-prompt-builder.js';
 // ── Options ──────────────────────────────────────────────────────────────────
 
 /**
+ * Build the PHASE 3.6 — Intent Tension Check block (PRI-468, SPEC §17).
+ *
+ * When `intentGrounding` is true, returns the SPEC §17 verbatim text that
+ * instructs the LLM to optionally produce an `intentTension` field.
+ *
+ * When false/undefined, returns `''` (empty string) so that
+ * `${phase35Block}${phase36Block}CRITICAL:` is byte-identical to
+ * `${phase35Block}CRITICAL:` — preserving the pre-PRI-468 prompt output
+ * (EP-03: no silent fallback).
+ *
+ * This is a pure function — no I/O, no side effects, never throws.
+ */
+function buildIntentTensionBlock(intentGrounding?: boolean): string {
+  if (!intentGrounding) {
+    return '';
+  }
+
+  // SPEC §17 — verbatim text. The LLM is told:
+  // - INTENT.md is optional reference, not a hard rule system
+  // - source='none' / evidenceStrength='weak' when evidence is insufficient
+  // - intent_suspect only for contradiction, vagueness, outdatedness, or
+  //   repeated challenge — not for strategic preference
+  // - intentTension is an optional additive field
+  // - PD surfaces tension; Owner decides value
+  return `
+PHASE 3.6 — Intent Tension Check:
+You may be given an optional Owner-owned INTENT.md.
+
+Use it only as a stable reference for judging whether the pain indicates tension between:
+- the Owner's stated long-term intent
+- the current focus
+- the Agent's actions
+- the Owner's correction
+
+Do not assume every failure is intent drift.
+
+Do not treat INTENT.md as a hard rule system.
+Hard runtime boundaries belong to RuleHost.
+
+If evidence is insufficient, use source='none' or evidenceStrength='weak'.
+
+Only mark intent_suspect when INTENT.md is contradictory, vague, outdated, or repeatedly challenged by confirmed Pain evidence.
+Do not mark intent_suspect merely because you prefer another strategy.
+
+Return intentTension as an optional additive field.
+
+PD surfaces tension.
+Owner decides value.
+`;
+}
+
+/**
  * Options for RootCausePromptBuilder constructor and buildRootCauseInstruction.
  *
  * Uses an opts-object pattern to satisfy @typescript-eslint/max-params.
@@ -55,6 +107,14 @@ export interface RootCausePromptBuilderOptions {
   outputLanguage?: OutputLanguage;
   /** T-E (PRI-371): Inject core axiom grounding as PHASE 3.5 (default: false) */
   coreGrounding?: boolean;
+  /**
+   * PRI-468: Inject intent tension check as PHASE 3.6 (default: false).
+   *
+   * When true, inserts the SPEC §17 text instructing the LLM to optionally
+   * produce an `intentTension` field. When false/undefined, the prompt is
+   * byte-identical to the pre-PRI-468 prompt (EP-03: no silent fallback).
+   */
+  intentGrounding?: boolean;
 }
 
 // ── Instruction builder ──────────────────────────────────────────────────────
@@ -77,7 +137,7 @@ export function buildRootCauseProtocolInstruction(
 ): string {
   const adapter = opts.adapter ?? new DefaultSchemaPromptAdapter();
   const schema = opts.schema ?? DiagRootCauseOutputV1Schema;
-  const { outputLanguage, coreGrounding } = opts;
+  const { outputLanguage, coreGrounding, intentGrounding } = opts;
 
   const example = adapter.generateExample(schema);
   const constraints = adapter.generateConstraints(schema);
@@ -95,6 +155,13 @@ export function buildRootCauseProtocolInstruction(
     outputLanguage,
     fallback: '\n',
   });
+
+  // PRI-468: When intentGrounding is true, insert PHASE 3.6.
+  // When false or undefined, output is byte-identical to the pre-PRI-468
+  // prompt (EP-03: no silent fallback). The fallback is '' (empty string)
+  // so that `${phase35Block}${phase36Block}CRITICAL:` produces the same
+  // string as `${phase35Block}CRITICAL:` when intentGrounding is off.
+  const phase36Block = buildIntentTensionBlock(intentGrounding);
 
   return `You are a root cause analysis expert. Follow this protocol:
 
@@ -123,7 +190,7 @@ Classify into ONE: People | Design | Assumption | Tooling
 - Design: architecture defects, missing gates, process gaps
 - Assumption: wrong assumptions about env/versions/deps
 - Tooling: tool misconfiguration, API changes
-${phase35Block}CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
+${phase35Block}${phase36Block}CRITICAL: Your ENTIRE response must be ONLY the JSON object below. Do NOT include any text before or after the JSON. Do NOT wrap the JSON in markdown code fences. Do NOT add explanatory prose. Output the raw JSON object and nothing else.
 
 COMPLETE EXAMPLE OUTPUT (follow this exact structure):
 ${example}
@@ -180,6 +247,7 @@ export class RootCausePromptBuilder {
       schema: opts.schema ?? this.schema,
       outputLanguage: opts.outputLanguage,
       coreGrounding: opts.coreGrounding,
+      intentGrounding: opts.intentGrounding,
     });
   }
 
@@ -200,7 +268,7 @@ export class RootCausePromptBuilder {
     opts: BuildPromptOptions = {},
   ): PromptBuildResult {
     const limits = opts.limits ?? DEFAULT_PROMPT_BUILDER_LIMITS;
-    const { outputLanguage, coreGrounding } = opts;
+    const { outputLanguage, coreGrounding, intentGrounding, intentDoc } = opts;
 
     const truncationWarnings: string[] = [];
 
@@ -233,9 +301,13 @@ export class RootCausePromptBuilder {
     const diagnosticInstruction = this.buildRootCauseInstruction({
       outputLanguage,
       coreGrounding,
+      intentGrounding,
     });
 
     // DPB-04: Explicit top-level fields at the prompt level
+    // PRI-468: Only include `intentDoc` when intentGrounding is on AND a doc
+    // was successfully read. When absent, the prompt is byte-identical to
+    // the pre-PRI-468 prompt (EP-03: no silent fallback).
     const promptInput: PromptInput = {
       taskId: payload.taskId,
       contextHash: payload.contextHash,
@@ -245,6 +317,7 @@ export class RootCausePromptBuilder {
       context: compactContext,
       diagnosticInstruction,
       ...(truncationWarnings.length > 0 ? { truncationWarnings } : {}),
+      ...(intentGrounding && intentDoc ? { intentDoc } : {}),
     };
 
     // DPB-02: Output is ONLY JSON — no markdown, no file ops, no tool calls

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -215,6 +215,20 @@ export { DiagRootCauseRunner } from './internalization/diag-rootcause-runner.js'
 export { DiagDistillerRunner } from './internalization/diag-distiller-runner.js';
 export { DiagRouterRunner } from './internalization/diag-router-runner.js';
 export { DefaultDiagRootCauseValidator } from './diagnostician/diag-rootcause-output.js';
+export {
+  IntentTensionSchema,
+  IntentTensionSourceSchema,
+  EvidenceStrengthSchema,
+  IntentRelatedFieldSchema,
+  SuggestedOwnerActionSchema,
+} from './diagnostician/diag-rootcause-output.js';
+export type {
+  IntentTension,
+  IntentTensionSource,
+  EvidenceStrength,
+  IntentRelatedField,
+  SuggestedOwnerAction,
+} from './diagnostician/diag-rootcause-output.js';
 export { DefaultDiagDistillerValidator } from './diagnostician/diag-distiller-output.js';
 export { DisabledDiagnosticianRunner } from './pain-signal-runtime-factory.js';
 // Runtime Adapter (M4)
@@ -1662,8 +1676,9 @@ export type {
 export { SimpleLRU, DetectionFunnelCore } from './detection/index.js';
 
 
-// Intent Engineering MVP (PRI-465 / PRI-466 / PRI-467) — pure logic: parser,
-// hasher, validator, and the bounded+escaped friction block builder.
+// Intent Engineering MVP (PRI-465 / PRI-466 / PRI-467 / PRI-468) — pure logic:
+// parser, hasher, validator, the bounded+escaped friction block builder, and
+// the IntentDocReader port interface (core-owned, plugin-implemented).
 export {
   INTENT_MAX_BYTES,
   INTENT_DOC_TEMPLATE,
@@ -1673,10 +1688,15 @@ export {
   computeIntentContentHash,
   validateIntentDocSections,
   buildIntentFrictionBlock,
+  NullIntentDocReader,
 } from './intent/index.js';
 export type {
   IntentDocSections,
   IntentDocWarning,
   IntentDocWarningCode,
   IntentFrictionBlockInput,
+  IntentDocReader,
+  IntentDocReadResult,
+  IntentDocReference,
+  IntentDocReadReason,
 } from './intent/index.js';

--- a/packages/principles-core/src/runtime-v2/intent/index.ts
+++ b/packages/principles-core/src/runtime-v2/intent/index.ts
@@ -1,2 +1,3 @@
 export * from './intent-doc.js';
 export * from './intent-friction-block.js';
+export * from './intent-doc-reader-port.js';

--- a/packages/principles-core/src/runtime-v2/intent/intent-doc-reader-port.ts
+++ b/packages/principles-core/src/runtime-v2/intent/intent-doc-reader-port.ts
@@ -1,0 +1,112 @@
+/**
+ * IntentDocReader — port interface for reading INTENT.md from the plugin layer.
+ *
+ * PRI-468 / SPEC §12 — the diagnostician Stage A runner needs INTENT.md
+ * content to optionally produce `intentTension`. Core cannot do I/O, so it
+ * defines this port; the plugin provides a concrete implementation that
+ * wraps `safeReadIntentDoc()` with feature-flag checking.
+ *
+ * Contract (SPEC §12):
+ *   - When `intent_engineering` flag is off, implementations MUST return
+ *     `{ ok: false, flagEnabled: false, reason: 'flag_disabled' }` WITHOUT
+ *     any filesystem access.
+ *   - Implementations MUST NOT throw — all error paths return a structured
+ *     `reason` + `nextAction` (EP-03 / ERR-002: no silent fallback).
+ *   - `doc.raw` is unescaped; the caller is responsible for escaping when
+ *     injecting into a prompt (SPEC §12.2 trust boundary).
+ *
+ * This interface is intentionally minimal — it returns only the fields the
+ * diagnostician runner needs: `raw` (for prompt injection) and
+ * `contentHash` (for `intentTension.intentDocHash` lineage). Validation
+ * warnings are NOT surfaced here because the diagnostician does not act on
+ * them; they remain visible via `pd intent show`.
+ */
+
+/**
+ * A successfully read INTENT.md reference.
+ *
+ * `raw` is the unescaped file content. `contentHash` is the SHA-256 hash
+ * used for `intentTension.intentDocHash` lineage (SPEC §16.2).
+ */
+export interface IntentDocReference {
+  /** Raw INTENT.md content (unescaped — caller escapes for prompt injection). */
+  readonly raw: string;
+  /** SHA-256 content hash for deduplication and audit (e.g. "sha256:abc..."). */
+  readonly contentHash: string;
+  /** Absolute path to the INTENT.md file (for telemetry only — never read by core). */
+  readonly path: string;
+}
+
+/**
+ * Structured reason for a degraded read path.
+ *
+ * Mirrors `SafeReadIntentDocReason` from the plugin layer (PRI-467), but
+ * defined here so core has no plugin-layer import.
+ */
+export type IntentDocReadReason =
+  | 'flag_disabled'
+  | 'not_found'
+  | 'oversized'
+  | 'read_error';
+
+/**
+ * Result of reading INTENT.md.
+ *
+ * When `ok === true`, `doc` is present. When `ok === false`, `reason` and
+ * `nextAction` are present (EP-03 / ERR-002: no silent fallback).
+ */
+export interface IntentDocReadResult {
+  /** True when the doc was successfully read and parsed. */
+  readonly ok: boolean;
+  /** True when the INTENT.md file exists on disk (false when not_found). */
+  readonly found: boolean;
+  /** True when the intent_engineering flag is enabled. */
+  readonly flagEnabled: boolean;
+  /** The parsed IntentDoc, present only when ok=true. */
+  readonly doc?: IntentDocReference;
+  /** Structured reason for a degraded path (present when ok=false). */
+  readonly reason?: IntentDocReadReason;
+  /** Next action for the operator (present when ok=false). */
+  readonly nextAction?: string;
+}
+
+/**
+ * Port interface for reading INTENT.md.
+ *
+ * Core defines this interface; the plugin provides a concrete implementation
+ * that wraps `safeReadIntentDoc(workspaceDir)` with feature-flag checking.
+ *
+ * The implementation is expected to be a closure bound to a specific
+ * workspaceDir (created in `pain-signal-runtime-factory.ts`), so this
+ * method takes no arguments.
+ */
+export interface IntentDocReader {
+  /**
+   * Read INTENT.md for the bound workspace.
+   *
+   * NEVER throws — all error paths return a structured result.
+   * When `intent_engineering` flag is off, returns `flag_disabled` WITHOUT
+   * any filesystem access (SPEC §12).
+   */
+  readIntentDoc(): IntentDocReadResult;
+}
+
+/**
+ * No-op IntentDocReader for backward compatibility.
+ *
+ * Used when no reader is provided (e.g., in unit tests that don't care
+ * about INTENT). Always returns `flag_disabled` — ensuring the runner
+ * behaves as if the flag is off, producing byte-identical prompts.
+ */
+export class NullIntentDocReader implements IntentDocReader {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  readIntentDoc(): IntentDocReadResult {
+    return {
+      ok: false,
+      found: false,
+      flagEnabled: false,
+      reason: 'flag_disabled',
+      nextAction: 'No IntentDocReader configured — intent_engineering is effectively off.',
+    };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/__fixtures__/intent-tension-cases.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/__fixtures__/intent-tension-cases.ts
@@ -1,0 +1,286 @@
+/**
+ * A/B Evaluation Cases for PRI-468 Intent Engineering MVP (SPEC §23.5).
+ *
+ * 10 reference cases comparing flag-off vs flag-on diagnosis with the
+ * Owner's expected judgment. Used as an offline evaluation dataset and
+ * as test fixtures asserting the IntentTension schema accepts the
+ * expected shapes.
+ *
+ * Composition (SPEC §23.5):
+ *   - 4 positive cases   (§23.6)
+ *   - 4 negative cases   (§23.7)
+ *   - 2 intent_suspect   (§23.8)
+ *
+ * Each case is a plain data record — no LLM call. The `expectedIntentTension`
+ * field documents the Owner's expected Stage A output when the flag is on.
+ * When the flag is off, intentTension MUST be absent (SPEC §3 — no new
+ * output when flag off).
+ */
+import type { IntentTension } from '../../../diagnostician/diag-rootcause-output.js';
+
+/**
+ * A single A/B evaluation case.
+ *
+ * - `id`: stable case identifier
+ * - `scenario`: human-readable description of the Agent action under test
+ * - `flagOffDiagnosis`: what Stage A would produce with intent_engineering off
+ *    (intentTension field MUST be absent)
+ * - `flagOnExpectedIntentTension`: the intentTension the Owner expects when
+ *    the flag is on. `null` means the Owner expects NO intentTension even
+ *    with the flag on (the negative-case contract per §23.7).
+ * - `ownerExpectedJudgment`: the Owner's value decision, recorded for
+ *    future IntentDecisionRecord (PRI-470) wiring. NOT auto-applied.
+ */
+export interface IntentTensionCase {
+  readonly id: string;
+  readonly category: 'positive' | 'negative' | 'intent_suspect';
+  readonly scenario: string;
+  readonly flagOffDiagnosis: {
+    readonly summary: string;
+    readonly rootCause: string;
+    /** Always undefined when flag off — no intentTension output (SPEC §3). */
+    readonly intentTension: undefined;
+  };
+  readonly flagOnExpectedIntentTension: IntentTension | null;
+  readonly ownerExpectedJudgment: string;
+}
+
+// ── §23.6 Positive cases (4) ────────────────────────────────────────────────
+// Expect: source = action_drift | healthy_tension; evidenceStrength ≥ moderate
+
+const POSITIVE_CASE_1: IntentTensionCase = {
+  id: 'pos-01-heavy-dashboard-in-mvp',
+  category: 'positive',
+  scenario: 'Agent builds a heavy analytics dashboard during MVP stage.',
+  flagOffDiagnosis: {
+    summary: 'Agent over-engineered a dashboard feature.',
+    rootCause: 'Design: Agent expanded scope beyond the minimal viable loop.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: {
+    source: 'action_drift',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['current_strategic_focus', 'non_negotiables'],
+    evidence: [
+      'INTENT says current focus is validating the smallest Pain → Principle loop.',
+      'Agent designed a heavy dashboard with multiple chart types.',
+      'Owner correction says the result increased review burden.',
+    ],
+    explanation:
+      'The work may be useful later, but it optimized presentation completeness before validating the current learning loop.',
+    suggestedOwnerAction: 'confirm_drift',
+    intentDocHash: 'sha256:fixture-pos-01',
+  },
+  ownerExpectedJudgment: 'Confirm drift — pause dashboard expansion, refocus on the minimal loop.',
+};
+
+const POSITIVE_CASE_2: IntentTensionCase = {
+  id: 'pos-02-large-scope-expansion',
+  category: 'positive',
+  scenario: 'Agent greatly expands task scope beyond the Owner-stated boundary.',
+  flagOffDiagnosis: {
+    summary: 'Agent expanded scope without approval.',
+    rootCause: 'People: Agent did not check scope boundaries before acting.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: {
+    source: 'action_drift',
+    evidenceStrength: 'strong',
+    relatedIntentFields: ['non_negotiables', 'stop_escalation'],
+    evidence: [
+      'INTENT non_negotiables explicitly forbids autonomous scope expansion.',
+      'Agent added three unrelated modules in one PR.',
+      'The escalation crossed the stop_escalation boundary.',
+    ],
+    explanation:
+      'The action directly violated a non-negotiable boundary and crossed the stop_escalation threshold.',
+    suggestedOwnerAction: 'confirm_drift',
+    intentDocHash: 'sha256:fixture-pos-02',
+  },
+  ownerExpectedJudgment: 'Confirm drift — revert the out-of-scope modules, re-state the boundary.',
+};
+
+const POSITIVE_CASE_3: IntentTensionCase = {
+  id: 'pos-03-too-many-candidate-principles',
+  category: 'positive',
+  scenario: 'Agent generates an excessive number of candidate principles, increasing Owner attention load.',
+  flagOffDiagnosis: {
+    summary: 'Agent produced too many candidate principles.',
+    rootCause: 'Design: Principle generation lacked prioritization against Owner attention budget.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: {
+    source: 'action_drift',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['current_strategic_focus'],
+    evidence: [
+      'INTENT current_strategic_focus prioritizes a single validated principle.',
+      'Agent emitted 7 candidate principles in one run.',
+      'Owner has corrected this pattern twice before.',
+    ],
+    explanation:
+      'Flooding the review queue conflicts with the focus on a single validated principle.',
+    suggestedOwnerAction: 'confirm_drift',
+    intentDocHash: 'sha256:fixture-pos-03',
+  },
+  ownerExpectedJudgment: 'Confirm drift — collapse candidates into one, defer the rest.',
+};
+
+const POSITIVE_CASE_4: IntentTensionCase = {
+  id: 'pos-04-correct-but-wrong-stage-refactor',
+  category: 'positive',
+  scenario: 'Agent performs a technically correct but stage-inappropriate large refactor.',
+  flagOffDiagnosis: {
+    summary: 'Agent did a large refactor.',
+    rootCause: 'Design: Refactor was technically sound but mistimed.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: {
+    source: 'healthy_tension',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['current_strategic_focus', 'why'],
+    evidence: [
+      'INTENT why states the current stage is finding product-market fit, not hardening.',
+      'The refactor improves code quality but does not advance the current focus.',
+      'Owner acknowledged the value but deferred it.',
+    ],
+    explanation:
+      'Genuine strategic trade-off: the work is valuable but optimizing for the wrong stage.',
+    suggestedOwnerAction: 'observe',
+    intentDocHash: 'sha256:fixture-pos-04',
+  },
+  ownerExpectedJudgment: 'Observe — acknowledge value, defer until the focus shifts to hardening.',
+};
+
+// ── §23.7 Negative cases (4) ────────────────────────────────────────────────
+// Expect: source = none; no intent_suspect; no revise_intent
+
+const NEGATIVE_CASE_1: IntentTensionCase = {
+  id: 'neg-01-ordinary-test-failure',
+  category: 'negative',
+  scenario: 'An ordinary unit test failure with no INTENT relevance.',
+  flagOffDiagnosis: {
+    summary: 'A unit test failed due to a stale mock.',
+    rootCause: 'Tooling: Test mock was not updated after API change.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: null,
+  ownerExpectedJudgment: 'No intent tension — fix the mock and move on.',
+};
+
+const NEGATIVE_CASE_2: IntentTensionCase = {
+  id: 'neg-02-small-code-cleanup',
+  category: 'negative',
+  scenario: 'Small-scope code cleanup that does not touch INTENT boundaries.',
+  flagOffDiagnosis: {
+    summary: 'Agent renamed a few local variables for clarity.',
+    rootCause: 'Design: Minor readability improvement.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: null,
+  ownerExpectedJudgment: 'No intent tension — accept the cleanup.',
+};
+
+const NEGATIVE_CASE_3: IntentTensionCase = {
+  id: 'neg-03-on-focus-feature-progress',
+  category: 'negative',
+  scenario: 'Feature progress that aligns with the INTENT current focus.',
+  flagOffDiagnosis: {
+    summary: 'Agent implemented the next step of the focus feature.',
+    rootCause: 'Design: Aligned incremental progress.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: null,
+  ownerExpectedJudgment: 'No intent tension — continue.',
+};
+
+const NEGATIVE_CASE_4: IntentTensionCase = {
+  id: 'neg-04-alternative-proposal-no-intent-evidence',
+  category: 'negative',
+  scenario: 'Agent proposes an alternative approach, but there is no evidence the INTENT is stale.',
+  flagOffDiagnosis: {
+    summary: 'Agent proposed an alternative implementation.',
+    rootCause: 'Design: Alternative considered and rejected.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: null,
+  ownerExpectedJudgment: 'No intent tension — the proposal is valid exploration, not drift evidence.',
+};
+
+// ── §23.8 intent_suspect special cases (2) ──────────────────────────────────
+// Expect: source = intent_suspect; suggestedOwnerAction = revise_intent
+
+const INTENT_SUSPECT_CASE_1: IntentTensionCase = {
+  id: 'suspect-01-vague-desired-outcome',
+  category: 'intent_suspect',
+  scenario: 'INTENT Desired Outcome is too vague ("Make product better").',
+  flagOffDiagnosis: {
+    summary: 'Diagnosis could not anchor on a concrete outcome.',
+    rootCause: 'Assumption: Outcome statement lacked testable criteria.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: {
+    source: 'intent_suspect',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['desired_outcome'],
+    evidence: [
+      'INTENT desired_outcome is "Make product better".',
+      'This statement admits any action as aligned.',
+      'Two recent Pain signals conflicted on whether scope expansion was drift.',
+    ],
+    explanation:
+      'The Desired Outcome is too vague to distinguish drift from healthy exploration — the INTENT itself needs revision.',
+    suggestedOwnerAction: 'revise_intent',
+    intentDocHash: 'sha256:fixture-suspect-01',
+  },
+  ownerExpectedJudgment: 'Revise INTENT — make the desired outcome concrete and testable.',
+};
+
+const INTENT_SUSPECT_CASE_2: IntentTensionCase = {
+  id: 'suspect-02-intent-conflicts-with-confirmed-pain-patterns',
+  category: 'intent_suspect',
+  scenario: 'INTENT conflicts with multiple confirmed Pain patterns.',
+  flagOffDiagnosis: {
+    summary: 'Diagnosis found repeated friction with the stated focus.',
+    rootCause: 'Assumption: Stated focus may be outdated.',
+    intentTension: undefined,
+  },
+  flagOnExpectedIntentTension: {
+    source: 'intent_suspect',
+    evidenceStrength: 'strong',
+    relatedIntentFields: ['current_strategic_focus', 'non_negotiables'],
+    evidence: [
+      'INTENT current_strategic_focus says "ship the minimal loop".',
+      'Three confirmed Pain patterns show the minimal loop cannot unblock users.',
+      'Owner has twice manually redirected around the stated focus.',
+    ],
+    explanation:
+      'The stated focus conflicts with confirmed field evidence — the INTENT is likely stale and should be revised.',
+    suggestedOwnerAction: 'revise_intent',
+    intentDocHash: 'sha256:fixture-suspect-02',
+  },
+  ownerExpectedJudgment: 'Revise INTENT — update the current focus to reflect field evidence.',
+};
+
+// ── Exported dataset ─────────────────────────────────────────────────────────
+
+export const INTENT_TENSION_CASES: readonly IntentTensionCase[] = [
+  POSITIVE_CASE_1,
+  POSITIVE_CASE_2,
+  POSITIVE_CASE_3,
+  POSITIVE_CASE_4,
+  NEGATIVE_CASE_1,
+  NEGATIVE_CASE_2,
+  NEGATIVE_CASE_3,
+  NEGATIVE_CASE_4,
+  INTENT_SUSPECT_CASE_1,
+  INTENT_SUSPECT_CASE_2,
+];
+
+/** Count assertions for SPEC §23.5 composition (used by the fixtures test). */
+export const INTENT_TENSION_CASE_COUNTS = {
+  total: INTENT_TENSION_CASES.length,
+  positive: INTENT_TENSION_CASES.filter((c) => c.category === 'positive').length,
+  negative: INTENT_TENSION_CASES.filter((c) => c.category === 'negative').length,
+  intent_suspect: INTENT_TENSION_CASES.filter((c) => c.category === 'intent_suspect').length,
+} as const;

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/diag-rootcause-intent-tension.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/diag-rootcause-intent-tension.test.ts
@@ -1,0 +1,426 @@
+/**
+ * DiagRootCauseRunner — PRI-468 INTENT.md injection integration tests.
+ *
+ * Verifies that Stage A correctly:
+ *   1. Does NOT inject INTENT.md when intent_engineering flag is off (byte-identical)
+ *   2. Injects INTENT.md when flag is on AND reader returns ok
+ *   3. Degrades gracefully (no INTENT, emits telemetry) when reader returns not_found
+ *   4. Degrades gracefully when reader returns flag_disabled
+ *   5. Behaves as before when no intentDocReader is provided (backward compat)
+ *
+ * ERR entries considered:
+ *   - EP-01 / ERR-001: readResult treated as unknown, fields checked via Object.hasOwn
+ *   - EP-02 / ERR-025: production path; no plugin imports in core test
+ *   - EP-03 / ERR-002: every degraded path emits telemetry with reason + nextAction
+ *   - EP-09: tests use mock readers with structured returns (no real fs in core tests)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiagRootCauseRunner } from '../diag-rootcause-runner.js';
+import type { DiagRootCauseRunnerDeps } from '../diag-rootcause-runner.js';
+import type { DiagRootCauseOutputV1 } from '../../diagnostician/diag-rootcause-output.js';
+import type { IntentDocReader, IntentDocReadResult } from '../../intent/intent-doc-reader-port.js';
+import { MemoryPIArtifactStore } from '../pi-artifact-store.js';
+import type { RuntimeStateManager } from '../../store/runtime-state-manager.js';
+import type { RunHandle, RunStatus } from '../../runtime-protocol.js';
+import type { StoreEventEmitter } from '../../store/event-emitter.js';
+import type { TaskRecord } from '../../task-status.js';
+import { createPITaskDiagnosticJson } from '../pitask-metadata.js';
+import { MOCK_ROOT_CAUSE_OUTPUTS } from './__fixtures__/split-pipeline-mock-outputs.js';
+import type { EffectivePdConfig } from '../../config/pd-config-types.js';
+import { getDefaultPdConfig } from '../../config/pd-config-defaults.js';
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const ROOTCAUSE_TASK_ID = 'diag_rootcause-001';
+const RUN_ID = 'run-rootcause-001';
+const OWNER = 'test-intent-owner';
+const RUNTIME_KIND = 'test-double';
+
+const INTENT_RAW = `# INTENT.md
+
+## 1. Why
+Validate the smallest Pain → Principle loop before scaling.
+
+## 2. Desired Outcome
+One real Pain Case reviewed by Owner within 5 minutes.
+
+## 3. Non-negotiables
+No premature dashboards.
+
+## 4. Stop / Escalation
+Stop if review burden increases.
+
+## 5. Current Strategic Focus
+Tighten the learning loop.
+`;
+const INTENT_CONTENT_HASH = 'sha256:test-intent-hash-abc123';
+const INTENT_PATH = '/workspace/.principles/INTENT.md';
+
+function makeRootCauseTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ROOTCAUSE_TASK_ID,
+    taskKind: 'diag_rootcause',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeRootCauseOutput(): DiagRootCauseOutputV1 {
+  return {
+    ...MOCK_ROOT_CAUSE_OUTPUTS.R6,
+    diagnosisId: 'diag-001',
+    taskId: ROOTCAUSE_TASK_ID,
+  };
+}
+
+function makeContextPayload() {
+  return {
+    sourceRefs: ['ref-1', 'ref-2'],
+    conversationWindow: [],
+    trajectorySummary: '',
+    painSignal: { painId: 'pain-001', painType: 'tool_failure', source: 'test', reason: 'test reason', score: 70 },
+  };
+}
+
+/** Build an EffectivePdConfig with intent_engineering flag on or off. */
+function makeEffectiveConfig(opts: { intentEngineering?: boolean; coreGrounding?: boolean }): EffectivePdConfig {
+  const base = getDefaultPdConfig();
+  return {
+    config: {
+      ...base,
+      features: {
+        ...base.features,
+        intent_engineering: {
+          category: 'quiet',
+          enabled: opts.intentEngineering === true,
+        },
+        ...(opts.coreGrounding !== undefined
+          ? { diagnostician_core_grounding: { category: 'quiet', enabled: opts.coreGrounding } }
+          : {}),
+      },
+    },
+    source: 'user_config',
+    warnings: [],
+    featuresChangedFromDefault: opts.intentEngineering ? ['intent_engineering'] : [],
+  };
+}
+
+// ── Telemetry mock helper ───────────────────────────────────────────────────
+// `noUncheckedIndexedAccess` makes Record<string, X>[key] return X | undefined,
+// and `unknown` has no `.eventType`. This helper narrows mock call args safely
+// (test-only — mirrors the pattern in diag-distiller-runner.test.ts).
+type TelemetryCallArg = { eventType: string; payload?: Record<string, unknown> };
+function telemetryEventType(call: readonly unknown[]): string | undefined {
+  const event = call[0] as TelemetryCallArg | undefined;
+  return event?.eventType;
+}
+function telemetryPayload(call: readonly unknown[]): Record<string, unknown> | undefined {
+  const event = call[0] as TelemetryCallArg | undefined;
+  return event?.payload;
+}
+
+/** Create a mock IntentDocReader that returns the given result. */
+function makeIntentDocReader(result: IntentDocReadResult): IntentDocReader {
+  return {
+    readIntentDoc: vi.fn().mockReturnValue(result),
+  };
+}
+
+// ── Mock factory ─────────────────────────────────────────────────────────────
+
+function createMockDeps(overrides: Partial<DiagRootCauseRunnerDeps> = {}): DiagRootCauseRunnerDeps & {
+  _stateManager: Record<string, ReturnType<typeof vi.fn>>;
+  _runtimeAdapter: Record<string, ReturnType<typeof vi.fn>>;
+  _validator: Record<string, ReturnType<typeof vi.fn>>;
+  _contextAssembler: Record<string, ReturnType<typeof vi.fn>>;
+  _eventEmitter: { emitTelemetry: ReturnType<typeof vi.fn> };
+} {
+  const taskRecord = makeRootCauseTask();
+  const output = makeRootCauseOutput();
+
+  const _stateManager = {
+    acquireLease: vi.fn().mockResolvedValue(taskRecord),
+    getTask: vi.fn().mockResolvedValue(taskRecord),
+    getRunsByTask: vi.fn().mockResolvedValue([{ runId: RUN_ID, taskId: ROOTCAUSE_TASK_ID }]),
+    getValidRunsByTaskTolerant: vi.fn().mockResolvedValue({
+      runs: [{ runId: RUN_ID, taskId: ROOTCAUSE_TASK_ID }],
+      degradedRuns: [],
+    }),
+    updateRunOutput: vi.fn().mockResolvedValue(undefined),
+    markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+    markTaskFailed: vi.fn().mockResolvedValue(undefined),
+    markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+    getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+  };
+
+  const runHandle: RunHandle = { runId: RUN_ID, runtimeKind: RUNTIME_KIND, startedAt: new Date().toISOString() };
+  const succeededStatus: RunStatus = { status: 'succeeded', runId: RUN_ID };
+
+  const _runtimeAdapter = {
+    kind: vi.fn().mockReturnValue(RUNTIME_KIND),
+    getCapabilities: vi.fn(),
+    healthCheck: vi.fn(),
+    startRun: vi.fn().mockResolvedValue(runHandle),
+    pollRun: vi.fn().mockResolvedValue(succeededStatus),
+    fetchOutput: vi.fn().mockResolvedValue({ payload: output }),
+    cancelRun: vi.fn().mockResolvedValue(undefined),
+    fetchArtifacts: vi.fn(),
+  };
+
+  const _validator = {
+    validate: vi.fn().mockResolvedValue({ valid: true, errors: [] }),
+  };
+
+  const _contextAssembler = {
+    assemble: vi.fn().mockResolvedValue(makeContextPayload()),
+  };
+
+  const _eventEmitter = {
+    emitTelemetry: vi.fn(),
+    on: vi.fn(),
+    emit: vi.fn(),
+  };
+
+  return {
+    stateManager: _stateManager as unknown as RuntimeStateManager,
+    runtimeAdapter: _runtimeAdapter,
+    eventEmitter: _eventEmitter as unknown as StoreEventEmitter,
+    artifactStore: new MemoryPIArtifactStore(),
+    validator: _validator,
+    contextAssembler: _contextAssembler,
+    _stateManager,
+    _runtimeAdapter,
+    _validator,
+    _contextAssembler,
+    _eventEmitter,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DiagRootCauseRunner — PRI-468 INTENT.md injection', () => {
+  beforeEach(() => {
+    // No global setup needed — each test creates its own deps
+  });
+
+  it('flag off → does NOT inject INTENT.md (byte-identical to pre-PRI-468)', async () => {
+    const reader = makeIntentDocReader({
+      ok: false, found: false, flagEnabled: false, reason: 'flag_disabled',
+    });
+    const deps = createMockDeps({ intentDocReader: reader });
+    const runner = new DiagRootCauseRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+      effectiveConfig: makeEffectiveConfig({ intentEngineering: false }),
+    });
+
+    await runner.run(ROOTCAUSE_TASK_ID);
+
+    // Reader should NOT have been called (flag off → short-circuit)
+    expect(reader.readIntentDoc).not.toHaveBeenCalled();
+
+    // Verify the prompt message does NOT contain intentDoc or PHASE 3.6
+    const startRunCall = deps._runtimeAdapter.startRun?.mock.calls[0];
+    const message = startRunCall?.[0]?.inputPayload as string;
+    expect(message).not.toContain('intentDoc');
+    expect(message).not.toContain('PHASE 3.6');
+    expect(message).not.toContain('Intent Tension Check');
+  });
+
+  it('flag on + reader ok → injects INTENT.md and PHASE 3.6', async () => {
+    const reader = makeIntentDocReader({
+      ok: true,
+      found: true,
+      flagEnabled: true,
+      doc: {
+        raw: INTENT_RAW,
+        contentHash: INTENT_CONTENT_HASH,
+        path: INTENT_PATH,
+      },
+    });
+    const deps = createMockDeps({ intentDocReader: reader });
+    const runner = new DiagRootCauseRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+      effectiveConfig: makeEffectiveConfig({ intentEngineering: true }),
+    });
+
+    await runner.run(ROOTCAUSE_TASK_ID);
+
+    // Reader was called
+    expect(reader.readIntentDoc).toHaveBeenCalledTimes(1);
+
+    // Verify the prompt message contains intentDoc and PHASE 3.6
+    const startRunCall = deps._runtimeAdapter.startRun?.mock.calls[0];
+    const message = startRunCall?.[0]?.inputPayload as string;
+    const parsed = JSON.parse(message) as Record<string, unknown>;
+
+    expect(parsed).toHaveProperty('intentDoc');
+    const intentDoc = parsed.intentDoc as Record<string, unknown>;
+    expect(intentDoc.raw).toBe(INTENT_RAW);
+    expect(intentDoc.contentHash).toBe(INTENT_CONTENT_HASH);
+    expect(intentDoc.path).toBe(INTENT_PATH);
+
+    // PHASE 3.6 should be in the diagnosticInstruction
+    const instruction = parsed.diagnosticInstruction as string;
+    expect(instruction).toContain('PHASE 3.6');
+    expect(instruction).toContain('Intent Tension Check');
+  });
+
+  it('flag on + reader returns not_found → degrades gracefully with telemetry', async () => {
+    const reader = makeIntentDocReader({
+      ok: false,
+      found: false,
+      flagEnabled: true,
+      reason: 'not_found',
+      nextAction: 'Create .principles/INTENT.md using "pd intent init".',
+    });
+    const deps = createMockDeps({ intentDocReader: reader });
+    const runner = new DiagRootCauseRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+      effectiveConfig: makeEffectiveConfig({ intentEngineering: true }),
+    });
+
+    await runner.run(ROOTCAUSE_TASK_ID);
+
+    // Reader was called
+    expect(reader.readIntentDoc).toHaveBeenCalledTimes(1);
+
+    // Telemetry emitted with reason + nextAction (EP-03 / ERR-002)
+    const telemetryCall = deps._eventEmitter.emitTelemetry.mock.calls.find(
+      (call: readonly unknown[]) => telemetryEventType(call) === 'diag_rootcause_intent_doc_read_failed',
+    );
+    expect(telemetryCall).toBeDefined();
+    if (!telemetryCall) return; // type narrowing after assertion
+    const tp = telemetryPayload(telemetryCall);
+    expect(tp?.reason).toBe('not_found');
+    expect(tp?.nextAction).toContain('pd intent init');
+
+    // Prompt does NOT contain intentDoc or PHASE 3.6
+    const startRunMock = deps._runtimeAdapter.startRun;
+    if (!startRunMock) throw new Error('startRun mock not configured');
+    const [startRunCall] = startRunMock.mock.calls;
+    const message = startRunCall?.[0]?.inputPayload as string;
+    const parsed = JSON.parse(message) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('intentDoc');
+    const instruction = parsed.diagnosticInstruction as string;
+    expect(instruction).not.toContain('PHASE 3.6');
+  });
+
+  it('flag on + reader returns oversized → degrades gracefully with telemetry', async () => {
+    const reader = makeIntentDocReader({
+      ok: false,
+      found: true,
+      flagEnabled: true,
+      reason: 'oversized',
+      nextAction: 'INTENT.md exceeds 32KB. Reduce content.',
+    });
+    const deps = createMockDeps({ intentDocReader: reader });
+    const runner = new DiagRootCauseRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+      effectiveConfig: makeEffectiveConfig({ intentEngineering: true }),
+    });
+
+    await runner.run(ROOTCAUSE_TASK_ID);
+
+    // Telemetry emitted with reason='oversized'
+    const telemetryCall = deps._eventEmitter.emitTelemetry.mock.calls.find(
+      (call: readonly unknown[]) => telemetryEventType(call) === 'diag_rootcause_intent_doc_read_failed',
+    );
+    expect(telemetryCall).toBeDefined();
+    if (!telemetryCall) return; // type narrowing after assertion
+    const tp = telemetryPayload(telemetryCall);
+    expect(tp?.reason).toBe('oversized');
+
+    // Prompt does NOT contain intentDoc
+    const startRunMock = deps._runtimeAdapter.startRun;
+    if (!startRunMock) throw new Error('startRun mock not configured');
+    const [startRunCall] = startRunMock.mock.calls;
+    const message = startRunCall?.[0]?.inputPayload as string;
+    const parsed = JSON.parse(message) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('intentDoc');
+  });
+
+  it('no intentDocReader provided → behaves as before (backward compat)', async () => {
+    // No intentDocReader in deps
+    const deps = createMockDeps();
+    const runner = new DiagRootCauseRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+      effectiveConfig: makeEffectiveConfig({ intentEngineering: true }),
+    });
+
+    await runner.run(ROOTCAUSE_TASK_ID);
+
+    // Prompt does NOT contain intentDoc (no reader → no injection)
+    const startRunMock = deps._runtimeAdapter.startRun;
+    if (!startRunMock) throw new Error('startRun mock not configured');
+    const [startRunCall] = startRunMock.mock.calls;
+    const message = startRunCall?.[0]?.inputPayload as string;
+    const parsed = JSON.parse(message) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('intentDoc');
+
+    // PHASE 3.6 NOT injected (intentGrounding downgraded to false because no reader)
+    const instruction = parsed.diagnosticInstruction as string;
+    expect(instruction).not.toContain('PHASE 3.6');
+
+    // No intent_doc_read_failed telemetry (we didn't even try to read)
+    const telemetryCall = deps._eventEmitter.emitTelemetry.mock.calls.find(
+      (call: readonly unknown[]) => telemetryEventType(call) === 'diag_rootcause_intent_doc_read_failed',
+    );
+    expect(telemetryCall).toBeUndefined();
+  });
+
+  it('no effectiveConfig → flag off behavior, no reader call', async () => {
+    const reader = makeIntentDocReader({
+      ok: true,
+      found: true,
+      flagEnabled: true,
+      doc: { raw: INTENT_RAW, contentHash: INTENT_CONTENT_HASH, path: INTENT_PATH },
+    });
+    const deps = createMockDeps({ intentDocReader: reader });
+    // No effectiveConfig → flag resolution skipped, intentGrounding stays false
+    const runner = new DiagRootCauseRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    await runner.run(ROOTCAUSE_TASK_ID);
+
+    // Reader NOT called (no effectiveConfig → flag not read → intentGrounding false)
+    expect(reader.readIntentDoc).not.toHaveBeenCalled();
+
+    const startRunMock = deps._runtimeAdapter.startRun;
+    if (!startRunMock) throw new Error('startRun mock not configured');
+    const [startRunCall] = startRunMock.mock.calls;
+    const message = startRunCall?.[0]?.inputPayload as string;
+    const parsed = JSON.parse(message) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('intentDoc');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/diag-router-intent-tension.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/diag-router-intent-tension.test.ts
@@ -1,0 +1,399 @@
+/**
+ * DiagRouterRunner — PRI-468 Stage C intentTension additive passthrough tests.
+ *
+ * Verifies SPEC §18 requirements:
+ *   1. Stage A has intentTension → Stage C passes it through
+ *   2. Stage A has NO intentTension → Stage C does NOT generate one
+ *   3. Stage A has NO intentTension + LLM hallucinated one → Stage C strips it
+ *   4. Stage A has intentTension + LLM also produced one → Stage A wins (source of truth)
+ *
+ * ERR entries considered:
+ *   - EP-01 / ERR-001: context.rootCauseOutput is schema-validated before reaching here
+ *   - EP-01 / ERR-013: Object.hasOwn used for field presence check (not `in`)
+ *   - EP-02 / ERR-009: fail-loud on missing required fields via schema validation
+ *   - EP-03 / ERR-002: stripping hallucinated intentTension emits telemetry (observable)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DiagRouterRunner } from '../diag-router-runner.js';
+import type { DiagRouterRunnerDeps } from '../diag-router-runner.js';
+import type { DiagnosticianOutputV1 } from '../../diagnostician-output.js';
+import type { DiagRootCauseOutputV1, IntentTension } from '../../diagnostician/diag-rootcause-output.js';
+import type { DiagDistillerOutputV1 } from '../../diagnostician/diag-distiller-output.js';
+import type { CommitResult } from '../../store/commit/diagnostician-committer.js';
+import type { RuntimeStateManager } from '../../store/runtime-state-manager.js';
+import type { RunHandle, RunStatus } from '../../runtime-protocol.js';
+import type { StoreEventEmitter } from '../../store/event-emitter.js';
+import { MemoryPIArtifactStore } from '../pi-artifact-store.js';
+import type { TaskRecord } from '../../task-status.js';
+import { createPITaskDiagnosticJson } from '../pitask-metadata.js';
+import { MOCK_ROOT_CAUSE_OUTPUTS, MOCK_DISTILLER_OUTPUTS, MOCK_ROUTER_OUTPUTS } from './__fixtures__/split-pipeline-mock-outputs.js';
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const ROUTER_TASK_ID = 'diag_router-001';
+const ROOTCAUSE_TASK_ID = 'diag_rootcause-001';
+const DISTILLER_TASK_ID = 'diag_distiller-001';
+const RUN_ID = 'run-router-001';
+const OWNER = 'test-router-intent-owner';
+const RUNTIME_KIND = 'test-double';
+const ROOTCAUSE_ARTIFACT_ID = 'pi-art-rc-001';
+const DISTILLER_ARTIFACT_ID = 'pi-art-dist-001';
+
+const VALID_INTENT_TENSION: IntentTension = {
+  source: 'action_drift',
+  evidenceStrength: 'moderate',
+  relatedIntentFields: ['current_strategic_focus', 'non_negotiables'],
+  evidence: [
+    'INTENT says current focus is validating the smallest Pain → Principle loop.',
+    'Agent designed a heavy dashboard.',
+    'Owner correction says the result increased review burden.',
+  ],
+  explanation:
+    'The work may be useful later, but it optimized presentation completeness before validating the current learning loop.',
+  suggestedOwnerAction: 'confirm_drift',
+  intentDocHash: 'sha256:abc123',
+};
+
+function makeRootCauseTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ROOTCAUSE_TASK_ID,
+    taskKind: 'diag_rootcause',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'diag-rootcause://run-rc-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: '{}',
+    ...overrides,
+  };
+}
+
+function makeDistillerTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: DISTILLER_TASK_ID,
+    taskKind: 'diag_distiller',
+    status: 'succeeded',
+    attemptCount: 1,
+    maxAttempts: 3,
+    resultRef: 'diag-distiller://run-dist-001',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: '{}',
+    ...overrides,
+  };
+}
+
+function makeRouterTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: ROUTER_TASK_ID,
+    taskKind: 'diag_router',
+    status: 'pending',
+    attemptCount: 0,
+    maxAttempts: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    diagnosticJson: createPITaskDiagnosticJson({
+      dependencyTaskIds: [ROOTCAUSE_TASK_ID, DISTILLER_TASK_ID],
+      channel: 'prompt',
+      timeoutMs: 300_000,
+      inputArtifactRefs: [],
+      outputArtifactRefs: [],
+    }),
+    ...overrides,
+  };
+}
+
+function makeRootCauseOutput(intentTension?: IntentTension): DiagRootCauseOutputV1 {
+  const base = {
+    ...MOCK_ROOT_CAUSE_OUTPUTS.R6,
+    diagnosisId: 'diag-001',
+    taskId: ROOTCAUSE_TASK_ID,
+  };
+  return intentTension ? { ...base, intentTension } : base;
+}
+
+function makeDistillerOutput(): DiagDistillerOutputV1 {
+  return {
+    ...MOCK_DISTILLER_OUTPUTS.R6,
+    taskId: DISTILLER_TASK_ID,
+    sourceRootCauseArtifactId: ROOTCAUSE_ARTIFACT_ID,
+  };
+}
+
+function makeRouterOutput(intentTension?: unknown): DiagnosticianOutputV1 {
+  const base: DiagnosticianOutputV1 = {
+    ...MOCK_ROUTER_OUTPUTS.R6,
+    diagnosisId: 'diag-001',
+  };
+  if (intentTension !== undefined) {
+    return { ...base, intentTension: intentTension as IntentTension };
+  }
+  return base;
+}
+
+/** Pre-populate a MemoryPIArtifactStore with both predecessor artifacts. */
+function populatePredecessorArtifacts(store: MemoryPIArtifactStore, rootCauseOutput: DiagRootCauseOutputV1): void {
+  store.upsertArtifact({
+    artifactId: ROOTCAUSE_ARTIFACT_ID,
+    artifactKind: 'principle',
+    sourceTaskId: ROOTCAUSE_TASK_ID,
+    lineageArtifactIds: [],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify(rootCauseOutput),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+  store.upsertArtifact({
+    artifactId: DISTILLER_ARTIFACT_ID,
+    artifactKind: 'principle',
+    sourceTaskId: DISTILLER_TASK_ID,
+    lineageArtifactIds: [ROOTCAUSE_ARTIFACT_ID],
+    validationStatus: 'pending',
+    contentJson: JSON.stringify(makeDistillerOutput()),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+// ── Mock factory ─────────────────────────────────────────────────────────────
+
+function createMockDeps(
+  rootCauseOutput: DiagRootCauseOutputV1,
+  routerOutput: DiagnosticianOutputV1,
+  overrides: Partial<DiagRouterRunnerDeps> = {},
+): DiagRouterRunnerDeps & {
+  _stateManager: Record<string, ReturnType<typeof vi.fn>>;
+  _runtimeAdapter: Record<string, ReturnType<typeof vi.fn>>;
+  _committer: Record<string, ReturnType<typeof vi.fn>>;
+  _eventEmitter: { emitTelemetry: ReturnType<typeof vi.fn> };
+} {
+  const taskRecord = makeRouterTask();
+
+  const _stateManager = {
+    acquireLease: vi.fn().mockResolvedValue(taskRecord),
+    getTask: vi.fn().mockImplementation((id: string) => {
+      if (id === ROUTER_TASK_ID) return Promise.resolve(taskRecord);
+      if (id === ROOTCAUSE_TASK_ID) return Promise.resolve(makeRootCauseTask());
+      if (id === DISTILLER_TASK_ID) return Promise.resolve(makeDistillerTask());
+      return Promise.resolve(undefined);
+    }),
+    getRunsByTask: vi.fn().mockResolvedValue([{ runId: RUN_ID, taskId: ROUTER_TASK_ID }]),
+    getValidRunsByTaskTolerant: vi.fn().mockResolvedValue({
+      runs: [{ runId: RUN_ID, taskId: ROUTER_TASK_ID }],
+      degradedRuns: [],
+    }),
+    updateRunOutput: vi.fn().mockResolvedValue(undefined),
+    markTaskSucceeded: vi.fn().mockResolvedValue(undefined),
+    markTaskFailed: vi.fn().mockResolvedValue(undefined),
+    markTaskRetryWait: vi.fn().mockResolvedValue(undefined),
+    getRetryPolicy: vi.fn().mockReturnValue({ shouldRetry: () => false }),
+  };
+
+  const runHandle: RunHandle = { runId: RUN_ID, runtimeKind: RUNTIME_KIND, startedAt: new Date().toISOString() };
+  const succeededStatus: RunStatus = { status: 'succeeded', runId: RUN_ID };
+
+  const _runtimeAdapter = {
+    kind: vi.fn().mockReturnValue(RUNTIME_KIND),
+    getCapabilities: vi.fn(),
+    healthCheck: vi.fn(),
+    startRun: vi.fn().mockResolvedValue(runHandle),
+    pollRun: vi.fn().mockResolvedValue(succeededStatus),
+    fetchOutput: vi.fn().mockResolvedValue({ payload: routerOutput }),
+    cancelRun: vi.fn().mockResolvedValue(undefined),
+    fetchArtifacts: vi.fn(),
+  };
+
+  const commitResult: CommitResult = {
+    commitId: 'commit-001',
+    artifactId: 'art-001',
+    candidateCount: 1,
+  };
+
+  const _committer = {
+    commit: vi.fn().mockResolvedValue(commitResult),
+  };
+
+  const _eventEmitter = {
+    emitTelemetry: vi.fn(),
+    on: vi.fn(),
+    emit: vi.fn(),
+  };
+
+  const artifactStore = new MemoryPIArtifactStore();
+  populatePredecessorArtifacts(artifactStore, rootCauseOutput);
+
+  return {
+    stateManager: _stateManager as unknown as RuntimeStateManager,
+    runtimeAdapter: _runtimeAdapter,
+    eventEmitter: _eventEmitter as unknown as StoreEventEmitter,
+    artifactStore,
+    committer: _committer,
+    _stateManager,
+    _runtimeAdapter,
+    _committer,
+    _eventEmitter,
+    ...overrides,
+  };
+}
+
+// ── Telemetry mock helper ───────────────────────────────────────────────────
+// `noUncheckedIndexedAccess` makes Record<string, X>[key] return X | undefined,
+// and `unknown` has no `.eventType`. This helper narrows mock call args safely
+// (test-only — mirrors the pattern in diag-distiller-runner.test.ts).
+type TelemetryCallArg = { eventType: string; payload?: Record<string, unknown> };
+function telemetryEventType(call: readonly unknown[]): string | undefined {
+  const event = call[0] as TelemetryCallArg | undefined;
+  return event?.eventType;
+}
+function telemetryPayload(call: readonly unknown[]): Record<string, unknown> | undefined {
+  const event = call[0] as TelemetryCallArg | undefined;
+  return event?.payload;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DiagRouterRunner — PRI-468 Stage C intentTension passthrough', () => {
+  it('Stage A has intentTension → Stage C passes it through', async () => {
+    const rootCause = makeRootCauseOutput(VALID_INTENT_TENSION);
+    const routerOut = makeRouterOutput(); // LLM did NOT produce intentTension
+    const deps = createMockDeps(rootCause, routerOut);
+
+    const runner = new DiagRouterRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROUTER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+
+    // Verify the committed output has intentTension from Stage A
+    const commitMock = deps._committer.commit;
+    if (!commitMock) throw new Error('commit mock not configured');
+    const [commitCall] = commitMock.mock.calls;
+    const committedOutput = commitCall?.[0]?.output as DiagnosticianOutputV1;
+    expect(committedOutput.intentTension).toBeDefined();
+    expect(committedOutput.intentTension).toEqual(VALID_INTENT_TENSION);
+  });
+
+  it('Stage A has NO intentTension → Stage C does NOT generate one', async () => {
+    const rootCause = makeRootCauseOutput(); // No intentTension
+    const routerOut = makeRouterOutput(); // LLM also did not produce one
+    const deps = createMockDeps(rootCause, routerOut);
+
+    const runner = new DiagRouterRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROUTER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+
+    // Verify the committed output does NOT have intentTension
+    const commitMock = deps._committer.commit;
+    if (!commitMock) throw new Error('commit mock not configured');
+    const [commitCall] = commitMock.mock.calls;
+    const committedOutput = commitCall?.[0]?.output as DiagnosticianOutputV1;
+    expect(committedOutput.intentTension).toBeUndefined();
+  });
+
+  it('Stage A has NO intentTension + LLM hallucinated one → Stage C strips it with telemetry', async () => {
+    const rootCause = makeRootCauseOutput(); // No intentTension
+    // LLM hallucinated an intentTension
+    const hallucinatedTension: IntentTension = {
+      source: 'healthy_tension',
+      evidenceStrength: 'weak',
+      relatedIntentFields: ['why'],
+      evidence: ['fake evidence'],
+      explanation: 'hallucinated',
+      suggestedOwnerAction: 'dismiss',
+    };
+    const routerOut = makeRouterOutput(hallucinatedTension);
+    const deps = createMockDeps(rootCause, routerOut);
+
+    const runner = new DiagRouterRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROUTER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+
+    // Verify the committed output does NOT have intentTension (stripped)
+    const commitMock = deps._committer.commit;
+    if (!commitMock) throw new Error('commit mock not configured');
+    const [commitCall] = commitMock.mock.calls;
+    const committedOutput = commitCall?.[0]?.output as DiagnosticianOutputV1;
+    expect(committedOutput.intentTension).toBeUndefined();
+
+    // Verify telemetry was emitted for the strip (EP-03 / ERR-002: observable)
+    const telemetryCalls = deps._eventEmitter.emitTelemetry.mock.calls.filter(
+      (call: readonly unknown[]) => telemetryEventType(call) === 'diag_router_invariant_override',
+    );
+    const intentTensionCall = telemetryCalls.find(
+      (call: readonly unknown[]) => telemetryPayload(call)?.field === 'intentTension',
+    );
+    expect(intentTensionCall).toBeDefined();
+    if (!intentTensionCall) return; // type narrowing after assertion
+    const payload = telemetryPayload(intentTensionCall);
+    expect(payload?.field).toBe('intentTension');
+    expect(payload?.reason).toContain('stripped');
+  });
+
+  it('Stage A has intentTension + LLM also produced one → Stage A wins (source of truth)', async () => {
+    const rootCause = makeRootCauseOutput(VALID_INTENT_TENSION);
+    // LLM produced a DIFFERENT intentTension
+    const llmTension: IntentTension = {
+      source: 'none',
+      evidenceStrength: 'weak',
+      relatedIntentFields: ['why'],
+      evidence: ['llm evidence'],
+      explanation: 'llm explanation',
+      suggestedOwnerAction: 'observe',
+    };
+    const routerOut = makeRouterOutput(llmTension);
+    const deps = createMockDeps(rootCause, routerOut);
+
+    const runner = new DiagRouterRunner(deps, {
+      owner: OWNER,
+      runtimeKind: RUNTIME_KIND,
+      pollIntervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    const result = await runner.run(ROUTER_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+
+    // Verify the committed output has Stage A's intentTension (not LLM's)
+    const commitMock = deps._committer.commit;
+    if (!commitMock) throw new Error('commit mock not configured');
+    const [commitCall] = commitMock.mock.calls;
+    const committedOutput = commitCall?.[0]?.output as DiagnosticianOutputV1;
+    expect(committedOutput.intentTension).toEqual(VALID_INTENT_TENSION);
+    expect(committedOutput.intentTension).not.toEqual(llmTension);
+
+    // Verify telemetry was emitted for the override (filter to intentTension field —
+    // `evidence` is always overridden in postFetchTransform, so find() would match it first)
+    const telemetryCalls = deps._eventEmitter.emitTelemetry.mock.calls.filter(
+      (call: readonly unknown[]) => telemetryEventType(call) === 'diag_router_invariant_override',
+    );
+    const intentTensionCall = telemetryCalls.find(
+      (call: readonly unknown[]) => telemetryPayload(call)?.field === 'intentTension',
+    );
+    expect(intentTensionCall).toBeDefined();
+    if (!intentTensionCall) return; // type narrowing after assertion
+    const payload = telemetryPayload(intentTensionCall);
+    expect(payload?.field).toBe('intentTension');
+    expect(payload?.reason).toContain('overridden');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/intent-tension-cases.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/intent-tension-cases.test.ts
@@ -1,0 +1,122 @@
+/**
+ * A/B Evaluation Cases fixtures test (SPEC §23.5–§23.8).
+ *
+ * Validates the offline evaluation dataset:
+ *   - 10 total cases (4 positive + 4 negative + 2 intent_suspect)
+ *   - Positive cases: source ∈ {action_drift, healthy_tension}, strength ≥ moderate
+ *   - Negative cases: no intentTension expected (null)
+ *   - intent_suspect cases: source = intent_suspect, action = revise_intent
+ *   - All expected intentTension values pass the IntentTensionSchema
+ *   - No case carries a `confidence` field (SPEC §16.3)
+ *
+ * ERR entries considered:
+ *   - EP-01 / ERR-001: fixtures validated against TypeBox schema at runtime
+ *   - EP-02 / ERR-009: composition counts asserted fail-loud
+ *   - EP-03 / ERR-002: negative cases explicitly assert null (no silent skip)
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import { IntentTensionSchema } from '../../diagnostician/diag-rootcause-output.js';
+import {
+  INTENT_TENSION_CASES,
+  INTENT_TENSION_CASE_COUNTS,
+} from './__fixtures__/intent-tension-cases.js';
+
+describe('IntentTension A/B evaluation cases (SPEC §23.5)', () => {
+  it('has the required composition: 4 positive + 4 negative + 2 intent_suspect = 10', () => {
+    expect(INTENT_TENSION_CASE_COUNTS.total).toBe(10);
+    expect(INTENT_TENSION_CASE_COUNTS.positive).toBe(4);
+    expect(INTENT_TENSION_CASE_COUNTS.negative).toBe(4);
+    expect(INTENT_TENSION_CASE_COUNTS.intent_suspect).toBe(2);
+  });
+
+  it('every case id is unique', () => {
+    const ids = INTENT_TENSION_CASES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every flag-off diagnosis has intentTension === undefined (SPEC §3: no new output when flag off)', () => {
+    for (const c of INTENT_TENSION_CASES) {
+      expect(c.flagOffDiagnosis.intentTension).toBeUndefined();
+    }
+  });
+
+  describe('positive cases (§23.6)', () => {
+    const positives = INTENT_TENSION_CASES.filter((c) => c.category === 'positive');
+    it('all have expected intentTension (not null)', () => {
+      for (const c of positives) {
+        expect(c.flagOnExpectedIntentTension, `case ${c.id}`).not.toBeNull();
+      }
+    });
+    it('source is action_drift or healthy_tension', () => {
+      for (const c of positives) {
+        const src = c.flagOnExpectedIntentTension?.source;
+        expect(src, `case ${c.id}`).toMatch(/^(action_drift|healthy_tension)$/);
+      }
+    });
+    it('evidenceStrength is at least moderate', () => {
+      for (const c of positives) {
+        const strength = c.flagOnExpectedIntentTension?.evidenceStrength;
+        expect(strength, `case ${c.id}`).toMatch(/^(moderate|strong)$/);
+      }
+    });
+    it('all expected intentTension values pass IntentTensionSchema', () => {
+      for (const c of positives) {
+        const tension = c.flagOnExpectedIntentTension;
+        expect(tension, `case ${c.id}`).toBeDefined();
+        if (!tension) continue; // type narrowing after assertion
+        expect(Value.Check(IntentTensionSchema, tension), `case ${c.id}`).toBe(true);
+      }
+    });
+  });
+
+  describe('negative cases (§23.7)', () => {
+    const negatives = INTENT_TENSION_CASES.filter((c) => c.category === 'negative');
+    it('all expect NO intentTension even with flag on (null)', () => {
+      for (const c of negatives) {
+        expect(c.flagOnExpectedIntentTension, `case ${c.id}`).toBeNull();
+      }
+    });
+  });
+
+  describe('intent_suspect cases (§23.8)', () => {
+    const suspects = INTENT_TENSION_CASES.filter((c) => c.category === 'intent_suspect');
+    it('all have source = intent_suspect', () => {
+      for (const c of suspects) {
+        expect(c.flagOnExpectedIntentTension?.source, `case ${c.id}`).toBe('intent_suspect');
+      }
+    });
+    it('all suggest revise_intent', () => {
+      for (const c of suspects) {
+        expect(c.flagOnExpectedIntentTension?.suggestedOwnerAction, `case ${c.id}`).toBe('revise_intent');
+      }
+    });
+    it('all expected intentTension values pass IntentTensionSchema', () => {
+      for (const c of suspects) {
+        const tension = c.flagOnExpectedIntentTension;
+        expect(tension, `case ${c.id}`).toBeDefined();
+        if (!tension) continue; // type narrowing after assertion
+        expect(Value.Check(IntentTensionSchema, tension), `case ${c.id}`).toBe(true);
+      }
+    });
+  });
+
+  it('no expected intentTension carries a `confidence` field (SPEC §16.3)', () => {
+    for (const c of INTENT_TENSION_CASES) {
+      const tension = c.flagOnExpectedIntentTension;
+      if (tension === null) continue;
+      expect(
+        Object.hasOwn(tension as unknown as object, 'confidence'),
+        `case ${c.id} must not carry confidence`,
+      ).toBe(false);
+    }
+  });
+
+  it('all non-null expected intentTension values pass the schema (cross-cut)', () => {
+    for (const c of INTENT_TENSION_CASES) {
+      const tension = c.flagOnExpectedIntentTension;
+      if (tension === null) continue;
+      expect(Value.Check(IntentTensionSchema, tension), `case ${c.id}`).toBe(true);
+    }
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/diag-rootcause-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/diag-rootcause-runner.ts
@@ -26,6 +26,7 @@ import type { DiagnosticianContextPayload } from '../context-payload.js';
 import type { ContextAssembler } from '../store/context/context-assembler.js';
 import type { TaskRecord } from '../task-status.js';
 import type { EffectivePdConfig } from '../config/pd-config-types.js';
+import type { IntentDocReader } from '../intent/intent-doc-reader-port.js';
 import { PDRuntimeError, type PDErrorCategory } from '../error-categories.js';
 import { hydratePITaskRecord } from './pitask-metadata.js';
 import { RootCausePromptBuilder } from '../diagnostician/rootcause-prompt-builder.js';
@@ -53,6 +54,17 @@ interface DiagRootCauseContext {
 export interface DiagRootCauseRunnerDeps extends PeerRunnerDeps {
   readonly validator: DiagRootCauseValidator;
   readonly contextAssembler: ContextAssembler;
+  /**
+   * PRI-468: Optional INTENT.md reader for Stage A intent tension check.
+   *
+   * When provided AND `intent_engineering` flag is on, the runner reads
+   * INTENT.md and injects it into the Stage A prompt as reference context
+   * for the LLM to optionally produce `intentTension`.
+   *
+   * When absent or flag off, the runner behaves as before (byte-identical
+   * prompt — EP-03: no silent fallback).
+   */
+  readonly intentDocReader?: IntentDocReader;
 }
 
 // ── Options ──────────────────────────────────────────────────────────────────
@@ -77,6 +89,7 @@ export class DiagRootCauseRunner extends BasePeerRunner<DiagRootCauseContext, Di
   private readonly validator: DiagRootCauseValidator;
   private readonly contextAssembler: ContextAssembler;
   private readonly effectiveConfig?: EffectivePdConfig;
+  private readonly intentDocReader?: IntentDocReader;
 
   constructor(deps: DiagRootCauseRunnerDeps, options: DiagRootCauseRunnerOptions) {
     super(deps, options, {
@@ -88,6 +101,7 @@ export class DiagRootCauseRunner extends BasePeerRunner<DiagRootCauseContext, Di
     this.validator = deps.validator;
     this.contextAssembler = deps.contextAssembler;
     this.effectiveConfig = options.effectiveConfig;
+    this.intentDocReader = deps.intentDocReader;
   }
 
   // ── Abstract implementations ───────────────────────────────────────────────
@@ -141,15 +155,54 @@ export class DiagRootCauseRunner extends BasePeerRunner<DiagRootCauseContext, Di
   async invokeRuntime(taskId: string, context: DiagRootCauseContext): Promise<RunHandle> {
     // T-E (PRI-371): Read diagnostician_core_grounding flag from effective config.
     let coreGrounding = false;
+    // PRI-468: Read intent_engineering flag from effective config.
+    let intentGrounding = false;
     if (this.effectiveConfig) {
       const featureFlags = computeFeatureFlagsFromConfig(this.effectiveConfig);
       coreGrounding = isFeatureEnabled(featureFlags, 'diagnostician_core_grounding');
+      intentGrounding = isFeatureEnabled(featureFlags, 'intent_engineering');
+    }
+
+    // PRI-468: When intent_engineering is on AND a reader is configured,
+    // attempt to read INTENT.md. On any degraded path (not_found, oversized,
+    // read_error, flag_disabled, or no reader configured), intentGrounding
+    // is downgraded to false and the prompt is byte-identical to the
+    // pre-PRI-468 prompt (EP-03 / ERR-002: graceful degradation with
+    // observable telemetry).
+    let intentDoc: { raw: string; contentHash: string; path: string } | undefined;
+    if (intentGrounding && !this.intentDocReader) {
+      // Flag on but no reader wired — downgrade silently (factory misconfiguration
+      // is not a per-task event; it's a startup-time issue). The prompt stays
+      // byte-identical to pre-PRI-468.
+      intentGrounding = false;
+    } else if (intentGrounding && this.intentDocReader) {
+      const readResult = this.intentDocReader.readIntentDoc();
+      if (readResult.ok && readResult.doc) {
+        intentDoc = {
+          raw: readResult.doc.raw,
+          contentHash: readResult.doc.contentHash,
+          path: readResult.doc.path,
+        };
+      } else {
+        // EP-03 / ERR-002: degrade gracefully but observably.
+        // Flag stays on in config, but we do not inject INTENT — emit
+        // telemetry so the operator can see why INTENT was not injected.
+        this.emitEvent('intent_doc_read_failed', taskId, {
+          reason: readResult.reason ?? 'unknown',
+          nextAction: readResult.nextAction ?? 'Check INTENT.md configuration.',
+          flagEnabled: readResult.flagEnabled,
+          found: readResult.found,
+        });
+        intentGrounding = false;
+      }
     }
 
     const builder = new RootCausePromptBuilder();
     const { message } = builder.buildPrompt(context.painPayload, {
       outputLanguage: this.resolvedOptions.outputLanguage,
       coreGrounding,
+      intentGrounding,
+      intentDoc,
     });
 
     return this.runtimeAdapter.startRun({

--- a/packages/principles-core/src/runtime-v2/internalization/diag-router-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/diag-router-runner.ts
@@ -415,22 +415,20 @@ export class DiagRouterRunner extends BasePeerRunner<DiagRouterContext, Diagnost
       // PRI-468: intentTension ← Stage A (additive passthrough, SPEC §18)
       //
       // Stage C MUST NOT generate intentTension when Stage A omitted it
-      // (SPEC §18.2). Only copy it through when Stage A actually produced one.
-      // Use Object.hasOwn to check for the presence of the field on the
-      // Stage A output (Runtime Contract Rule 5 — EP-01 / ERR-013).
-      if (Object.hasOwn(context.rootCauseOutput, 'intentTension')) {
-        const stageAIntentTension = context.rootCauseOutput.intentTension;
-        if (stageAIntentTension !== undefined) {
-          // Passthrough: copy Stage A intentTension to Stage C output.
-          // If LLM also produced one, override with Stage A (source of truth).
-          if (output.intentTension !== undefined) {
-            this.emitEvent('invariant_override', taskId, {
-              field: 'intentTension',
-              reason: 'LLM output had intentTension — overridden with Stage A passthrough value (SPEC §18.1)',
-            });
-          }
-          output.intentTension = stageAIntentTension;
+      // (SPEC §18.2). Only copy it through when Stage A actually produced
+      // a defined value. If Stage A did not produce one (absent or
+      // undefined), strip any LLM-hallucinated intentTension.
+      const stageAIntentTension = context.rootCauseOutput.intentTension;
+      if (stageAIntentTension !== undefined) {
+        // Passthrough: copy Stage A intentTension to Stage C output.
+        // If LLM also produced one, override with Stage A (source of truth).
+        if (output.intentTension !== undefined) {
+          this.emitEvent('invariant_override', taskId, {
+            field: 'intentTension',
+            reason: 'LLM output had intentTension — overridden with Stage A passthrough value (SPEC §18.1)',
+          });
         }
+        output.intentTension = stageAIntentTension;
       }
       // When Stage A did NOT produce intentTension, we do NOT add one.
       // If LLM hallucinated one, strip it to enforce SPEC §18.2.

--- a/packages/principles-core/src/runtime-v2/internalization/diag-router-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/diag-router-runner.ts
@@ -411,6 +411,36 @@ export class DiagRouterRunner extends BasePeerRunner<DiagRouterContext, Diagnost
         }
         output.confidence = stageBConfidence;
       }
+
+      // PRI-468: intentTension ← Stage A (additive passthrough, SPEC §18)
+      //
+      // Stage C MUST NOT generate intentTension when Stage A omitted it
+      // (SPEC §18.2). Only copy it through when Stage A actually produced one.
+      // Use Object.hasOwn to check for the presence of the field on the
+      // Stage A output (Runtime Contract Rule 5 — EP-01 / ERR-013).
+      if (Object.hasOwn(context.rootCauseOutput, 'intentTension')) {
+        const stageAIntentTension = context.rootCauseOutput.intentTension;
+        if (stageAIntentTension !== undefined) {
+          // Passthrough: copy Stage A intentTension to Stage C output.
+          // If LLM also produced one, override with Stage A (source of truth).
+          if (output.intentTension !== undefined) {
+            this.emitEvent('invariant_override', taskId, {
+              field: 'intentTension',
+              reason: 'LLM output had intentTension — overridden with Stage A passthrough value (SPEC §18.1)',
+            });
+          }
+          output.intentTension = stageAIntentTension;
+        }
+      }
+      // When Stage A did NOT produce intentTension, we do NOT add one.
+      // If LLM hallucinated one, strip it to enforce SPEC §18.2.
+      else if (output.intentTension !== undefined) {
+        this.emitEvent('invariant_override', taskId, {
+          field: 'intentTension',
+          reason: 'LLM output had intentTension but Stage A did not produce one — stripped (SPEC §18.2: additive only, never generates)',
+        });
+        delete output.intentTension;
+      }
     }
   }
 

--- a/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-runtime-factory.ts
@@ -39,6 +39,7 @@ import { storeEmitter } from './store/event-emitter.js';
 import { WorkflowFunnelLoader } from '../workflow-funnel-loader.js';
 import type { RuntimeKind, PDRuntimeAdapter } from './runtime-protocol.js';
 import type { LedgerAdapter } from './candidate-intake.js';
+import type { IntentDocReader } from './intent/intent-doc-reader-port.js';
 import {
   resolveAgentRuntimeBinding,
   checkAgentRuntimeReadiness,
@@ -57,6 +58,17 @@ export interface PainSignalRuntimeFactoryOptions {
   effectiveConfig?: EffectivePdConfig;
   /** PRI-306: Env var accessor for readiness checks. Defaults to process.env. */
   getEnvVar?: (name: string) => string | undefined;
+  /**
+   * PRI-468: Optional INTENT.md reader for Stage A intent tension check.
+   *
+   * Provided by the plugin layer (which owns filesystem I/O). When present
+   * AND `intent_engineering` flag is on, Stage A reads INTENT.md and
+   * injects it into the prompt. When absent, intent_engineering degrades
+   * silently to off (telemetry emitted by the runner).
+   *
+   * Core never performs filesystem I/O — it only consumes the port.
+   */
+  intentDocReader?: IntentDocReader;
 }
 
 /** Funnel name for the Runtime v2 diagnosis path. */
@@ -489,7 +501,7 @@ export async function createPainSignalBridge(
     // The bridge (PainSignalBridge.onPainDetected) is the sole invocation point.
 
     const rootCauseRunner = new DiagRootCauseRunner(
-      { stateManager, runtimeAdapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDiagRootCauseValidator(), contextAssembler },
+      { stateManager, runtimeAdapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDiagRootCauseValidator(), contextAssembler, intentDocReader: opts.intentDocReader },
       { owner: opts.owner ?? 'pain-signal-bridge', runtimeKind: runtimeConfig.runtimeKind, outputLanguage, effectiveConfig: opts.effectiveConfig },
     );
     const distillerRunner = new DiagDistillerRunner(

--- a/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
+++ b/packages/principles-core/src/runtime-v2/pain-to-principle-service.ts
@@ -15,6 +15,7 @@ import type { PainDetectedData, PainSignalBridgeResult, PainProvenance, PainEvid
 import { PDRuntimeError } from './error-categories.js';
 import type { LedgerAdapter } from './candidate-intake.js';
 import type { EffectivePdConfig } from './config/pd-config-types.js';
+import type { IntentDocReader } from './intent/intent-doc-reader-port.js';
 
 export type FailureCategory =
   | 'runtime_unavailable'
@@ -42,6 +43,11 @@ export interface PainToPrincipleServiceOptions {
   /** PRI-369: When true, recordPain returns immediately after task creation (status='submitted').
    *  The diagnosis runs in background via orchestrator wakeOnce/recovery-sweep. */
   asyncMode?: boolean;
+  /**
+   * PRI-468: Optional INTENT.md reader for Stage A intent tension check.
+   * Plugin layer supplies the concrete I/O adapter; core only consumes the port.
+   */
+  intentDocReader?: IntentDocReader;
 }
 
 export interface PainToPrincipleInput {
@@ -142,6 +148,7 @@ export class PainToPrincipleService {
           autoIntakeEnabled: false, // No intake in async mode — intake happens after diagnosis completes
           effectiveConfig: this.opts.effectiveConfig,
           getEnvVar: this.opts.getEnvVar,
+          intentDocReader: this.opts.intentDocReader,
         });
 
         // Create task as pending (does not run diagnosis)
@@ -182,6 +189,7 @@ export class PainToPrincipleService {
         autoIntakeEnabled: this.opts.autoIntakeEnabled,
         effectiveConfig: this.opts.effectiveConfig,
         getEnvVar: this.opts.getEnvVar,
+        intentDocReader: this.opts.intentDocReader,
       });
 
       const bridgeResult = await bridge.onPainDetected(painData);


### PR DESCRIPTION
## Summary

Implements PRI-468: Stage A optional `intentTension` + Stage C additive passthrough — the diagnostic-side of Intent Engineering MVP (SPEC §16-§18).

### What changed
- **IntentTensionSchema** (`diag-rootcause-output.ts`): TypeBox schema with `additionalProperties: false` — forbids `confidence` (SPEC §16.3). Fields: `source`, `evidenceStrength`, `relatedIntentFields`, `evidence` (maxItems 3), `explanation`, `suggestedOwnerAction`, optional `intentDocHash`.
- **Stage A prompt** (`rootcause-prompt-builder.ts`): `buildIntentTensionBlock()` returns `''` when flag off (byte-identical prompt), SPEC §17 verbatim text when on. Injected as PHASE 3.6.
- **IntentDocReader port** (`intent-doc-reader-port.ts`): Core-owned interface, plugin-implemented. `NullIntentDocReader` for backward compat.
- **DiagRootCauseRunner** (`diag-rootcause-runner.ts`): Reads INTENT.md via port when `intent_engineering` flag on. On read failure: degrades gracefully, emits `diag_rootcause_intent_doc_read_failed` telemetry with reason + nextAction (EP-03).
- **Stage C** (`diag-router-runner.ts`): Additive passthrough in `postFetchTransform()` — copies Stage A `intentTension`, strips LLM-hallucinated ones with `diag_router_invariant_override` telemetry, never generates its own.
- **Plugin adapter** (`intent-doc-reader-adapter.ts`): Wraps `safeReadIntentDoc` → core `IntentDocReader` port. Pure type mapping, no new I/O.
- **A/B evaluation fixtures** (`intent-tension-cases.ts`): 10 cases (4 positive + 4 negative + 2 intent_suspect) per SPEC §23.5-§23.8.
- **Wiring**: `intentDocReader` propagated through `pain-signal-runtime-factory` → `pain-to-principle-service` → plugin hooks/commands.

### Flag-off invariant (EP-03)
When `intent_engineering` is off (default, category `quiet`):
- No INTENT.md read (short-circuits before reader call)
- No intent cache access
- Prompt is byte-identical to pre-PRI-468
- No `intentTension` in output
- No new telemetry

---

## MVP Three Questions

1. **What happens if we DON'T do this?** Stage A cannot surface intent tensions. Owner has no structured signal when Agent actions drift from INTENT.md. The INTENT.md anchor (PRI-466/467) becomes documentation-only with no diagnostic feedback loop. This will be raised again the first time an Owner notices drift and has no pain-signal evidence to review.

2. **How is it observed?** When flag on + INTENT.md exists + Stage A detects tension: `intentTension` appears in the diagnosis output (visible via `pd status --json` and future Pain Card UI in PRI-470). When Stage C strips a hallucinated tension: `diag_router_invariant_override` telemetry is emitted. When INTENT.md read fails: `diag_rootcause_intent_doc_read_failed` telemetry with reason + nextAction.

3. **How is it disabled?** `intent_engineering` feature flag in `.pd/config.yaml` (category `quiet`, default `false`). Setting `enabled: false` restores byte-identical pre-PRI-468 behavior. No PR revert needed.

4. **What emotional value does it deliver?** Reduces **失控感** (loss-of-control feeling): Owner-authored INTENT.md now has a diagnostic feedback loop — when Agent actions drift from intent, the tension surfaces as structured evidence rather than requiring Owner to manually cross-reference. Creates **沉淀感** (sedimentation feeling): intent tensions accumulate as reviewable diagnosis artifacts, building institutional memory of where Agent behavior and Owner intent diverge.

---

## Emotional Value Review

Per `docs/product/emotional-value.md` §7:

| Dimension | Assessment |
|-----------|------------|
| Negative emotion reduced | 失控感 (Owner sees drift evidence, not just outcomes) |
| Positive feeling created | 沉淀感 (tensions accumulate as reviewable artifacts) |
| Owner attention cost | Low — `intentTension` is optional and additive; Owner only sees it when tension exists |
| Reversibility | Full — flag off = byte-identical pre-PRI-468 behavior |
| Observable | Yes — diagnosis output + telemetry events |

---

## ERR Checklist

| ERR | Title | How avoided |
|-----|-------|-------------|
| ERR-001 | `as` bypasses validation | IntentTensionSchema uses `additionalProperties: false`; validator Step 6b explicitly checks for forbidden `confidence` field; no `as` on untrusted LLM output |
| ERR-002 | Silent fallback | Every degraded path (not_found, oversized, read_error, flag_disabled, no reader) emits telemetry with reason + nextAction |
| ERR-005 | Array element type not validated | `relatedIntentFields` and `evidence` use `Type.Array(...)` with element type constraints; validator Step 6 checks evidence entries |
| ERR-009 | Required field missing → silent skip | Validator Step 6b uses `if (Object.hasOwn(record, 'intentTension'))` — fail-loud if present but malformed |
| ERR-013 | `in` operator on untrusted keys | Uses `Object.hasOwn()` throughout (validator, tests) |
| ERR-014 | Raw JSON.stringify on unknown | Telemetry payloads use structured objects with known fields |
| ERR-015 | Stale loop state | Stage C `postFetchTransform` gets fresh Stage A output each run; no cached state |

---

## Test Description

### New test files (4 files, 36 tests)
- `intent-tension-schema.test.ts` (13 tests): Schema accepts valid, rejects invalid (confidence, unknown source, wrong types, maxItems violation, additionalProperties)
- `diag-rootcause-intent-tension.test.ts` (6 tests): Flag off = no injection; flag on + ok = injects; flag on + not_found = telemetry + no injection; flag on + oversized = telemetry; no reader = backward compat; no effectiveConfig = flag off
- `diag-router-intent-tension.test.ts` (4 tests): Stage A has tension → Stage C passes through; Stage A no tension → Stage C doesn't generate; Stage A no tension + LLM hallucinated → Stage C strips with telemetry; Stage A has tension + LLM different → Stage A wins
- `intent-tension-cases.test.ts` (13 tests): A/B fixture composition (10 cases, 4+4+2), schema compliance, no confidence field, unique IDs

### Modified test files
- `diag-rootcause-output.test.ts`: +39 tests for intentTension valid/invalid cases in validator
- `rootcause-prompt-builder.test.ts`: +13 tests for PHASE 3.6 injection (flag on/off, intentDoc presence)
- `intent-doc-reader-adapter.test.ts` (4 tests, new): Plugin adapter ok/flag_disabled/not_found/oversized paths

### Test results
- Core: 5570 passed | 3 skipped | 3 todo
- Plugin: 1882 passed | 12 skipped
- Lint: clean
- verify:merge: clean (all packages typecheck + build)

---

## Remaining Risks

1. **`intentDocHash` strict enforcement (deferred)**: The schema accepts `intentDocHash` and the prompt includes the hash for the LLM to echo, but the runner does not currently override the LLM's value with the actual `contentHash`. If the LLM hallucinates a wrong hash, it would pass validation. Hardening: runner should inject `intentDocHash = context.intentDoc.contentHash` in `succeedTask`. This is a small follow-up; documented here for transparency.

2. **A/B evaluation is offline only**: The 10 fixtures validate schema compliance and expected outcomes, but real LLM behavior on these cases is not yet measured. PRI-470 (future) will run the evaluation against a live LLM.

3. **Stage C `postFetchTransform` assumes Stage A output is already committed**: The additive passthrough reads Stage A's `intentTension` from the upstream artifact. If Stage A failed or was skipped, Stage C correctly produces no `intentTension` (tested in `diag-router-intent-tension.test.ts` test 2).

---

## Diff Scope

25 files changed (16 modified, 9 new):
- `packages/principles-core/src/runtime-v2/diagnostician/` — schema, validator, prompt builder + tests
- `packages/principles-core/src/runtime-v2/internalization/` — Stage A runner, Stage C runner + tests + fixtures
- `packages/principles-core/src/runtime-v2/intent/` — IntentDocReader port
- `packages/principles-core/src/runtime-v2/` — index exports, factory, service, architecture regression
- `packages/openclaw-plugin/src/core/` — adapter
- `packages/openclaw-plugin/src/hooks/` + `commands/` — wiring
- `packages/openclaw-plugin/tests/` — adapter test, anti-growth whitelist

No unrelated files. No stale-main rollback (ERR-012).

Refs: PRI-465, PRI-466, PRI-467
