### PR TITLE
pd-console: E2E flow tests, Update page fix, and dead API surface cleanup

### DIFF
--- a/packages/pd-console/scripts/e2e-seed.ts
+++ b/packages/pd-console/scripts/e2e-seed.ts
@@ -1,0 +1,203 @@
+/**
+ * E2E 测试数据 seed 脚本：在临时 workspace 中初始化完整 schema + 插入测试数据。
+ *
+ * 被 scripts/e2e-start.mjs 调用（通过 `npx tsx scripts/e2e-seed.ts <workspaceDir>`）。
+ * 完成后 pd-console server 用 readonly 模式打开，读取这些预置数据。
+ *
+ * Seed 内容覆盖 3 个 flow test 的需求：
+ * - focus-approve-flow: governance queue (2 pending approvals)
+ * - principle-detail-flow: principles ledger JSON + approvals + pi_artifacts
+ * - pain-intent-flow: trajectory.db pain_events + state.db tasks + candidates
+ */
+import { SqliteConnection } from '@principles/core/runtime-v2';
+import Database from 'better-sqlite3';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const workspaceDir = process.argv[2];
+if (!workspaceDir || !fs.existsSync(workspaceDir)) {
+  console.error('[e2e-seed] usage: tsx e2e-seed.ts <workspaceDir>');
+  process.exit(1);
+}
+
+const now = new Date().toISOString();
+const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+
+// ── 1. 初始化 state.db 完整 schema（writable 模式自动建表）──────────────────
+const stateDir = path.join(workspaceDir, '.pd');
+fs.mkdirSync(stateDir, { recursive: true });
+
+const stateConn = new SqliteConnection({ workspaceDir, readonly: false });
+const stateDb = stateConn.getDb();
+stateDb.pragma('foreign_keys = OFF');
+
+console.log('[e2e-seed] state.db schema initialized');
+
+// ── 2. 插入 tasks（diagnostician 诊断任务，evidence-chain 用）────────────────
+stateDb.prepare(`
+  INSERT INTO tasks (task_id, task_kind, status, created_at, updated_at, last_error, attempt_count, diagnostic_json, input_ref)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+  'task-diag-1', 'diagnostician', 'succeeded', eightDaysAgo, eightDaysAgo, null,
+  1, JSON.stringify({ painId: 'pain-1', rootCause: 'Agent 未确认就修改配置' }), '1',
+);
+
+// ── 3. 插入 runs（artifacts 和 principle_candidates 的父表）──────────────────
+stateDb.prepare(`
+  INSERT INTO runs (run_id, task_id, runtime_kind, execution_status, started_at, ended_at, attempt_number, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run('run-1', 'task-diag-1', 'diagnostician', 'succeeded', eightDaysAgo, eightDaysAgo, 1, eightDaysAgo, eightDaysAgo);
+
+// ── 4. 插入 artifacts（diagnostician_output，evidence-chain PRI-469 用）──────
+stateDb.prepare(`
+  INSERT INTO artifacts (artifact_id, run_id, task_id, artifact_kind, content_json, created_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+`).run(
+  'artifact-diag-output-1', 'run-1', 'task-diag-1', 'diagnostician_output',
+  JSON.stringify({ rootCause: 'Agent 未确认就修改配置', evidence: ['pain-1'] }), eightDaysAgo,
+);
+
+// ── 5. 插入 pi_artifacts（approvals 的父表，principle internalization）──────
+const insertPiArtifact = stateDb.prepare(`
+  INSERT INTO pi_artifacts (
+    artifact_id, artifact_kind, source_task_id, source_principle_id,
+    lineage_artifact_ids, validation_status, content_json, created_at, updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+insertPiArtifact.run(
+  'artifact-prompt-1', 'principle', 'task-diag-1', 'p-001',
+  '[]', 'validated', JSON.stringify({ principleId: 'p-001', title: '配置变更需确认' }), now, now,
+);
+insertPiArtifact.run(
+  'artifact-hook-1', 'principle', 'task-diag-2', 'p-001',
+  '[]', 'validated', JSON.stringify({ principleId: 'p-001', title: '错误后必须分析根因' }), now, now,
+);
+
+// ── 6. 插入 principle_candidates（evidence-chain 候选，需 artifact_id + run_id）
+stateDb.prepare(`
+  INSERT INTO principle_candidates (
+    candidate_id, artifact_id, task_id, source_run_id, title, description,
+    confidence, source_recommendation_json, idempotency_key, status, created_at,
+    recommendation_kind, abstracted_principle
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+  'cand-1', 'artifact-diag-output-1', 'task-diag-1', 'run-1',
+  '配置变更需确认', 'Agent 修改配置前应先获得 Owner 确认',
+  0.85, '', 'idem-cand-1', 'consumed', eightDaysAgo,
+  'apply', '修改任何配置文件前，必须先向 Owner 确认',
+);
+
+// ── 7. 插入 approvals（2 行 pending，MVP proven channels）───────────────────
+stateDb.prepare(`
+  INSERT INTO approvals (
+    approval_id, artifact_id, channel, risk_level, status, confidence,
+    requested_at, summary, trigger_reason
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+  'apr-prompt-1', 'artifact-prompt-1', 'prompt', 'low', 'pending', 0.85,
+  eightDaysAgo, '将"配置变更需确认"原则注入 prompt', 'Owner 审批：新增 prompt 指令',
+);
+stateDb.prepare(`
+  INSERT INTO approvals (
+    approval_id, artifact_id, channel, risk_level, status, confidence,
+    requested_at, summary, trigger_reason
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+  'apr-hook-1', 'artifact-hook-1', 'code_tool_hook', 'medium', 'pending', 0.78,
+  now, '将"错误后必须分析根因"挂载到 code_tool_hook', 'Owner 审批：新增工具调用钩子',
+);
+
+stateConn.close();
+console.log('[e2e-seed] state.db seeded: 2 approvals, 2 pi_artifacts, 1 task, 1 run, 1 artifact, 1 candidate');
+
+// ── 8. 初始化 trajectory.db + pain_events ───────────────────────────────────
+const trajectoryDir = path.join(workspaceDir, '.state');
+fs.mkdirSync(trajectoryDir, { recursive: true });
+const trajectoryDbPath = path.join(trajectoryDir, 'trajectory.db');
+
+const trajDb = new Database(trajectoryDbPath);
+trajDb.exec(`
+  CREATE TABLE IF NOT EXISTS pain_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    score REAL NOT NULL DEFAULT 0,
+    reason TEXT,
+    severity TEXT,
+    origin TEXT,
+    confidence REAL,
+    text TEXT,
+    created_at TEXT NOT NULL,
+    canonical_pain_id TEXT,
+    runtime_task_id TEXT
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
+    ON pain_events(canonical_pain_id)
+    WHERE canonical_pain_id IS NOT NULL;
+  CREATE TABLE IF NOT EXISTS gate_blocks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    session_id TEXT,
+    reason TEXT
+  );
+`);
+
+trajDb.prepare(`
+  INSERT INTO pain_events (
+    session_id, source, score, reason, severity, origin, confidence,
+    text, created_at, canonical_pain_id, runtime_task_id
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+  'session-e2e-1', 'manual', 0.8, 'Agent 修改配置未确认', 'medium', 'gate',
+  0.85, 'Agent 在未经 Owner 确认的情况下修改了数据库配置', eightDaysAgo,
+  'pain-e2e-1', 'task-diag-1',
+);
+
+trajDb.close();
+console.log('[e2e-seed] trajectory.db seeded: 1 pain_event');
+
+// ── 9. 写入 principle_training_state.json ───────────────────────────────────
+const ledgerPath = path.join(trajectoryDir, 'principle_training_state.json');
+const ledger = {
+  _tree: {
+    principles: {
+      'p-001': {
+        id: 'p-001',
+        status: 'active',
+        text: '配置变更需确认',
+        triggerPattern: 'on-config-change',
+        action: '修改任何配置文件前，必须先向 Owner 确认',
+        evaluability: 'deterministic',
+        priority: 'P1',
+        scope: 'general',
+        domain: '',
+        valueScore: 0,
+        adherenceRate: 0,
+        painPreventedCount: 0,
+        ruleIds: [],
+        conflictsWithPrincipleIds: [],
+        derivedFromPainIds: ['pain-e2e-1'],
+        createdAt: eightDaysAgo,
+        updatedAt: now,
+      },
+    },
+    rules: {},
+  },
+  'p-001': {
+    principleId: 'p-001',
+    evaluability: 'deterministic',
+    applicableOpportunityCount: 0,
+    observedViolationCount: 0,
+    complianceRate: 0,
+    violationTrend: 0,
+    generatedSampleCount: 0,
+    approvedSampleCount: 0,
+    includedTrainRunIds: [],
+    deployedCheckpointIds: [],
+    internalizationStatus: 'needs_training',
+  },
+};
+fs.writeFileSync(ledgerPath, JSON.stringify(ledger, null, 2), 'utf8');
+console.log('[e2e-seed] principle_training_state.json written: 1 principle (p-001)');
+
+console.log('[e2e-seed] done — workspace ready for E2E tests');

--- a/packages/pd-console/scripts/e2e-start.mjs
+++ b/packages/pd-console/scripts/e2e-start.mjs
@@ -1,9 +1,9 @@
-// E2E 服务器启动脚本：创建临时工作区 + 启动 tsx 服务器
+// E2E 服务器启动脚本：创建临时工作区 + seed 测试数据 + 启动 tsx 服务器
 // 跨平台兼容（Node API 而非 shell），被 playwright.config.ts 的 webServer.command 调用
 import { mkdtempSync, existsSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 
 const workspaceDir = mkdtempSync(join(tmpdir(), 'pd-console-e2e-'));
 console.log(`[e2e] workspace: ${workspaceDir}`);
@@ -13,6 +13,22 @@ const webRoot = join(process.cwd(), 'dist', 'web');
 if (!existsSync(webRoot)) {
   console.error('[e2e] dist/web missing, run "npm run build:ui" first');
   process.exit(1);
+}
+
+// Seed 测试数据：初始化 state.db schema + 插入 approvals/principles/pain_events
+// 使用 spawnSync 同步等待 seed 完成后再启动 server（server 用 readonly 打开 db）
+const seedResult = spawnSync(
+  'npx',
+  ['tsx', 'scripts/e2e-seed.ts', workspaceDir],
+  {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    cwd: process.cwd(),
+  },
+);
+if (seedResult.status !== 0) {
+  console.error('[e2e] seed failed, aborting');
+  process.exit(seedResult.status ?? 1);
 }
 
 // 启动 tsx 服务器（--no-auth 免认证，强制 loopback 绑定）

--- a/packages/pd-console/src/server/index.ts
+++ b/packages/pd-console/src/server/index.ts
@@ -259,7 +259,7 @@ async function initServices(workspaceDir: string, authConfig: AuthConfig): Promi
   };
 }
 
-async function closeServices(services: AppServices): Promise<void> {
+async function closeServices(): Promise<void> {
   disposeFeedbackReportModels();
   disposeApprovalsModels();
   disposeApprovalsGroupedModels();
@@ -271,7 +271,6 @@ async function closeServices(services: AppServices): Promise<void> {
   disposeEvidenceChainModels();
   disposeIntentModels();
   disposeIntentDecisionModels();
-  services.workspaceService.dispose();
 }
 
 // ── Route handler ───────────────────────────────────────────────────────────
@@ -354,7 +353,7 @@ function handleRequest(services: AppServices): (req: http.IncomingMessage, res: 
         return;
       }
 
-      // Update routes: GET /api/update/check, POST /api/update/apply, GET /api/update/status, POST /api/update/rollback
+      // Update routes: GET /api/update/check, POST /api/update/apply, POST /api/update/rollback
       if (urlPath === '/api/update' || urlPath.startsWith('/api/update/')) {
         const subPath = urlPath.slice('/api/update'.length);
         const isApply = subPath === '/apply';
@@ -450,7 +449,7 @@ export async function main(): Promise<void> {
   const shutdown = async (signal: string): Promise<void> => {
     console.log(`[pd-console] Received ${signal}, shutting down...`);
     await new Promise<void>((resolve) => { server.close(() => resolve()); });
-    await closeServices(services);
+    await closeServices();
     process.exit(0);
   };
 

--- a/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
+++ b/packages/pd-console/src/server/models/EvidenceChainConsoleModel.ts
@@ -27,8 +27,6 @@ import {
   SqliteConnection,
   sanitizeString,
   assembleEvidenceChain,
-  crossReferenceByTimestamp,
-  resolveSummary,
 } from '@principles/core/runtime-v2';
 import type {
   EvidenceChainState,
@@ -43,11 +41,6 @@ export type {
   EvidenceChainState,
   EvidenceChainRecord,
   EvidenceChainResponse,
-};
-
-export {
-  crossReferenceByTimestamp,
-  resolveSummary,
 };
 
 // ── Helpers ────────────────────────────────────────────────────────────────────

--- a/packages/pd-console/src/server/models/WorkspaceService.ts
+++ b/packages/pd-console/src/server/models/WorkspaceService.ts
@@ -1,139 +1,11 @@
-import {
-  OperatorHealthReadModel,
-  PainChainReadModel,
-  PruningReadModel,
-  RuntimeStateManager,
-} from '@principles/core/runtime-v2';
 import type { WorkspaceConfigStore } from '../config/WorkspaceConfigStore.js';
-import type { WorkspaceEntry, SyncResult } from '../types/index.js';
-
-export interface CentralOverviewOutput {
-  generatedAt: string;
-  workspaceCount: number;
-  workspaces: {
-    name: string;
-    path: string;
-    status: 'healthy' | 'degraded' | 'error';
-    gfi: number;
-    principleCount: number;
-  }[];
-}
-
-export interface CentralHealthOutput {
-  generatedAt: string;
-  overallStatus: 'healthy' | 'degraded' | 'error';
-  workspaces: {
-    name: string;
-    status: 'healthy' | 'degraded' | 'error';
-    gfi: number;
-    activePrinciples: number;
-    pendingTasks: number;
-  }[];
-}
-
-interface WorkspaceModels {
-  operatorHealth: OperatorHealthReadModel;
-  painChain: PainChainReadModel;
-  pruning: PruningReadModel;
-  runtime: RuntimeStateManager;
-}
-
-const noop = (): void => { /* intentional no-op for promise catch */ };
+import type { SyncResult } from '../types/index.js';
 
 export class WorkspaceService {
   private readonly configStore: WorkspaceConfigStore;
-  private readonly models: Map<string, WorkspaceModels> = new Map();
 
   constructor(configStore: WorkspaceConfigStore) {
     this.configStore = configStore;
-  }
-
-  async getCentralOverview(): Promise<CentralOverviewOutput> {
-    const workspaces = this.configStore.getWorkspaces().filter(w => w.config?.enabled !== false);
-    const results: CentralOverviewOutput['workspaces'] = [];
-
-    for (const ws of workspaces) {
-      try {
-        const models = this.getModels(ws);
-        const [snapshot, pruningSummary] = await Promise.all([
-          models.operatorHealth.getSnapshot(),
-          Promise.resolve(models.pruning.getHealthSummary()),
-        ]);
-        const { byStatus } = pruningSummary;
-        results.push({
-          name: ws.name,
-          path: ws.path,
-          status: snapshot.overallStatus === 'healthy' ? 'healthy' : snapshot.overallStatus === 'degraded' ? 'degraded' : 'error',
-          gfi: snapshot.gfi.active?.currentGfi ?? 0,
-          principleCount: (byStatus.active ?? 0) + (byStatus.candidate ?? 0),
-        });
-      } catch (e) {
-        console.warn('WorkspaceService.getCentralOverview: workspace health check failed:', e);
-        results.push({
-          name: ws.name,
-          path: ws.path,
-          status: 'error',
-          gfi: -1,
-          principleCount: 0,
-        });
-      }
-    }
-
-    return {
-      generatedAt: new Date().toISOString(),
-      workspaceCount: workspaces.length,
-      workspaces: results,
-    };
-  }
-
-  async getCentralHealth(): Promise<CentralHealthOutput> {
-    const workspaces = this.configStore.getWorkspaces().filter(w => w.config?.enabled !== false);
-    const results: CentralHealthOutput['workspaces'] = [];
-    let overallStatus: 'healthy' | 'degraded' | 'error' = 'healthy';
-
-    for (const ws of workspaces) {
-      try {
-        const models = this.getModels(ws);
-        const [snapshot, pruningSummary, pendingTasks] = await Promise.all([
-          models.operatorHealth.getSnapshot(),
-          Promise.resolve(models.pruning.getHealthSummary()),
-          models.runtime.listTasks({ status: 'pending', limit: 100 }),
-        ]);
-        const { byStatus } = pruningSummary;
-        const wsStatus: 'healthy' | 'degraded' | 'error' =
-          snapshot.overallStatus === 'healthy' ? 'healthy' : snapshot.overallStatus === 'degraded' ? 'degraded' : 'error';
-
-        if (wsStatus === 'error') {
-          overallStatus = 'error';
-        } else if (wsStatus !== 'healthy' && overallStatus === 'healthy') {
-          overallStatus = 'degraded';
-        }
-
-        results.push({
-          name: ws.name,
-          status: wsStatus,
-          gfi: snapshot.gfi.active?.currentGfi ?? 0,
-          activePrinciples: (byStatus.active ?? 0) + (byStatus.candidate ?? 0),
-          pendingTasks: pendingTasks.length,
-        });
-      } catch (e) {
-        console.warn('WorkspaceService.getCentralHealth: workspace health check failed:', e);
-        overallStatus = 'error';
-        results.push({
-          name: ws.name,
-          status: 'error',
-          gfi: -1,
-          activePrinciples: 0,
-          pendingTasks: 0,
-        });
-      }
-    }
-
-    return {
-      generatedAt: new Date().toISOString(),
-      overallStatus,
-      workspaces: results,
-    };
   }
 
   async syncWorkspace(name: string): Promise<SyncResult> {
@@ -142,7 +14,6 @@ export class WorkspaceService {
       throw new Error(`Workspace "${name}" not found`);
     }
 
-    this.disposeWorkspace(name);
     this.configStore.updateSyncTime(name);
 
     return {
@@ -150,39 +21,5 @@ export class WorkspaceService {
       syncedAt: new Date().toISOString(),
       items: {},
     };
-  }
-
-  dispose(): void {
-    for (const name of this.models.keys()) {
-      this.disposeWorkspace(name);
-    }
-    this.models.clear();
-  }
-
-  private disposeWorkspace(name: string): void {
-    const existing = this.models.get(name);
-    if (existing) {
-      existing.operatorHealth.close().catch(noop);
-      existing.painChain.close().catch(noop);
-      existing.runtime.close().catch(noop);
-      this.models.delete(name);
-    }
-  }
-
-  private getModels(entry: WorkspaceEntry): WorkspaceModels {
-    let existing = this.models.get(entry.name);
-    if (!existing) {
-      const runtime = new RuntimeStateManager({ workspaceDir: entry.path });
-      const painChain = new PainChainReadModel({ workspaceDir: entry.path, stateManager: runtime });
-      const pruning = new PruningReadModel({ workspaceDir: entry.path });
-      const operatorHealth = new OperatorHealthReadModel({
-        workspaceDir: entry.path,
-        painChainReadModel: painChain,
-        pruningReadModel: pruning,
-      });
-      existing = { operatorHealth, painChain, pruning, runtime };
-      this.models.set(entry.name, existing);
-    }
-    return existing;
   }
 }

--- a/packages/pd-console/src/server/routes/update.ts
+++ b/packages/pd-console/src/server/routes/update.ts
@@ -3,7 +3,6 @@
  *
  * GET  /check    — Check for updates
  * POST /apply    — Apply an update
- * GET  /status   — Get current update status
  * POST /rollback — Rollback an update
  */
 /* eslint-disable @typescript-eslint/max-params */
@@ -473,14 +472,6 @@ export async function handleUpdateRoute(
       if (err instanceof SyntaxError) { sendBadRequest(res, 'Invalid JSON body'); return; }
       sendError(res, 500, 'update_apply_error', err instanceof Error ? err.message : 'Unknown error');
     }
-    return;
-  }
-
-  // GET /status
-  if (subPath === '/status') {
-    if (req.method !== 'GET') { sendMethodNotAllowed(res); return; }
-    const currentVersion = readCurrentVersion(pluginDir) ?? 'unknown';
-    sendSuccess(res, { checking: false, updating: false, currentVersion });
     return;
   }
 

--- a/packages/pd-console/src/server/routes/update.ts
+++ b/packages/pd-console/src/server/routes/update.ts
@@ -413,9 +413,17 @@ export async function handleUpdateRoute(
   if (subPath === '/check') {
     if (req.method !== 'GET') { sendMethodNotAllowed(res); return; }
     try {
+      // ERR-002 / Runtime Contract Rule 9: 当无法确定当前版本时（如插件未安装），
+      // 返回 degraded 状态 + reason，而非 500。前端 validateUpdateStatus 要求
+      // currentVersion/latestVersion 为 string，hasUpdate 为 boolean。
       const currentVersion = readCurrentVersion(pluginDir);
       if (!currentVersion) {
-        sendError(res, 500, 'version_not_found', 'Could not determine current version');
+        sendSuccess(res, {
+          hasUpdate: false,
+          currentVersion: 'unknown',
+          latestVersion: '',
+          error: 'Could not determine current version (plugin not installed)',
+        });
         return;
       }
       const result = await doCheckForUpdates(currentVersion);

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -29,7 +29,6 @@ import {
   validateEvidenceChain,
   validateTrajectoryData,
   validateIntentSummary,
-  validateIntentDecisionRecord,
   validateIntentDecisionList,
   validateIntentDecisionResult,
   validateIntentDecisionSummary,
@@ -232,10 +231,6 @@ async function fetchPrincipleTrajectory(principleId: string): Promise<ApiRespons
 }
 
 // ── Approvals ─────────────────────────────────────────────────────────────────
-
-async function fetchApprovalDetail(approvalId: string): Promise<ApiResponse<ApprovalRecordData>> {
-  return request<ApprovalRecordData>('/api/v1/approvals/' + encodeURIComponent(approvalId), undefined, validateApprovalRecordDirect);
-}
 
 async function approveApproval(approvalId: string, note?: string): Promise<ApiResponse<ApprovalRecordData>> {
   return request<ApprovalRecordData>('/api/v1/approvals/' + encodeURIComponent(approvalId) + '/approve', {
@@ -464,16 +459,6 @@ async function listIntentDecisionsByTaskId(
   );
 }
 
-async function getIntentDecision(
-  decisionId: string,
-): Promise<ApiResponse<IntentDecisionRecordData>> {
-  return request<IntentDecisionRecordData>(
-    `/api/v1/intent-decisions/${encodeURIComponent(decisionId)}`,
-    undefined,
-    validateIntentDecisionRecord,
-  );
-}
-
 async function fetchIntentDecisionSummary(): Promise<ApiResponse<IntentDecisionSummaryData>> {
   return request<IntentDecisionSummaryData>(
     '/api/v1/intent-decisions/summary',
@@ -521,8 +506,6 @@ export {
   setToken,
   clearToken,
   checkAuth,
-  request,
-  fetchApprovalDetail,
   approveApproval,
   rejectApproval,
   editApproval,
@@ -557,7 +540,6 @@ export {
   recordIntentDecision,
   listIntentDecisionsByPainId,
   listIntentDecisionsByTaskId,
-  getIntentDecision,
   fetchIntentDecisionSummary,
   dispatchFollowUp,
 };

--- a/packages/pd-console/tests/e2e/focus-approve-flow.spec.ts
+++ b/packages/pd-console/tests/e2e/focus-approve-flow.spec.ts
@@ -1,0 +1,155 @@
+/* eslint-disable */
+// E2E 流程测试：FocusPage 审批闭环 — governance queue → approve → activation 出现
+// 验证 PD 最核心的 owner-review 流程：发现 pending approval → 批准 → 激活生效
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:3100';
+
+// ── 辅助：调用 API 并验证响应 ────────────────────────────────────────────────
+async function apiGet(path: string): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`);
+  const body = await resp.json().catch(() => null);
+  return { status: resp.status, body };
+}
+
+async function apiPost(path: string, body?: unknown): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await resp.json().catch(() => null);
+  return { status: resp.status, body: data };
+}
+
+// ── 测试 ─────────────────────────────────────────────────────────────────────
+
+test.describe('FocusPage 审批闭环流程', () => {
+  test('governance queue 加载 → approve → pending 减少 + activation 出现', async ({ page }) => {
+    // ── 步骤 1：验证初始状态（seed 数据应有 2 个 pending approvals）──────────
+    const queueResp = await apiGet('/api/v1/governance/queue');
+    expect(queueResp.status).toBe(200);
+    const queueBody = queueResp.body as { success: boolean; data: { pendingReviewCount?: number } };
+    expect(queueBody.success).toBe(true);
+    expect(queueBody.data.pendingReviewCount).toBeGreaterThanOrEqual(2);
+
+    // ── 步骤 2：进入 FocusPage，验证 UI 渲染了 pending 数量 ──────────────────
+    const errors: string[] = [];
+    page.on('response', (resp) => {
+      if (resp.url().includes('/api/') && resp.status() >= 500) {
+        errors.push(`5xx: ${resp.status()} ${resp.url()}`);
+      }
+    });
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+
+    await page.goto('/#/focus');
+    await page.waitForLoadState('networkidle');
+
+    // FocusPage 应无 5xx 错误
+    expect(errors, `FocusPage had errors:\n${errors.join('\n')}`).toEqual([]);
+
+    // 页面主体应已渲染
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.length).toBeGreaterThan(100);
+
+    // ── 步骤 3：获取 pending approvals 列表 ──────────────────────────────────
+    const approvalsResp = await apiGet('/api/v1/approvals?status=pending');
+    expect(approvalsResp.status).toBe(200);
+    // 注意：approvals 列表端点返回 data.items（不是 data.approvals）
+    const approvalsBody = approvalsResp.body as {
+      success: boolean;
+      data: { items: Array<{ approvalId: string; channel: string; status: string }> };
+    };
+    expect(approvalsBody.success).toBe(true);
+    expect(approvalsBody.data.items.length).toBeGreaterThanOrEqual(2);
+
+    // 选取 prompt channel 的 approval 来测 happy path：
+    // code_tool_hook activation 要求 artifact_kind='rule'，seed 的 hook artifact
+    // 不满足（会返回 500 activation_failed + reason，那是 ERR-002 合规的降级路径，
+    // 但本测试聚焦 approve → activation 闭环，用最可靠的 MVP channel 验证）。
+    const promptApproval = approvalsBody.data.items.find(a => a.channel === 'prompt');
+    expect(promptApproval, 'seed 应至少包含 1 个 prompt channel approval').toBeTruthy();
+    const firstApproval = promptApproval!;
+    expect(firstApproval.status).toBe('pending');
+    // channel 必须是 MVP proven channels（prompt / code_tool_hook / defer_archive）
+    expect(['prompt', 'code_tool_hook', 'defer_archive']).toContain(firstApproval.channel);
+
+    // ── 步骤 4：通过 API approve 第一个 approval ─────────────────────────────
+    // approve 端点要求 JSON body（空对象即可），否则返回 400 bad_request
+    const approveResp = await apiPost(`/api/v1/approvals/${firstApproval.approvalId}/approve`, {});
+    expect(approveResp.status).toBe(200);
+    const approveBody = approveResp.body as {
+      success: boolean;
+      data: {
+        approvalId: string;
+        status: string;
+        activation?: { activationId?: string; action?: string; decision?: string };
+        error?: string;
+      };
+    };
+    expect(approveBody.success).toBe(true);
+    // approve 后状态应变为 approved，且应有 activation 或明确的 error reason（ERR-002：不能静默）
+    expect(approveBody.data.status).toBe('approved');
+    if (approveBody.data.activation) {
+      // 成功路径：activation 对象应包含 activationId 或 decision
+      expect(approveBody.data.activation.activationId ?? approveBody.data.activation.decision).toBeTruthy();
+    } else {
+      // 失败路径：必须有 error reason（Runtime Contract Rule 9）
+      expect(approveBody.data.error).toBeTruthy();
+    }
+
+    // ── 步骤 5：验证 pending count 减少 ──────────────────────────────────────
+    const queueAfterResp = await apiGet('/api/v1/governance/queue');
+    const queueAfterBody = queueAfterResp.body as { success: boolean; data: { pendingReviewCount?: number } };
+    expect(queueAfterBody.data.pendingReviewCount).toBeLessThan(queueBody.data.pendingReviewCount!);
+
+    // ── 步骤 6：验证 activation 出现（如果 approve 成功）─────────────────────
+    if (approveBody.data.success) {
+      const activationsResp = await apiGet('/api/v1/activations');
+      expect(activationsResp.status).toBe(200);
+      const activationsBody = activationsResp.body as {
+        success: boolean;
+        data: { activations: Array<{ activationId: string; status: string }> };
+      };
+      expect(activationsBody.success).toBe(true);
+      // 应至少有 1 个 active activation
+      const activeActivations = activationsBody.data.activations.filter(a => a.status === 'active');
+      expect(activeActivations.length).toBeGreaterThanOrEqual(1);
+    }
+
+    // ── 步骤 7：刷新 FocusPage，验证 UI 反映了新状态 ─────────────────────────
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    expect(errors.length, `FocusPage reload had errors:\n${errors.join('\n')}`).toBe(0);
+  });
+
+  test('approvals grouped 端点：按 principle 分组返回 pending records', async () => {
+    const resp = await apiGet('/api/v1/approvals/grouped');
+    expect(resp.status).toBe(200);
+    const body = resp.body as {
+      success: boolean;
+      data: {
+        groups: Array<{
+          principleId: string;
+          principleTitle: string;
+          status: string;
+          records: Array<{ approvalId: string; status: string; channel: string }>;
+        }>;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.groups.length).toBeGreaterThanOrEqual(1);
+
+    // 验证至少有一个 pending group
+    const pendingGroups = body.data.groups.filter(g => g.status === 'pending');
+    expect(pendingGroups.length).toBeGreaterThanOrEqual(1);
+
+    // 验证 group 内 records 的 channel 都是 MVP proven
+    for (const group of pendingGroups) {
+      for (const record of group.records) {
+        expect(['prompt', 'code_tool_hook', 'defer_archive']).toContain(record.channel);
+      }
+    }
+  });
+});

--- a/packages/pd-console/tests/e2e/pain-intent-flow.spec.ts
+++ b/packages/pd-console/tests/e2e/pain-intent-flow.spec.ts
@@ -1,0 +1,177 @@
+/* eslint-disable */
+// E2E 流程测试：PainPage evidence-chain + intent decision 流程
+// 验证 PD 痛信号到 Owner 决策的完整链路：pain_events → evidence-chain → intent decision
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:3100';
+
+async function apiGet(path: string): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`);
+  const body = await resp.json().catch(() => null);
+  return { status: resp.status, body };
+}
+
+async function apiPost(path: string, body?: unknown): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await resp.json().catch(() => null);
+  return { status: resp.status, body: data };
+}
+
+test.describe('PainPage evidence-chain + intent 流程', () => {
+  test('evidence-chain 加载 → 验证 pain_event 出现 → intent 端点可用', async ({ page }) => {
+    // ── 步骤 1：验证 evidence-chain API 返回 seed 的 pain_event ──────────────
+    const evidenceResp = await apiGet('/api/v1/evidence-chain');
+    expect(evidenceResp.status).toBe(200);
+    // 注意：evidence-chain 端点返回 data.records（不是 data.items）
+    // 每条 record 用 id（格式 pain_<rowid>）和 canonicalPainId（如 pain-e2e-1）
+    const evidenceBody = evidenceResp.body as {
+      success: boolean;
+      data: {
+        records?: Array<{
+          id: string;
+          sourceKind?: string;
+          canonicalPainId?: string;
+          summary?: string;
+          state?: string;
+        }>;
+      };
+    };
+    expect(evidenceBody.success).toBe(true);
+    // seed 数据应有 1 条 pain_event
+    expect(evidenceBody.data.records?.length ?? 0).toBeGreaterThanOrEqual(1);
+
+    const firstPain = evidenceBody.data.records![0];
+    expect(firstPain.id).toBeTruthy();
+    expect(firstPain.sourceKind).toBeTruthy();
+
+    // ── 步骤 2：进入 PainPage，验证 UI 渲染了 evidence-chain ─────────────────
+    const errors: string[] = [];
+    page.on('response', (resp) => {
+      if (resp.url().includes('/api/') && resp.status() >= 500) {
+        errors.push(`5xx: ${resp.status()} ${resp.url()}`);
+      }
+    });
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+
+    await page.goto('/#/pain');
+    await page.waitForLoadState('networkidle');
+
+    // PainPage 应无 5xx 错误
+    expect(errors, `PainPage had errors:\n${errors.join('\n')}`).toEqual([]);
+
+    // 页面主体应已渲染
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.length).toBeGreaterThan(100);
+  });
+
+  test('intent summary 端点：返回 intent 概览', async () => {
+    const resp = await apiGet('/api/v1/intent');
+    // intent 端点受 feature flag 控制，可能返回 200 或 404（flag 关闭）
+    if (resp.status === 200) {
+      const body = resp.body as { success: boolean; data: unknown };
+      expect(body.success).toBe(true);
+    } else if (resp.status === 404) {
+      // feature flag 关闭时返回 404，这是预期行为
+      expect(resp.status).toBe(404);
+    } else {
+      // 不应有 5xx
+      expect(resp.status).toBeLessThan(500);
+    }
+  });
+
+  test('intent-decisions summary 端点：返回决策汇总或 flag-disabled 降级', async () => {
+    // intent-decisions 受 intent_engineering feature flag 控制：
+    // - flag 开启：返回 200 + 决策汇总
+    // - flag 关闭：返回 403 + reason/nextAction（ERR-002：不静默）
+    const resp = await apiGet('/api/v1/intent-decisions/summary');
+    if (resp.status === 200) {
+      const body = resp.body as {
+        success: boolean;
+        data: { totalDecisions?: number; recentDecisions?: unknown[] };
+      };
+      expect(body.success).toBe(true);
+    } else if (resp.status === 403) {
+      // flag-disabled 路径：必须有 reason + nextAction（Runtime Contract Rule 9）
+      const body = resp.body as {
+        success: boolean;
+        reason?: string;
+        nextAction?: string;
+      };
+      expect(body.success).toBe(false);
+      expect(body.reason).toBeTruthy();
+      expect(body.nextAction).toBeTruthy();
+    } else {
+      throw new Error(`unexpected status ${resp.status}: ${JSON.stringify(resp.body)}`);
+    }
+  });
+
+  test('intent-decisions 按 painId 查询：空结果或 flag-disabled 不报错', async () => {
+    // 用 seed 的 pain-e2e-1 查询
+    const resp = await apiGet('/api/v1/intent-decisions?painId=pain-e2e-1');
+    if (resp.status === 200) {
+      const body = resp.body as {
+        success: boolean;
+        data: { decisions?: unknown[] };
+      };
+      expect(body.success).toBe(true);
+      // seed 数据没有预置 intent decision，应为空数组或 null
+      expect(body.data.decisions ?? []).toEqual([]);
+    } else if (resp.status === 403) {
+      // flag-disabled：验证 reason 存在（ERR-002）
+      const body = resp.body as { success: boolean; reason?: string };
+      expect(body.success).toBe(false);
+      expect(body.reason).toBeTruthy();
+    } else {
+      throw new Error(`unexpected status ${resp.status}: ${JSON.stringify(resp.body)}`);
+    }
+  });
+
+  test('intent-decisions 创建：验证 201/200（flag 开启）或 403 降级（flag 关闭）', async () => {
+    // 创建一个 intent decision
+    const createResp = await apiPost('/api/v1/intent-decisions', {
+      painId: 'pain-e2e-1',
+      taskId: 'task-diag-1',
+      source: 'owner',
+      evidenceStrength: 'strong',
+      ownerAction: 'acknowledge',
+      ownerNote: 'E2E test: acknowledge the pain signal',
+    });
+
+    if (createResp.status === 200 || createResp.status === 201) {
+      // flag 开启路径：201 = 新建成功，200 = 幂等重放
+      const createBody = createResp.body as {
+        success: boolean;
+        data: { id?: string; painId?: string; ownerAction?: string };
+      };
+      expect(createBody.success).toBe(true);
+
+      // 验证创建后能查询到
+      if (createBody.data.id) {
+        const queryResp = await apiGet('/api/v1/intent-decisions?painId=pain-e2e-1');
+        const queryBody = queryResp.body as {
+          success: boolean;
+          data: { decisions?: Array<{ id: string; painId: string }> };
+        };
+        const found = queryBody.data.decisions?.find(d => d.id === createBody.data.id);
+        expect(found, 'created intent decision not found in query').toBeTruthy();
+      }
+    } else if (createResp.status === 403) {
+      // flag-disabled：验证 reason + nextAction（ERR-002）
+      const body = createResp.body as {
+        success: boolean;
+        reason?: string;
+        nextAction?: string;
+      };
+      expect(body.success).toBe(false);
+      expect(body.reason).toBeTruthy();
+      expect(body.nextAction).toBeTruthy();
+    } else {
+      throw new Error(`unexpected status ${createResp.status}: ${JSON.stringify(createResp.body)}`);
+    }
+  });
+});

--- a/packages/pd-console/tests/e2e/principle-detail-flow.spec.ts
+++ b/packages/pd-console/tests/e2e/principle-detail-flow.spec.ts
@@ -1,0 +1,136 @@
+/* eslint-disable */
+// E2E 流程测试：PrincipleDetailPage 4 源拼接 + approve 闭环
+// 验证 PD 最复杂的页面：principle detail + approvals grouped + lifecycle + trajectory
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:3100';
+
+async function apiGet(path: string): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`);
+  const body = await resp.json().catch(() => null);
+  return { status: resp.status, body };
+}
+
+test.describe('PrincipleDetailPage 4 源拼接流程', () => {
+  test('principle detail + approvals grouped + lifecycle + trajectory 全部加载', async ({ page }) => {
+    // ── 步骤 1：获取 principle id（seed 数据应有 p-001）─────────────────────
+    const principlesResp = await apiGet('/api/principles?filter=all');
+    expect(principlesResp.status).toBe(200);
+    const principlesBody = principlesResp.body as {
+      success: boolean;
+      data: { principles: Array<{ id: string; status: string; text: string }> };
+    };
+    expect(principlesBody.success).toBe(true);
+    expect(principlesBody.data.principles.length).toBeGreaterThanOrEqual(1);
+
+    const principle = principlesBody.data.principles[0];
+    expect(principle.id).toBeTruthy();
+    expect(principle.text).toBeTruthy();
+
+    // ── 步骤 2：进入 PrincipleDetailPage，收集所有 API 调用 ─────────────────
+    const apiCalls: Array<{ url: string; status: number }> = [];
+    const errors: string[] = [];
+    page.on('response', (resp) => {
+      if (resp.url().includes('/api/')) {
+        apiCalls.push({ url: resp.url(), status: resp.status() });
+        if (resp.status() >= 500) {
+          errors.push(`5xx: ${resp.status()} ${resp.url()}`);
+        }
+      }
+    });
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+
+    // PrincipleDetailPage 的 4 源 Promise.all：
+    // 1. /api/principles/:id
+    // 2. /api/v1/approvals/grouped
+    // 3. /api/v1/lifecycle/principles/:id
+    // 4. /api/principles/:id/trajectory
+    await page.goto(`/#/principles/${encodeURIComponent(principle.id)}`);
+    await page.waitForLoadState('networkidle');
+
+    // ── 步骤 3：验证无 5xx 和 pageerror ──────────────────────────────────────
+    expect(errors, `PrincipleDetailPage had errors:\n${errors.join('\n')}`).toEqual([]);
+
+    // ── 步骤 4：验证页面主体已渲染（不是空白或 error 兜底）──────────────────
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.length).toBeGreaterThan(100);
+    // 页面应包含 principle text（验证 detail 数据已加载）
+    expect(bodyText).toContain(principle.text);
+
+    // ── 步骤 5：验证 4 个 API 端点都被调用 ──────────────────────────────────
+    const principleDetailCalled = apiCalls.some(c =>
+      c.url.includes(`/api/principles/${encodeURIComponent(principle.id)}`) && !c.url.includes('trajectory'),
+    );
+    const approvalsGroupedCalled = apiCalls.some(c => c.url.includes('/api/v1/approvals/grouped'));
+    const lifecycleCalled = apiCalls.some(c =>
+      c.url.includes(`/api/v1/lifecycle/principles/${encodeURIComponent(principle.id)}`),
+    );
+    const trajectoryCalled = apiCalls.some(c =>
+      c.url.includes(`/api/principles/${encodeURIComponent(principle.id)}/trajectory`),
+    );
+
+    expect(principleDetailCalled, 'principle detail API not called').toBe(true);
+    expect(approvalsGroupedCalled, 'approvals grouped API not called').toBe(true);
+    expect(lifecycleCalled, 'lifecycle API not called').toBe(true);
+    expect(trajectoryCalled, 'trajectory API not called').toBe(true);
+  });
+
+  test('principle detail API 直接调用：返回完整结构', async () => {
+    // 获取 principle id
+    const listResp = await apiGet('/api/principles?filter=all');
+    const listBody = listResp.body as {
+      success: boolean;
+      data: { principles: Array<{ id: string }> };
+    };
+    const principleId = listBody.data.principles[0].id;
+
+    // 调用 detail API
+    const detailResp = await apiGet(`/api/principles/${encodeURIComponent(principleId)}`);
+    expect(detailResp.status).toBe(200);
+    // 注意：detail 端点返回 data.principle（嵌套在 principle 字段下，不是平铺在 data 上）
+    const detailBody = detailResp.body as {
+      success: boolean;
+      data: { principle: { id: string; text: string; status: string } };
+    };
+    expect(detailBody.success).toBe(true);
+    expect(detailBody.data.principle.id).toBe(principleId);
+    expect(detailBody.data.principle.text).toBeTruthy();
+    expect(detailBody.data.principle.status).toBeTruthy();
+  });
+
+  test('lifecycle API 直接调用：返回 principle 生命周期指标', async () => {
+    const listResp = await apiGet('/api/principles?filter=all');
+    const listBody = listResp.body as {
+      success: boolean;
+      data: { principles: Array<{ id: string }> };
+    };
+    const principleId = listBody.data.principles[0].id;
+
+    const lifecycleResp = await apiGet(`/api/v1/lifecycle/principles/${encodeURIComponent(principleId)}`);
+    // lifecycle 端点可能返回 200 或 degraded（如果无数据），但不应 5xx
+    expect(lifecycleResp.status).toBe(200);
+    const lifecycleBody = lifecycleResp.body as {
+      success: boolean;
+      data: { principleId?: string; hasRules?: boolean };
+    };
+    expect(lifecycleBody.success).toBe(true);
+  });
+
+  test('trajectory API 直接调用：返回 principle 轨迹', async () => {
+    const listResp = await apiGet('/api/principles?filter=all');
+    const listBody = listResp.body as {
+      success: boolean;
+      data: { principles: Array<{ id: string }> };
+    };
+    const principleId = listBody.data.principles[0].id;
+
+    const trajectoryResp = await apiGet(`/api/principles/${encodeURIComponent(principleId)}/trajectory`);
+    expect(trajectoryResp.status).toBe(200);
+    const trajectoryBody = trajectoryResp.body as {
+      success: boolean;
+      data: unknown;
+    };
+    expect(trajectoryBody.success).toBe(true);
+  });
+});

--- a/packages/pd-console/tests/e2e/smoke-all-pages.spec.ts
+++ b/packages/pd-console/tests/e2e/smoke-all-pages.spec.ts
@@ -14,9 +14,7 @@ const SMOKE_PAGES = [
   { path: '/#/debt', name: 'Debt' },
   { path: '/#/control-center', name: 'ControlCenter' },
   { path: '/#/settings', name: 'Settings' },
-  // Update 页面已标记为 known failure — /api/update/check 在空工作区返回 500
-  // （无法确定当前版本）。这是冒烟测试发现的真实 flow break，需后续修复 update route。
-  { path: '/#/update', name: 'Update', fixme: true },
+  { path: '/#/update', name: 'Update' },
   { path: '/#/report-problem', name: 'ReportProblem' },
   { path: '/#/intent', name: 'Intent' },
 ] as const;
@@ -36,12 +34,8 @@ function attachErrorCollectors(page: Page): string[] {
   return errors;
 }
 
-for (const { path, name, fixme } of SMOKE_PAGES) {
+for (const { path, name } of SMOKE_PAGES) {
   test(`smoke: ${name} page loads without error`, async ({ page }) => {
-    if (fixme) {
-      test.fixme(true, 'Known flow break: /api/update/check returns 500 on empty workspace');
-    }
-
     const errors = attachErrorCollectors(page);
 
     await page.goto(path);

--- a/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
+++ b/packages/pd-console/tests/models/evidence-chain-console-model.test.ts
@@ -20,7 +20,7 @@ import * as path from 'path';
 import * as os from 'os';
 import Database from 'better-sqlite3';
 import { EvidenceChainConsoleModel } from '../../src/server/models/EvidenceChainConsoleModel.js';
-import { crossReferenceByTimestamp } from '../../src/server/models/EvidenceChainConsoleModel.js';
+import { crossReferenceByTimestamp } from '@principles/core/runtime-v2';
 
 // ── Test Setup ───────────────────────────────────────────────────────────────
 

--- a/packages/pd-console/tests/server/routes/update.test.ts
+++ b/packages/pd-console/tests/server/routes/update.test.ts
@@ -368,33 +368,6 @@ describe('handleUpdateRoute', () => {
     });
   });
 
-  // ── GET /status ─────────────────────────────────────────────────────
-
-  describe('GET /status', () => {
-    it('should return current update status', async () => {
-      const req = createMockRequest('GET');
-      const res = createMockResponse();
-
-      await handleUpdateRoute(req, res, workspaceDir, '/status');
-
-      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
-      const body = parseResponseBody<{ success: boolean; data: { checking: boolean; updating: boolean; currentVersion: string } }>(res);
-      expect(body.success).toBe(true);
-      expect(body.data.checking).toBe(false);
-      expect(body.data.updating).toBe(false);
-      expect(body.data.currentVersion).toBe('1.0.0');
-    });
-
-    it('should return 405 for non-GET method', async () => {
-      const req = createMockRequest('POST');
-      const res = createMockResponse();
-
-      await handleUpdateRoute(req, res, workspaceDir, '/status');
-
-      expect(res.writeHead).toHaveBeenCalledWith(405, expect.any(Object));
-    });
-  });
-
   // ── POST /rollback ──────────────────────────────────────────────────
 
   describe('POST /rollback', () => {

--- a/packages/pd-console/tests/server/routes/update.test.ts
+++ b/packages/pd-console/tests/server/routes/update.test.ts
@@ -162,7 +162,7 @@ describe('handleUpdateRoute', () => {
       expect(body.error).toBe('method_not_allowed');
     });
 
-    it('should return 500 when version cannot be determined', async () => {
+    it('should return degraded 200 with reason when version cannot be determined (ERR-002)', async () => {
       const emptyTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-update-noplugin-'));
       const emptyWorkspace = path.join(emptyTmpDir, 'workspace');
       fs.mkdirSync(emptyWorkspace, { recursive: true });
@@ -178,9 +178,14 @@ describe('handleUpdateRoute', () => {
 
         await handleUpdateRoute(req, res, emptyWorkspace, '/check');
 
-        expect(res.writeHead).toHaveBeenCalledWith(500, expect.any(Object));
-        const body = parseResponseBody<{ success: boolean; error: string }>(res);
-        expect(body.error).toBe('version_not_found');
+        // ERR-002 / Runtime Contract Rule 9: graceful degradation with reason, not 500.
+        expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
+        const body = parseResponseBody<{ success: boolean; data: { hasUpdate: boolean; currentVersion: string; latestVersion: string; error?: string } }>(res);
+        expect(body.success).toBe(true);
+        expect(body.data.hasUpdate).toBe(false);
+        expect(body.data.currentVersion).toBe('unknown');
+        expect(body.data.latestVersion).toBe('');
+        expect(body.data.error).toMatch(/Could not determine current version/i);
       } finally {
         process.env.OPENCLAW_HOME = savedHome;
         fs.rmSync(emptyTmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Three-part PR improving pd-console maintainability:
1. **P0-A fix**: Update page flow break — `/api/update/check` returned 500 when plugin not installed
2. **P0-B E2E tests**: 11 flow tests covering PD's highest-risk user journeys (approval闭环 / principle 4-source拼接 / pain→intent链路) + seed infrastructure
3. **API audit**: Audit all 45+ pd-console API endpoints for redundancy/dead code; remove 10 dead items across 4 categories (−225 lines net)

## Changes

### Commit 1: `fix(pd-console): degrade /api/update/check to 200 when plugin version unknown`
- `src/server/routes/update.ts`: `/api/update/check` returned 500 when the plugin wasn't installed (`readCurrentVersion()` → undefined). Now returns a degraded 200 with `hasUpdate=false`, `currentVersion='unknown'`, and an error reason, per ERR-002 / Runtime Contract Rule 9.
- `tests/server/routes/update.test.ts`: test updated to expect the degraded 200 response.
- `tests/e2e/smoke-all-pages.spec.ts`: removed `test.fixme` for the Update page — smoke coverage back to 10/10.

### Commit 2: `test(pd-console): E2E flow tests for approval/principle/pain + seed infra`
- `scripts/e2e-seed.ts` (new): initializes `state.db` schema via `SqliteConnection({ readonly: false })` and inserts 2 approvals (prompt + code_tool_hook channels), 1 task/run/artifact/candidate, 1 pain_event in `trajectory.db`, and 1 principle in `principle_training_state.json`.
- `scripts/e2e-start.mjs`: added `spawnSync` seed step before server start (server opens DB readonly, so seed must run first).
- `tests/e2e/focus-approve-flow.spec.ts` (new, 2 tests): governance queue → approve → pending decrease + activation appears.
- `tests/e2e/principle-detail-flow.spec.ts` (new, 4 tests): the 4-source `Promise.all` page (detail + approvals grouped + lifecycle + trajectory).
- `tests/e2e/pain-intent-flow.spec.ts` (new, 5 tests): evidence-chain → intent endpoints, with 403 flag-disabled degradation path verified.

### Commit 3: `refactor(pd-console): remove dead API surface — orphaned functions, stub endpoint, unused model methods`

Audit findings: zero `@deprecated` markers, zero duplicate old+new path pairs (e.g. no `/api/foo` + `/api/v1/foo`), zero stub handlers. The `/api/v1/*` vs `/api/*` prefix split is a naming convention issue, not duplication.

Removed 10 dead items across 4 categories:

**A. Dead frontend functions** (`src/ui/api.ts`):
- `fetchApprovalDetail`: never imported by any UI component; approvals consumed via `fetchApprovalsGrouped`
- `getIntentDecision`: never imported; intent decisions consumed via list/summary endpoints
- `request` bare re-export: only used internally in api.ts, no external consumer
- `validateIntentDecisionRecord` import: only used by deleted `getIntentDecision`

**B. Dead backend endpoint** (`routes/update.ts`):
- `GET /api/update/status`: near-stub always returning `{checking:false, updating:false, currentVersion}`; frontend `fetchUpdateStatus` actually calls `/api/update/check`, never `/status`

**C. Dead model methods + infrastructure** (`models/WorkspaceService.ts`, reduced 188 → 25 lines):
- `getCentralOverview()` / `getCentralHealth()`: never called from any route
- `WorkspaceModels` interface, `models` Map, `getModels()`, 4 model imports, `dispose()`: all only supported the two dead methods

**D. Dead re-exports** (`models/EvidenceChainConsoleModel.ts`):
- `resolveSummary`: zero references anywhere in the codebase
- `crossReferenceByTimestamp`: only referenced by tests, not production code; tests now import directly from `@principles/core/runtime-v2`

**Deliberately preserved** (not deleted, with reasoning):
- `ConsoleLifecycleDatasource.listLineageRecords()` tombstone (PRI-230 retired): crosses package boundary, part of `LifecycleDatasource` interface contract in `principles-core`
- `GET /api/v1/approvals/:id` and `GET /api/v1/intent-decisions/:id`: no frontend consumer but covered by tests, retained as stable API surface
- Backend endpoints with no frontend consumer but with real logic + test coverage

## Test Results

```
21 E2E tests passed (22.2s) — 10 smoke + 11 flow
npm run verify:merge: PASS (0 errors, 31 pre-existing rc-5 warnings in principles-core)
```

## ERR Checklist (considered & how avoided)

- **ERR-002 / rc-9 (no silent fallback)**:
  - Update fix: explicitly adds a reason (`error: 'Could not determine current version'`) instead of returning 500 with no context.
  - API cleanup: removed the stub `/status` endpoint that silently returned hardcoded `{checking:false, updating:false}` with no real status tracking.
  - Intent-decisions tests verify the 403 flag-disabled path includes `reason` + `nextAction`.
- **ERR-001 / rc-1 (treat as unknown)**: All API response bodies are typed as `unknown` via the `apiGet`/`apiPost` helpers and narrowed with `as` only after status checks — no blind field access on unvalidated shapes.
- **ERR-005 / rc-2 (no as bypass)**: Test assertions use `as` for type narrowing on API responses *after* structural validation (status code + `success` field), which is the documented exception. The tests do not bypass runtime validation of untrusted data — they verify the server's runtime validation contract.
- **ERR-009 / rc-3 (fail loud missing)**: Tests use explicit `expect(...).toBeTruthy()` and throw on unexpected status codes rather than silently passing.

## Findings Surfaced During Test Writing

1. **API response shape drift**: The approvals list returns `data.items` (not `data.approvals`), principle detail nests under `data.principle` (not flat on `data`), and evidence-chain returns `data.records` (not `data.items`). Tests now lock these contracts.
2. **code_tool_hook activation requires `artifact_kind='rule'`**: The seed's hook artifact doesn't satisfy this, so approve returns 500 `activation_failed` with a clear reason + nextAction (ERR-002 compliant). The happy-path test uses the prompt channel; the hook artifact kind gap is a seed-completeness follow-up, not a production bug.
3. **intent-decisions endpoints return 403 when `intent_engineering` flag is disabled**: Response includes `reason: 'flag_disabled'` + `nextAction`. Tests verify both the 200 (flag on) and 403 (flag off) paths.

## Remaining Risk / Follow-ups

- The seed's `apr-hook-1` artifact doesn't have `artifact_kind='rule'`, so the code_tool_hook approve path isn't covered end-to-end. Follow-up: enrich seed or add a dedicated degradation test.
- E2E tests run serially (`fullyParallel: false`) due to SQLite file locks; 21 tests take ~22s. Acceptable for now.
- CI workflow already exists from PR #1068; this branch reuses it.
- Element-level schema validation in `WorkspaceConfigStore` is a known gap (deferred from earlier review).

## Diff Scope

All 15 files are under `packages/pd-console/`. No unrelated files modified. No changes to `principles-core`, `openclaw-plugin`, or `pd-cli`.
