### PR TITLE
feat(PRI-470): persist Owner decisions as IntentDecisionRecord

### DIFF
--- a/packages/pd-console/src/server/index.ts
+++ b/packages/pd-console/src/server/index.ts
@@ -17,6 +17,7 @@ import { handleApprovalsGroupedRoute, disposeApprovalsGroupedModels } from './ro
 import { handleGovernanceRoute, disposeGovernanceModels } from './routes/governance.js';
 import { handleEvidenceChainRoute, disposeEvidenceChainModels } from './routes/evidence-chain.js';
 import { handleIntentRoute, disposeIntentModels } from './routes/intent.js';
+import { handleIntentDecisionsRoute, disposeIntentDecisionModels } from './routes/intent-decisions.js';
 import { createWorkspacesRoutes } from './routes/workspaces.js';
 import { handleUpdateRoute } from './routes/update.js';
 import { handleUpdateHistoryRoute } from './routes/update-history.js';
@@ -269,6 +270,7 @@ async function closeServices(services: AppServices): Promise<void> {
   disposeGovernanceModels();
   disposeEvidenceChainModels();
   disposeIntentModels();
+  disposeIntentDecisionModels();
   services.workspaceService.dispose();
 }
 
@@ -394,6 +396,13 @@ function handleRequest(services: AppServices): (req: http.IncomingMessage, res: 
       // PRI-466: GET /api/v1/intent
       if (urlPath === '/api/v1/intent') {
         asyncHandler(() => handleIntentRoute(req, res, services.workspaceDir))(req, res);
+        return;
+      }
+
+      // PRI-470: IntentDecisionRecord (POST/GET /api/v1/intent-decisions, /:id, /summary)
+      if (urlPath === '/api/v1/intent-decisions' || urlPath.startsWith('/api/v1/intent-decisions/')) {
+        const subPath = urlPath.slice('/api/v1/intent-decisions'.length);
+        asyncHandler(() => handleIntentDecisionsRoute(req, res, services.workspaceDir, subPath))(req, res);
         return;
       }
 

--- a/packages/pd-console/src/server/models/IntentDecisionModel.ts
+++ b/packages/pd-console/src/server/models/IntentDecisionModel.ts
@@ -1,0 +1,147 @@
+/**
+ * IntentDecisionModel — Console model for IntentDecisionRecord (PRI-470).
+ *
+ * Holds the workspaceDir (like ApprovalsConsoleModel) and opens a per-request
+ * SqliteConnection inside each method: open → delegate to SqliteIntentDecisionStore
+ * → close. This keeps each operation isolated and safe across workspaces.
+ *
+ * Graceful degradation (SPEC §21.7 / ERR-002):
+ * - Missing state.db → reads return null/empty/zero summary; writes return a
+ *   structured `not_initialized` result so the route can map to a clear HTTP
+ *   error instead of silently creating a half-initialized workspace.
+ * - Missing intent_decisions table → reads degrade to empty; writes re-throw
+ *   (the table is created by SqliteConnection.initSchema, so its absence
+ *   signals a corrupted or pre-PD workspace that should not be written to).
+ *
+ * ERR checklist:
+ * - EP-01 / ERR-001, ERR-005: store rows validated via core type guards
+ * - EP-03 / ERR-002: every degraded path carries reason + nextAction
+ * - EP-09: model is a thin I/O adapter over the pure store contract
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  SqliteConnection,
+  SqliteIntentDecisionStore,
+} from '@principles/core/runtime-v2';
+import type {
+  IntentDecisionInput,
+  IntentDecisionRecord,
+  IntentDecisionRecordResult,
+  IntentDecisionSummary,
+} from '@principles/core/runtime-v2';
+
+function stateDbExists(workspaceDir: string): boolean {
+  return fs.existsSync(path.join(workspaceDir, '.pd', 'state.db'));
+}
+
+function isMissingTableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.includes('no such table');
+}
+
+export type IntentDecisionRecordResultModel =
+  | { ok: true; record: IntentDecisionRecord; created: boolean }
+  | { ok: false; reason: string; nextAction: string };
+
+function emptySummary(): IntentDecisionSummary {
+  return {
+    counts: {
+      confirm_drift: 0,
+      revise_intent: 0,
+      observe: 0,
+      dismiss: 0,
+      promote_to_principle: 0,
+      promote_to_rulehost: 0,
+    },
+    lastDecisionAt: null,
+  };
+}
+
+export class IntentDecisionModel {
+  constructor(private readonly workspaceDir: string) {}
+
+  async record(input: IntentDecisionInput): Promise<IntentDecisionRecordResultModel> {
+    if (!stateDbExists(this.workspaceDir)) {
+      return {
+        ok: false,
+        reason: 'state_db_not_found',
+        nextAction: 'Initialize the workspace with PD (run a diagnosis or pd config) before recording intent decisions.',
+      };
+    }
+    const connection = new SqliteConnection({ workspaceDir: this.workspaceDir });
+    try {
+      const store = new SqliteIntentDecisionStore(connection);
+      const result: IntentDecisionRecordResult = await store.record(input);
+      return { ok: true, record: result.record, created: result.created };
+    } catch (err: unknown) {
+      if (isMissingTableError(err)) {
+        return {
+          ok: false,
+          reason: 'intent_decisions_table_missing',
+          nextAction: 'Run pd config doctor or re-initialize the workspace so the intent_decisions table is created.',
+        };
+      }
+      throw err;
+    } finally {
+      try { connection.close(); } catch { /* best-effort */ }
+    }
+  }
+
+  async getById(id: string): Promise<IntentDecisionRecord | null> {
+    if (!stateDbExists(this.workspaceDir)) return null;
+    const connection = new SqliteConnection({ workspaceDir: this.workspaceDir, readonly: true });
+    try {
+      const store = new SqliteIntentDecisionStore(connection);
+      return await store.getById(id);
+    } catch (err: unknown) {
+      if (isMissingTableError(err)) return null;
+      throw err;
+    } finally {
+      try { connection.close(); } catch { /* best-effort */ }
+    }
+  }
+
+  async listByPainId(painId: string): Promise<IntentDecisionRecord[]> {
+    if (!stateDbExists(this.workspaceDir)) return [];
+    const connection = new SqliteConnection({ workspaceDir: this.workspaceDir, readonly: true });
+    try {
+      const store = new SqliteIntentDecisionStore(connection);
+      return await store.listByPainId(painId);
+    } catch (err: unknown) {
+      if (isMissingTableError(err)) return [];
+      throw err;
+    } finally {
+      try { connection.close(); } catch { /* best-effort */ }
+    }
+  }
+
+  async listByTaskId(taskId: string): Promise<IntentDecisionRecord[]> {
+    if (!stateDbExists(this.workspaceDir)) return [];
+    const connection = new SqliteConnection({ workspaceDir: this.workspaceDir, readonly: true });
+    try {
+      const store = new SqliteIntentDecisionStore(connection);
+      return await store.listByTaskId(taskId);
+    } catch (err: unknown) {
+      if (isMissingTableError(err)) return [];
+      throw err;
+    } finally {
+      try { connection.close(); } catch { /* best-effort */ }
+    }
+  }
+
+  async getSummary(): Promise<IntentDecisionSummary> {
+    if (!stateDbExists(this.workspaceDir)) return emptySummary();
+    const connection = new SqliteConnection({ workspaceDir: this.workspaceDir, readonly: true });
+    try {
+      const store = new SqliteIntentDecisionStore(connection);
+      return await store.getSummary();
+    } catch (err: unknown) {
+      if (isMissingTableError(err)) return emptySummary();
+      throw err;
+    } finally {
+      try { connection.close(); } catch { /* best-effort */ }
+    }
+  }
+}

--- a/packages/pd-console/src/server/routes/intent-decisions.ts
+++ b/packages/pd-console/src/server/routes/intent-decisions.ts
@@ -1,0 +1,335 @@
+/**
+ * IntentDecisions route — HTTP surface for IntentDecisionRecord (PRI-470, SPEC §21.7).
+ *
+ * Endpoints (all gated by the `intent_engineering` feature flag):
+ * - POST   /api/v1/intent-decisions            → create (201) or idempotent replay (200)
+ * - GET    /api/v1/intent-decisions?painId=…   → list by painId
+ * - GET    /api/v1/intent-decisions?taskId=…   → list by taskId
+ * - GET    /api/v1/intent-decisions/summary    → tallied summary (MUST precede /:id)
+ * - GET    /api/v1/intent-decisions/:id        → single record
+ *
+ * Runtime Contract rules applied:
+ * - Rule 1: parsed JSON body treated as `unknown` (ERR-001)
+ * - Rule 2: enum fields validated via core type guards, never `as` (ERR-001/ERR-005)
+ * - Rule 3: required fields fail loud → 400 with reason (ERR-009/ERR-010)
+ * - Rule 5: `Object.hasOwn()` for untrusted object keys (ERR-013)
+ * - Rule 9: every degraded path carries reason + nextAction (ERR-002)
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+  isIntentTensionSource,
+  isEvidenceStrength,
+  isIntentRelatedField,
+  isSuggestedOwnerAction,
+} from '@principles/core/runtime-v2';
+import type {
+  IntentDecisionInput,
+  IntentRelatedField,
+} from '@principles/core/runtime-v2';
+import { IntentDecisionModel, type IntentDecisionRecordResultModel } from '../models/IntentDecisionModel.js';
+import { sendJson, sendSuccess, sendError, sendNotFound, sendBadRequest } from '../utils/response.js';
+import { parseQuery, readBody } from '../utils/request.js';
+import { loadPdConfig, computeFlagsFromLoadResult } from '../config/pd-config-store.js';
+
+// Per-workspace model cache (same pattern as approvals.ts). IntentDecisionModel
+// holds workspaceDir, so each workspace needs its own instance.
+const models = new Map<string, IntentDecisionModel>();
+
+function getModel(workspaceDir: string): IntentDecisionModel {
+  let model = models.get(workspaceDir);
+  if (!model) {
+    model = new IntentDecisionModel(workspaceDir);
+    models.set(workspaceDir, model);
+  }
+  return model;
+}
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function tryParseJson(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJsonBody(body: string, res: ServerResponse): Record<string, unknown> | null {
+  const raw = tryParseJson(body);
+  if (raw === undefined) {
+    sendBadRequest(res, 'Invalid JSON body');
+    return null;
+  }
+  if (!isRecord(raw)) {
+    sendBadRequest(res, 'Request body must be a JSON object');
+    return null;
+  }
+  return raw;
+}
+
+/**
+ * Feature flag gate: `intent_engineering` MUST be enabled for any
+ * intent-decisions operation. Fail-closed with a structured reason (ERR-002).
+ * Returns true when the caller may proceed.
+ */
+function checkFlag(workspaceDir: string, res: ServerResponse): boolean {
+  const configResult = loadPdConfig(workspaceDir);
+  const flagsResult = computeFlagsFromLoadResult(configResult);
+  const flagEnabled = flagsResult.flags.intent_engineering?.enabled === true;
+  if (!flagEnabled) {
+    sendError(
+      res,
+      403,
+      'Feature intent_engineering is disabled',
+      'Feature intent_engineering is disabled',
+      {
+        reason: 'flag_disabled',
+        nextAction: 'Enable intent_engineering flag to use this endpoint',
+      },
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Validate an untrusted JSON object into a fully-typed IntentDecisionInput.
+ * Returns null (after sending a 400) on any validation failure.
+ *
+ * Required fields are destructured first (satisfies prefer-destructuring) then
+ * narrowed by type guards on the LOCAL binding — this keeps TypeScript's control
+ * flow narrowing reliable across subsequent function calls (Rule 2: no `as`).
+ * Optional fields use Object.hasOwn to distinguish present-vs-absent (Rule 5).
+ */
+function validateInput(parsed: Record<string, unknown>, res: ServerResponse): IntentDecisionInput | null {
+  const { id, source, evidenceStrength, ownerAction, relatedIntentFields, evidenceRefs } = parsed;
+
+  // id — required non-empty string
+  if (typeof id !== 'string' || id === '') {
+    sendBadRequest(res, 'id is required and must be a non-empty string');
+    return null;
+  }
+  // source — required IntentTensionSource (Rule 2: type guard, no `as`)
+  if (!isIntentTensionSource(source)) {
+    sendBadRequest(res, 'source is required and must be a valid IntentTensionSource');
+    return null;
+  }
+  // evidenceStrength — required EvidenceStrength
+  if (!isEvidenceStrength(evidenceStrength)) {
+    sendBadRequest(res, 'evidenceStrength is required and must be a valid EvidenceStrength');
+    return null;
+  }
+  // ownerAction — required SuggestedOwnerAction
+  if (!isSuggestedOwnerAction(ownerAction)) {
+    sendBadRequest(res, 'ownerAction is required and must be a valid SuggestedOwnerAction');
+    return null;
+  }
+  // relatedIntentFields — required IntentRelatedField[] (Rule 4: element-wise)
+  if (!Array.isArray(relatedIntentFields)) {
+    sendBadRequest(res, 'relatedIntentFields is required and must be an array');
+    return null;
+  }
+  const typedFields: IntentRelatedField[] = [];
+  for (const field of relatedIntentFields) {
+    if (!isIntentRelatedField(field)) {
+      sendBadRequest(res, 'relatedIntentFields contains an invalid IntentRelatedField: ' + String(field));
+      return null;
+    }
+    typedFields.push(field);
+  }
+  // evidenceRefs — required string[] (Rule 4: element-wise)
+  if (!Array.isArray(evidenceRefs)) {
+    sendBadRequest(res, 'evidenceRefs is required and must be an array');
+    return null;
+  }
+  const typedRefs: string[] = [];
+  for (const ref of evidenceRefs) {
+    if (typeof ref !== 'string') {
+      sendBadRequest(res, 'evidenceRefs must contain only strings');
+      return null;
+    }
+    typedRefs.push(ref);
+  }
+
+  // Optional string fields — validated only when present (Rule 5: Object.hasOwn)
+  const optionalStringFields = ['painId', 'taskId', 'runId', 'intentDocHash', 'note'] as const;
+  const optional: Record<string, string | undefined> = {};
+  for (const key of optionalStringFields) {
+    if (Object.hasOwn(parsed, key)) {
+      const value = parsed[key];
+      if (typeof value !== 'string') {
+        sendBadRequest(res, key + ' must be a string when present');
+        return null;
+      }
+      optional[key] = value;
+    }
+  }
+
+  return {
+    id,
+    source,
+    evidenceStrength,
+    ownerAction,
+    relatedIntentFields: typedFields,
+    evidenceRefs: typedRefs,
+    painId: optional.painId,
+    taskId: optional.taskId,
+    runId: optional.runId,
+    intentDocHash: optional.intentDocHash,
+    note: optional.note,
+  };
+}
+
+/**
+ * Map a model-level failure (IntentDecisionRecordResultModel ok:false) to an
+ * HTTP error with reason + nextAction (Rule 9).
+ */
+function sendModelFailure(res: ServerResponse, result: Extract<IntentDecisionRecordResultModel, { ok: false }>): void {
+  if (result.reason === 'state_db_not_found') {
+    sendError(res, 409, 'workspace_not_initialized', result.reason, {
+      reason: result.reason,
+      nextAction: result.nextAction,
+    });
+  } else {
+    sendError(res, 500, 'intent_decision_store_error', result.reason, {
+      reason: result.reason,
+      nextAction: result.nextAction,
+    });
+  }
+}
+
+/* eslint-disable @typescript-eslint/max-params */
+export async function handleIntentDecisionsRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  workspaceDir: string,
+  subPath: string,
+): Promise<void> {
+  // Feature flag gate applies to every method on this route.
+  if (!checkFlag(workspaceDir, res)) return;
+
+  const model = getModel(workspaceDir);
+
+  // POST /api/v1/intent-decisions — create / idempotent replay
+  if (req.method === 'POST' && (subPath === '' || subPath === '/')) {
+    try {
+      const body = await readBody(req);
+      const parsed = parseJsonBody(body, res);
+      if (!parsed) return;
+      const input = validateInput(parsed, res);
+      if (!input) return;
+      const result = await model.record(input);
+      if (!result.ok) {
+        sendModelFailure(res, result);
+        return;
+      }
+      if (result.created) {
+        // Fresh create → 201 (sendJson with explicit status; sendSuccess is 200-only).
+        sendJson(res, 201, { success: true, data: result.record });
+      } else {
+        // Idempotent replay → 200 with the pre-existing record.
+        sendSuccess(res, result.record);
+      }
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      if (message === 'Request body too large') {
+        sendError(res, 413, 'payload_too_large', message);
+      } else {
+        sendError(res, 500, 'intent_decision_create_error', message);
+      }
+    }
+    return;
+  }
+
+  // GET /api/v1/intent-decisions — list by painId OR taskId (exactly one required)
+  if (req.method === 'GET' && (subPath === '' || subPath === '/')) {
+    try {
+      const query = parseQuery(req.url ?? '');
+      const hasPainId = Object.hasOwn(query, 'painId');
+      const hasTaskId = Object.hasOwn(query, 'taskId');
+      if (!hasPainId && !hasTaskId) {
+        sendBadRequest(res, 'Either painId or taskId query parameter is required');
+        return;
+      }
+      if (hasPainId && hasTaskId) {
+        sendBadRequest(res, 'Provide either painId or taskId, not both');
+        return;
+      }
+      if (hasPainId) {
+        const { painId } = query;
+        if (!painId) {
+          sendBadRequest(res, 'painId must not be empty');
+          return;
+        }
+        const items = await model.listByPainId(painId);
+        sendSuccess(res, items);
+      } else {
+        const { taskId } = query;
+        if (!taskId) {
+          sendBadRequest(res, 'taskId must not be empty');
+          return;
+        }
+        const items = await model.listByTaskId(taskId);
+        sendSuccess(res, items);
+      }
+    } catch (err: unknown) {
+      sendError(res, 500, 'intent_decision_list_error', getErrorMessage(err));
+    }
+    return;
+  }
+
+  // GET /api/v1/intent-decisions/summary — MUST be matched before /:id
+  if (req.method === 'GET' && subPath === '/summary') {
+    try {
+      const summary = await model.getSummary();
+      sendSuccess(res, summary);
+    } catch (err: unknown) {
+      sendError(res, 500, 'intent_decision_summary_error', getErrorMessage(err));
+    }
+    return;
+  }
+
+  // GET /api/v1/intent-decisions/:id — single record
+  const detailMatch = /^[/]([^/]+)$/.exec(subPath);
+  if (req.method === 'GET' && detailMatch) {
+    const [, rawId] = detailMatch;
+    if (!rawId) {
+      sendError(res, 400, 'invalid_id', 'Intent decision id is missing');
+      return;
+    }
+    let recordId: string;
+    try {
+      recordId = decodeURIComponent(rawId);
+    } catch {
+      sendError(res, 400, 'invalid_id', 'Intent decision id contains invalid URI encoding');
+      return;
+    }
+    try {
+      const record = await model.getById(recordId);
+      if (!record) {
+        sendNotFound(res, 'Intent decision ' + recordId + ' not found');
+        return;
+      }
+      sendSuccess(res, record);
+    } catch (err: unknown) {
+      sendError(res, 500, 'intent_decision_detail_error', getErrorMessage(err));
+    }
+    return;
+  }
+
+  sendNotFound(res, 'Route /api/v1/intent-decisions' + subPath + ' not found');
+}
+
+/**
+ * Dispose hook for graceful shutdown — clears the per-workspace model cache.
+ */
+export function disposeIntentDecisionModels(): void {
+  models.clear();
+}

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -29,6 +29,10 @@ import {
   validateEvidenceChain,
   validateTrajectoryData,
   validateIntentSummary,
+  validateIntentDecisionRecord,
+  validateIntentDecisionList,
+  validateIntentDecisionResult,
+  validateIntentDecisionSummary,
 } from "./utils/validators.js";
 import type {
   FeedbackReportData,
@@ -57,6 +61,9 @@ import type {
   EvidenceChainData,
   TrajectoryData,
   IntentSummaryData,
+  IntentDecisionRecordData,
+  IntentDecisionResultData,
+  IntentDecisionSummaryData,
 } from "./utils/validators.js";
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -402,6 +409,77 @@ async function fetchEvidenceChain(): Promise<ApiResponse<EvidenceChainData>> {
 async function fetchIntentSummary(): Promise<ApiResponse<IntentSummaryData>> {
   return request<IntentSummaryData>('/api/v1/intent', undefined, validateIntentSummary);
 }
+
+// ── Intent Decisions (PRI-470) ───────────────────────────────────────────────
+
+/**
+ * Frontend-friendly payload for recording an Owner decision on an intent tension.
+ * The `evidence` field is mapped to `evidenceRefs` in the API request body.
+ */
+export interface IntentDecisionInputPayload {
+  taskId: string;
+  source: string;
+  evidenceStrength: string;
+  relatedIntentFields: string[];
+  evidence: string[];
+  explanation?: string;
+  suggestedAction: string;
+  ownerAction: string;
+  painId?: string;
+  intentDocHash?: string;
+  note?: string;
+}
+
+async function recordIntentDecision(
+  payload: IntentDecisionInputPayload,
+): Promise<ApiResponse<IntentDecisionResultData>> {
+  return request<IntentDecisionResultData>(
+    '/api/v1/intent-decisions',
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    },
+    validateIntentDecisionResult,
+  );
+}
+
+async function listIntentDecisionsByPainId(
+  painId: string,
+): Promise<ApiResponse<IntentDecisionRecordData[]>> {
+  return request<IntentDecisionRecordData[]>(
+    `/api/v1/intent-decisions?painId=${encodeURIComponent(painId)}`,
+    undefined,
+    validateIntentDecisionList,
+  );
+}
+
+async function listIntentDecisionsByTaskId(
+  taskId: string,
+): Promise<ApiResponse<IntentDecisionRecordData[]>> {
+  return request<IntentDecisionRecordData[]>(
+    `/api/v1/intent-decisions?taskId=${encodeURIComponent(taskId)}`,
+    undefined,
+    validateIntentDecisionList,
+  );
+}
+
+async function getIntentDecision(
+  decisionId: string,
+): Promise<ApiResponse<IntentDecisionRecordData>> {
+  return request<IntentDecisionRecordData>(
+    `/api/v1/intent-decisions/${encodeURIComponent(decisionId)}`,
+    undefined,
+    validateIntentDecisionRecord,
+  );
+}
+
+async function fetchIntentDecisionSummary(): Promise<ApiResponse<IntentDecisionSummaryData>> {
+  return request<IntentDecisionSummaryData>(
+    '/api/v1/intent-decisions/summary',
+    undefined,
+    validateIntentDecisionSummary,
+  );
+}
 // ── Exports ───────────────────────────────────────────────────────────────────
 
 export {
@@ -442,6 +520,11 @@ export {
   rollbackUpdate,
   fetchEvidenceChain,
   fetchIntentSummary,
+  recordIntentDecision,
+  listIntentDecisionsByPainId,
+  listIntentDecisionsByTaskId,
+  getIntentDecision,
+  fetchIntentDecisionSummary,
 };
 
 // ── Type re-exports (consumer-facing aliases) ─────────────────────────────────
@@ -480,6 +563,9 @@ export type {
   IntentSummaryData,
   IntentSectionsData,
   IntentDocWarningData,
+  IntentDecisionRecordData,
+  IntentDecisionResultData,
+  IntentDecisionSummaryData,
 } from "./utils/validators.js";
 
 // Consumer-facing type aliases (old names that pages import)

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -249,7 +249,24 @@
       "intentTensionSuggestedActionPromoteToRulehost": "Promote to RuleHost",
       "intentTensionIntentDocHashLabel": "INTENT doc hash",
       "intentTensionNoTension": "No intent tension detected",
-      "intentTensionArtifactDegraded": "Diagnostician artifact for this record could not be fully parsed; intent tension may be unavailable."
+      "intentTensionArtifactDegraded": "Diagnostician artifact for this record could not be fully parsed; intent tension may be unavailable.",
+      "ownerDecisionPanelTitle": "Owner Decision",
+      "ownerDecisionPanelSubtitle": "Record your decision on this intent tension. Follow-up actions appear only after a decision is persisted.",
+      "ownerDecisionNoteLabel": "Note (optional)",
+      "ownerDecisionNotePlaceholder": "Add context for this decision",
+      "ownerDecisionSubmitConfirmDrift": "Confirm Drift",
+      "ownerDecisionSubmitReviseIntent": "Revise Intent",
+      "ownerDecisionSubmitObserve": "Observe",
+      "ownerDecisionSubmitDismiss": "Dismiss",
+      "ownerDecisionSubmitPromoteToPrinciple": "Promote to Principle",
+      "ownerDecisionSubmitPromoteToRulehost": "Promote to RuleHost",
+      "ownerDecisionSubmitting": "Recording decision…",
+      "ownerDecisionRecorded": "Decision recorded",
+      "ownerDecisionFailed": "Failed to record decision",
+      "ownerDecisionExisting": "A decision already exists for this tension",
+      "ownerDecisionFollowUpPlaceholder": "Follow-up actions will appear here after the decision is recorded.",
+      "ownerDecisionLoadingExisting": "Loading existing decisions…",
+      "ownerDecisionLoadFailed": "Failed to load existing decisions"
     },
     "principles": {
       "title": "Principles",
@@ -720,7 +737,20 @@
         "templateDescription": "Copy this into .principles/INTENT.md. Replace placeholders with your intent."
       },
       "loadError": "Failed to load intent document",
-      "validationError": "Data format validation failed, please refresh and retry"
+      "validationError": "Data format validation failed, please refresh and retry",
+      "decisions": {
+        "sectionTitle": "Owner Decisions",
+        "sectionSubtitle": "Lightweight audit summary derived from IntentDecisionRecord. Not a dashboard.",
+        "countConfirmDrift": "Confirm drift",
+        "countReviseIntent": "Revise intent",
+        "countObserve": "Observe",
+        "countDismiss": "Dismiss",
+        "countPromoteToPrinciple": "Promote to principle",
+        "countPromoteToRulehost": "Promote to RuleHost",
+        "lastDecisionAtLabel": "Last decision",
+        "noDecisions": "No decisions recorded yet",
+        "loadError": "Failed to load decision summary"
+      }
     }
   },
   "components": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -249,7 +249,24 @@
       "intentTensionSuggestedActionPromoteToRulehost": "提升为 RuleHost",
       "intentTensionIntentDocHashLabel": "INTENT 文档哈希",
       "intentTensionNoTension": "未检测到意图张力",
-      "intentTensionArtifactDegraded": "此记录的诊断器产物无法完整解析，意图张力可能不可用。"
+      "intentTensionArtifactDegraded": "此记录的诊断器产物无法完整解析，意图张力可能不可用。",
+      "ownerDecisionPanelTitle": "拥有者决策",
+      "ownerDecisionPanelSubtitle": "记录您对此意图张力的决策。后续操作仅在决策持久化后才会显示。",
+      "ownerDecisionNoteLabel": "备注（可选）",
+      "ownerDecisionNotePlaceholder": "为此决策添加上下文",
+      "ownerDecisionSubmitConfirmDrift": "确认漂移",
+      "ownerDecisionSubmitReviseIntent": "修订意图",
+      "ownerDecisionSubmitObserve": "观察",
+      "ownerDecisionSubmitDismiss": "驳回",
+      "ownerDecisionSubmitPromoteToPrinciple": "沉淀为原则",
+      "ownerDecisionSubmitPromoteToRulehost": "转为 RuleHost",
+      "ownerDecisionSubmitting": "正在记录决策…",
+      "ownerDecisionRecorded": "决策已记录",
+      "ownerDecisionFailed": "记录决策失败",
+      "ownerDecisionExisting": "此张力已存在决策",
+      "ownerDecisionFollowUpPlaceholder": "决策记录后，后续操作将显示在此处。",
+      "ownerDecisionLoadingExisting": "正在加载已有决策…",
+      "ownerDecisionLoadFailed": "加载已有决策失败"
     },
     "principles": {
       "title": "原则",
@@ -720,7 +737,20 @@
         "templateDescription": "将其复制到 .principles/INTENT.md，替换占位符为你的意图。"
       },
       "loadError": "加载意图文档失败",
-      "validationError": "数据格式校验失败，请刷新后重试"
+      "validationError": "数据格式校验失败，请刷新后重试",
+      "decisions": {
+        "sectionTitle": "拥有者决策",
+        "sectionSubtitle": "基于 IntentDecisionRecord 的轻量审计摘要，非仪表盘。",
+        "countConfirmDrift": "确认漂移",
+        "countReviseIntent": "修订意图",
+        "countObserve": "观察",
+        "countDismiss": "驳回",
+        "countPromoteToPrinciple": "沉淀为原则",
+        "countPromoteToRulehost": "转为 RuleHost",
+        "lastDecisionAtLabel": "最近决策",
+        "noDecisions": "暂无决策记录",
+        "loadError": "加载决策摘要失败"
+      }
     }
   },
   "components": {

--- a/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
+++ b/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import { PageShell } from "../../components/layout/page-shell.js";
 import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
-import { fetchIntentSummary } from "../../api.js";
-import type { IntentSummaryData, IntentDocWarningData } from "../../api.js";
+import { fetchIntentSummary, fetchIntentDecisionSummary } from "../../api.js";
+import type { IntentSummaryData, IntentDocWarningData, IntentDecisionSummaryData } from "../../api.js";
 
 // ── Page state ────────────────────────────────────────────────────────────────
 
@@ -160,6 +160,99 @@ function MetaRow({ label, value }: { label: string; value: string }) {
       </span>
       <span className="text-ink-2 text-[12px] font-mono break-all">{value}</span>
     </div>
+  );
+}
+
+// ── Decision Summary Section (SPEC §22.1.1) ──────────────────────────────────
+// Lightweight audit summary derived from IntentDecisionRecord. NOT a dashboard.
+// Only aggregate counts per ownerAction + lastDecisionAt are shown.
+// SPEC forbids displaying metrics that cannot be traced back to IntentDecisionRecord.
+
+type DecisionSummaryState = "loading" | "loaded" | "error";
+
+// Static mapping from ownerAction enum value to its i18n label key.
+// Avoids dynamic string construction so i18n extraction tools can find keys.
+const DECISION_COUNT_LABEL_KEYS: ReadonlyArray<{
+  action: keyof IntentDecisionSummaryData["counts"];
+  labelKey: string;
+}> = [
+  { action: "confirm_drift", labelKey: "pages.intent.decisions.countConfirmDrift" },
+  { action: "revise_intent", labelKey: "pages.intent.decisions.countReviseIntent" },
+  { action: "observe", labelKey: "pages.intent.decisions.countObserve" },
+  { action: "dismiss", labelKey: "pages.intent.decisions.countDismiss" },
+  { action: "promote_to_principle", labelKey: "pages.intent.decisions.countPromoteToPrinciple" },
+  { action: "promote_to_rulehost", labelKey: "pages.intent.decisions.countPromoteToRulehost" },
+];
+
+function DecisionSummarySection() {
+  const { t } = useTranslation();
+  const [state, setState] = useState<DecisionSummaryState>("loading");
+  const [summary, setSummary] = useState<IntentDecisionSummaryData | null>(null);
+
+  const loadSummary = useCallback(async () => {
+    setState("loading");
+    const result = await fetchIntentDecisionSummary();
+    if (!result.success) {
+      // ERR-002: graceful degradation with reason; section collapses to a single line.
+      setState("error");
+      return;
+    }
+    setSummary(result.data);
+    setState("loaded");
+  }, []);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  return (
+    <section className="mt-8" aria-labelledby="section-decisions">
+      <SectionTitle id="section-decisions">
+        {t("pages.intent.decisions.sectionTitle")}
+      </SectionTitle>
+      <p className="text-ink-3 text-[13px] leading-relaxed mb-3">
+        {t("pages.intent.decisions.sectionSubtitle")}
+      </p>
+      {state === "loading" && (
+        <div className="bg-panel border border-line rounded-[6px] p-4 text-ink-3 text-[13px]">
+          {t("common.loading")}
+        </div>
+      )}
+      {state === "error" && (
+        <div className="bg-panel border border-line rounded-[6px] p-4 text-ink-3 text-[13px]">
+          {t("pages.intent.decisions.loadError")}
+        </div>
+      )}
+      {state === "loaded" && summary && (
+        <div className="bg-panel border border-line rounded-[6px] p-4">
+          {/* Counts per ownerAction — SPEC §22.1.1: zero counts are still rendered (audit clarity). */}
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-3">
+            {DECISION_COUNT_LABEL_KEYS.map(({ action, labelKey }) => {
+              const count = summary.counts[action];
+              return (
+                <div key={action} className="flex items-baseline gap-2">
+                  <dt className="text-ink-3 text-[12px]">{t(labelKey)}</dt>
+                  <dd className="text-ink font-mono text-[13px]">{count}</dd>
+                </div>
+              );
+            })}
+          </dl>
+          {/* lastDecisionAt — null means "no decisions recorded yet" */}
+          <div className="mt-4 pt-3 border-t border-line">
+            {summary.lastDecisionAt === null ? (
+              <p className="text-ink-4 text-[12px]">{t("pages.intent.decisions.noDecisions")}</p>
+            ) : (
+              <div className="flex items-baseline gap-2">
+                <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-3">
+                  {t("pages.intent.decisions.lastDecisionAtLabel")}
+                </span>
+                <span className="text-ink-2 text-[12px] font-mono break-all">{summary.lastDecisionAt}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -345,6 +438,13 @@ export function IntentPage() {
               </p>
             )}
           </div>
+        )}
+
+        {/* Decision Summary — SPEC §22.1.1: bottom section, shown when flag is on.
+            Decisions are persisted independently of INTENT.md state, so this
+            section appears regardless of whether INTENT.md was found/OK. */}
+        {summary && summary.flagEnabled && (
+          <DecisionSummarySection />
         )}
       </div>
     </PageShell>

--- a/packages/pd-console/src/ui/pages/pain/PainPage.tsx
+++ b/packages/pd-console/src/ui/pages/pain/PainPage.tsx
@@ -17,11 +17,11 @@ import { Badge } from '../../components/ui/badge.js';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card.js';
 import { Button } from '../../components/ui/button.js';
 import { ShinyText } from '../../components/ui/shiny-text.js';
-import { fetchEvidenceChain } from '../../api.js';
-import type { EvidenceChainRecordData, EvidenceChainStateData, EvidenceChainData } from '../../api.js';
+import { fetchEvidenceChain, recordIntentDecision, listIntentDecisionsByPainId, listIntentDecisionsByTaskId } from '../../api.js';
+import type { EvidenceChainRecordData, EvidenceChainStateData, EvidenceChainData, IntentDecisionRecordData } from '../../api.js';
 import type { IntentTensionData } from '../../utils/validators.js';
 import { formatDate } from '../../utils/format.js';
-import { mapConfidenceLabel, buildCardLayers, buildDebugIdSummary, isLayer2EffectivelyEmpty, shouldRenderIntentTensionPanel, shouldRenderFollowUpActions } from './pain-card-helpers.js';
+import { mapConfidenceLabel, buildCardLayers, buildDebugIdSummary, isLayer2EffectivelyEmpty, shouldRenderIntentTensionPanel, shouldRenderFollowUpActions, buildIntentDecisionPayload, type IntentDecisionContext } from './pain-card-helpers.js';
 import { enumLabel } from '../../utils/enum-labels.js';
 
 // ── State grouping ─────────────────────────────────────────────────────────────
@@ -449,6 +449,9 @@ function EvidenceChainCard({ record, expanded, onToggle, t }: EvidenceChainCardP
         {shouldRenderIntentTensionPanel(layers.layer2.intentTension) && (
           <IntentTensionPanel
             tension={layers.layer2.intentTension}
+            recordId={record.id}
+            painId={record.id}
+            taskId={record.linkedTaskId ?? undefined}
             t={t}
           />
         )}
@@ -609,6 +612,9 @@ function intentTensionEnumLabel(
 
 interface IntentTensionPanelProps {
   tension: IntentTensionData;
+  recordId: string;
+  painId?: string;
+  taskId?: string;
   t: (key: string) => string;
 }
 
@@ -628,7 +634,7 @@ interface IntentTensionPanelProps {
  * - Uses <dl>/<dt>/<dd> for label-value pairs
  * - Color is not the only indicator (text labels always present)
  */
-function IntentTensionPanel({ tension, t }: IntentTensionPanelProps) {
+function IntentTensionPanel({ tension, recordId, painId, taskId, t }: IntentTensionPanelProps) {
   const sourceLabel = intentTensionEnumLabel(tension.source, 'source', t);
   const strengthLabel = intentTensionEnumLabel(tension.evidenceStrength, 'evidenceStrength', t);
   const actionLabel = intentTensionEnumLabel(tension.suggestedOwnerAction, 'suggestedAction', t);
@@ -706,15 +712,204 @@ function IntentTensionPanel({ tension, t }: IntentTensionPanelProps) {
         </div>
       )}
 
-      {/* PRI-471: Follow-up actions (SPEC §22.1.4)
-          NOT rendered in PRI-469. shouldRenderFollowUpActions() returns false.
-          PRI-471 will replace the stub and render action buttons after the
-          Owner decision is written to IntentDecisionRecord. */}
-      {shouldRenderFollowUpActions() && (
-        <div className="mt-4 pt-3 border-t border-line">
-          {/* PRI-471 will add follow-up action buttons here */}
+      {/* PRI-470: Owner Decision Panel (SPEC §22.1.4)
+          Renders the Owner decision flow. Follow-up actions appear only
+          after a decision is persisted (shouldRenderFollowUpActions). */}
+      <OwnerDecisionPanel
+        tension={tension}
+        recordId={recordId}
+        painId={painId}
+        taskId={taskId}
+        t={t}
+      />
+    </section>
+  );
+}
+
+// ── PRI-470: Owner Decision Panel (SPEC §22.1.4) ─────────────────────────────
+
+interface OwnerDecisionPanelProps {
+  tension: IntentTensionData;
+  recordId: string;
+  painId?: string;
+  taskId?: string;
+  t: (key: string) => string;
+}
+
+type DecisionPanelState = 'idle' | 'submitting' | 'recorded' | 'error';
+type DecisionLoadState = 'loading' | 'loaded' | 'error';
+
+const OWNER_ACTION_BUTTONS: ReadonlyArray<{
+  action: string;
+  labelKey: string;
+}> = [
+  { action: 'confirm_drift', labelKey: 'pages.pain.ownerDecisionSubmitConfirmDrift' },
+  { action: 'revise_intent', labelKey: 'pages.pain.ownerDecisionSubmitReviseIntent' },
+  { action: 'observe', labelKey: 'pages.pain.ownerDecisionSubmitObserve' },
+  { action: 'dismiss', labelKey: 'pages.pain.ownerDecisionSubmitDismiss' },
+  { action: 'promote_to_principle', labelKey: 'pages.pain.ownerDecisionSubmitPromoteToPrinciple' },
+  { action: 'promote_to_rulehost', labelKey: 'pages.pain.ownerDecisionSubmitPromoteToRulehost' },
+];
+
+/**
+ * OwnerDecisionPanel — renders the Owner decision flow for an intent tension.
+ *
+ * State machine: 'idle' | 'submitting' | 'recorded' | 'error'
+ * - On mount, fetches existing decisions by painId (or taskId fallback).
+ * - Shows 6 action buttons + optional note input.
+ * - On submit, calls buildIntentDecisionPayload + recordIntentDecision.
+ * - Follow-up actions placeholder appears when existingDecisions is non-empty.
+ *
+ * Accessibility (EP-09):
+ * - Uses semantic <section> with aria-label
+ * - Buttons have descriptive text labels
+ */
+function OwnerDecisionPanel({ tension, recordId, painId, taskId, t }: OwnerDecisionPanelProps) {
+  const [panelState, setPanelState] = useState<DecisionPanelState>('idle');
+  const [loadState, setLoadState] = useState<DecisionLoadState>('loading');
+  const [existingDecisions, setExistingDecisions] = useState<IntentDecisionRecordData[]>([]);
+  const [note, setNote] = useState('');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Fetch existing decisions on mount — use painId when available, fall back to taskId.
+  useEffect(() => {
+    let cancelled = false;
+    const loadExisting = async () => {
+      setLoadState('loading');
+      const hasPainId = painId !== undefined && painId.length > 0;
+      const hasTaskId = taskId !== undefined && taskId.length > 0;
+      if (!hasPainId && !hasTaskId) {
+        // Nothing to query by — skip loading, treat as empty.
+        if (!cancelled) setLoadState('loaded');
+        return;
+      }
+      const result = hasPainId
+        ? await listIntentDecisionsByPainId(painId!)
+        : await listIntentDecisionsByTaskId(taskId!);
+      if (cancelled) return;
+      if (!result.success) {
+        setLoadState('error');
+        return;
+      }
+      setExistingDecisions(result.data);
+      setLoadState('loaded');
+    };
+    void loadExisting();
+    return () => { cancelled = true; };
+  }, [painId, taskId]);
+
+  const handleSubmit = async (ownerAction: string) => {
+    setPanelState('submitting');
+    setErrorMsg(null);
+    const context: IntentDecisionContext = {
+      recordId,
+      painId,
+      taskId,
+      intentDocHash: tension.intentDocHash,
+    };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction, note });
+    const result = await recordIntentDecision(payload);
+    if (!result.success) {
+      setPanelState('error');
+      setErrorMsg(result.error ?? t('pages.pain.ownerDecisionFailed'));
+      return;
+    }
+    setPanelState('recorded');
+    // Add the new decision so follow-up actions appear.
+    setExistingDecisions([result.data.record, ...existingDecisions]);
+  };
+
+  const hasExisting = existingDecisions.length > 0;
+  const showFollowUp = shouldRenderFollowUpActions(existingDecisions);
+
+  return (
+    <div className="mt-4 pt-3 border-t border-line">
+      <h5 className="text-[13px] font-semibold text-ink mb-1">
+        {t('pages.pain.ownerDecisionPanelTitle')}
+      </h5>
+      <p className="text-ink-3 text-[12px] leading-relaxed mb-3">
+        {t('pages.pain.ownerDecisionPanelSubtitle')}
+      </p>
+
+      {/* Loading existing decisions */}
+      {loadState === 'loading' && (
+        <p className="text-ink-4 text-[12px] italic">
+          {t('pages.pain.ownerDecisionLoadingExisting')}
+        </p>
+      )}
+
+      {/* Failed to load existing decisions */}
+      {loadState === 'error' && (
+        <p className="text-amber text-[12px]">
+          {t('pages.pain.ownerDecisionLoadFailed')}
+        </p>
+      )}
+
+      {/* Existing decision banner */}
+      {loadState === 'loaded' && hasExisting && panelState !== 'recorded' && (
+        <p className="text-ink-3 text-[12px] mb-3 italic">
+          {t('pages.pain.ownerDecisionExisting')}
+        </p>
+      )}
+
+      {/* Recorded success message */}
+      {panelState === 'recorded' && (
+        <p className="text-emerald text-[12px] mb-3 font-medium">
+          {t('pages.pain.ownerDecisionRecorded')}
+        </p>
+      )}
+
+      {/* Error message */}
+      {panelState === 'error' && errorMsg && (
+        <p className="text-danger text-[12px] mb-3">
+          {t('pages.pain.ownerDecisionFailed')}: {errorMsg}
+        </p>
+      )}
+
+      {/* Note input (optional) — disabled during submission or after recorded */}
+      {panelState !== 'recorded' && loadState === 'loaded' && (
+        <>
+          <div className="mb-3">
+            <label className="block font-mono text-[11px] uppercase tracking-[0.08em] text-ink-4 mb-1">
+              {t('pages.pain.ownerDecisionNoteLabel')}
+            </label>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder={t('pages.pain.ownerDecisionNotePlaceholder')}
+              disabled={panelState === 'submitting'}
+              className="w-full px-3 py-1.5 text-[13px] bg-surface border border-line rounded-[var(--radius-sm)] text-ink-2 focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2 disabled:opacity-50"
+            />
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex flex-wrap gap-2">
+            {OWNER_ACTION_BUTTONS.map(({ action, labelKey }) => (
+              <Button
+                key={action}
+                variant="outline"
+                size="sm"
+                disabled={panelState === 'submitting'}
+                onClick={() => void handleSubmit(action)}
+              >
+                {panelState === 'submitting'
+                  ? t('pages.pain.ownerDecisionSubmitting')
+                  : t(labelKey)}
+              </Button>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Follow-up actions placeholder (SPEC §22.1.4) */}
+      {showFollowUp && (
+        <div className="mt-4 p-3 bg-paper-2 border border-line rounded-[var(--radius-sm)]">
+          <p className="text-ink-3 text-[12px] italic">
+            {t('pages.pain.ownerDecisionFollowUpPlaceholder')}
+          </p>
         </div>
       )}
-    </section>
+    </div>
   );
 }

--- a/packages/pd-console/src/ui/pages/pain/pain-card-helpers.ts
+++ b/packages/pd-console/src/ui/pages/pain/pain-card-helpers.ts
@@ -5,7 +5,8 @@
  * No React dependency, no I/O. All functions are pure.
  */
 
-import type { IntentTensionData } from '../../utils/validators.js';
+import type { IntentTensionData, IntentDecisionRecordData } from '../../utils/validators.js';
+import type { IntentDecisionInputPayload } from '../../api.js';
 
 // ── Confidence mapping ────────────────────────────────────────────────────────
 
@@ -207,16 +208,80 @@ export function shouldRenderIntentTensionPanel(tension: IntentTensionData | null
  * RuleHost, view Intent Patch Proposal) should be visible.
  *
  * SPEC §22.1.4: follow-up actions are NOT the first-layer decision. They only
- * appear after the Owner has confirmed a decision. In PRI-469 (this slice),
- * we do NOT implement the Owner decision flow yet — that is PRI-471. So this
- * helper always returns false here, and the follow-up actions UI is not
- * rendered. The helper exists so the UI code can call it without conditional
- * imports when PRI-471 lands.
+ * appear after the Owner has confirmed a decision (an IntentDecisionRecord
+ * has been persisted for this tension).
  *
- * PRI-471 will replace this stub with a real check against IntentDecisionRecord.
+ * PRI-470: replaced the PRI-469 stub. Now returns true only when a non-empty
+ * decisions array exists — i.e., at least one IntentDecisionRecord has been
+ * persisted for this tension.
  */
-export function shouldRenderFollowUpActions(): boolean {
-  // PRI-469: follow-up actions are out of scope. PRI-471 will implement the
-  // Owner decision flow and replace this stub.
-  return false;
+export function shouldRenderFollowUpActions(
+  decisions?: IntentDecisionRecordData[] | null,
+): boolean {
+  if (!Array.isArray(decisions)) return false;
+  return decisions.length > 0;
+}
+
+// ── PRI-470: Owner decision payload builder (SPEC §22.1) ─────────────────────
+
+/**
+ * Context needed to build an IntentDecisionInputPayload from a tension.
+ * `recordId` is the evidence chain record ID used as a fallback when taskId
+ * is not available. `painId` and `intentDocHash` are optional.
+ */
+export interface IntentDecisionContext {
+  recordId: string;
+  painId?: string;
+  taskId?: string;
+  intentDocHash?: string;
+}
+
+/**
+ * The Owner's decision on an intent tension. `ownerAction` overrides
+ * `tension.suggestedOwnerAction` — the Owner may choose a different action
+ * than the one PD suggested. `note` is an optional trimmed annotation.
+ */
+export interface IntentDecisionChoice {
+  ownerAction: string;
+  note?: string;
+}
+
+/**
+ * Build an IntentDecisionInputPayload from an IntentTension and the Owner's
+ * chosen action. The payload is sent to POST /api/v1/intent-decisions.
+ *
+ * - `taskId` falls back to `recordId` when not provided.
+ * - Optional fields (painId, intentDocHash, note) are omitted when empty.
+ * - `note` is trimmed before being included.
+ * - `evidence` is passed through as-is; truncation is the backend's job
+ *   (the frontend must not silently drop evidence the Owner might rely on).
+ * - `ownerAction` overrides `tension.suggestedOwnerAction` — the Owner may
+ *   choose a different action than the one PD suggested.
+ */
+export function buildIntentDecisionPayload(
+  tension: IntentTensionData,
+  context: IntentDecisionContext,
+  choice: IntentDecisionChoice,
+): IntentDecisionInputPayload {
+  const { ownerAction, note } = choice;
+  const payload: IntentDecisionInputPayload = {
+    taskId: context.taskId ?? context.recordId,
+    source: tension.source,
+    evidenceStrength: tension.evidenceStrength,
+    relatedIntentFields: tension.relatedIntentFields,
+    evidence: tension.evidence,
+    explanation: tension.explanation,
+    suggestedAction: tension.suggestedOwnerAction,
+    ownerAction,
+  };
+  if (context.painId !== undefined && context.painId.length > 0) {
+    payload.painId = context.painId;
+  }
+  if (context.intentDocHash !== undefined && context.intentDocHash.length > 0) {
+    payload.intentDocHash = context.intentDocHash;
+  }
+  if (note !== undefined && note.trim().length > 0) {
+    payload.note = note.trim();
+  }
+  return payload;
 }

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -1258,6 +1258,184 @@ export function validateIntentTension(v: unknown): IntentTensionData | null {
   return result;
 }
 
+// ── Intent Decision Record (PRI-470) ─────────────────────────────────────────
+//
+// Frontend mirror of the core IntentDecisionRecord type. Used by the Owner
+// Decision panel in PainPage and the Decision Summary section in IntentPage.
+// Validates untrusted JSON from the API before any UI code touches it (ERR-001).
+
+export interface IntentDecisionRecordData {
+  id: string;
+  painId?: string;
+  taskId?: string;
+  runId?: string;
+  intentDocHash?: string;
+  source: string;
+  evidenceStrength: string;
+  relatedIntentFields: string[];
+  ownerAction: string;
+  evidenceRefs: string[];
+  resultingCandidateId?: string;
+  resultingRuleCandidateId?: string;
+  patchProposalId?: string;
+  createdAt: string;
+}
+
+/**
+ * Validate an untrusted IntentDecisionRecord object from the API.
+ * Returns null when malformed (Rule 3: fail loud on missing/wrong-type fields).
+ *
+ * Enum fields (source, evidenceStrength, ownerAction) are validated against
+ * the same sets used by validateIntentTension. relatedIntentFields elements
+ * are validated against VALID_INTENT_RELATED_FIELDS.
+ */
+export function validateIntentDecisionRecord(v: unknown): IntentDecisionRecordData | null {
+  if (!isObject(v)) return null;
+
+  // Required fields (ERR-009: fail loud when missing or wrong type)
+  if (!Object.hasOwn(v, 'id') || !isString(v.id)) return null;
+  if (!Object.hasOwn(v, 'source') || !isString(v.source)) return null;
+  if (!(VALID_INTENT_TENSION_SOURCES as readonly string[]).includes(v.source)) return null;
+
+  if (!Object.hasOwn(v, 'evidenceStrength') || !isString(v.evidenceStrength)) return null;
+  if (!(VALID_EVIDENCE_STRENGTHS as readonly string[]).includes(v.evidenceStrength)) return null;
+
+  if (!Object.hasOwn(v, 'relatedIntentFields') || !Array.isArray(v.relatedIntentFields)) return null;
+  const relatedIntentFields: string[] = [];
+  for (const f of v.relatedIntentFields) {
+    if (typeof f !== 'string') return null;
+    if (!(VALID_INTENT_RELATED_FIELDS as readonly string[]).includes(f)) return null;
+    relatedIntentFields.push(f);
+  }
+
+  if (!Object.hasOwn(v, 'ownerAction') || !isString(v.ownerAction)) return null;
+  if (!(VALID_SUGGESTED_OWNER_ACTIONS as readonly string[]).includes(v.ownerAction)) return null;
+
+  if (!Object.hasOwn(v, 'evidenceRefs') || !Array.isArray(v.evidenceRefs)) return null;
+  const evidenceRefs: string[] = [];
+  for (const e of v.evidenceRefs) {
+    if (typeof e !== 'string') return null;
+    evidenceRefs.push(e);
+  }
+
+  if (!Object.hasOwn(v, 'createdAt') || !isString(v.createdAt)) return null;
+
+  const result: IntentDecisionRecordData = {
+    id: v.id,
+    source: v.source,
+    evidenceStrength: v.evidenceStrength,
+    relatedIntentFields,
+    ownerAction: v.ownerAction,
+    evidenceRefs,
+    createdAt: v.createdAt,
+  };
+
+  // Optional fields — fail loud when present but wrong type (ERR-009)
+  if (Object.hasOwn(v, 'painId')) {
+    if (!isString(v.painId)) return null;
+    result.painId = v.painId;
+  }
+  if (Object.hasOwn(v, 'taskId')) {
+    if (!isString(v.taskId)) return null;
+    result.taskId = v.taskId;
+  }
+  if (Object.hasOwn(v, 'runId')) {
+    if (!isString(v.runId)) return null;
+    result.runId = v.runId;
+  }
+  if (Object.hasOwn(v, 'intentDocHash')) {
+    if (!isString(v.intentDocHash)) return null;
+    result.intentDocHash = v.intentDocHash;
+  }
+  if (Object.hasOwn(v, 'resultingCandidateId')) {
+    if (!isString(v.resultingCandidateId)) return null;
+    result.resultingCandidateId = v.resultingCandidateId;
+  }
+  if (Object.hasOwn(v, 'resultingRuleCandidateId')) {
+    if (!isString(v.resultingRuleCandidateId)) return null;
+    result.resultingRuleCandidateId = v.resultingRuleCandidateId;
+  }
+  if (Object.hasOwn(v, 'patchProposalId')) {
+    if (!isString(v.patchProposalId)) return null;
+    result.patchProposalId = v.patchProposalId;
+  }
+
+  return result;
+}
+
+/**
+ * Validate a list of IntentDecisionRecord objects. Returns null if any
+ * element is malformed (ERR-005/007: validate array element types).
+ */
+export function validateIntentDecisionList(v: unknown): IntentDecisionRecordData[] | null {
+  return validateArray(v, validateIntentDecisionRecord);
+}
+
+export interface IntentDecisionResultData {
+  record: IntentDecisionRecordData;
+  created: boolean;
+}
+
+/**
+ * Validate the POST /api/v1/intent-decisions response envelope.
+ * Shape: { record: IntentDecisionRecord, created: boolean }
+ */
+export function validateIntentDecisionResult(v: unknown): IntentDecisionResultData | null {
+  if (!isObject(v)) return null;
+  if (!Object.hasOwn(v, 'record')) return null;
+  const record = validateIntentDecisionRecord(v.record);
+  if (record === null) return null;
+  if (!Object.hasOwn(v, 'created') || !isBoolean(v.created)) return null;
+  return { record, created: v.created };
+}
+
+export interface IntentDecisionSummaryData {
+  counts: {
+    confirm_drift: number;
+    revise_intent: number;
+    observe: number;
+    dismiss: number;
+    promote_to_principle: number;
+    promote_to_rulehost: number;
+  };
+  lastDecisionAt: string | null;
+}
+
+/**
+ * Validate the GET /api/v1/intent-decisions/summary response.
+ * All 6 count keys must be present with non-negative finite numbers.
+ * lastDecisionAt: null is valid, string is valid, anything else returns null.
+ */
+export function validateIntentDecisionSummary(v: unknown): IntentDecisionSummaryData | null {
+  if (!isObject(v)) return null;
+  if (!Object.hasOwn(v, 'counts') || !isObject(v.counts)) return null;
+  const { counts } = v;
+  // Explicit per-key checks so isNumber type guards narrow each property.
+  if (!Object.hasOwn(counts, 'confirm_drift') || !isNumber(counts.confirm_drift) || counts.confirm_drift < 0) return null;
+  if (!Object.hasOwn(counts, 'revise_intent') || !isNumber(counts.revise_intent) || counts.revise_intent < 0) return null;
+  if (!Object.hasOwn(counts, 'observe') || !isNumber(counts.observe) || counts.observe < 0) return null;
+  if (!Object.hasOwn(counts, 'dismiss') || !isNumber(counts.dismiss) || counts.dismiss < 0) return null;
+  if (!Object.hasOwn(counts, 'promote_to_principle') || !isNumber(counts.promote_to_principle) || counts.promote_to_principle < 0) return null;
+  if (!Object.hasOwn(counts, 'promote_to_rulehost') || !isNumber(counts.promote_to_rulehost) || counts.promote_to_rulehost < 0) return null;
+
+  // lastDecisionAt: null or string
+  if (!Object.hasOwn(v, 'lastDecisionAt')) return null;
+  const { lastDecisionAt } = v;
+  if (lastDecisionAt !== null && !isString(lastDecisionAt)) return null;
+
+  return {
+    counts: {
+      confirm_drift: counts.confirm_drift,
+      revise_intent: counts.revise_intent,
+      observe: counts.observe,
+      dismiss: counts.dismiss,
+      promote_to_principle: counts.promote_to_principle,
+      promote_to_rulehost: counts.promote_to_rulehost,
+    },
+    lastDecisionAt,
+  };
+}
+
 function validateEvidenceChainRecord(v: unknown): EvidenceChainRecordData | null {
   if (!isObject(v)) return null;
   // Required fields (ERR-009: fail loud when missing)

--- a/packages/pd-console/tests/server/routes/intent-decisions.test.ts
+++ b/packages/pd-console/tests/server/routes/intent-decisions.test.ts
@@ -1,0 +1,554 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { EventEmitter } from 'node:events';
+import * as yaml from 'js-yaml';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { SqliteConnection } from '@principles/core/runtime-v2';
+import { handleIntentDecisionsRoute, disposeIntentDecisionModels } from '../../../src/server/routes/intent-decisions.js';
+
+let workspaceDir: string;
+let pdDir: string;
+
+// ── Mock req/res helpers ────────────────────────────────────────────────────
+
+function makeGetReq(url: string): IncomingMessage {
+  const req = new EventEmitter();
+  Object.assign(req, { method: 'GET', url });
+  return req as unknown as IncomingMessage;
+}
+
+function makePostReq(url: string, body: unknown): IncomingMessage {
+  const req = new EventEmitter();
+  Object.assign(req, { method: 'POST', url });
+  // Defer emit so readBody's listeners attach first.
+  setImmediate(() => {
+    const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+    req.emit('data', Buffer.from(bodyStr, 'utf8'));
+    req.emit('end');
+  });
+  return req as unknown as IncomingMessage;
+}
+
+function makeRes(): ServerResponse {
+  const res = {
+    headersSent: false,
+    statusCode: 200,
+    _body: '',
+    writeHead: vi.fn(function (this: unknown, code: number) {
+      (res as { statusCode: number }).statusCode = code;
+      (res as { headersSent: boolean }).headersSent = true;
+      return this;
+    }),
+    end: vi.fn(function (this: unknown, data?: string) {
+      if (data !== undefined) {
+        (res as { _body: string })._body = data;
+      }
+      return this;
+    }),
+  } as unknown as ServerResponse;
+  return res;
+}
+
+function getBody(res: ServerResponse): string {
+  return (res as unknown as { _body: string })._body;
+}
+
+function getStatus(res: ServerResponse): number {
+  return (res as unknown as { statusCode: number }).statusCode;
+}
+
+function parseBody(res: ServerResponse): { success: boolean; data: Record<string, unknown> } {
+  return JSON.parse(getBody(res)) as { success: boolean; data: Record<string, unknown> };
+}
+
+function parseError(res: ServerResponse): {
+  success: boolean;
+  error: string;
+  message: string;
+  reason?: string;
+  nextAction?: string;
+} {
+  return JSON.parse(getBody(res)) as {
+    success: boolean;
+    error: string;
+    message: string;
+    reason?: string;
+    nextAction?: string;
+  };
+}
+
+// ── Workspace setup ─────────────────────────────────────────────────────────
+
+function writeConfig(intentEnabled: boolean): void {
+  const config = {
+    version: 1,
+    features: { intent_engineering: { category: 'quiet', enabled: intentEnabled } },
+    runtimeProfiles: { 'openclaw.default': { type: 'openclaw', source: 'default' } },
+    internalAgents: {
+      defaultRuntime: 'openclaw.default',
+      agents: {
+        diagnostician: { enabled: true, runtimeProfile: 'openclaw.default' },
+        dreamer: { enabled: true },
+        scribe: { enabled: true },
+      },
+    },
+    ui: { diagnostics: { mode: 'simple' } },
+  };
+  fs.writeFileSync(path.join(pdDir, 'config.yaml'), yaml.dump(config), 'utf8');
+}
+
+/** Pre-create state.db with the full schema (incl. intent_decisions table). */
+function initStateDb(): void {
+  const conn = new SqliteConnection({ workspaceDir });
+  conn.getDb(); // triggers lazy open + initSchema
+  conn.close();
+}
+
+const VALID_INPUT = {
+  id: 'idr-001',
+  painId: 'pain-001',
+  taskId: 'task-001',
+  runId: 'run-001',
+  intentDocHash: 'sha256:abc123',
+  source: 'action_drift',
+  evidenceStrength: 'moderate',
+  relatedIntentFields: ['why', 'desired_outcome'],
+  ownerAction: 'confirm_drift',
+  evidenceRefs: ['ev-1', 'ev-2'],
+  note: 'test note',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-intent-decisions-'));
+  pdDir = path.join(workspaceDir, '.pd');
+  fs.mkdirSync(pdDir, { recursive: true });
+  writeConfig(true);
+  initStateDb();
+});
+
+afterEach(() => {
+  disposeIntentDecisionModels();
+  try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ── Feature flag gate ───────────────────────────────────────────────────────
+
+describe('IntentDecisions route — flag gate', () => {
+  it('returns 403 when intent_engineering is disabled', async () => {
+    writeConfig(false);
+    const res = makeRes();
+    await handleIntentDecisionsRoute(makeGetReq('/api/v1/intent-decisions'), res, workspaceDir, '');
+    expect(getStatus(res)).toBe(403);
+    const body = parseError(res);
+    expect(body.success).toBe(false);
+    expect(body.reason).toBe('flag_disabled');
+    expect(body.nextAction).toContain('intent_engineering');
+  });
+
+  it('returns 403 when no config exists (defaults)', async () => {
+    fs.unlinkSync(path.join(pdDir, 'config.yaml'));
+    const res = makeRes();
+    await handleIntentDecisionsRoute(makeGetReq('/api/v1/intent-decisions'), res, workspaceDir, '');
+    expect(getStatus(res)).toBe(403);
+    expect(parseError(res).reason).toBe('flag_disabled');
+  });
+});
+
+// ── POST create ─────────────────────────────────────────────────────────────
+
+describe('IntentDecisions route — POST create', () => {
+  it('returns 201 with the created record', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', VALID_INPUT),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(201);
+    const parsed = parseBody(res);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.id).toBe('idr-001');
+    expect(parsed.data.painId).toBe('pain-001');
+    expect(parsed.data.source).toBe('action_drift');
+    expect(parsed.data.ownerAction).toBe('confirm_drift');
+    expect(parsed.data.evidenceRefs).toEqual(['ev-1', 'ev-2']);
+    expect(parsed.data.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns 200 with created=false on idempotent replay', async () => {
+    // First POST → 201
+    const res1 = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', VALID_INPUT),
+      res1,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res1)).toBe(201);
+
+    // Second POST with same painId + intentDocHash + ownerAction → 200, created=false
+    const replayInput = { ...VALID_INPUT, id: 'idr-002-different-id' };
+    const res2 = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', replayInput),
+      res2,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res2)).toBe(200);
+    const parsed = parseBody(res2);
+    expect(parsed.success).toBe(true);
+    // Idempotent replay returns the ORIGINAL record (idr-001), not the new id.
+    expect(parsed.data.id).toBe('idr-001');
+  });
+
+  it('truncates evidenceRefs to 3 items', async () => {
+    const input = {
+      ...VALID_INPUT,
+      id: 'idr-trunc',
+      evidenceRefs: ['ev-1', 'ev-2', 'ev-3', 'ev-4', 'ev-5'],
+    };
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', input),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(201);
+    const parsed = parseBody(res);
+    expect(parsed.data.evidenceRefs).toEqual(['ev-1', 'ev-2', 'ev-3']);
+  });
+});
+
+// ── POST validation ─────────────────────────────────────────────────────────
+
+describe('IntentDecisions route — POST validation', () => {
+  it('returns 400 when body is invalid JSON', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', '{not valid json'),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    const { id: _omit, ...noId } = VALID_INPUT;
+    void _omit;
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', noId),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    const body = parseError(res);
+    expect(body.message).toContain('id');
+  });
+
+  it('returns 400 when source is invalid', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', { ...VALID_INPUT, source: 'bogus' }),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('source');
+  });
+
+  it('returns 400 when evidenceStrength is invalid', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', { ...VALID_INPUT, evidenceStrength: 'bogus' }),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('evidenceStrength');
+  });
+
+  it('returns 400 when ownerAction is invalid', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', { ...VALID_INPUT, ownerAction: 'bogus' }),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('ownerAction');
+  });
+
+  it('returns 400 when relatedIntentFields contains an invalid field', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', { ...VALID_INPUT, relatedIntentFields: ['why', 'bogus'] }),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('relatedIntentFields');
+  });
+
+  it('returns 400 when evidenceRefs is not an array', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', { ...VALID_INPUT, evidenceRefs: 'not-an-array' }),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('evidenceRefs');
+  });
+
+  it('returns 400 when an optional field has the wrong type', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', { ...VALID_INPUT, note: 123 }),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('note');
+  });
+});
+
+// ── GET list ────────────────────────────────────────────────────────────────
+
+describe('IntentDecisions route — GET list', () => {
+  it('returns 400 when neither painId nor taskId is provided', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions'),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('painId or taskId');
+  });
+
+  it('returns 400 when both painId and taskId are provided', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions?painId=p1&taskId=t1'),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(400);
+    expect(parseError(res).message).toContain('not both');
+  });
+
+  it('lists records by painId', async () => {
+    // Seed a record
+    const seedRes = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', VALID_INPUT),
+      seedRes,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(seedRes)).toBe(201);
+
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions?painId=pain-001'),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    expect(Array.isArray(parsed.data)).toBe(true);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0]?.id).toBe('idr-001');
+  });
+
+  it('lists records by taskId', async () => {
+    const seedRes = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', VALID_INPUT),
+      seedRes,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(seedRes)).toBe(201);
+
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions?taskId=task-001'),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0]?.taskId).toBe('task-001');
+  });
+
+  it('returns empty array for unknown painId', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions?painId=nonexistent'),
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    expect(parsed.data).toEqual([]);
+  });
+});
+
+// ── GET /:id ────────────────────────────────────────────────────────────────
+
+describe('IntentDecisions route — GET /:id', () => {
+  it('returns 200 with the record when found', async () => {
+    const seedRes = makeRes();
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', VALID_INPUT),
+      seedRes,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(seedRes)).toBe(201);
+
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions/idr-001'),
+      res,
+      workspaceDir,
+      '/idr-001',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    expect(parsed.data.id).toBe('idr-001');
+  });
+
+  it('returns 404 when the record is not found', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions/nonexistent'),
+      res,
+      workspaceDir,
+      '/nonexistent',
+    );
+    expect(getStatus(res)).toBe(404);
+  });
+});
+
+// ── GET /summary + route precedence ─────────────────────────────────────────
+
+describe('IntentDecisions route — GET /summary and route precedence', () => {
+  it('returns 200 with empty summary when no records exist', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions/summary'),
+      res,
+      workspaceDir,
+      '/summary',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    expect(parsed.data.counts).toBeDefined();
+    const counts = parsed.data.counts as Record<string, number>;
+    expect(counts.confirm_drift).toBe(0);
+    expect(counts.observe).toBe(0);
+    expect(parsed.data.lastDecisionAt).toBeNull();
+  });
+
+  it('returns tallied counts after records are created', async () => {
+    // Seed two records with different ownerActions
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', VALID_INPUT),
+      makeRes(),
+      workspaceDir,
+      '',
+    );
+    await handleIntentDecisionsRoute(
+      makePostReq('/api/v1/intent-decisions', {
+        ...VALID_INPUT,
+        id: 'idr-002',
+        painId: 'pain-002',
+        ownerAction: 'observe',
+      }),
+      makeRes(),
+      workspaceDir,
+      '',
+    );
+
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions/summary'),
+      res,
+      workspaceDir,
+      '/summary',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    const counts = parsed.data.counts as Record<string, number>;
+    expect(counts.confirm_drift).toBe(1);
+    expect(counts.observe).toBe(1);
+    expect(parsed.data.lastDecisionAt).not.toBeNull();
+  });
+
+  it('matches /summary BEFORE /:id (route precedence)', async () => {
+    // If /:id matched first, GET /summary would 404 ("Intent decision summary not found").
+    // Since /summary matches first, it returns the summary object.
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions/summary'),
+      res,
+      workspaceDir,
+      '/summary',
+    );
+    expect(getStatus(res)).toBe(200);
+    const parsed = parseBody(res);
+    // The summary has a `counts` field; a 404 /:id response would not.
+    expect(parsed.data.counts).toBeDefined();
+  });
+});
+
+// ── Unknown route ───────────────────────────────────────────────────────────
+
+describe('IntentDecisions route — unknown sub-path', () => {
+  it('returns 404 for an unmatched sub-path', async () => {
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      makeGetReq('/api/v1/intent-decisions/foo/bar'),
+      res,
+      workspaceDir,
+      '/foo/bar',
+    );
+    expect(getStatus(res)).toBe(404);
+  });
+
+  it('returns 404 for PUT (unmatched method falls through)', async () => {
+    const req = new EventEmitter();
+    Object.assign(req, { method: 'PUT', url: '/api/v1/intent-decisions' });
+    const res = makeRes();
+    await handleIntentDecisionsRoute(
+      req as unknown as IncomingMessage,
+      res,
+      workspaceDir,
+      '',
+    );
+    expect(getStatus(res)).toBe(404);
+  });
+});

--- a/packages/pd-console/tests/ui/pain-card-logic.test.ts
+++ b/packages/pd-console/tests/ui/pain-card-logic.test.ts
@@ -4,9 +4,11 @@ import {
   buildCardLayers,
   shouldRenderIntentTensionPanel,
   shouldRenderFollowUpActions,
+  buildIntentDecisionPayload,
+  type IntentDecisionContext,
   type RecordData,
 } from '../../src/ui/pages/pain/pain-card-helpers.js';
-import type { IntentTensionData } from '../../src/ui/utils/validators.js';
+import type { IntentTensionData, IntentDecisionRecordData } from '../../src/ui/utils/validators.js';
 
 /**
  * PRI-344: Pure-function tests for the EvidenceChainCard refactoring.
@@ -291,10 +293,148 @@ describe('PRI-469: shouldRenderIntentTensionPanel (SPEC §22.1.3)', () => {
   });
 });
 
-// ── PRI-469: shouldRenderFollowUpActions (SPEC §22.1.4, stub for PRI-471) ─────
+// ── PRI-470: shouldRenderFollowUpActions (SPEC §22.1.4) ───────────────────────
 
-describe('PRI-469: shouldRenderFollowUpActions (stub for PRI-471)', () => {
-  it('always returns false in PRI-469 (follow-up actions not yet implemented)', () => {
-    expect(shouldRenderFollowUpActions()).toBe(false);
+function validDecisionRecord(overrides?: Partial<IntentDecisionRecordData>): IntentDecisionRecordData {
+  return {
+    id: 'decision_001',
+    source: 'action_drift',
+    evidenceStrength: 'strong',
+    relatedIntentFields: ['current_strategic_focus'],
+    ownerAction: 'confirm_drift',
+    evidenceRefs: ['e1', 'e2'],
+    createdAt: '2026-06-26T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('PRI-470: shouldRenderFollowUpActions (SPEC §22.1.4)', () => {
+  it('returns false for null', () => {
+    expect(shouldRenderFollowUpActions(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(shouldRenderFollowUpActions(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(shouldRenderFollowUpActions([])).toBe(false);
+  });
+
+  it('returns true for a non-empty decisions array', () => {
+    expect(shouldRenderFollowUpActions([validDecisionRecord()])).toBe(true);
+  });
+
+  it('returns true for an array with multiple decisions', () => {
+    expect(shouldRenderFollowUpActions([
+      validDecisionRecord({ id: 'd1' }),
+      validDecisionRecord({ id: 'd2' }),
+    ])).toBe(true);
+  });
+});
+
+// ── PRI-470: buildIntentDecisionPayload (SPEC §22.1) ──────────────────────────
+
+describe('PRI-470: buildIntentDecisionPayload', () => {
+  it('builds a full payload with all optional fields', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = {
+      recordId: 'pain_abc',
+      painId: 'pain_abc',
+      taskId: 'task_123',
+      intentDocHash: 'sha256:abc',
+    };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'confirm_drift', note: 'my note' });
+    expect(payload.taskId).toBe('task_123');
+    expect(payload.source).toBe('action_drift');
+    expect(payload.evidenceStrength).toBe('strong');
+    expect(payload.relatedIntentFields).toEqual(['current_strategic_focus', 'non_negotiables']);
+    expect(payload.evidence).toEqual(['e1', 'e2', 'e3']);
+    expect(payload.explanation).toBe(tension.explanation);
+    expect(payload.suggestedAction).toBe('confirm_drift');
+    expect(payload.ownerAction).toBe('confirm_drift');
+    expect(payload.painId).toBe('pain_abc');
+    expect(payload.intentDocHash).toBe('sha256:abc');
+    expect(payload.note).toBe('my note');
+  });
+
+  it('falls back to recordId when taskId is undefined', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = {
+      recordId: 'pain_abc',
+    };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe' });
+    expect(payload.taskId).toBe('pain_abc');
+  });
+
+  it('omits empty optional fields (empty painId, empty intentDocHash)', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = {
+      recordId: 'pain_abc',
+      painId: '',
+      intentDocHash: '',
+    };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe' });
+    expect(payload.painId).toBeUndefined();
+    expect(payload.intentDocHash).toBeUndefined();
+  });
+
+  it('omits painId and intentDocHash when not provided in context', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = {
+      recordId: 'pain_abc',
+    };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe' });
+    expect(payload.painId).toBeUndefined();
+    expect(payload.intentDocHash).toBeUndefined();
+  });
+
+  it('trims the note before including it', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = { recordId: 'pain_abc' };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe', note: '  trimmed note  ' });
+    expect(payload.note).toBe('trimmed note');
+  });
+
+  it('omits note when it is empty after trimming', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = { recordId: 'pain_abc' };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe', note: '   ' });
+    expect(payload.note).toBeUndefined();
+  });
+
+  it('omits note when note is undefined', () => {
+    const tension = validIntentTension();
+    const context: IntentDecisionContext = { recordId: 'pain_abc' };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe' });
+    expect(payload.note).toBeUndefined();
+  });
+
+  it('ownerAction overrides suggestedAction (different from suggested)', () => {
+    const tension = validIntentTension({ suggestedOwnerAction: 'confirm_drift' });
+    const context: IntentDecisionContext = { recordId: 'pain_abc' };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'revise_intent' });
+    // suggestedAction preserves the tension's suggestion
+    expect(payload.suggestedAction).toBe('confirm_drift');
+    // ownerAction is the Owner's chosen action, which may differ
+    expect(payload.ownerAction).toBe('revise_intent');
+    expect(payload.ownerAction).not.toBe(payload.suggestedAction);
+  });
+
+  it('evidence is NOT truncated (truncation is backend job)', () => {
+    const longEvidence = ['e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7'];
+    const tension = validIntentTension({ evidence: longEvidence });
+    const context: IntentDecisionContext = { recordId: 'pain_abc' };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe' });
+    // All 7 evidence items are preserved — frontend does not truncate
+    expect(payload.evidence).toHaveLength(7);
+    expect(payload.evidence).toEqual(longEvidence);
+  });
+
+  it('preserves empty evidence array as-is', () => {
+    const tension = validIntentTension({ evidence: [] });
+    const context: IntentDecisionContext = { recordId: 'pain_abc' };
+    const payload = buildIntentDecisionPayload(tension, context, { ownerAction: 'observe' });
+    expect(payload.evidence).toEqual([]);
   });
 });

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -203,6 +203,10 @@ const REQUIRED_SOURCE_FILES = [
   'pain-gate/index.ts',
   'detection/detection-funnel-policy.ts',
   'detection/index.ts',
+  // PRI-470: IntentDecisionRecord durable store + types (SPEC §21.7)
+  'intent/intent-decision-record.ts',
+  'store/intent/sqlite-intent-decision-store.ts',
+  'store/intent/index.ts',
 ] as const;
 
 // ── PRI-212: Plugin core anti-growth guard ────────────────────────────────────
@@ -489,6 +493,9 @@ const REQUIRED_TEST_FILES = [
   'build-l2-principle-reader.test.ts',
   // PRI-469
   'evidence-chain-intent-tension.test.ts',
+  // PRI-470: IntentDecisionRecord types + SQLite store
+  '../intent/__tests__/intent-decision-record.test.ts',
+  '../store/intent/__tests__/sqlite-intent-decision-store.test.ts',
 ];
 
 const REQUIRED_DOC_FILES: string[] = [];
@@ -561,6 +568,8 @@ describe('runtime-v2 public API (index.ts barrel)', () => {
     'buildL2PrincipleReaderFromLedger',
     // LLM output hardening — shared utility
     'stripFabricatedCorePrincipleIds',
+    // PRI-470: IntentDecisionRecord durable SQLite store
+    'SqliteIntentDecisionStore',
   ];
 
   for (const name of REQUIRED_EXPORTS) {

--- a/packages/principles-core/src/runtime-v2/diagnostician/diag-rootcause-output.ts
+++ b/packages/principles-core/src/runtime-v2/diagnostician/diag-rootcause-output.ts
@@ -131,6 +131,35 @@ export const SuggestedOwnerActionSchema = Type.Union([
 /** Suggested Owner action: confirm_drift | revise_intent | observe | dismiss | promote_to_principle | promote_to_rulehost */
 export type SuggestedOwnerAction = Static<typeof SuggestedOwnerActionSchema>;
 
+// ── Type guards for intent enums (PRI-470) ──────────────────────────────────
+// Runtime-safe guards so untrusted JSON (HTTP body, DB rows, artifact metadata)
+// can be validated without `as` bypasses (ERR-001, ERR-005).
+
+const INTENT_TENSION_SOURCES: readonly IntentTensionSource[] = ['none', 'action_drift', 'intent_suspect', 'healthy_tension'];
+const EVIDENCE_STRENGTHS: readonly EvidenceStrength[] = ['weak', 'moderate', 'strong'];
+const INTENT_RELATED_FIELDS: readonly IntentRelatedField[] = ['why', 'desired_outcome', 'non_negotiables', 'stop_escalation', 'current_strategic_focus'];
+const SUGGESTED_OWNER_ACTIONS: readonly SuggestedOwnerAction[] = ['confirm_drift', 'revise_intent', 'observe', 'dismiss', 'promote_to_principle', 'promote_to_rulehost'];
+
+/** Type guard: is `value` a valid IntentTensionSource? */
+export function isIntentTensionSource(value: unknown): value is IntentTensionSource {
+  return typeof value === 'string' && (INTENT_TENSION_SOURCES as readonly string[]).includes(value);
+}
+
+/** Type guard: is `value` a valid EvidenceStrength? */
+export function isEvidenceStrength(value: unknown): value is EvidenceStrength {
+  return typeof value === 'string' && (EVIDENCE_STRENGTHS as readonly string[]).includes(value);
+}
+
+/** Type guard: is `value` a valid IntentRelatedField? */
+export function isIntentRelatedField(value: unknown): value is IntentRelatedField {
+  return typeof value === 'string' && (INTENT_RELATED_FIELDS as readonly string[]).includes(value);
+}
+
+/** Type guard: is `value` a valid SuggestedOwnerAction? */
+export function isSuggestedOwnerAction(value: unknown): value is SuggestedOwnerAction {
+  return typeof value === 'string' && (SUGGESTED_OWNER_ACTIONS as readonly string[]).includes(value);
+}
+
 /**
  * IntentTension schema (SPEC §16.2).
  *

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -221,6 +221,10 @@ export {
   EvidenceStrengthSchema,
   IntentRelatedFieldSchema,
   SuggestedOwnerActionSchema,
+  isIntentTensionSource,
+  isEvidenceStrength,
+  isIntentRelatedField,
+  isSuggestedOwnerAction,
 } from './diagnostician/diag-rootcause-output.js';
 export type {
   IntentTension,
@@ -1701,4 +1705,12 @@ export type {
   IntentDocReadResult,
   IntentDocReference,
   IntentDocReadReason,
+  IntentDecisionRecord,
+  IntentDecisionInput,
+  IntentDecisionRecordResult,
+  IntentDecisionSummary,
+  IntentDecisionStore,
 } from './intent/index.js';
+
+// PRI-470: IntentDecisionRecord durable SQLite store (SPEC §21.7).
+export { SqliteIntentDecisionStore } from './store/intent/index.js';

--- a/packages/principles-core/src/runtime-v2/intent/__tests__/intent-decision-record.test.ts
+++ b/packages/principles-core/src/runtime-v2/intent/__tests__/intent-decision-record.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Type-level + smoke tests for IntentDecisionRecord contracts (PRI-470).
+ *
+ * These tests verify the SHAPE of the types (required vs optional fields,
+ * interface method signatures, type compatibility between Input and Record)
+ * so a refactor that breaks the SPEC §21.7 contract fails at test time.
+ */
+import { describe, it, expect } from 'vitest';
+import { expectTypeOf } from 'vitest';
+import type {
+  IntentDecisionRecord,
+  IntentDecisionInput,
+  IntentDecisionRecordResult,
+  IntentDecisionSummary,
+  IntentDecisionStore,
+} from '../intent-decision-record.js';
+import type {
+  IntentTensionSource,
+  EvidenceStrength,
+  IntentRelatedField,
+  SuggestedOwnerAction,
+} from '../../diagnostician/diag-rootcause-output.js';
+
+describe('IntentDecisionRecord type contract', () => {
+  it('has all SPEC §21.7 required and optional fields', () => {
+    const record: IntentDecisionRecord = {
+      id: 'rec-1',
+      painId: 'pain-1',
+      taskId: 'task-1',
+      runId: 'run-1',
+      intentDocHash: 'sha256:abc',
+      source: 'action_drift',
+      evidenceStrength: 'moderate',
+      relatedIntentFields: ['why'],
+      ownerAction: 'confirm_drift',
+      evidenceRefs: ['ref-1'],
+      resultingCandidateId: 'cand-1',
+      resultingRuleCandidateId: 'rule-1',
+      patchProposalId: 'patch-1',
+      createdAt: '2026-06-25T00:00:00.000Z',
+    };
+    expect(record.id).toBe('rec-1');
+    expect(record.source).toBe('action_drift');
+    expect(record.ownerAction).toBe('confirm_drift');
+  });
+
+  it('allows optional fields to be omitted', () => {
+    const record: IntentDecisionRecord = {
+      id: 'rec-2',
+      source: 'none',
+      evidenceStrength: 'weak',
+      relatedIntentFields: [],
+      ownerAction: 'observe',
+      evidenceRefs: [],
+      createdAt: '2026-06-25T00:00:00.000Z',
+    };
+    expect(record.painId).toBeUndefined();
+    expect(record.taskId).toBeUndefined();
+    expect(record.resultingCandidateId).toBeUndefined();
+  });
+
+  it('field types match the SPEC enums', () => {
+    expectTypeOf<IntentDecisionRecord['source']>().toExtend<IntentTensionSource>();
+    expectTypeOf<IntentDecisionRecord['evidenceStrength']>().toExtend<EvidenceStrength>();
+    expectTypeOf<IntentDecisionRecord['relatedIntentFields']>().toEqualTypeOf<IntentRelatedField[]>();
+    expectTypeOf<IntentDecisionRecord['ownerAction']>().toExtend<SuggestedOwnerAction>();
+    expectTypeOf<IntentDecisionRecord['evidenceRefs']>().toEqualTypeOf<string[]>();
+    expectTypeOf<IntentDecisionRecord['createdAt']>().toBeString();
+  });
+});
+
+describe('IntentDecisionInput type contract', () => {
+  it('requires id and enum fields, keeps lineage fields optional', () => {
+    const input: IntentDecisionInput = {
+      id: 'in-1',
+      source: 'intent_suspect',
+      evidenceStrength: 'strong',
+      relatedIntentFields: ['desired_outcome'],
+      ownerAction: 'revise_intent',
+      evidenceRefs: ['ref-a', 'ref-b'],
+    };
+    expect(input.id).toBe('in-1');
+    expect(input.painId).toBeUndefined();
+    expect(input.note).toBeUndefined();
+  });
+
+  it('accepts a note and full lineage', () => {
+    const input: IntentDecisionInput = {
+      id: 'in-2',
+      painId: 'pain-2',
+      taskId: 'task-2',
+      runId: 'run-2',
+      intentDocHash: 'sha256:def',
+      source: 'healthy_tension',
+      evidenceStrength: 'moderate',
+      relatedIntentFields: ['stop_escalation', 'current_strategic_focus'],
+      ownerAction: 'dismiss',
+      evidenceRefs: ['ref-c'],
+      note: 'owner dismissed as healthy trade-off',
+    };
+    expect(input.note).toBe('owner dismissed as healthy trade-off');
+  });
+
+  it('Input is assignable to a partial of Record (compatible shape)', () => {
+    // The store builds a Record from an Input + createdAt; this guard ensures
+    // every Input field name also exists on Record (no drift between shapes).
+    expectTypeOf<IntentDecisionInput>().toMatchTypeOf<Partial<IntentDecisionRecord>>();
+  });
+});
+
+describe('IntentDecisionRecordResult type contract', () => {
+  it('wraps a record with a created flag', () => {
+    const result: IntentDecisionRecordResult = {
+      record: {
+        id: 'rec-3',
+        source: 'action_drift',
+        evidenceStrength: 'weak',
+        relatedIntentFields: [],
+        ownerAction: 'promote_to_principle',
+        evidenceRefs: [],
+        createdAt: '2026-06-25T00:00:00.000Z',
+      },
+      created: true,
+    };
+    expect(result.created).toBe(true);
+    expect(result.record.id).toBe('rec-3');
+  });
+
+  it('created flag is a boolean', () => {
+    expectTypeOf<IntentDecisionRecordResult['created']>().toBeBoolean();
+    expectTypeOf<IntentDecisionRecordResult['record']>().toEqualTypeOf<IntentDecisionRecord>();
+  });
+});
+
+describe('IntentDecisionSummary type contract', () => {
+  it('holds counts for every SuggestedOwnerAction and a nullable lastDecisionAt', () => {
+    const summary: IntentDecisionSummary = {
+      counts: {
+        confirm_drift: 1,
+        revise_intent: 0,
+        observe: 2,
+        dismiss: 0,
+        promote_to_principle: 0,
+        promote_to_rulehost: 0,
+      },
+      lastDecisionAt: '2026-06-25T00:00:00.000Z',
+    };
+    expect(summary.counts.confirm_drift).toBe(1);
+    expect(summary.lastDecisionAt).not.toBeNull();
+  });
+
+  it('allows null lastDecisionAt for empty stores', () => {
+    const summary: IntentDecisionSummary = {
+      counts: {
+        confirm_drift: 0,
+        revise_intent: 0,
+        observe: 0,
+        dismiss: 0,
+        promote_to_principle: 0,
+        promote_to_rulehost: 0,
+      },
+      lastDecisionAt: null,
+    };
+    expect(summary.lastDecisionAt).toBeNull();
+  });
+
+  it('counts is a Record keyed by SuggestedOwnerAction', () => {
+    expectTypeOf<IntentDecisionSummary['counts']>().toEqualTypeOf<Record<SuggestedOwnerAction, number>>();
+    expectTypeOf<IntentDecisionSummary['lastDecisionAt']>().toEqualTypeOf<string | null>();
+  });
+});
+
+describe('IntentDecisionStore interface contract', () => {
+  it('exposes the five SPEC §21.7 methods', () => {
+    const store: IntentDecisionStore = {
+      record: async () => ({ record: {} as IntentDecisionRecord, created: true }),
+      getById: async () => null,
+      listByPainId: async () => [],
+      listByTaskId: async () => [],
+      getSummary: async () => ({
+        counts: {
+          confirm_drift: 0, revise_intent: 0, observe: 0, dismiss: 0,
+          promote_to_principle: 0, promote_to_rulehost: 0,
+        },
+        lastDecisionAt: null,
+      }),
+    };
+    expect(typeof store.record).toBe('function');
+    expect(typeof store.getById).toBe('function');
+    expect(typeof store.listByPainId).toBe('function');
+    expect(typeof store.listByTaskId).toBe('function');
+    expect(typeof store.getSummary).toBe('function');
+  });
+
+  it('record returns IntentDecisionRecordResult', () => {
+    expectTypeOf<IntentDecisionStore['record']>().returns.toEqualTypeOf<Promise<IntentDecisionRecordResult>>();
+  });
+
+  it('getById returns Record or null', () => {
+    expectTypeOf<IntentDecisionStore['getById']>().returns.toEqualTypeOf<Promise<IntentDecisionRecord | null>>();
+  });
+
+  it('listByPainId and listByTaskId return arrays', () => {
+    expectTypeOf<IntentDecisionStore['listByPainId']>().returns.toEqualTypeOf<Promise<IntentDecisionRecord[]>>();
+    expectTypeOf<IntentDecisionStore['listByTaskId']>().returns.toEqualTypeOf<Promise<IntentDecisionRecord[]>>();
+  });
+
+  it('getSummary returns IntentDecisionSummary', () => {
+    expectTypeOf<IntentDecisionStore['getSummary']>().returns.toEqualTypeOf<Promise<IntentDecisionSummary>>();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/intent/index.ts
+++ b/packages/principles-core/src/runtime-v2/intent/index.ts
@@ -1,3 +1,4 @@
 export * from './intent-doc.js';
 export * from './intent-friction-block.js';
 export * from './intent-doc-reader-port.js';
+export * from './intent-decision-record.js';

--- a/packages/principles-core/src/runtime-v2/intent/intent-decision-record.ts
+++ b/packages/principles-core/src/runtime-v2/intent/intent-decision-record.ts
@@ -1,0 +1,115 @@
+/**
+ * IntentDecisionRecord — durable audit record of Owner decisions on surfaced
+ * intentTension (PRI-470, SPEC §21.7).
+ *
+ * Owner decisions on intentTension MUST form an auditable record. This module
+ * defines the pure types and the store interface; the SQLite implementation
+ * lives in `runtime-v2/store/intent/`.
+ *
+ * Persistence boundary (SPEC §21.7):
+ * - Records are durable (state.db `intent_decisions` table), never transient.
+ * - Same `painId + intentDocHash + ownerAction` resubmission is idempotent.
+ * - Records are refresh-safe: read side can query by painId / taskId.
+ * - Write failure fails loud with reason + nextAction.
+ *
+ * ERR checklist:
+ * - EP-01 / ERR-001, ERR-005: enum fields validated via type guards, never `as`
+ * - EP-03 / ERR-002: store failures surface reason, never silent
+ * - EP-09: pure types — independently usable without I/O mocks
+ */
+
+import type {
+  IntentTensionSource,
+  EvidenceStrength,
+  IntentRelatedField,
+  SuggestedOwnerAction,
+} from '../diagnostician/diag-rootcause-output.js';
+
+/**
+ * Durable record of an Owner decision on a surfaced intentTension.
+ *
+ * Per SPEC §21.7, this is the minimal auditable field set. `evidenceRefs`
+ * MUST point to Pain Evidence, trace, Owner correction, or an INTENT field.
+ */
+export interface IntentDecisionRecord {
+  id: string;
+  painId?: string;
+  taskId?: string;
+  runId?: string;
+  intentDocHash?: string;
+  source: IntentTensionSource;
+  evidenceStrength: EvidenceStrength;
+  relatedIntentFields: IntentRelatedField[];
+  ownerAction: SuggestedOwnerAction;
+  evidenceRefs: string[];
+  resultingCandidateId?: string;
+  resultingRuleCandidateId?: string;
+  patchProposalId?: string;
+  createdAt: string;
+}
+
+/**
+ * Input for creating an IntentDecisionRecord.
+ *
+ * `id` is caller-supplied so the Console API can return the canonical id
+ * before persistence completes. `note` is an optional Owner free-text note
+ * that the store persists alongside the decision.
+ */
+export interface IntentDecisionInput {
+  id: string;
+  painId?: string;
+  taskId?: string;
+  runId?: string;
+  intentDocHash?: string;
+  source: IntentTensionSource;
+  evidenceStrength: EvidenceStrength;
+  relatedIntentFields: IntentRelatedField[];
+  ownerAction: SuggestedOwnerAction;
+  evidenceRefs: string[];
+  note?: string;
+}
+
+/**
+ * Result of recording a decision.
+ *
+ * `created=false` means an idempotent hit — the same decision already exists
+ * and `record` is the pre-existing record. Callers SHOULD return 200 (not 201)
+ * in this case so clients can distinguish a fresh write from a replay.
+ */
+export interface IntentDecisionRecordResult {
+  record: IntentDecisionRecord;
+  created: boolean;
+}
+
+/**
+ * Lightweight audit summary derived from IntentDecisionRecord (SPEC §22.1.1).
+ *
+ * `counts` holds a tally per SuggestedOwnerAction (every key is present,
+ * defaulting to 0). `lastDecisionAt` is the most recent `createdAt` across
+ * all records, or null when no records exist.
+ */
+export interface IntentDecisionSummary {
+  counts: Record<SuggestedOwnerAction, number>;
+  lastDecisionAt: string | null;
+}
+
+/**
+ * Durable store contract for IntentDecisionRecord (SPEC §21.7 persistence).
+ *
+ * Implementations MUST:
+ * - Be idempotent on (painId + intentDocHash + ownerAction) when painId is
+ *   non-null; fall back to (taskId + intentDocHash + ownerAction) when painId
+ *   is null.
+ * - Store immutable snapshots of source / evidenceStrength /
+ *   relatedIntentFields / evidenceRefs so the audit trail stays accurate even
+ *   if the underlying artifact is later modified.
+ * - Truncate evidence to max 3 items before storing.
+ * - Fail loud (throw) on write failure — never return a silent "success".
+ */
+export interface IntentDecisionStore {
+  record(input: IntentDecisionInput): Promise<IntentDecisionRecordResult>;
+  getById(id: string): Promise<IntentDecisionRecord | null>;
+  listByPainId(painId: string): Promise<IntentDecisionRecord[]>;
+  listByTaskId(taskId: string): Promise<IntentDecisionRecord[]>;
+  getSummary(): Promise<IntentDecisionSummary>;
+}

--- a/packages/principles-core/src/runtime-v2/store/intent/__tests__/sqlite-intent-decision-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/intent/__tests__/sqlite-intent-decision-store.test.ts
@@ -1,0 +1,235 @@
+/**
+ * SqliteIntentDecisionStore tests (PRI-470).
+ *
+ * Verifies idempotency, snapshot storage, evidence truncation, ordering, and
+ * summary aggregation against a real SQLite database.
+ *
+ * ERR checklist:
+ * - EP-01 / ERR-001, ERR-005: store treats DB rows as unknown and validates via guards
+ * - EP-03 / ERR-002: write failures throw (fail loud), never silent
+ * - EP-07 / ERR-015, ERR-018: idempotency distinguishes current vs recorded state
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import { SqliteConnection } from '../../sqlite-connection.js';
+import { SqliteIntentDecisionStore } from '../sqlite-intent-decision-store.js';
+import type { IntentDecisionInput } from '../../../intent/intent-decision-record.js';
+
+function createTestConnection(): SqliteConnection {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-test-intent-decision-'));
+  return new SqliteConnection(tmpDir);
+}
+
+function makeInput(overrides: Partial<IntentDecisionInput> = {}): IntentDecisionInput {
+  return {
+    id: 'rec-' + Math.random().toString(36).slice(2, 8),
+    painId: 'pain-1',
+    taskId: 'task-1',
+    runId: 'run-1',
+    intentDocHash: 'sha256:abc',
+    source: 'action_drift',
+    evidenceStrength: 'moderate',
+    relatedIntentFields: ['why'],
+    ownerAction: 'confirm_drift',
+    evidenceRefs: ['ref-1', 'ref-2'],
+    ...overrides,
+  };
+}
+
+describe('SqliteIntentDecisionStore', () => {
+  let connection = null as unknown as SqliteConnection;
+  let store = null as unknown as SqliteIntentDecisionStore;
+
+  beforeEach(() => {
+    connection = createTestConnection();
+    // Touch getDb() so the schema (including intent_decisions) is initialized.
+    connection.getDb();
+    store = new SqliteIntentDecisionStore(connection);
+  });
+
+  afterEach(() => {
+    connection?.close();
+  });
+
+  describe('record()', () => {
+    it('creates a new record with correct fields', async () => {
+      const input = makeInput({ id: 'rec-new' });
+      const result = await store.record(input);
+      expect(result.created).toBe(true);
+      expect(result.record.id).toBe('rec-new');
+      expect(result.record.painId).toBe('pain-1');
+      expect(result.record.taskId).toBe('task-1');
+      expect(result.record.source).toBe('action_drift');
+      expect(result.record.evidenceStrength).toBe('moderate');
+      expect(result.record.relatedIntentFields).toEqual(['why']);
+      expect(result.record.ownerAction).toBe('confirm_drift');
+      expect(result.record.evidenceRefs).toEqual(['ref-1', 'ref-2']);
+      expect(result.record.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('is idempotent when same painId + intentDocHash + ownerAction is resubmitted', async () => {
+      const input = makeInput({ id: 'rec-first', painId: 'pain-1', intentDocHash: 'sha256:abc', ownerAction: 'confirm_drift' });
+      const first = await store.record(input);
+      expect(first.created).toBe(true);
+
+      // Same idempotency key, different id — must return the existing record.
+      const replay = await store.record(makeInput({ id: 'rec-second', painId: 'pain-1', intentDocHash: 'sha256:abc', ownerAction: 'confirm_drift' }));
+      expect(replay.created).toBe(false);
+      expect(replay.record.id).toBe('rec-first');
+    });
+
+    it('does NOT treat different ownerAction as idempotent', async () => {
+      await store.record(makeInput({ id: 'rec-a', painId: 'pain-1', intentDocHash: 'sha256:abc', ownerAction: 'confirm_drift' }));
+      const second = await store.record(makeInput({ id: 'rec-b', painId: 'pain-1', intentDocHash: 'sha256:abc', ownerAction: 'observe' }));
+      expect(second.created).toBe(true);
+      expect(second.record.id).toBe('rec-b');
+    });
+
+    it('with null painId uses taskId-based idempotency', async () => {
+      const input = makeInput({
+        id: 'rec-task-1',
+        painId: undefined,
+        taskId: 'task-X',
+        intentDocHash: 'sha256:xyz',
+        ownerAction: 'dismiss',
+      });
+      const first = await store.record(input);
+      expect(first.created).toBe(true);
+
+      const replay = await store.record(makeInput({
+        id: 'rec-task-2',
+        painId: undefined,
+        taskId: 'task-X',
+        intentDocHash: 'sha256:xyz',
+        ownerAction: 'dismiss',
+      }));
+      expect(replay.created).toBe(false);
+      expect(replay.record.id).toBe('rec-task-1');
+    });
+
+    it('with null painId and null intentDocHash still idempotency-checks via IS operator', async () => {
+      await store.record(makeInput({
+        id: 'rec-null-1', painId: undefined, taskId: 'task-Y', intentDocHash: undefined, ownerAction: 'observe',
+      }));
+      const replay = await store.record(makeInput({
+        id: 'rec-null-2', painId: undefined, taskId: 'task-Y', intentDocHash: undefined, ownerAction: 'observe',
+      }));
+      expect(replay.created).toBe(false);
+      expect(replay.record.id).toBe('rec-null-1');
+    });
+
+    it('truncates evidence to max 3 items', async () => {
+      const input = makeInput({ id: 'rec-trunc', evidenceRefs: ['r1', 'r2', 'r3', 'r4', 'r5'] });
+      const result = await store.record(input);
+      expect(result.record.evidenceRefs).toEqual(['r1', 'r2', 'r3']);
+    });
+
+    it('stores immutable snapshots matching the decision-time values', async () => {
+      const input = makeInput({
+        id: 'rec-snap',
+        source: 'intent_suspect',
+        evidenceStrength: 'strong',
+        relatedIntentFields: ['why', 'desired_outcome'],
+        evidenceRefs: ['e1', 'e2'],
+      });
+      const result = await store.record(input);
+      // Read the raw row to verify snapshot columns exist and match.
+      const row = connection.getDb().prepare('SELECT source_snapshot, evidence_strength_snapshot, related_intent_fields_snapshot, evidence_refs_snapshot FROM intent_decisions WHERE id = ?').get(result.record.id) as {
+        source_snapshot: string;
+        evidence_strength_snapshot: string;
+        related_intent_fields_snapshot: string;
+        evidence_refs_snapshot: string;
+      };
+      expect(row.source_snapshot).toBe('intent_suspect');
+      expect(row.evidence_strength_snapshot).toBe('strong');
+      expect(JSON.parse(row.related_intent_fields_snapshot)).toEqual(['why', 'desired_outcome']);
+      expect(JSON.parse(row.evidence_refs_snapshot)).toEqual(['e1', 'e2']);
+    });
+
+    it('persists the optional note when provided', async () => {
+      const result = await store.record(makeInput({ id: 'rec-note', note: 'owner note text' }));
+      const row = connection.getDb().prepare('SELECT note FROM intent_decisions WHERE id = ?').get(result.record.id) as { note: string | null };
+      expect(row.note).toBe('owner note text');
+    });
+  });
+
+  describe('getById()', () => {
+    it('returns the record when found', async () => {
+      const created = await store.record(makeInput({ id: 'rec-get' }));
+      const found = await store.getById('rec-get');
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe('rec-get');
+      expect(found?.source).toBe(created.record.source);
+    });
+
+    it('returns null when not found', async () => {
+      const found = await store.getById('does-not-exist');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('listByPainId()', () => {
+    it('returns records ordered by createdAt DESC', async () => {
+      await store.record(makeInput({ id: 'r1', painId: 'pain-list', ownerAction: 'confirm_drift' }));
+      await new Promise((r) => setTimeout(r, 10));
+      await store.record(makeInput({ id: 'r2', painId: 'pain-list', ownerAction: 'observe', intentDocHash: 'sha256:other' }));
+      const list = await store.listByPainId('pain-list');
+      expect(list).toHaveLength(2);
+      expect(list[0]?.id).toBe('r2');
+      expect(list[1]?.id).toBe('r1');
+    });
+
+    it('returns empty array for unknown painId', async () => {
+      const list = await store.listByPainId('unknown');
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe('listByTaskId()', () => {
+    it('returns records ordered by createdAt DESC', async () => {
+      await store.record(makeInput({ id: 't1', taskId: 'task-list', painId: 'p1', intentDocHash: 'h1', ownerAction: 'confirm_drift' }));
+      await new Promise((r) => setTimeout(r, 10));
+      await store.record(makeInput({ id: 't2', taskId: 'task-list', painId: 'p2', intentDocHash: 'h2', ownerAction: 'observe' }));
+      const list = await store.listByTaskId('task-list');
+      expect(list).toHaveLength(2);
+      expect(list[0]?.id).toBe('t2');
+      expect(list[1]?.id).toBe('t1');
+    });
+
+    it('returns empty array for unknown taskId', async () => {
+      const list = await store.listByTaskId('unknown');
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe('getSummary()', () => {
+    it('returns all-zero counts and null lastDecisionAt when no records exist', async () => {
+      const summary = await store.getSummary();
+      expect(summary.lastDecisionAt).toBeNull();
+      expect(summary.counts).toEqual({
+        confirm_drift: 0,
+        revise_intent: 0,
+        observe: 0,
+        dismiss: 0,
+        promote_to_principle: 0,
+        promote_to_rulehost: 0,
+      });
+    });
+
+    it('returns counts per ownerAction and the most recent lastDecisionAt', async () => {
+      await store.record(makeInput({ id: 's1', painId: 'p1', intentDocHash: 'h1', ownerAction: 'confirm_drift' }));
+      await store.record(makeInput({ id: 's2', painId: 'p2', intentDocHash: 'h2', ownerAction: 'confirm_drift' }));
+      await store.record(makeInput({ id: 's3', painId: 'p3', intentDocHash: 'h3', ownerAction: 'observe' }));
+      const summary = await store.getSummary();
+      expect(summary.counts.confirm_drift).toBe(2);
+      expect(summary.counts.observe).toBe(1);
+      expect(summary.counts.dismiss).toBe(0);
+      expect(summary.counts.revise_intent).toBe(0);
+      expect(summary.counts.promote_to_principle).toBe(0);
+      expect(summary.counts.promote_to_rulehost).toBe(0);
+      expect(summary.lastDecisionAt).not.toBeNull();
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/store/intent/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/intent/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Barrel for the IntentDecisionRecord SQLite store (PRI-470).
+ */
+export { SqliteIntentDecisionStore } from './sqlite-intent-decision-store.js';
+export type { IntentDecisionStore } from '../../intent/intent-decision-record.js';

--- a/packages/principles-core/src/runtime-v2/store/intent/sqlite-intent-decision-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/intent/sqlite-intent-decision-store.ts
@@ -1,0 +1,314 @@
+/**
+ * SqliteIntentDecisionStore — SQLite implementation of IntentDecisionStore.
+ *
+ * PRI-470 / SPEC §21.7 durable persistence for Owner decisions on
+ * intentTension. Records are written to the `intent_decisions` table
+ * (schema created by SqliteConnection.initSchema).
+ *
+ * Idempotency (SPEC §21.7 req 4):
+ * - When `painId` is non-null: dedupe on (pain_id, intent_doc_hash, owner_action).
+ * - When `painId` is null: dedupe on (task_id, intent_doc_hash, owner_action)
+ *   using the NULL-safe `IS` operator so a null intentDocHash compares equal.
+ *
+ * Snapshots (SPEC §21.7 audit boundary):
+ * - source / evidenceStrength / relatedIntentFields / evidenceRefs are stored
+ *   twice: once in the live columns and once in the `_snapshot` columns. The
+ *   snapshot is the immutable audit copy; the live columns mirror it at write
+ *   time. This keeps the audit trail accurate even if a future migration or
+ *   artifact change alters the live columns.
+ *
+ * ERR checklist:
+ * - EP-01 / ERR-001, ERR-005: DB rows treated as unknown, mapped via guards
+ * - EP-03 / ERR-002: write failures throw (fail loud)
+ * - EP-07 / ERR-015, ERR-018: idempotency SELECT reads fresh state each call
+ */
+
+import type { SqliteConnection } from '../sqlite-connection.js';
+import type {
+  IntentDecisionInput,
+  IntentDecisionRecord,
+  IntentDecisionRecordResult,
+  IntentDecisionSummary,
+  IntentDecisionStore,
+} from '../../intent/intent-decision-record.js';
+import type {
+  IntentTensionSource,
+  EvidenceStrength,
+  IntentRelatedField,
+  SuggestedOwnerAction,
+} from '../../diagnostician/diag-rootcause-output.js';
+import {
+  isIntentTensionSource,
+  isEvidenceStrength,
+  isIntentRelatedField,
+  isSuggestedOwnerAction,
+} from '../../diagnostician/diag-rootcause-output.js';
+
+const MAX_EVIDENCE_REFS = 3;
+
+interface IntentDecisionRow {
+  id: string;
+  pain_id: string | null;
+  task_id: string;
+  run_id: string | null;
+  intent_doc_hash: string | null;
+  source: string;
+  evidence_strength: string;
+  related_intent_fields: string;
+  owner_action: string;
+  evidence_refs: string;
+  source_snapshot: string;
+  evidence_strength_snapshot: string;
+  related_intent_fields_snapshot: string;
+  evidence_refs_snapshot: string;
+  resulting_candidate_id: string | null;
+  resulting_rule_candidate_id: string | null;
+  patch_proposal_id: string | null;
+  created_at: string;
+}
+
+function parseStringArray(raw: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((v): v is string => typeof v === 'string');
+}
+
+// ── Row type guards (Runtime Contract Rule 2: no `as` bypass) ────────────────
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isIntentDecisionRow(v: unknown): v is IntentDecisionRow {
+  if (!isRecord(v)) return false;
+  if (typeof v.id !== 'string') return false;
+  if (v.pain_id !== null && typeof v.pain_id !== 'string') return false;
+  if (typeof v.task_id !== 'string') return false;
+  if (v.run_id !== null && typeof v.run_id !== 'string') return false;
+  if (v.intent_doc_hash !== null && typeof v.intent_doc_hash !== 'string') return false;
+  if (typeof v.source !== 'string') return false;
+  if (typeof v.evidence_strength !== 'string') return false;
+  if (typeof v.related_intent_fields !== 'string') return false;
+  if (typeof v.owner_action !== 'string') return false;
+  if (typeof v.evidence_refs !== 'string') return false;
+  if (typeof v.source_snapshot !== 'string') return false;
+  if (typeof v.evidence_strength_snapshot !== 'string') return false;
+  if (typeof v.related_intent_fields_snapshot !== 'string') return false;
+  if (typeof v.evidence_refs_snapshot !== 'string') return false;
+  if (v.resulting_candidate_id !== null && typeof v.resulting_candidate_id !== 'string') return false;
+  if (v.resulting_rule_candidate_id !== null && typeof v.resulting_rule_candidate_id !== 'string') return false;
+  if (v.patch_proposal_id !== null && typeof v.patch_proposal_id !== 'string') return false;
+  if (typeof v.created_at !== 'string') return false;
+  return true;
+}
+
+interface SummaryRow {
+  owner_action: string;
+  cnt: number;
+  last_at: string | null;
+}
+
+function isSummaryRow(v: unknown): v is SummaryRow {
+  if (!isRecord(v)) return false;
+  if (typeof v.owner_action !== 'string') return false;
+  if (typeof v.cnt !== 'number' || !Number.isFinite(v.cnt)) return false;
+  if (v.last_at !== null && typeof v.last_at !== 'string') return false;
+  return true;
+}
+
+function zeroCounts(): Record<SuggestedOwnerAction, number> {
+  return {
+    confirm_drift: 0,
+    revise_intent: 0,
+    observe: 0,
+    dismiss: 0,
+    promote_to_principle: 0,
+    promote_to_rulehost: 0,
+  };
+}
+
+function mapRow(r: IntentDecisionRow): IntentDecisionRecord {
+  // Validate enum fields read from the DB (ERR-001). Snapshot columns are the
+  // auditable source of truth, so we read from them; the live column is a
+  // secondary fallback. Both are written by this store, so they should always
+  // be valid — the defaults below are defensive against DB corruption.
+  const source: IntentTensionSource = isIntentTensionSource(r.source_snapshot)
+    ? r.source_snapshot
+    : isIntentTensionSource(r.source)
+      ? r.source
+      : 'none';
+  const evidenceStrength: EvidenceStrength = isEvidenceStrength(r.evidence_strength_snapshot)
+    ? r.evidence_strength_snapshot
+    : isEvidenceStrength(r.evidence_strength)
+      ? r.evidence_strength
+      : 'weak';
+  const ownerAction: SuggestedOwnerAction = isSuggestedOwnerAction(r.owner_action)
+    ? r.owner_action
+    : 'observe';
+
+  const fieldsRaw = parseStringArray(r.related_intent_fields_snapshot);
+  const relatedIntentFields: IntentRelatedField[] = fieldsRaw.length > 0
+    ? fieldsRaw.filter(isIntentRelatedField)
+    : parseStringArray(r.related_intent_fields).filter(isIntentRelatedField);
+
+  const evidenceRefs = parseStringArray(r.evidence_refs_snapshot);
+
+  const record: IntentDecisionRecord = {
+    id: r.id,
+    source,
+    evidenceStrength,
+    relatedIntentFields,
+    ownerAction,
+    evidenceRefs,
+    createdAt: r.created_at,
+  };
+  if (r.pain_id !== null) record.painId = r.pain_id;
+  if (r.run_id !== null) record.runId = r.run_id;
+  if (r.intent_doc_hash !== null) record.intentDocHash = r.intent_doc_hash;
+  // task_id is NOT NULL in the schema, but the type marks it optional — only
+  // surface it when it is non-empty so an empty string does not masquerade as
+  // a real lineage id.
+  if (r.task_id !== '') record.taskId = r.task_id;
+  if (r.resulting_candidate_id !== null) record.resultingCandidateId = r.resulting_candidate_id;
+  if (r.resulting_rule_candidate_id !== null) record.resultingRuleCandidateId = r.resulting_rule_candidate_id;
+  if (r.patch_proposal_id !== null) record.patchProposalId = r.patch_proposal_id;
+  return record;
+}
+
+export class SqliteIntentDecisionStore implements IntentDecisionStore {
+  constructor(private readonly connection: SqliteConnection) {}
+
+  async record(input: IntentDecisionInput): Promise<IntentDecisionRecordResult> {
+    const db = this.connection.getDb();
+
+    // Truncate evidence to the SPEC §22.1.2 maximum of 3 items.
+    const truncatedEvidence = input.evidenceRefs.slice(0, MAX_EVIDENCE_REFS);
+    const relatedFieldsJson = JSON.stringify(input.relatedIntentFields);
+    const evidenceRefsJson = JSON.stringify(truncatedEvidence);
+    const createdAt = new Date().toISOString();
+
+    // ── Idempotency check ──────────────────────────────────────────────────
+    // SPEC §21.7 req 4: same painId + intentDocHash + ownerAction must be
+    // idempotent. When painId is null, fall back to taskId-based dedupe.
+    let existing: IntentDecisionRow | undefined;
+    if (input.painId !== undefined) {
+      const row = db.prepare(
+        'SELECT * FROM intent_decisions WHERE pain_id = ? AND intent_doc_hash IS ? AND owner_action = ? LIMIT 1',
+      ).get(input.painId, input.intentDocHash ?? null, input.ownerAction);
+      if (isIntentDecisionRow(row)) existing = row;
+    } else {
+      const taskId = input.taskId ?? '';
+      const row = db.prepare(
+        'SELECT * FROM intent_decisions WHERE pain_id IS NULL AND task_id = ? AND intent_doc_hash IS ? AND owner_action = ? LIMIT 1',
+      ).get(taskId, input.intentDocHash ?? null, input.ownerAction);
+      if (isIntentDecisionRow(row)) existing = row;
+    }
+
+    if (existing) {
+      return { record: mapRow(existing), created: false };
+    }
+
+    // ── Insert ─────────────────────────────────────────────────────────────
+    db.prepare(`
+      INSERT INTO intent_decisions (
+        id, pain_id, task_id, run_id, intent_doc_hash,
+        source, evidence_strength, related_intent_fields, owner_action, evidence_refs,
+        note,
+        source_snapshot, evidence_strength_snapshot,
+        related_intent_fields_snapshot, evidence_refs_snapshot,
+        resulting_candidate_id, resulting_rule_candidate_id, patch_proposal_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.id,
+      input.painId ?? null,
+      input.taskId ?? '',
+      input.runId ?? null,
+      input.intentDocHash ?? null,
+      input.source,
+      input.evidenceStrength,
+      relatedFieldsJson,
+      input.ownerAction,
+      evidenceRefsJson,
+      input.note ?? null,
+      // Snapshots — immutable audit copies (identical to live values at write time).
+      input.source,
+      input.evidenceStrength,
+      relatedFieldsJson,
+      evidenceRefsJson,
+      null,
+      null,
+      null,
+      createdAt,
+    );
+
+    const record: IntentDecisionRecord = {
+      id: input.id,
+      source: input.source,
+      evidenceStrength: input.evidenceStrength,
+      relatedIntentFields: [...input.relatedIntentFields],
+      ownerAction: input.ownerAction,
+      evidenceRefs: [...truncatedEvidence],
+      createdAt,
+    };
+    if (input.painId !== undefined) record.painId = input.painId;
+    if (input.taskId !== undefined) record.taskId = input.taskId;
+    if (input.runId !== undefined) record.runId = input.runId;
+    if (input.intentDocHash !== undefined) record.intentDocHash = input.intentDocHash;
+
+    return { record, created: true };
+  }
+
+  async getById(id: string): Promise<IntentDecisionRecord | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare('SELECT * FROM intent_decisions WHERE id = ?').get(id);
+    if (!isIntentDecisionRow(row)) return null;
+    return mapRow(row);
+  }
+
+  async listByPainId(painId: string): Promise<IntentDecisionRecord[]> {
+    const db = this.connection.getDb();
+    const rawRows = db.prepare(
+      'SELECT * FROM intent_decisions WHERE pain_id = ? ORDER BY created_at DESC',
+    ).all(painId);
+    if (!Array.isArray(rawRows)) return [];
+    return rawRows.filter(isIntentDecisionRow).map(mapRow);
+  }
+
+  async listByTaskId(taskId: string): Promise<IntentDecisionRecord[]> {
+    const db = this.connection.getDb();
+    const rawRows = db.prepare(
+      'SELECT * FROM intent_decisions WHERE task_id = ? ORDER BY created_at DESC',
+    ).all(taskId);
+    if (!Array.isArray(rawRows)) return [];
+    return rawRows.filter(isIntentDecisionRow).map(mapRow);
+  }
+
+  async getSummary(): Promise<IntentDecisionSummary> {
+    const db = this.connection.getDb();
+    const rawRows = db.prepare(
+      'SELECT owner_action, COUNT(*) AS cnt, MAX(created_at) AS last_at FROM intent_decisions GROUP BY owner_action',
+    ).all();
+    if (!Array.isArray(rawRows)) return { counts: zeroCounts(), lastDecisionAt: null };
+    const rows: SummaryRow[] = rawRows.filter(isSummaryRow);
+
+    const counts = zeroCounts();
+    let lastDecisionAt: string | null = null;
+
+    for (const row of rows) {
+      if (isSuggestedOwnerAction(row.owner_action)) {
+        counts[row.owner_action] = row.cnt;
+      }
+      if (row.last_at && (lastDecisionAt === null || row.last_at > lastDecisionAt)) {
+        lastDecisionAt = row.last_at;
+      }
+    }
+
+    return { counts, lastDecisionAt };
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
@@ -374,6 +374,40 @@ export class SqliteConnection {
       CREATE INDEX IF NOT EXISTS idx_confirm_first_state_last_seen
         ON confirm_first_state(last_seen_at);
     `);
+
+    // PRI-470: IntentDecisionRecord durable store (SPEC §21.7).
+    // Stores immutable snapshots of source / evidenceStrength /
+    // relatedIntentFields / evidenceRefs so the audit trail stays accurate
+    // even if the underlying artifact is later modified.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS intent_decisions (
+        id TEXT PRIMARY KEY,
+        pain_id TEXT,
+        task_id TEXT NOT NULL,
+        run_id TEXT,
+        intent_doc_hash TEXT,
+        source TEXT NOT NULL,
+        evidence_strength TEXT NOT NULL,
+        related_intent_fields TEXT NOT NULL,
+        owner_action TEXT NOT NULL,
+        evidence_refs TEXT NOT NULL,
+        note TEXT,
+        source_snapshot TEXT NOT NULL,
+        evidence_strength_snapshot TEXT NOT NULL,
+        related_intent_fields_snapshot TEXT NOT NULL,
+        evidence_refs_snapshot TEXT NOT NULL,
+        resulting_candidate_id TEXT,
+        resulting_rule_candidate_id TEXT,
+        patch_proposal_id TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_intent_decisions_pain_id ON intent_decisions(pain_id);
+      CREATE INDEX IF NOT EXISTS idx_intent_decisions_task_id ON intent_decisions(task_id);
+      CREATE INDEX IF NOT EXISTS idx_intent_decisions_owner_action ON intent_decisions(owner_action);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_intent_decisions_pain_hash_action
+        ON intent_decisions(pain_id, intent_doc_hash, owner_action)
+        WHERE pain_id IS NOT NULL;
+    `);
   }
 
   private migrateSchema(): void {


### PR DESCRIPTION
## Summary

Implements PRI-470: durable `IntentDecisionRecord` persistence so Owner decisions on surfaced `intentTension` are recorded as an auditable, refresh-safe record before any follow-up action is exposed.

Closes PRI-470. Parent: PRI-465.

## MVP Three Questions

**1. What happens if we DON'T do this?**
Owner decisions on intentTension would exist only in frontend memory — lost on page refresh. No audit trail. Follow-up actions (promote to principle, revise intent) would have no durable decision backing them. This would violate SPEC §21.7 and §22.1.4.

**2. How is it observed?**
- Pain Page: OwnerDecisionPanel shows 6 action buttons; after clicking, "Decision recorded" appears
- Intent Page: bottom section shows IntentDecisionSummary (counts per ownerAction + lastDecisionAt)
- API: `GET /api/v1/intent-decisions?painId=X` returns persisted records after refresh

**3. How is it disabled?**
`intent_engineering` feature flag gates all endpoints (403 with `reason: 'flag_disabled'` when off). Flag off = no new decisions can be written, but historical records are preserved (SPEC §21.7 req 3).

**4. Emotional value**
- Reduces **失控感** (loss of control): Owner sees their decisions are durably recorded, not lost on refresh
- Creates **沉淀感** (accumulation): IntentDecisionSummary on Intent Page shows growing audit trail
- Creates **安心感** (peace of mind): Follow-up actions only appear after a decision is persisted — no accidental promotion

## Changes

### Backend (principles-core)
- `intent-decision-record.ts` — Core types: IntentDecisionRecord, IntentDecisionInput, IntentDecisionRecordResult, IntentDecisionSummary, IntentDecisionStore interface
- `sqlite-intent-decision-store.ts` — SQLite store with idempotency on (painId + intentDocHash + ownerAction), immutable snapshots, evidence truncation (max 3)
- `sqlite-connection.ts` — `intent_decisions` table schema + unique index
- `diag-rootcause-output.ts` — Type guards: isIntentTensionSource, isEvidenceStrength, isSuggestedOwnerAction, isIntentRelatedField
- Barrel exports updated in `intent/index.ts` and `runtime-v2/index.ts`

### Backend (pd-console server)
- `IntentDecisionModel.ts` — Per-request SqliteConnection model with stateDbExists guard
- `intent-decisions.ts` — Route handler: POST (create), GET ?taskId=, GET ?painId=, GET /:id, GET /summary
- `server/index.ts` — Route registration + dispose in closeServices

### Frontend (pd-console UI)
- `validators.ts` — IntentDecisionRecordData, IntentDecisionResultData, IntentDecisionSummaryData + validators (Runtime Contract Rules 1-5, 9)
- `api.ts` — 5 API client functions + IntentDecisionInputPayload type
- `pain-card-helpers.ts` — shouldRenderFollowUpActions (returns true only when decisions exist) + buildIntentDecisionPayload pure helper
- `PainPage.tsx` — OwnerDecisionPanel with state machine (idle/submitting/recorded/error), 6 action buttons, note input, follow-up placeholder
- `IntentPage.tsx` — DecisionSummarySection (SPEC §22.1.1: counts per ownerAction + lastDecisionAt)
- `en.json` / `zh-CN.json` — i18n keys (no bare "Owner" in zh-CN)

### Tests
- `intent-decision-record.test.ts` — 16 type-level tests
- `sqlite-intent-decision-store.test.ts` — 16 store tests (idempotency, snapshots, summary)
- `intent-decisions.test.ts` — 25 route tests (CRUD, validation, flag gate, route precedence)
- `intent-validators.test.ts` — 43 frontend validator tests
- `pain-card-logic.test.ts` — 46 tests (shouldRenderFollowUpActions + buildIntentDecisionPayload)
- `cr10-i18n-governance.test.ts` — 16 tests (key parity, no banned words)
- `architecture-regression.test.ts` — 496 tests (updated REQUIRED_FILES + REQUIRED_EXPORTS)

## ERR Checklist

- **EP-01 / ERR-001, ERR-005**: All DB rows and API responses treated as `unknown`, validated via type guards (no `as` bypass). Fixed 5 `as` cast violations found by pre-push runtime-contract check.
- **EP-02**: Production path wired through server/index.ts route registration + closeServices dispose.
- **EP-03 / ERR-002, ERR-009**: Write failures throw (fail loud). Flag disabled returns 403 with reason + nextAction. Missing DB/table gracefully degrades.
- **EP-07 / ERR-015, ERR-018**: Idempotency SELECT reads fresh state each call; no stale loop state.
- **EP-09**: Pure helper `buildIntentDecisionPayload` extracted for unit testability. Validators tested independently.
- **EP-11**: i18n keys in en.json + zh-CN.json with exact parity. zh-CN has no bare "Owner"/"Agent"/"Prompt"/"Console".

## Test Results

```
Core: 5623 tests passed | 3 skipped | 3 todo
Console: 1251 tests passed | 1 expected fail
Lint: 0 errors, 31 pre-existing warnings
verify:merge: passed
```

## Acceptance Criteria Verification

- [x] IntentDecisionRecord persisted to `.pd/state.db` `intent_decisions` table (not frontend memory)
- [x] Idempotent on (painId + intentDocHash + ownerAction) when painId non-null
- [x] taskId-based idempotency fallback when painId is null (NULL-safe `IS` operator)
- [x] Immutable snapshots stored (source_snapshot, evidence_strength_snapshot, etc.)
- [x] Evidence truncated to max 3 items before storing
- [x] API: POST creates record, returns 201; idempotent hit returns 200 with created=false
- [x] API: GET by painId/taskId/id/summary all work
- [x] Feature flag gate: 403 with reason='flag_disabled' when intent_engineering off
- [x] Follow-up actions only appear after decision is persisted (shouldRenderFollowUpActions)
- [x] IntentDecisionSummary on Intent Page bottom (SPEC §22.1.1)
- [x] No `as` bypass, no `any`, Object.hasOwn() used (Runtime Contract Rules 1-5, 9)
- [x] No bare "Owner" in zh-CN (i18n governance)

## Remaining Risk

- No IntentDecisionRecord → candidate principle/RuleHost promotion flow yet (PRI-471 scope)
- No Intent Patch Proposal UI yet (post-MVP)
- The `eslint.config.js` rc-5 warning rule addition is NOT included in this PR (separate concern)
