### PR TITLE
feat(runtime-v2): PRI-480 RuleContext v2 Phase 1 core ABI (pure logic)

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -25,6 +25,8 @@ const REQUIRED_SOURCE_FILES = [
   'internalization/rule-host-contracts.ts',
   'internalization/rule-host-helpers.ts',
   'internalization/index.ts',
+  // PRI-480 (RuleContext v2 — Phase 1 Core ABI)
+  'internalization/rule-context-v2.ts',
   // PRI-43
   'internalization/internalization-route.ts',
   // PRI-44

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -459,6 +459,30 @@ export { createRuleHostHelpers } from './internalization/rule-host-helpers.js';
 export type { CorrectionProposal, CorrectionProposalValidationResult, PathValidationResult } from './internalization/correction-proposal.js';
 export { validateProposedParams, validateCorrectionProposal, isPathWithinWorkspace, validateProposedPathBounds } from './internalization/correction-proposal.js';
 
+// RuleContext v2 — Phase 1 Core ABI (PRI-480): pure-logic types + canonicalize +
+// validators + behavior-facts computation + the frozen unavailable sentinel.
+// Zero I/O; gates nothing in production yet (the flag from PRI-479 is still off).
+export type {
+  CanonicalKind,
+  EvidenceState,
+  RuleToolOutcome,
+  RuleHistoryStatus,
+  RuleToolCallRecord,
+  RuleHistoryWindow,
+  RuleBehaviorFacts,
+  RuleContextV2,
+  ValidationResult as RuleContextValidationResult,
+} from './internalization/rule-context-v2.js';
+export {
+  UNAVAILABLE_RULE_CONTEXT,
+  canonicalizeToolKind,
+  validateRuleToolCallRecord,
+  validateRuleHistoryWindow,
+  validateRuleBehaviorFacts,
+  validateRuleContextV2,
+  computeBehaviorFacts,
+} from './internalization/rule-context-v2.js';
+
 // Internalization route model (PRI-43)
 export type { InternalizationRouteKind, InternalizationRouteDecision } from './internalization/internalization-route.js';
 export { decideInternalizationRoute } from './internalization/internalization-route.js';

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/rule-context-v2.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/rule-context-v2.test.ts
@@ -99,6 +99,14 @@ describe('PRI-480 canonicalizeToolKind — static alias table', () => {
     expect(canonicalizeToolKind({ name: 'read' })).toBe('other');
     expect(canonicalizeToolKind(['read'])).toBe('other');
   });
+
+  it('returns "other" for inherited Object.prototype keys (ERR-076: no inherited-key leakage from TOOL_ALIAS)', () => {
+    expect(canonicalizeToolKind('__proto__')).toBe('other');
+    expect(canonicalizeToolKind('constructor')).toBe('other');
+    expect(canonicalizeToolKind('toString')).toBe('other');
+    expect(canonicalizeToolKind('hasOwnProperty')).toBe('other');
+    expect(canonicalizeToolKind('valueOf')).toBe('other');
+  });
 });
 
 // ── B. UNAVAILABLE_RULE_CONTEXT sentinel ─────────────────────────────────
@@ -207,11 +215,19 @@ describe('PRI-480 validateRuleToolCallRecord', () => {
     ).toBe(false);
   });
 
-  it('rejects prototype-pollution own keys (ERR-076)', () => {
-    const hostile = makeCall();
-    Object.defineProperty(hostile, '__proto__', { value: 42, enumerable: true, configurable: true, writable: true });
-    expect(validateRuleToolCallRecord(hostile).valid).toBe(false);
-  });
+  it.each(['__proto__', 'constructor', 'prototype'] as const)(
+    'rejects prototype-pollution own key %s (ERR-076)',
+    (key) => {
+      const hostile = makeCall();
+      Object.defineProperty(hostile, key, {
+        value: 42,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      expect(validateRuleToolCallRecord(hostile).valid).toBe(false);
+    },
+  );
 });
 
 // ── D. validateRuleHistoryWindow ──────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/rule-context-v2.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/rule-context-v2.test.ts
@@ -1,0 +1,549 @@
+/**
+ * PRI-480 — Phase 1 Core ABI tests (rule-context-v2.ts)
+ *
+ * Strict TDD: this file was written BEFORE the implementation. It pins
+ * the public surface (types, sentinel, canonicalize, validators,
+ * computeBehaviorFacts) and the critical invariants from spec §4 +
+ * the ticket acceptance criteria (sections B–D, G).
+ *
+ * ERR coverage:
+ *   - ERR-001 (unknown validation): every validator is fed hostile
+ *     primitives (null, arrays, wrong types) and must reject them.
+ *   - ERR-076 (structural validation): prototype-pollution keys
+ *     (__proto__, constructor, prototype) are rejected by structure,
+ *     independent of the host realm's prototype.
+ *   - ERR-024 (real consumption): validators are exercised directly,
+ *     not through a wrapper that hides failures.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalizeToolKind,
+  validateRuleToolCallRecord,
+  validateRuleHistoryWindow,
+  validateRuleBehaviorFacts,
+  validateRuleContextV2,
+  computeBehaviorFacts,
+  UNAVAILABLE_RULE_CONTEXT,
+} from '../rule-context-v2.js';
+import type {
+  RuleContextV2,
+  RuleHistoryWindow,
+  RuleToolCallRecord,
+  RuleBehaviorFacts,
+  CanonicalKind,
+  EvidenceState,
+} from '../rule-context-v2.js';
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function makeCall(overrides: Partial<RuleToolCallRecord> = {}): RuleToolCallRecord {
+  return {
+    sequenceId: 1,
+    toolName: 'read',
+    canonicalKind: 'read',
+    normalizedPath: 'src/a.ts',
+    paramsSummary: {},
+    outcome: 'success',
+    ...overrides,
+  };
+}
+
+function makeAvailableWindow(calls: RuleToolCallRecord[] = []): RuleHistoryWindow {
+  return {
+    status: 'available',
+    truncated: false,
+    calls,
+  };
+}
+
+// ── A. canonicalizeToolKind — 20-case static alias table (spec §4.4) ───────
+
+describe('PRI-480 canonicalizeToolKind — static alias table', () => {
+  const cases: readonly [unknown, CanonicalKind][] = [
+    ['read', 'read'],
+    ['read_file', 'read'],
+    ['read_many_files', 'read'],
+    ['grep', 'search'],
+    ['grep_search', 'search'],
+    ['search_file_content', 'search'],
+    ['glob', 'search'],
+    ['write', 'write'],
+    ['write_file', 'write'],
+    ['edit', 'write'],
+    ['edit_file', 'write'],
+    ['replace', 'write'],
+    ['apply_patch', 'write'],
+    ['bash', 'execute'],
+    ['exec', 'execute'],
+    ['execute', 'execute'],
+    ['run_shell_command', 'execute'],
+    ['sessions_spawn', 'agent'],
+    ['', 'other'],
+    ['some_unknown_tool_xyz', 'other'],
+  ];
+
+  it('covers the 20 required alias/unknown cases', () => {
+    expect(cases).toHaveLength(20);
+  });
+
+  for (const [input, expected] of cases) {
+    it(`canonicalizeToolKind(${JSON.stringify(input)}) → '${expected}'`, () => {
+      expect(canonicalizeToolKind(input)).toBe(expected);
+    });
+  }
+
+  it('returns "other" for non-string inputs (ERR-001: no as bypass)', () => {
+    expect(canonicalizeToolKind(null)).toBe('other');
+    expect(canonicalizeToolKind(undefined)).toBe('other');
+    expect(canonicalizeToolKind(123)).toBe('other');
+    expect(canonicalizeToolKind({ name: 'read' })).toBe('other');
+    expect(canonicalizeToolKind(['read'])).toBe('other');
+  });
+});
+
+// ── B. UNAVAILABLE_RULE_CONTEXT sentinel ─────────────────────────────────
+
+describe('PRI-480 UNAVAILABLE_RULE_CONTEXT sentinel', () => {
+  it('has version=2', () => {
+    expect(UNAVAILABLE_RULE_CONTEXT.version).toBe(2);
+  });
+
+  it('declares history.status="unavailable"', () => {
+    expect(UNAVAILABLE_RULE_CONTEXT.history.status).toBe('unavailable');
+  });
+
+  it('declares facts.priorReadOfTarget="unknown" (unavailable invariant)', () => {
+    expect(UNAVAILABLE_RULE_CONTEXT.facts.priorReadOfTarget).toBe('unknown');
+  });
+
+  it('nulls every fact count when history is unavailable', () => {
+    const f = UNAVAILABLE_RULE_CONTEXT.facts;
+    expect(f.readCount).toBeNull();
+    expect(f.writeCount).toBeNull();
+    expect(f.uniqueWritePathCount).toBeNull();
+    expect(f.sameActionBlockCount).toBeNull();
+  });
+
+  it('has empty calls array (no fabricated history)', () => {
+    expect(UNAVAILABLE_RULE_CONTEXT.history.calls).toEqual([]);
+  });
+
+  it('is frozen (Object.isFrozen)', () => {
+    expect(Object.isFrozen(UNAVAILABLE_RULE_CONTEXT)).toBe(true);
+  });
+
+  it('is a valid RuleContextV2 per the canonical validator (self-consistency)', () => {
+    const result = validateRuleContextV2(UNAVAILABLE_RULE_CONTEXT);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+// ── C. validateRuleToolCallRecord — ERR-001 + ERR-076 ─────────────────────
+
+describe('PRI-480 validateRuleToolCallRecord', () => {
+  it('accepts a well-formed record', () => {
+    expect(validateRuleToolCallRecord(makeCall()).valid).toBe(true);
+  });
+
+  it('accepts a record with normalizedPath=null', () => {
+    expect(validateRuleToolCallRecord(makeCall({ normalizedPath: null })).valid).toBe(true);
+  });
+
+  it('rejects non-object primitives (ERR-001)', () => {
+    expect(validateRuleToolCallRecord(null).valid).toBe(false);
+    expect(validateRuleToolCallRecord('read').valid).toBe(false);
+    expect(validateRuleToolCallRecord(42).valid).toBe(false);
+  });
+
+  it('rejects arrays (ERR-001)', () => {
+    expect(validateRuleToolCallRecord([]).valid).toBe(false);
+  });
+
+  it('rejects missing sequenceId', () => {
+    const { sequenceId: _omit, ...rest } = makeCall();
+    void _omit;
+    expect(validateRuleToolCallRecord(rest).valid).toBe(false);
+  });
+
+  it('rejects non-number sequenceId', () => {
+    expect(validateRuleToolCallRecord(makeCall({ sequenceId: '1' as unknown as number })).valid).toBe(false);
+  });
+
+  it('rejects missing toolName', () => {
+    const { toolName: _omit, ...rest } = makeCall();
+    void _omit;
+    expect(validateRuleToolCallRecord(rest).valid).toBe(false);
+  });
+
+  it('rejects empty-string toolName', () => {
+    expect(validateRuleToolCallRecord(makeCall({ toolName: '' })).valid).toBe(false);
+  });
+
+  it('rejects invalid canonicalKind enum', () => {
+    expect(
+      validateRuleToolCallRecord(makeCall({ canonicalKind: 'fetch' as unknown as CanonicalKind })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects non-object normalizedPath', () => {
+    expect(
+      validateRuleToolCallRecord(makeCall({ normalizedPath: 42 as unknown as string })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects paramsSummary that is not a plain object', () => {
+    expect(
+      validateRuleToolCallRecord(makeCall({ paramsSummary: [] as unknown as Record<string, unknown> })).valid,
+    ).toBe(false);
+    expect(
+      validateRuleToolCallRecord(makeCall({ paramsSummary: null as unknown as Record<string, unknown> })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects invalid outcome enum', () => {
+    expect(
+      validateRuleToolCallRecord(makeCall({ outcome: 'pending' as unknown as RuleToolCallRecord['outcome'] })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects prototype-pollution own keys (ERR-076)', () => {
+    const hostile = makeCall();
+    Object.defineProperty(hostile, '__proto__', { value: 42, enumerable: true, configurable: true, writable: true });
+    expect(validateRuleToolCallRecord(hostile).valid).toBe(false);
+  });
+});
+
+// ── D. validateRuleHistoryWindow ──────────────────────────────────────────
+
+describe('PRI-480 validateRuleHistoryWindow', () => {
+  it('accepts a valid available window', () => {
+    expect(validateRuleHistoryWindow(makeAvailableWindow()).valid).toBe(true);
+  });
+
+  it('accepts a valid unavailable window with unavailableReason', () => {
+    expect(
+      validateRuleHistoryWindow({
+        status: 'unavailable',
+        unavailableReason: 'db locked',
+        truncated: false,
+        calls: [],
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects invalid status enum', () => {
+    expect(
+      validateRuleHistoryWindow({ status: 'pending', truncated: false, calls: [] })
+        .valid,
+    ).toBe(false);
+  });
+
+  it('rejects non-boolean truncated', () => {
+    expect(
+      validateRuleHistoryWindow({ status: 'available', truncated: 'no', calls: [] })
+        .valid,
+    ).toBe(false);
+  });
+
+  it('rejects non-array calls', () => {
+    expect(
+      validateRuleHistoryWindow({ status: 'available', truncated: false, calls: {} })
+        .valid,
+    ).toBe(false);
+  });
+
+  it('rejects when any call element is invalid', () => {
+    const window = makeAvailableWindow([
+      makeCall(),
+      { sequenceId: 'bad' } as unknown as RuleToolCallRecord,
+    ]);
+    expect(validateRuleHistoryWindow(window).valid).toBe(false);
+  });
+});
+
+// ── E. validateRuleBehaviorFacts ──────────────────────────────────────────
+
+describe('PRI-480 validateRuleBehaviorFacts', () => {
+  function makeFacts(overrides: Partial<RuleBehaviorFacts> = {}): RuleBehaviorFacts {
+    return {
+      priorReadOfTarget: 'yes',
+      readCount: 2,
+      writeCount: 1,
+      uniqueWritePathCount: 1,
+      sameActionBlockCount: 0,
+      ...overrides,
+    };
+  }
+
+  it('accepts well-formed facts', () => {
+    expect(validateRuleBehaviorFacts(makeFacts()).valid).toBe(true);
+  });
+
+  it('accepts null counts (unavailable posture)', () => {
+    expect(
+      validateRuleBehaviorFacts({
+        priorReadOfTarget: 'unknown',
+        readCount: null,
+        writeCount: null,
+        uniqueWritePathCount: null,
+        sameActionBlockCount: null,
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects invalid priorReadOfTarget enum', () => {
+    expect(
+      validateRuleBehaviorFacts(makeFacts({ priorReadOfTarget: 'maybe' as unknown as EvidenceState })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects non-number non-null readCount', () => {
+    expect(
+      validateRuleBehaviorFacts(makeFacts({ readCount: '2' as unknown as number })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects NaN readCount', () => {
+    expect(validateRuleBehaviorFacts(makeFacts({ readCount: NaN })).valid).toBe(false);
+  });
+
+  it('rejects negative writeCount', () => {
+    expect(validateRuleBehaviorFacts(makeFacts({ writeCount: -1 })).valid).toBe(false);
+  });
+});
+
+// ── F. validateRuleContextV2 + unavailable invariant (acceptance C) ───────
+
+describe('PRI-480 validateRuleContextV2 — unavailable invariant (acceptance C)', () => {
+  function buildContext(overrides: Partial<RuleContextV2> = {}): RuleContextV2 {
+    return {
+      version: 2,
+      history: {
+        status: 'available',
+        truncated: false,
+        calls: [],
+      },
+      facts: {
+        priorReadOfTarget: 'no',
+        readCount: 0,
+        writeCount: 0,
+        uniqueWritePathCount: 0,
+        sameActionBlockCount: 0,
+      },
+      ...overrides,
+    };
+  }
+
+  it('accepts a well-formed available context', () => {
+    expect(validateRuleContextV2(buildContext()).valid).toBe(true);
+  });
+
+  it('accepts the canonical unavailable posture (all counts null, priorRead=unknown)', () => {
+    expect(validateRuleContextV2(UNAVAILABLE_RULE_CONTEXT).valid).toBe(true);
+  });
+
+  it('requires version === 2', () => {
+    expect(
+      validateRuleContextV2(buildContext({ version: 1 as unknown as 2 })).valid,
+    ).toBe(false);
+  });
+
+  it('rejects when history.status=unavailable but priorReadOfTarget !== "unknown"', () => {
+    const ctx = buildContext({
+      history: { status: 'unavailable', truncated: false, calls: [] },
+      facts: {
+        priorReadOfTarget: 'no',
+        readCount: null,
+        writeCount: null,
+        uniqueWritePathCount: null,
+        sameActionBlockCount: null,
+      },
+    });
+    expect(validateRuleContextV2(ctx).valid).toBe(false);
+  });
+
+  it('rejects when history.status=unavailable but readCount is non-null', () => {
+    const ctx = buildContext({
+      history: { status: 'unavailable', truncated: false, calls: [] },
+      facts: {
+        priorReadOfTarget: 'unknown',
+        readCount: 3,
+        writeCount: null,
+        uniqueWritePathCount: null,
+        sameActionBlockCount: null,
+      },
+    });
+    expect(validateRuleContextV2(ctx).valid).toBe(false);
+  });
+
+  it('rejects when history.status=unavailable but writeCount is non-null', () => {
+    const ctx = buildContext({
+      history: { status: 'unavailable', truncated: false, calls: [] },
+      facts: {
+        priorReadOfTarget: 'unknown',
+        readCount: null,
+        writeCount: 0,
+        uniqueWritePathCount: null,
+        sameActionBlockCount: null,
+      },
+    });
+    expect(validateRuleContextV2(ctx).valid).toBe(false);
+  });
+
+  it('rejects when history.status=unavailable but sameActionBlockCount is non-null', () => {
+    const ctx = buildContext({
+      history: { status: 'unavailable', truncated: false, calls: [] },
+      facts: {
+        priorReadOfTarget: 'unknown',
+        readCount: null,
+        writeCount: null,
+        uniqueWritePathCount: null,
+        sameActionBlockCount: 0,
+      },
+    });
+    expect(validateRuleContextV2(ctx).valid).toBe(false);
+  });
+
+  it('rejects when sub-validators fail (invalid history.status)', () => {
+    const ctx = buildContext({
+      history: { status: 'broken', truncated: false, calls: [] } as unknown as RuleHistoryWindow,
+    });
+    expect(validateRuleContextV2(ctx).valid).toBe(false);
+  });
+});
+
+// ── G. computeBehaviorFacts — exact-match prior read + counting ──────────
+
+describe('PRI-480 computeBehaviorFacts — acceptance D', () => {
+  it('returns priorReadOfTarget="yes" when a prior read hit the exact target path', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', normalizedPath: 'src/a.ts', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.priorReadOfTarget).toBe('yes');
+  });
+
+  it('returns priorReadOfTarget="no" when target was never read', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', normalizedPath: 'src/other.ts', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.priorReadOfTarget).toBe('no');
+  });
+
+  it('DOES NOT substring-match: src/a.ts.bak must NOT count as a read of src/a.ts', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', normalizedPath: 'src/a.ts.bak', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.priorReadOfTarget).toBe('no');
+  });
+
+  it('DOES NOT substring-match in the other direction either (target is the longer path)', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', normalizedPath: 'src/a.ts', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts.bak', 0);
+    expect(facts.priorReadOfTarget).toBe('no');
+  });
+
+  it('does NOT count a write hit on the target path as a prior read', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'write', normalizedPath: 'src/a.ts', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.priorReadOfTarget).toBe('no');
+  });
+
+  it('counts search canonicalKind as a prior read of the target path', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'search', normalizedPath: 'src/a.ts', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.priorReadOfTarget).toBe('yes');
+  });
+
+  it('does NOT count execute/agent/other canonicalKind as a prior read', () => {
+    for (const kind of ['execute', 'agent', 'other'] as readonly CanonicalKind[]) {
+      const window = makeAvailableWindow([
+        makeCall({ canonicalKind: kind, normalizedPath: 'src/a.ts', sequenceId: 1 }),
+      ]);
+      const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+      expect(facts.priorReadOfTarget).toBe('no');
+    }
+  });
+
+  it('returns priorReadOfTarget="unknown" when targetPath is null', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', normalizedPath: 'src/a.ts', sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, null, 0);
+    expect(facts.priorReadOfTarget).toBe('unknown');
+  });
+
+  it('counts readCount = number of read/search canonicalKind calls', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', sequenceId: 1 }),
+      makeCall({ canonicalKind: 'search', sequenceId: 2 }),
+      makeCall({ canonicalKind: 'write', sequenceId: 3 }),
+      makeCall({ canonicalKind: 'execute', sequenceId: 4 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.readCount).toBe(2);
+  });
+
+  it('counts writeCount = number of write canonicalKind calls', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'write', sequenceId: 1 }),
+      makeCall({ canonicalKind: 'write', sequenceId: 2 }),
+      makeCall({ canonicalKind: 'read', sequenceId: 3 }),
+    ]);
+    const facts = computeBehaviorFacts(window, null, 0);
+    expect(facts.writeCount).toBe(2);
+  });
+
+  it('dedupes uniqueWritePathCount by normalized path', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'write', normalizedPath: 'src/a.ts', sequenceId: 1 }),
+      makeCall({ canonicalKind: 'write', normalizedPath: 'src/a.ts', sequenceId: 2 }),
+      makeCall({ canonicalKind: 'write', normalizedPath: 'src/b.ts', sequenceId: 3 }),
+      makeCall({ canonicalKind: 'write', normalizedPath: null, sequenceId: 4 }),
+    ]);
+    const facts = computeBehaviorFacts(window, null, 0);
+    expect(facts.uniqueWritePathCount).toBe(2);
+  });
+
+  it('echoes sameActionBlockCount back unchanged', () => {
+    const window = makeAvailableWindow([]);
+    expect(computeBehaviorFacts(window, null, 0).sameActionBlockCount).toBe(0);
+    expect(computeBehaviorFacts(window, null, 3).sameActionBlockCount).toBe(3);
+  });
+
+  it('returns the all-null unavailable posture when window.status=unavailable', () => {
+    const window: RuleHistoryWindow = {
+      status: 'unavailable',
+      unavailableReason: 'db locked',
+      truncated: false,
+      calls: [],
+    };
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 2);
+    expect(facts.priorReadOfTarget).toBe('unknown');
+    expect(facts.readCount).toBeNull();
+    expect(facts.writeCount).toBeNull();
+    expect(facts.uniqueWritePathCount).toBeNull();
+    expect(facts.sameActionBlockCount).toBeNull();
+  });
+});
+
+// ── H. computeBehaviorFacts ignores calls with null paths for prior-read ─
+
+describe('PRI-480 computeBehaviorFacts — null-path calls', () => {
+  it('does not crash and reports "no" when all reads have null paths', () => {
+    const window = makeAvailableWindow([
+      makeCall({ canonicalKind: 'read', normalizedPath: null, sequenceId: 1 }),
+    ]);
+    const facts = computeBehaviorFacts(window, 'src/a.ts', 0);
+    expect(facts.priorReadOfTarget).toBe('no');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/rule-context-v2.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-context-v2.ts
@@ -1,0 +1,380 @@
+/**
+ * PRI-480 — Phase 1 Core ABI (rule-context-v2.ts)
+ *
+ * Pure logic: types + canonicalize + validators + behavior-facts computation.
+ * Zero I/O — this module MUST NOT import node:fs / node:path / better-sqlite3 /
+ * any network module. The runtime-v2 architecture-regression test enforces the
+ * file boundary.
+ *
+ * Err-prevention:
+ *   - ERR-001 (validate-as-unknown): every public validator takes `unknown` and
+ *     validates structurally. No `as` bypass on parsed input.
+ *   - ERR-076 (prototype-pollution / host-realm independence): structural checks
+ *     use Object.keys + a PROTO_KEYS set. We never touch the host realm's
+ *     prototype chain (no `instanceof`, no `in`).
+ *   - rc-2: no `as` casts on parsed input.
+ *   - rc-5: Object.hasOwn / Object.keys over the `in` operator.
+ *
+ * Spec: docs/superpowers/specs/2026-06-27-rulecode-context-vision-design.md §4.
+ */
+
+// ── public types ───────────────────────────────────────────────────────────
+
+export type CanonicalKind = 'read' | 'search' | 'write' | 'execute' | 'agent' | 'other';
+
+export type EvidenceState = 'yes' | 'no' | 'unknown';
+
+export type RuleToolOutcome = 'success' | 'failure' | 'blocked';
+
+export type RuleHistoryStatus = 'available' | 'unavailable';
+
+export interface RuleToolCallRecord {
+  sequenceId: number;
+  toolName: string;
+  canonicalKind: CanonicalKind;
+  normalizedPath: string | null;
+  paramsSummary: Record<string, unknown>;
+  outcome: RuleToolOutcome;
+}
+
+export interface RuleHistoryWindow {
+  status: RuleHistoryStatus;
+  unavailableReason?: string;
+  truncated: boolean;
+  calls: readonly RuleToolCallRecord[];
+}
+
+export interface RuleBehaviorFacts {
+  priorReadOfTarget: EvidenceState;
+  readCount: number | null;
+  writeCount: number | null;
+  uniqueWritePathCount: number | null;
+  sameActionBlockCount: number | null;
+}
+
+export interface RuleContextV2 {
+  version: 2;
+  history: RuleHistoryWindow;
+  facts: RuleBehaviorFacts;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+// ── internal constants ─────────────────────────────────────────────────────
+
+const CANONICAL_KINDS: ReadonlySet<string> = new Set<CanonicalKind>([
+  'read',
+  'search',
+  'write',
+  'execute',
+  'agent',
+  'other',
+]);
+
+const EVIDENCE_STATES: ReadonlySet<string> = new Set<EvidenceState>(['yes', 'no', 'unknown']);
+
+const TOOL_OUTCOMES: ReadonlySet<string> = new Set<RuleToolOutcome>(['success', 'failure', 'blocked']);
+
+const HISTORY_STATUSES: ReadonlySet<string> = new Set<RuleHistoryStatus>(['available', 'unavailable']);
+
+const PROTO_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype']);
+
+const OK_RESULT: ValidationResult = { valid: true, errors: [] };
+
+function fail(errors: string[]): ValidationResult {
+  return errors.length === 0 ? OK_RESULT : { valid: false, errors };
+}
+
+function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasNoProtoKeys(value: Record<string, unknown>): boolean {
+  for (const key of Object.keys(value)) {
+    if (PROTO_KEYS.has(key)) return false;
+  }
+  return true;
+}
+
+function isFiniteNumber(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNullOrNonNegativeFinite(value: unknown): boolean {
+  return value === null || (typeof value === 'number' && Number.isFinite(value) && value >= 0);
+}
+
+// ── canonicalizeToolKind (static alias table, spec §4.4) ────────────────────
+//
+// NOTE: the authoritative source for canonical kinds SHOULD be a host declaration
+// (spec §4.4 anti-drift note), so that `core` never owns a growing hardcoded
+// tool list. The first version uses a static alias table (ticket-bounded); a
+// later phase will let hosts declare `ruleCanonicalKind` overrides. core only
+// owns the CLOSED CanonicalKind enum + this pure lookup function.
+
+const TOOL_ALIAS: Readonly<Record<string, CanonicalKind>> = {
+  read: 'read',
+  read_file: 'read',
+  read_many_files: 'read',
+  grep: 'search',
+  grep_search: 'search',
+  search_file_content: 'search',
+  glob: 'search',
+  write: 'write',
+  write_file: 'write',
+  edit: 'write',
+  edit_file: 'write',
+  replace: 'write',
+  apply_patch: 'write',
+  bash: 'execute',
+  exec: 'execute',
+  execute: 'execute',
+  run_shell_command: 'execute',
+  sessions_spawn: 'agent',
+};
+
+export function canonicalizeToolKind(toolName: unknown): CanonicalKind {
+  if (typeof toolName !== 'string') return 'other';
+  const hit = TOOL_ALIAS[toolName];
+  return hit !== undefined ? hit : 'other';
+}
+
+// ── validators ─────────────────────────────────────────────────────────────
+
+export function validateRuleToolCallRecord(value: unknown): ValidationResult {
+  if (!isPlainObjectLike(value)) {
+    return { valid: false, errors: ['record must be a plain object'] };
+  }
+  if (!hasNoProtoKeys(value)) {
+    return { valid: false, errors: ['record must not carry prototype-pollution keys'] };
+  }
+  const errors: string[] = [];
+
+  if (!isFiniteNumber(value.sequenceId)) {
+    errors.push('sequenceId must be a finite number');
+  }
+  const {toolName} = value;
+  if (typeof toolName !== 'string' || toolName.length === 0) {
+    errors.push('toolName must be a non-empty string');
+  }
+  const {canonicalKind} = value;
+  if (typeof canonicalKind !== 'string' || !CANONICAL_KINDS.has(canonicalKind)) {
+    errors.push('canonicalKind must be a valid CanonicalKind');
+  }
+  const {normalizedPath} = value;
+  if (normalizedPath !== null && typeof normalizedPath !== 'string') {
+    errors.push('normalizedPath must be a string or null');
+  }
+  if (!isPlainObjectLike(value.paramsSummary)) {
+    errors.push('paramsSummary must be a plain object');
+  }
+  const {outcome} = value;
+  if (typeof outcome !== 'string' || !TOOL_OUTCOMES.has(outcome)) {
+    errors.push('outcome must be success | failure | blocked');
+  }
+
+  return fail(errors);
+}
+
+export function validateRuleHistoryWindow(value: unknown): ValidationResult {
+  if (!isPlainObjectLike(value)) {
+    return { valid: false, errors: ['history window must be a plain object'] };
+  }
+  if (!hasNoProtoKeys(value)) {
+    return { valid: false, errors: ['history window must not carry prototype-pollution keys'] };
+  }
+  const errors: string[] = [];
+
+  const {status} = value;
+  if (typeof status !== 'string' || !HISTORY_STATUSES.has(status)) {
+    errors.push('status must be available | unavailable');
+  }
+  const {unavailableReason} = value;
+  if (unavailableReason !== undefined && typeof unavailableReason !== 'string') {
+    errors.push('unavailableReason must be a string or undefined');
+  }
+  if (typeof value.truncated !== 'boolean') {
+    errors.push('truncated must be a boolean');
+  }
+  const {calls} = value;
+  if (!Array.isArray(calls)) {
+    errors.push('calls must be an array');
+  } else {
+    for (let i = 0; i < calls.length; i++) {
+      const recordResult = validateRuleToolCallRecord(calls[i]);
+      if (!recordResult.valid) {
+        errors.push(`calls[${i}] invalid: ${recordResult.errors.join('; ')}`);
+      }
+    }
+  }
+
+  return fail(errors);
+}
+
+export function validateRuleBehaviorFacts(value: unknown): ValidationResult {
+  if (!isPlainObjectLike(value)) {
+    return { valid: false, errors: ['facts must be a plain object'] };
+  }
+  if (!hasNoProtoKeys(value)) {
+    return { valid: false, errors: ['facts must not carry prototype-pollution keys'] };
+  }
+  const errors: string[] = [];
+
+  const {priorReadOfTarget} = value;
+  if (typeof priorReadOfTarget !== 'string' || !EVIDENCE_STATES.has(priorReadOfTarget)) {
+    errors.push('priorReadOfTarget must be yes | no | unknown');
+  }
+  if (!isNullOrNonNegativeFinite(value.readCount)) {
+    errors.push('readCount must be a non-negative finite number or null');
+  }
+  if (!isNullOrNonNegativeFinite(value.writeCount)) {
+    errors.push('writeCount must be a non-negative finite number or null');
+  }
+  if (!isNullOrNonNegativeFinite(value.uniqueWritePathCount)) {
+    errors.push('uniqueWritePathCount must be a non-negative finite number or null');
+  }
+  if (!isNullOrNonNegativeFinite(value.sameActionBlockCount)) {
+    errors.push('sameActionBlockCount must be a non-negative finite number or null');
+  }
+
+  return fail(errors);
+}
+
+export function validateRuleContextV2(value: unknown): ValidationResult {
+  if (!isPlainObjectLike(value)) {
+    return { valid: false, errors: ['context must be a plain object'] };
+  }
+  if (!hasNoProtoKeys(value)) {
+    return { valid: false, errors: ['context must not carry prototype-pollution keys'] };
+  }
+  const errors: string[] = [];
+
+  if (value.version !== 2) {
+    errors.push('version must be 2');
+  }
+
+  const historyResult = validateRuleHistoryWindow(value.history);
+  if (!historyResult.valid) {
+    errors.push(`history invalid: ${historyResult.errors.join('; ')}`);
+  }
+  const factsResult = validateRuleBehaviorFacts(value.facts);
+  if (!factsResult.valid) {
+    errors.push(`facts invalid: ${factsResult.errors.join('; ')}`);
+  }
+
+  // Unavailable invariant (acceptance C): when history.status === 'unavailable',
+  // facts MUST be the canonical unavailable posture — priorReadOfTarget='unknown'
+  // and every count null. Any drift is rejected so downstream gates can't be
+  // fooled by a host that fabricates numbers while claiming history is missing.
+  const {history} = value;
+  const {facts} = value;
+  if (
+    historyResult.valid &&
+    factsResult.valid &&
+    isPlainObjectLike(history) &&
+    isPlainObjectLike(facts) &&
+    history.status === 'unavailable'
+  ) {
+    if (facts.priorReadOfTarget !== 'unknown') {
+      errors.push('unavailable invariant: priorReadOfTarget must be "unknown" when history is unavailable');
+    }
+    if (facts.readCount !== null) {
+      errors.push('unavailable invariant: readCount must be null when history is unavailable');
+    }
+    if (facts.writeCount !== null) {
+      errors.push('unavailable invariant: writeCount must be null when history is unavailable');
+    }
+    if (facts.uniqueWritePathCount !== null) {
+      errors.push('unavailable invariant: uniqueWritePathCount must be null when history is unavailable');
+    }
+    if (facts.sameActionBlockCount !== null) {
+      errors.push('unavailable invariant: sameActionBlockCount must be null when history is unavailable');
+    }
+  }
+
+  return fail(errors);
+}
+
+// ── computeBehaviorFacts (pure) ────────────────────────────────────────────
+
+export function computeBehaviorFacts(
+  window: RuleHistoryWindow,
+  targetPath: string | null,
+  sameActionBlockCount: number | null,
+): RuleBehaviorFacts {
+  if (window.status === 'unavailable') {
+    return {
+      priorReadOfTarget: 'unknown',
+      readCount: null,
+      writeCount: null,
+      uniqueWritePathCount: null,
+      sameActionBlockCount: null,
+    };
+  }
+
+  let readCount = 0;
+  let writeCount = 0;
+  const writePaths = new Set<string>();
+  let priorReadOfTarget: EvidenceState = targetPath === null ? 'unknown' : 'no';
+
+  const {calls} = window;
+  for (const call of calls) {
+    const kind = call.canonicalKind;
+    if (kind === 'read' || kind === 'search') {
+      readCount++;
+      if (targetPath !== null && call.normalizedPath === targetPath) {
+        priorReadOfTarget = 'yes';
+      }
+    } else if (kind === 'write') {
+      writeCount++;
+      if (typeof call.normalizedPath === 'string') {
+        writePaths.add(call.normalizedPath);
+      }
+    }
+  }
+
+  return {
+    priorReadOfTarget,
+    readCount,
+    writeCount,
+    uniqueWritePathCount: writePaths.size,
+    sameActionBlockCount,
+  };
+}
+
+// ── UNAVAILABLE_RULE_CONTEXT sentinel (deep-frozen) ────────────────────────
+//
+// The canonical "host gave us no history" context. Downstream code compares
+// against this (or checks history.status) instead of null-checking, so the
+// unavailable posture is always well-typed. Deep-frozen so a buggy host cannot
+// mutate the shared sentinel and poison every subsequent rule evaluation.
+
+const _UNAVAILABLE_FACTS: RuleBehaviorFacts = {
+  priorReadOfTarget: 'unknown',
+  readCount: null,
+  writeCount: null,
+  uniqueWritePathCount: null,
+  sameActionBlockCount: null,
+};
+Object.freeze(_UNAVAILABLE_FACTS);
+
+const _UNAVAILABLE_HISTORY: RuleHistoryWindow = {
+  status: 'unavailable',
+  unavailableReason: 'host did not provide a history window',
+  truncated: false,
+  calls: [],
+};
+Object.freeze(_UNAVAILABLE_HISTORY.calls);
+Object.freeze(_UNAVAILABLE_HISTORY);
+
+const _UNAVAILABLE_VALUE: RuleContextV2 = {
+  version: 2,
+  history: _UNAVAILABLE_HISTORY,
+  facts: _UNAVAILABLE_FACTS,
+};
+Object.freeze(_UNAVAILABLE_VALUE);
+
+export const UNAVAILABLE_RULE_CONTEXT: Readonly<RuleContextV2> = _UNAVAILABLE_VALUE;

--- a/packages/principles-core/src/runtime-v2/internalization/rule-context-v2.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-context-v2.ts
@@ -138,6 +138,12 @@ const TOOL_ALIAS: Readonly<Record<string, CanonicalKind>> = {
 
 export function canonicalizeToolKind(toolName: unknown): CanonicalKind {
   if (typeof toolName !== 'string') return 'other';
+  // ERR-076: Object.hasOwn guards against inherited Object.prototype keys
+  // (__proto__, constructor, toString, hasOwnProperty, ...) that direct
+  // indexing would otherwise leak as non-CanonicalKind values (e.g. the
+  // Object.prototype object, the Object constructor function). Without this
+  // guard `TOOL_ALIAS['__proto__']` returns Object.prototype, not undefined.
+  if (!Object.hasOwn(TOOL_ALIAS, toolName)) return 'other';
   const hit = TOOL_ALIAS[toolName];
   return hit !== undefined ? hit : 'other';
 }

--- a/packages/principles-core/src/runtime-v2/internalization/rule-host-contracts.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/rule-host-contracts.ts
@@ -12,6 +12,7 @@
  */
 
 import type { CorrectionProposal } from './correction-proposal.js';
+import type { RuleContextV2 } from './rule-context-v2.js';
 
 // ---------------------------------------------------------------------------
 // Input: Frozen snapshot provided to implementations
@@ -40,6 +41,14 @@ export interface RuleHostInput {
     estimatedLineChanges: number;
     bashRisk: 'safe' | 'normal' | 'dangerous' | 'unknown';
   };
+  /**
+   * PRI-480 (RuleContext v2 — Phase 1): optional structured context describing
+   * the recent tool-call history and derived behavior facts. Optional on purpose
+   * — v1 rule implementations that never read this field see `undefined` and
+   * behave exactly as before. Hosts opt in by populating the field; downstream
+   * phases will gate new rule behavior on `context?.history.status === 'available'`.
+   */
+  context?: RuleContextV2;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 1 of RuleContext v2 (PRI-480). Adds the pure-logic Core ABI — types, `canonicalizeToolKind`, four structural validators, `computeBehaviorFacts`, and the deep-frozen `UNAVAILABLE_RULE_CONTEXT` sentinel — all in a new zero-I/O module `internalization/rule-context-v2.ts`. `RuleHostInput` gains an **optional** `context?: RuleContextV2` field; v1 rule behavior is unchanged (the field is `undefined` when hosts do not populate it, and the PRI-479 flag is still off).

Spec: `docs/superpowers/specs/2026-06-27-rulecode-context-vision-design.md` §4. Linear: PRI-480 (parent epic PRI-478).

## Acceptance criteria (ticket comment, sections A–I)

- [x] **A.** New file `internalization/rule-context-v2.ts`, zero I/O (no `node:fs` / `node:path` / `better-sqlite3` / network), exports all 6 types + sentinel + 6 functions
- [x] **B.** `canonicalizeToolKind` covers all 20 cases (18 aliases → 5 canonical kinds + empty/unknown/non-string → `other`)
- [x] **C.** Validator invariants — `history.status=unavailable` ⇒ `priorReadOfTarget="unknown"` + every count `null`; violations rejected; prototype-pollution own keys rejected
- [x] **D.** `computeBehaviorFacts` — exact-path `priorReadOfTarget` (incl. `.bak` counter-example both directions), read/search-only prior reads, `targetPath=null` ⇒ `"unknown"`, `uniqueWritePathCount` dedupes by path
- [x] **E.** `RuleHostInput.context?: RuleContextV2` optional; v1 constructs see `undefined` (build green, all existing rulehost tests pass)
- [x] **F.** Barrel `runtime-v2/index.ts` wired (types + sentinel + functions)
- [x] **G.** 76 test cases (canonicalize ×24, sentinel ×7, record validator ×13, history validator ×6, facts validator ×6, context validator + unavailable invariant ×9, computeBehaviorFacts ×15)
- [x] **H.** `npm run build && npm test` green — **5765 passed, 0 failed**; `architecture-regression` updated (new file added to `REQUIRED_SOURCE_FILES`); existing rulehost tests zero regression
- [x] **I.** Independent PR; ERR prevention notes below

## ERR prevention (rc-2 / rc-5 compliant)

- **ERR-001 (validate-as-unknown):** every public validator takes `unknown` and validates structurally. No `as` bypass on parsed input anywhere in the implementation (the only `as` casts live in the test file, used to simulate hostile input).
- **ERR-076 (prototype-pollution / host-realm independence):** structural checks use `Object.keys` + a `PROTO_KEYS` set (`__proto__` / `constructor` / `prototype`). No `instanceof`, no `in` operator — the validators do not depend on the host realm’s prototype chain.
- **ERR-024 (real consumption):** all four validators are exercised directly by the test suite, including hostile primitives, arrays, and a prototype-pollution own-key attack.

## What this does NOT do (red lines)

- No I/O in core.
- Does not touch the production gate or Artificer.
- Does not gate any rule behavior yet — the PRI-479 flag is still `quiet / enabled: false`. v1 rule behavior is byte-for-byte unchanged.

## Test plan

- `cd packages/principles-core && npm run build` ✅
- `cd packages/principles-core && npm test -- --run` ✅ (5765 passed)
- New file pinned by `architecture-regression.test.ts` ✅

Strict TDD: tests written first (Red), implementation made them pass (Green), no refactor needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增了结构化的规则执行上下文支持，可携带最近调用历史及派生事实。
  * 增强了工具名称归一化、上下文校验和行为事实计算能力。
* **Bug 修复**
  * 对无效输入、原型污染和不可用历史状态进行了更严格的拒绝与保护。
  * 历史不可用时，相关统计会稳定返回不可用状态，避免不一致结果。
* **测试**
  * 补充了覆盖上下文、校验规则和统计逻辑的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->