### PR TITLE
fix(pd-console): empathyObserver 本地 LLM 提示 + 移除侧边栏 Alt+x 快捷键

### DIFF
--- a/packages/pd-console/src/ui/App.tsx
+++ b/packages/pd-console/src/ui/App.tsx
@@ -44,65 +44,6 @@ function AuthRoutes() {
   }, [verifyAuth]);
 
   useEffect(() => {
-    if (authed !== true) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!e.altKey) return;
-
-      const target = e.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === "INPUT" ||
-         target.tagName === "TEXTAREA" ||
-         target.tagName === "SELECT" ||
-         target.isContentEditable)
-      ) {
-        return;
-      }
-
-      let targetPath: string | null = null;
-      switch (e.key) {
-        case "3":
-          targetPath = "/focus";
-          break;
-        case "4":
-          targetPath = "/pain";
-          break;
-        case "5":
-          targetPath = "/principles";
-          break;
-        case "6":
-          targetPath = "/activation";
-          break;
-        case "7":
-          targetPath = "/debt";
-          break;
-        case "8":
-          targetPath = "/control-center";
-          break;
-        case "9":
-          targetPath = "/report-problem";
-          break;
-        case "0":
-          targetPath = "/settings";
-          break;
-        default:
-          return;
-      }
-
-      if (targetPath) {
-        e.preventDefault();
-        navigate(targetPath);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [authed, navigate]);
-
-  useEffect(() => {
     if (!showSplash) return;
     if (authed === null) return; // still checking
     // Wait for splash animation to complete before navigating

--- a/packages/pd-console/src/ui/components/layout/app-sidebar.tsx
+++ b/packages/pd-console/src/ui/components/layout/app-sidebar.tsx
@@ -38,19 +38,19 @@ function ThresholdMark({ className }: { className?: string }) {
 }
 
 const mainNavItems = [
-  { id: "focus", labelKey: "components.sidebar.focus", href: "/focus", icon: Focus, shortcut: "Alt+3" },
-  { id: "pain", labelKey: "components.sidebar.pain", href: "/pain", icon: AlertTriangle, shortcut: "Alt+4" },
-  { id: "principles", labelKey: "components.sidebar.principles", href: "/principles", icon: BookOpen, shortcut: "Alt+5" },
-  { id: "activation", labelKey: "components.sidebar.activation", href: "/activation", icon: Zap, shortcut: "Alt+6" },
-  { id: "debt", labelKey: "components.sidebar.debt", href: "/debt", icon: Archive, shortcut: "Alt+7" },
-  { id: "intent", labelKey: "components.sidebar.intent", href: "/intent", icon: Compass, shortcut: "" },
+  { id: "focus", labelKey: "components.sidebar.focus", href: "/focus", icon: Focus },
+  { id: "pain", labelKey: "components.sidebar.pain", href: "/pain", icon: AlertTriangle },
+  { id: "principles", labelKey: "components.sidebar.principles", href: "/principles", icon: BookOpen },
+  { id: "activation", labelKey: "components.sidebar.activation", href: "/activation", icon: Zap },
+  { id: "debt", labelKey: "components.sidebar.debt", href: "/debt", icon: Archive },
+  { id: "intent", labelKey: "components.sidebar.intent", href: "/intent", icon: Compass },
 ];
 
 const toolNavItems = [
-  { id: "control-center", labelKey: "components.sidebar.controlCenter", href: "/control-center", icon: Settings, shortcut: "Alt+8" },
-  { id: "report-problem", labelKey: "components.sidebar.reportProblem", href: "/report-problem", icon: MessageSquare, shortcut: "Alt+9" },
-  { id: "settings", labelKey: "components.sidebar.settings", href: "/settings", icon: Settings, shortcut: "Alt+0" },
-  { id: "update", labelKey: "components.sidebar.update", href: "/update", icon: RefreshCw, shortcut: "" },
+  { id: "control-center", labelKey: "components.sidebar.controlCenter", href: "/control-center", icon: Settings },
+  { id: "report-problem", labelKey: "components.sidebar.reportProblem", href: "/report-problem", icon: MessageSquare },
+  { id: "settings", labelKey: "components.sidebar.settings", href: "/settings", icon: Settings },
+  { id: "update", labelKey: "components.sidebar.update", href: "/update", icon: RefreshCw },
 ];
 
 export function AppSidebar() {
@@ -119,10 +119,6 @@ export function AppSidebar() {
                     role="status"
                     aria-label={t("components.sidebar.pendingApprovalsAria", { count: pendingCount })}
                   />
-                ) : item.shortcut ? (
-                  <span className="text-ink-4 font-mono text-[11px]">
-                    {item.shortcut}
-                  </span>
                 ) : null}
               </Link>
             );
@@ -158,10 +154,6 @@ export function AppSidebar() {
                       role="status"
                       aria-label={t("components.sidebar.degradedSignalsAria", { count: degradedCount })}
                     />
-                  ) : item.shortcut ? (
-                    <span className="text-ink-4 font-mono text-[11px]">
-                      {item.shortcut}
-                    </span>
                   ) : null}
                 </Link>
               );

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -650,7 +650,7 @@
       "readinessLabel": "Readiness",
       "empathyCostHint": {
         "body": "Empathy Observer is on — every unmatched message triggers an LLM call (current model: {{provider}}/{{model}}).",
-        "muted": "To reduce cost, switch pd-empathy-observer.policy.model in workflows.yaml to a cheaper model.",
+        "muted": "To reduce cost, consider using a local LLM model (e.g. Ollama), or switch pd-empathy-observer.policy.model in workflows.yaml to a cheaper model.",
         "ack": "Got it"
       },
       "workflow": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -650,7 +650,7 @@
       "readinessLabel": "就绪状态",
       "empathyCostHint": {
         "body": "共情观察器已启用 — 每次关键词未命中时会调用 LLM 做深度分析（当前模型：{{provider}}/{{model}}）。",
-        "muted": "如需节省成本，在 workflows.yaml 的 pd-empathy-observer.policy.model 换更便宜模型。",
+        "muted": "如需节省成本，建议使用本地 LLM 模型（如 Ollama），或在 workflows.yaml 的 pd-empathy-observer.policy.model 换更便宜模型。",
         "ack": "知道了"
       },
       "workflow": {

--- a/packages/pd-console/tests/navigation-mvp.test.ts
+++ b/packages/pd-console/tests/navigation-mvp.test.ts
@@ -90,12 +90,6 @@ describe('Console Rebuild Navigation — CR2', () => {
       expect(sidebarSrc).toContain('LogOut');
     });
 
-    it('has keyboard shortcut hints (Alt+)', () => {
-      expect(sidebarSrc).toContain('Alt+3');
-      expect(sidebarSrc).toContain('Alt+4');
-      expect(sidebarSrc).toContain('Alt+5');
-    });
-
     it('no health red dot, no DNA logo', () => {
       expect(sidebarSrc).not.toContain('alertCount');
       expect(sidebarSrc).not.toContain('DNA');


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: N/A（用户反馈的体验改进）
- 解决的产品问题（一句话）: empathyObserver 成本提示缺少本地 LLM 建议；侧边栏 Alt+x 快捷键提示鸡肋且影响美观
- emotional-value：降低 [信息过载] 创造 [掌控感]
  - 如无明确情绪价值，说明为何仍是必要的: 成本提示帮助 owner 控制 token 开销；删除快捷键提示减少视觉噪音
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🔧 重构/优化
- [ ] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- empathyObserver 成本提示文案加入"建议使用本地 LLM 模型（如 Ollama）"建议（zh-CN + en）
- 删除 App.tsx 中的 Alt+3..Alt+0 keydown 监听器（快捷键功能）
- 删除 app-sidebar.tsx 中 mainNavItems/toolNavItems 的 shortcut 字段及 UI 显示逻辑
- 移除 navigation-mvp.test.ts 中对应的快捷键合约测试

### 影响范围
- [ ] packages/principles-core
- [ ] packages/openclaw-plugin
- [ ] packages/pd-cli
- [x] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否
- [ ] 是（需 maintainer 批准，附理由）: ___

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 启动 pd-console，确保 empathyObserver 已启用（在控制中心打开）
- [ ] 动作 1: 进入控制中心页面
  - 观察: 看到 empathyObserver 成本提示条，文案包含"建议使用本地 LLM 模型（如 Ollama）"
- [ ] 动作 2: 查看左侧菜单栏
  - 观察: 菜单项右侧不再显示 "Alt+3" 到 "Alt+0" 的快捷键提示文本
- [ ] 动作 3: 按 Alt+3 等快捷键
  - 观察: 不再触发页面导航（功能已移除）
- 证据: ___

## 风险与可逆性（agent 填）
- 主要风险: 删除快捷键功能可能影响少数依赖键盘导航的用户（但 Alt+数字 非标准无障碍模式，影响极小）
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否
  - [ ] 是（名称: ___）
  - 规则引用: `mvp-q-3-how-disabled` —— 纯 UI 删除，PR revert 即可回滚，无需 flag
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会——成本提示缺少本地 LLM 建议是用户主动反馈；快捷键提示影响美观也是用户主动反馈
- `mvp-q-2-how-observed`: 如何观察它生效？进入控制中心看 empathyObserver 提示文案；查看侧边栏无 Alt+x 文本
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（i18n 文案）
- [x] 无破坏性变更（快捷键移除是 intentional UI 简化）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：未删除源文件，仅删除字段和逻辑
- [x] Core 边界检查：本 PR 未修改 principles-core
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性）
- [x] N/A — 本 PR 未修改 core store 契约

### ERR Checklist（必填）
- ERR-001 (parsed JSON as any): N/A — 本 PR 仅修改 i18n 文案和删除 UI 逻辑，不处理不可信数据
- ERR-013 (Object.hasOwn vs in): N/A — 本 PR 未涉及不可信对象键检查
- ERR-009 (fail loud missing): N/A — 本 PR 未涉及必填字段校验

### Runtime Contract 自检（必填）
- [x] 本 PR 不处理不可信数据
- 遵守方式说明（N/A 时填理由）: 本 PR 仅修改 i18n 文案字符串和删除 UI 快捷键逻辑，不涉及 parsed JSON / LLM output / DB diagnosticJson / artifact metadata 处理

### CLI Gate 自检（条件性）
- [x] N/A — 本 PR 未修改 CLI 命令

### Feature Flag 注册检查（条件性）
- [x] N/A — 本 PR 未引入新功能子系统

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`（"为未来铺路"）
- [x] 无 `antipattern-completeness`（"为完整性"）
- [x] 无 `antipattern-review-missing`（"review 时觉得缺失"）
- [x] 无 `antipattern-core-io`（"在 core 写 I/O 代码"）

## 测试结果（agent 填）
- [ ] `cd packages/principles-core && npm run test`: 未运行（本 PR 未修改 core）
- [ ] `cd packages/openclaw-plugin && npm run test`: 未运行（本 PR 未修改 plugin）
- [x] `npm run lint`: 通过（0 errors，31 个预存 warnings 均与本次变更无关）
- [x] `npm run verify:merge`: 通过（pre-push 钩子已执行）
- [x] `cd packages/pd-console && npm run test`: 通过（1674 passed | 1 expected fail）
- [x] `cd packages/pd-console && npx tsc --noEmit`: 通过
- [x] `cd packages/pd-console && npm run build:ui`: 通过

## 相关 Issue
N/A（用户反馈的体验改进）
