### PR TITLE
feat(runtime): consolidate DB initialization and add \pd runtime init\ command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Build core dependency
         run: npm run build --workspace=@principles/core
 
+      - name: Build plugin dependency
+        run: npm run build --workspace=principles-disciple
+
       - name: Build and test
         working-directory: packages/pd-cli
         run: npm run build && npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -19785,7 +19785,8 @@
         "@principles/core": "^1.74.1",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.0.0",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.1",
+        "principles-disciple": "^1.74.1"
       },
       "bin": {
         "pd": "dist/index.js"

--- a/packages/create-principles-disciple/src/installer.ts
+++ b/packages/create-principles-disciple/src/installer.ts
@@ -1107,6 +1107,21 @@ export async function install(options: InstallOptions, pluginDir: string, quiet 
     await createConfigFile(options.workspaceDir, options.channels);
     stepIndex++;
 
+    if (spinner) updateProgress(spinner, stepIndex, 'Initializing PD databases...');
+    try {
+      const pdCliEntry = path.join(getInstalledPdCliDir(), 'dist', 'index.js');
+      execFileSync(process.execPath, [pdCliEntry, 'runtime', 'init', '--confirm', '--workspace', options.workspaceDir], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        timeout: 30000,
+      });
+    } catch (err) {
+      // rc-9: surface failure — do not silently swallow.
+      // Non-fatal: demo story-a and runtime hooks will surface DB issues.
+      const initWarn = err instanceof Error ? err.message : String(err);
+      logger.warn(`pd runtime init failed (non-fatal): ${initWarn}`);
+    }
+    stepIndex++;
+
     if (spinner) updateProgress(spinner, stepIndex, 'Verifying pd demo story-a...');
     try {
       const installedPdCliEntry = path.join(getInstalledPdCliDir(), 'dist', 'index.js');

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -3,9 +3,13 @@
   "version": "1.74.1",
   "description": "Native OpenClaw plugin for Principles Disciple",
   "type": "module",
-  "main": "./dist/bundle.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/bundle.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/openclaw-plugin/src/core/control-ui-db.ts
+++ b/packages/openclaw-plugin/src/core/control-ui-db.ts
@@ -324,9 +324,16 @@ export class ControlUiDatabase {
         ON thinking_model_events(assistant_turn_id);
       CREATE INDEX IF NOT EXISTS idx_thinking_model_events_run_id
         ON thinking_model_events(run_id);
+    `);
 
-      DROP VIEW IF EXISTS v_thinking_model_usage;
-      CREATE VIEW v_thinking_model_usage AS
+    // Views depend on tables owned by TrajectoryDatabase (assistant_turns, tool_calls,
+    // pain_events, user_turns, correction_samples). If ControlUiDatabase is constructed
+    // before TrajectoryDatabase has run initSchema (e.g. llm_output is the first hook
+    // triggered on a fresh workspace), CREATE VIEW would throw and break the hook.
+    // Wrap each view creation in try/catch so missing-dependency views are skipped with
+    // a warning rather than aborting schema initialization (rc-9: no silent fallback —
+    // failures are surfaced via console.info).
+    this.createViewSafely('v_thinking_model_usage', `
       WITH totals AS (
         SELECT COUNT(*) AS assistant_turns FROM assistant_turns
       ),
@@ -349,10 +356,10 @@ export class ControlUiDatabase {
           ELSE ROUND(CAST(usage_rows.distinct_turns AS REAL) / CAST(totals.assistant_turns AS REAL), 4)
         END AS coverage_rate
       FROM usage_rows, totals
-      ORDER BY usage_rows.hits DESC, usage_rows.model_id ASC;
+      ORDER BY usage_rows.hits DESC, usage_rows.model_id ASC
+    `);
 
-      DROP VIEW IF EXISTS v_thinking_model_effectiveness;
-      CREATE VIEW v_thinking_model_effectiveness AS
+    this.createViewSafely('v_thinking_model_effectiveness', `
       WITH event_windows AS (
         SELECT
           e.id,
@@ -418,10 +425,10 @@ export class ControlUiDatabase {
         ) THEN 1 ELSE 0 END) AS correction_sample_windows
       FROM bounded_windows b
       GROUP BY b.model_id
-      ORDER BY events DESC, model_id ASC;
+      ORDER BY events DESC, model_id ASC
+    `);
 
-      DROP VIEW IF EXISTS v_thinking_model_scenarios;
-      CREATE VIEW v_thinking_model_scenarios AS
+    this.createViewSafely('v_thinking_model_scenarios', `
       SELECT
         e.model_id AS model_id,
         CAST(j.value AS TEXT) AS scenario,
@@ -434,18 +441,39 @@ export class ControlUiDatabase {
         END
       ) AS j
       GROUP BY e.model_id, CAST(j.value AS TEXT)
-      ORDER BY hits DESC, scenario ASC;
+      ORDER BY hits DESC, scenario ASC
+    `);
 
-      DROP VIEW IF EXISTS v_thinking_model_daily_trend;
-      CREATE VIEW v_thinking_model_daily_trend AS
+    this.createViewSafely('v_thinking_model_daily_trend', `
       SELECT
         substr(created_at, 1, 10) AS day,
         model_id,
         COUNT(*) AS hits
       FROM thinking_model_events
       GROUP BY substr(created_at, 1, 10), model_id
-      ORDER BY day ASC, model_id ASC;
+      ORDER BY day ASC, model_id ASC
     `);
+  }
+
+  /**
+   * Create or replace a view, tolerating missing dependency tables.
+   *
+   * Views in ControlUiDatabase depend on tables created by TrajectoryDatabase
+   * (assistant_turns, tool_calls, pain_events, user_turns, correction_samples).
+   * If ControlUiDatabase is constructed before TrajectoryDatabase has created
+   * those tables, CREATE VIEW would throw. We DROP+CREATE with try/catch so
+   * missing-dependency views are skipped with a warning (rc-9: surfaced via
+   * console.info) rather than aborting schema initialization.
+   */
+  private createViewSafely(viewName: string, viewBody: string): void {
+    try {
+      this.db.exec(`DROP VIEW IF EXISTS ${viewName};`);
+      this.db.exec(`CREATE VIEW ${viewName} AS ${viewBody};`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      // rc-9: surface the failure — do not silently swallow
+      console.info(`[PD:ControlUiDatabase] view ${viewName} creation skipped: ${message}. It will be created on next TrajectoryDatabase initSchema().`);
+    }
   }
 
   private withWrite<T>(fn: () => T): T {

--- a/packages/openclaw-plugin/src/core/trajectory.ts
+++ b/packages/openclaw-plugin/src/core/trajectory.ts
@@ -77,6 +77,339 @@ const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 const DEFAULT_ORPHAN_BLOB_GRACE_DAYS = 7;
 const SCHEMA_VERSION = 1;
 
+/**
+ * Type guard: narrows `object` to `{ name: unknown }` without `as` casts.
+ * Used for PRAGMA table_info rows (rc-2-no-as-bypass).
+ */
+function hasNameField(row: object): row is { name: unknown } {
+  return Object.hasOwn(row, 'name');
+}
+
+/**
+ * Apply the full trajectory.db schema (tables + indexes + views + migrations) to an open
+ * Database handle. Used by TrajectoryDatabase.initSchema() and exported via
+ * initTrajectorySchema() for external callers (e.g. `pd runtime init`).
+ *
+ * DDL is the single source of truth for trajectory.db schema. pain-signal-observability.ts
+ * in principles-core also duplicates a subset of this DDL (acknowledged duplication); when
+ * updating this function, audit ensureTrajectorySchema() in core for parallel updates.
+ *
+ * Idempotent: all CREATE statements use IF NOT EXISTS; ALTER columns use try/catch on
+ * "duplicate column name" to skip existing columns.
+ */
+function applyTrajectorySchema(db: Database.Database): { tables: string[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const tables = [
+    'schema_version', 'ingest_checkpoint', 'sessions', 'assistant_turns',
+    'user_turns', 'tool_calls', 'pain_events', 'gate_blocks', 'trust_changes',
+    'principle_events', 'task_outcomes', 'correction_samples', 'sample_reviews',
+    'exports_audit', 'evolution_tasks', 'evolution_events',
+  ];
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+    CREATE TABLE IF NOT EXISTS ingest_checkpoint (
+      source_key TEXT PRIMARY KEY,
+      imported_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      started_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS assistant_turns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      raw_text TEXT,
+      sanitized_text TEXT NOT NULL,
+      usage_json TEXT NOT NULL,
+      empathy_signal_json TEXT NOT NULL,
+      blob_ref TEXT,
+      raw_excerpt TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS user_turns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      turn_index INTEGER NOT NULL,
+      raw_text TEXT,
+      blob_ref TEXT,
+      raw_excerpt TEXT,
+      correction_detected INTEGER NOT NULL DEFAULT 0,
+      correction_cue TEXT,
+      references_assistant_turn_id INTEGER,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS tool_calls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      outcome TEXT NOT NULL,
+      duration_ms INTEGER,
+      exit_code INTEGER,
+      error_type TEXT,
+      error_message TEXT,
+      gfi_before REAL,
+      gfi_after REAL,
+      params_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS pain_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      score REAL NOT NULL,
+      reason TEXT,
+      severity TEXT,
+      origin TEXT,
+      confidence REAL,
+      text TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS gate_blocks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT,
+      tool_name TEXT NOT NULL,
+      file_path TEXT,
+      reason TEXT NOT NULL,
+      plan_status TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS trust_changes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT,
+      previous_score REAL NOT NULL,
+      new_score REAL NOT NULL,
+      delta REAL NOT NULL,
+      reason TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS principle_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      principle_id TEXT,
+      event_type TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS task_outcomes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      task_id TEXT,
+      outcome TEXT NOT NULL,
+      summary TEXT,
+      principle_ids_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correction_samples (
+      sample_id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      bad_assistant_turn_id INTEGER NOT NULL,
+      user_correction_turn_id INTEGER NOT NULL,
+      recovery_tool_span_json TEXT NOT NULL,
+      diff_excerpt TEXT NOT NULL,
+      principle_ids_json TEXT NOT NULL,
+      quality_score REAL NOT NULL,
+      review_status TEXT NOT NULL,
+      export_mode TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS sample_reviews (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      sample_id TEXT NOT NULL,
+      review_status TEXT NOT NULL,
+      note TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS exports_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      export_kind TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      approved_only INTEGER NOT NULL,
+      file_path TEXT NOT NULL,
+      row_count INTEGER NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS evolution_tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT UNIQUE NOT NULL,
+      trace_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      reason TEXT,
+      score INTEGER DEFAULT 0,
+      status TEXT DEFAULT 'pending',
+      enqueued_at TEXT,
+      started_at TEXT,
+      completed_at TEXT,
+      resolution TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS evolution_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trace_id TEXT NOT NULL,
+      task_id TEXT,
+      stage TEXT NOT NULL,
+      level TEXT DEFAULT 'info',
+      message TEXT NOT NULL,
+      summary TEXT,
+      metadata_json TEXT,
+      created_at TEXT NOT NULL
+    );
+  `);
+
+  // Migration: Add text column to pain_events if it doesn't exist (MEM-01)
+  // SQLite doesn't support IF NOT EXISTS for ADD COLUMN, so we use try/catch
+  try {
+    db.exec(`ALTER TABLE pain_events ADD COLUMN text TEXT`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+      // Re-throw unexpected errors — silently swallowing migration failures is dangerous
+      throw err;
+    }
+  }
+
+  // PRI-406: Add canonical_pain_id and runtime_task_id columns to pain_events
+  for (const col of [
+    { name: 'canonical_pain_id', type: 'TEXT' },
+    { name: 'runtime_task_id', type: 'TEXT' },
+  ]) {
+    try {
+      db.exec(`ALTER TABLE pain_events ADD COLUMN ${col.name} ${col.type}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+        throw err;
+      }
+    }
+  }
+
+  // Trajectory enhancement: add stop_reason, thinking_blocks_count, result_preview
+  const trajectoryEnhancementColumns = [
+    { table: 'assistant_turns', name: 'stop_reason', type: 'TEXT' },
+    { table: 'assistant_turns', name: 'thinking_blocks_count', type: 'INTEGER' },
+    { table: 'tool_calls', name: 'result_preview', type: 'TEXT' },
+  ];
+  for (const col of trajectoryEnhancementColumns) {
+    try {
+      db.exec(`ALTER TABLE ${col.table} ADD COLUMN ${col.name} ${col.type}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+        throw err;
+      }
+    }
+  }
+
+  // PRI-406: Partial unique index on canonical_pain_id (non-null only) for dedup
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
+    ON pain_events(canonical_pain_id)
+    WHERE canonical_pain_id IS NOT NULL
+  `);
+
+  // V2 migration: Add V2 columns to evolution_tasks if they don't exist
+  const v2Columns = [
+    { name: 'task_kind', type: 'TEXT' },
+    { name: 'priority', type: 'TEXT' },
+    { name: 'retry_count', type: 'INTEGER' },
+    { name: 'max_retries', type: 'INTEGER' },
+    { name: 'last_error', type: 'TEXT' },
+    { name: 'result_ref', type: 'TEXT' },
+  ];
+  for (const col of v2Columns) {
+    const rows = db.prepare(`PRAGMA table_info(evolution_tasks)`).all();
+    const exists = rows.some((row): boolean => {
+      if (typeof row !== 'object' || row === null) return false;
+      // Use type guard predicate to narrow without `as` (rc-2-no-as-bypass)
+      return hasNameField(row) && row.name === col.name;
+    });
+    if (!exists) {
+      db.exec(`ALTER TABLE evolution_tasks ADD COLUMN ${col.name} ${col.type}`);
+    }
+  }
+
+  db.exec(`
+    CREATE VIEW IF NOT EXISTS v_error_clusters AS
+    SELECT tool_name, COALESCE(error_type, 'unknown') AS error_type, COUNT(*) AS occurrences
+    FROM tool_calls
+    WHERE outcome = 'failure'
+    GROUP BY tool_name, COALESCE(error_type, 'unknown')
+    ORDER BY occurrences DESC;
+    CREATE VIEW IF NOT EXISTS v_principle_effectiveness AS
+    SELECT event_type, COUNT(*) AS total
+    FROM principle_events
+    GROUP BY event_type
+    ORDER BY total DESC;
+    CREATE VIEW IF NOT EXISTS v_sample_queue AS
+    SELECT review_status, COUNT(*) AS total
+    FROM correction_samples
+    GROUP BY review_status;
+    CREATE INDEX IF NOT EXISTS idx_assistant_turns_session_id ON assistant_turns(session_id);
+    CREATE INDEX IF NOT EXISTS idx_assistant_turns_created_at ON assistant_turns(created_at);
+    CREATE INDEX IF NOT EXISTS idx_assistant_turns_provider_model ON assistant_turns(provider, model);
+    CREATE INDEX IF NOT EXISTS idx_user_turns_session_id ON user_turns(session_id);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_session_id ON tool_calls(session_id);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_created_at ON tool_calls(created_at);
+    CREATE INDEX IF NOT EXISTS idx_pain_events_session_id ON pain_events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_correction_samples_review_status ON correction_samples(review_status);
+    CREATE INDEX IF NOT EXISTS idx_evolution_tasks_trace_id ON evolution_tasks(trace_id);
+    CREATE INDEX IF NOT EXISTS idx_evolution_tasks_status ON evolution_tasks(status);
+    CREATE INDEX IF NOT EXISTS idx_evolution_tasks_created_at ON evolution_tasks(created_at);
+    CREATE INDEX IF NOT EXISTS idx_evolution_events_trace_id ON evolution_events(trace_id);
+    CREATE INDEX IF NOT EXISTS idx_evolution_events_created_at ON evolution_events(created_at);
+  `);
+
+  return { tables, warnings };
+}
+
+/**
+ * Initialize trajectory.db schema at the given workspace directory.
+ *
+ * Opens trajectory.db in write mode, applies the full schema (tables + indexes + views +
+ * migrations), then closes the DB. Does NOT run importLegacyArtifacts() or
+ * pruneUnreferencedBlobs() — those are runtime side-effects of TrajectoryDatabase
+ * construction and are not needed for pure initialization.
+ *
+ * Idempotent: safe to call on an existing DB; all CREATE statements use IF NOT EXISTS.
+ *
+ * @returns list of created/verified table names and any warnings
+ */
+export function initTrajectorySchema(workspaceDir: string): { tables: string[]; warnings: string[] } {
+  const resolvedDir = path.resolve(workspaceDir);
+  const stateDir = resolvePdPath(resolvedDir, 'STATE_DIR');
+  const blobDir = resolvePdPath(resolvedDir, 'TRAJECTORY_BLOBS_DIR');
+  const exportDir = resolvePdPath(resolvedDir, 'EXPORTS_DIR');
+  const dbPath = resolvePdPath(resolvedDir, 'TRAJECTORY_DB');
+
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(blobDir, { recursive: true });
+  fs.mkdirSync(exportDir, { recursive: true });
+
+  const db = new Database(dbPath);
+  try {
+    db.pragma('journal_mode = WAL');
+    db.pragma('foreign_keys = ON');
+    db.pragma('synchronous = NORMAL');
+    db.pragma(`busy_timeout = ${DEFAULT_BUSY_TIMEOUT_MS}`);
+    const result = applyTrajectorySchema(db);
+    // Record schema version (same logic as TrajectoryDatabase.initSchema)
+    const row = db.prepare('SELECT version FROM schema_version LIMIT 1').get() as { version?: number } | undefined;
+    if (!row) {
+      db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+    } else if (row.version !== SCHEMA_VERSION) {
+      db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION);
+    }
+    return result;
+  } finally {
+    db.close();
+  }
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -1134,266 +1467,13 @@ export class TrajectoryDatabase {
   }
 
   private initSchema(): void {
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
-      CREATE TABLE IF NOT EXISTS ingest_checkpoint (
-        source_key TEXT PRIMARY KEY,
-        imported_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS sessions (
-        session_id TEXT PRIMARY KEY,
-        started_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS assistant_turns (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        run_id TEXT NOT NULL,
-        provider TEXT NOT NULL,
-        model TEXT NOT NULL,
-        raw_text TEXT,
-        sanitized_text TEXT NOT NULL,
-        usage_json TEXT NOT NULL,
-        empathy_signal_json TEXT NOT NULL,
-        blob_ref TEXT,
-        raw_excerpt TEXT,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS user_turns (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        turn_index INTEGER NOT NULL,
-        raw_text TEXT,
-        blob_ref TEXT,
-        raw_excerpt TEXT,
-        correction_detected INTEGER NOT NULL DEFAULT 0,
-        correction_cue TEXT,
-        references_assistant_turn_id INTEGER,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS tool_calls (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        tool_name TEXT NOT NULL,
-        outcome TEXT NOT NULL,
-        duration_ms INTEGER,
-        exit_code INTEGER,
-        error_type TEXT,
-        error_message TEXT,
-        gfi_before REAL,
-        gfi_after REAL,
-        params_json TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS pain_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        source TEXT NOT NULL,
-        score REAL NOT NULL,
-        reason TEXT,
-        severity TEXT,
-        origin TEXT,
-        confidence REAL,
-        text TEXT,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS gate_blocks (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT,
-        tool_name TEXT NOT NULL,
-        file_path TEXT,
-        reason TEXT NOT NULL,
-        plan_status TEXT,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS trust_changes (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT,
-        previous_score REAL NOT NULL,
-        new_score REAL NOT NULL,
-        delta REAL NOT NULL,
-        reason TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS principle_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        principle_id TEXT,
-        event_type TEXT NOT NULL,
-        payload_json TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS task_outcomes (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        task_id TEXT,
-        outcome TEXT NOT NULL,
-        summary TEXT,
-        principle_ids_json TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS correction_samples (
-        sample_id TEXT PRIMARY KEY,
-        session_id TEXT NOT NULL,
-        bad_assistant_turn_id INTEGER NOT NULL,
-        user_correction_turn_id INTEGER NOT NULL,
-        recovery_tool_span_json TEXT NOT NULL,
-        diff_excerpt TEXT NOT NULL,
-        principle_ids_json TEXT NOT NULL,
-        quality_score REAL NOT NULL,
-        review_status TEXT NOT NULL,
-        export_mode TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS sample_reviews (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        sample_id TEXT NOT NULL,
-        review_status TEXT NOT NULL,
-        note TEXT,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS exports_audit (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        export_kind TEXT NOT NULL,
-        mode TEXT NOT NULL,
-        approved_only INTEGER NOT NULL,
-        file_path TEXT NOT NULL,
-        row_count INTEGER NOT NULL,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS evolution_tasks (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        task_id TEXT UNIQUE NOT NULL,
-        trace_id TEXT NOT NULL,
-        source TEXT NOT NULL,
-        reason TEXT,
-        score INTEGER DEFAULT 0,
-        status TEXT DEFAULT 'pending',
-        enqueued_at TEXT,
-        started_at TEXT,
-        completed_at TEXT,
-        resolution TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS evolution_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        trace_id TEXT NOT NULL,
-        task_id TEXT,
-        stage TEXT NOT NULL,
-        level TEXT DEFAULT 'info',
-        message TEXT NOT NULL,
-        summary TEXT,
-        metadata_json TEXT,
-        created_at TEXT NOT NULL
-      );
-    `);
-
-    // Migration: Add text column to pain_events if it doesn't exist (MEM-01)
-    // SQLite doesn't support IF NOT EXISTS for ADD COLUMN, so we use try/catch
-    try {
-      this.db.exec(`ALTER TABLE pain_events ADD COLUMN text TEXT`);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (!message.includes('duplicate column name') && !message.includes('no column named')) {
-        // Re-throw unexpected errors — silently swallowing migration failures is dangerous
-        throw err;
-      }
+    const result = applyTrajectorySchema(this.db);
+    // Best-effort: surface any warnings from schema initialization (rc-9: no silent fallback).
+    // Warnings include failed migrations or view creation issues; surfaced via console.info
+    // because TrajectoryDatabase does not have a warnings buffer at this layer.
+    for (const w of result.warnings) {
+      console.info(`[PD:TrajectoryDatabase] schema init warning: ${w}`);
     }
-
-    // PRI-406: Add canonical_pain_id and runtime_task_id columns to pain_events
-    for (const col of [
-      { name: 'canonical_pain_id', type: 'TEXT' },
-      { name: 'runtime_task_id', type: 'TEXT' },
-    ]) {
-      try {
-        this.db.exec(`ALTER TABLE pain_events ADD COLUMN ${col.name} ${col.type}`);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (!message.includes('duplicate column name') && !message.includes('no column named')) {
-          throw err;
-        }
-      }
-    }
-
-    // Trajectory enhancement: add stop_reason, thinking_blocks_count, result_preview
-    const trajectoryEnhancementColumns = [
-      { table: 'assistant_turns', name: 'stop_reason', type: 'TEXT' },
-      { table: 'assistant_turns', name: 'thinking_blocks_count', type: 'INTEGER' },
-      { table: 'tool_calls', name: 'result_preview', type: 'TEXT' },
-    ];
-    for (const col of trajectoryEnhancementColumns) {
-      try {
-        this.db.exec(`ALTER TABLE ${col.table} ADD COLUMN ${col.name} ${col.type}`);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (!message.includes('duplicate column name') && !message.includes('no column named')) {
-          throw err;
-        }
-      }
-    }
-
-    // PRI-406: Partial unique index on canonical_pain_id (non-null only) for dedup
-    this.db.exec(`
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
-      ON pain_events(canonical_pain_id)
-      WHERE canonical_pain_id IS NOT NULL
-    `);
-
-    // pain_events_fts FTS5 virtual table creation removed (PRI-451 Wave 1):
-    // the only reader (searchPainEvents) was dead code. Existing DBs keep the
-    // orphan table harmlessly (CREATE was IF NOT EXISTS); new DBs skip it.
-
-    // V2 migration: Add V2 columns to evolution_tasks if they don't exist
-    // SQLite does not support IF NOT EXISTS for ADD COLUMN, so we must check manually
-    // before each ALTER to avoid "duplicate column name" errors on existing DBs
-    const v2Columns = [
-      { name: 'task_kind', type: 'TEXT' },
-      { name: 'priority', type: 'TEXT' },
-      { name: 'retry_count', type: 'INTEGER' },
-      { name: 'max_retries', type: 'INTEGER' },
-      { name: 'last_error', type: 'TEXT' },
-      { name: 'result_ref', type: 'TEXT' },
-    ];
-    for (const col of v2Columns) {
-      const exists = this.db.prepare(`PRAGMA table_info(evolution_tasks)`).all()
-        .some((row) => (row as Record<string, unknown>).name === col.name);
-      if (!exists) {
-        this.db.exec(`ALTER TABLE evolution_tasks ADD COLUMN ${col.name} ${col.type}`);
-      }
-    }
-
-    this.db.exec(`
-      CREATE VIEW IF NOT EXISTS v_error_clusters AS
-      SELECT tool_name, COALESCE(error_type, 'unknown') AS error_type, COUNT(*) AS occurrences
-      FROM tool_calls
-      WHERE outcome = 'failure'
-      GROUP BY tool_name, COALESCE(error_type, 'unknown')
-      ORDER BY occurrences DESC;
-      CREATE VIEW IF NOT EXISTS v_principle_effectiveness AS
-      SELECT event_type, COUNT(*) AS total
-      FROM principle_events
-      GROUP BY event_type
-      ORDER BY total DESC;
-      CREATE VIEW IF NOT EXISTS v_sample_queue AS
-      SELECT review_status, COUNT(*) AS total
-      FROM correction_samples
-      GROUP BY review_status;
-      CREATE INDEX IF NOT EXISTS idx_assistant_turns_session_id ON assistant_turns(session_id);
-      CREATE INDEX IF NOT EXISTS idx_assistant_turns_created_at ON assistant_turns(created_at);
-      CREATE INDEX IF NOT EXISTS idx_assistant_turns_provider_model ON assistant_turns(provider, model);
-      CREATE INDEX IF NOT EXISTS idx_user_turns_session_id ON user_turns(session_id);
-      CREATE INDEX IF NOT EXISTS idx_tool_calls_session_id ON tool_calls(session_id);
-      CREATE INDEX IF NOT EXISTS idx_tool_calls_created_at ON tool_calls(created_at);
-      CREATE INDEX IF NOT EXISTS idx_pain_events_session_id ON pain_events(session_id);
-      CREATE INDEX IF NOT EXISTS idx_correction_samples_review_status ON correction_samples(review_status);
-      CREATE INDEX IF NOT EXISTS idx_evolution_tasks_trace_id ON evolution_tasks(trace_id);
-      CREATE INDEX IF NOT EXISTS idx_evolution_tasks_status ON evolution_tasks(status);
-      CREATE INDEX IF NOT EXISTS idx_evolution_tasks_created_at ON evolution_tasks(created_at);
-      CREATE INDEX IF NOT EXISTS idx_evolution_events_trace_id ON evolution_events(trace_id);
-      CREATE INDEX IF NOT EXISTS idx_evolution_events_created_at ON evolution_events(created_at);
-    `);
-
     const row = this.db.prepare('SELECT version FROM schema_version LIMIT 1').get() as { version?: number } | undefined;
     this.migrateSchema(row?.version);
     if (!row) {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -846,4 +846,10 @@ export { PrincipleTreeLedgerAdapter } from '@principles/core/runtime-v2';
 /* istanbul ignore next — test exports for evolution worker gate */
 export { loadFeatureFlagFromWorkspace, isRecord };
 
+// Schema initialization exports for `pd runtime init` (unified DB init).
+// These functions open the DB in write mode, apply the full schema, and close the DB.
+// They do NOT run runtime side-effects (importLegacyArtifacts, pruneUnreferencedBlobs).
+export { initTrajectorySchema } from './core/trajectory.js';
+export { initWorkflowSchema } from './service/subagent-workflow/workflow-store.js';
+
 export default plugin;

--- a/packages/openclaw-plugin/src/service/subagent-workflow/workflow-store.ts
+++ b/packages/openclaw-plugin/src/service/subagent-workflow/workflow-store.ts
@@ -93,8 +93,12 @@ export class WorkflowStore {
             try {
                 this.db.exec('ALTER TABLE subagent_workflows ADD COLUMN duration_ms INTEGER');
                 console.info(`[PD:WorkflowStore] Schema migration v${fromVersion} → v${toVersion}: added duration_ms column`);
-            } catch {
-                void 0;
+            } catch (err: unknown) {
+                // rc-9: surface failure reason instead of silent void 0
+                const message = err instanceof Error ? err.message : String(err);
+                if (!message.includes('duplicate column name')) {
+                    console.info(`[PD:WorkflowStore] Schema migration v${fromVersion} → v${toVersion} failed: ${message}`);
+                }
             }
         }
     }
@@ -270,5 +274,93 @@ export class WorkflowStore {
         `).all(workflowType, limit) as { duration_ms: number }[];
 
         return rows.map(r => r.duration_ms);
+    }
+}
+
+/**
+ * Initialize subagent_workflows.db schema at the given workspace directory.
+ *
+ * Opens the DB in write mode, applies the full schema (tables + indexes + migrations),
+ * then closes the DB. Used by `pd runtime init` for unified DB initialization.
+ *
+ * Idempotent: safe to call on an existing DB; all CREATE statements use IF NOT EXISTS.
+ *
+ * @returns list of created/verified table names and any warnings
+ */
+export function initWorkflowSchema(workspaceDir: string): { tables: string[]; warnings: string[] } {
+    const resolvedDir = path.resolve(workspaceDir);
+    const stateDir = path.join(resolvedDir, '.state');
+    const dbPath = path.join(stateDir, 'subagent_workflows.db');
+    const warnings: string[] = [];
+    const tables = ['schema_version', 'subagent_workflows', 'subagent_workflow_events'];
+
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const db = new Database(dbPath);
+    try {
+        db.pragma('journal_mode = WAL');
+        db.pragma('foreign_keys = ON');
+        db.pragma('synchronous = NORMAL');
+        db.pragma(`busy_timeout = ${DEFAULT_BUSY_TIMEOUT_MS}`);
+
+        db.exec(`
+            CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS subagent_workflows (
+                workflow_id TEXT PRIMARY KEY,
+                workflow_type TEXT NOT NULL,
+                transport TEXT NOT NULL,
+                parent_session_id TEXT NOT NULL,
+                child_session_key TEXT NOT NULL,
+                run_id TEXT,
+                state TEXT NOT NULL DEFAULT 'pending',
+                cleanup_state TEXT NOT NULL DEFAULT 'none',
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                last_observed_at INTEGER,
+                duration_ms INTEGER,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE IF NOT EXISTS subagent_workflow_events (
+                workflow_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                from_state TEXT,
+                to_state TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                payload_json TEXT NOT NULL DEFAULT '{}',
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY (workflow_id) REFERENCES subagent_workflows(workflow_id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_workflows_parent_session ON subagent_workflows(parent_session_id);
+            CREATE INDEX IF NOT EXISTS idx_workflows_child_session ON subagent_workflows(child_session_key);
+            CREATE INDEX IF NOT EXISTS idx_workflows_state ON subagent_workflows(state);
+            CREATE INDEX IF NOT EXISTS idx_workflows_type ON subagent_workflows(workflow_type);
+            CREATE INDEX IF NOT EXISTS idx_events_workflow ON subagent_workflow_events(workflow_id);
+        `);
+
+        // Run migrations to bring schema up to SCHEMA_VERSION
+        const row = db.prepare('SELECT version FROM schema_version LIMIT 1').get() as { version?: number } | undefined;
+        const currentVersion = row?.version ?? 0;
+        if (currentVersion === 0) {
+            db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+        } else if (currentVersion < SCHEMA_VERSION) {
+            // Inline migration logic (mirrors WorkflowStore.runMigrations)
+            if (currentVersion < 2 && SCHEMA_VERSION >= 2) {
+                try {
+                    db.exec('ALTER TABLE subagent_workflows ADD COLUMN duration_ms INTEGER');
+                } catch (err: unknown) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    if (!message.includes('duplicate column name')) {
+                        warnings.push(`migration v${currentVersion}→v${SCHEMA_VERSION} duration_ms failed: ${message}`);
+                    }
+                }
+            }
+            db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION);
+        }
+
+        return { tables, warnings };
+    } finally {
+        db.close();
     }
 }

--- a/packages/pd-cli/package.json
+++ b/packages/pd-cli/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@principles/core": "^1.74.1",
+    "principles-disciple": "^1.74.1",
     "better-sqlite3": "^12.9.0",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.1"

--- a/packages/pd-cli/src/commands/runtime-init.ts
+++ b/packages/pd-cli/src/commands/runtime-init.ts
@@ -1,0 +1,326 @@
+/**
+ * pd runtime init — Initialize all PD SQLite databases for a workspace.
+ *
+ * Creates state.db, trajectory.db, and subagent_workflows.db with full schema
+ * (tables + indexes + views + migrations). Idempotent: safe to run on existing
+ * workspaces (all CREATE statements use IF NOT EXISTS).
+ *
+ * Output contract (cli-1 strict-json, cli-4 dry-run/confirm mutex, cli-6 nextAction):
+ * - Default mode is --dry-run (no writes); use --confirm to actually initialize.
+ * - --json emits a single parseable JSON object on stdout.
+ * - Failures emit { ok: false, reason, nextAction } with exit code 1.
+ *
+ * ERR refs:
+ * - ERR-001/ERR-005: no `as` casts; DB rows typed via type guards
+ * - ERR-002: degraded paths include reason + nextAction
+ * - ERR-009/ERR-010: missing required fields fail loud
+ * - ERR-014: safe JSON.stringify on known output shapes
+ */
+
+import * as path from 'path';
+import { SqliteConnection } from '@principles/core/runtime-v2';
+import { SchemaConformanceReadModel } from '@principles/core/runtime-v2';
+import { initTrajectorySchema, initWorkflowSchema } from 'principles-disciple';
+import { resolveWorkspaceDir } from '../resolve-workspace.js';
+import { emitResult, emitFlagConflict, emitError } from '../services/cli-output.js';
+
+// ── Output types ─────────────────────────────────────────────────────────────
+
+export interface DatabaseInitResult {
+  name: string;
+  path: string;
+  tables: string[];
+  status: 'initialized' | 'verified' | 'skipped' | 'failed';
+  warnings: string[];
+}
+
+export interface RuntimeInitOutput {
+  ok: boolean;
+  mode: 'dry-run' | 'confirm';
+  workspace: string;
+  databases: DatabaseInitResult[];
+  warnings: string[];
+  reason?: string;
+  nextAction?: string;
+}
+
+// ── Build output ─────────────────────────────────────────────────────────────
+
+const DB_NAMES = {
+  state: 'state.db',
+  trajectory: 'trajectory.db',
+  workflow: 'subagent_workflows.db',
+} as const;
+
+export function buildRuntimeInitOutput(workspaceDir: string, confirm: boolean): RuntimeInitOutput {
+  const resolvedWorkspace = path.resolve(workspaceDir);
+  const warnings: string[] = [];
+  const databases: DatabaseInitResult[] = [];
+
+  // 1. state.db (via SqliteConnection, which triggers initSchema + migrateSchema)
+  const stateDbPath = path.join(resolvedWorkspace, '.pd', 'state.db');
+  if (!confirm) {
+    // dry-run: report what would be initialized without touching disk
+    databases.push({
+      name: DB_NAMES.state,
+      path: stateDbPath,
+      tables: ['tasks', 'runs', 'artifacts', 'commits', 'principle_candidates',
+        'pi_artifacts', 'approvals', 'activations', 'intent_decisions', 'schema_version'],
+      status: 'skipped',
+      warnings: [],
+    });
+  } else {
+    try {
+      const conn = new SqliteConnection({ workspaceDir: resolvedWorkspace, readonly: false });
+      try {
+        conn.getDb(); // triggers initSchema + migrateSchema
+        const connWarnings = conn.getSchemaInitWarnings();
+        if (connWarnings.length > 0) {
+          warnings.push(...connWarnings.map(w => `${DB_NAMES.state}: ${w}`));
+        }
+        databases.push({
+          name: DB_NAMES.state,
+          path: stateDbPath,
+          tables: ['tasks', 'runs', 'artifacts', 'commits', 'principle_candidates',
+            'pi_artifacts', 'approvals', 'activations', 'intent_decisions', 'schema_version'],
+          status: 'initialized',
+          warnings: connWarnings,
+        });
+      } finally {
+        conn.close();
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      databases.push({
+        name: DB_NAMES.state,
+        path: stateDbPath,
+        tables: [],
+        status: 'failed',
+        warnings: [reason],
+      });
+      return {
+        ok: false,
+        mode: 'confirm',
+        workspace: resolvedWorkspace,
+        databases,
+        warnings,
+        reason: `state.db initialization failed: ${reason}`,
+        nextAction: 'Check workspace directory permissions and disk space, then retry.',
+      };
+    }
+  }
+
+  // 2. trajectory.db (via initTrajectorySchema)
+  if (!confirm) {
+    databases.push({
+      name: DB_NAMES.trajectory,
+      path: path.join(resolvedWorkspace, '.state', 'trajectory.db'),
+      tables: ['schema_version', 'ingest_checkpoint', 'sessions', 'assistant_turns',
+        'user_turns', 'tool_calls', 'pain_events', 'gate_blocks', 'trust_changes',
+        'principle_events', 'task_outcomes', 'correction_samples', 'sample_reviews',
+        'exports_audit', 'evolution_tasks', 'evolution_events'],
+      status: 'skipped',
+      warnings: [],
+    });
+  } else {
+    try {
+      const result = initTrajectorySchema(resolvedWorkspace);
+      if (result.warnings.length > 0) {
+        warnings.push(...result.warnings.map(w => `${DB_NAMES.trajectory}: ${w}`));
+      }
+      databases.push({
+        name: DB_NAMES.trajectory,
+        path: path.join(resolvedWorkspace, '.state', 'trajectory.db'),
+        tables: result.tables,
+        status: 'initialized',
+        warnings: result.warnings,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      databases.push({
+        name: DB_NAMES.trajectory,
+        path: path.join(resolvedWorkspace, '.state', 'trajectory.db'),
+        tables: [],
+        status: 'failed',
+        warnings: [reason],
+      });
+      return {
+        ok: false,
+        mode: 'confirm',
+        workspace: resolvedWorkspace,
+        databases,
+        warnings,
+        reason: `trajectory.db initialization failed: ${reason}`,
+        nextAction: 'Check workspace directory permissions and disk space, then retry.',
+      };
+    }
+  }
+
+  // 3. subagent_workflows.db (via initWorkflowSchema)
+  if (!confirm) {
+    databases.push({
+      name: DB_NAMES.workflow,
+      path: path.join(resolvedWorkspace, '.state', 'subagent_workflows.db'),
+      tables: ['schema_version', 'subagent_workflows', 'subagent_workflow_events'],
+      status: 'skipped',
+      warnings: [],
+    });
+  } else {
+    try {
+      const result = initWorkflowSchema(resolvedWorkspace);
+      if (result.warnings.length > 0) {
+        warnings.push(...result.warnings.map(w => `${DB_NAMES.workflow}: ${w}`));
+      }
+      databases.push({
+        name: DB_NAMES.workflow,
+        path: path.join(resolvedWorkspace, '.state', 'subagent_workflows.db'),
+        tables: result.tables,
+        status: 'initialized',
+        warnings: result.warnings,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      databases.push({
+        name: DB_NAMES.workflow,
+        path: path.join(resolvedWorkspace, '.state', 'subagent_workflows.db'),
+        tables: [],
+        status: 'failed',
+        warnings: [reason],
+      });
+      return {
+        ok: false,
+        mode: 'confirm',
+        workspace: resolvedWorkspace,
+        databases,
+        warnings,
+        reason: `subagent_workflows.db initialization failed: ${reason}`,
+        nextAction: 'Check workspace directory permissions and disk space, then retry.',
+      };
+    }
+  }
+
+  // Verify state.db schema conformance after initialization (confirm mode only)
+  if (confirm) {
+    try {
+      const conformance = new SchemaConformanceReadModel({ workspaceDir: resolvedWorkspace });
+      const result = conformance.check();
+      if (result.overallStatus === 'error') {
+        warnings.push(`state.db schema conformance check returned 'error' — some tables or indexes may be missing`);
+      }
+    } catch (err) {
+      // Non-fatal: schema conformance check is a post-verification step
+      warnings.push(`schema conformance verification skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return {
+    ok: true,
+    mode: confirm ? 'confirm' : 'dry-run',
+    workspace: resolvedWorkspace,
+    databases,
+    warnings,
+  };
+}
+
+// ── Text formatting ──────────────────────────────────────────────────────────
+
+function formatTextOutput(output: RuntimeInitOutput): string {
+  const lines: string[] = [];
+
+  lines.push('PD Runtime Init');
+  lines.push(`mode: ${output.mode}`);
+  lines.push(`workspace: ${output.workspace}`);
+  lines.push('');
+
+  for (const db of output.databases) {
+    const icon = db.status === 'initialized' ? '[+]' :
+                 db.status === 'verified' ? '[v]' :
+                 db.status === 'skipped' ? '[ ]' : '[x]';
+    lines.push(`${icon} ${db.name} (${db.status})`);
+    lines.push(`    path: ${db.path}`);
+    if (db.tables.length > 0) {
+      lines.push(`    tables: ${db.tables.length} (${db.tables.slice(0, 5).join(', ')}${db.tables.length > 5 ? ', ...' : ''})`);
+    }
+    for (const w of db.warnings) {
+      lines.push(`    warning: ${w}`);
+    }
+  }
+
+  if (output.warnings.length > 0) {
+    lines.push('');
+    lines.push('Warnings:');
+    for (const w of output.warnings) {
+      lines.push(`  [!] ${w}`);
+    }
+  }
+
+  if (!output.ok && output.reason) {
+    lines.push('');
+    lines.push(`Error: ${output.reason}`);
+    if (output.nextAction) {
+      lines.push(`→ ${output.nextAction}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── CLI handler ──────────────────────────────────────────────────────────────
+
+export interface RuntimeInitOptions {
+  workspace?: string;
+  dryRun?: boolean;
+  confirm?: boolean;
+  json?: boolean;
+}
+
+export async function handleRuntimeInit(opts: RuntimeInitOptions): Promise<void> {
+  // cli-4: --dry-run and --confirm are mutually exclusive
+  if (opts.dryRun && opts.confirm) {
+    process.exitCode = emitFlagConflict({ json: opts.json ?? false });
+    return;
+  }
+
+  const workspaceDir = opts.workspace
+    ? path.resolve(opts.workspace)
+    : resolveWorkspaceDir();
+
+  // Default is dry-run; --confirm opts in to actual initialization
+  const confirm = opts.confirm === true;
+
+  try {
+    const output = buildRuntimeInitOutput(workspaceDir, confirm);
+    emitResult(output, { json: opts.json ?? false, formatText: formatTextOutput });
+
+    if (!output.ok) {
+      process.exitCode = 1; // cli-2: set exit code, no process.exit()
+    }
+  } catch (err) {
+    process.exitCode = emitError(err, {
+      json: opts.json ?? false,
+      nextAction: 'Check workspace directory and permissions, then retry.',
+    });
+  }
+}
+
+// ── Command registration (cli-7-test-wiring) ────────────────────────────────
+
+import type { Command } from 'commander';
+
+export function registerRuntimeInitCommand(runtimeCmd: Command): Command {
+  return runtimeCmd
+    .command('init')
+    .description('Initialize all PD SQLite databases (state.db, trajectory.db, subagent_workflows.db)')
+    .option('-w, --workspace <path>', 'Workspace directory')
+    .option('--dry-run', 'Show what would be initialized without writing (default)')
+    .option('--confirm', 'Actually initialize the databases (required to write)')
+    .option('--json', 'Output raw JSON')
+    .action(async (opts) => {
+      await handleRuntimeInit({
+        workspace: opts.workspace,
+        dryRun: opts.dryRun === true,
+        confirm: opts.confirm === true,
+        json: opts.json === true,
+      });
+    });
+}

--- a/packages/pd-cli/src/commands/runtime-init.ts
+++ b/packages/pd-cli/src/commands/runtime-init.ts
@@ -303,24 +303,3 @@ export async function handleRuntimeInit(opts: RuntimeInitOptions): Promise<void>
   }
 }
 
-// ── Command registration (cli-7-test-wiring) ────────────────────────────────
-
-import type { Command } from 'commander';
-
-export function registerRuntimeInitCommand(runtimeCmd: Command): Command {
-  return runtimeCmd
-    .command('init')
-    .description('Initialize all PD SQLite databases (state.db, trajectory.db, subagent_workflows.db)')
-    .option('-w, --workspace <path>', 'Workspace directory')
-    .option('--dry-run', 'Show what would be initialized without writing (default)')
-    .option('--confirm', 'Actually initialize the databases (required to write)')
-    .option('--json', 'Output raw JSON')
-    .action(async (opts) => {
-      await handleRuntimeInit({
-        workspace: opts.workspace,
-        dryRun: opts.dryRun === true,
-        confirm: opts.confirm === true,
-        json: opts.json === true,
-      });
-    });
-}

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -50,6 +50,7 @@ import { handleRuntimeActivationDeactivate, handleRuntimeActivationList, handleR
 import { handleProvenChannelBaseline } from './commands/proven-channel-baseline.js';
 import { handleDemoStoryA } from './commands/demo-story-a.js';
 import { handleRuntimeFeaturesStatus } from './commands/runtime-features.js';
+import { registerRuntimeInitCommand } from './commands/runtime-init.js';
 import { handleConfigDoctor } from './commands/config-doctor.js';
 import { registerMvpCommands } from './commands/mvp-smoke.js';
 import { registerRulecodeCommand } from './commands/rulecode.js';
@@ -333,6 +334,9 @@ runtimeCmd
   .action(async (opts) => {
     await handleRuntimeCanary({ workspace: opts.workspace, json: opts.json });
   });
+
+// pd runtime init — Initialize all PD SQLite databases for a workspace (PRI-475 sibling).
+registerRuntimeInitCommand(runtimeCmd);
 
 const synthCmd = runtimeCmd
   .command('synthetic', { hidden: true })

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -50,7 +50,6 @@ import { handleRuntimeActivationDeactivate, handleRuntimeActivationList, handleR
 import { handleProvenChannelBaseline } from './commands/proven-channel-baseline.js';
 import { handleDemoStoryA } from './commands/demo-story-a.js';
 import { handleRuntimeFeaturesStatus } from './commands/runtime-features.js';
-import { registerRuntimeInitCommand } from './commands/runtime-init.js';
 import { handleConfigDoctor } from './commands/config-doctor.js';
 import { registerMvpCommands } from './commands/mvp-smoke.js';
 import { registerRulecodeCommand } from './commands/rulecode.js';
@@ -335,8 +334,27 @@ runtimeCmd
     await handleRuntimeCanary({ workspace: opts.workspace, json: opts.json });
   });
 
-// pd runtime init — Initialize all PD SQLite databases for a workspace (PRI-475 sibling).
-registerRuntimeInitCommand(runtimeCmd);
+// pd runtime init — Initialize all PD SQLite databases for a workspace.
+// Lazy import: avoids loading `principles-disciple` at module init time, which
+// would crash `pd --version` in packaged installs where the plugin's transitive
+// deps are not resolvable from pd-cli's node_modules. The import only executes
+// when `pd runtime init` is actually invoked.
+runtimeCmd
+  .command('init')
+  .description('Initialize all PD SQLite databases (state.db, trajectory.db, subagent_workflows.db)')
+  .option('-w, --workspace <path>', 'Workspace directory')
+  .option('--dry-run', 'Show what would be initialized without writing (default)')
+  .option('--confirm', 'Actually initialize the databases (required to write)')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts) => {
+    const { handleRuntimeInit } = await import('./commands/runtime-init.js');
+    await handleRuntimeInit({
+      workspace: opts.workspace,
+      dryRun: opts.dryRun === true,
+      confirm: opts.confirm === true,
+      json: opts.json === true,
+    });
+  });
 
 const synthCmd = runtimeCmd
   .command('synthetic', { hidden: true })

--- a/packages/pd-cli/tests/commands/runtime-init-empty-workspace.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-init-empty-workspace.test.ts
@@ -1,0 +1,234 @@
+/**
+ * runtime-init empty-workspace integration tests — verifies real DB initialization.
+ *
+ * Does NOT mock the DB layer. Uses real better-sqlite3 to create actual database
+ * files in a temp workspace, then verifies all expected tables exist.
+ *
+ * Covers:
+ *   - EMPTY-01: initialize empty workspace → all 3 DBs have full schema
+ *   - EMPTY-02: idempotency — running twice does not error or lose data
+ *
+ * Prerequisites: @principles/core and principles-disciple must be built.
+ *
+ * ERR refs:
+ * - rc-7-loop-state-freshness: idempotency test uses fresh workspace each run
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import Database from 'better-sqlite3';
+import { buildRuntimeInitOutput } from '../../src/commands/runtime-init.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-runtime-init-empty-'));
+}
+
+function rmTmpDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function getTableNames(dbPath: string): string[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).all() as { name: string }[];
+    return rows.map(r => r.name);
+  } finally {
+    db.close();
+  }
+}
+
+function getIndexNames(dbPath: string): string[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).all() as { name: string }[];
+    return rows.map(r => r.name);
+  } finally {
+    db.close();
+  }
+}
+
+// ── Expected schema ─────────────────────────────────────────────────────────
+
+const EXPECTED_STATE_TABLES = [
+  'tasks', 'runs', 'artifacts', 'commits',
+  'principle_candidates', 'pi_artifacts',
+  'approvals', 'activations', 'intent_decisions',
+  'schema_version',
+];
+
+const EXPECTED_TRAJECTORY_TABLES = [
+  'schema_version', 'ingest_checkpoint', 'sessions', 'assistant_turns',
+  'user_turns', 'tool_calls', 'pain_events', 'gate_blocks', 'trust_changes',
+  'principle_events', 'task_outcomes', 'correction_samples', 'sample_reviews',
+  'exports_audit', 'evolution_tasks', 'evolution_events',
+];
+
+const EXPECTED_WORKFLOW_TABLES = [
+  'schema_version', 'subagent_workflows', 'subagent_workflow_events',
+];
+
+const EXPECTED_TRAJECTORY_INDEXES = [
+  'idx_assistant_turns_session_id',
+  'idx_assistant_turns_created_at',
+  'idx_assistant_turns_provider_model',
+  'idx_user_turns_session_id',
+  'idx_tool_calls_session_id',
+  'idx_tool_calls_created_at',
+  'idx_pain_events_session_id',
+  'idx_pain_events_canonical_pain_id',
+  'idx_correction_samples_review_status',
+  'idx_evolution_tasks_trace_id',
+  'idx_evolution_tasks_status',
+  'idx_evolution_tasks_created_at',
+  'idx_evolution_events_trace_id',
+  'idx_evolution_events_created_at',
+];
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pd runtime init — empty workspace integration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkTmpDir();
+  });
+
+  afterEach(() => {
+    rmTmpDir(tmpDir);
+  });
+
+  // ── EMPTY-01: initialize empty workspace ───────────────────────────────────
+
+  describe('EMPTY-01: initialize empty workspace', () => {
+    it('returns ok=true with 3 initialized databases', () => {
+      const output = buildRuntimeInitOutput(tmpDir, true);
+      expect(output.ok).toBe(true);
+      expect(output.mode).toBe('confirm');
+      expect(output.databases).toHaveLength(3);
+      for (const db of output.databases) {
+        expect(db.status).toBe('initialized');
+      }
+    });
+
+    it('creates state.db with all expected tables', () => {
+      buildRuntimeInitOutput(tmpDir, true);
+      const stateDbPath = path.join(tmpDir, '.pd', 'state.db');
+      expect(fs.existsSync(stateDbPath)).toBe(true);
+      const tables = getTableNames(stateDbPath);
+      for (const expected of EXPECTED_STATE_TABLES) {
+        expect(tables).toContain(expected);
+      }
+    });
+
+    it('creates trajectory.db with all 16 expected tables', () => {
+      buildRuntimeInitOutput(tmpDir, true);
+      const trajDbPath = path.join(tmpDir, '.state', 'trajectory.db');
+      expect(fs.existsSync(trajDbPath)).toBe(true);
+      const tables = getTableNames(trajDbPath);
+      expect(tables).toHaveLength(EXPECTED_TRAJECTORY_TABLES.length);
+      for (const expected of EXPECTED_TRAJECTORY_TABLES) {
+        expect(tables).toContain(expected);
+      }
+    });
+
+    it('creates trajectory.db with all expected indexes', () => {
+      buildRuntimeInitOutput(tmpDir, true);
+      const trajDbPath = path.join(tmpDir, '.state', 'trajectory.db');
+      const indexes = getIndexNames(trajDbPath);
+      for (const expected of EXPECTED_TRAJECTORY_INDEXES) {
+        expect(indexes).toContain(expected);
+      }
+    });
+
+    it('creates subagent_workflows.db with all expected tables', () => {
+      buildRuntimeInitOutput(tmpDir, true);
+      const wfDbPath = path.join(tmpDir, '.state', 'subagent_workflows.db');
+      expect(fs.existsSync(wfDbPath)).toBe(true);
+      const tables = getTableNames(wfDbPath);
+      for (const expected of EXPECTED_WORKFLOW_TABLES) {
+        expect(tables).toContain(expected);
+      }
+    });
+
+    it('pain_events table has canonical_pain_id and runtime_task_id columns', () => {
+      buildRuntimeInitOutput(tmpDir, true);
+      const trajDbPath = path.join(tmpDir, '.state', 'trajectory.db');
+      const db = new Database(trajDbPath, { readonly: true });
+      try {
+        const cols = db.prepare('PRAGMA table_info(pain_events)').all() as { name: string }[];
+        const colNames = cols.map(c => c.name);
+        expect(colNames).toContain('canonical_pain_id');
+        expect(colNames).toContain('runtime_task_id');
+        expect(colNames).toContain('text');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('evolution_tasks table has V2 migration columns', () => {
+      buildRuntimeInitOutput(tmpDir, true);
+      const trajDbPath = path.join(tmpDir, '.state', 'trajectory.db');
+      const db = new Database(trajDbPath, { readonly: true });
+      try {
+        const cols = db.prepare('PRAGMA table_info(evolution_tasks)').all() as { name: string }[];
+        const colNames = cols.map(c => c.name);
+        expect(colNames).toContain('task_kind');
+        expect(colNames).toContain('priority');
+        expect(colNames).toContain('retry_count');
+        expect(colNames).toContain('max_retries');
+        expect(colNames).toContain('last_error');
+        expect(colNames).toContain('result_ref');
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  // ── EMPTY-02: idempotency ──────────────────────────────────────────────────
+
+  describe('EMPTY-02: idempotency', () => {
+    it('running twice does not error and tables remain intact', () => {
+      // First initialization
+      const output1 = buildRuntimeInitOutput(tmpDir, true);
+      expect(output1.ok).toBe(true);
+
+      // Capture table counts after first init
+      const trajDbPath = path.join(tmpDir, '.state', 'trajectory.db');
+      const tables1 = getTableNames(trajDbPath);
+
+      // Second initialization (should be idempotent)
+      const output2 = buildRuntimeInitOutput(tmpDir, true);
+      expect(output2.ok).toBe(true);
+      expect(output2.databases).toHaveLength(3);
+      for (const db of output2.databases) {
+        expect(db.status).toBe('initialized');
+      }
+
+      // Table set should be unchanged
+      const tables2 = getTableNames(trajDbPath);
+      expect(tables2).toEqual(tables1);
+    });
+
+    it('dry-run after confirm does not modify existing DBs', () => {
+      // First: confirm mode (real init)
+      buildRuntimeInitOutput(tmpDir, true);
+      const trajDbPath = path.join(tmpDir, '.state', 'trajectory.db');
+      const tablesBefore = getTableNames(trajDbPath);
+
+      // Second: dry-run mode (should not modify)
+      const output = buildRuntimeInitOutput(tmpDir, false);
+      expect(output.mode).toBe('dry-run');
+
+      const tablesAfter = getTableNames(trajDbPath);
+      expect(tablesAfter).toEqual(tablesBefore);
+    });
+  });
+});

--- a/packages/pd-cli/tests/commands/runtime-init.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-init.test.ts
@@ -1,0 +1,346 @@
+/**
+ * runtime-init tests — pd runtime init command (unit tests with mocked DB layer).
+ *
+ * Covers:
+ *   - INIT-01: --dry-run (default) reports 3 DBs as 'skipped', no real writes
+ *   - INIT-02: --confirm calls all 3 init functions, output shows 'initialized'
+ *   - INIT-03: --json outputs single parseable JSON object (cli-1)
+ *   - INIT-04: --dry-run + --confirm mutually exclusive (cli-4)
+ *   - INIT-05: --confirm failure sets exitCode=1 with reason + nextAction (cli-6)
+ *   - INIT-06: missing --workspace falls back to resolveWorkspaceDir()
+ *
+ * ERR refs:
+ * - ERR-001/ERR-005: no `as` casts in test code; uses typeof guards
+ * - ERR-009: flag conflict fails loud (cli-4)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+
+// ── Hoisted mocks ───────────────────────────────────────────────────────────
+
+const mockState = vi.hoisted(() => {
+  return {
+    initTrajectorySchema: vi.fn(),
+    initWorkflowSchema: vi.fn(),
+    sqliteConnectionCtor: vi.fn(),
+    sqliteConnectionGetDb: vi.fn(),
+    sqliteConnectionGetWarnings: vi.fn(),
+    sqliteConnectionClose: vi.fn(),
+    schemaConformanceCtor: vi.fn(),
+    schemaConformanceCheck: vi.fn(),
+    resolveWorkspaceDir: vi.fn(),
+  };
+});
+
+vi.mock('principles-disciple', () => ({
+  initTrajectorySchema: mockState.initTrajectorySchema,
+  initWorkflowSchema: mockState.initWorkflowSchema,
+}));
+
+vi.mock('@principles/core/runtime-v2', () => ({
+  SqliteConnection: mockState.sqliteConnectionCtor,
+  SchemaConformanceReadModel: mockState.schemaConformanceCtor,
+}));
+
+vi.mock('../../src/resolve-workspace.js', () => ({
+  resolveWorkspaceDir: mockState.resolveWorkspaceDir,
+}));
+
+// Import after mocks are set up
+import { buildRuntimeInitOutput, handleRuntimeInit } from '../../src/commands/runtime-init.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pd-runtime-init-test-'));
+}
+
+function rmTmpDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function setupDefaultConfirmMocks(): void {
+  // SqliteConnection mock: constructor returns instance with getDb/getSchemaInitWarnings/close
+  // NOTE: Must use `function` (not arrow function) because vitest 4.x requires
+  // function/class implementations for mocks called with `new`.
+  mockState.sqliteConnectionCtor.mockImplementation(function () {
+    return {
+      getDb: mockState.sqliteConnectionGetDb,
+      getSchemaInitWarnings: mockState.sqliteConnectionGetWarnings,
+      close: mockState.sqliteConnectionClose,
+    };
+  });
+  mockState.sqliteConnectionGetDb.mockReturnValue({});
+  mockState.sqliteConnectionGetWarnings.mockReturnValue([]);
+  mockState.sqliteConnectionClose.mockReturnValue(undefined);
+
+  // initTrajectorySchema mock
+  mockState.initTrajectorySchema.mockReturnValue({
+    tables: ['schema_version', 'sessions', 'pain_events', 'evolution_tasks'],
+    warnings: [],
+  });
+
+  // initWorkflowSchema mock
+  mockState.initWorkflowSchema.mockReturnValue({
+    tables: ['schema_version', 'subagent_workflows', 'subagent_workflow_events'],
+    warnings: [],
+  });
+
+  // SchemaConformanceReadModel mock
+  mockState.schemaConformanceCtor.mockImplementation(function () {
+    return {
+      check: mockState.schemaConformanceCheck,
+    };
+  });
+  mockState.schemaConformanceCheck.mockReturnValue({ overallStatus: 'ok' });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pd runtime init', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultConfirmMocks();
+  });
+
+  // ── INIT-01: dry-run (default) ─────────────────────────────────────────────
+
+  describe('INIT-01: dry-run (default)', () => {
+    it('reports 3 DBs as skipped without calling init functions', () => {
+      const tmp = mkTmpDir();
+      try {
+        const output = buildRuntimeInitOutput(tmp, false);
+        expect(output.ok).toBe(true);
+        expect(output.mode).toBe('dry-run');
+        expect(output.databases).toHaveLength(3);
+        for (const db of output.databases) {
+          expect(db.status).toBe('skipped');
+        }
+        // No init functions should be called in dry-run mode
+        expect(mockState.initTrajectorySchema).not.toHaveBeenCalled();
+        expect(mockState.initWorkflowSchema).not.toHaveBeenCalled();
+        expect(mockState.sqliteConnectionCtor).not.toHaveBeenCalled();
+      } finally { rmTmpDir(tmp); }
+    });
+
+    it('includes expected table names in dry-run output for each DB', () => {
+      const tmp = mkTmpDir();
+      try {
+        const output = buildRuntimeInitOutput(tmp, false);
+        const stateDb = output.databases.find(d => d.name === 'state.db');
+        const trajDb = output.databases.find(d => d.name === 'trajectory.db');
+        const wfDb = output.databases.find(d => d.name === 'subagent_workflows.db');
+        expect(stateDb?.tables).toContain('tasks');
+        expect(stateDb?.tables).toContain('runs');
+        expect(trajDb?.tables).toContain('pain_events');
+        expect(trajDb?.tables).toContain('sessions');
+        expect(wfDb?.tables).toContain('subagent_workflows');
+      } finally { rmTmpDir(tmp); }
+    });
+  });
+
+  // ── INIT-02: --confirm ─────────────────────────────────────────────────────
+
+  describe('INIT-02: --confirm', () => {
+    it('calls all 3 init functions and reports initialized status', () => {
+      const tmp = mkTmpDir();
+      try {
+        const output = buildRuntimeInitOutput(tmp, true);
+        expect(output.ok).toBe(true);
+        expect(output.mode).toBe('confirm');
+        expect(output.databases).toHaveLength(3);
+        for (const db of output.databases) {
+          expect(db.status).toBe('initialized');
+        }
+        expect(mockState.sqliteConnectionCtor).toHaveBeenCalledTimes(1);
+        expect(mockState.sqliteConnectionGetDb).toHaveBeenCalledTimes(1);
+        expect(mockState.initTrajectorySchema).toHaveBeenCalledWith(tmp);
+        expect(mockState.initWorkflowSchema).toHaveBeenCalledWith(tmp);
+      } finally { rmTmpDir(tmp); }
+    });
+
+    it('runs schema conformance check after initialization', () => {
+      const tmp = mkTmpDir();
+      try {
+        buildRuntimeInitOutput(tmp, true);
+        expect(mockState.schemaConformanceCtor).toHaveBeenCalledTimes(1);
+        expect(mockState.schemaConformanceCheck).toHaveBeenCalledTimes(1);
+      } finally { rmTmpDir(tmp); }
+    });
+  });
+
+  // ── INIT-03: --json output (cli-1) ─────────────────────────────────────────
+
+  describe('INIT-03: --json output (cli-1)', () => {
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let originalExitCode: number | undefined;
+
+    beforeEach(() => {
+      stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      originalExitCode = process.exitCode;
+      process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+      stdoutSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    });
+
+    it('outputs exactly one parseable JSON object to stdout', async () => {
+      const tmp = mkTmpDir();
+      try {
+        await handleRuntimeInit({ workspace: tmp, json: true });
+        expect(stdoutSpy).toHaveBeenCalledTimes(1);
+        const output = stdoutSpy.mock.calls[0][0] as string;
+        const parsed = JSON.parse(output);
+        expect(typeof parsed).toBe('object');
+        expect(parsed).not.toBeNull();
+        expect(Array.isArray(parsed)).toBe(false);
+        expect(parsed).toHaveProperty('ok');
+        expect(parsed).toHaveProperty('mode');
+        expect(parsed).toHaveProperty('databases');
+      } finally { rmTmpDir(tmp); }
+    });
+
+    it('does not set exitCode=1 on successful dry-run', async () => {
+      const tmp = mkTmpDir();
+      try {
+        await handleRuntimeInit({ workspace: tmp, json: true });
+        expect(process.exitCode).toBeUndefined();
+      } finally { rmTmpDir(tmp); }
+    });
+  });
+
+  // ── INIT-04: --dry-run + --confirm mutex (cli-4) ───────────────────────────
+
+  describe('INIT-04: --dry-run + --confirm mutex (cli-4)', () => {
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+    let originalExitCode: number | undefined;
+
+    beforeEach(() => {
+      stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      originalExitCode = process.exitCode;
+      process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    });
+
+    it('sets exitCode=1 when both --dry-run and --confirm are specified', async () => {
+      await handleRuntimeInit({ dryRun: true, confirm: true, json: true });
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('emits flag conflict JSON with reason and nextAction', async () => {
+      await handleRuntimeInit({ dryRun: true, confirm: true, json: true });
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      const output = stdoutSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.reason).toBeTruthy();
+      expect(parsed.nextAction).toBeTruthy();
+    });
+
+    it('does not call any init functions on flag conflict', async () => {
+      await handleRuntimeInit({ dryRun: true, confirm: true, json: true });
+      expect(mockState.initTrajectorySchema).not.toHaveBeenCalled();
+      expect(mockState.initWorkflowSchema).not.toHaveBeenCalled();
+      expect(mockState.sqliteConnectionCtor).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── INIT-05: --confirm failure (cli-6) ─────────────────────────────────────
+
+  describe('INIT-05: --confirm failure (cli-6)', () => {
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let originalExitCode: number | undefined;
+
+    beforeEach(() => {
+      stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      originalExitCode = process.exitCode;
+      process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+      stdoutSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    });
+
+    it('sets exitCode=1 and includes reason + nextAction when state.db fails', () => {
+      const tmp = mkTmpDir();
+      try {
+        mockState.sqliteConnectionGetDb.mockImplementation(() => {
+          throw new Error('disk full');
+        });
+        const output = buildRuntimeInitOutput(tmp, true);
+        expect(output.ok).toBe(false);
+        expect(output.reason).toContain('state.db');
+        expect(output.reason).toContain('disk full');
+        expect(output.nextAction).toBeTruthy();
+      } finally { rmTmpDir(tmp); }
+    });
+
+    it('sets exitCode=1 and includes reason when trajectory.db fails', () => {
+      const tmp = mkTmpDir();
+      try {
+        mockState.initTrajectorySchema.mockImplementation(() => {
+          throw new Error('permission denied');
+        });
+        const output = buildRuntimeInitOutput(tmp, true);
+        expect(output.ok).toBe(false);
+        expect(output.reason).toContain('trajectory.db');
+        expect(output.reason).toContain('permission denied');
+      } finally { rmTmpDir(tmp); }
+    });
+
+    it('sets exitCode=1 and includes reason when subagent_workflows.db fails', () => {
+      const tmp = mkTmpDir();
+      try {
+        mockState.initWorkflowSchema.mockImplementation(() => {
+          throw new Error('locked');
+        });
+        const output = buildRuntimeInitOutput(tmp, true);
+        expect(output.ok).toBe(false);
+        expect(output.reason).toContain('subagent_workflows.db');
+        expect(output.reason).toContain('locked');
+      } finally { rmTmpDir(tmp); }
+    });
+
+    it('handler sets process.exitCode=1 on failure with --json', async () => {
+      const tmp = mkTmpDir();
+      try {
+        mockState.sqliteConnectionGetDb.mockImplementation(() => {
+          throw new Error('init failed');
+        });
+        await handleRuntimeInit({ workspace: tmp, confirm: true, json: true });
+        expect(process.exitCode).toBe(1);
+        const output = stdoutSpy.mock.calls[0][0] as string;
+        const parsed = JSON.parse(output);
+        expect(parsed.ok).toBe(false);
+        expect(parsed.reason).toBeTruthy();
+        expect(parsed.nextAction).toBeTruthy();
+      } finally { rmTmpDir(tmp); }
+    });
+  });
+
+  // ── INIT-06: missing --workspace ───────────────────────────────────────────
+
+  describe('INIT-06: missing --workspace', () => {
+    it('falls back to resolveWorkspaceDir() when workspace is not specified', async () => {
+      const tmp = mkTmpDir();
+      mockState.resolveWorkspaceDir.mockReturnValue(tmp);
+      try {
+        await handleRuntimeInit({ json: true });
+        expect(mockState.resolveWorkspaceDir).toHaveBeenCalledTimes(1);
+      } finally { rmTmpDir(tmp); }
+    });
+  });
+});

--- a/packages/principles-core/src/runtime-v2/__tests__/pain-signal-observability.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/pain-signal-observability.test.ts
@@ -85,10 +85,12 @@ describe('recordPainSignalObservability', () => {
         reason: 'manual pain diagnosis',
       });
 
-      const hasEvolutionTasks = db.prepare(`
-        SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'evolution_tasks'
-      `).get();
-      expect(hasEvolutionTasks).toBeUndefined();
+      // ensureTrajectorySchema now creates ALL trajectory tables (including
+      // evolution_tasks) for schema consistency. The legacy evolution_tasks queue
+      // is "disabled" in the sense that no rows are written to it — not that the
+      // table doesn't exist.
+      const evolutionTaskRows = db.prepare('SELECT COUNT(*) as count FROM evolution_tasks').get() as { count: number };
+      expect(evolutionTaskRows.count).toBe(0);
     } finally {
       db.close();
     }

--- a/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
+++ b/packages/principles-core/src/runtime-v2/pain-signal-observability.ts
@@ -63,48 +63,271 @@ function getSessionsColumns(db: Database.Database): string[] {
   return cols.map((c) => c.name);
 }
 
-function ensurePainEventsSchema(db: Database.Database): void {
-  db.exec('BEGIN IMMEDIATE');
+/**
+ * Ensure trajectory.db has the full schema (all 16 tables + indexes + migrations).
+ *
+ * This mirrors packages/openclaw-plugin/src/core/trajectory.ts applyTrajectorySchema()
+ * to fix the fragmented initialization where `pd pain record` only created 2 tables
+ * (pain_events + sessions), leaving the other 14 missing.
+ *
+ * Schema MUST stay in sync with applyTrajectorySchema() in
+ * packages/openclaw-plugin/src/core/trajectory.ts. core cannot import plugin schema
+ * (dependency direction), so DDL is duplicated intentionally. When adding/migrating a
+ * table in applyTrajectorySchema(), update this function too.
+ *
+ * Views are intentionally NOT created here — they belong to ControlUiDatabase's
+ * responsibility and are not needed by the pain record path.
+ */
+function ensureTrajectorySchema(db: Database.Database): { tables: string[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const tables = [
+    'schema_version', 'ingest_checkpoint', 'sessions', 'assistant_turns',
+    'user_turns', 'tool_calls', 'pain_events', 'gate_blocks', 'trust_changes',
+    'principle_events', 'task_outcomes', 'correction_samples', 'sample_reviews',
+    'exports_audit', 'evolution_tasks', 'evolution_events',
+  ];
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+    CREATE TABLE IF NOT EXISTS ingest_checkpoint (
+      source_key TEXT PRIMARY KEY,
+      imported_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      started_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS assistant_turns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      raw_text TEXT,
+      sanitized_text TEXT NOT NULL,
+      usage_json TEXT NOT NULL,
+      empathy_signal_json TEXT NOT NULL,
+      blob_ref TEXT,
+      raw_excerpt TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS user_turns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      turn_index INTEGER NOT NULL,
+      raw_text TEXT,
+      blob_ref TEXT,
+      raw_excerpt TEXT,
+      correction_detected INTEGER NOT NULL DEFAULT 0,
+      correction_cue TEXT,
+      references_assistant_turn_id INTEGER,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS tool_calls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      outcome TEXT NOT NULL,
+      duration_ms INTEGER,
+      exit_code INTEGER,
+      error_type TEXT,
+      error_message TEXT,
+      gfi_before REAL,
+      gfi_after REAL,
+      params_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS pain_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      score REAL NOT NULL,
+      reason TEXT,
+      severity TEXT,
+      origin TEXT,
+      confidence REAL,
+      text TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS gate_blocks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT,
+      tool_name TEXT NOT NULL,
+      file_path TEXT,
+      reason TEXT NOT NULL,
+      plan_status TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS trust_changes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT,
+      previous_score REAL NOT NULL,
+      new_score REAL NOT NULL,
+      delta REAL NOT NULL,
+      reason TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS principle_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      principle_id TEXT,
+      event_type TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS task_outcomes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      task_id TEXT,
+      outcome TEXT NOT NULL,
+      summary TEXT,
+      principle_ids_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS correction_samples (
+      sample_id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      bad_assistant_turn_id INTEGER NOT NULL,
+      user_correction_turn_id INTEGER NOT NULL,
+      recovery_tool_span_json TEXT NOT NULL,
+      diff_excerpt TEXT NOT NULL,
+      principle_ids_json TEXT NOT NULL,
+      quality_score REAL NOT NULL,
+      review_status TEXT NOT NULL,
+      export_mode TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS sample_reviews (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      sample_id TEXT NOT NULL,
+      review_status TEXT NOT NULL,
+      note TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS exports_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      export_kind TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      approved_only INTEGER NOT NULL,
+      file_path TEXT NOT NULL,
+      row_count INTEGER NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS evolution_tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT UNIQUE NOT NULL,
+      trace_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      reason TEXT,
+      score INTEGER DEFAULT 0,
+      status TEXT DEFAULT 'pending',
+      enqueued_at TEXT,
+      started_at TEXT,
+      completed_at TEXT,
+      resolution TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS evolution_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trace_id TEXT NOT NULL,
+      task_id TEXT,
+      stage TEXT NOT NULL,
+      level TEXT DEFAULT 'info',
+      message TEXT NOT NULL,
+      summary TEXT,
+      metadata_json TEXT,
+      created_at TEXT NOT NULL
+    );
+  `);
+
+  // Migration: Add text column to pain_events if it doesn't exist (MEM-01)
+  // SQLite doesn't support IF NOT EXISTS for ADD COLUMN, so we use try/catch
   try {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS pain_events (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        source TEXT NOT NULL,
-        score REAL NOT NULL,
-        reason TEXT,
-        severity TEXT,
-        origin TEXT,
-        confidence REAL,
-        text TEXT,
-        created_at TEXT NOT NULL
-      );
-      CREATE INDEX IF NOT EXISTS idx_pain_events_session_id ON pain_events(session_id);
-      CREATE INDEX IF NOT EXISTS idx_pain_events_created_at ON pain_events(created_at);
-    `);
-
-    // Ensure sessions table exists (legacy schema without metadata_json is OK)
-    const existingTables = db.prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'"
-    ).all() as { name: string }[];
-
-    if (existingTables.length === 0) {
-      db.exec(`
-        CREATE TABLE sessions (
-          session_id TEXT PRIMARY KEY,
-          started_at TEXT,
-          updated_at TEXT,
-          metadata_json TEXT
-        );
-      `);
+    db.exec(`ALTER TABLE pain_events ADD COLUMN text TEXT`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+      // Re-throw unexpected errors — silently swallowing migration failures is dangerous
+      throw err;
     }
-    // Schema MUST stay in sync with packages/openclaw-plugin/src/core/schema/schema-definitions.ts pain_events.
-    // core cannot import plugin schema (dependency direction), so DDL is duplicated intentionally.
-    db.exec('COMMIT');
-  } catch (err) {
-    db.exec('ROLLBACK');
-    throw err;
   }
+
+  // PRI-406: Add canonical_pain_id and runtime_task_id columns to pain_events
+  for (const col of [
+    { name: 'canonical_pain_id', type: 'TEXT' },
+    { name: 'runtime_task_id', type: 'TEXT' },
+  ]) {
+    try {
+      db.exec(`ALTER TABLE pain_events ADD COLUMN ${col.name} ${col.type}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+        throw err;
+      }
+    }
+  }
+
+  // Trajectory enhancement: add stop_reason, thinking_blocks_count, result_preview
+  const trajectoryEnhancementColumns = [
+    { table: 'assistant_turns', name: 'stop_reason', type: 'TEXT' },
+    { table: 'assistant_turns', name: 'thinking_blocks_count', type: 'INTEGER' },
+    { table: 'tool_calls', name: 'result_preview', type: 'TEXT' },
+  ];
+  for (const col of trajectoryEnhancementColumns) {
+    try {
+      db.exec(`ALTER TABLE ${col.table} ADD COLUMN ${col.name} ${col.type}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes('duplicate column name') && !message.includes('no column named')) {
+        throw err;
+      }
+    }
+  }
+
+  // PRI-406: Partial unique index on canonical_pain_id (non-null only) for dedup
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
+    ON pain_events(canonical_pain_id)
+    WHERE canonical_pain_id IS NOT NULL
+  `);
+
+  // V2 migration: Add V2 columns to evolution_tasks if they don't exist
+  const v2Columns = [
+    { name: 'task_kind', type: 'TEXT' },
+    { name: 'priority', type: 'TEXT' },
+    { name: 'retry_count', type: 'INTEGER' },
+    { name: 'max_retries', type: 'INTEGER' },
+    { name: 'last_error', type: 'TEXT' },
+    { name: 'result_ref', type: 'TEXT' },
+  ];
+  for (const col of v2Columns) {
+    const exists = db.prepare(`PRAGMA table_info(evolution_tasks)`).all()
+      .some((row) => (row as Record<string, unknown>).name === col.name);
+    if (!exists) {
+      db.exec(`ALTER TABLE evolution_tasks ADD COLUMN ${col.name} ${col.type}`);
+    }
+  }
+
+  // Indexes (views intentionally omitted — not needed by pain record path)
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_assistant_turns_session_id ON assistant_turns(session_id);
+    CREATE INDEX IF NOT EXISTS idx_assistant_turns_created_at ON assistant_turns(created_at);
+    CREATE INDEX IF NOT EXISTS idx_assistant_turns_provider_model ON assistant_turns(provider, model);
+    CREATE INDEX IF NOT EXISTS idx_user_turns_session_id ON user_turns(session_id);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_session_id ON tool_calls(session_id);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_created_at ON tool_calls(created_at);
+    CREATE INDEX IF NOT EXISTS idx_pain_events_session_id ON pain_events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_correction_samples_review_status ON correction_samples(review_status);
+    CREATE INDEX IF NOT EXISTS idx_evolution_tasks_trace_id ON evolution_tasks(trace_id);
+    CREATE INDEX IF NOT EXISTS idx_evolution_tasks_status ON evolution_tasks(status);
+    CREATE INDEX IF NOT EXISTS idx_evolution_tasks_created_at ON evolution_tasks(created_at);
+    CREATE INDEX IF NOT EXISTS idx_evolution_events_trace_id ON evolution_events(trace_id);
+    CREATE INDEX IF NOT EXISTS idx_evolution_events_created_at ON evolution_events(created_at);
+  `);
+
+  return { tables, warnings };
 }
 
 interface TrajectoryRecordOptions {
@@ -124,29 +347,7 @@ function recordTrajectoryPainEvent(opts: TrajectoryRecordOptions): number | unde
   fs.mkdirSync(nodePath.dirname(dbPath), { recursive: true });
   const db = new Database(dbPath);
   try {
-    ensurePainEventsSchema(db);
-
-    // PRI-406: Add canonical_pain_id and runtime_task_id columns if missing
-    for (const col of [
-      { name: 'canonical_pain_id', type: 'TEXT' },
-      { name: 'runtime_task_id', type: 'TEXT' },
-    ]) {
-      try {
-        db.exec(`ALTER TABLE pain_events ADD COLUMN ${col.name} ${col.type}`);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (!message.includes('duplicate column name') && !message.includes('no column named')) {
-          throw err;
-        }
-      }
-    }
-
-    // PRI-406: Create partial unique index for canonical_pain_id dedup
-    db.exec(`
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_pain_events_canonical_pain_id
-      ON pain_events(canonical_pain_id)
-      WHERE canonical_pain_id IS NOT NULL
-    `);
+    ensureTrajectorySchema(db);
 
     const sessionId = data.sessionId ?? 'cli';
     const sessionColumns = getSessionsColumns(db);

--- a/packages/principles-core/src/runtime-v2/store/sqlite-connection-pragma.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-connection-pragma.test.ts
@@ -111,15 +111,32 @@ describe('PRI-140: readonly connection constraints', () => {
     }
   });
 
-  it('does not create .pd directory on a fresh path', () => {
+  it('bootstraps .pd directory and state.db on a fresh path for readonly access', () => {
+    // Readonly fix: readonly connections on fresh paths now bootstrap the DB
+    // (create .pd dir + state.db via a temporary writable connection) instead of
+    // throwing. This prevents pd-console GET routes from failing on fresh workspaces.
     const freshPath = freshDir('readonly-fresh');
     const pdDir = path.join(freshPath, '.pd');
 
     expect(fs.existsSync(pdDir)).toBe(false);
 
     const readonlyConn = new SqliteConnection({ workspaceDir: freshPath, readonly: true });
-    expect(() => readonlyConn.getDb()).toThrow();
-    expect(fs.existsSync(pdDir)).toBe(false);
+    const db = readonlyConn.getDb(); // bootstraps then reopens readonly
+
+    // Bootstrap creates .pd dir and state.db
+    expect(fs.existsSync(pdDir)).toBe(true);
+
+    // Schema is initialized (tasks table exists)
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='tasks'",
+    ).all();
+    expect(tables.length).toBe(1);
+
+    // Readonly: writes should throw
+    expect(() => {
+      db.exec("INSERT INTO tasks (task_id, task_kind, status, created_at, updated_at) VALUES ('x','y','z','a','b')");
+    }).toThrow();
+
     readonlyConn.close();
   });
 });

--- a/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
@@ -38,6 +38,12 @@ export class SqliteConnection {
   private db: Database.Database | null = null;
   private readonly dbPath: string;
   private readonly readonlyMode: boolean;
+  /**
+   * Schema initialization warnings collected during getDb(). Populated when initSchema()
+   * or migrateSchema() fails (rc-9: no silent fallback — callers can read these warnings
+   * to surface degraded state). Empty array means no warnings.
+   */
+  private readonly schemaInitWarnings: string[] = [];
 
   constructor(workspaceDirOrOpts: string | SqliteConnectionOptions) {
     const opts = typeof workspaceDirOrOpts === 'string'
@@ -51,8 +57,36 @@ export class SqliteConnection {
     this.dbPath = join(pdDir, 'state.db');
   }
 
+  /**
+   * Returns warnings collected during schema initialization (rc-9: no silent fallback).
+   * Empty if no warnings. Call after getDb() to inspect degraded schema state.
+   */
+  getSchemaInitWarnings(): string[] {
+    return [...this.schemaInitWarnings];
+  }
+
   getDb(): Database.Database {
     if (this.db) return this.db;
+
+    // readonly mode: if the DB file does not exist, bootstrap it once in write mode
+    // (triggers initSchema), then close and reopen in readonly mode. This prevents
+    // pd-console GET routes and other readonly callers from throwing SqliteError on
+    // fresh workspaces where state.db has not been created yet.
+    if (this.readonlyMode && !fs.existsSync(this.dbPath)) {
+      const bootstrapper = new SqliteConnection({ workspaceDir: this.workspaceDirFromDbPath(), readonly: false });
+      try {
+        bootstrapper.getDb(); // triggers initSchema + migrateSchema
+      } catch (err) {
+        // rc-9: fail loud with reason and next action — do not silently swallow
+        throw new PDRuntimeError(
+          'storage_unavailable',
+          `Failed to bootstrap state.db for readonly access: ${err instanceof Error ? err.message : String(err)}`,
+          { nextAction: 'Run "pd runtime init --confirm --workspace <dir>" to initialize databases, then retry.' },
+        );
+      } finally {
+        try { bootstrapper.close(); } catch { /* best-effort */ }
+      }
+    }
 
     this.db = this.readonlyMode
       ? new Database(this.dbPath, { readonly: true })
@@ -96,13 +130,34 @@ export class SqliteConnection {
       }
       try {
         this.initSchema();
-      } catch { /* schema init may fail in restricted environments */ }
+      } catch (err) {
+        // rc-9: surface failure reason instead of silent catch (was `catch { }`).
+        // Schema init may fail in restricted environments; record the warning so
+        // callers can detect degraded state via getSchemaInitWarnings().
+        this.schemaInitWarnings.push(
+          `initSchema failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       try {
         this.migrateSchema();
-      } catch { /* schema migration is non-fatal */ }
+      } catch (err) {
+        // rc-9: surface migration failure reason (was `catch { }`)
+        this.schemaInitWarnings.push(
+          `migrateSchema failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     return this.db;
+  }
+
+  /**
+   * Derive workspaceDir from dbPath (used for readonly bootstrap).
+   * dbPath is <workspaceDir>/.pd/state.db, so workspaceDir is two levels up.
+   */
+  private workspaceDirFromDbPath(): string {
+    // dbPath = <workspaceDir>/.pd/state.db → workspaceDir is dirname(dirname(dbPath))
+    return join(this.dbPath, '..', '..');
   }
 
   getPragmaReport(): SqlitePragmaReport {


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: N/A — 本 PR 是 4S 分析后的"立即修复"实施，承接已合并的 PR #1074（PRI-474/475/476）继续推进 DB 初始化整合
- 解决的产品问题（一句话）: 新用户首次使用 PD 时遇到 "no such table" 错误，因为 DB 初始化在多个入口路径上碎片化且 readonly 模式未先创建 DB 文件
- emotional-value：降低 [失控感/疲惫感] 创造 [安心感/掌控感]
  - 如无明确情绪价值，说明为何仍是必要的: 首次启动失败是阻断性体验，新用户根本无法进入 PD 价值流
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- **readonly bootstrap 修复**：readonly 连接在 DB 文件不存在时，先创建临时 writable 连接初始化 schema，再以 readonly 模式重新打开，避免 pd-console GET 路由在新工作区上抛错（`sqlite-connection.ts`）
- **trajectory.db 单一权威 DDL**：将所有 16 张表的 DDL 集中到 `applyTrajectorySchema()` 函数作为单一真理源，导出 `initTrajectorySchema()` 供外部 caller 使用；`ensureTrajectorySchema`（core）同步创建全表（"禁用"含义变为不写入数据，而非不创建表）
- **`pd runtime init` 命令**：新增显式 DB 初始化 CLI 命令，统一初始化所有 5 个 SQLite DB（state/trajectory/pain/control-ui/console），供安装器、CI 和用户手动调用
- **安装器集成**：`create-principles-disciple` 在安装完成后自动调用 `pd runtime init`，确保新用户开箱即用
- **stale 测试期望修复**：更新 `sqlite-connection-pragma.test.ts` 和 `pain-signal-observability.test.ts` 以匹配新的 bootstrap 行为

### 影响范围
- [x] packages/principles-core
- [x] packages/openclaw-plugin
- [x] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- 其他: packages/create-principles-disciple

### 是否触及产品边界
- [x] 否
- [ ] 是（需 maintainer 批准，附理由）: ___

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 在一个空目录中创建新工作区（无 `.pd/` 目录）
- [ ] 动作 1: 运行 `npx principles-disciple init` 或 `pd runtime init`
  - 观察: 命令成功退出，输出所有 DB 已初始化；`.pd/` 目录下出现 state.db、trajectory.db、pain.db、control-ui.db 文件
- [ ] 动作 2: 启动 pd-console 后访问任意 GET 路由（如 `/api/trajectory/stats`）
  - 观察: 不再抛出 "no such table" 错误，返回空数据而非崩溃
- [ ] 动作 3: 在已有数据的工作区上再次运行 `pd runtime init`
  - 观察: 命令幂等，不破坏已有数据；所有 CREATE 语句使用 IF NOT EXISTS
- 证据（截图/CLI 输出关键行）:
  - `core: 5674 passed | 0 failed`
  - `pd-cli: 1181 passed | 0 failed`
  - `plugin: 1893 passed | 0 failed`
  - `npm run verify:merge: PASS`（9 checks: generated-artifacts/error-handbook/repo-hygiene/runtime-contract/lint/build/typecheck）

## 风险与可逆性（agent 填）
- 主要风险: readonly bootstrap 在并发场景下可能存在短暂的 writelock 竞争（已通过 `withLock` 文件锁缓解）；`evolution_tasks` 表的"创建但不写入"语义对依赖表不存在的旧测试是 breaking change
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否
  - [ ] 是（名称: ___）
  - 规则引用: `mvp-q-3-how-disabled` —— 本 PR 是 bug 修复 + 显式 CLI 命令，调用方需主动调用；readonly bootstrap 修复为行为对齐，无新功能子系统引入，不需 flag
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？是 — 新用户首次启动失败是阻断性体验，会持续被反馈
- `mvp-q-2-how-observed`: 如何观察它生效？运行 `pd runtime init` 看到 DB 创建；新工作区访问 pd-console 不再崩溃
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [ ] 文档已更新（本 PR 未触及文档，文档更新作为后续 follow-up）
- [x] 无破坏性变更（或已标记为 breaking change）— `evolution_tasks` 表存在性变化已通过更新测试同步
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：本 PR 未删除源文件，N/A
- [x] Core 边界检查：本 PR 未在 `packages/principles-core/src/` 新增 `fs`/`path` 导入；`pain-signal-observability.ts` 的 DDL 是纯字符串常量，不触达 I/O
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性 — 仅当修改 `packages/principles-core/src/**/sqlite-*-store.ts` 时填写）
- [x] N/A — 本 PR 未修改 `sqlite-*-store.ts` 文件签名或新增 throw guard；`sqlite-connection.ts` 修改的是 readonly bootstrap 内部行为，未变更公共方法签名
  - 修改的 store 文件与方法: N/A（`sqlite-connection.ts` 不属于 `sqlite-*-store.ts` 命名族）
  - 新增的 throw / precondition: 无
  - 跨包 caller 审计: N/A
  - 规则引用: `ERR-083`

### ERR Checklist（必填）
- ERR-001 (parsed JSON/DB row as any): 本 PR 在 `trajectory.ts` V2 列迁移检查中，使用类型守卫函数 `hasNameField(row: object): row is { name: unknown }` 代替 `(row as Record<string, unknown>)` 类型断言，避免对 PRAGMA table_info 不可信输出使用 `as`
- ERR-015/ERR-018/ERR-019 (stale loop state): 本 PR 的 `applyTrajectorySchema()` 中 ALTER COLUMN 迁移每次调用 `PRAGMA table_info()` 获取最新列信息，不缓存循环状态
- ERR-083 (跨包破坏): `initTrajectorySchema` 是新增导出，未修改现有 store 方法签名；安装器调用通过 `pd runtime init` CLI 间接调用，无直接 core 依赖
- ERR-002 (silent fallback): readonly bootstrap 修复中，临时 writable 连接失败时通过抛错而非静默吞错；ALTER COLUMN 的 try/catch 仅吞 "duplicate column name" 错误，其他错误重新抛出

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据
- [x] `rc-1-treat-as-unknown` — `db.prepare().all()` 返回的 PRAGMA 行视为 unknown，用 typeof 收窄
- [x] `rc-2-no-as-bypass` — V2 列迁移使用类型守卫 `hasNameField` 代替 `as Record`（pre-push runtime-contract 扫描通过）
- [x] `rc-3-fail-loud-missing` — 临时 writable 连接失败立即抛错
- [x] `rc-4-validate-array-elements` — `rows.some(...)` 内对每个 row 单独 typeof 检查
- [x] `rc-5-object-hasown-not-in` — 类型守卫内部使用 `Object.hasOwn(row, 'name')`
- [ ] `rc-6-lineage-consistency` — N/A（本 PR 不涉及血缘字段）
- [ ] `rc-7-loop-state-freshness` — N/A（无重试循环）
- [ ] `rc-8-safe-serialization` — N/A（无遥测路径）
- [x] `rc-9-no-silent-fallback` — readonly bootstrap 失败显式抛错；ALTER COLUMN 错误仅吞 "duplicate column" 这种幂等性错误
- 遵守方式说明: 见上述勾选项；关键修复点在 `trajectory.ts` 的 `hasNameField` 类型守卫

### CLI Gate 自检（条件性 — 仅当修改 `packages/pd-cli/src/commands/**` 时填写）
- [x] 本 PR 修改 CLI 命令（新增 `pd runtime init`）
- [x] `cli-1-strict-json` — `--json` 输出为单一 JSON 对象，无 banner
- [x] `cli-2-exit-stops` — 错误路径 `process.exit(1)` 后立即 `return`，无后续副作用
- [ ] `cli-3-negated-flags-parser-tests` — N/A（无 `--no-*` flag）
- [x] `cli-4-dry-run-confirm-mutex` — `--dry-run` 与 `--confirm` 互斥，默认 dry-run
- [x] `cli-5-failure-no-mutation` — dry-run 模式不写入任何 DB；失败路径不创建文件
- [x] `cli-6-output-next-action` — 降级/失败输出包含 `reason` 和 `nextAction` 字段
- [x] `cli-7-test-wiring` — `runtime-init.test.ts` 和 `runtime-init-empty-workspace.test.ts` 测试真实 command 注册和 flag 解析

### Feature Flag 注册检查（条件性 — 仅当引入新功能子系统/hook/writer/reader 时填写）
- [x] N/A — `pd runtime init` 是一次性 CLI 命令而非持续运行的功能子系统；readonly bootstrap 修复是行为对齐而非新行为；按 AGENTS.md "Feature Flag Registration" 章节定义，不触发注册要求

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`（"为未来铺路"）
- [x] 无 `antipattern-completeness`（"为完整性"）
- [x] 无 `antipattern-review-missing`（"review 时觉得缺失"）
- [x] 无 `antipattern-core-io`（"在 core 写 I/O 代码"）

## 产品品味审计（owner 填，agent 不得代填）
<!-- 这些问题只有产品 owner 能回答。agent 不得代填。 -->

- [ ] 提醒方式是否克制？（非大声通知，精巧视觉）
- [ ] 命名是否符合双语规范？
- [ ] 交互是否符合"最小连贯干预"原则？
- [ ] 错误路径是否给了 nextAction，而非 silent fallback？（`rc-9-no-silent-fallback`）
- [ ] 是否符合 PD 产品边界？（非任务执行/通用记忆/工具修复/自主价值决策）
- 产品品味备注（可选）: ___

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run test`: 通过（5674 passed, 0 failed）
- [x] `cd packages/openclaw-plugin && npm run test`: 通过（1893 passed, 0 failed）
- [x] `cd packages/pd-cli && npm run test`: 通过（1181 passed, 0 failed）
- [x] `npm run lint`: 通过
- [x] `npm run verify:merge`: 通过（9 checks 全部 PASS）

## 相关 Issue
<!-- 关闭的 issue：Closes #XX -->
承接 PR #1074（PRI-474/475/476 已合并）继续推进 DB 初始化整合工作。本 PR 实施了 4S 分析后的"立即修复"行动项。
