### PR TITLE
feat: PRI-474/475/476 schema regression guards + PR template contract checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -68,6 +68,23 @@ PR 模板分层说明：
 - [ ] Core 边界检查：本 PR 是否在 `packages/principles-core/src/` 新增了 `fs`/`path` 导入？如果是，是否更新了 `architecture-regression.test.ts` 的白名单和 `eslint.config.js` 的豁免列表？
   - 规则引用: `antipattern-core-io`
 
+### Core Store 契约变更审计（条件性 — 仅当修改 `packages/principles-core/src/**/sqlite-*-store.ts` 时填写）
+<!-- 若本 PR 修改了 core store 方法的签名、新增 throw guard、或新增 precondition，
+     必须列出所有跨包 caller 并确认已验证。参考 ERR-083。 -->
+<!-- 触发条件：packages/principles-core/src/**/sqlite-*-store.ts 中任何方法的
+     签名变更、新增 throw、或新增 precondition（如 FK 校验、必填字段校验） -->
+
+- [ ] N/A — 本 PR 未修改 core store 契约
+- 或填写审计结果:
+  - 修改的 store 文件与方法: ___
+  - 新增的 throw / precondition: ___
+  - 跨包 caller 审计（列出所有 caller 文件路径 + 是否已验证）:
+    - `packages/openclaw-plugin/...`: 已验证 / 未验证
+    - `packages/pd-cli/...`: 已验证 / 未验证
+    - `packages/pd-console/...`: 已验证 / 未验证
+    - `packages/create-principles-disciple/...`: 已验证 / 未验证
+  - 规则引用: `ERR-083` — 共享 store 契约变更必须审计跨包 caller
+
 ### ERR Checklist（必填）
 <!-- 列出本 PR 考虑过的 ERR 条目（最少 3 个），及如何避免复发。参考 docs/ERROR_PATTERN_INDEX.md -->
 <!-- 示例：ERR-001 (parsed JSON as any) — 本 PR 使用 typeof 类型守卫，未使用 as 绕过 -->

--- a/packages/principles-core/src/runtime-v2/__tests__/schema-float-precision.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/schema-float-precision.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Schema Float Precision Regression Test (PRI-476 / M5)
+ *
+ * Prevents recurrence of P0-1: pain_events.score was declared INTEGER, which
+ * truncated floating-point pain scores (e.g., 39.9 → 39) and caused severity
+ * misclassification (39.9 should be 'moderate' ≥40, but 39 is 'mild').
+ *
+ * This test writes floating-point values into all REAL columns that carry
+ * semantic meaning (score, confidence) and asserts the read-back value
+ * preserves precision. If a schema change accidentally reverts REAL to
+ * INTEGER, the test fails.
+ *
+ * Scope:
+ *   - pain_events.score (trajectory.db) — the P0-1 field
+ *   - pain_events.confidence (trajectory.db)
+ *   - approvals.confidence (state.db)
+ *   - pi_artifacts REAL fields (state.db) — if any
+ */
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import Database from 'better-sqlite3';
+import { describe, expect, it, afterEach } from 'vitest';
+import { recordPainSignalObservability } from '../pain-signal-observability.js';
+import { SqliteConnection } from '../store/sqlite-connection.js';
+import { SqlitePIArtifactStore } from '../store/artifact/sqlite-pi-artifact-store.js';
+import { SqliteApprovalQueueStore } from '../activation/sqlite-approval-store.js';
+import type { PIArtifactRecord } from '../internalization/pi-artifact.js';
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(): { workspaceDir: string; stateDir: string } {
+  const workspaceDir = mkdtempSync(join(tmpdir(), 'pd-float-precision-'));
+  tempDirs.push(workspaceDir);
+  return { workspaceDir, stateDir: join(workspaceDir, '.state') };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('Schema float precision regression (PRI-476 / M5)', () => {
+  describe('pain_events.score preserves floating-point precision (P0-1 guard)', () => {
+    it('writes score=75.5 and reads back 75.5 (not 75)', () => {
+      const { workspaceDir, stateDir } = makeWorkspace();
+      recordPainSignalObservability({
+        workspaceDir,
+        stateDir,
+        canonicalPainId: 'canonical-float-001',
+        data: {
+          painId: 'float-test-001',
+          taskId: 'task-float-001',
+          painType: 'user_frustration',
+          source: 'manual',
+          reason: 'float precision test',
+          score: 75.5,
+          sessionId: 'cli',
+          agentId: 'pd-cli',
+        },
+      });
+
+      const db = new Database(join(stateDir, 'trajectory.db'), { readonly: true });
+      try {
+        const row = db.prepare('SELECT score FROM pain_events WHERE canonical_pain_id = ?')
+          .get('canonical-float-001') as { score: number } | undefined;
+        // If score were INTEGER, 75.5 would be truncated to 75.
+        expect(row).toBeDefined();
+        expect(row?.score).toBe(75.5);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('writes score=39.9 and reads back 39.9 (not 39)', () => {
+      // P0-1 core case: INTEGER truncation would turn 39.9 into 39.
+      // This test guards the float precision of pain scores.
+      const { workspaceDir, stateDir } = makeWorkspace();
+      recordPainSignalObservability({
+        workspaceDir,
+        stateDir,
+        canonicalPainId: 'canonical-float-002',
+        data: {
+          painId: 'float-test-002',
+          taskId: 'task-float-002',
+          painType: 'user_frustration',
+          source: 'manual',
+          reason: 'float precision test',
+          score: 39.9,
+          sessionId: 'cli',
+          agentId: 'pd-cli',
+        },
+      });
+
+      const db = new Database(join(stateDir, 'trajectory.db'), { readonly: true });
+      try {
+        const row = db.prepare('SELECT score FROM pain_events WHERE canonical_pain_id = ?')
+          .get('canonical-float-002') as { score: number } | undefined;
+        expect(row).toBeDefined();
+        expect(row?.score).toBe(39.9);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('writes score=40.0 (moderate boundary) and reads back 40.0', () => {
+      const { workspaceDir, stateDir } = makeWorkspace();
+      recordPainSignalObservability({
+        workspaceDir,
+        stateDir,
+        canonicalPainId: 'canonical-float-003',
+        data: {
+          painId: 'float-test-003',
+          taskId: 'task-float-003',
+          painType: 'user_frustration',
+          source: 'manual',
+          reason: 'moderate boundary test',
+          score: 40.0,
+          sessionId: 'cli',
+          agentId: 'pd-cli',
+        },
+      });
+
+      const db = new Database(join(stateDir, 'trajectory.db'), { readonly: true });
+      try {
+        const row = db.prepare('SELECT score, severity FROM pain_events WHERE canonical_pain_id = ?')
+          .get('canonical-float-003') as { score: number; severity: string } | undefined;
+        expect(row).toBeDefined();
+        expect(row?.score).toBe(40.0);
+        expect(row?.severity).toBe('moderate');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('writes score=0.333 (high precision) and reads back with ≤5 decimal precision', () => {
+      const { workspaceDir, stateDir } = makeWorkspace();
+      recordPainSignalObservability({
+        workspaceDir,
+        stateDir,
+        canonicalPainId: 'canonical-float-004',
+        data: {
+          painId: 'float-test-004',
+          taskId: 'task-float-004',
+          painType: 'user_frustration',
+          source: 'manual',
+          reason: 'high precision test',
+          score: 0.333,
+          sessionId: 'cli',
+          agentId: 'pd-cli',
+        },
+      });
+
+      const db = new Database(join(stateDir, 'trajectory.db'), { readonly: true });
+      try {
+        const row = db.prepare('SELECT score FROM pain_events WHERE canonical_pain_id = ?')
+          .get('canonical-float-004') as { score: number } | undefined;
+        expect(row).toBeDefined();
+        // SQLite REAL is IEEE 754 double; 0.333 should be preserved.
+        expect(row?.score).toBeCloseTo(0.333, 5);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  describe('approvals.confidence preserves floating-point precision', () => {
+    it('writes confidence=0.85 and reads back 0.85', () => {
+      const { workspaceDir } = makeWorkspace();
+      const conn = new SqliteConnection({ workspaceDir });
+
+      try {
+        const db = conn.getDb();
+
+        // Seed parent task for FK validation
+        db.prepare(
+          "INSERT OR IGNORE INTO tasks (task_id, task_kind, status, created_at, updated_at)" +
+          " VALUES (?, 'diagnosis', 'pending', ?, ?)",
+        ).run('task-conf-001', new Date().toISOString(), new Date().toISOString());
+
+        // Seed parent pi_artifact for FK validation
+        const artifactStore = new SqlitePIArtifactStore(conn);
+        const now = new Date().toISOString();
+        const artifact: PIArtifactRecord = {
+          artifactId: 'art-conf-001',
+          artifactKind: 'principle',
+          sourceTaskId: 'task-conf-001',
+          lineageArtifactIds: [],
+          validationStatus: 'pending',
+          contentJson: '{}',
+          createdAt: now,
+          updatedAt: now,
+        };
+        artifactStore.createArtifact(artifact);
+
+        // Enqueue approval with float confidence
+        const approvalStore = new SqliteApprovalQueueStore(conn);
+        approvalStore.enqueue({
+          artifactId: 'art-conf-001',
+          channel: 'prompt',
+          riskLevel: 'low',
+          confidence: 0.85,
+          summary: 'confidence precision test',
+          triggerReason: 'test',
+        }, now);
+
+        // Read back and verify precision
+        const row = db.prepare('SELECT confidence FROM approvals WHERE artifact_id = ?')
+          .get('art-conf-001') as { confidence: number } | undefined;
+        expect(row).toBeDefined();
+        expect(row?.confidence).toBe(0.85);
+      } finally {
+        conn.close();
+      }
+    });
+
+    it('writes confidence=0.333 and reads back 0.333', () => {
+      const { workspaceDir } = makeWorkspace();
+      const conn = new SqliteConnection({ workspaceDir });
+
+      try {
+        const db = conn.getDb();
+        db.prepare(
+          "INSERT OR IGNORE INTO tasks (task_id, task_kind, status, created_at, updated_at)" +
+          " VALUES (?, 'diagnosis', 'pending', ?, ?)",
+        ).run('task-conf-002', new Date().toISOString(), new Date().toISOString());
+
+        const artifactStore = new SqlitePIArtifactStore(conn);
+        const now = new Date().toISOString();
+        artifactStore.createArtifact({
+          artifactId: 'art-conf-002',
+          artifactKind: 'principle',
+          sourceTaskId: 'task-conf-002',
+          lineageArtifactIds: [],
+          validationStatus: 'pending',
+          contentJson: '{}',
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        const approvalStore = new SqliteApprovalQueueStore(conn);
+        approvalStore.enqueue({
+          artifactId: 'art-conf-002',
+          channel: 'prompt',
+          riskLevel: 'low',
+          confidence: 0.333,
+          summary: 'high precision confidence test',
+          triggerReason: 'test',
+        }, now);
+
+        const row = db.prepare('SELECT confidence FROM approvals WHERE artifact_id = ?')
+          .get('art-conf-002') as { confidence: number } | undefined;
+        expect(row).toBeDefined();
+        expect(row?.confidence).toBeCloseTo(0.333, 5);
+      } finally {
+        conn.close();
+      }
+    });
+  });
+
+  describe('schema column types are REAL (not INTEGER)', () => {
+    it('pain_events.score column type is REAL', () => {
+      const { workspaceDir, stateDir } = makeWorkspace();
+      // Trigger schema creation by recording a pain signal
+      recordPainSignalObservability({
+        workspaceDir,
+        stateDir,
+        canonicalPainId: 'canonical-schema-check-001',
+        data: {
+          painId: 'schema-check-001',
+          taskId: 'task-schema-001',
+          painType: 'user_frustration',
+          source: 'manual',
+          reason: 'schema type check',
+          score: 50,
+          sessionId: 'cli',
+          agentId: 'pd-cli',
+        },
+      });
+
+      const db = new Database(join(stateDir, 'trajectory.db'), { readonly: true });
+      try {
+        const cols = db.prepare('PRAGMA table_info(pain_events)').all() as { name: string; type: string }[];
+        const scoreCol = cols.find((c) => c.name === 'score');
+        expect(scoreCol).toBeDefined();
+        // SQLite type affinity: REAL type name gives REAL affinity.
+        // If someone changes this to INTEGER, the test fails.
+        expect(scoreCol?.type?.toUpperCase()).toBe('REAL');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('approvals.confidence column type is REAL', () => {
+      const { workspaceDir } = makeWorkspace();
+      const conn = new SqliteConnection({ workspaceDir });
+
+      try {
+        const db = conn.getDb();
+        const cols = db.prepare('PRAGMA table_info(approvals)').all() as { name: string; type: string }[];
+        const confidenceCol = cols.find((c) => c.name === 'confidence');
+        expect(confidenceCol).toBeDefined();
+        expect(confidenceCol?.type?.toUpperCase()).toBe('REAL');
+      } finally {
+        conn.close();
+      }
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/schema-float-precision.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/schema-float-precision.test.ts
@@ -10,11 +10,13 @@
  * preserves precision. If a schema change accidentally reverts REAL to
  * INTEGER, the test fails.
  *
- * Scope:
+ * Scope (per PRI-476 acceptance criteria):
  *   - pain_events.score (trajectory.db) — the P0-1 field
- *   - pain_events.confidence (trajectory.db)
  *   - approvals.confidence (state.db)
- *   - pi_artifacts REAL fields (state.db) — if any
+ *
+ * Note: pain_events.confidence is hardcoded to 1 (integer) in the writer
+ * (pain-signal-observability.ts), so float-precision testing is not applicable.
+ * pi_artifacts has no REAL columns carrying semantic meaning, so it is excluded.
  */
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';

--- a/packages/principles-core/src/runtime-v2/__tests__/schema-orphan-detection.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/schema-orphan-detection.test.ts
@@ -96,8 +96,23 @@ function collectProductionSourceFiles(): string[] {
 }
 
 /**
+ * Strip comments from TypeScript source so that commented-out SQL statements
+ * are not counted as write paths (avoids false negatives in orphan detection).
+ * Handles line comments (//) and block comments (slash-star ... star-slash).
+ * Simplified: does not parse string literals, but SQL rarely contains //.
+ */
+function stripComments(source: string): string {
+  // Strip block comments first (may span multiple lines)
+  let result = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  // Strip line comments
+  result = result.replace(/\/\/.*$/gm, '');
+  return result;
+}
+
+/**
  * Check whether a table name appears in any INSERT/REPLACE/UPDATE statement
- * in the given source file content.
+ * in the given source file content. Comments are stripped first to avoid
+ * false negatives from commented-out write paths.
  */
 function hasWritePath(table: string, fileContents: string[]): boolean {
   // Match INSERT INTO <table>, INSERT OR IGNORE INTO <table>,
@@ -107,7 +122,7 @@ function hasWritePath(table: string, fileContents: string[]): boolean {
     `(INSERT\\s+(OR\\s+(IGNORE|REPLACE)\\s+)?INTO|REPLACE\\s+INTO|UPDATE)\\s+${table}\\b`,
     'i',
   );
-  return fileContents.some((content) => pattern.test(content));
+  return fileContents.some((content) => pattern.test(stripComments(content)));
 }
 
 describe('Schema orphan table detection (PRI-475 / M2)', () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/schema-orphan-detection.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/schema-orphan-detection.test.ts
@@ -19,10 +19,13 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
-// __dirname in vitest points to the source file location:
+// ESM-safe __dirname derivation (packages/principles-core is "type": "module").
+// Points to the source file location:
 // .../packages/principles-core/src/runtime-v2/__tests__/
 // sqlite-connection.ts is at .../packages/principles-core/src/runtime-v2/store/
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONNECTION_FILE = path.resolve(__dirname, '../store/sqlite-connection.ts');
 // PACKAGES_DIR is .../packages/ (contains all monorepo packages).
 // From __tests__/ go up 4 levels: __tests__ -> runtime-v2 -> src -> principles-core -> packages

--- a/packages/principles-core/src/runtime-v2/__tests__/schema-orphan-detection.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/schema-orphan-detection.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Schema Orphan Table Detection Test (PRI-475 / M2)
+ *
+ * Prevents recurrence of P3-12 (confirm_first_state orphan table): a table
+ * whose CREATE TABLE DDL remains in sqlite-connection.ts but has no write
+ * path (INSERT/REPLACE/UPDATE) in production code becomes an orphan —
+ * it misleads new developers and accumulates schema debt.
+ *
+ * Approach:
+ * 1. Read sqlite-connection.ts and extract all CREATE TABLE names.
+ * 2. For each table, scan production source files (*.ts, excluding *.test.ts)
+ *    for INSERT/REPLACE/UPDATE statements referencing that table.
+ * 3. A table with no write path fails the test unless it is in the
+ *    INTENTIONAL_EMPTY_TABLES allowlist (with a documented reason).
+ *
+ * This is a static source scan, not a runtime DB inspection, so it catches
+ * tables whose DDL exists but whose store class was deleted (the P3-12 case).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// __dirname in vitest points to the source file location:
+// .../packages/principles-core/src/runtime-v2/__tests__/
+// sqlite-connection.ts is at .../packages/principles-core/src/runtime-v2/store/
+const CONNECTION_FILE = path.resolve(__dirname, '../store/sqlite-connection.ts');
+// PACKAGES_DIR is .../packages/ (contains all monorepo packages).
+// From __tests__/ go up 4 levels: __tests__ -> runtime-v2 -> src -> principles-core -> packages
+const PACKAGES_DIR = path.resolve(__dirname, '../../../..');
+
+// Allowlist: tables that intentionally have no write path.
+// Each entry MUST include a reason comment explaining why the table is empty.
+const INTENTIONAL_EMPTY_TABLES: ReadonlySet<string> = new Set<string>([
+  // (none currently — all tables have write paths)
+  // To add an entry, append the table name and document why it is empty.
+]);
+
+/**
+ * Extract table names from all CREATE TABLE IF NOT EXISTS statements
+ * in sqlite-connection.ts.
+ */
+function extractCreatedTables(source: string): string[] {
+  const tables: string[] = [];
+  const pattern = /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+(\w+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    const [, tableName] = match;
+    if (typeof tableName === 'string') {
+      tables.push(tableName);
+    }
+  }
+  return tables;
+}
+
+/**
+ * Collect all production .ts source files under packages/ (excluding tests).
+ * Returns absolute paths.
+ */
+function collectProductionSourceFiles(): string[] {
+  const results: string[] = [];
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip node_modules, dist, .trae, .git
+        if (
+          entry.name === 'node_modules' ||
+          entry.name === 'dist' ||
+          entry.name === '.trae' ||
+          entry.name === '.git'
+        ) {
+          continue;
+        }
+        walk(fullPath);
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith('.ts') &&
+        !entry.name.endsWith('.test.ts') &&
+        !entry.name.endsWith('.spec.ts') &&
+        !entry.name.endsWith('.d.ts')
+      ) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(PACKAGES_DIR);
+  return results;
+}
+
+/**
+ * Check whether a table name appears in any INSERT/REPLACE/UPDATE statement
+ * in the given source file content.
+ */
+function hasWritePath(table: string, fileContents: string[]): boolean {
+  // Match INSERT INTO <table>, INSERT OR IGNORE INTO <table>,
+  // INSERT OR REPLACE INTO <table>, REPLACE INTO <table>,
+  // UPDATE <table>
+  const pattern = new RegExp(
+    `(INSERT\\s+(OR\\s+(IGNORE|REPLACE)\\s+)?INTO|REPLACE\\s+INTO|UPDATE)\\s+${table}\\b`,
+    'i',
+  );
+  return fileContents.some((content) => pattern.test(content));
+}
+
+describe('Schema orphan table detection (PRI-475 / M2)', () => {
+  const connectionSource = fs.readFileSync(CONNECTION_FILE, 'utf-8');
+  const createdTables = extractCreatedTables(connectionSource);
+  const sourceFiles = collectProductionSourceFiles();
+  const fileContents = sourceFiles.map((f) => {
+    try {
+      return fs.readFileSync(f, 'utf-8');
+    } catch {
+      return '';
+    }
+  });
+
+  it('sqlite-connection.ts should define at least one table', () => {
+    expect(createdTables.length).toBeGreaterThan(0);
+  });
+
+  it('confirm_first_state table should NOT exist (P3-12 regression guard)', () => {
+    // P3-12: confirm_first_state was an orphan table whose store class was
+    // deleted. The DDL was replaced with DROP IF EXISTS in PRI-473.
+    // This test fails if someone re-adds the CREATE TABLE statement.
+    expect(createdTables).not.toContain('confirm_first_state');
+  });
+
+  describe.each(createdTables)('table "%s" has a write path', (table) => {
+    it(`${table} should have at least one INSERT/REPLACE/UPDATE in production code`, () => {
+      const isAllowlisted = INTENTIONAL_EMPTY_TABLES.has(table);
+      const hasWrite = hasWritePath(table, fileContents);
+
+      if (isAllowlisted) {
+        // Allowlisted tables are expected to have no write path.
+        // If they gain one, that's fine — no assertion failure.
+        return;
+      }
+
+      expect(hasWrite).toBe(true);
+    });
+  });
+
+  it('INTENTIONAL_EMPTY_TABLES allowlist entries must all exist in schema', () => {
+    // If an allowlisted table no longer exists in the schema, the allowlist
+    // entry is stale and should be removed.
+    for (const allowlisted of INTENTIONAL_EMPTY_TABLES) {
+      expect(createdTables).toContain(allowlisted);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements 3 mid-term preventive measures (M2/M4/M5) from the 4S root cause analysis of the database backend issue (ERR-083 / P0-1 / P3-12).

**Closes PRI-474, PRI-475, PRI-476**

| Issue | Measure | Change |
|-------|---------|--------|
| PRI-474 (M4) | Contract change audit | Add conditional checklist to PR template |
| PRI-475 (M2) | Schema orphan table detection | Static source scan test (13 tests) |
| PRI-476 (M5) | Float precision regression | Write+read-back precision test (8 tests) |

## Changes

### 1. PRI-474 — PR Template Contract Checklist (`.github/PULL_REQUEST_TEMPLATE.md`)
- Added a conditional "Core Store 契约变更审计" section that triggers when `packages/principles-core/src/**/sqlite-*-store.ts` files are modified
- Requires authors to audit cross-package callers when tightening store contracts (new throw guards, preconditions, or signature changes)
- **Defends against**: ERR-083 recurrence (contract tightening without caller audit)

### 2. PRI-475 — Schema Orphan Table Detection (`schema-orphan-detection.test.ts`)
- Static source scan that enumerates `CREATE TABLE` statements in `sqlite-connection.ts`
- Verifies each table has at least one `INSERT`/`REPLACE`/`UPDATE` write path in production code
- Explicit regression guard: `confirm_first_state` table must NOT exist
- **Defends against**: P3-12 recurrence (orphan table DDL retained but no writer)

### 3. PRI-476 — Float Precision Regression (`schema-float-precision.test.ts`)
- Writes floating-point values to `pain_events.score` and `approvals.confidence` (REAL columns)
- Reads them back and asserts precision is preserved (75.5, 39.9, 0.333, 0.85, etc.)
- Adds `PRAGMA table_info` assertions to catch column type regressions (REAL → INTEGER)
- **Defends against**: P0-1 recurrence (REAL column silently downgraded to INTEGER, truncating 75.5 → 75)

## ERR Checklist

ERR entries considered and how this PR avoids each:

- **ERR-083** (contract tightening without caller audit) → PRI-474 adds PR template checklist requiring caller audit
- **ERR-001** (treat parsed data as unknown) → Tests use `typeof` guards and optional chaining, no `as` bypass on untrusted data
- **ERR-005** (array element validation) → `extractCreatedTables` uses `typeof` guard on regex capture group
- **ERR-009/ERR-010** (fail loud on missing required fields) → Tests assert `toBeDefined()` before accessing fields

## Runtime Contract Checklist

- [x] `rc-1-treat-as-unknown` — DB rows cast to typed shape with `| undefined`, validated with `expect().toBeDefined()`
- [x] `rc-2-no-as-bypass` — No `as` to bypass runtime validation; `as` only used for DB return type annotation (established pattern)
- [x] `rc-5-object-hasown-not-in` — N/A (no untrusted object key checks in new code)
- [x] `rc-9-no-silent-fallback` — All test assertions are explicit; no silent fallbacks

## Core Store 契约变更审计

- [x] N/A — 本 PR 未修改 core store 契约（仅新增测试文件和 PR 模板）

## Tests Run

```
# New test files
cd packages/principles-core && npx vitest run src/runtime-v2/__tests__/schema-orphan-detection.test.ts src/runtime-v2/__tests__/schema-float-precision.test.ts
→ 21 tests passed (13 + 8)

# Full verify:merge gate (pre-push)
npm run verify:merge
→ All passed (check:generated-artifacts, check:error-handbook, check:repo-hygiene, check:runtime-contract, lint, build, typecheck)
```

## Remaining Risk

- The 31 lint warnings are pre-existing `rc-5` warnings in files not touched by this PR
- The orphan detection test uses a filesystem walk that runs on every test execution; could be slow on very large repos but completes in ~49ms currently
- The float precision test creates temp workspaces via `mkdtempSync`; cleaned up in `afterEach`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 更新了提交模板，新增核心存储契约变更审计检查项，便于在相关改动时补充影响范围与回归核对信息。
* **Tests**
  * 新增浮点精度回归测试，覆盖写入与读取流程，确保数值不会被意外截断。
  * 新增孤儿表检测测试，帮助发现 schema 中存在但缺少写入路径的表，并加强对过期允许列表的校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->