### PR TITLE
feat(pd-console): redesign control center agent switches with dependency grouping and progressive disclosure

### DIFF
--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -652,7 +652,53 @@
         "body": "Empathy Observer is on — every unmatched message triggers an LLM call (current model: {{provider}}/{{model}}).",
         "muted": "To reduce cost, switch pd-empathy-observer.policy.model in workflows.yaml to a cheaper model.",
         "ack": "Got it"
-      }
+      },
+      "workflow": {
+        "title": "PD Behavior Loop",
+        "subtitle": "From error to principle, from principle to change",
+        "phase01": "Detect Error",
+        "phase01Desc": "Observe Agent behavior\nIdentify patterns to improve",
+        "phase02": "Form Principle",
+        "phase02Desc": "Distill experience into\na followable principle",
+        "phase03": "Owner Approval",
+        "phase03Desc": "You decide which principles\ncan take effect",
+        "phase04": "Change Behavior",
+        "phase04Desc": "Principle acts on\nAgent's next behavior",
+        "loopHint": "After behavior changes, PD keeps observing — forming a closed loop. 9 agents are distributed across this loop, each with its own role."
+      },
+      "status": {
+        "enabled": "Enabled",
+        "notReady": "Not Ready",
+        "corePipeline": "Core Pipeline",
+        "corePipelineOk": "OK",
+        "corePipelineDegraded": "Degraded",
+        "corePipelineParalyzed": "Paralyzed",
+        "needsConfig": "Needs Config"
+      },
+      "groups": {
+        "coreTrio": "Core Trio",
+        "coreTrioTag": "Must together",
+        "coreTrioHint": "Disabling any one breaks the error-to-principle pipeline",
+        "codeChain": "Code Chain",
+        "codeChainTag": "Recommend together",
+        "codeChainHint": "Only artificer degrades to prompt-only; only evaluator is meaningless",
+        "qualityPolish": "Quality Polish",
+        "qualityPolishTag": "Optional · toggle individually",
+        "qualityPolishHint": "Refines principles; disabling is fine, just slightly rougher quality",
+        "sidechain": "Sidechain",
+        "sidechainTag": "Independent · toggle individually",
+        "sidechainHint": "Does not affect the main pipeline; only pain signal detection precision"
+      },
+      "impact": {
+        "label": "If disabled",
+        "confirmTitle": "Confirm disabling core agent",
+        "confirmAck": "Confirm disable",
+        "confirmCancel": "Cancel"
+      },
+      "techDetail": "Technical Details",
+      "profileLabelShort": "Runtime",
+      "unknownAgentsWarning": "Detected {{count}} unrecognized agent(s): {{names}}. They are not shown in groups.",
+      "footerNote": "9 agents are distributed across the internalization pipeline and sidechain services. The Core Trio must be enabled together — otherwise PD cannot turn errors into principles."
     },
     "login": {
       "title": "Login",

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -652,7 +652,53 @@
         "body": "共情观察器已启用 — 每次关键词未命中时会调用 LLM 做深度分析（当前模型：{{provider}}/{{model}}）。",
         "muted": "如需节省成本，在 workflows.yaml 的 pd-empathy-observer.policy.model 换更便宜模型。",
         "ack": "知道了"
-      }
+      },
+      "workflow": {
+        "title": "PD 行为回路",
+        "subtitle": "从错误到原则，从原则到改变",
+        "phase01": "发现错误",
+        "phase01Desc": "观察智能体行为\n识别需要改进的模式",
+        "phase02": "形成原则",
+        "phase02Desc": "把经验提炼成\n可遵循的原则",
+        "phase03": "拥有者审批",
+        "phase03Desc": "你决定哪些原则\n可以生效",
+        "phase04": "改变行为",
+        "phase04Desc": "原则作用于\n智能体下次行为",
+        "loopHint": "行为改变后，PD 继续观察 —— 形成闭环。9 个代理分布在这条回路上，各司其职。"
+      },
+      "status": {
+        "enabled": "已启用",
+        "notReady": "未就绪",
+        "corePipeline": "核心管道",
+        "corePipelineOk": "正常",
+        "corePipelineDegraded": "降级可用",
+        "corePipelineParalyzed": "瘫痪",
+        "needsConfig": "需配置"
+      },
+      "groups": {
+        "coreTrio": "核心三件套",
+        "coreTrioTag": "必须一起开",
+        "coreTrioHint": "关掉任何一个，PD 都无法把错误转化为原则",
+        "codeChain": "代码实现链",
+        "codeChainTag": "推荐一起开",
+        "codeChainHint": "只开 artificer 会降级为纯提示通道；只开 evaluator 无意义",
+        "qualityPolish": "质量打磨",
+        "qualityPolishTag": "可选 · 单独开关",
+        "qualityPolishHint": "让原则更精炼，关掉也能用，只是质量略粗",
+        "sidechain": "侧链服务",
+        "sidechainTag": "独立 · 单独开关",
+        "sidechainHint": "不影响主管道，只影响 pain 信号检测精度"
+      },
+      "impact": {
+        "label": "关掉会怎样",
+        "confirmTitle": "确认关闭核心代理",
+        "confirmAck": "确认关闭",
+        "confirmCancel": "取消"
+      },
+      "techDetail": "技术细节",
+      "profileLabelShort": "运行时",
+      "unknownAgentsWarning": "检测到 {{count}} 个未识别的代理：{{names}}。它们未被分组显示。",
+      "footerNote": "9 个代理分布在内化管道与侧链服务两条路径上。核心三件套必须一起开，否则 PD 无法把错误转化为原则。"
     },
     "login": {
       "title": "登录",

--- a/packages/pd-console/src/ui/pages/control-center/AgentCard.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/AgentCard.tsx
@@ -200,6 +200,7 @@ export function AgentCard({
 
   return (
     <div
+      data-agent-card={agent.name}
       className={cn(
         "bg-surface border border-line-2 rounded-[4px] mb-[6px] overflow-hidden transition-colors hover:border-line",
         !meta.isCore && "border-dashed",

--- a/packages/pd-console/src/ui/pages/control-center/AgentCard.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/AgentCard.tsx
@@ -1,0 +1,409 @@
+import { useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronRight } from "lucide-react";
+import { cn } from "../../../lib/utils.js";
+import type { AgentMeta } from "../../utils/agent-metadata.js";
+import type {
+  RedactedAgentSummary,
+  RedactedRuntimeProfileSummary,
+} from "../../api.js";
+
+/**
+ * AgentCard — 三层渐进式披露代理卡片 + 核心代理内联确认
+ *
+ * L1（折叠态）：状态点 + 显示名 + agent.name + 角色一句话 + 开关 + 展开箭头
+ * L2（展开态）：详细说明段落 + impact-box + 技术细节 toggle + profile-row
+ * L3（嵌套折叠）：技术细节 grid
+ *
+ * 核心代理（isCore=true）关闭时显示内联确认条（不弹模态）。
+ *
+ * rc 合规：
+ * - rc-1: agent/profiles 由父组件已验证；meta 是静态数据
+ * - rc-2: 无 as 绕过
+ * - rc-8: 无 JSON 序列化
+ *
+ * 品牌约束（PRI-CR1 B.4.4）：
+ * - 禁止 translateY / scale hover（rotate 仅用于箭头朝向，允许）
+ * - 无硬编码十六进制色值
+ */
+
+export type AgentLocale = "zh-CN" | "en";
+
+interface AgentCardProps {
+  agent: RedactedAgentSummary;
+  meta: AgentMeta;
+  profiles: RedactedRuntimeProfileSummary[];
+  onBindingChange: (
+    agentName: string,
+    runtimeProfile: string,
+    enabled: boolean,
+  ) => void;
+  saving: string | null;
+  locale: AgentLocale;
+}
+
+/** 状态点样式：ready / notready / off */
+function statusDotClasses(agent: RedactedAgentSummary): string {
+  const base = "w-2 h-2 rounded-full border-2 shrink-0";
+  if (!agent.enabled) {
+    return cn(base, "border-ink-4 bg-surface opacity-50");
+  }
+  switch (agent.readiness) {
+    case "ready":
+      return cn(base, "border-green bg-green");
+    case "not_ready":
+      return cn(base, "border-amber bg-surface");
+    case "needs_setup":
+      return cn(base, "border-amber bg-surface");
+    default:
+      return cn(base, "border-ink-4 bg-surface");
+  }
+}
+
+/** impact-box 左边框色 */
+function impactBorderClass(level: AgentMeta["impactLevel"]): string {
+  switch (level) {
+    case "danger":
+      return "border-l-danger";
+    case "green":
+      return "border-l-green";
+    default:
+      return "border-l-amber";
+  }
+}
+
+/** impact label 色 */
+function impactLabelClass(level: AgentMeta["impactLevel"]): string {
+  switch (level) {
+    case "danger":
+      return "text-danger";
+    case "green":
+      return "text-green";
+    default:
+      return "text-ink-4";
+  }
+}
+
+/**
+ * 渲染含反引号 code 片段的文本。
+ * 输入示例：'`DiagnosticianContextPayload`（pain 信号上下文）'
+ * 输出：[<code>DiagnosticianContextPayload</code>, "（pain 信号上下文）"]
+ */
+function renderTextWithCode(text: string): ReactNode[] {
+  const parts = text.split("`");
+  const nodes: ReactNode[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === undefined) continue;
+    if (i % 2 === 0) {
+      if (part.length > 0) {
+        nodes.push(part);
+      }
+    } else {
+      // Odd index = content between backticks = code
+      nodes.push(
+        <code
+          key={`code-${i}`}
+          className="font-mono text-[11px] text-ink-2 bg-paper-2 px-[5px] py-[1px] rounded-[2px]"
+        >
+          {part}
+        </code>,
+      );
+    }
+  }
+  return nodes;
+}
+
+export function AgentCard({
+  agent,
+  meta,
+  profiles,
+  onBindingChange,
+  saving,
+  locale,
+}: AgentCardProps) {
+  const { t } = useTranslation();
+  const isSaving = saving === agent.name;
+
+  // L2 / L3 / confirm 状态
+  const [isOpen, setIsOpen] = useState(false);
+  const [showTechDetail, setShowTechDetail] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+
+  // locale 决定取 Zh 还是 En 字段
+  const isZh = locale === "zh-CN";
+  const displayName = isZh ? meta.displayNameZh : meta.displayNameEn;
+  const role = isZh ? meta.roleZh : meta.roleEn;
+  const detail = isZh ? meta.detailZh : meta.detailEn;
+  const impact = isZh ? meta.impactZh : meta.impactEn;
+  const techDetail = isZh ? meta.techDetailZh : meta.techDetailEn;
+  const mvpNote = isZh ? meta.mvpNoteZh : meta.mvpNoteEn;
+
+  // 段落用 \n\n 分隔
+  const detailParagraphs = detail.split("\n\n").filter((p) => p.length > 0);
+
+  // 头部点击：toggle isOpen（但点击 toggle 按钮 / confirm-bar / tech-toggle 不触发）
+  const handleHeadClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (
+      target.closest("[data-agent-toggle]") ||
+      target.closest("[data-confirm-bar]") ||
+      target.closest("[data-tech-toggle]")
+    ) {
+      return;
+    }
+    setIsOpen((prev) => !prev);
+  };
+
+  // toggle 按钮点击
+  const handleToggleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (agent.enabled) {
+      // 当前 on → 要关
+      if (meta.isCore) {
+        // 核心代理：显示内联确认 + 自动展开
+        setConfirming(true);
+        setIsOpen(true);
+      } else {
+        // 非核心代理：直接关
+        onBindingChange(agent.name, agent.runtimeProfileId, false);
+      }
+    } else {
+      // 当前 off → 要开
+      onBindingChange(agent.name, agent.runtimeProfileId, true);
+    }
+  };
+
+  // 确认停用
+  const handleConfirmOff = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onBindingChange(agent.name, agent.runtimeProfileId, false);
+    setConfirming(false);
+  };
+
+  // 取消确认
+  const handleCancelConfirm = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setConfirming(false);
+  };
+
+  // tech-toggle 点击
+  const handleTechToggleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowTechDetail((prev) => !prev);
+  };
+
+  // profile select 变更
+  const handleProfileChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onBindingChange(agent.name, e.target.value, agent.enabled);
+  };
+
+  return (
+    <div
+      className={cn(
+        "bg-surface border border-line-2 rounded-[4px] mb-[6px] overflow-hidden transition-colors hover:border-line",
+        !meta.isCore && "border-dashed",
+        !agent.enabled && "opacity-72",
+      )}
+    >
+      {/* ── L1: 头部（始终显示） ── */}
+      <div
+        className="px-[16px] py-[12px] cursor-pointer flex items-center gap-[12px]"
+        onClick={handleHeadClick}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isOpen}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setIsOpen((prev) => !prev);
+          }
+        }}
+      >
+        {/* 状态点 */}
+        <div className={statusDotClasses(agent)} aria-hidden="true" />
+
+        {/* 名称 + 角色 */}
+        <div className="flex-1 min-w-0">
+          <div
+            className={cn(
+              "text-[14px] font-semibold tracking-[-0.005em] flex items-center gap-[8px]",
+              agent.enabled ? "text-ink" : "text-ink-3",
+            )}
+          >
+            <span>{displayName}</span>
+            <span className="font-mono text-[11.5px] text-ink-4 font-normal">
+              {agent.name}
+            </span>
+          </div>
+          <div className="text-[12.5px] text-ink-3 mt-[2px] leading-[1.5]">
+            {role}
+          </div>
+        </div>
+
+        {/* 开关按钮 */}
+        <button
+          type="button"
+          data-agent-toggle
+          onClick={handleToggleClick}
+          disabled={isSaving}
+          aria-label={
+            agent.enabled
+              ? t("pages.controlCenter.agentDisabled")
+              : t("pages.controlCenter.agentEnabled")
+          }
+          className={cn(
+            "rounded-[3px] px-[14px] py-[6px] text-[12.5px] font-medium transition-colors disabled:opacity-50",
+            agent.enabled
+              ? "border border-gov bg-gov text-paper hover:bg-gov-2"
+              : "border border-line bg-surface text-ink hover:border-line-2",
+          )}
+        >
+          {isSaving
+            ? t("pages.controlCenter.saving")
+            : agent.enabled
+              ? t("pages.controlCenter.on")
+              : t("pages.controlCenter.off")}
+        </button>
+
+        {/* 展开箭头（rotate 允许） */}
+        <ChevronRight
+          className={cn(
+            "w-[14px] h-[14px] text-ink-4 transition-transform shrink-0",
+            isOpen && "rotate-90",
+          )}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* ── L2: 展开内容（isOpen 控制） ── */}
+      {isOpen && (
+        <div className="px-[16px] pb-[14px] border-t border-line-2 bg-panel">
+          {/* 详细说明段落 */}
+          <div className="pt-[14px] text-[13px] text-ink-3 leading-[1.62]">
+            {detailParagraphs.map((para, i) => (
+              <p key={i} className={i > 0 ? "mt-2" : undefined}>
+                {renderTextWithCode(para)}
+              </p>
+            ))}
+          </div>
+
+          {/* MVP note（仅 philosopher/rolloutReviewer 有） */}
+          {mvpNote && (
+            <div className="mt-3 text-[12px] text-ink-4 font-mono italic">
+              {mvpNote}
+            </div>
+          )}
+
+          {/* impact-box */}
+          <div
+            className={cn(
+              "mt-[12px] px-[12px] py-[10px] border border-line-2 border-l-[2.5px] rounded-[4px] bg-paper-2 text-[12.5px] text-ink-3 leading-[1.55]",
+              impactBorderClass(meta.impactLevel),
+            )}
+          >
+            <span
+              className={cn(
+                "block mb-[3px] text-[10px] font-mono uppercase tracking-[0.08em] font-medium",
+                impactLabelClass(meta.impactLevel),
+              )}
+            >
+              {t("pages.controlCenter.impact.label")}
+            </span>
+            {impact}
+          </div>
+
+          {/* L3: 技术细节（嵌套折叠，仅当有 techDetail 内容时显示） */}
+          {Object.keys(techDetail).length > 0 && (
+            <>
+              <div
+                data-tech-toggle
+                className="mt-[12px] pt-[12px] border-t border-line-2 flex items-center gap-[6px] cursor-pointer text-[11px] text-ink-4 font-mono uppercase tracking-[0.04em] hover:text-ink-2 transition-colors"
+                onClick={handleTechToggleClick}
+                role="button"
+                tabIndex={0}
+                aria-expanded={showTechDetail}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setShowTechDetail((prev) => !prev);
+                  }
+                }}
+              >
+                <ChevronRight
+                  className={cn(
+                    "w-[12px] h-[12px] transition-transform",
+                    showTechDetail && "rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+                {t("pages.controlCenter.techDetail")}
+              </div>
+              {showTechDetail && (
+                <div className="mt-2 grid grid-cols-[72px_1fr] gap-x-[14px] gap-y-[6px] text-[12px] leading-[1.55]">
+                  {Object.entries(techDetail).map(([k, v]) => (
+                    <div key={k} className="contents">
+                      <div className="text-ink-4 font-mono text-[10.5px] uppercase tracking-[0.04em] pt-px">
+                        {k}
+                      </div>
+                      <div className="text-ink-3">
+                        {renderTextWithCode(v)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+
+          {/* profile-row */}
+          <div className="mt-[12px] pt-[12px] border-t border-line-2 flex items-center gap-[10px] text-[12px]">
+            <span className="text-ink-4 font-mono text-[10.5px] uppercase tracking-[0.04em]">
+              {t("pages.controlCenter.profileLabelShort")}
+            </span>
+            <select
+              value={agent.runtimeProfileId}
+              onChange={handleProfileChange}
+              disabled={isSaving}
+              className="font-mono text-[11px] text-ink-2 bg-surface border border-line-2 rounded-[3px] px-2 py-1 cursor-pointer focus:outline-none focus:border-gov disabled:opacity-50"
+              aria-label={t("pages.controlCenter.profileLabel")}
+            >
+              {profiles.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 内联确认条（仅核心代理 confirming=true 时） */}
+          {confirming && (
+            <div
+              data-confirm-bar
+              className="mt-[10px] px-[12px] py-[10px] border border-danger rounded-[4px] bg-danger/10 text-[12px] text-ink-2 leading-[1.55]"
+            >
+              <div>{impact}</div>
+              <div className="mt-2 flex gap-[8px]">
+                <button
+                  type="button"
+                  onClick={handleConfirmOff}
+                  className="text-[11.5px] px-[12px] py-[4px] rounded-[3px] border border-transparent bg-danger text-paper font-medium hover:opacity-90 transition-opacity focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
+                >
+                  {t("pages.controlCenter.impact.confirmAck")}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelConfirm}
+                  className="text-[11.5px] px-[12px] py-[4px] rounded-[3px] border border-line bg-transparent text-ink-3 hover:border-line-2 transition-colors focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
+                >
+                  {t("pages.controlCenter.impact.confirmCancel")}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/pd-console/src/ui/pages/control-center/AgentGroup.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/AgentGroup.tsx
@@ -71,6 +71,15 @@ export function AgentGroup({
   const groupTagLabel = isZh ? groupMeta.tagLabelZh : groupMeta.tagLabelEn;
   const groupHint = isZh ? groupMeta.hintZh : groupMeta.hintEn;
 
+  // rc-2/rc-5: 先用类型守卫缩窄 agent.name，避免 as 绕过；
+  // 空状态判断基于过滤后的 knownAgents，避免"全部未知时仍渲染 group header 但无卡片"
+  // 用对象级类型谓词让 TS 在后续 map 中正确缩窄 agent.name（Array.filter 对
+  // 子属性的 string 谓词不会传播到元素类型）
+  const knownAgents = agents.filter(
+    (agent): agent is RedactedAgentSummary & { name: keyof typeof AGENT_METADATA } =>
+      isKnownAgentName(agent.name),
+  );
+
   return (
     <div className="mb-[20px]">
       {/* group header */}
@@ -85,17 +94,13 @@ export function AgentGroup({
       </div>
 
       {/* agent cards */}
-      {agents.length === 0 ? (
+      {knownAgents.length === 0 ? (
         // rc-9: 空状态显式提示（不静默）
         <div className="py-2 px-4 text-[12.5px] text-ink-4 italic">
           —
         </div>
       ) : (
-        agents.map((agent) => {
-          // rc-2/rc-5: 用类型守卫缩窄 agent.name，避免 as 绕过
-          if (!isKnownAgentName(agent.name)) {
-            return null;
-          }
+        knownAgents.map((agent) => {
           const meta = AGENT_METADATA[agent.name];
           return (
             <AgentCard

--- a/packages/pd-console/src/ui/pages/control-center/AgentGroup.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/AgentGroup.tsx
@@ -1,0 +1,115 @@
+import { useTranslation } from "react-i18next";
+import { cn } from "../../../lib/utils.js";
+import {
+  AGENT_METADATA,
+  type AgentGroupMeta,
+} from "../../utils/agent-metadata.js";
+import { isKnownAgentName } from "../../utils/control-center-helpers.js";
+import type {
+  RedactedAgentSummary,
+  RedactedRuntimeProfileSummary,
+} from "../../api.js";
+import { AgentCard, type AgentLocale } from "./AgentCard.js";
+
+/**
+ * AgentGroup — 依赖分组容器
+ *
+ * 渲染 group header（名称 + 标签 + 提示）+ 该组所有 AgentCard。
+ * 标签样式按 GroupTag（must/recommend/optional/independent）区分。
+ *
+ * rc 合规：
+ * - rc-2/rc-5: 父组件已用 groupAgentsByDependency 过滤未知代理，本组件用
+ *   isKnownAgentName 类型守卫二次校验 agent.name 后取 meta（防御性，不静默）
+ * - rc-9: 若 agents 为空数组，渲染 group header 但显示空状态提示
+ *
+ * 品牌约束：无 translateY / scale hover，无硬编码色值
+ */
+
+interface AgentGroupProps {
+  groupMeta: AgentGroupMeta;
+  agents: RedactedAgentSummary[];
+  profiles: RedactedRuntimeProfileSummary[];
+  onBindingChange: (
+    agentName: string,
+    runtimeProfile: string,
+    enabled: boolean,
+  ) => void;
+  saving: string | null;
+  locale: AgentLocale;
+}
+
+/** gtag 样式按 GroupTag 区分 */
+function gtagClasses(tag: AgentGroupMeta["tag"]): string {
+  const base =
+    "text-[10px] font-mono px-[7px] py-[2px] rounded-[2px] tracking-[0.02em] font-medium border border-transparent";
+  switch (tag) {
+    case "must":
+      return cn(base, "bg-danger/10 text-danger border-danger/22");
+    case "recommend":
+      return cn(base, "bg-amber/10 text-amber border-amber/22");
+    case "optional":
+      return cn(base, "bg-paper-2 text-ink-4 border-line-2");
+    case "independent":
+      return cn(base, "bg-green/10 text-green border-green/22");
+    default:
+      return base;
+  }
+}
+
+export function AgentGroup({
+  groupMeta,
+  agents,
+  profiles,
+  onBindingChange,
+  saving,
+  locale,
+}: AgentGroupProps) {
+  const { t } = useTranslation();
+  const isZh = locale === "zh-CN";
+
+  const groupName = isZh ? groupMeta.labelZh : groupMeta.labelEn;
+  const groupTagLabel = isZh ? groupMeta.tagLabelZh : groupMeta.tagLabelEn;
+  const groupHint = isZh ? groupMeta.hintZh : groupMeta.hintEn;
+
+  return (
+    <div className="mb-[20px]">
+      {/* group header */}
+      <div className="px-[14px] py-[9px] bg-paper-2 border border-line-2 rounded-[4px] flex items-center gap-[10px] mb-[8px]">
+        <span className="text-[12.5px] font-semibold text-ink-2">
+          {groupName}
+        </span>
+        <span className={gtagClasses(groupMeta.tag)}>{groupTagLabel}</span>
+        <span className="ml-auto text-[11px] text-ink-4 font-mono leading-[1.4] max-w-[32ch] text-right">
+          {groupHint}
+        </span>
+      </div>
+
+      {/* agent cards */}
+      {agents.length === 0 ? (
+        // rc-9: 空状态显式提示（不静默）
+        <div className="py-2 px-4 text-[12.5px] text-ink-4 italic">
+          —
+        </div>
+      ) : (
+        agents.map((agent) => {
+          // rc-2/rc-5: 用类型守卫缩窄 agent.name，避免 as 绕过
+          if (!isKnownAgentName(agent.name)) {
+            return null;
+          }
+          const meta = AGENT_METADATA[agent.name];
+          return (
+            <AgentCard
+              key={agent.name}
+              agent={agent}
+              meta={meta}
+              profiles={profiles}
+              onBindingChange={onBindingChange}
+              saving={saving}
+              locale={locale}
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
@@ -21,11 +21,20 @@ import type {
 import {
   computeOverallReadiness,
   groupAgentsByReadiness,
+  groupAgentsByDependency,
+  isKnownAgentName,
   redactDiagnosticsForCopy,
 } from "../../utils/control-center-helpers.js";
 import { enumLabel } from "../../utils/enum-labels.js";
 import type { ControlCenterDiagnostics } from "../../utils/control-center-helpers.js";
 import { EmpathyObserverCostHint } from "./EmpathyObserverCostHint.js";
+import { WorkflowDiagram } from "./WorkflowDiagram.js";
+import { AgentGroup } from "./AgentGroup.js";
+import { AgentCard, type AgentLocale } from "./AgentCard.js";
+import {
+  AGENT_GROUPS,
+  AGENT_METADATA,
+} from "../../utils/agent-metadata.js";
 
 // ── Runtime validators (H section / ERR-001/005/009/013) ─────────────────────
 
@@ -351,7 +360,20 @@ function readinessTagClasses(readiness: ReadinessStatus): string {
 
 // ── Sub-components ───────────────────────────────────────────────────────────
 
-function OverallStatusCard({
+/**
+ * CompactStatusBar — 紧凑状态条（替代 OverallStatusCard）
+ *
+ * 取自原型 control-center.html 第 153-168 行。一行展示：
+ * 已启用 N/M · 未就绪 N 项 · 核心管道 状态 · [需配置] pill
+ *
+ * 核心管道状态 = core_trio + code_chain 中已启用代理的就绪情况：
+ * - paralyzed: core_trio 任一 disabled 或有 not_ready
+ * - degraded: 有 needs_setup
+ * - ok: 全 ready
+ *
+ * rc-2: 用 Object.hasOwn 守卫 agent.name 查 AGENT_METADATA（无 as 绕过）
+ */
+function CompactStatusBar({
   readiness,
   agents,
 }: {
@@ -362,118 +384,74 @@ function OverallStatusCard({
 
   const enabledCount = agents.filter((a) => a.enabled).length;
   const totalCount = agents.length;
+  const notReadyCount = agents.filter(
+    (a) => a.enabled && a.readiness !== "ready",
+  ).length;
 
-  let messageKey: string;
-  switch (readiness) {
-    case "ready":
-      messageKey = "pages.controlCenter.configReady";
-      break;
-    case "needs_setup":
-      messageKey = "pages.controlCenter.configNeedsSetup";
-      break;
-    case "not_ready":
-      messageKey = "pages.controlCenter.configNotReady";
-      break;
-    case "disabled":
-      messageKey = "pages.controlCenter.configDisabled";
-      break;
-    default:
-      messageKey = "pages.controlCenter.configUnknown";
-      break;
+  // 核心管道状态：core_trio + code_chain 中已启用代理
+  // rc-2: 用 isKnownAgentName 类型守卫缩窄，不用 as 绕过
+  const coreAgents = agents.filter((a) => {
+    if (!isKnownAgentName(a.name)) return false;
+    const meta = AGENT_METADATA[a.name];
+    return meta.group === "core_trio" || meta.group === "code_chain";
+  });
+
+  const enabledCoreAgents = coreAgents.filter((a) => a.enabled);
+  const coreTrioAgents = coreAgents.filter((a) => {
+    if (!isKnownAgentName(a.name)) return false;
+    const meta = AGENT_METADATA[a.name];
+    return meta.group === "core_trio";
+  });
+  const coreTrioAnyDisabled = coreTrioAgents.some((a) => !a.enabled);
+  const coreAnyNotReady = enabledCoreAgents.some(
+    (a) => a.readiness === "not_ready",
+  );
+  const coreAnyNeedsSetup = enabledCoreAgents.some(
+    (a) => a.readiness === "needs_setup",
+  );
+
+  let corePipelineKey: string;
+  let needsConfig = false;
+  if (coreTrioAnyDisabled || coreAnyNotReady) {
+    corePipelineKey = "pages.controlCenter.status.corePipelineParalyzed";
+    needsConfig = true;
+  } else if (coreAnyNeedsSetup) {
+    corePipelineKey = "pages.controlCenter.status.corePipelineDegraded";
+    needsConfig = true;
+  } else {
+    corePipelineKey = "pages.controlCenter.status.corePipelineOk";
   }
 
   return (
-    <div className="bg-panel border border-line rounded-[6px] px-[18px] py-[14px]">
-      <div className="flex items-center gap-3 mb-2">
-        <span className={readinessTagClasses(readiness)}>
-          {enumLabel('readiness', readiness, t)}
+    <div className="mt-5 px-[16px] py-[11px] bg-surface border border-line-2 rounded-[4px] flex items-center gap-[16px] text-[12.5px] text-ink-3 flex-wrap">
+      <div className="flex items-center gap-[6px]">
+        <span className="text-ink-4 font-mono text-[11px] uppercase tracking-[0.04em]">
+          {t("pages.controlCenter.status.enabled")}
         </span>
-        <span className="text-ink-3 text-[13px]">
-          {enabledCount}/{totalCount} {t("pages.controlCenter.agentEnabled").toLowerCase()}
-        </span>
-      </div>
-      <p className="text-ink-2 text-[14px] leading-relaxed">
-        {t(messageKey)}
-      </p>
-    </div>
-  );
-}
-
-function AgentRow({
-  agent,
-  profiles,
-  onBindingChange,
-  saving,
-}: {
-  agent: RedactedAgentSummary;
-  profiles: RedactedRuntimeProfileSummary[];
-  onBindingChange: (
-    agentName: string,
-    runtimeProfile: string,
-    enabled: boolean,
-  ) => void;
-  saving: string | null;
-}) {
-  const { t } = useTranslation();
-  const isSaving = saving === agent.name;
-
-  return (
-    <div className="flex items-center gap-4 py-[10px] border-b border-line last:border-b-0">
-      {/* Agent name */}
-      <div className="min-w-[140px]">
-        <span className="text-ink text-[13px] font-medium">{agent.name}</span>
-      </div>
-
-      {/* Readiness tag */}
-      <div className="min-w-[100px]">
-        <span className={readinessTagClasses(agent.readiness)}>
-          {enumLabel('readiness', agent.readiness, t)}
+        <span className="text-ink font-semibold">
+          <span className="font-mono">{enabledCount}</span> /{" "}
+          <span className="font-mono">{totalCount}</span>
         </span>
       </div>
-
-      {/* Profile selector */}
-      <div className="flex-1">
-        <select
-          value={agent.runtimeProfileId}
-          onChange={(e) => {
-            onBindingChange(agent.name, e.target.value, agent.enabled);
-          }}
-          disabled={isSaving}
-          className="bg-surface border border-line rounded-[3px] px-2 py-1 text-[12.5px] text-ink focus:outline-none focus:border-gov disabled:opacity-50"
-          aria-label={t("pages.controlCenter.profileLabel")}
-        >
-          {profiles.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.label}
-            </option>
-          ))}
-        </select>
+      <div className="flex items-center gap-[6px]">
+        <span className="text-ink-4 font-mono text-[11px] uppercase tracking-[0.04em]">
+          {t("pages.controlCenter.status.notReady")}
+        </span>
+        <span className="text-ink font-semibold">
+          <span className="font-mono">{notReadyCount}</span>
+        </span>
       </div>
-
-      {/* Enable/disable toggle */}
-      <button
-        type="button"
-        onClick={() => {
-          onBindingChange(agent.name, agent.runtimeProfileId, !agent.enabled);
-        }}
-        disabled={isSaving}
-        className={
-          agent.enabled
-            ? "border border-gov bg-gov text-paper rounded-[3px] px-[14px] py-[6px] text-[12.5px] font-medium hover:bg-gov-2 transition-colors disabled:opacity-50"
-            : "border border-line bg-surface text-ink rounded-[3px] px-[14px] py-[6px] text-[12.5px] font-medium hover:border-line-2 transition-colors disabled:opacity-50"
-        }
-        aria-label={
-          agent.enabled
-            ? t("pages.controlCenter.agentDisabled")
-            : t("pages.controlCenter.agentEnabled")
-        }
-      >
-        {isSaving
-          ? t("pages.controlCenter.saving")
-          : agent.enabled
-            ? t("pages.controlCenter.on")
-            : t("pages.controlCenter.off")}
-      </button>
+      <div className="flex items-center gap-[6px]">
+        <span className="text-ink-4 font-mono text-[11px] uppercase tracking-[0.04em]">
+          {t("pages.controlCenter.status.corePipeline")}
+        </span>
+        <span className="text-ink font-semibold">{t(corePipelineKey)}</span>
+      </div>
+      {needsConfig && (
+        <span className="ml-auto px-[9px] py-[3px] rounded-[2px] text-[10.5px] font-mono tracking-[0.02em] font-medium border border-amber text-amber bg-amber/10">
+          {t("pages.controlCenter.status.needsConfig")}
+        </span>
+      )}
     </div>
   );
 }
@@ -715,7 +693,7 @@ function AdvancedDiagnostics({
 type LoadingState = "loading" | "loaded" | "error";
 
 export function ControlCenterPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [configData, setConfigData] = useState<ConfigSummaryData | null>(null);
   const [catalogData, setCatalogData] = useState<ConfigCatalogData | null>(
     null,
@@ -876,13 +854,12 @@ export function ControlCenterPage() {
         {t("pages.controlCenter.subtitle")}
       </p>
 
-      {/* Section 1: Config Readiness Card */}
-      <section aria-labelledby="section-readiness">
-        <OverallStatusCard
-          readiness={overallReadiness}
-          agents={configData.agents}
-        />
-      </section>
+      {/* Section 1: 行为回路图 + 紧凑状态条（替代 OverallStatusCard） */}
+      <WorkflowDiagram />
+      <CompactStatusBar
+        readiness={overallReadiness}
+        agents={configData.agents}
+      />
 
       {/* Empathy Observer cost hint — spec 2026-06-27 §4.1
           Gate 1: only mount when empathyObserver is enabled AND localStorage
@@ -909,7 +886,7 @@ export function ControlCenterPage() {
         );
       })()}
 
-      {/* Section 2: Internal Agents */}
+      {/* Section 2: Internal Agents — 按依赖分组 */}
       <section className="mt-8" aria-labelledby="section-agents">
         <SectionTitle id="section-agents">
           {t("pages.controlCenter.internalAgents")}
@@ -917,21 +894,38 @@ export function ControlCenterPage() {
         <p className="text-ink-3 text-[13px] leading-relaxed mb-3">
           {t("pages.controlCenter.internalAgentsDescription")}
         </p>
-        <div className="bg-panel border border-line rounded-[6px] px-[18px] py-[6px]">
-          {configData.agents.length === 0 ? (
-            <div className="py-3 text-ink-3 text-[13px]">—</div>
-          ) : (
-            configData.agents.map((agent) => (
-              <AgentRow
-                key={agent.name}
-                agent={agent}
-                profiles={availableProfiles}
-                onBindingChange={handleBindingChange}
-                saving={savingAgent}
-              />
-            ))
-          )}
-        </div>
+        {(() => {
+          const { groups, unknown } = groupAgentsByDependency(
+            configData.agents,
+          );
+          const locale: AgentLocale = i18n.language.startsWith("en")
+            ? "en"
+            : "zh-CN";
+          return (
+            <>
+              {AGENT_GROUPS.map((groupMeta) => (
+                <AgentGroup
+                  key={groupMeta.id}
+                  groupMeta={groupMeta}
+                  agents={groups[groupMeta.id]}
+                  profiles={availableProfiles}
+                  onBindingChange={handleBindingChange}
+                  saving={savingAgent}
+                  locale={locale}
+                />
+              ))}
+              {/* rc-9: 未知代理不静默 */}
+              {unknown.length > 0 && (
+                <div className="mt-3 px-3 py-2 border border-amber/30 border-l-2 border-l-amber rounded-[4px] bg-amber/10 text-[12.5px] text-ink-3">
+                  {t("pages.controlCenter.unknownAgentsWarning", {
+                    count: unknown.length,
+                    names: unknown.map((a) => a.name).join(", "),
+                  })}
+                </div>
+              )}
+            </>
+          );
+        })()}
       </section>
 
       {/* Section 3: Default Runtime */}
@@ -951,6 +945,11 @@ export function ControlCenterPage() {
       <section className="mt-8" aria-labelledby="section-diagnostics">
         <AdvancedDiagnostics config={configData} />
       </section>
+
+      {/* Footer note */}
+      <p className="mt-10 pt-[18px] border-t border-line-2 text-ink-4 text-[12px] leading-[1.6] max-w-[60ch] font-mono">
+        {t("pages.controlCenter.footerNote")}
+      </p>
       </div>
     </PageShell>
   );

--- a/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/ControlCenterPage.tsx
@@ -402,7 +402,13 @@ function CompactStatusBar({
     const meta = AGENT_METADATA[a.name];
     return meta.group === "core_trio";
   });
+  const codeChainAgents = coreAgents.filter((a) => {
+    if (!isKnownAgentName(a.name)) return false;
+    const meta = AGENT_METADATA[a.name];
+    return meta.group === "code_chain";
+  });
   const coreTrioAnyDisabled = coreTrioAgents.some((a) => !a.enabled);
+  const codeChainAnyDisabled = codeChainAgents.some((a) => !a.enabled);
   const coreAnyNotReady = enabledCoreAgents.some(
     (a) => a.readiness === "not_ready",
   );
@@ -410,14 +416,21 @@ function CompactStatusBar({
     (a) => a.readiness === "needs_setup",
   );
 
+  // 状态优先级（per AGENT_METADATA.impactZh）:
+  // - paralyzed: core_trio 任一 disabled 或 enabled 但 not_ready
+  //   （core_trio 是入口，关掉任何一个整个管道瘫痪）
+  // - degraded: code_chain 任一 disabled（降级运行，非瘫痪）
+  //             或 enabled 但 needs_setup
+  // - ok: 全 ready
+  //
+  // needsConfig 标记仅用于 readiness 异常（not_ready / needs_setup），
+  // 不用于主动 disabled — 主动 disable 是 owner 的有意决策，不是配置缺失。
   let corePipelineKey: string;
-  let needsConfig = false;
+  const needsConfig = coreAnyNotReady || coreAnyNeedsSetup;
   if (coreTrioAnyDisabled || coreAnyNotReady) {
     corePipelineKey = "pages.controlCenter.status.corePipelineParalyzed";
-    needsConfig = true;
-  } else if (coreAnyNeedsSetup) {
+  } else if (codeChainAnyDisabled || coreAnyNeedsSetup) {
     corePipelineKey = "pages.controlCenter.status.corePipelineDegraded";
-    needsConfig = true;
   } else {
     corePipelineKey = "pages.controlCenter.status.corePipelineOk";
   }

--- a/packages/pd-console/src/ui/pages/control-center/WorkflowDiagram.tsx
+++ b/packages/pd-console/src/ui/pages/control-center/WorkflowDiagram.tsx
@@ -1,0 +1,116 @@
+import { useTranslation } from "react-i18next";
+import { ChevronRight, RefreshCw } from "lucide-react";
+
+/**
+ * WorkflowDiagram — PD 行为回路 4 阶段图
+ *
+ * 纯展示组件，所有文本来自 i18n。Phase 03（Owner 审批）用虚线边框 +
+ * gov 色调高亮，强调"人在治理中心"（品牌 Principle 3）。
+ *
+ * 视觉规格取自 design-prototype/control-center.html 第 115-151 行。
+ *
+ * rc 合规：
+ * - rc-1: 纯展示组件，消费 i18n 字符串（已受控），无 untrusted 数据
+ * - rc-8: 无 JSON 序列化路径
+ *
+ * 品牌约束（PRI-CR1 B.4.4）：
+ * - 禁止 translateY / scale hover 效果（仅 rotate 允许用于箭头朝向）
+ * - 无硬编码十六进制色值，全用 token
+ */
+export function WorkflowDiagram() {
+  const { t } = useTranslation();
+
+  const phases = [
+    {
+      num: "01",
+      nameKey: "pages.controlCenter.workflow.phase01",
+      descKey: "pages.controlCenter.workflow.phase01Desc",
+      isHuman: false,
+    },
+    {
+      num: "02",
+      nameKey: "pages.controlCenter.workflow.phase02",
+      descKey: "pages.controlCenter.workflow.phase02Desc",
+      isHuman: false,
+    },
+    {
+      num: "03",
+      nameKey: "pages.controlCenter.workflow.phase03",
+      descKey: "pages.controlCenter.workflow.phase03Desc",
+      isHuman: true,
+    },
+    {
+      num: "04",
+      nameKey: "pages.controlCenter.workflow.phase04",
+      descKey: "pages.controlCenter.workflow.phase04Desc",
+      isHuman: false,
+    },
+  ] as const;
+
+  return (
+    <div className="mt-8 bg-surface border border-line-2 rounded-[8px] px-[22px] py-[18px]">
+      {/* 标题行：mono eyebrow + 分隔线 */}
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-[11px] font-mono uppercase tracking-[0.1em] text-ink-4 font-medium">
+          {t("pages.controlCenter.workflow.title")}
+        </span>
+        <span className="text-[11px] font-mono uppercase tracking-[0.1em] text-ink-4">
+          {t("pages.controlCenter.workflow.subtitle")}
+        </span>
+        <span className="flex-1 h-px bg-line-2" aria-hidden="true" />
+      </div>
+
+      {/* 4 phase + 3 箭头 grid */}
+      <div className="grid grid-cols-[1fr_24px_1fr_24px_1fr_24px_1fr] items-stretch">
+        {phases.map((phase, idx) => (
+          <div key={phase.num} className="contents">
+            <div
+              className={
+                phase.isHuman
+                  ? "px-[10px] py-[12px] text-center flex flex-col gap-[5px] justify-center border border-dashed border-gov bg-gov/10 rounded-[4px]"
+                  : "px-[10px] py-[12px] text-center flex flex-col gap-[5px] justify-center bg-paper-2 border border-line-2 rounded-[4px]"
+              }
+            >
+              <div className="text-[10px] font-mono text-ink-4 tracking-[0.06em]">
+                {phase.num}
+              </div>
+              <div
+                className={
+                  phase.isHuman
+                    ? "text-[14px] font-semibold text-gov tracking-[-0.005em]"
+                    : "text-[14px] font-semibold text-ink tracking-[-0.005em]"
+                }
+              >
+                {t(phase.nameKey)}
+              </div>
+              <div
+                className={
+                  phase.isHuman
+                    ? "text-[11.5px] text-gov-2 italic leading-[1.45] whitespace-pre-line"
+                    : "text-[11.5px] text-ink-3 leading-[1.45] whitespace-pre-line"
+                }
+              >
+                {t(phase.descKey)}
+              </div>
+            </div>
+            {/* 箭头（最后一个 phase 后无箭头） */}
+            {idx < phases.length - 1 && (
+              <div className="flex items-center justify-center text-ink-4 font-mono">
+                <ChevronRight className="w-[18px] h-[18px]" aria-hidden="true" />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* loop hint */}
+      <div className="mt-[14px] pt-[12px] border-t border-line-2 flex items-center gap-[10px] text-[11.5px] text-ink-4 font-mono leading-[1.5]">
+        <RefreshCw
+          className="w-[14px] h-[14px] text-gov shrink-0"
+          aria-hidden="true"
+        />
+        <span>{t("pages.controlCenter.workflow.loopHint")}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/pd-console/src/ui/utils/agent-metadata.ts
+++ b/packages/pd-console/src/ui/utils/agent-metadata.ts
@@ -1,0 +1,352 @@
+/**
+ * Agent Metadata — Control Center agent grouping & role descriptions
+ *
+ * Pure data module (no React, no I/O). Defines:
+ * - Which dependency cluster each of the 9 internal agents belongs to
+ * - Bilingual role / detail / impact / tech-detail text for progressive disclosure
+ * - Whether toggling the agent off requires inline confirmation (isCore)
+ *
+ * Content source: design-prototype/control-center.html (approved prototype).
+ * Agent names match INTERNAL_AGENT_NAMES from @principles/core (camelCase).
+ *
+ * ERR entries:
+ * - rc-1: pure static data, no untrusted input
+ * - rc-2: no `as` bypasses
+ * - rc-5: consumers use Object.hasOwn() to look up metadata by agent name
+ */
+
+import type { InternalAgentName } from '@principles/core/runtime-v2';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type AgentGroup = 'core_trio' | 'code_chain' | 'quality_polish' | 'sidechain';
+export type ImpactLevel = 'danger' | 'amber' | 'green';
+export type GroupTag = 'must' | 'recommend' | 'optional' | 'independent';
+
+export interface AgentMeta {
+  name: InternalAgentName;
+  group: AgentGroup;
+  /** 中文角色名（如"诊断师"） */
+  displayNameZh: string;
+  displayNameEn: string;
+  /** 一句话角色（L1 折叠态显示） */
+  roleZh: string;
+  roleEn: string;
+  /** 展开后的详细说明（L2），段落用 \n\n 分隔 */
+  detailZh: string;
+  detailEn: string;
+  /** 关掉会怎样（L2 impact box） */
+  impactLevel: ImpactLevel;
+  impactZh: string;
+  impactEn: string;
+  /** 技术细节（L3 嵌套折叠）— 键为标签，值可含反引号包裹的 code 片段 */
+  techDetailZh: Record<string, string>;
+  techDetailEn: Record<string, string>;
+  /** 是否核心代理（关掉需 inline confirm）。true 对应原型 data-core="true" */
+  isCore: boolean;
+  /** MVP 状态说明（可选，仅 philosopher/rolloutReviewer 有） */
+  mvpNoteZh?: string;
+  mvpNoteEn?: string;
+}
+
+export interface AgentGroupMeta {
+  id: AgentGroup;
+  labelZh: string;
+  labelEn: string;
+  tag: GroupTag;
+  tagLabelZh: string;
+  tagLabelEn: string;
+  hintZh: string;
+  hintEn: string;
+}
+
+// ── Group order (matches render order on the page) ───────────────────────────
+
+export const GROUP_ORDER: AgentGroup[] = [
+  'core_trio',
+  'code_chain',
+  'quality_polish',
+  'sidechain',
+];
+
+// ── Group metadata ───────────────────────────────────────────────────────────
+
+export const AGENT_GROUPS: AgentGroupMeta[] = [
+  {
+    id: 'core_trio',
+    labelZh: '核心三件套',
+    labelEn: 'Core Trio',
+    tag: 'must',
+    tagLabelZh: '必须一起开',
+    tagLabelEn: 'Must together',
+    hintZh: '关掉任何一个，PD 都无法把错误转化为原则',
+    hintEn: 'Disabling any one breaks the error-to-principle pipeline',
+  },
+  {
+    id: 'code_chain',
+    labelZh: '代码实现链',
+    labelEn: 'Code Chain',
+    tag: 'recommend',
+    tagLabelZh: '推荐一起开',
+    tagLabelEn: 'Recommend together',
+    hintZh: '只开 artificer 会降级为纯提示通道；只开 evaluator 无意义',
+    hintEn: 'Only artificer degrades to prompt-only; only evaluator is meaningless',
+  },
+  {
+    id: 'quality_polish',
+    labelZh: '质量打磨',
+    labelEn: 'Quality Polish',
+    tag: 'optional',
+    tagLabelZh: '可选 · 单独开关',
+    tagLabelEn: 'Optional · toggle individually',
+    hintZh: '让原则更精炼，关掉也能用，只是质量略粗',
+    hintEn: 'Refines principles; disabling is fine, just slightly rougher quality',
+  },
+  {
+    id: 'sidechain',
+    labelZh: '侧链服务',
+    labelEn: 'Sidechain',
+    tag: 'independent',
+    tagLabelZh: '独立 · 单独开关',
+    tagLabelEn: 'Independent · toggle individually',
+    hintZh: '不影响主管道，只影响 pain 信号检测精度',
+    hintEn: 'Does not affect the main pipeline; only pain signal detection precision',
+  },
+];
+
+// ── Agent metadata (covers all 9 INTERNAL_AGENT_NAMES) ───────────────────────
+
+export const AGENT_METADATA: Record<InternalAgentName, AgentMeta> = {
+  diagnostician: {
+    name: 'diagnostician',
+    group: 'core_trio',
+    displayNameZh: '诊断师',
+    displayNameEn: 'Diagnostician',
+    roleZh: '问"为什么会出错"，找到根本原因',
+    roleEn: 'Asks "why did it go wrong" and finds the root cause',
+    detailZh:
+      '当 Agent 做错了什么，诊断师负责像事故复盘一样追问"为什么"，找到根本原因，而不是只记下"出错了"。然后把原因抽象成一条原则候选。\n\n它其实是 3 个子阶段串联：找根因 → 抽象原则 → 决定怎么处理。',
+    detailEn:
+      'When an Agent makes a mistake, the Diagnostician runs a post-mortem asking "why" to find the root cause — not just recording "it failed". It then abstracts the cause into a principle candidate.\n\nIt is actually 3 sub-stages chained: find root cause → abstract principle → decide how to handle.',
+    impactLevel: 'danger',
+    impactZh: 'Pain 信号无法进入内化管道。诊断是入口，关掉后整个流程瘫痪，无法生成新的原则候选。',
+    impactEn: 'Pain signals cannot enter the internalization pipeline. Diagnosis is the entry point; disabling paralyzes the entire flow — no new principle candidates can be generated.',
+    techDetailZh: {
+      '输入': '`DiagnosticianContextPayload`（pain 信号上下文）',
+      '输出': '`DiagnosticianOutputV1` · rootCause / violatedPrinciples / recommendations[] / confidence',
+      '编排': '由 `PainSignalBridge` 触发；`diagnostician_split_pipeline` flag 控制单体 vs 3 段拆分',
+      '阶段': '`diag_rootcause` → `diag_distiller` → `diag_router`',
+    },
+    techDetailEn: {
+      'Input': '`DiagnosticianContextPayload` (pain signal context)',
+      'Output': '`DiagnosticianOutputV1` · rootCause / violatedPrinciples / recommendations[] / confidence',
+      'Orchestration': 'Triggered by `PainSignalBridge`; `diagnostician_split_pipeline` flag controls monolithic vs 3-stage split',
+      'Stages': '`diag_rootcause` → `diag_distiller` → `diag_router`',
+    },
+    isCore: true,
+  },
+
+  dreamer: {
+    name: 'dreamer',
+    group: 'core_trio',
+    displayNameZh: '梦想家',
+    displayNameEn: 'Dreamer',
+    roleZh: '想出 2-3 种不同的纠正方案',
+    roleEn: 'Proposes 2-3 distinct correction options',
+    detailZh:
+      '诊断完成后，梦想家从不同角度提出多个纠正方案——就像 brainstorming，先发散再收敛。每个方案都包含"当时做错了什么 / 应该怎么做 / 为什么"。\n\n它是内化引擎的第一站，接收诊断产物，输出候选方案。',
+    detailEn:
+      'After diagnosis, the Dreamer proposes multiple correction options from different angles — like brainstorming, diverge first then converge. Each option includes "what went wrong / what should be done / why".\n\nIt is the first stop of the internalization engine, receiving diagnosis output and producing candidates.',
+    impactLevel: 'danger',
+    impactZh: '内化引擎失去入口。Dreamer 是链首，关掉后无候选方案生成，内化瘫痪。',
+    impactEn: 'The internalization engine loses its entry point. Dreamer is the chain head; disabling means no candidates are generated — internalization is paralyzed.',
+    techDetailZh: {
+      '输入': '诊断阶段的 distilled principle / candidate artifact',
+      '输出': '`DreamerOutput` · 1-5 个候选，每个含 badDecision / betterDecision / riskLevel / strategicPerspective',
+      '注意': '`InternalizationAutoConsumerService` 当前仅自动消费 dreamer，下游需手动触发',
+    },
+    techDetailEn: {
+      'Input': 'Distilled principle / candidate artifact from the diagnosis stage',
+      'Output': '`DreamerOutput` · 1-5 candidates, each with badDecision / betterDecision / riskLevel / strategicPerspective',
+      'Note': '`InternalizationAutoConsumerService` currently only auto-consumes dreamer; downstream must be triggered manually',
+    },
+    isCore: true,
+  },
+
+  scribe: {
+    name: 'scribe',
+    group: 'core_trio',
+    displayNameZh: '抄写员',
+    displayNameEn: 'Scribe',
+    roleZh: '把方案写成正式的原则条文',
+    roleEn: 'Writes the chosen option into a formal principle statement',
+    detailZh:
+      '梦想家给出多个方案后，抄写员负责把选中的方案转写成清晰、可执行的原则条文——就像把会议纪要整理成正式文档。\n\n这条原则文本是后续所有工作的承载者：评估员会反向溯源到这里做质量校验。',
+    detailEn:
+      'After the Dreamer proposes multiple options, the Scribe transforms the selected one into a clear, executable principle statement — like turning meeting notes into a formal document.\n\nThis principle text is the carrier for all downstream work: the Evaluator traces back here for quality checks.',
+    impactLevel: 'danger',
+    impactZh: '无原则文本产出。Scribe 是原则承载者，关掉后管道断裂，核心瘫痪。',
+    impactEn: 'No principle text is produced. Scribe is the principle carrier; disabling breaks the pipeline — core is paralyzed.',
+    techDetailZh: {
+      '输入': 'Philosopher artifact（或 dreamer 直连）',
+      '输出': '`ScribeOutputV1` · principleDraft + sourcePhilosopherArtifactId（lineage 强制校验）',
+      '语言': '支持 Owner 偏好语言（`outputLanguage`，PRI-336）',
+    },
+    techDetailEn: {
+      'Input': 'Philosopher artifact (or direct from dreamer)',
+      'Output': '`ScribeOutputV1` · principleDraft + sourcePhilosopherArtifactId (lineage enforced)',
+      'Language': 'Supports Owner preferred language (`outputLanguage`, PRI-336)',
+    },
+    isCore: true,
+  },
+
+  artificer: {
+    name: 'artificer',
+    group: 'code_chain',
+    displayNameZh: '工匠',
+    displayNameEn: 'Artificer',
+    roleZh: '把原则变成可执行的拦截代码',
+    roleEn: 'Turns the principle into executable interception code',
+    detailZh:
+      '原则写好后，工匠负责把它变成代码——一个 `evaluate()` 函数，会在 Agent 发起工具调用时拦截检查。这比"提示词"更刚性、更可靠。\n\n同时生成 golden trace 测试用例，确保代码行为符合预期。',
+    detailEn:
+      'Once the principle is written, the Artificer turns it into code — an `evaluate()` function that intercepts and checks Agent tool calls. This is more rigid and reliable than "prompt wording".\n\nIt also generates golden trace test cases to ensure the code behaves as intended.',
+    impactLevel: 'amber',
+    impactZh: '降级运行。退回纯 prompt 通道，principle 文本仍可内化，但无 RuleHost 实现代码。',
+    impactEn: 'Degraded mode. Falls back to prompt-only channel; principle text can still be internalized, but no RuleHost implementation code.',
+    techDetailZh: {
+      '输入': 'Scribe artifact（principleDraft）',
+      '输出': '`ArtificerRuleOutput` · implementationCode + goldenTraceCases + affectedTools',
+      '信任边界': 'activation-capable，LLM 输出作 `unknown` 处理，validateOutput + lineage 通过才 commit',
+      'L2 模式': '`rulehost-code-generation` flag 开启 write-test-fix 循环（沙盒回放 → 重试，最多 3 次）',
+    },
+    techDetailEn: {
+      'Input': 'Scribe artifact (principleDraft)',
+      'Output': '`ArtificerRuleOutput` · implementationCode + goldenTraceCases + affectedTools',
+      'Trust boundary': 'activation-capable; LLM output treated as `unknown`; commit only after validateOutput + lineage pass',
+      'L2 mode': '`rulehost-code-generation` flag enables write-test-fix loop (sandbox replay → retry, max 3)',
+    },
+    isCore: true,
+  },
+
+  evaluator: {
+    name: 'evaluator',
+    group: 'code_chain',
+    displayNameZh: '评估员',
+    displayNameEn: 'Evaluator',
+    roleZh: '审查原则和代码质量，决定能否生效',
+    roleEn: 'Reviews principle & code quality, decides whether it can activate',
+    detailZh:
+      '工匠写完代码后，评估员做质量审查：原则是否清晰？代码是否符合原则意图？有没有覆盖足够多的场景？\n\n给出 approved / needs_revision / rejected 决策。只有 approved 的原则才能通过 RuleHost 通道激活。',
+    detailEn:
+      'After the Artificer writes the code, the Evaluator does a quality review: is the principle clear? Does the code match the principle intent? Does it cover enough scenarios?\n\nIt returns an approved / needs_revision / rejected decision. Only approved principles can activate via the RuleHost channel.',
+    impactLevel: 'amber',
+    impactZh: '降级运行。Principle 仍写入，但无 validated 标记，RuleHost 通道无法激活。',
+    impactEn: 'Degraded mode. Principle is still written, but without the validated mark — RuleHost channel cannot activate.',
+    techDetailZh: {
+      '输入': 'Artificer artifact + Scribe artifact（反向溯源 principle 文本）',
+      '输出': '`EvaluatorOutputV1/V2` · decision + score + strengths/concerns + codeReview',
+      'V2 模式': '运行 adversarial sandbox replay，通过则持久化 `artifactKind: "rule"` artifact',
+    },
+    techDetailEn: {
+      'Input': 'Artificer artifact + Scribe artifact (reverse-traces principle text)',
+      'Output': '`EvaluatorOutputV1/V2` · decision + score + strengths/concerns + codeReview',
+      'V2 mode': 'Runs adversarial sandbox replay; on pass, persists `artifactKind: "rule"` artifact',
+    },
+    isCore: true,
+  },
+
+  philosopher: {
+    name: 'philosopher',
+    group: 'quality_polish',
+    displayNameZh: '哲学家',
+    displayNameEn: 'Philosopher',
+    roleZh: '从多个方案中选出最优并精炼',
+    roleEn: 'Selects the best option from multiple candidates and refines it',
+    detailZh:
+      '梦想家给出多个方案后，哲学家负责收敛——选出最优的一个，精炼成单一原则候选。\n\n关掉它，梦想家的产出会直接交给抄写员，原则可能略粗糙，但人工审批时仍可修改。',
+    detailEn:
+      'After the Dreamer proposes multiple options, the Philosopher converges — selects the best one and refines it into a single principle candidate.\n\nDisabling it means the Dreamer output goes directly to the Scribe; principles may be slightly rougher, but can still be edited during Owner review.',
+    impactLevel: 'green',
+    impactZh: '无影响。Dreamer 产出直接给 Scribe，质量略粗但人工审批可纠正。属设计预期。',
+    impactEn: 'No impact. Dreamer output goes directly to Scribe; slightly rougher quality but Owner review can correct. This is by design.',
+    techDetailZh: {
+      'MVP 状态': 'MVP-Quiet（ADR-0014 §2.5）。默认关闭，代码保留。',
+      '输出': '`PhilosopherOutputV1` · principleCandidate + sourceDreamerArtifactId',
+    },
+    techDetailEn: {
+      'MVP status': 'MVP-Quiet (ADR-0014 §2.5). Off by default; code retained.',
+      'Output': '`PhilosopherOutputV1` · principleCandidate + sourceDreamerArtifactId',
+    },
+    isCore: false,
+    mvpNoteZh: 'MVP-Quiet（ADR-0014 §2.5）。默认关闭，代码保留。',
+    mvpNoteEn: 'MVP-Quiet (ADR-0014 §2.5). Off by default; code retained.',
+  },
+
+  rolloutReviewer: {
+    name: 'rolloutReviewer',
+    group: 'quality_polish',
+    displayNameZh: '上线评审员',
+    displayNameEn: 'Rollout Reviewer',
+    roleZh: '原则生效前的最后一道审查',
+    roleEn: 'Final review before a principle goes live',
+    detailZh:
+      '评估员通过后，上线评审员做最终把关——评估上线风险、安全检查，决定是否真的推向 rollout。\n\n它本就是 MVP-Quiet 默认关闭的，关掉不影响任何功能。',
+    detailEn:
+      'After the Evaluator passes, the Rollout Reviewer does the final gate — assessing rollout risks and safety checks, deciding whether to actually push to rollout.\n\nIt is already MVP-Quiet (off by default); disabling does not affect any functionality.',
+    impactLevel: 'green',
+    impactZh: '无影响。本就是 MVP-Quiet 默认关闭。',
+    impactEn: 'No impact. Already MVP-Quiet (off by default).',
+    techDetailZh: {
+      'MVP 状态': 'MVP-Quiet。不在 `MVP_CORE_TASK_KINDS` 白名单中。',
+      '输出': '`RolloutReviewerOutputV1` · approve_rollout / needs_revision / reject + rolloutRisks + safetyChecks',
+      '实现': '唯一不继承 `BasePeerRunner` 的 peer runner',
+    },
+    techDetailEn: {
+      'MVP status': 'MVP-Quiet. Not in the `MVP_CORE_TASK_KINDS` whitelist.',
+      'Output': '`RolloutReviewerOutputV1` · approve_rollout / needs_revision / reject + rolloutRisks + safetyChecks',
+      'Implementation': 'The only peer runner that does not extend `BasePeerRunner`',
+    },
+    isCore: false,
+    mvpNoteZh: 'MVP-Quiet。不在 MVP_CORE_TASK_KINDS 白名单中。',
+    mvpNoteEn: 'MVP-Quiet. Not in the MVP_CORE_TASK_KINDS whitelist.',
+  },
+
+  correctionObserver: {
+    name: 'correctionObserver',
+    group: 'sidechain',
+    displayNameZh: '纠正观察员',
+    displayNameEn: 'Correction Observer',
+    roleZh: '后台优化"纠错关键词"，减少误报',
+    roleEn: 'Background optimizer for "correction keywords", reducing false positives',
+    detailZh:
+      'PD 用一组关键词检测 Agent 是否在被纠正。但关键词会过时或误报。纠正观察员定期审查历史，自动调整关键词权重，衰减误报。\n\n它在后台每 15 分钟跑一次，不影响主管道。',
+    detailEn:
+      'PD uses a set of keywords to detect whether an Agent is being corrected. But keywords go stale or produce false positives. The Correction Observer periodically reviews history, auto-adjusting keyword weights and decaying false positives.\n\nIt runs in the background every 15 minutes and does not affect the main pipeline.',
+    impactLevel: 'amber',
+    impactZh: '纠错关键词停止自优化。确定性 pain 检测仍工作，但误报会逐步累积。',
+    impactEn: 'Correction keywords stop self-optimizing. Deterministic pain detection still works, but false positives gradually accumulate.',
+    techDetailZh: {},
+    techDetailEn: {},
+    isCore: true,
+  },
+
+  empathyObserver: {
+    name: 'empathyObserver',
+    group: 'sidechain',
+    displayNameZh: '共情观察员',
+    displayNameEn: 'Empathy Observer',
+    roleZh: '从用户语气中捕捉传统检测漏掉的挫败感',
+    roleEn: 'Catches frustration that traditional detection misses',
+    detailZh:
+      '传统 pain 检测只能抓"命令失败""抛异常"这类硬错误。但用户说"又来了""怎么还是这样"时，其实已经很不满意了——这种情感摩擦硬检测抓不到。\n\n共情观察员用语义分析实时捕捉这类信号，弥补检测盲区。',
+    detailEn:
+      'Traditional pain detection only catches hard errors like "command failed" or "exception thrown". But when a user says "here we go again" or "why is this still happening", they are already frustrated — this emotional friction is invisible to hard detection.\n\nThe Empathy Observer uses semantic analysis to catch these signals in real time, covering the detection blind spot.',
+    impactLevel: 'amber',
+    impactZh: '退回纯确定性 pain 检测。常规对话下 pain 触发稀疏，内化速度显著下降。',
+    impactEn: 'Falls back to deterministic-only pain detection. In normal conversation, pain triggers become sparse — internalization speed drops significantly.',
+    techDetailZh: {},
+    techDetailEn: {},
+    isCore: true,
+  },
+};

--- a/packages/pd-console/src/ui/utils/control-center-helpers.ts
+++ b/packages/pd-console/src/ui/utils/control-center-helpers.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ReadinessStatus } from '../api.js';
+import { AGENT_METADATA, type AgentGroup } from './agent-metadata.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -126,6 +127,51 @@ export function groupAgentsByReadiness(
   }
 
   return groups;
+}
+
+// ── Group Agents by Dependency Cluster ───────────────────────────────────────
+
+export type AgentDependencyGroups = Record<AgentGroup, RedactedAgentSummary[]>;
+
+/**
+ * Type guard: is `name` a known internal agent with metadata?
+ * Replaces `as keyof typeof AGENT_METADATA` (rc-2: no `as` bypass).
+ */
+export function isKnownAgentName(name: string): name is keyof typeof AGENT_METADATA {
+  return Object.hasOwn(AGENT_METADATA, name);
+}
+
+/**
+ * Group agents by dependency cluster (core_trio / code_chain / quality_polish / sidechain).
+ * Agents not found in AGENT_METADATA go to the `unknown` bucket for fail-loud
+ * handling by the caller (rc-5: Object.hasOwn lookup; rc-9: no silent fallback).
+ *
+ * Group insertion order matches GROUP_ORDER (core_trio → code_chain → quality_polish → sidechain),
+ * so Object.keys(groups) returns the render order.
+ */
+export function groupAgentsByDependency(
+  agents: RedactedAgentSummary[],
+): { groups: AgentDependencyGroups; unknown: RedactedAgentSummary[] } {
+  const groups: AgentDependencyGroups = {
+    core_trio: [],
+    code_chain: [],
+    quality_polish: [],
+    sidechain: [],
+  };
+  const unknown: RedactedAgentSummary[] = [];
+
+  for (const agent of agents) {
+    // rc-5: Object.hasOwn for untrusted keys (agent.name comes from server response)
+    if (isKnownAgentName(agent.name)) {
+      const meta = AGENT_METADATA[agent.name];
+      groups[meta.group].push(agent);
+    } else {
+      // rc-9: unknown agents go to a separate bucket; caller decides how to surface
+      unknown.push(agent);
+    }
+  }
+
+  return { groups, unknown };
 }
 
 // ── Redacted Diagnostics for Copy ────────────────────────────────────────────

--- a/packages/pd-console/tests/e2e/control-center-agent-toggle.spec.ts
+++ b/packages/pd-console/tests/e2e/control-center-agent-toggle.spec.ts
@@ -1,0 +1,270 @@
+/* eslint-disable */
+// E2E 流程测试：Control Center 代理开关切换 — 验证开关真实影响 .pd/config.yaml 持久化
+// 和 UI 状态。这是 PR #1086 的功能验证测试，确保开关不是"装饰按钮"而是真实
+// 调用 PATCH /api/v1/config/agents/:name/binding，后端写入 config.yaml，
+// resolveAgentRuntimeBinding 在运行时读取该字段决定代理是否执行。
+//
+// 链路核实（PR #1086 评审）：
+//   UI toggle → onBindingChange → PATCH /api/v1/config/agents/:name/binding
+//   → pd-config-store.updateAgentBinding → 写 .pd/config.yaml
+//   → resolveAgentRuntimeBinding(effective, name).readiness === 'disabled' when enabled=false
+//   → runtime-internalization-run-rulehost.ts 检查 binding，artificer/evaluator
+//     关闭时 capability.enabled=false，整个 rulehost 管道降级
+//
+// 测试策略：
+//   1. 页面结构：4 依赖分组 + 9 代理 + WorkflowDiagram + CompactStatusBar
+//   2. 核心代理开关（scribe）：内联确认 → PATCH → 持久化 → 状态栏反映
+//   3. 非核心代理开关（philosopher）：无确认 → PATCH → 持久化
+//
+// 状态隔离：workers=1 + serial 模式；afterAll 通过 API 恢复 philosopher 为默认 disabled
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:3100';
+
+// ── API 辅助 ─────────────────────────────────────────────────────────────────
+
+async function apiGet(path: string): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`);
+  const body = await resp.json().catch(() => null);
+  return { status: resp.status, body };
+}
+
+async function apiPatch(path: string, body: unknown): Promise<{ status: number; body: unknown }> {
+  const resp = await fetch(`${BASE_URL}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await resp.json().catch(() => null);
+  return { status: resp.status, body: data };
+}
+
+/** 从 GET /summary 提取指定 agent 的 enabled 状态 */
+async function getAgentEnabled(agentName: string): Promise<boolean> {
+  const resp = await apiGet('/api/v1/config/summary');
+  expect(resp.status).toBe(200);
+  const body = resp.body as {
+    success: boolean;
+    data: { agents: Array<{ name: string; enabled: boolean }> };
+  };
+  expect(body.success).toBe(true);
+  const agent = body.data.agents.find((a) => a.name === agentName);
+  expect(agent, `agent '${agentName}' should exist in summary`).toBeTruthy();
+  return agent!.enabled;
+}
+
+/** 通过 API 设置 agent 的 enabled 状态（用于测试 setup/teardown） */
+async function setAgentEnabled(agentName: string, enabled: boolean): Promise<void> {
+  const resp = await apiPatch(`/api/v1/config/agents/${agentName}/binding`, {
+    runtimeProfile: 'openclaw.default',
+    enabled,
+  });
+  expect(resp.status).toBe(200);
+}
+
+// ── UI 辅助 ──────────────────────────────────────────────────────────────────
+
+/** 收集页面 5xx 和未捕获异常 */
+function attachErrorCollectors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('response', (resp) => {
+    if (resp.url().includes('/api/') && resp.status() >= 500) {
+      errors.push(`5xx: ${resp.status()} ${resp.url()}`);
+    }
+  });
+  page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+  return errors;
+}
+
+// ── 测试 ─────────────────────────────────────────────────────────────────────
+
+test.describe('Control Center 代理开关切换', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('页面结构：4 依赖分组 + 9 代理 + WorkflowDiagram + CompactStatusBar', async ({ page }) => {
+    const errors = attachErrorCollectors(page);
+
+    await page.goto('/#/control-center');
+    await page.waitForLoadState('networkidle');
+
+    // 无 5xx 或 pageerror
+    expect(errors, `ControlCenter had errors:\n${errors.join('\n')}`).toEqual([]);
+
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.length).toBeGreaterThan(100);
+
+    // ── 4 依赖分组标题 ──
+    const expectedGroups = ['核心三件套', '代码实现链', '质量打磨', '侧链服务'];
+    for (const groupName of expectedGroups) {
+      expect(bodyText, `group '${groupName}' should render`).toContain(groupName);
+    }
+
+    // ── 9 代理 name（camelCase，出现在 L1 头部 mono span）──
+    const expectedAgents = [
+      'diagnostician',
+      'dreamer',
+      'scribe',
+      'artificer',
+      'evaluator',
+      'philosopher',
+      'rolloutReviewer',
+      'correctionObserver',
+      'empathyObserver',
+    ];
+    for (const agentName of expectedAgents) {
+      expect(bodyText, `agent '${agentName}' should render`).toContain(agentName);
+    }
+
+    // ── WorkflowDiagram：4 个 phase 编号 ──
+    const phaseNumbers = ['01', '02', '03', '04'];
+    for (const num of phaseNumbers) {
+      expect(bodyText, `workflow phase '${num}' should render`).toContain(num);
+    }
+
+    // ── CompactStatusBar：核心管道 label ──
+    expect(bodyText, `CompactStatusBar 'corePipeline' label should render`).toContain('核心管道');
+  });
+
+  test('核心代理 scribe 关闭需内联确认 → PATCH 持久化 → 状态栏显示瘫痪', async ({ page }) => {
+    // ── Setup: 确保 scribe 初始为 enabled ──
+    await setAgentEnabled('scribe', true);
+    expect(await getAgentEnabled('scribe')).toBe(true);
+
+    const errors = attachErrorCollectors(page);
+
+    await page.goto('/#/control-center');
+    await page.waitForLoadState('networkidle');
+
+    // ── 找到 scribe 的 AgentCard 和开关按钮 ──
+    // 用 data-agent-card 精确定位卡片（避免 text=scribe 匹配到祖先 div 导致
+    // 错误定位到其他代理的 toggle 按钮）
+    const scribeCard = page.locator('[data-agent-card="scribe"]');
+    await expect(scribeCard).toBeVisible();
+
+    const scribeToggle = scribeCard.locator('[data-agent-toggle]');
+    await expect(scribeToggle).toBeVisible();
+    await expect(scribeToggle).toHaveText('开');
+
+    // ── 点击关闭 scribe ──
+    await scribeToggle.click();
+
+    // ── 核心代理：应出现内联确认条（data-confirm-bar）──
+    const confirmBar = page.locator('[data-confirm-bar]').first();
+    await expect(confirmBar, 'core agent disable should show inline confirm bar').toBeVisible({ timeout: 3000 });
+
+    // 确认条内应有 "确认关闭" 按钮
+    const confirmButton = confirmBar.locator('button', { hasText: '确认关闭' });
+    await expect(confirmButton).toBeVisible();
+
+    // ── 点击确认关闭 ──
+    await confirmButton.click();
+
+    // 等待 PATCH 请求完成
+    await page.waitForLoadState('networkidle');
+
+    // ── 验证 UI：scribe 开关文本变为 "关" ──
+    await expect(scribeToggle).toHaveText('关');
+
+    // ── 验证 API：GET /summary 中 scribe.enabled=false ──
+    const scribeEnabledAfter = await getAgentEnabled('scribe');
+    expect(scribeEnabledAfter, 'scribe should be disabled after confirm').toBe(false);
+
+    // ── 验证 CompactStatusBar：核心管道显示 "瘫痪" ──
+    // core_trio 中 scribe disabled → paralyzed
+    const statusBarText = await page.locator('body').innerText();
+    expect(statusBarText, 'CompactStatusBar should show paralyzed when core_trio agent disabled').toContain('瘫痪');
+
+    // 无 5xx 或 pageerror
+    expect(errors, `test had errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+
+  test('核心代理 scribe 重新开启：无确认 → PATCH 持久化 → 状态栏恢复', async ({ page }) => {
+    // ── 前置：scribe 应为 disabled（上一个测试的副作用）──
+    expect(await getAgentEnabled('scribe')).toBe(false);
+
+    const errors = attachErrorCollectors(page);
+
+    await page.goto('/#/control-center');
+    await page.waitForLoadState('networkidle');
+
+    // ── 找到 scribe 开关按钮（文本 "关"）──
+    const scribeCard = page.locator('[data-agent-card="scribe"]');
+    await expect(scribeCard).toBeVisible();
+
+    const scribeToggle = scribeCard.locator('[data-agent-toggle]');
+    await expect(scribeToggle).toBeVisible();
+    await expect(scribeToggle).toHaveText('关');
+
+    // ── 点击开启（turning on 永远不确认）──
+    await scribeToggle.click();
+
+    // ── 不应出现确认条 ──
+    const confirmBar = page.locator('[data-confirm-bar]');
+    await expect(confirmBar, 'turning on should NOT show confirm bar').toHaveCount(0);
+
+    // 等待 PATCH 完成
+    await page.waitForLoadState('networkidle');
+
+    // ── 验证 UI：开关文本变为 "开" ──
+    await expect(scribeToggle).toHaveText('开');
+
+    // ── 验证 API：scribe.enabled=true ──
+    expect(await getAgentEnabled('scribe')).toBe(true);
+
+    // ── 验证 CompactStatusBar：不再显示 "瘫痪" ──
+    const statusBarText = await page.locator('body').innerText();
+    expect(statusBarText, 'CompactStatusBar should not show paralyzed when core_trio restored').not.toContain('瘫痪');
+
+    // 无 5xx 或 pageerror
+    expect(errors, `test had errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+
+  test('非核心代理 philosopher 关闭：无确认 → PATCH 持久化', async ({ page }) => {
+    // ── Setup: 通过 API 先开启 philosopher（默认 disabled）──
+    await setAgentEnabled('philosopher', true);
+    expect(await getAgentEnabled('philosopher')).toBe(true);
+
+    const errors = attachErrorCollectors(page);
+
+    await page.goto('/#/control-center');
+    await page.waitForLoadState('networkidle');
+
+    // ── 找到 philosopher 开关按钮（文本 "开"）──
+    const philosopherCard = page.locator('[data-agent-card="philosopher"]');
+    await expect(philosopherCard).toBeVisible();
+
+    const philosopherToggle = philosopherCard.locator('[data-agent-toggle]');
+    await expect(philosopherToggle).toBeVisible();
+    await expect(philosopherToggle).toHaveText('开');
+
+    // ── 点击关闭 ──
+    await philosopherToggle.click();
+
+    // ── 非核心代理：不应出现确认条 ──
+    const confirmBar = page.locator('[data-confirm-bar]');
+    await expect(confirmBar, 'non-core agent disable should NOT show confirm bar').toHaveCount(0);
+
+    // 等待 PATCH 完成
+    await page.waitForLoadState('networkidle');
+
+    // ── 验证 UI：开关文本变为 "关" ──
+    await expect(philosopherToggle).toHaveText('关');
+
+    // ── 验证 API：philosopher.enabled=false ──
+    expect(await getAgentEnabled('philosopher')).toBe(false);
+
+    // 无 5xx 或 pageerror
+    expect(errors, `test had errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+
+  // ── Cleanup: 恢复 philosopher 为默认 disabled 状态 ──
+  test.afterAll(async () => {
+    // philosopher 默认 disabled，恢复以避免影响后续 spec
+    try {
+      await setAgentEnabled('philosopher', false);
+    } catch {
+      // best-effort cleanup — 不阻塞测试退出
+    }
+  });
+});

--- a/packages/pd-console/tests/ui/agent-card.test.ts
+++ b/packages/pd-console/tests/ui/agent-card.test.ts
@@ -1,0 +1,82 @@
+/**
+ * AgentCard — source-code contract test
+ *
+ * Verifies the three-layer progressive disclosure card implements:
+ * - L1 (always visible) / L2 (isOpen) / L3 (showTechDetail) structure
+ * - Inline confirm bar for core agents (isCore=true) — no modal
+ * - i18n keys for impact / techDetail
+ * - Brand constraints (no translate-y/scale hover, no hex colors)
+ * - rc-2: no `as` bypass
+ *
+ * Spec: .trae/documents/control-center-agent-redesign.md (步骤 5)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(__dirname, "..", "..", "src", "ui");
+
+function readSrc(relPath: string): string {
+  return readFileSync(join(SRC_ROOT, relPath), "utf-8");
+}
+
+describe("AgentCard: source-code contract", () => {
+  const source = readSrc("pages/control-center/AgentCard.tsx");
+
+  it("exports AgentCard function and AgentLocale type", () => {
+    expect(source).toMatch(/export\s+function\s+AgentCard/);
+    expect(source).toMatch(/export\s+type\s+AgentLocale/);
+  });
+
+  it("uses useState for isOpen, showTechDetail, and confirming", () => {
+    // Destructuring pattern: const [isOpen, setIsOpen] = useState(false)
+    // isOpen appears before useState, so regex must match that order
+    expect(source).toMatch(/isOpen.*useState/);
+    expect(source).toMatch(/showTechDetail.*useState/);
+    expect(source).toMatch(/confirming.*useState/);
+  });
+
+  it("calls onBindingChange callback for toggle/confirm/profile actions", () => {
+    expect(source).toContain("onBindingChange");
+  });
+
+  it("renders inline confirm bar with bg-danger/10 and border-danger for core agents", () => {
+    expect(source).toContain("bg-danger/10");
+    expect(source).toContain("border-danger");
+    expect(source).toContain("data-confirm-bar");
+  });
+
+  it("renders L2 content conditionally on isOpen", () => {
+    expect(source).toMatch(/\{isOpen\s*&&/);
+  });
+
+  it("renders L3 tech detail conditionally on showTechDetail", () => {
+    expect(source).toMatch(/\{showTechDetail\s*&&/);
+  });
+
+  it("references impact i18n keys (label, confirmAck, confirmCancel)", () => {
+    expect(source).toContain("pages.controlCenter.impact.label");
+    expect(source).toContain("pages.controlCenter.impact.confirmAck");
+    expect(source).toContain("pages.controlCenter.impact.confirmCancel");
+  });
+
+  it("references techDetail i18n key", () => {
+    expect(source).toContain("pages.controlCenter.techDetail");
+  });
+
+  it("allows rotate-90 for arrow expansion (rotate is permitted; translate-y/scale are not)", () => {
+    expect(source).toContain("rotate-90");
+  });
+
+  it("does not use forbidden translate-y-* or scale-* hover effects (PRI-CR1 B.4.4)", () => {
+    expect(source).not.toMatch(/translate-y-/);
+    expect(source).not.toMatch(/scale-/);
+  });
+
+  it("does not use hardcoded hex color values (must use design tokens)", () => {
+    expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+});

--- a/packages/pd-console/tests/ui/agent-group.test.ts
+++ b/packages/pd-console/tests/ui/agent-group.test.ts
@@ -1,0 +1,82 @@
+/**
+ * AgentGroup — source-code contract test
+ *
+ * Verifies the dependency-group container:
+ * - Renders group header (name + tag + hint)
+ * - Applies distinct tag styles per GroupTag (must/recommend/optional/independent)
+ * - Renders AgentCard for each agent
+ * - rc-2/rc-5: uses isKnownAgentName type guard (internally Object.hasOwn) for agent metadata lookup
+ * - rc-9: empty agents array shows fallback (not silent)
+ * - Brand constraints (no translate-y/scale hover, no hex colors)
+ *
+ * Spec: .trae/documents/control-center-agent-redesign.md (步骤 6)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(__dirname, "..", "..", "src", "ui");
+
+function readSrc(relPath: string): string {
+  return readFileSync(join(SRC_ROOT, relPath), "utf-8");
+}
+
+describe("AgentGroup: source-code contract", () => {
+  const source = readSrc("pages/control-center/AgentGroup.tsx");
+
+  it("exports AgentGroup function", () => {
+    expect(source).toMatch(/export\s+function\s+AgentGroup/);
+  });
+
+  it("renders group header with groupName, groupTagLabel, groupHint", () => {
+    expect(source).toContain("groupName");
+    expect(source).toContain("groupTagLabel");
+    expect(source).toContain("groupHint");
+  });
+
+  it("applies must tag style with bg-danger/10 + text-danger", () => {
+    expect(source).toContain("bg-danger/10");
+    expect(source).toContain("text-danger");
+  });
+
+  it("applies recommend tag style with bg-amber/10 + text-amber", () => {
+    expect(source).toContain("bg-amber/10");
+    expect(source).toContain("text-amber");
+  });
+
+  it("applies optional tag style with bg-paper-2", () => {
+    expect(source).toContain("bg-paper-2");
+  });
+
+  it("applies independent tag style with bg-green/10 + text-green", () => {
+    expect(source).toContain("bg-green/10");
+    expect(source).toContain("text-green");
+  });
+
+  it("imports and renders AgentCard for each agent", () => {
+    expect(source).toMatch(/import\s+.*AgentCard.*from/);
+    expect(source).toContain("agents.map");
+  });
+
+  it("has empty state fallback (rc-9: no silent fallback)", () => {
+    expect(source).toMatch(/agents\.length\s*===\s*0/);
+  });
+
+  it("uses isKnownAgentName type guard for agent metadata lookup (rc-2/rc-5)", () => {
+    // isKnownAgentName 内部用 Object.hasOwn（rc-5），表层用类型守卫缩窄（rc-2，不用 as）
+    expect(source).toMatch(/import\s+.*isKnownAgentName.*from/);
+    expect(source).toContain("isKnownAgentName(agent.name)");
+  });
+
+  it("does not use forbidden translate-y-* or scale-* hover effects (PRI-CR1 B.4.4)", () => {
+    expect(source).not.toMatch(/translate-y-/);
+    expect(source).not.toMatch(/scale-/);
+  });
+
+  it("does not use hardcoded hex color values (must use design tokens)", () => {
+    expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+});

--- a/packages/pd-console/tests/ui/agent-group.test.ts
+++ b/packages/pd-console/tests/ui/agent-group.test.ts
@@ -56,13 +56,14 @@ describe("AgentGroup: source-code contract", () => {
     expect(source).toContain("text-green");
   });
 
-  it("imports and renders AgentCard for each agent", () => {
+  it("imports and renders AgentCard for each known agent", () => {
     expect(source).toMatch(/import\s+.*AgentCard.*from/);
-    expect(source).toContain("agents.map");
+    expect(source).toContain("knownAgents.map");
   });
 
-  it("has empty state fallback (rc-9: no silent fallback)", () => {
-    expect(source).toMatch(/agents\.length\s*===\s*0/);
+  it("has empty state fallback based on filtered knownAgents (rc-9: no silent fallback)", () => {
+    // 空状态判断基于过滤后的 knownAgents，避免"全部未知时仍渲染 group header 但无卡片"
+    expect(source).toMatch(/knownAgents\.length\s*===\s*0/);
   });
 
   it("uses isKnownAgentName type guard for agent metadata lookup (rc-2/rc-5)", () => {

--- a/packages/pd-console/tests/ui/agent-metadata.test.ts
+++ b/packages/pd-console/tests/ui/agent-metadata.test.ts
@@ -68,9 +68,15 @@ describe("AGENT_METADATA: coverage", () => {
     for (const name of EXPECTED_AGENT_NAMES) {
       const meta = AGENT_METADATA[name];
       if (sidechainAgentsWithEmptyTechDetail.has(name)) {
-        // sidechain agents: techDetail may be empty (design choice)
-        expect(meta.techDetailZh).toBeDefined();
-        expect(meta.techDetailEn).toBeDefined();
+        // sidechain agents: techDetail may be empty (design choice),
+        // but must still be a non-null object (downstream does
+        // Object.keys(techDetail) — null would crash the component)
+        expect(meta.techDetailZh).not.toBeNull();
+        expect(typeof meta.techDetailZh).toBe("object");
+        expect(Array.isArray(meta.techDetailZh)).toBe(false);
+        expect(meta.techDetailEn).not.toBeNull();
+        expect(typeof meta.techDetailEn).toBe("object");
+        expect(Array.isArray(meta.techDetailEn)).toBe(false);
       } else {
         // all other agents: techDetail must be non-empty bilingual
         expect(Object.keys(meta.techDetailZh).length).toBeGreaterThan(0);

--- a/packages/pd-console/tests/ui/agent-metadata.test.ts
+++ b/packages/pd-console/tests/ui/agent-metadata.test.ts
@@ -1,0 +1,161 @@
+/**
+ * agent-metadata — runtime contract test
+ *
+ * Pure data module (no React, no I/O), so we can import it directly and
+ * assert on the runtime values. Verifies:
+ * - AGENT_METADATA covers all 9 internal agent names
+ * - AGENT_GROUPS has 4 groups matching GROUP_ORDER
+ * - Each agent has non-empty bilingual fields
+ * - isCore / group / impactLevel assignments match the design spec
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AGENT_METADATA,
+  AGENT_GROUPS,
+  GROUP_ORDER,
+} from "../../src/ui/utils/agent-metadata.js";
+
+const EXPECTED_AGENT_NAMES = [
+  "diagnostician",
+  "dreamer",
+  "scribe",
+  "artificer",
+  "evaluator",
+  "philosopher",
+  "rolloutReviewer",
+  "correctionObserver",
+  "empathyObserver",
+] as const;
+
+const EXPECTED_GROUP_IDS = [
+  "core_trio",
+  "code_chain",
+  "quality_polish",
+  "sidechain",
+] as const;
+
+describe("AGENT_METADATA: coverage", () => {
+  it("covers all 9 internal agent names", () => {
+    for (const name of EXPECTED_AGENT_NAMES) {
+      expect(Object.hasOwn(AGENT_METADATA, name)).toBe(true);
+    }
+    expect(Object.keys(AGENT_METADATA)).toHaveLength(9);
+  });
+
+  it("each agent has non-empty bilingual display name, role, detail, impact", () => {
+    for (const name of EXPECTED_AGENT_NAMES) {
+      const meta = AGENT_METADATA[name];
+      expect(meta.displayNameZh.length).toBeGreaterThan(0);
+      expect(meta.displayNameEn.length).toBeGreaterThan(0);
+      expect(meta.roleZh.length).toBeGreaterThan(0);
+      expect(meta.roleEn.length).toBeGreaterThan(0);
+      expect(meta.detailZh.length).toBeGreaterThan(0);
+      expect(meta.detailEn.length).toBeGreaterThan(0);
+      expect(meta.impactZh.length).toBeGreaterThan(0);
+      expect(meta.impactEn.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each agent has non-empty techDetail records (zh + en), or intentionally empty for sidechain agents", () => {
+    // sidechain agents (correctionObserver, empathyObserver) have simpler logic
+    // where the detail text already covers technical aspects; AgentCard handles
+    // empty techDetail gracefully via `Object.keys(techDetail).length > 0` guard
+    const sidechainAgentsWithEmptyTechDetail = new Set([
+      "correctionObserver",
+      "empathyObserver",
+    ]);
+    for (const name of EXPECTED_AGENT_NAMES) {
+      const meta = AGENT_METADATA[name];
+      if (sidechainAgentsWithEmptyTechDetail.has(name)) {
+        // sidechain agents: techDetail may be empty (design choice)
+        expect(meta.techDetailZh).toBeDefined();
+        expect(meta.techDetailEn).toBeDefined();
+      } else {
+        // all other agents: techDetail must be non-empty bilingual
+        expect(Object.keys(meta.techDetailZh).length).toBeGreaterThan(0);
+        expect(Object.keys(meta.techDetailEn).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("impactLevel is one of danger/amber/green", () => {
+    for (const name of EXPECTED_AGENT_NAMES) {
+      const meta = AGENT_METADATA[name];
+      expect(["danger", "amber", "green"]).toContain(meta.impactLevel);
+    }
+  });
+});
+
+describe("AGENT_METADATA: isCore assignment", () => {
+  it("isCore=true for core agents (require inline confirm on disable)", () => {
+    const coreAgents = [
+      "diagnostician",
+      "dreamer",
+      "scribe",
+      "artificer",
+      "evaluator",
+      "correctionObserver",
+      "empathyObserver",
+    ];
+    for (const name of coreAgents) {
+      expect(AGENT_METADATA[name].isCore).toBe(true);
+    }
+  });
+
+  it("isCore=false for optional agents (MVP-Quiet, direct toggle)", () => {
+    const optionalAgents = ["philosopher", "rolloutReviewer"];
+    for (const name of optionalAgents) {
+      expect(AGENT_METADATA[name].isCore).toBe(false);
+    }
+  });
+});
+
+describe("AGENT_METADATA: group assignment", () => {
+  it("core_trio = diagnostician, dreamer, scribe", () => {
+    expect(AGENT_METADATA.diagnostician.group).toBe("core_trio");
+    expect(AGENT_METADATA.dreamer.group).toBe("core_trio");
+    expect(AGENT_METADATA.scribe.group).toBe("core_trio");
+  });
+
+  it("code_chain = artificer, evaluator", () => {
+    expect(AGENT_METADATA.artificer.group).toBe("code_chain");
+    expect(AGENT_METADATA.evaluator.group).toBe("code_chain");
+  });
+
+  it("quality_polish = philosopher, rolloutReviewer", () => {
+    expect(AGENT_METADATA.philosopher.group).toBe("quality_polish");
+    expect(AGENT_METADATA.rolloutReviewer.group).toBe("quality_polish");
+  });
+
+  it("sidechain = correctionObserver, empathyObserver", () => {
+    expect(AGENT_METADATA.correctionObserver.group).toBe("sidechain");
+    expect(AGENT_METADATA.empathyObserver.group).toBe("sidechain");
+  });
+});
+
+describe("AGENT_GROUPS + GROUP_ORDER", () => {
+  it("has 4 groups matching GROUP_ORDER", () => {
+    expect(AGENT_GROUPS).toHaveLength(4);
+    expect(AGENT_GROUPS.map((g) => g.id)).toEqual([...EXPECTED_GROUP_IDS]);
+    expect(GROUP_ORDER).toEqual([...EXPECTED_GROUP_IDS]);
+  });
+
+  it("each group has non-empty bilingual label, tagLabel, hint", () => {
+    for (const g of AGENT_GROUPS) {
+      expect(g.labelZh.length).toBeGreaterThan(0);
+      expect(g.labelEn.length).toBeGreaterThan(0);
+      expect(g.tagLabelZh.length).toBeGreaterThan(0);
+      expect(g.tagLabelEn.length).toBeGreaterThan(0);
+      expect(g.hintZh.length).toBeGreaterThan(0);
+      expect(g.hintEn.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each group tag is one of must/recommend/optional/independent", () => {
+    const validTags = ["must", "recommend", "optional", "independent"];
+    for (const g of AGENT_GROUPS) {
+      expect(validTags).toContain(g.tag);
+    }
+  });
+});

--- a/packages/pd-console/tests/ui/control-center-helpers.test.ts
+++ b/packages/pd-console/tests/ui/control-center-helpers.test.ts
@@ -5,7 +5,9 @@ import {
   redactDiagnosticsForCopy,
   computeOverallReadiness,
   groupAgentsByReadiness,
+  groupAgentsByDependency,
   type ControlCenterDiagnostics,
+  type RedactedAgentSummary,
 } from '../../src/ui/utils/control-center-helpers.js';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -315,5 +317,112 @@ describe('redactDiagnosticsForCopy', () => {
     expect(result).toContain('feature-49');
     expect(result).not.toContain('+');
     expect(result).not.toContain('more');
+  });
+});
+
+// ── groupAgentsByDependency ──────────────────────────────────────────────────
+
+describe('groupAgentsByDependency', () => {
+  function makeAgent(
+    name: string,
+    overrides: Partial<RedactedAgentSummary> = {},
+  ): RedactedAgentSummary {
+    return {
+      name,
+      enabled: true,
+      runtimeProfileId: 'default',
+      runtimeProfileLabel: 'openclaw: default',
+      readiness: 'ready',
+      ...overrides,
+    };
+  }
+
+  const allKnownAgents: RedactedAgentSummary[] = [
+    makeAgent('diagnostician'),
+    makeAgent('dreamer'),
+    makeAgent('scribe'),
+    makeAgent('artificer'),
+    makeAgent('evaluator'),
+    makeAgent('philosopher'),
+    makeAgent('rolloutReviewer'),
+    makeAgent('correctionObserver'),
+    makeAgent('empathyObserver'),
+  ];
+
+  it('assigns all 9 known agents to the correct 4 groups', () => {
+    const { groups, unknown } = groupAgentsByDependency(allKnownAgents);
+    expect(unknown).toHaveLength(0);
+    expect(groups.core_trio.map((a) => a.name)).toEqual([
+      'diagnostician',
+      'dreamer',
+      'scribe',
+    ]);
+    expect(groups.code_chain.map((a) => a.name)).toEqual([
+      'artificer',
+      'evaluator',
+    ]);
+    expect(groups.quality_polish.map((a) => a.name)).toEqual([
+      'philosopher',
+      'rolloutReviewer',
+    ]);
+    expect(groups.sidechain.map((a) => a.name)).toEqual([
+      'correctionObserver',
+      'empathyObserver',
+    ]);
+  });
+
+  it('sends unknown agent names to the unknown bucket (rc-9: no silent fallback)', () => {
+    const agents = [
+      makeAgent('diagnostician'),
+      makeAgent('unknownAgent'),
+      makeAgent('empathyObserver'),
+    ];
+    const { groups, unknown } = groupAgentsByDependency(agents);
+    expect(unknown).toHaveLength(1);
+    expect(unknown[0].name).toBe('unknownAgent');
+    expect(groups.core_trio).toHaveLength(1);
+    expect(groups.sidechain).toHaveLength(1);
+  });
+
+  it('returns empty groups and empty unknown for an empty array', () => {
+    const { groups, unknown } = groupAgentsByDependency([]);
+    expect(unknown).toHaveLength(0);
+    expect(groups.core_trio).toHaveLength(0);
+    expect(groups.code_chain).toHaveLength(0);
+    expect(groups.quality_polish).toHaveLength(0);
+    expect(groups.sidechain).toHaveLength(0);
+  });
+
+  it('returns groups with keys matching GROUP_ORDER order', () => {
+    const { groups } = groupAgentsByDependency(allKnownAgents);
+    expect(Object.keys(groups)).toEqual([
+      'core_trio',
+      'code_chain',
+      'quality_polish',
+      'sidechain',
+    ]);
+  });
+
+  it('preserves insertion order within each group', () => {
+    // Pass agents in a shuffled order
+    const shuffled: RedactedAgentSummary[] = [
+      makeAgent('scribe'),
+      makeAgent('evaluator'),
+      makeAgent('diagnostician'),
+      makeAgent('dreamer'),
+      makeAgent('artificer'),
+    ];
+    const { groups } = groupAgentsByDependency(shuffled);
+    // core_trio should preserve the shuffled insertion order: scribe, diagnostician, dreamer
+    expect(groups.core_trio.map((a) => a.name)).toEqual([
+      'scribe',
+      'diagnostician',
+      'dreamer',
+    ]);
+    // code_chain should preserve: evaluator, artificer
+    expect(groups.code_chain.map((a) => a.name)).toEqual([
+      'evaluator',
+      'artificer',
+    ]);
   });
 });

--- a/packages/pd-console/tests/ui/workflow-diagram.test.ts
+++ b/packages/pd-console/tests/ui/workflow-diagram.test.ts
@@ -1,0 +1,70 @@
+/**
+ * WorkflowDiagram — source-code contract test
+ *
+ * The vitest config uses 'node' environment (no jsdom), so we cannot mount
+ * React components. Instead we verify the source-code contract: the component
+ * renders the 4-phase behavior loop diagram with Phase 03 (Owner review)
+ * highlighted, uses i18n keys, and follows brand constraints.
+ *
+ * Spec: .trae/documents/control-center-agent-redesign.md (步骤 4)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(__dirname, "..", "..", "src", "ui");
+
+function readSrc(relPath: string): string {
+  return readFileSync(join(SRC_ROOT, relPath), "utf-8");
+}
+
+describe("WorkflowDiagram: source-code contract", () => {
+  const source = readSrc("pages/control-center/WorkflowDiagram.tsx");
+
+  it("exports WorkflowDiagram function", () => {
+    expect(source).toMatch(/export\s+function\s+WorkflowDiagram/);
+  });
+
+  it("references all 4 phase i18n keys (phase01-04)", () => {
+    expect(source).toContain("workflow.phase01");
+    expect(source).toContain("workflow.phase02");
+    expect(source).toContain("workflow.phase03");
+    expect(source).toContain("workflow.phase04");
+  });
+
+  it("references all 4 phase description i18n keys", () => {
+    expect(source).toContain("workflow.phase01Desc");
+    expect(source).toContain("workflow.phase02Desc");
+    expect(source).toContain("workflow.phase03Desc");
+    expect(source).toContain("workflow.phase04Desc");
+  });
+
+  it("references workflow.title, workflow.subtitle, workflow.loopHint", () => {
+    expect(source).toContain("workflow.title");
+    expect(source).toContain("workflow.subtitle");
+    expect(source).toContain("workflow.loopHint");
+  });
+
+  it("highlights Phase 03 (Owner review) with border-dashed + border-gov + bg-gov/10", () => {
+    expect(source).toContain("border-dashed");
+    expect(source).toContain("border-gov");
+    expect(source).toContain("bg-gov/10");
+  });
+
+  it("uses lucide-react ChevronRight and RefreshCw icons", () => {
+    expect(source).toMatch(/import\s+.*ChevronRight.*from\s+["']lucide-react["']/);
+    expect(source).toMatch(/import\s+.*RefreshCw.*from\s+["']lucide-react["']/);
+  });
+
+  it("does not use forbidden translate-y-* or scale-* hover effects (PRI-CR1 B.4.4)", () => {
+    expect(source).not.toMatch(/translate-y-/);
+    expect(source).not.toMatch(/scale-/);
+  });
+
+  it("does not use hardcoded hex color values (must use design tokens)", () => {
+    expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+});


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: N/A（用户直接请求的 UI 重设计）
- 解决的产品问题（一句话）: 控制中心代理开关原设计过于平庸（扁平 9 个代理 + on/off 开关），无法体现代理间依赖关系，用户不知道哪些必须一起开
- emotional-value：降低 [失控感/信息过载] 创造 [掌控感/清醒感]
  - 如无明确情绪价值，说明为何仍是必要的: 用户能一眼看清代理依赖分组与关停影响，不再面对 9 个扁平开关无所适从
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🔧 重构/优化
- [x] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- 用 4 个依赖分组（核心三件套 / 代码实现链 / 质量打磨 / 侧链服务）替代扁平 9 代理列表，每组带 must/recommend/optional/independent 标签
- 新增 WorkflowDiagram 行为回路图（4 阶段：发现错误 → 形成原则 → 拥有者审批 → 改变行为），Phase 03 高亮
- 新增 AgentCard 三层渐进式披露（L1 折叠态角色一句话 / L2 详细说明+impact / L3 技术细节），核心代理关闭用内联确认条（非模态）
- 导出 `isKnownAgentName` 类型守卫替代 `Object.hasOwn` 内联检查（rc-2: 不用 as 绕过；rc-5: 底层仍用 Object.hasOwn）
- 新增 5 个测试文件 + 扩展 1 个，覆盖元数据、helpers、workflow 图、agent 卡片、agent 分组

### 影响范围
- [ ] packages/principles-core
- [ ] packages/openclaw-plugin
- [ ] packages/pd-cli
- [x] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否
- [ ] 是（需 maintainer 批准，附理由）: ___

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 启动 pd-console dev server（`cd packages/pd-console && npm run dev`）
- [ ] 动作 1: 访问 `http://127.0.0.1:3100/#/control-center`
  - 观察: 顶部出现 4 阶段行为回路图（Phase 03 "拥有者审批" 有虚线高亮边框），下方紧凑状态条显示"已启用 N/9"和核心管道状态
- [ ] 动作 2: 滚动到"内部智能体"区，查看 4 个分组
  - 观察: 核心三件套（红色 must 标签）、代码实现链（琥珀 recommend）、质量打磨（灰色 optional）、侧链服务（绿色 independent）依次排列，每组带提示语
- [ ] 动作 3: 点击诊断师卡片头部展开
  - 观察: L2 显示详细说明段落 + 红色 impact-box（"Pain 信号无法进入内化管道…"）+ 技术细节 toggle + profile 下拉
- [ ] 动作 4: 点击诊断师的"开"按钮（当前启用态）
  - 观察: 不弹模态，直接在卡片内显示内联确认条（红色背景 + 确认停用/取消按钮），卡片自动展开
- [ ] 动作 5: 点击"技术细节"toggle
  - 观察: L3 显示 grid 布局的技术字段（输入/输出/编排/阶段），含反引号 code 片段高亮
- [ ] 动作 6: 切换语言到 English（如有 i18n 切换器）
  - 观察: 所有代理名、角色、详细说明、impact、技术细节切换为英文
- 证据（截图/CLI 输出关键行）: `npm run build` 通过，`npm run test` 1587 passed

## 风险与可逆性（agent 填）
- 主要风险: UI 重构可能遗漏原有功能（已保留 EmpathyObserverCostHint / DefaultRuntimeSelector / AdvancedDiagnostics / 所有 validators）
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否
  - [ ] 是（名称: ___）
  - 规则引用: `mvp-q-3-how-disabled` —— 纯 UI 重构，无新功能子系统，PR revert 即可
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会——控制中心是 owner 每次配置 PD 的入口，平庸的开关设计持续造成认知负担
- `mvp-q-2-how-observed`: 如何观察它生效？访问控制中心页面，看到分组+回路图+渐进式卡片
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（plan 文档在 .trae/documents/）
- [x] 无破坏性变更（或已标记为 breaking change）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：未删除源文件
- [x] Core 边界检查：本 PR 未在 `packages/principles-core/src/` 新增 fs/path 导入
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性 — 仅当修改 `packages/principles-core/src/**/sqlite-*-store.ts` 时填写）
- [x] N/A — 本 PR 未修改 core store 契约

### ERR Checklist（必填）
- ERR-001 (parsed JSON as any): 本 PR 用 `isKnownAgentName` 类型守卫缩窄 `agent.name`，未用 `as keyof typeof AGENT_METADATA` 绕过
- ERR-005 (数组元素类型未验证): `renderTextWithCode` 用 `if (part === undefined) continue` 显式检查 `parts[i]`，未用 `parts[i]!` 非空断言
- ERR-013 (Object.hasOwn vs in): 所有代理名查找用 `isKnownAgentName`（内部 `Object.hasOwn`），不用 `in`
- ERR-002 (silent fallback): 第二个 filter 重新调用 `isKnownAgentName` 防御性检查，未知代理用 amber 提示条显式告警

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据（agent.name 来自 server response）
- [x] `rc-1-treat-as-unknown` — agent.name 视为 string，用类型守卫缩窄
- [x] `rc-2-no-as-bypass` — 用 `isKnownAgentName` 类型守卫，不用 as
- [ ] `rc-3-fail-loud-missing` — N/A（无必填字段校验）
- [ ] `rc-4-validate-array-elements` — N/A（无数组元素校验）
- [x] `rc-5-object-hasown-not-in` — `isKnownAgentName` 内部用 Object.hasOwn
- [ ] `rc-6-lineage-consistency` — N/A
- [ ] `rc-7-loop-state-freshness` — N/A
- [ ] `rc-8-safe-serialization` — N/A
- [x] `rc-9-no-silent-fallback` — 未知代理用 amber 提示条，空 agents 数组显示 fallback
- 遵守方式说明: agent.name 来自 server response，用类型守卫缩窄后查 AGENT_METADATA；未知代理进 unknown bucket 显式告警

### CLI Gate 自检（条件性 — 仅当修改 `packages/pd-cli/src/commands/**` 时填写）
- [x] N/A — 本 PR 未修改 CLI 命令

### Feature Flag 注册检查（条件性 — 仅当引入新功能子系统/hook/writer/reader 时填写）
- [x] N/A — 本 PR 未引入新功能子系统（纯 UI 重构）

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`（"为未来铺路"）
- [x] 无 `antipattern-completeness`（"为完整性"）
- [x] 无 `antipattern-review-missing`（"review 时觉得缺失"）
- [x] 无 `antipattern-core-io`（"在 core 写 I/O 代码"）

## 产品品味审计（owner 填，agent 不得代填）
<!-- 这些问题只有产品 owner 能回答。agent 不得代填。 -->

- [ ] 提醒方式是否克制？（非大声通知，精巧视觉）
- [ ] 命名是否符合双语规范？
- [ ] 交互是否符合"最小连贯干预"原则？
- [ ] 错误路径是否给了 nextAction，而非 silent fallback？（`rc-9-no-silent-fallback`）
- [ ] 是否符合 PD 产品边界？（非任务执行/通用记忆/工具修复/自主价值决策）
- 产品品味备注（可选）: ___

## 测试结果（agent 填）
- [ ] `cd packages/principles-core && npm run test`: 未运行（本 PR 未修改 core）
- [ ] `cd packages/openclaw-plugin && npm run test`: 未运行（本 PR 未修改 plugin）
- [x] `npm run lint`: 通过（0 errors, 31 warnings 均为预存在）
- [x] `npm run verify:merge`: 通过（pre-push hook 已运行）

## 相关 Issue
<!-- 关闭的 issue：Closes #XX -->
N/A（用户直接请求的 UI 重设计，无对应 Linear issue）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 控制中心新增了更清晰的状态概览、流程示意图和页脚说明，帮助快速了解整体运行情况。
  * 代理列表改为按分组展示，并支持展开查看详情、技术细节和运行状态。
  * 新增核心代理停用确认提示与分组切换说明，减少误操作。
* **改进**
  * 补充了中英文界面文案，覆盖流程阶段、状态、提示和警告信息。
  * 对未知代理增加了醒目提示，提升页面可读性与可用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->