### PR TITLE
feat(intent): bilingual INTENT.md (zh-CN/en) + version history

### DIFF
--- a/packages/openclaw-plugin/src/commands/pain.ts
+++ b/packages/openclaw-plugin/src/commands/pain.ts
@@ -8,7 +8,7 @@ import type { EvolutionLoopEvent } from '../core/evolution-types.js';
 import { computeHash } from '../utils/hashing.js';
 import { PainToPrincipleService, PrincipleTreeLedgerAdapter } from '@principles/core/runtime-v2';
 import { loadPdConfigForPlugin } from '../core/pd-config-loader.js';
-import { createIntentDocReader } from '../core/intent-doc-reader-adapter.js';
+import { createIntentDocReader, resolveIntentLang } from '../core/intent-doc-reader-adapter.js';
 
 /**
  * Creates a visual progress bar (e.g., [██████░░░░])
@@ -322,7 +322,7 @@ export async function handlePainReportCommand(ctx: PluginCommandContext): Promis
       autoIntakeEnabled: true,
       effectiveConfig: configResult.effective,
       getEnvVar: (name: string) => process.env[name],
-      intentDocReader: createIntentDocReader(wctx.workspaceDir, 'zh-CN'),
+      intentDocReader: createIntentDocReader(wctx.workspaceDir, resolveIntentLang(wctx.workspaceDir)),
     });
 
     const result = await service.recordPain({

--- a/packages/openclaw-plugin/src/commands/pain.ts
+++ b/packages/openclaw-plugin/src/commands/pain.ts
@@ -322,7 +322,7 @@ export async function handlePainReportCommand(ctx: PluginCommandContext): Promis
       autoIntakeEnabled: true,
       effectiveConfig: configResult.effective,
       getEnvVar: (name: string) => process.env[name],
-      intentDocReader: createIntentDocReader(wctx.workspaceDir),
+      intentDocReader: createIntentDocReader(wctx.workspaceDir, 'zh-CN'),
     });
 
     const result = await service.recordPain({

--- a/packages/openclaw-plugin/src/core/intent-doc-reader-adapter.ts
+++ b/packages/openclaw-plugin/src/core/intent-doc-reader-adapter.ts
@@ -18,13 +18,35 @@
  * It will be added to KNOWN_PLUGIN_CORE_FILES in architecture-regression.test.ts.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { safeReadIntentDoc } from './intent-doc-reader.js';
+import {
+  getIntentFilename,
+} from '@principles/core/runtime-v2';
 import type {
   IntentDocReader,
   IntentDocReadResult,
   IntentDocReference,
   IntentLang,
 } from '@principles/core/runtime-v2';
+
+const INTENT_DIR = '.principles';
+
+/**
+ * Detect which language's INTENT file exists on disk.
+ * Priority: zh-CN first, then en. Defaults to zh-CN if neither exists.
+ *
+ * This lets hooks avoid hardcoding a single language — the Owner may have
+ * created either INTENT.zh-CN.md or INTENT.en.md.
+ */
+export function resolveIntentLang(workspaceDir: string): IntentLang {
+  const zhPath = path.join(workspaceDir, INTENT_DIR, getIntentFilename('zh-CN'));
+  if (fs.existsSync(zhPath)) return 'zh-CN';
+  const enPath = path.join(workspaceDir, INTENT_DIR, getIntentFilename('en'));
+  if (fs.existsSync(enPath)) return 'en';
+  return 'zh-CN';
+}
 
 /**
  * Create an IntentDocReader bound to a specific workspace and language.

--- a/packages/openclaw-plugin/src/core/intent-doc-reader-adapter.ts
+++ b/packages/openclaw-plugin/src/core/intent-doc-reader-adapter.ts
@@ -23,19 +23,20 @@ import type {
   IntentDocReader,
   IntentDocReadResult,
   IntentDocReference,
+  IntentLang,
 } from '@principles/core/runtime-v2';
 
 /**
- * Create an IntentDocReader bound to a specific workspace.
+ * Create an IntentDocReader bound to a specific workspace and language.
  *
- * The returned reader is stateless beyond the workspace binding — each
+ * The returned reader is stateless beyond the (workspace, lang) binding — each
  * `readIntentDoc()` call delegates to `safeReadIntentDoc()`, which owns
- * the TTL+mtime cache.
+ * the TTL+mtime cache keyed by `${workspaceDir}:${lang}`.
  */
-export function createIntentDocReader(workspaceDir: string): IntentDocReader {
+export function createIntentDocReader(workspaceDir: string, lang: IntentLang): IntentDocReader {
   return {
     readIntentDoc(): IntentDocReadResult {
-      const result = safeReadIntentDoc(workspaceDir);
+      const result = safeReadIntentDoc(workspaceDir, lang);
 
       if (result.ok && result.doc) {
         const doc = result.doc;

--- a/packages/openclaw-plugin/src/core/intent-doc-reader.ts
+++ b/packages/openclaw-plugin/src/core/intent-doc-reader.ts
@@ -93,14 +93,31 @@ const _intentDocCache = new Map<string, CachedIntentDoc>();
 
 /**
  * Reset the intent doc cache for test isolation.
- * Accepts an optional cache key (workspaceDir:lang) to delete a single entry;
- * omit to clear the whole cache.
+ *
+ * - No args: clear the whole cache.
+ * - workspaceDir only: delete all entries for that workspace (any lang).
+ *   Keys are formatted as `${workspaceDir}:${lang}`, so we match by prefix.
+ * - workspaceDir + lang: delete the single `${workspaceDir}:${lang}` entry.
+ *
+ * Note: prompt.ts resetPromptStateForTest passes workspaceDir only — the
+ * previous signature treated it as a literal cache key, which never matched
+ * the `${workspaceDir}:${lang}` format and silently left entries behind.
  */
-export function resetIntentDocCacheForTest(cacheKey?: string): void {
-  if (cacheKey) {
-    _intentDocCache.delete(cacheKey);
-  } else {
+export function resetIntentDocCacheForTest(workspaceDir?: string, lang?: IntentLang): void {
+  if (workspaceDir === undefined) {
     _intentDocCache.clear();
+    return;
+  }
+  if (lang !== undefined) {
+    _intentDocCache.delete(`${workspaceDir}:${lang}`);
+    return;
+  }
+  // workspaceDir only — clear all langs for this workspace by prefix.
+  const prefix = `${workspaceDir}:`;
+  for (const key of _intentDocCache.keys()) {
+    if (key.startsWith(prefix)) {
+      _intentDocCache.delete(key);
+    }
   }
 }
 

--- a/packages/openclaw-plugin/src/core/intent-doc-reader.ts
+++ b/packages/openclaw-plugin/src/core/intent-doc-reader.ts
@@ -26,17 +26,18 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   INTENT_MAX_BYTES,
+  getIntentFilename,
   parseIntentDocSections,
   computeIntentContentHash,
   validateIntentDocSections,
   type IntentDocSections,
   type IntentDocWarning,
+  type IntentLang,
 } from '@principles/core/runtime-v2';
 import { loadFeatureFlagFromConfig } from './pd-config-loader.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-const INTENT_FILENAME = 'INTENT.md';
 const INTENT_DIR = '.principles';
 const INTENT_CACHE_TTL_MS = 60_000; // 1 minute (SPEC §12.1)
 
@@ -92,11 +93,12 @@ const _intentDocCache = new Map<string, CachedIntentDoc>();
 
 /**
  * Reset the intent doc cache for test isolation.
- * Call in beforeEach() to ensure tests don't pollute each other.
+ * Accepts an optional cache key (workspaceDir:lang) to delete a single entry;
+ * omit to clear the whole cache.
  */
-export function resetIntentDocCacheForTest(workspaceDir?: string): void {
-  if (workspaceDir) {
-    _intentDocCache.delete(workspaceDir);
+export function resetIntentDocCacheForTest(cacheKey?: string): void {
+  if (cacheKey) {
+    _intentDocCache.delete(cacheKey);
   } else {
     _intentDocCache.clear();
   }
@@ -104,8 +106,12 @@ export function resetIntentDocCacheForTest(workspaceDir?: string): void {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function getIntentFilePath(workspaceDir: string): string {
-  return path.join(workspaceDir, INTENT_DIR, INTENT_FILENAME);
+function getIntentFilePath(workspaceDir: string, lang: IntentLang): string {
+  return path.join(workspaceDir, INTENT_DIR, getIntentFilename(lang));
+}
+
+function getCacheKey(workspaceDir: string, lang: IntentLang): string {
+  return `${workspaceDir}:${lang}`;
 }
 
 function buildDocFromRaw(raw: string, filePath: string, readAt: string): IntentDoc {
@@ -135,11 +141,13 @@ function buildDocFromRaw(raw: string, filePath: string, readAt: string): IntentD
  * 4. Never throws — all errors return structured reason + nextAction.
  *
  * @param workspaceDir - Absolute path to the workspace root
+ * @param lang - Mandatory language code ('zh-CN' | 'en'); selects INTENT.${lang}.md
  * @param options - Optional logger for debug-level diagnostics
  * @returns SafeReadIntentDocResult (never throws)
  */
 export function safeReadIntentDoc(
   workspaceDir: string,
+  lang: IntentLang,
   options?: { logger?: { debug?: (msg: string) => void; warn?: (msg: string) => void } },
 ): SafeReadIntentDocResult {
   // SPEC §12 — Flag check FIRST. Flag off → no fs access, no cache access.
@@ -150,16 +158,17 @@ export function safeReadIntentDoc(
       found: false,
       flagEnabled: false,
       reason: 'flag_disabled',
-      nextAction: 'Enable the intent_engineering feature flag in .pd/config.yaml to read INTENT.md.',
+      nextAction: `Enable the intent_engineering feature flag in .pd/config.yaml to read ${getIntentFilename(lang)}.`,
       warnings: [],
     };
   }
 
-  const filePath = getIntentFilePath(workspaceDir);
+  const cacheKey = getCacheKey(workspaceDir, lang);
+  const filePath = getIntentFilePath(workspaceDir, lang);
   const now = Date.now();
 
   // Check cache freshness (TTL + mtime)
-  const cached = _intentDocCache.get(workspaceDir);
+  const cached = _intentDocCache.get(cacheKey);
   if (cached && (now - cached.loadedAt) < INTENT_CACHE_TTL_MS) {
     // Cache is within TTL. Verify mtime hasn't changed.
     try {
@@ -185,13 +194,13 @@ export function safeReadIntentDoc(
     // Check existence first
     if (!fs.existsSync(filePath)) {
       // Invalidate stale cache entry if any
-      _intentDocCache.delete(workspaceDir);
+      _intentDocCache.delete(cacheKey);
       return {
         ok: false,
         found: false,
         flagEnabled: true,
         reason: 'not_found',
-        nextAction: 'Create .principles/INTENT.md using "pd intent init".',
+        nextAction: `Create .principles/${getIntentFilename(lang)} using "pd intent init".`,
         warnings: [],
       };
     }
@@ -200,13 +209,13 @@ export function safeReadIntentDoc(
 
     // SPEC §12 — 32KB size cap
     if (stat.size > INTENT_MAX_BYTES) {
-      _intentDocCache.delete(workspaceDir);
+      _intentDocCache.delete(cacheKey);
       return {
         ok: false,
         found: true,
         flagEnabled: true,
         reason: 'oversized',
-        nextAction: `INTENT.md exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content.`,
+        nextAction: `${getIntentFilename(lang)} exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content.`,
         warnings: [],
       };
     }
@@ -219,13 +228,13 @@ export function safeReadIntentDoc(
     // an oversized file would enter parse/hash/cache as ok:true.
     const actualBytes = Buffer.byteLength(raw, 'utf8');
     if (actualBytes > INTENT_MAX_BYTES) {
-      _intentDocCache.delete(workspaceDir);
+      _intentDocCache.delete(cacheKey);
       return {
         ok: false,
         found: true,
         flagEnabled: true,
         reason: 'oversized',
-        nextAction: `INTENT.md exceeds ${INTENT_MAX_BYTES} bytes (${actualBytes} bytes after read). Reduce content.`,
+        nextAction: `${getIntentFilename(lang)} exceeds ${INTENT_MAX_BYTES} bytes (${actualBytes} bytes after read). Reduce content.`,
         warnings: [],
       };
     }
@@ -233,7 +242,7 @@ export function safeReadIntentDoc(
     const doc = buildDocFromRaw(raw, filePath, new Date(now).toISOString());
 
     // Update cache
-    _intentDocCache.set(workspaceDir, {
+    _intentDocCache.set(cacheKey, {
       doc,
       mtime: stat.mtimeMs,
       loadedAt: now,
@@ -248,15 +257,15 @@ export function safeReadIntentDoc(
     };
   } catch (err) {
     // ERR-002 — graceful degradation with reason + nextAction
-    _intentDocCache.delete(workspaceDir);
+    _intentDocCache.delete(cacheKey);
     const message = err instanceof Error ? err.message : String(err);
-    options?.logger?.warn?.(`[PD:Intent] safeReadIntentDoc failed: workspace=${workspaceDir}, error=${message}`);
+    options?.logger?.warn?.(`[PD:Intent] safeReadIntentDoc failed: workspace=${workspaceDir}, lang=${lang}, error=${message}`);
     return {
       ok: false,
       found: false,
       flagEnabled: true,
       reason: 'read_error',
-      nextAction: 'Check filesystem permissions for .principles/INTENT.md.',
+      nextAction: `Check filesystem permissions for .principles/${getIntentFilename(lang)}.`,
       warnings: [],
     };
   }

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -64,7 +64,7 @@ function createPainToPrincipleService(wctx: WorkspaceContext): PainToPrincipleSe
     // PRI-468: wire INTENT.md reader so Stage A can produce intentTension
     // when intent_engineering flag is on. Adapter performs no I/O beyond
     // delegating to safeReadIntentDoc (which owns the flag-first check).
-    intentDocReader: createIntentDocReader(wctx.workspaceDir),
+    intentDocReader: createIntentDocReader(wctx.workspaceDir, 'zh-CN'),
   });
 }
 

--- a/packages/openclaw-plugin/src/hooks/pain.ts
+++ b/packages/openclaw-plugin/src/hooks/pain.ts
@@ -28,7 +28,7 @@ import { resolveWorkspaceDirForRuntimeV2 } from '../utils/workspace-resolver.js'
 import { PainToPrincipleService, PrincipleTreeLedgerAdapter, type PainDetectedData } from '@principles/core/runtime-v2';
 import { evaluatePainDiagnosticGate } from '../core/pain-diagnostic-gate.js';
 import { loadPdConfigForPlugin, loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
-import { createIntentDocReader } from '../core/intent-doc-reader-adapter.js';
+import { createIntentDocReader, resolveIntentLang } from '../core/intent-doc-reader-adapter.js';
 import { evaluateTriggerController } from '@principles/core/runtime-v2';
 import { isSharedCooldownActive, markSharedEpisodeAsDiagnosed } from './trigger-cooldown-tracker.js';
 import { buildManualPainObservation, resolveSourceKind } from './raw-observation-adapter.js';
@@ -64,7 +64,7 @@ function createPainToPrincipleService(wctx: WorkspaceContext): PainToPrincipleSe
     // PRI-468: wire INTENT.md reader so Stage A can produce intentTension
     // when intent_engineering flag is on. Adapter performs no I/O beyond
     // delegating to safeReadIntentDoc (which owns the flag-first check).
-    intentDocReader: createIntentDocReader(wctx.workspaceDir, 'zh-CN'),
+    intentDocReader: createIntentDocReader(wctx.workspaceDir, resolveIntentLang(wctx.workspaceDir)),
   });
 }
 

--- a/packages/openclaw-plugin/src/hooks/prompt.ts
+++ b/packages/openclaw-plugin/src/hooks/prompt.ts
@@ -1013,7 +1013,7 @@ export async function handleBeforePromptBuild(
   try {
     const intentFlag = loadFeatureFlagFromConfig(workspaceDir, 'intent_engineering', logger);
     if (intentFlag.enabled) {
-      const intentResult = safeReadIntentDoc(workspaceDir, { logger });
+      const intentResult = safeReadIntentDoc(workspaceDir, 'zh-CN', { logger });
       if (intentResult.ok && intentResult.doc) {
         const block = buildIntentFrictionBlock({ rawIntentMd: intentResult.doc.raw });
         if (block.length > 0) {

--- a/packages/openclaw-plugin/src/hooks/prompt.ts
+++ b/packages/openclaw-plugin/src/hooks/prompt.ts
@@ -31,6 +31,7 @@ import { buildEmpathyObservation, resolveSourceKind } from './raw-observation-ad
 import { evaluateEvidenceTriage } from './triage-adapter.js';
 import { loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
 import { safeReadIntentDoc, resetIntentDocCacheForTest } from '../core/intent-doc-reader.js';
+import { resolveIntentLang } from '../core/intent-doc-reader-adapter.js';
 import { buildIntentFrictionBlock } from '@principles/core/runtime-v2';
 import { CorrectionCueLearner } from '../core/correction-cue-learner.js';
 import {
@@ -1013,7 +1014,7 @@ export async function handleBeforePromptBuild(
   try {
     const intentFlag = loadFeatureFlagFromConfig(workspaceDir, 'intent_engineering', logger);
     if (intentFlag.enabled) {
-      const intentResult = safeReadIntentDoc(workspaceDir, 'zh-CN', { logger });
+      const intentResult = safeReadIntentDoc(workspaceDir, resolveIntentLang(workspaceDir), { logger });
       if (intentResult.ok && intentResult.doc) {
         const block = buildIntentFrictionBlock({ rawIntentMd: intentResult.doc.raw });
         if (block.length > 0) {

--- a/packages/openclaw-plugin/tests/commands/pain.test.ts
+++ b/packages/openclaw-plugin/tests/commands/pain.test.ts
@@ -8,6 +8,10 @@ vi.mock('../../src/core/workspace-context.js');
 vi.mock('../../src/core/pd-config-loader.js', () => ({
   loadPdConfigForPlugin: vi.fn().mockReturnValue({ ok: true, effective: {}, source: 'defaults', warnings: [], errors: [] }),
 }));
+vi.mock('../../src/core/intent-doc-reader-adapter.js', () => ({
+  createIntentDocReader: vi.fn().mockReturnValue({ readIntentDoc: vi.fn() }),
+  resolveIntentLang: vi.fn().mockReturnValue('zh-CN'),
+}));
 vi.mock('@principles/core/runtime-v2', () => ({
   PainToPrincipleService: vi.fn(),
   PrincipleTreeLedgerAdapter: vi.fn(function(this: any) { this.stateDir = ''; }),

--- a/packages/openclaw-plugin/tests/core/intent-doc-reader-adapter.test.ts
+++ b/packages/openclaw-plugin/tests/core/intent-doc-reader-adapter.test.ts
@@ -57,7 +57,7 @@ function writeConfigEnablingIntent(workspaceDir: string, enabled: boolean): void
 function writeIntentMd(workspaceDir: string, content: string): void {
   const intentDir = path.join(workspaceDir, '.principles');
   fs.mkdirSync(intentDir, { recursive: true });
-  fs.writeFileSync(path.join(intentDir, 'INTENT.md'), content, 'utf8');
+  fs.writeFileSync(path.join(intentDir, 'INTENT.zh-CN.md'), content, 'utf8');
 }
 
 describe('createIntentDocReader (PRI-468 adapter)', () => {
@@ -78,7 +78,7 @@ describe('createIntentDocReader (PRI-468 adapter)', () => {
     const content = '# Why\nValidate the loop\n';
     writeIntentMd(workspaceDir, content);
 
-    const reader = createIntentDocReader(workspaceDir);
+    const reader = createIntentDocReader(workspaceDir, 'zh-CN');
     const result = reader.readIntentDoc();
 
     expect(result.ok).toBe(true);
@@ -90,7 +90,7 @@ describe('createIntentDocReader (PRI-468 adapter)', () => {
     expect(typeof result.doc?.contentHash).toBe('string');
     expect(result.doc?.contentHash.length).toBeGreaterThan(0);
     expect(typeof result.doc?.path).toBe('string');
-    expect(result.doc?.path).toContain('INTENT.md');
+    expect(result.doc?.path).toContain('INTENT.zh-CN.md');
   });
 
   it('returns ok=false with reason=flag_disabled when flag off (no fs access)', () => {
@@ -98,7 +98,7 @@ describe('createIntentDocReader (PRI-468 adapter)', () => {
     // Even with a file present, flag off → flag_disabled
     writeIntentMd(workspaceDir, '# Why\nx\n');
 
-    const reader = createIntentDocReader(workspaceDir);
+    const reader = createIntentDocReader(workspaceDir, 'zh-CN');
     const result = reader.readIntentDoc();
 
     expect(result.ok).toBe(false);
@@ -113,7 +113,7 @@ describe('createIntentDocReader (PRI-468 adapter)', () => {
     writeConfigEnablingIntent(workspaceDir, true);
     // No INTENT.md written
 
-    const reader = createIntentDocReader(workspaceDir);
+    const reader = createIntentDocReader(workspaceDir, 'zh-CN');
     const result = reader.readIntentDoc();
 
     expect(result.ok).toBe(false);
@@ -130,7 +130,7 @@ describe('createIntentDocReader (PRI-468 adapter)', () => {
     const big = '# Why\n' + 'a'.repeat(33 * 1024);
     writeIntentMd(workspaceDir, big);
 
-    const reader = createIntentDocReader(workspaceDir);
+    const reader = createIntentDocReader(workspaceDir, 'zh-CN');
     const result = reader.readIntentDoc();
 
     expect(result.ok).toBe(false);

--- a/packages/openclaw-plugin/tests/core/intent-doc-reader.test.ts
+++ b/packages/openclaw-plugin/tests/core/intent-doc-reader.test.ts
@@ -67,7 +67,7 @@ function writeConfig(workspaceDir: string, intentFlagEnabled: boolean): void {
 function writeIntentMd(workspaceDir: string, content: string): string {
   const intentDir = path.join(workspaceDir, '.principles');
   fs.mkdirSync(intentDir, { recursive: true });
-  const filePath = path.join(intentDir, 'INTENT.md');
+  const filePath = path.join(intentDir, 'INTENT.zh-CN.md');
   fs.writeFileSync(filePath, content, 'utf8');
   return filePath;
 }
@@ -117,7 +117,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
     writeConfig(workspaceDir, false);
     // Do NOT write INTENT.md — if the reader accesses fs, it would still
     // return not_found, but the contract requires flag_disabled first.
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.flagEnabled).toBe(false);
     expect(result.reason).toBe('flag_disabled');
@@ -129,7 +129,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('returns flag_disabled even when INTENT.md exists (flag off short-circuits before fs)', () => {
     writeConfig(workspaceDir, false);
     writeIntentMd(workspaceDir, VALID_INTENT);
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.flagEnabled).toBe(false);
     expect(result.reason).toBe('flag_disabled');
@@ -139,7 +139,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   // SPEC §12 — flag on + missing file → not_found with nextAction
   it('returns not_found when INTENT.md does not exist (flag on)', () => {
     writeConfig(workspaceDir, true);
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.found).toBe(false);
     expect(result.flagEnabled).toBe(true);
@@ -152,7 +152,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('returns ok=true with full IntentDoc for valid INTENT.md (flag on)', () => {
     writeConfig(workspaceDir, true);
     const filePath = writeIntentMd(workspaceDir, VALID_INTENT);
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.found).toBe(true);
     expect(result.flagEnabled).toBe(true);
@@ -177,7 +177,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
     // INTENT_MAX_BYTES = 32 * 1024 = 32768
     const oversized = 'A'.repeat(33000);
     writeIntentMd(workspaceDir, oversized);
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.found).toBe(true);
     expect(result.flagEnabled).toBe(true);
@@ -190,7 +190,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('returns ok=true with missing_section warnings when INTENT.md has no section headers', () => {
     writeConfig(workspaceDir, true);
     writeIntentMd(workspaceDir, INTENT_MISSING_SECTIONS);
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.found).toBe(true);
     expect(result.flagEnabled).toBe(true);
@@ -205,8 +205,8 @@ describe('safeReadIntentDoc (PRI-467)', () => {
     writeConfig(workspaceDir, true);
     // Pass a non-existent workspace dir — should not throw
     const badDir = path.join(os.tmpdir(), 'pd-nonexistent-' + Date.now());
-    expect(() => safeReadIntentDoc(badDir)).not.toThrow();
-    const result = safeReadIntentDoc(badDir);
+    expect(() => safeReadIntentDoc(badDir, 'zh-CN')).not.toThrow();
+    const result = safeReadIntentDoc(badDir, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBeTruthy();
     expect(result.nextAction).toBeTruthy();
@@ -216,14 +216,14 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('returns cached doc on second call within TTL (same object identity = cache hit)', () => {
     writeConfig(workspaceDir, true);
     writeIntentMd(workspaceDir, VALID_INTENT);
-    const first = safeReadIntentDoc(workspaceDir);
+    const first = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(first.ok).toBe(true);
     expect(first.doc).toBeDefined();
 
     // Second call immediately (within TTL, same mtime) → cache hit.
     // Cache hit returns the SAME doc object reference (cached.doc).
     // A fresh read would build a new doc object, breaking identity.
-    const second = safeReadIntentDoc(workspaceDir);
+    const second = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(second.ok).toBe(true);
     expect(second.doc).toBeDefined();
     expect(second.doc).toBe(first.doc); // object identity proves cache hit
@@ -234,12 +234,12 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('invalidates cache when INTENT.md mtime changes (returns fresh content)', () => {
     writeConfig(workspaceDir, true);
     writeIntentMd(workspaceDir, VALID_INTENT);
-    const first = safeReadIntentDoc(workspaceDir);
+    const first = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(first.ok).toBe(true);
     expect(first.doc!.sections.why).toContain('behavior internalization system');
 
     // Wait a bit so mtime changes, then write new content
-    const newPath = path.join(workspaceDir, '.principles', 'INTENT.md');
+    const newPath = path.join(workspaceDir, '.principles', 'INTENT.zh-CN.md');
     const futureTime = new Date(Date.now() + 2000);
     const newContent = VALID_INTENT.replace(
       'behavior internalization system',
@@ -249,7 +249,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
     // Force mtime to a future time to ensure mtime differs from cached
     fs.utimesSync(newPath, futureTime, futureTime);
 
-    const second = safeReadIntentDoc(workspaceDir);
+    const second = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(second.ok).toBe(true);
     expect(second.doc).toBeDefined();
     // Fresh content should reflect the updated text
@@ -261,17 +261,17 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('fail-open with structured reason when file becomes oversized after caching', () => {
     writeConfig(workspaceDir, true);
     writeIntentMd(workspaceDir, VALID_INTENT);
-    const first = safeReadIntentDoc(workspaceDir);
+    const first = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(first.ok).toBe(true);
 
     // Overwrite with oversized content + force mtime change
-    const filePath = path.join(workspaceDir, '.principles', 'INTENT.md');
+    const filePath = path.join(workspaceDir, '.principles', 'INTENT.zh-CN.md');
     const oversized = 'B'.repeat(33000);
     fs.writeFileSync(filePath, oversized, 'utf8');
     const futureTime = new Date(Date.now() + 2000);
     fs.utimesSync(filePath, futureTime, futureTime);
 
-    const second = safeReadIntentDoc(workspaceDir);
+    const second = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(second.ok).toBe(false);
     expect(second.reason).toBe('oversized');
     expect(second.nextAction).toBeTruthy();
@@ -281,7 +281,7 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('reads INTENT.md from .principles/INTENT.md inside the workspace', () => {
     writeConfig(workspaceDir, true);
     const filePath = writeIntentMd(workspaceDir, VALID_INTENT);
-    const result = safeReadIntentDoc(workspaceDir);
+    const result = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.doc!.path).toBe(filePath);
     // Path must be inside workspace
@@ -292,9 +292,9 @@ describe('safeReadIntentDoc (PRI-467)', () => {
   it('returns stable contentHash across reads of the same content', () => {
     writeConfig(workspaceDir, true);
     writeIntentMd(workspaceDir, VALID_INTENT);
-    const first = safeReadIntentDoc(workspaceDir);
+    const first = safeReadIntentDoc(workspaceDir, 'zh-CN');
     resetIntentDocCacheForTest(); // force fresh read
-    const second = safeReadIntentDoc(workspaceDir);
+    const second = safeReadIntentDoc(workspaceDir, 'zh-CN');
     expect(first.doc!.contentHash).toBe(second.doc!.contentHash);
   });
 });

--- a/packages/openclaw-plugin/tests/hooks/prompt-intent-injection.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/prompt-intent-injection.test.ts
@@ -168,9 +168,13 @@ vi.mock('../../src/core/intent-doc-reader.js', async (importOriginal) => {
   const actual = await importOriginal() as typeof import('../../src/core/intent-doc-reader.js');
   return {
     ...actual,
-    safeReadIntentDoc: (workspaceDir: string, options?: { logger?: unknown }) => {
+    safeReadIntentDoc: (
+      workspaceDir: string,
+      lang: 'zh-CN' | 'en',
+      options?: { logger?: unknown },
+    ) => {
       _safeReadIntentDocCalls.push({ workspaceDir });
-      return actual.safeReadIntentDoc(workspaceDir, options);
+      return actual.safeReadIntentDoc(workspaceDir, lang, options);
     },
   };
 });
@@ -208,7 +212,7 @@ function writeConfig(dir: string, intentFlagEnabled: boolean): void {
 function writeIntentMd(dir: string, content: string): void {
   const intentDir = path.join(dir, '.principles');
   fs.mkdirSync(intentDir, { recursive: true });
-  fs.writeFileSync(path.join(intentDir, 'INTENT.md'), content, 'utf8');
+  fs.writeFileSync(path.join(intentDir, 'INTENT.zh-CN.md'), content, 'utf8');
 }
 
 const VALID_INTENT = `# INTENT.md

--- a/packages/pd-cli/src/commands/__tests__/intent-flag-wiring.test.ts
+++ b/packages/pd-cli/src/commands/__tests__/intent-flag-wiring.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { Command } from 'commander';
-import { registerIntentCommand } from '../intent.js';
+import { registerIntentCommand, parseLang } from '../intent.js';
 
 type ActionOptions = Record<string, unknown>;
 interface CapturedAction {
@@ -257,5 +257,26 @@ describe('pd intent --lang — parser-level dispatch (cli-7)', () => {
     await program.parseAsync(['node', 'pd', 'intent', 'show']);
     expect(captured.opts).not.toBeNull();
     expect(captured.opts?.lang).toBeUndefined();
+  });
+});
+
+describe('parseLang — invalid value rejection (rc-9)', () => {
+  it('returns zh-CN when value is undefined (default)', () => {
+    expect(parseLang(undefined)).toBe('zh-CN');
+  });
+
+  it('returns zh-CN when value is zh-CN', () => {
+    expect(parseLang('zh-CN')).toBe('zh-CN');
+  });
+
+  it('returns en when value is en', () => {
+    expect(parseLang('en')).toBe('en');
+  });
+
+  it('returns null for invalid value (no silent fallback)', () => {
+    expect(parseLang('fr')).toBeNull();
+    expect(parseLang('zh')).toBeNull();
+    expect(parseLang('english')).toBeNull();
+    expect(parseLang('')).toBeNull();
   });
 });

--- a/packages/pd-cli/src/commands/__tests__/intent-flag-wiring.test.ts
+++ b/packages/pd-cli/src/commands/__tests__/intent-flag-wiring.test.ts
@@ -54,7 +54,7 @@ describe('pd intent — command registration', () => {
 });
 
 describe('pd intent init — option metadata', () => {
-  it('has --workspace (-w), --force, --dry-run, --confirm, and --json options', () => {
+  it('has --workspace (-w), --force, --dry-run, --confirm, --lang, and --json options', () => {
     const program = freshProgram();
     registerIntentCommand(program);
     const intentCmd = requireCmd(program.commands.find((c) => c.name() === 'intent'), 'intent');
@@ -65,6 +65,7 @@ describe('pd intent init — option metadata', () => {
     expect(initCmd.options.find((o) => o.long === '--force')).toBeDefined();
     expect(initCmd.options.find((o) => o.long === '--dry-run')).toBeDefined();
     expect(initCmd.options.find((o) => o.long === '--confirm')).toBeDefined();
+    expect(initCmd.options.find((o) => o.long === '--lang')).toBeDefined();
     expect(initCmd.options.find((o) => o.long === '--json')).toBeDefined();
   });
 
@@ -82,7 +83,7 @@ describe('pd intent init — option metadata', () => {
 });
 
 describe('pd intent show — option metadata', () => {
-  it('has --workspace (-w) and --json options, no --force', () => {
+  it('has --workspace (-w), --lang, and --json options, no --force', () => {
     const program = freshProgram();
     registerIntentCommand(program);
     const intentCmd = requireCmd(program.commands.find((c) => c.name() === 'intent'), 'intent');
@@ -90,6 +91,7 @@ describe('pd intent show — option metadata', () => {
 
     expect(showCmd.options.find((o) => o.long === '--workspace')).toBeDefined();
     expect(showCmd.options.find((o) => o.long === '--workspace')?.short).toBe('-w');
+    expect(showCmd.options.find((o) => o.long === '--lang')).toBeDefined();
     expect(showCmd.options.find((o) => o.long === '--json')).toBeDefined();
     expect(showCmd.options.find((o) => o.long === '--force')).toBeUndefined();
   });
@@ -193,5 +195,67 @@ describe('pd intent show — parser-level dispatch', () => {
     await program.parseAsync(['node', 'pd', 'intent', 'show', '-w', '/tmp/ws']);
     expect(captured.opts).not.toBeNull();
     expect(captured.opts?.workspace).toBe('/tmp/ws');
+  });
+});
+
+describe('pd intent --lang — parser-level dispatch (cli-7)', () => {
+  it('init: parses --lang zh-CN', async () => {
+    const program = freshProgram();
+    const intentCmd = registerIntentCommand(program);
+    const initCmd = requireCmd(intentCmd.commands.find((c) => c.name() === 'init'), 'init');
+    const captured: CapturedAction = { opts: null };
+    attachCapture(initCmd, captured);
+
+    await program.parseAsync(['node', 'pd', 'intent', 'init', '--lang', 'zh-CN']);
+    expect(captured.opts).not.toBeNull();
+    expect(captured.opts?.lang).toBe('zh-CN');
+  });
+
+  it('init: parses --lang en', async () => {
+    const program = freshProgram();
+    const intentCmd = registerIntentCommand(program);
+    const initCmd = requireCmd(intentCmd.commands.find((c) => c.name() === 'init'), 'init');
+    const captured: CapturedAction = { opts: null };
+    attachCapture(initCmd, captured);
+
+    await program.parseAsync(['node', 'pd', 'intent', 'init', '--lang', 'en']);
+    expect(captured.opts).not.toBeNull();
+    expect(captured.opts?.lang).toBe('en');
+  });
+
+  it('init: lang defaults to undefined when not passed', async () => {
+    const program = freshProgram();
+    const intentCmd = registerIntentCommand(program);
+    const initCmd = requireCmd(intentCmd.commands.find((c) => c.name() === 'init'), 'init');
+    const captured: CapturedAction = { opts: null };
+    attachCapture(initCmd, captured);
+
+    await program.parseAsync(['node', 'pd', 'intent', 'init']);
+    expect(captured.opts).not.toBeNull();
+    expect(captured.opts?.lang).toBeUndefined();
+  });
+
+  it('show: parses --lang en', async () => {
+    const program = freshProgram();
+    const intentCmd = registerIntentCommand(program);
+    const showCmd = requireCmd(intentCmd.commands.find((c) => c.name() === 'show'), 'show');
+    const captured: CapturedAction = { opts: null };
+    attachCapture(showCmd, captured);
+
+    await program.parseAsync(['node', 'pd', 'intent', 'show', '--lang', 'en']);
+    expect(captured.opts).not.toBeNull();
+    expect(captured.opts?.lang).toBe('en');
+  });
+
+  it('show: lang defaults to undefined when not passed', async () => {
+    const program = freshProgram();
+    const intentCmd = registerIntentCommand(program);
+    const showCmd = requireCmd(intentCmd.commands.find((c) => c.name() === 'show'), 'show');
+    const captured: CapturedAction = { opts: null };
+    attachCapture(showCmd, captured);
+
+    await program.parseAsync(['node', 'pd', 'intent', 'show']);
+    expect(captured.opts).not.toBeNull();
+    expect(captured.opts?.lang).toBeUndefined();
   });
 });

--- a/packages/pd-cli/src/commands/intent.ts
+++ b/packages/pd-cli/src/commands/intent.ts
@@ -2,13 +2,16 @@
  * pd intent — Owner-authored INTENT.md management (PRI-466).
  *
  * Subcommands:
- *   - init : create .principles/INTENT.md from the canonical template
- *   - show : display a read-only summary of INTENT.md (sections, hash, warnings)
+ *   - init : create .principles/INTENT.{lang}.md from the canonical template
+ *   - show : display a read-only summary of INTENT.{lang}.md (sections, hash, warnings)
  *
  * `init` is not gated by the intent_engineering flag — the Owner can
  * initialise the intent doc at any time. `show` IS gated: flag-off returns
  * a structured `flag_disabled` result without touching the filesystem,
  * matching the Console backend contract.
+ *
+ * Bilingual: --lang zh-CN|en (default zh-CN) selects the intent doc language.
+ * File naming: INTENT.zh-CN.md / INTENT.en.md via getIntentFilename(lang).
  *
  * JSON mode is strict: --json outputs exactly one parseable JSON object on
  * stdout (CLI Operator Gate rule 1). Failure paths include structured
@@ -27,13 +30,14 @@ import * as path from 'node:path';
 import type { Command } from 'commander';
 import {
   INTENT_MAX_BYTES,
-  INTENT_DOC_TEMPLATE,
+  getIntentFilename,
+  createIntentTemplate,
   parseIntentDocSections,
   computeIntentContentHash,
   validateIntentDocSections,
   isFeatureEnabled,
 } from '@principles/core/runtime-v2';
-import type { IntentDocSections, IntentDocWarning } from '@principles/core/runtime-v2';
+import type { IntentDocSections, IntentDocWarning, IntentLang } from '@principles/core/runtime-v2';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import { loadPdConfig, computeFlagsFromLoadResult } from '../services/pd-config-loader.js';
 import { emitResult } from '../services/cli-output.js';
@@ -41,7 +45,10 @@ import { emitResult } from '../services/cli-output.js';
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const INTENT_DIR = '.principles';
-const INTENT_FILENAME = 'INTENT.md';
+
+function parseLang(value: string | undefined): IntentLang {
+  return value === 'en' ? 'en' : 'zh-CN';
+}
 
 // ── Output types ─────────────────────────────────────────────────────────────
 
@@ -68,8 +75,8 @@ export interface IntentShowOutput {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function getIntentFilePath(workspaceDir: string): string {
-  return path.join(workspaceDir, INTENT_DIR, INTENT_FILENAME);
+function getIntentFilePath(workspaceDir: string, lang: IntentLang): string {
+  return path.join(workspaceDir, INTENT_DIR, getIntentFilename(lang));
 }
 
 function sectionsToRecord(sections: IntentDocSections): Record<string, string> {
@@ -82,9 +89,9 @@ function sectionsToRecord(sections: IntentDocSections): Record<string, string> {
   return record;
 }
 
-function formatIntentShowText(o: IntentShowOutput): string {
+function formatIntentShowText(o: IntentShowOutput, filename: string): string {
   const lines: string[] = [];
-  lines.push(`INTENT.md — ${o.path}`);
+  lines.push(`${filename} — ${o.path}`);
   lines.push(`Content hash: ${o.contentHash}`);
   lines.push(`Last edited:  ${o.lastEditedAt}`);
   lines.push('');
@@ -114,9 +121,12 @@ export interface IntentInitOptions {
   json?: boolean;
   dryRun?: boolean;
   confirm?: boolean;
+  lang?: string;
 }
 
 export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
+  const lang = parseLang(opts.lang);
+
   // CLI Gate rule 4: --dry-run and --confirm must be mutually exclusive.
   if (opts.dryRun && opts.confirm) {
     const output: IntentInitOutput = {
@@ -141,7 +151,7 @@ export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
   let dir: string;
   try {
     workspaceDir = resolveWorkspaceDir(opts.workspace);
-    filePath = getIntentFilePath(workspaceDir);
+    filePath = getIntentFilePath(workspaceDir, lang);
     dir = path.dirname(filePath);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
@@ -160,6 +170,8 @@ export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
     return;
   }
 
+  const filename = getIntentFilename(lang);
+
   // CLI Gate rule 4: state-mutating command defaults to dry-run unless --confirm.
   const isDryRun = opts.dryRun === true || opts.confirm !== true;
 
@@ -170,11 +182,11 @@ export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
         path: filePath,
         overwritten: false,
         reason: 'file_exists',
-        nextAction: `Use --force to overwrite: pd intent init --force --confirm --workspace "${workspaceDir}"`,
+        nextAction: `Use --force to overwrite: pd intent init --force --confirm --lang ${lang} --workspace "${workspaceDir}"`,
       };
       emitResult(output, {
         json: opts.json ?? false,
-        formatText: (o) => `INTENT.md already exists at ${o.path}\n→ ${o.nextAction}`,
+        formatText: (o) => `${filename} already exists at ${o.path}\n→ ${o.nextAction}`,
       });
       process.exitCode = 1;
       return;
@@ -186,17 +198,17 @@ export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
         path: filePath,
         overwritten: opts.force === true,
         reason: 'dry_run',
-        nextAction: `Confirm write: pd intent init --confirm${opts.force ? ' --force' : ''} --workspace "${workspaceDir}"`,
+        nextAction: `Confirm write: pd intent init --confirm --lang ${lang}${opts.force ? ' --force' : ''} --workspace "${workspaceDir}"`,
       };
       emitResult(output, {
         json: opts.json ?? false,
-        formatText: (o) => `[dry-run] Would create INTENT.md at ${o.path}${o.overwritten ? ' (overwritten)' : ''}\n→ ${o.nextAction}`,
+        formatText: (o) => `[dry-run] Would create ${filename} at ${o.path}${o.overwritten ? ' (overwritten)' : ''}\n→ ${o.nextAction}`,
       });
       return;
     }
 
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(filePath, INTENT_DOC_TEMPLATE, 'utf8');
+    fs.writeFileSync(filePath, createIntentTemplate(lang), 'utf8');
 
     const output: IntentInitOutput = {
       status: 'ok',
@@ -205,7 +217,7 @@ export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
     };
     emitResult(output, {
       json: opts.json ?? false,
-      formatText: (o) => `Created INTENT.md at ${o.path}${o.overwritten ? ' (overwritten)' : ''}\nNext: edit the file to declare your project intent, then run "pd intent show".`,
+      formatText: (o) => `Created ${filename} at ${o.path}${o.overwritten ? ' (overwritten)' : ''}\nNext: edit the file to declare your project intent, then run "pd intent show --lang ${lang}".`,
     });
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
@@ -228,9 +240,12 @@ export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
 export interface IntentShowOptions {
   workspace?: string;
   json?: boolean;
+  lang?: string;
 }
 
 export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
+  const lang = parseLang(opts.lang);
+
   // CLI Gate rule 6: workspace resolution inside try/catch for structured errors.
   let workspaceDir: string;
   try {
@@ -258,6 +273,8 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
   const flagsResult = computeFlagsFromLoadResult(configResult);
   const flagEnabled = isFeatureEnabled(flagsResult, 'intent_engineering');
 
+  const filename = getIntentFilename(lang);
+
   if (!flagEnabled) {
     const output: IntentShowOutput = {
       status: 'flag_disabled',
@@ -265,7 +282,7 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
       found: false,
       warnings: [],
       reason: 'flag_disabled',
-      nextAction: 'Enable the intent_engineering feature flag in .pd/config.yaml to read INTENT.md.',
+      nextAction: `Enable the intent_engineering feature flag in .pd/config.yaml to read ${filename}.`,
     };
     emitResult(output, {
       json: opts.json ?? false,
@@ -274,7 +291,7 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
     return;
   }
 
-  const filePath = getIntentFilePath(workspaceDir);
+  const filePath = getIntentFilePath(workspaceDir, lang);
 
   try {
     if (!fs.existsSync(filePath)) {
@@ -284,11 +301,11 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
         found: false,
         warnings: [],
         reason: 'not_found',
-        nextAction: `Create INTENT.md: pd intent init --workspace "${workspaceDir}"`,
+        nextAction: `Create ${filename}: pd intent init --lang ${lang} --workspace "${workspaceDir}"`,
       };
       emitResult(output, {
         json: opts.json ?? false,
-        formatText: (o) => `INTENT.md not found.\n→ ${o.nextAction}`,
+        formatText: (o) => `${filename} not found.\n→ ${o.nextAction}`,
       });
       return;
     }
@@ -301,11 +318,11 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
         found: true,
         warnings: [],
         reason: 'oversized',
-        nextAction: `INTENT.md exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content.`,
+        nextAction: `${filename} exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content.`,
       };
       emitResult(output, {
         json: opts.json ?? false,
-        formatText: (o) => `INTENT.md is too large.\n→ ${o.nextAction}`,
+        formatText: (o) => `${filename} is too large.\n→ ${o.nextAction}`,
       });
       return;
     }
@@ -327,7 +344,7 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
     };
     emitResult(output, {
       json: opts.json ?? false,
-      formatText: (o) => formatIntentShowText(o),
+      formatText: (o) => formatIntentShowText(o, filename),
     });
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
@@ -341,7 +358,7 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
     };
     emitResult(output, {
       json: opts.json ?? false,
-      formatText: (o) => `Error reading INTENT.md: ${o.reason}\n→ ${o.nextAction}`,
+      formatText: (o) => `Error reading ${filename}: ${o.reason}\n→ ${o.nextAction}`,
     });
     process.exitCode = 1;
   }
@@ -356,11 +373,12 @@ export function registerIntentCommand(parentCmd: Command): Command {
 
   intentCmd
     .command('init')
-    .description('Create .principles/INTENT.md from the canonical template')
+    .description('Create .principles/INTENT.{lang}.md from the canonical template')
     .option('-w, --workspace <path>', 'Workspace directory')
-    .option('--force', 'Overwrite existing INTENT.md')
+    .option('--force', 'Overwrite existing INTENT file')
     .option('--dry-run', 'Show what would happen without writing (default)')
-    .option('--confirm', 'Actually write the file (required to create INTENT.md)')
+    .option('--confirm', 'Actually write the file (required to create INTENT file)')
+    .option('--lang <lang>', 'Language: zh-CN or en (default: zh-CN)')
     .option('--json', 'Output raw JSON')
     .action(async (opts) => {
       await handleIntentInit({
@@ -369,18 +387,21 @@ export function registerIntentCommand(parentCmd: Command): Command {
         json: opts.json === true,
         dryRun: opts.dryRun === true,
         confirm: opts.confirm === true,
+        lang: opts.lang,
       });
     });
 
   intentCmd
     .command('show')
-    .description('Display a read-only summary of INTENT.md (sections, hash, warnings)')
+    .description('Display a read-only summary of INTENT.{lang}.md (sections, hash, warnings)')
     .option('-w, --workspace <path>', 'Workspace directory')
+    .option('--lang <lang>', 'Language: zh-CN or en (default: zh-CN)')
     .option('--json', 'Output raw JSON')
     .action(async (opts) => {
       await handleIntentShow({
         workspace: opts.workspace,
         json: opts.json === true,
+        lang: opts.lang,
       });
     });
 

--- a/packages/pd-cli/src/commands/intent.ts
+++ b/packages/pd-cli/src/commands/intent.ts
@@ -46,8 +46,21 @@ import { emitResult } from '../services/cli-output.js';
 
 const INTENT_DIR = '.principles';
 
-function parseLang(value: string | undefined): IntentLang {
-  return value === 'en' ? 'en' : 'zh-CN';
+/**
+ * Parse and validate the --lang option.
+ *
+ * Returns:
+ *   - 'zh-CN' | 'en' when value is undefined (default zh-CN) or a valid lang.
+ *   - null when value is a non-empty string that is neither 'zh-CN' nor 'en'.
+ *
+ * rc-9: invalid values MUST NOT silently fall back to zh-CN — that would
+ * let a typo like `--lang zh` quietly write to INTENT.zh-CN.md. Callers
+ * emit a structured `invalid_lang` error when null is returned.
+ */
+export function parseLang(value: string | undefined): IntentLang | null {
+  if (value === undefined) return 'zh-CN';
+  if (value === 'zh-CN' || value === 'en') return value;
+  return null;
 }
 
 // ── Output types ─────────────────────────────────────────────────────────────
@@ -61,7 +74,7 @@ export interface IntentInitOutput {
 }
 
 export interface IntentShowOutput {
-  status: 'ok' | 'flag_disabled' | 'not_found' | 'oversized' | 'read_error';
+  status: 'ok' | 'skipped' | 'flag_disabled' | 'not_found' | 'oversized' | 'read_error';
   flagEnabled: boolean;
   found: boolean;
   path?: string;
@@ -126,6 +139,23 @@ export interface IntentInitOptions {
 
 export async function handleIntentInit(opts: IntentInitOptions): Promise<void> {
   const lang = parseLang(opts.lang);
+
+  // rc-9: invalid --lang must not silently fall back. Emit structured error.
+  if (lang === null) {
+    const output: IntentInitOutput = {
+      status: 'skipped',
+      path: '',
+      overwritten: false,
+      reason: 'invalid_lang',
+      nextAction: `--lang must be 'zh-CN' or 'en'. Received: ${opts.lang ?? ''}`,
+    };
+    emitResult(output, {
+      json: opts.json ?? false,
+      formatText: (o) => `Error: ${o.reason}\n→ ${o.nextAction}`,
+    });
+    process.exitCode = 1;
+    return;
+  }
 
   // CLI Gate rule 4: --dry-run and --confirm must be mutually exclusive.
   if (opts.dryRun && opts.confirm) {
@@ -246,6 +276,24 @@ export interface IntentShowOptions {
 export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
   const lang = parseLang(opts.lang);
 
+  // rc-9: invalid --lang must not silently fall back. Emit structured error.
+  if (lang === null) {
+    const output: IntentShowOutput = {
+      status: 'skipped',
+      flagEnabled: false,
+      found: false,
+      warnings: [],
+      reason: 'invalid_lang',
+      nextAction: `--lang must be 'zh-CN' or 'en'. Received: ${opts.lang ?? ''}`,
+    };
+    emitResult(output, {
+      json: opts.json ?? false,
+      formatText: (o) => `Error: ${o.reason}\n→ ${o.nextAction}`,
+    });
+    process.exitCode = 1;
+    return;
+  }
+
   // CLI Gate rule 6: workspace resolution inside try/catch for structured errors.
   let workspaceDir: string;
   try {
@@ -301,7 +349,7 @@ export async function handleIntentShow(opts: IntentShowOptions): Promise<void> {
         found: false,
         warnings: [],
         reason: 'not_found',
-        nextAction: `Create ${filename}: pd intent init --lang ${lang} --workspace "${workspaceDir}"`,
+        nextAction: `Create ${filename}: pd intent init --confirm --lang ${lang} --workspace "${workspaceDir}"`,
       };
       emitResult(output, {
         json: opts.json ?? false,

--- a/packages/pd-cli/tests/commands/intent.test.ts
+++ b/packages/pd-cli/tests/commands/intent.test.ts
@@ -59,7 +59,7 @@ function writeConfig(intentEnabled: boolean): void {
 }
 
 function getIntentPath(): string {
-  return path.join(workspaceDir, '.principles', 'INTENT.md');
+  return path.join(workspaceDir, '.principles', 'INTENT.zh-CN.md');
 }
 
 const VALID_INTENT = `# INTENT.md
@@ -107,7 +107,7 @@ describe('handleIntentInit', () => {
     expect(logSpy).toHaveBeenCalled();
     const jsonOutput = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(jsonOutput.status).toBe('dry_run');
-    expect(jsonOutput.path).toContain('INTENT.md');
+    expect(jsonOutput.path).toContain('INTENT.zh-CN.md');
     expect(jsonOutput.reason).toBe('dry_run');
     expect(jsonOutput.nextAction).toContain('--confirm');
 
@@ -177,7 +177,7 @@ describe('handleIntentInit', () => {
     expect(logSpy).toHaveBeenCalled();
     const jsonOutput = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(jsonOutput.status).toBe('ok');
-    expect(jsonOutput.path).toContain('INTENT.md');
+    expect(jsonOutput.path).toContain('INTENT.zh-CN.md');
     expect(jsonOutput.overwritten).toBe(false);
 
     logSpy.mockRestore();
@@ -311,7 +311,7 @@ describe('handleIntentShow', () => {
     await handleIntentShow({ workspace: workspaceDir, json: false });
 
     const textOutput = logSpy.mock.calls[0][0] as string;
-    expect(textOutput).toContain('INTENT.md');
+    expect(textOutput).toContain('INTENT.zh-CN.md');
     expect(textOutput).toContain('Content hash:');
     expect(textOutput).toContain('Last edited:');
     expect(textOutput).toContain('## 1. Why');

--- a/packages/pd-console/src/server/models/IntentPageModel.ts
+++ b/packages/pd-console/src/server/models/IntentPageModel.ts
@@ -2,12 +2,14 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   INTENT_MAX_BYTES,
-  INTENT_DOC_TEMPLATE,
+  getIntentFilename,
+  createIntentTemplate,
   parseIntentDocSections,
   computeIntentContentHash,
   validateIntentDocSections,
   type IntentDocSections,
   type IntentDocWarning,
+  type IntentLang,
 } from '@principles/core/runtime-v2';
 
 export interface IntentPageResult {
@@ -50,7 +52,6 @@ export interface IntentRawContentResult {
   nextAction?: string;
 }
 
-const INTENT_FILENAME = 'INTENT.md';
 const INTENT_DIR = '.principles';
 
 export class IntentPageModel {
@@ -60,7 +61,7 @@ export class IntentPageModel {
     this.workspaceDir = workspaceDir;
   }
 
-  async getSummary(flagEnabled: boolean): Promise<IntentPageResult> {
+  async getSummary(flagEnabled: boolean, lang: IntentLang): Promise<IntentPageResult> {
     if (!flagEnabled) {
       return {
         ok: false,
@@ -68,11 +69,11 @@ export class IntentPageModel {
         flagEnabled: false,
         warnings: [],
         reason: 'flag_disabled',
-        nextAction: 'Enable the intent_engineering feature flag in .pd/config.yaml to read INTENT.md.',
+        nextAction: `Enable the intent_engineering feature flag in .pd/config.yaml to read ${getIntentFilename(lang)}.`,
       };
     }
 
-    const filePath = path.join(this.workspaceDir, INTENT_DIR, INTENT_FILENAME);
+    const filePath = path.join(this.workspaceDir, INTENT_DIR, getIntentFilename(lang));
 
     try {
       if (!fs.existsSync(filePath)) {
@@ -82,7 +83,7 @@ export class IntentPageModel {
           flagEnabled: true,
           warnings: [],
           reason: 'not_found',
-          nextAction: 'Create .principles/INTENT.md using "pd intent init".',
+          nextAction: `Create .principles/${getIntentFilename(lang)} using "pd intent init".`,
         };
       }
 
@@ -94,7 +95,7 @@ export class IntentPageModel {
           flagEnabled: true,
           warnings: [],
           reason: 'oversized',
-          nextAction: `INTENT.md exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content.`,
+          nextAction: `${getIntentFilename(lang)} exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content.`,
         };
       }
 
@@ -120,35 +121,19 @@ export class IntentPageModel {
         sections: sectionRecord,
       };
     } catch (err) {
-      // Runtime Contract Rule #9: log underlying error for observability
-      // while preserving the never-throws contract.
-      console.error('[IntentPageModel] failed to read INTENT.md:', err);
+      console.error(`[IntentPageModel] failed to read ${getIntentFilename(lang)}:`, err);
       return {
         ok: false,
         found: false,
         flagEnabled: true,
         warnings: [],
         reason: 'read_error',
-        nextAction: 'Check filesystem permissions for .principles/INTENT.md.',
+        nextAction: `Check filesystem permissions for .principles/${getIntentFilename(lang)}.`,
       };
     }
   }
 
-  /**
-   * Read the raw content of INTENT.md for editing.
-   *
-   * Returns a structured result so callers can distinguish failure modes
-   * (file missing / oversized / read error / flag disabled) — rc-9-no-silent-
-   * fallback (ERR-002). The previous implementation collapsed all three into a
-   * bare `null`, which forced the route to claim `not_found` even when the real
-   * reason was a permission or read failure.
-   *
-   * Stat-first size guard keeps this path consistent with `getSummary()`, which
-   * returns `reason='oversized'` for files > INTENT_MAX_BYTES. Without the guard
-   * here, oversized files would be silently read into memory and only rejected
-   * on save — inconsistent with the read-only `getSummary` contract.
-   */
-  async getRawContent(flagEnabled: boolean): Promise<IntentRawContentResult> {
+  async getRawContent(flagEnabled: boolean, lang: IntentLang): Promise<IntentRawContentResult> {
     if (!flagEnabled) {
       return {
         ok: false,
@@ -157,53 +142,40 @@ export class IntentPageModel {
       };
     }
 
-    const filePath = path.join(this.workspaceDir, INTENT_DIR, INTENT_FILENAME);
+    const filePath = path.join(this.workspaceDir, INTENT_DIR, getIntentFilename(lang));
 
     try {
       if (!fs.existsSync(filePath)) {
         return {
           ok: false,
           reason: 'not_found',
-          nextAction: 'INTENT.md does not exist. Create it first using POST /api/v1/intent/init.',
+          nextAction: `${getIntentFilename(lang)} does not exist. Create it first using POST /api/v1/intent/init.`,
         };
       }
 
-      // Stat-first size guard. Use stat.size (byte length on disk) for the
-      // oversized path; `Buffer.byteLength(content, 'utf8')` is only meaningful
-      // post-read — and reading a 32 KiB+ file just to reject it is wasteful.
       const stat = fs.statSync(filePath);
       if (stat.size > INTENT_MAX_BYTES) {
         return {
           ok: false,
           reason: 'oversized',
-          nextAction: `INTENT.md exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content before opening the editor.`,
+          nextAction: `${getIntentFilename(lang)} exceeds ${INTENT_MAX_BYTES} bytes (${stat.size} bytes). Reduce content before opening the editor.`,
         };
       }
 
       const content = fs.readFileSync(filePath, 'utf8');
       return { ok: true, content, path: filePath };
     } catch (err) {
-      // rc-9-no-silent-fallback: distinguish I/O / permission errors from
-      // "file missing" so the route can map to a real status code instead of
-      // claiming not_found for everything (combining ERR-002 + ERR-010).
       const message = err instanceof Error ? err.message : String(err);
-      console.error('[IntentPageModel] failed to read raw INTENT.md:', err);
+      console.error(`[IntentPageModel] failed to read raw ${getIntentFilename(lang)}:`, err);
       return {
         ok: false,
         reason: 'read_error',
-        nextAction: `Could not read INTENT.md: ${message}. Check filesystem permissions.`,
+        nextAction: `Could not read ${getIntentFilename(lang)}: ${message}. Check filesystem permissions.`,
       };
     }
   }
 
-  /**
-   * Create INTENT.md from the SPEC §7 template.
-   * - Does NOT overwrite an existing file unless force=true (EP-03 idempotent).
-   * - Creates .principles/ directory if it doesn't exist.
-   * - Owner-owned: this is triggered by Owner clicking "Create template" in UI,
-   *   NOT by Agent auto-modification (SPEC §3.9 boundary preserved).
-   */
-  async createTemplate(flagEnabled: boolean, force: boolean): Promise<IntentInitResult> {
+  async createTemplate(flagEnabled: boolean, force: boolean, lang: IntentLang): Promise<IntentInitResult> {
     if (!flagEnabled) {
       return {
         ok: false,
@@ -214,15 +186,13 @@ export class IntentPageModel {
     }
 
     const dirPath = path.join(this.workspaceDir, INTENT_DIR);
-    const filePath = path.join(dirPath, INTENT_FILENAME);
+    const filePath = path.join(dirPath, getIntentFilename(lang));
 
     try {
-      // Create .principles/ directory if it doesn't exist
       if (!fs.existsSync(dirPath)) {
         fs.mkdirSync(dirPath, { recursive: true });
       }
 
-      // Don't overwrite existing file unless force=true
       if (fs.existsSync(filePath) && !force) {
         return {
           ok: true,
@@ -233,14 +203,14 @@ export class IntentPageModel {
         };
       }
 
-      fs.writeFileSync(filePath, INTENT_DOC_TEMPLATE, 'utf8');
+      fs.writeFileSync(filePath, createIntentTemplate(lang), 'utf8');
       return {
         ok: true,
         created: true,
         path: filePath,
       };
     } catch (err) {
-      console.error('[IntentPageModel] failed to create INTENT.md:', err);
+      console.error(`[IntentPageModel] failed to create ${getIntentFilename(lang)}:`, err);
       return {
         ok: false,
         created: false,
@@ -250,13 +220,7 @@ export class IntentPageModel {
     }
   }
 
-  /**
-   * Save user-edited INTENT.md content.
-   * - Validates content size (INTENT_MAX_BYTES) and type.
-   * - Overwrites the existing file (Owner explicitly clicked "Save").
-   * - Returns updated summary (hash, warnings) for UI refresh.
-   */
-  async saveContent(flagEnabled: boolean, content: unknown): Promise<IntentSaveResult> {
+  async saveContent(flagEnabled: boolean, content: unknown, lang: IntentLang): Promise<IntentSaveResult> {
     if (!flagEnabled) {
       return {
         ok: false,
@@ -266,7 +230,6 @@ export class IntentPageModel {
       };
     }
 
-    // Runtime Contract Rule #1 + #2: treat input as unknown, validate with typeof
     if (typeof content !== 'string') {
       return {
         ok: false,
@@ -276,7 +239,6 @@ export class IntentPageModel {
       };
     }
 
-    // Rule #3: fail loud on empty content
     if (content.length === 0) {
       return {
         ok: false,
@@ -286,7 +248,6 @@ export class IntentPageModel {
       };
     }
 
-    // Validate size limit
     const byteLength = Buffer.byteLength(content, 'utf8');
     if (byteLength > INTENT_MAX_BYTES) {
       return {
@@ -298,7 +259,7 @@ export class IntentPageModel {
     }
 
     const dirPath = path.join(this.workspaceDir, INTENT_DIR);
-    const filePath = path.join(dirPath, INTENT_FILENAME);
+    const filePath = path.join(dirPath, getIntentFilename(lang));
 
     try {
       if (!fs.existsSync(dirPath)) {
@@ -307,7 +268,6 @@ export class IntentPageModel {
 
       fs.writeFileSync(filePath, content, 'utf8');
 
-      // Return updated summary for UI refresh
       const sections = parseIntentDocSections(content);
       const warnings = validateIntentDocSections(sections);
       const contentHash = computeIntentContentHash(content);
@@ -322,12 +282,12 @@ export class IntentPageModel {
         warnings,
       };
     } catch (err) {
-      console.error('[IntentPageModel] failed to save INTENT.md:', err);
+      console.error(`[IntentPageModel] failed to save ${getIntentFilename(lang)}:`, err);
       return {
         ok: false,
         saved: false,
         reason: 'write_error',
-        nextAction: 'Check filesystem permissions for .principles/INTENT.md.',
+        nextAction: `Check filesystem permissions for .principles/${getIntentFilename(lang)}.`,
       };
     }
   }

--- a/packages/pd-console/src/server/models/IntentPageModel.ts
+++ b/packages/pd-console/src/server/models/IntentPageModel.ts
@@ -75,7 +75,11 @@ function recordVersion(args: {
   content: string;
   reason: string;
 }): void {
-  if (!stateDbExists(args.workspaceDir)) return;
+  // Note: no stateDbExists short-circuit. SqliteConnection creates the .pd
+  // dir and state.db file (with intent_doc_versions table via CREATE TABLE
+  // IF NOT EXISTS) on first open. Short-circuiting here would silently drop
+  // the first-write version history on fresh workspaces — the operator
+  // would see an empty history panel after their very first save.
   try {
     const connection = new SqliteConnection({ workspaceDir: args.workspaceDir });
     try {

--- a/packages/pd-console/src/server/models/IntentPageModel.ts
+++ b/packages/pd-console/src/server/models/IntentPageModel.ts
@@ -7,8 +7,11 @@ import {
   parseIntentDocSections,
   computeIntentContentHash,
   validateIntentDocSections,
+  SqliteConnection,
+  SqliteIntentDocVersionStore,
   type IntentDocSections,
   type IntentDocWarning,
+  type IntentDocVersion,
   type IntentLang,
 } from '@principles/core/runtime-v2';
 
@@ -52,7 +55,39 @@ export interface IntentRawContentResult {
   nextAction?: string;
 }
 
+export interface IntentVersionResult {
+  ok: boolean;
+  versions?: IntentDocVersion[];
+  reason?: string;
+  nextAction?: string;
+}
+
 const INTENT_DIR = '.principles';
+
+function stateDbExists(workspaceDir: string): boolean {
+  return fs.existsSync(path.join(workspaceDir, '.pd', 'state.db'));
+}
+
+/** Best-effort version record — never blocks save on failure. */
+function recordVersion(args: {
+  workspaceDir: string;
+  lang: IntentLang;
+  content: string;
+  reason: string;
+}): void {
+  if (!stateDbExists(args.workspaceDir)) return;
+  try {
+    const connection = new SqliteConnection({ workspaceDir: args.workspaceDir });
+    try {
+      const store = new SqliteIntentDocVersionStore(connection);
+      store.saveVersion({ lang: args.lang, content: args.content, reason: args.reason });
+    } finally {
+      try { connection.close(); } catch { /* best-effort */ }
+    }
+  } catch {
+    // Version recording is best-effort — never block save on failure.
+  }
+}
 
 export class IntentPageModel {
   private readonly workspaceDir: string;
@@ -203,7 +238,9 @@ export class IntentPageModel {
         };
       }
 
-      fs.writeFileSync(filePath, createIntentTemplate(lang), 'utf8');
+      const templateContent = createIntentTemplate(lang);
+      fs.writeFileSync(filePath, templateContent, 'utf8');
+      recordVersion({ workspaceDir: this.workspaceDir, lang, content: templateContent, reason: 'init' });
       return {
         ok: true,
         created: true,
@@ -273,6 +310,8 @@ export class IntentPageModel {
       const contentHash = computeIntentContentHash(content);
       const stat = fs.statSync(filePath);
 
+      recordVersion({ workspaceDir: this.workspaceDir, lang, content, reason: 'save' });
+
       return {
         ok: true,
         saved: true,
@@ -288,6 +327,35 @@ export class IntentPageModel {
         saved: false,
         reason: 'write_error',
         nextAction: `Check filesystem permissions for .principles/${getIntentFilename(lang)}.`,
+      };
+    }
+  }
+
+  async getVersions(lang: IntentLang): Promise<IntentVersionResult> {
+    if (!stateDbExists(this.workspaceDir)) {
+      return {
+        ok: false,
+        reason: 'state_db_not_found',
+        nextAction: 'Run a PD command that creates state.db first (e.g. pd pain list).',
+      };
+    }
+
+    try {
+      const connection = new SqliteConnection({ workspaceDir: this.workspaceDir, readonly: true });
+      try {
+        const store = new SqliteIntentDocVersionStore(connection);
+        const versions = await store.listVersions(lang);
+        return { ok: true, versions };
+      } finally {
+        try { connection.close(); } catch { /* best-effort */ }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[IntentPageModel] failed to list versions:`, err);
+      return {
+        ok: false,
+        reason: 'read_error',
+        nextAction: `Could not read version history: ${message}`,
       };
     }
   }

--- a/packages/pd-console/src/server/routes/intent.ts
+++ b/packages/pd-console/src/server/routes/intent.ts
@@ -113,6 +113,18 @@ export async function handleIntentRoute(
       return;
     }
 
+    // ── GET /api/v1/intent/versions — list version history ────────────────
+    if (req.method === 'GET' && subPath === '/versions') {
+      const model = getModel(workspaceDir);
+      const result = await model.getVersions(lang);
+      if (!result.ok) {
+        sendSuccess(res, { versions: [], reason: result.reason, nextAction: result.nextAction });
+        return;
+      }
+      sendSuccess(res, { versions: result.versions });
+      return;
+    }
+
     // ── POST /api/v1/intent/init — create INTENT.md template ──────────────
     if (req.method === 'POST' && subPath === '/init') {
       const flagEnabled = loadFlagEnabled(workspaceDir);

--- a/packages/pd-console/src/server/routes/intent.ts
+++ b/packages/pd-console/src/server/routes/intent.ts
@@ -3,6 +3,14 @@ import { IntentPageModel } from '../models/IntentPageModel.js';
 import { sendSuccess, sendError, sendJson } from '../utils/response.js';
 import { loadPdConfig, computeFlagsFromLoadResult } from '../config/pd-config-store.js';
 import { readBody } from '../utils/request.js';
+import type { IntentLang } from '@principles/core/runtime-v2';
+
+/** Parse lang from query string; default 'zh-CN' if missing/invalid. */
+function parseLang(req: IncomingMessage): IntentLang {
+  const url = new URL(req.url ?? '', 'http://localhost');
+  const lang = url.searchParams.get('lang');
+  return lang === 'en' ? 'en' : 'zh-CN';
+}
 
 const MODEL_CACHE_TTL_MS = 30 * 1000;
 
@@ -56,12 +64,13 @@ export async function handleIntentRoute(
   ctx: IntentRouteContext,
 ): Promise<void> {
   const { workspaceDir, subPath } = ctx;
+  const lang = parseLang(req);
   try {
     // ── GET /api/v1/intent — read Intent summary ──────────────────────────
     if (req.method === 'GET' && subPath === '') {
       const flagEnabled = loadFlagEnabled(workspaceDir);
       const model = getModel(workspaceDir);
-      const summary = await model.getSummary(flagEnabled);
+      const summary = await model.getSummary(flagEnabled, lang);
       sendSuccess(res, summary);
       return;
     }
@@ -80,7 +89,7 @@ export async function handleIntentRoute(
       }
 
       const model = getModel(workspaceDir);
-      const result = await model.getRawContent(flagEnabled);
+      const result = await model.getRawContent(flagEnabled, lang);
 
       if (!result.ok) {
         // Map model error reason → HTTP status (rc-9-no-silent-fallback).
@@ -143,7 +152,7 @@ export async function handleIntentRoute(
       }
 
       const model = getModel(workspaceDir);
-      const result = await model.createTemplate(flagEnabled, force);
+      const result = await model.createTemplate(flagEnabled, force, lang);
 
       if (result.ok) {
         if (result.created) {
@@ -213,7 +222,7 @@ export async function handleIntentRoute(
       }
 
       const model = getModel(workspaceDir);
-      const result = await model.saveContent(flagEnabled, bodyObj.content);
+      const result = await model.saveContent(flagEnabled, bodyObj.content, lang);
 
       if (result.ok) {
         sendSuccess(res, result);

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -37,6 +37,7 @@ import {
   validateIntentInitResult,
   validateIntentSaveResult,
   validateIntentRawContent,
+  validateIntentVersions,
 } from "./utils/validators.js";
 import type {
   FeedbackReportData,
@@ -73,6 +74,7 @@ import type {
   IntentInitResultData,
   IntentSaveResultData,
   IntentRawContentData,
+  IntentVersionData,
 } from "./utils/validators.js";
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -489,26 +491,6 @@ async function saveIntentContent(content: string, lang: 'zh-CN' | 'en' = 'zh-CN'
   );
 }
 
-export interface IntentVersionEntry {
-  id: string;
-  lang: string;
-  contentHash: string;
-  contentSnapshot: string;
-  reason: string;
-  createdAt: string;
-}
-
-export interface IntentVersionData {
-  versions: IntentVersionEntry[];
-}
-
-function validateIntentVersions(data: unknown): IntentVersionData | null {
-  if (typeof data !== 'object' || data === null) return null;
-  const obj = data as Record<string, unknown>;
-  if (!Array.isArray(obj.versions)) return null;
-  return { versions: obj.versions as IntentVersionEntry[] };
-}
-
 async function fetchIntentVersions(lang: 'zh-CN' | 'en' = 'zh-CN'): Promise<ApiResponse<IntentVersionData>> {
   return request<IntentVersionData>(
     `/api/v1/intent/versions?lang=${lang}`,
@@ -705,6 +687,8 @@ export type {
   LinkCandidateFollowUpData,
   GuideRulehostFollowUpData,
   GeneratePatchProposalFollowUpData,
+  IntentVersionEntry,
+  IntentVersionData,
 } from "./utils/validators.js";
 
 // Consumer-facing type aliases (old names that pages import)

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -443,8 +443,8 @@ async function fetchEvidenceChain(): Promise<ApiResponse<EvidenceChainData>> {
 
 // ── Intent Summary (PRI-466) ─────────────────────────────────────────────────
 
-async function fetchIntentSummary(): Promise<ApiResponse<IntentSummaryData>> {
-  return request<IntentSummaryData>('/api/v1/intent', undefined, validateIntentSummary);
+async function fetchIntentSummary(lang: 'zh-CN' | 'en' = 'zh-CN'): Promise<ApiResponse<IntentSummaryData>> {
+  return request<IntentSummaryData>(`/api/v1/intent?lang=${lang}`, undefined, validateIntentSummary);
 }
 
 // ── Intent Init / Edit (PRI-477 onboarding) ──────────────────────────────────
@@ -452,9 +452,9 @@ async function fetchIntentSummary(): Promise<ApiResponse<IntentSummaryData>> {
 /**
  * Fetch raw INTENT.md content for editing via GET /api/v1/intent/content.
  */
-async function fetchIntentContent(): Promise<ApiResponse<IntentRawContentData>> {
+async function fetchIntentContent(lang: 'zh-CN' | 'en' = 'zh-CN'): Promise<ApiResponse<IntentRawContentData>> {
   return request<IntentRawContentData>(
-    '/api/v1/intent/content',
+    `/api/v1/intent/content?lang=${lang}`,
     undefined,
     validateIntentRawContent,
   );
@@ -464,9 +464,9 @@ async function fetchIntentContent(): Promise<ApiResponse<IntentRawContentData>> 
  * Create INTENT.md from the SPEC §7 template via POST /api/v1/intent/init.
  * Does NOT overwrite an existing file unless force=true.
  */
-async function createIntentTemplate(force = false): Promise<ApiResponse<IntentInitResultData>> {
+async function createIntentTemplate(force = false, lang: 'zh-CN' | 'en' = 'zh-CN'): Promise<ApiResponse<IntentInitResultData>> {
   return request<IntentInitResultData>(
-    '/api/v1/intent/init',
+    `/api/v1/intent/init?lang=${lang}`,
     {
       method: 'POST',
       body: JSON.stringify({ force }),
@@ -478,9 +478,9 @@ async function createIntentTemplate(force = false): Promise<ApiResponse<IntentIn
 /**
  * Save user-edited INTENT.md content via PUT /api/v1/intent/content.
  */
-async function saveIntentContent(content: string): Promise<ApiResponse<IntentSaveResultData>> {
+async function saveIntentContent(content: string, lang: 'zh-CN' | 'en' = 'zh-CN'): Promise<ApiResponse<IntentSaveResultData>> {
   return request<IntentSaveResultData>(
-    '/api/v1/intent/content',
+    `/api/v1/intent/content?lang=${lang}`,
     {
       method: 'PUT',
       body: JSON.stringify({ content }),

--- a/packages/pd-console/src/ui/api.ts
+++ b/packages/pd-console/src/ui/api.ts
@@ -489,6 +489,34 @@ async function saveIntentContent(content: string, lang: 'zh-CN' | 'en' = 'zh-CN'
   );
 }
 
+export interface IntentVersionEntry {
+  id: string;
+  lang: string;
+  contentHash: string;
+  contentSnapshot: string;
+  reason: string;
+  createdAt: string;
+}
+
+export interface IntentVersionData {
+  versions: IntentVersionEntry[];
+}
+
+function validateIntentVersions(data: unknown): IntentVersionData | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const obj = data as Record<string, unknown>;
+  if (!Array.isArray(obj.versions)) return null;
+  return { versions: obj.versions as IntentVersionEntry[] };
+}
+
+async function fetchIntentVersions(lang: 'zh-CN' | 'en' = 'zh-CN'): Promise<ApiResponse<IntentVersionData>> {
+  return request<IntentVersionData>(
+    `/api/v1/intent/versions?lang=${lang}`,
+    undefined,
+    validateIntentVersions,
+  );
+}
+
 // ── Intent Decisions (PRI-470) ───────────────────────────────────────────────
 
 /**
@@ -625,6 +653,7 @@ export {
   fetchIntentContent,
   createIntentTemplate,
   saveIntentContent,
+  fetchIntentVersions,
   recordIntentDecision,
   listIntentDecisionsByPainId,
   listIntentDecisionsByTaskId,

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -871,7 +871,8 @@
         "loadError": "Failed to load decision summary"
       },
       "langSelector": {
-        "ariaLabel": "Select INTENT.md language"
+        "ariaLabel": "Select INTENT.md language",
+        "disabledWhileEditing": "Save or cancel your edit before switching language"
       },
       "versionHistory": {
         "title": "Version History",

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -869,6 +869,14 @@
         "lastDecisionAtLabel": "Last decision",
         "noDecisions": "No decisions recorded yet",
         "loadError": "Failed to load decision summary"
+      },
+      "langSelector": {
+        "ariaLabel": "Select INTENT.md language"
+      },
+      "versionHistory": {
+        "title": "Version History",
+        "reasonInit": "Initialized",
+        "reasonSave": "Saved"
       }
     },
     "debt": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -869,6 +869,14 @@
         "lastDecisionAtLabel": "最近决策",
         "noDecisions": "暂无决策记录",
         "loadError": "加载决策摘要失败"
+      },
+      "langSelector": {
+        "ariaLabel": "选择 INTENT.md 语言"
+      },
+      "versionHistory": {
+        "title": "版本历史",
+        "reasonInit": "初始化",
+        "reasonSave": "保存"
       }
     },
     "debt": {

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -871,7 +871,8 @@
         "loadError": "加载决策摘要失败"
       },
       "langSelector": {
-        "ariaLabel": "选择 INTENT.md 语言"
+        "ariaLabel": "选择 INTENT.md 语言",
+        "disabledWhileEditing": "请先保存或取消编辑，再切换语言"
       },
       "versionHistory": {
         "title": "版本历史",

--- a/packages/pd-console/src/ui/pages/intent/IntentOnboarding.tsx
+++ b/packages/pd-console/src/ui/pages/intent/IntentOnboarding.tsx
@@ -170,9 +170,11 @@ interface IntentEditorProps {
   onSaved: () => void;
   /** Called when user cancels editing — parent should hide the editor */
   onCancel: () => void;
+  /** Language for bilingual INTENT.md */
+  lang: 'zh-CN' | 'en';
 }
 
-export function IntentEditor({ initialContent, onSaved, onCancel }: IntentEditorProps) {
+export function IntentEditor({ initialContent, onSaved, onCancel, lang }: IntentEditorProps) {
   const { t } = useTranslation();
   const [content, setContent] = useState(initialContent);
   const [saving, setSaving] = useState(false);
@@ -196,7 +198,7 @@ export function IntentEditor({ initialContent, onSaved, onCancel }: IntentEditor
     }
 
     setSaving(true);
-    const result = await saveIntentContent(content);
+    const result = await saveIntentContent(content, lang);
     setSaving(false);
 
     if (!result.success) {
@@ -330,9 +332,11 @@ interface CreateIntentButtonProps {
   onCreated: (openEditor: boolean) => void;
   /** If true, show onboarding modal before creating. If false, create directly. */
   showOnboarding?: boolean;
+  /** Language for bilingual INTENT.md */
+  lang: 'zh-CN' | 'en';
 }
 
-export function CreateIntentButton({ onCreated, showOnboarding = false }: CreateIntentButtonProps) {
+export function CreateIntentButton({ onCreated, showOnboarding = false, lang }: CreateIntentButtonProps) {
   const { t } = useTranslation();
   const [busy, setBusy] = useState(false);
   const [showOnboardingModal, setShowOnboardingModal] = useState(
@@ -341,7 +345,7 @@ export function CreateIntentButton({ onCreated, showOnboarding = false }: Create
 
   async function createTemplate(openEditor: boolean) {
     setBusy(true);
-    const result = await createIntentTemplate(false);
+    const result = await createIntentTemplate(false, lang);
     setBusy(false);
 
     if (!result.success) {

--- a/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
+++ b/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
@@ -4,8 +4,8 @@ import { toast } from "sonner";
 import { PageShell } from "../../components/layout/page-shell.js";
 import { PageLoading } from "../../components/layout/page-loading.js";
 import { SectionTitle } from "../../components/layout/section-title.js";
-import { fetchIntentSummary, fetchIntentDecisionSummary, patchFeatureFlag, fetchIntentContent } from "../../api.js";
-import type { IntentSummaryData, IntentDocWarningData, IntentDecisionSummaryData } from "../../api.js";
+import { fetchIntentSummary, fetchIntentDecisionSummary, patchFeatureFlag, fetchIntentContent, fetchIntentVersions } from "../../api.js";
+import type { IntentSummaryData, IntentDocWarningData, IntentDecisionSummaryData, IntentVersionEntry } from "../../api.js";
 import { OnboardingModal, IntentEditor, CreateIntentButton, EditButton } from "./IntentOnboarding.js";
 
 // ── Page state ────────────────────────────────────────────────────────────────
@@ -321,6 +321,8 @@ export function IntentPage() {
   const [editorLoading, setEditorLoading] = useState(false);
   // Bilingual: language selector state
   const [lang, setLang] = useState<'zh-CN' | 'en'>('zh-CN');
+  // Version history
+  const [versions, setVersions] = useState<IntentVersionEntry[]>([]);
 
   const loadData = useCallback(async () => {
     setPageState("loading");
@@ -335,6 +337,12 @@ export function IntentPage() {
     // result.data is already validated by validateIntentSummary in the API layer
     setData(result.data);
     setPageState("loaded");
+    // Load version history in parallel (best-effort, never blocks page)
+    fetchIntentVersions(lang).then(v => {
+      if (v.success && v.data?.versions) {
+        setVersions(v.data.versions);
+      }
+    }).catch(() => { /* best-effort */ });
   }, [t, lang]);
 
   useEffect(() => {
@@ -586,6 +594,24 @@ export function IntentPage() {
             section appears regardless of whether INTENT.md was found/OK. */}
         {summary && summary.flagEnabled && (
           <DecisionSummarySection />
+        )}
+
+        {/* Version History — shows saved INTENT.md versions from SQLite */}
+        {versions.length > 0 && (
+          <details className="border border-line rounded-[3px] mt-6">
+            <summary className="cursor-pointer px-4 py-2 text-[13px] font-medium text-ink-2 select-none">
+              {t("pages.intent.versionHistory.title")} ({versions.length})
+            </summary>
+            <div className="px-4 py-2 border-t border-line">
+              {versions.map((v) => (
+                <div key={v.id} className="flex items-center gap-3 py-1 text-[12px] font-mono text-ink-2">
+                  <span className="text-ink-3">{v.createdAt.slice(0, 19).replace('T', ' ')}</span>
+                  <span className="px-1.5 py-0.5 rounded-[2px] bg-surface-2 text-ink-3">{v.reason}</span>
+                  <span className="text-ink-3">{v.contentHash.slice(0, 12)}</span>
+                </div>
+              ))}
+            </div>
+          </details>
         )}
       </div>
     </PageShell>

--- a/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
+++ b/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
@@ -137,7 +137,7 @@ function FlagToggleCard({ flagEnabled, onAfterEnable }: FlagToggleCardProps) {
   );
 }
 
-function NotFoundBanner({ onCreated }: { onCreated: (openEditor: boolean) => void }) {
+function NotFoundBanner({ onCreated, lang }: { onCreated: (openEditor: boolean) => void; lang: 'zh-CN' | 'en' }) {
   const { t } = useTranslation();
   return (
     <div className="bg-panel border border-line rounded-[6px] p-5">
@@ -148,7 +148,7 @@ function NotFoundBanner({ onCreated }: { onCreated: (openEditor: boolean) => voi
         {t("pages.intent.notFound.description")}
       </p>
       <div className="flex items-center gap-3">
-        <CreateIntentButton onCreated={onCreated} showOnboarding={true} />
+        <CreateIntentButton onCreated={onCreated} showOnboarding={true} lang={lang} />
         <span className="text-ink-4 text-[12px] font-mono">
           {t("pages.intent.notFound.nextAction")}
         </span>
@@ -319,11 +319,13 @@ export function IntentPage() {
   const [isEditing, setIsEditing] = useState(false);
   const [editorContent, setEditorContent] = useState("");
   const [editorLoading, setEditorLoading] = useState(false);
+  // Bilingual: language selector state
+  const [lang, setLang] = useState<'zh-CN' | 'en'>('zh-CN');
 
   const loadData = useCallback(async () => {
     setPageState("loading");
     setErrorMsg(null);
-    const result = await fetchIntentSummary();
+    const result = await fetchIntentSummary(lang);
     if (!result.success) {
       // ERR-002: graceful degradation with reason
       setErrorMsg(result.error ?? t("pages.intent.loadError"));
@@ -333,7 +335,7 @@ export function IntentPage() {
     // result.data is already validated by validateIntentSummary in the API layer
     setData(result.data);
     setPageState("loaded");
-  }, [t]);
+  }, [t, lang]);
 
   useEffect(() => {
     loadData();
@@ -342,7 +344,7 @@ export function IntentPage() {
   // PRI-477: Called when user clicks "Edit" — fetch raw content and open editor
   const handleStartEdit = useCallback(async () => {
     setEditorLoading(true);
-    const result = await fetchIntentContent();
+    const result = await fetchIntentContent(lang);
     setEditorLoading(false);
     if (!result.success) {
       toast.error(t("pages.intent.loadError"));
@@ -350,7 +352,7 @@ export function IntentPage() {
     }
     setEditorContent(result.data.content);
     setIsEditing(true);
-  }, [t]);
+  }, [t, lang]);
 
   // PRI-477: Called when template is created — refresh summary; optionally
   // open the editor immediately so the user can start filling.
@@ -364,13 +366,13 @@ export function IntentPage() {
     await loadData();
     if (!openEditor) return;
     setEditorLoading(true);
-    const result = await fetchIntentContent();
+    const result = await fetchIntentContent(lang);
     setEditorLoading(false);
     if (result.success) {
       setEditorContent(result.data.content);
       setIsEditing(true);
     }
-  }, [loadData]);
+  }, [loadData, lang]);
 
   // PRI-477: Called after successful save — close editor and refresh summary
   const handleSaved = useCallback(() => {
@@ -438,6 +440,16 @@ export function IntentPage() {
           {summary && (
             <FlagStatusBadge enabled={summary.flagEnabled} />
           )}
+          {/* Bilingual language selector */}
+          <select
+            value={lang}
+            onChange={(e) => setLang(e.target.value as 'zh-CN' | 'en')}
+            className="ml-auto border border-line bg-surface text-ink-2 rounded-[3px] px-2 py-1 text-[12px] font-mono focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
+            aria-label={t("pages.intent.langSelector.ariaLabel")}
+          >
+            <option value="zh-CN">中文</option>
+            <option value="en">English</option>
+          </select>
         </div>
         <p className="text-ink-3 text-[14px] max-w-[760px] leading-relaxed mb-7">
           {t("pages.intent.subtitle")}
@@ -453,7 +465,7 @@ export function IntentPage() {
 
         {/* Flag-on but file not found — PRI-477: add Create button + onboarding */}
         {summary && summary.flagEnabled && !summary.found && summary.reason === "not_found" && (
-          <NotFoundBanner onCreated={handleCreated} />
+          <NotFoundBanner onCreated={handleCreated} lang={lang} />
         )}
 
         {/* Flag-on but oversized */}
@@ -474,6 +486,7 @@ export function IntentPage() {
                   initialContent={editorContent}
                   onSaved={handleSaved}
                   onCancel={handleCancelEdit}
+                  lang={lang}
                 />
               </section>
             )}

--- a/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
+++ b/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
@@ -468,12 +468,18 @@ export function IntentPage() {
           {summary && (
             <FlagStatusBadge enabled={summary.flagEnabled} />
           )}
-          {/* Bilingual language selector */}
+          {/* Bilingual language selector
+              Disabled while editing to prevent silent loss of unsaved changes.
+              The P0 useEffect on [lang] resets editor state on lang change —
+              without disabling, switching lang mid-edit would discard the
+              user's draft with no confirmation. */}
           <select
             value={lang}
             onChange={(e) => setLang(e.target.value as 'zh-CN' | 'en')}
-            className="ml-auto border border-line bg-surface text-ink-2 rounded-[3px] px-2 py-1 text-[12px] font-mono focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
+            disabled={isEditing || editorLoading}
+            className="ml-auto border border-line bg-surface text-ink-2 rounded-[3px] px-2 py-1 text-[12px] font-mono focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
             aria-label={t("pages.intent.langSelector.ariaLabel")}
+            title={isEditing || editorLoading ? t("pages.intent.langSelector.disabledWhileEditing") : undefined}
           >
             <option value="zh-CN">中文</option>
             <option value="en">English</option>

--- a/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
+++ b/packages/pd-console/src/ui/pages/intent/IntentPage.tsx
@@ -324,6 +324,14 @@ export function IntentPage() {
   // Version history
   const [versions, setVersions] = useState<IntentVersionEntry[]>([]);
 
+  // Map raw backend reason codes to localized labels for the version history panel.
+  // Unknown reasons fall back to the raw string (observability over silent masking).
+  const versionReasonLabel = useCallback((reason: string): string => {
+    if (reason === 'init') return t("pages.intent.versionHistory.reasonInit");
+    if (reason === 'save') return t("pages.intent.versionHistory.reasonSave");
+    return reason;
+  }, [t]);
+
   const loadData = useCallback(async () => {
     setPageState("loading");
     setErrorMsg(null);
@@ -348,6 +356,18 @@ export function IntentPage() {
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // P0 fix: when language changes, reset editor state and stale versions.
+  // Without this, switching language while editing would keep the editor open
+  // with the old language's content — and saving would write that content
+  // into the NEW language's file (data corruption).
+  // Also clears stale versions so the panel doesn't show the old language's
+  // history while the new language's fetch is in flight or has failed.
+  useEffect(() => {
+    setIsEditing(false);
+    setEditorContent("");
+    setVersions([]);
+  }, [lang]);
 
   // PRI-477: Called when user clicks "Edit" — fetch raw content and open editor
   const handleStartEdit = useCallback(async () => {
@@ -606,7 +626,9 @@ export function IntentPage() {
               {versions.map((v) => (
                 <div key={v.id} className="flex items-center gap-3 py-1 text-[12px] font-mono text-ink-2">
                   <span className="text-ink-3">{v.createdAt.slice(0, 19).replace('T', ' ')}</span>
-                  <span className="px-1.5 py-0.5 rounded-[2px] bg-surface-2 text-ink-3">{v.reason}</span>
+                  <span className="px-1.5 py-0.5 rounded-[2px] bg-surface-2 text-ink-3">
+                    {versionReasonLabel(v.reason)}
+                  </span>
                   <span className="text-ink-3">{v.contentHash.slice(0, 12)}</span>
                 </div>
               ))}

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -2072,3 +2072,45 @@ export function validateIntentSaveResult(v: unknown): IntentSaveResultData | nul
 
   return result;
 }
+
+// ── Intent Version History (PRI-467) ─────────────────────────────────────────
+
+export interface IntentVersionEntry {
+  id: string;
+  lang: string;
+  contentHash: string;
+  contentSnapshot: string;
+  reason: string;
+  createdAt: string;
+}
+
+export interface IntentVersionData {
+  versions: IntentVersionEntry[];
+}
+
+function validateIntentVersionEntry(v: unknown): IntentVersionEntry | null {
+  if (!isObject(v)) return null;
+  // Required string fields — fail loud on missing or wrong type (rc-3, rc-4)
+  if (!Object.hasOwn(v, 'id') || !isString(v.id)) return null;
+  if (!Object.hasOwn(v, 'lang') || !isString(v.lang)) return null;
+  if (!Object.hasOwn(v, 'contentHash') || !isString(v.contentHash)) return null;
+  if (!Object.hasOwn(v, 'contentSnapshot') || !isString(v.contentSnapshot)) return null;
+  if (!Object.hasOwn(v, 'reason') || !isString(v.reason)) return null;
+  if (!Object.hasOwn(v, 'createdAt') || !isString(v.createdAt)) return null;
+  return {
+    id: v.id,
+    lang: v.lang,
+    contentHash: v.contentHash,
+    contentSnapshot: v.contentSnapshot,
+    reason: v.reason,
+    createdAt: v.createdAt,
+  };
+}
+
+export function validateIntentVersions(v: unknown): IntentVersionData | null {
+  if (!isObject(v)) return null;
+  if (!Object.hasOwn(v, 'versions') || !Array.isArray(v.versions)) return null;
+  const versions = validateArray(v.versions, validateIntentVersionEntry);
+  if (versions === null) return null;
+  return { versions };
+}

--- a/packages/pd-console/tests/e2e/intent-onboarding-flow.spec.ts
+++ b/packages/pd-console/tests/e2e/intent-onboarding-flow.spec.ts
@@ -116,7 +116,9 @@ test.describe.serial('PRI-477 Intent onboarding flow', () => {
     expect(body.success).toBe(true);
     expect(body.data.ok).toBe(true);
     expect(body.data.created).toBe(true);
-    expect(body.data.path).toContain('INTENT.md');
+    // Bilingual convention: filename is INTENT.${lang}.md (e.g. INTENT.zh-CN.md)
+    expect(body.data.path).toContain('INTENT.');
+    expect(body.data.path).toMatch(/INTENT\.(zh-CN|en)\.md$/);
   });
 
   test('POST /intent/init idempotent — already_exists without force', async () => {
@@ -152,7 +154,8 @@ test.describe.serial('PRI-477 Intent onboarding flow', () => {
     expect(typeof body.data.content).toBe('string');
     expect(body.data.content.length).toBeGreaterThan(0);
     expect(body.data.content).toContain('# INTENT.md');
-    expect(body.data.path).toContain('INTENT.md');
+    // Bilingual convention: filename is INTENT.${lang}.md (e.g. INTENT.zh-CN.md)
+    expect(body.data.path).toMatch(/INTENT\.(zh-CN|en)\.md$/);
   });
 
   // ── Step 6: PUT /intent/content 保存内容 ───────────────────────────────────

--- a/packages/pd-console/tests/models/intent-page-model.test.ts
+++ b/packages/pd-console/tests/models/intent-page-model.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 function writeIntent(content: string): void {
-  fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), content, 'utf8');
+  fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), content, 'utf8');
 }
 
 const VALID_INTENT = `# INTENT.md
@@ -57,7 +57,7 @@ Validate the smallest loop: Pain to Principle to Delta.
 describe('IntentPageModel — flag-off short-circuit', () => {
   it('returns flag_disabled without filesystem access', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(false);
+    const result = await model.getSummary(false, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.found).toBe(false);
     expect(result.flagEnabled).toBe(false);
@@ -68,7 +68,7 @@ describe('IntentPageModel — flag-off short-circuit', () => {
   it('does not read INTENT.md when flag is off', async () => {
     writeIntent(VALID_INTENT);
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(false);
+    const result = await model.getSummary(false, 'zh-CN');
     expect(result.reason).toBe('flag_disabled');
     expect(result.found).toBe(false);
   });
@@ -77,7 +77,7 @@ describe('IntentPageModel — flag-off short-circuit', () => {
 describe('IntentPageModel — flag-on, file missing', () => {
   it('returns not_found when INTENT.md does not exist', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.found).toBe(false);
     expect(result.reason).toBe('not_found');
@@ -90,7 +90,7 @@ describe('IntentPageModel — flag-on, file oversized', () => {
     const big = '# INTENT.md\n\n## 1. Why\n\n' + 'x'.repeat(33 * 1024) + '\n';
     writeIntent(big);
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.found).toBe(true);
     expect(result.reason).toBe('oversized');
@@ -101,11 +101,11 @@ describe('IntentPageModel — flag-on, valid file', () => {
   it('parses sections and returns hash/mtime', async () => {
     writeIntent(VALID_INTENT);
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.found).toBe(true);
     expect(result.flagEnabled).toBe(true);
-    expect(result.path).toContain('INTENT.md');
+    expect(result.path).toContain('INTENT.zh-CN.md');
     expect(result.contentHash).toMatch(/^sha256:/);
     expect(result.lastEditedAt).toBeDefined();
     expect(result.sections).toBeDefined();
@@ -116,7 +116,7 @@ describe('IntentPageModel — flag-on, valid file', () => {
   it('returns empty warnings for valid INTENT.md', async () => {
     writeIntent(VALID_INTENT);
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.warnings).toEqual([]);
   });
 });
@@ -125,7 +125,7 @@ describe('IntentPageModel — missing sections', () => {
   it('emits missing_section warnings for partial INTENT.md', async () => {
     writeIntent(`# INTENT.md\n\n## 1. Why\n\nJust the why section.\n`);
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.warnings.length).toBe(4);
     expect(result.warnings.every(w => w.code === 'missing_section')).toBe(true);
@@ -135,7 +135,7 @@ describe('IntentPageModel — missing sections', () => {
 describe('IntentPageModel — never-throws contract', () => {
   it('does not throw when workspaceDir does not exist', async () => {
     const model = new IntentPageModel(INVALID_PATH);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBeDefined();
   });
@@ -144,7 +144,7 @@ describe('IntentPageModel — never-throws contract', () => {
     fs.rmSync(principlesDir, { recursive: true, force: true });
     fs.writeFileSync(principlesDir, 'not a directory');
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBeDefined();
   });
@@ -153,9 +153,9 @@ describe('IntentPageModel — never-throws contract', () => {
     // Create a directory at the INTENT.md path: existsSync returns true,
     // statSync succeeds (small size), but readFileSync throws EISDIR.
     // This triggers the catch block in getSummary().
-    fs.mkdirSync(path.join(principlesDir, 'INTENT.md'), { recursive: true });
+    fs.mkdirSync(path.join(principlesDir, 'INTENT.zh-CN.md'), { recursive: true });
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getSummary(true);
+    const result = await model.getSummary(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.found).toBe(false);
     expect(result.flagEnabled).toBe(true);
@@ -169,42 +169,42 @@ describe('IntentPageModel — never-throws contract', () => {
 describe('IntentPageModel — createTemplate', () => {
   it('creates INTENT.md from template when file does not exist', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.createTemplate(true, false);
+    const result = await model.createTemplate(true, false, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.created).toBe(true);
-    expect(result.path).toContain('INTENT.md');
+    expect(result.path).toContain('INTENT.zh-CN.md');
 
     // Verify file exists and contains template content
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toContain('# INTENT.md');
     expect(content).toContain('## 1. Why');
   });
 
   it('returns already_exists without overwriting when file exists and force=false', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), 'existing content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'existing content', 'utf8');
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.createTemplate(true, false);
+    const result = await model.createTemplate(true, false, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.created).toBe(false);
     expect(result.reason).toBe('already_exists');
     expect(result.nextAction).toBeDefined();
 
     // File was NOT overwritten
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toBe('existing content');
   });
 
   it('overwrites existing file when force=true', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), 'old content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'old content', 'utf8');
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.createTemplate(true, true);
+    const result = await model.createTemplate(true, true, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.created).toBe(true);
 
     // File WAS overwritten with template
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toContain('# INTENT.md');
     expect(content).not.toContain('old content');
   });
@@ -215,18 +215,18 @@ describe('IntentPageModel — createTemplate', () => {
     expect(fs.existsSync(principlesDir)).toBe(false);
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.createTemplate(true, false);
+    const result = await model.createTemplate(true, false, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.created).toBe(true);
 
     // Directory and file should now exist
     expect(fs.existsSync(principlesDir)).toBe(true);
-    expect(fs.existsSync(path.join(principlesDir, 'INTENT.md'))).toBe(true);
+    expect(fs.existsSync(path.join(principlesDir, 'INTENT.zh-CN.md'))).toBe(true);
   });
 
   it('returns flag_disabled when flag is off', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.createTemplate(false, false);
+    const result = await model.createTemplate(false, false, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.created).toBe(false);
     expect(result.reason).toBe('flag_disabled');
@@ -235,7 +235,7 @@ describe('IntentPageModel — createTemplate', () => {
 
   it('returns write_error when workspaceDir does not exist', async () => {
     const model = new IntentPageModel(INVALID_PATH);
-    const result = await model.createTemplate(true, false);
+    const result = await model.createTemplate(true, false, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.created).toBe(false);
     expect(result.reason).toBe('write_error');
@@ -246,18 +246,18 @@ describe('IntentPageModel — createTemplate', () => {
 
 describe('IntentPageModel — getRawContent', () => {
   it('returns raw content when file exists', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), '# My Intent\n\ntest', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), '# My Intent\n\ntest', 'utf8');
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getRawContent(true);
+    const result = await model.getRawContent(true, 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.content).toBe('# My Intent\n\ntest');
-    expect(result.path).toContain('INTENT.md');
+    expect(result.path).toContain('INTENT.zh-CN.md');
   });
 
   it('returns not_found when file does not exist', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getRawContent(true);
+    const result = await model.getRawContent(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('not_found');
     expect(result.nextAction).toBeDefined();
@@ -265,10 +265,10 @@ describe('IntentPageModel — getRawContent', () => {
 
   it('returns oversized when file > 32KB (stat-first guard)', async () => {
     const big = '# INTENT.md\n\n## 1. Why\n\n' + 'x'.repeat(33 * 1024) + '\n';
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), big, 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), big, 'utf8');
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getRawContent(true);
+    const result = await model.getRawContent(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('oversized');
     expect(result.nextAction).toContain('32768');
@@ -276,7 +276,7 @@ describe('IntentPageModel — getRawContent', () => {
 
   it('returns flag_disabled when flag is off', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.getRawContent(false);
+    const result = await model.getRawContent(false, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('flag_disabled');
     expect(result.nextAction).toBeDefined();
@@ -287,7 +287,7 @@ describe('IntentPageModel — getRawContent', () => {
     // false, so the model returns not_found (not read_error). This is correct:
     // the file genuinely doesn't exist.
     const model = new IntentPageModel(INVALID_PATH);
-    const result = await model.getRawContent(true);
+    const result = await model.getRawContent(true, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('not_found');
     expect(result.nextAction).toBeDefined();
@@ -299,27 +299,27 @@ describe('IntentPageModel — getRawContent', () => {
 describe('IntentPageModel — saveContent', () => {
   it('saves valid content and returns updated metadata', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, '# INTENT.md\n\nnew content');
+    const result = await model.saveContent(true, '# INTENT.md\n\nnew content', 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.saved).toBe(true);
-    expect(result.path).toContain('INTENT.md');
+    expect(result.path).toContain('INTENT.zh-CN.md');
     expect(result.contentHash).toMatch(/^sha256:/);
     expect(result.lastEditedAt).toBeDefined();
 
     // Verify file was written
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toBe('# INTENT.md\n\nnew content');
   });
 
   it('overwrites existing file', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), 'old content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'old content', 'utf8');
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, 'new content');
+    const result = await model.saveContent(true, 'new content', 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.saved).toBe(true);
 
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toBe('new content');
   });
 
@@ -327,15 +327,15 @@ describe('IntentPageModel — saveContent', () => {
     fs.rmSync(principlesDir, { recursive: true, force: true });
 
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, 'content');
+    const result = await model.saveContent(true, 'content', 'zh-CN');
     expect(result.ok).toBe(true);
     expect(fs.existsSync(principlesDir)).toBe(true);
-    expect(fs.existsSync(path.join(principlesDir, 'INTENT.md'))).toBe(true);
+    expect(fs.existsSync(path.join(principlesDir, 'INTENT.zh-CN.md'))).toBe(true);
   });
 
   it('returns invalid_content when content is not a string', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, 123);
+    const result = await model.saveContent(true, 123, 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.saved).toBe(false);
     expect(result.reason).toBe('invalid_content');
@@ -343,7 +343,7 @@ describe('IntentPageModel — saveContent', () => {
 
   it('returns empty_content when content is empty string', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, '');
+    const result = await model.saveContent(true, '', 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.saved).toBe(false);
     expect(result.reason).toBe('empty_content');
@@ -351,7 +351,7 @@ describe('IntentPageModel — saveContent', () => {
 
   it('returns oversized when content > 32KB', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, 'x'.repeat(33 * 1024));
+    const result = await model.saveContent(true, 'x'.repeat(33 * 1024), 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.saved).toBe(false);
     expect(result.reason).toBe('oversized');
@@ -360,7 +360,7 @@ describe('IntentPageModel — saveContent', () => {
 
   it('returns flag_disabled when flag is off', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(false, 'content');
+    const result = await model.saveContent(false, 'content', 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.saved).toBe(false);
     expect(result.reason).toBe('flag_disabled');
@@ -369,7 +369,7 @@ describe('IntentPageModel — saveContent', () => {
 
   it('returns write_error when workspaceDir does not exist', async () => {
     const model = new IntentPageModel(INVALID_PATH);
-    const result = await model.saveContent(true, 'content');
+    const result = await model.saveContent(true, 'content', 'zh-CN');
     expect(result.ok).toBe(false);
     expect(result.saved).toBe(false);
     expect(result.reason).toBe('write_error');
@@ -377,7 +377,7 @@ describe('IntentPageModel — saveContent', () => {
 
   it('returns warnings for content with missing sections', async () => {
     const model = new IntentPageModel(workspaceDir);
-    const result = await model.saveContent(true, '# INTENT.md\n\n## 1. Why\n\nOnly why section.\n');
+    const result = await model.saveContent(true, '# INTENT.md\n\n## 1. Why\n\nOnly why section.\n', 'zh-CN');
     expect(result.ok).toBe(true);
     expect(result.warnings).toBeDefined();
     expect(result.warnings!.length).toBeGreaterThan(0);

--- a/packages/pd-console/tests/server/routes/intent.test.ts
+++ b/packages/pd-console/tests/server/routes/intent.test.ts
@@ -158,10 +158,10 @@ describe('Intent route — POST /api/v1/intent/init', () => {
     const body = parseBody(res);
     expect(body.success).toBe(true);
     expect(body.data.created).toBe(true);
-    expect(body.data.path).toContain('INTENT.md');
+    expect(body.data.path).toContain('INTENT.zh-CN.md');
 
     // Verify file exists on disk
-    const intentPath = path.join(principlesDir, 'INTENT.md');
+    const intentPath = path.join(principlesDir, 'INTENT.zh-CN.md');
     expect(fs.existsSync(intentPath)).toBe(true);
     const content = fs.readFileSync(intentPath, 'utf8');
     expect(content).toContain('# INTENT.md');
@@ -170,7 +170,7 @@ describe('Intent route — POST /api/v1/intent/init', () => {
 
   it('returns 200 with created=false when file already exists', async () => {
     // Pre-create the file
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), 'existing content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'existing content', 'utf8');
 
     const res = makeRes();
     await handleIntentRoute(makePostReq('/api/v1/intent/init', {}), res, { workspaceDir, subPath: '/init' });
@@ -181,12 +181,12 @@ describe('Intent route — POST /api/v1/intent/init', () => {
     expect(body.data.reason).toBe('already_exists');
 
     // Verify file was NOT overwritten
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toBe('existing content');
   });
 
   it('overwrites existing file when force=true', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), 'old content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'old content', 'utf8');
 
     const res = makeRes();
     await handleIntentRoute(makePostReq('/api/v1/intent/init', { force: true }), res, { workspaceDir, subPath: '/init' });
@@ -195,7 +195,7 @@ describe('Intent route — POST /api/v1/intent/init', () => {
     expect(body.data.created).toBe(true);
 
     // Verify file WAS overwritten with template
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toContain('# INTENT.md');
     expect(content).not.toContain('old content');
   });
@@ -211,7 +211,7 @@ describe('Intent route — POST /api/v1/intent/init', () => {
 
     // Directory and file should now exist
     expect(fs.existsSync(principlesDir)).toBe(true);
-    expect(fs.existsSync(path.join(principlesDir, 'INTENT.md'))).toBe(true);
+    expect(fs.existsSync(path.join(principlesDir, 'INTENT.zh-CN.md'))).toBe(true);
   });
 
   it('returns 403 when flag is disabled', async () => {
@@ -242,7 +242,7 @@ describe('Intent route — POST /api/v1/intent/init', () => {
 
 describe('Intent route — GET /api/v1/intent/content', () => {
   it('returns raw content when file exists', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), '# My Intent\n\ntest content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), '# My Intent\n\ntest content', 'utf8');
 
     const res = makeRes();
     await handleIntentRoute(makeGetReq('/api/v1/intent/content'), res, { workspaceDir, subPath: '/content' });
@@ -250,7 +250,7 @@ describe('Intent route — GET /api/v1/intent/content', () => {
     const body = parseBody(res);
     expect(body.data.content).toContain('# My Intent');
     expect(body.data.content).toContain('test content');
-    expect(body.data.path).toContain('INTENT.md');
+    expect(body.data.path).toContain('INTENT.zh-CN.md');
   });
 
   it('returns 404 when file does not exist', async () => {
@@ -278,7 +278,7 @@ describe('Intent route — GET /api/v1/intent/content', () => {
     // the file > INTENT_MAX_BYTES. Without this guard the editor would silently
     // load a > 32 KiB document while the read-only summary page rejects it.
     fs.writeFileSync(
-      path.join(principlesDir, 'INTENT.md'),
+      path.join(principlesDir, 'INTENT.zh-CN.md'),
       '# INTENT.md\n\n## 1. Why\n\n' + 'x'.repeat(33 * 1024) + '\n',
       'utf8',
     );
@@ -308,12 +308,12 @@ describe('Intent route — PUT /api/v1/intent/content', () => {
     expect(body.data.lastEditedAt).toBeTruthy();
 
     // Verify file was written
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toBe('# My Intent\n\nnew content');
   });
 
   it('overwrites existing file', async () => {
-    fs.writeFileSync(path.join(principlesDir, 'INTENT.md'), 'old content', 'utf8');
+    fs.writeFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'old content', 'utf8');
 
     const res = makeRes();
     await handleIntentRoute(
@@ -323,7 +323,7 @@ describe('Intent route — PUT /api/v1/intent/content', () => {
     );
     expect(getStatus(res)).toBe(200);
 
-    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.md'), 'utf8');
+    const content = fs.readFileSync(path.join(principlesDir, 'INTENT.zh-CN.md'), 'utf8');
     expect(content).toBe('new content');
   });
 

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1734,8 +1734,12 @@ export { SimpleLRU, DetectionFunnelCore } from './detection/index.js';
 export {
   INTENT_MAX_BYTES,
   INTENT_DOC_TEMPLATE,
+  INTENT_DOC_TEMPLATE_ZH,
+  INTENT_DOC_TEMPLATE_EN,
   INTENT_INJECT_MAX_CHARS,
   INTENT_TRUNCATION_MARKER,
+  getIntentFilename,
+  createIntentTemplate,
   parseIntentDocSections,
   computeIntentContentHash,
   validateIntentDocSections,
@@ -1757,6 +1761,7 @@ export type {
   IntentDecisionRecordResult,
   IntentDecisionSummary,
   IntentDecisionStore,
+  IntentLang,
   FollowUpPatch,
   IntentPatchProposal,
 } from './intent/index.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1771,7 +1771,7 @@ export type {
 } from './intent/index.js';
 
 // PRI-470: IntentDecisionRecord durable SQLite store (SPEC §21.7).
-export { SqliteIntentDecisionStore } from './store/intent/index.js';
+export { SqliteIntentDecisionStore, SqliteIntentDocVersionStore } from './store/intent/index.js';
 
 // Risk calculator — pure line-change estimation migrated from plugin (Stage 3)
 export type { FileModification } from './risk/index.js';

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1746,6 +1746,8 @@ export {
   buildIntentFrictionBlock,
   NullIntentDocReader,
   generateIntentPatchProposal,
+  computeVersionDiff,
+  formatVersionSummary,
 } from './intent/index.js';
 export type {
   IntentDocSections,
@@ -1762,6 +1764,8 @@ export type {
   IntentDecisionSummary,
   IntentDecisionStore,
   IntentLang,
+  IntentDocVersion,
+  IntentDocVersionStore,
   FollowUpPatch,
   IntentPatchProposal,
 } from './intent/index.js';

--- a/packages/principles-core/src/runtime-v2/intent/__tests__/intent-doc-version.test.ts
+++ b/packages/principles-core/src/runtime-v2/intent/__tests__/intent-doc-version.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeVersionDiff,
+  formatVersionSummary,
+  type IntentDocVersion,
+} from '../intent-doc-version.js';
+
+describe('computeVersionDiff', () => {
+  it('returns 5 section entries with changed=false for identical content', () => {
+    const content = '## 1. Why\nsame\n## 2. Desired Outcome\nsame\n';
+    const diff = computeVersionDiff(content, content);
+    expect(diff).toHaveLength(5);
+    expect(diff.every(d => d.changed === false)).toBe(true);
+  });
+
+  it('detects changed sections', () => {
+    const old = '## 1. Why\nold text\n## 2. Desired Outcome\nsame\n';
+    const next = '## 1. Why\nnew text\n## 2. Desired Outcome\nsame\n';
+    const diff = computeVersionDiff(old, next);
+    const whyDiff = diff.find(d => d.section === 'why');
+    expect(whyDiff?.changed).toBe(true);
+  });
+
+  it('detects unchanged sections alongside changed ones', () => {
+    const old = '## 1. Why\nold\n## 2. Desired Outcome\nsame content here\n';
+    const next = '## 1. Why\nnew\n## 2. Desired Outcome\nsame content here\n';
+    const diff = computeVersionDiff(old, next);
+    const desiredDiff = diff.find(d => d.section === 'desiredOutcome');
+    expect(desiredDiff?.changed).toBe(false);
+  });
+
+  it('treats missing section as empty string for comparison', () => {
+    const old = '## 1. Why\nhas content\n';
+    const next = '## 1. Why\nhas content\n## 2. Desired Outcome\nnew\n';
+    const diff = computeVersionDiff(old, next);
+    const desiredDiff = diff.find(d => d.section === 'desiredOutcome');
+    expect(desiredDiff?.changed).toBe(true);
+  });
+});
+
+describe('formatVersionSummary', () => {
+  it('formats version with index and preview', () => {
+    const version: IntentDocVersion = {
+      id: 'abc-123',
+      lang: 'zh-CN',
+      contentHash: 'sha256:def',
+      contentSnapshot: '## 1. Why\n这是很长的内容，需要被截断到80个字符以内显示预览。',
+      reason: '初始创建',
+      createdAt: '2026-06-28T10:00:00.000Z',
+    };
+    const summary = formatVersionSummary(version, 0);
+    expect(summary.label).toContain('初始创建');
+    expect(summary.label).toContain('v1');
+    expect(summary.preview.length).toBeLessThanOrEqual(80);
+  });
+
+  it('handles missing reason', () => {
+    const version: IntentDocVersion = {
+      id: 'abc-456',
+      lang: 'zh-CN',
+      contentHash: 'sha256:ghi',
+      contentSnapshot: 'content',
+      reason: null,
+      createdAt: '2026-06-28T10:00:00.000Z',
+    };
+    const summary = formatVersionSummary(version, 1);
+    expect(summary.label).toContain('v2');
+  });
+
+  it('truncates long previews with ellipsis', () => {
+    const longText = 'A'.repeat(200);
+    const version: IntentDocVersion = {
+      id: 'abc-789',
+      lang: 'en',
+      contentHash: 'sha256:jkl',
+      contentSnapshot: longText,
+      reason: 'edit',
+      createdAt: '2026-06-28T10:00:00.000Z',
+    };
+    const summary = formatVersionSummary(version, 0);
+    expect(summary.preview.length).toBeLessThanOrEqual(80);
+    expect(summary.preview.endsWith('...')).toBe(true);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/intent/__tests__/intent-doc-version.test.ts
+++ b/packages/principles-core/src/runtime-v2/intent/__tests__/intent-doc-version.test.ts
@@ -54,7 +54,7 @@ describe('formatVersionSummary', () => {
     expect(summary.preview.length).toBeLessThanOrEqual(80);
   });
 
-  it('handles missing reason', () => {
+  it('handles missing reason with zh-CN fallback', () => {
     const version: IntentDocVersion = {
       id: 'abc-456',
       lang: 'zh-CN',
@@ -65,6 +65,21 @@ describe('formatVersionSummary', () => {
     };
     const summary = formatVersionSummary(version, 1);
     expect(summary.label).toContain('v2');
+    expect(summary.label).toContain('无备注');
+  });
+
+  it('handles missing reason with en fallback (no Chinese text)', () => {
+    const version: IntentDocVersion = {
+      id: 'abc-en',
+      lang: 'en',
+      contentHash: 'sha256:en',
+      contentSnapshot: 'content',
+      reason: null,
+      createdAt: '2026-06-28T10:00:00.000Z',
+    };
+    const summary = formatVersionSummary(version, 0);
+    expect(summary.label).toContain('(no note)');
+    expect(summary.label).not.toContain('无备注');
   });
 
   it('truncates long previews with ellipsis', () => {

--- a/packages/principles-core/src/runtime-v2/intent/__tests__/intent-doc.test.ts
+++ b/packages/principles-core/src/runtime-v2/intent/__tests__/intent-doc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { INTENT_MAX_BYTES, INTENT_DOC_TEMPLATE, parseIntentDocSections, computeIntentContentHash, validateIntentDocSections, type IntentDocWarning, type IntentDocSections } from '../intent-doc.js';
+import { INTENT_MAX_BYTES, INTENT_DOC_TEMPLATE, parseIntentDocSections, computeIntentContentHash, validateIntentDocSections, type IntentDocWarning, type IntentDocSections, INTENT_DOC_TEMPLATE_ZH, INTENT_DOC_TEMPLATE_EN, getIntentFilename, createIntentTemplate } from '../intent-doc.js';
 
 const VALID = `# INTENT.md
 
@@ -91,5 +91,36 @@ describe('constants', () => {
   it('template has 5 headers', () => {
     expect(INTENT_DOC_TEMPLATE).toContain('## 1. Why');
     expect(INTENT_DOC_TEMPLATE).toContain('## 5. Current Strategic Focus');
+  });
+});
+
+describe('Intent bilingual templates', () => {
+  it('getIntentFilename returns lang-suffixed filename', () => {
+    expect(getIntentFilename('zh-CN')).toBe('INTENT.zh-CN.md');
+    expect(getIntentFilename('en')).toBe('INTENT.en.md');
+  });
+
+  it('INTENT_DOC_TEMPLATE_ZH contains Chinese guidance prompts', () => {
+    expect(INTENT_DOC_TEMPLATE_ZH).toContain('这个项目');
+    expect(INTENT_DOC_TEMPLATE_ZH).toContain('## 1. Why');
+  });
+
+  it('INTENT_DOC_TEMPLATE_EN contains enhanced prompts', () => {
+    expect(INTENT_DOC_TEMPLATE_EN).toContain('Why does this project matter?');
+    expect(INTENT_DOC_TEMPLATE_EN).toContain('## 1. Why');
+  });
+
+  it('createIntentTemplate returns correct template per lang', () => {
+    expect(createIntentTemplate('zh-CN')).toBe(INTENT_DOC_TEMPLATE_ZH);
+    expect(createIntentTemplate('en')).toBe(INTENT_DOC_TEMPLATE_EN);
+  });
+
+  it('both templates parse to 5 sections with same keys', () => {
+    const zhSections = parseIntentDocSections(INTENT_DOC_TEMPLATE_ZH);
+    const enSections = parseIntentDocSections(INTENT_DOC_TEMPLATE_EN);
+    const zhKeys = Object.keys(zhSections).sort();
+    const enKeys = Object.keys(enSections).sort();
+    expect(zhKeys).toEqual(['currentStrategicFocus', 'desiredOutcome', 'nonNegotiables', 'stopEscalation', 'why']);
+    expect(enKeys).toEqual(zhKeys);
   });
 });

--- a/packages/principles-core/src/runtime-v2/intent/index.ts
+++ b/packages/principles-core/src/runtime-v2/intent/index.ts
@@ -3,3 +3,4 @@ export * from './intent-friction-block.js';
 export * from './intent-doc-reader-port.js';
 export * from './intent-decision-record.js';
 export * from './intent-patch-proposal.js';
+export * from './intent-doc-version.js';

--- a/packages/principles-core/src/runtime-v2/intent/intent-doc-version.ts
+++ b/packages/principles-core/src/runtime-v2/intent/intent-doc-version.ts
@@ -1,0 +1,43 @@
+import { parseIntentDocSections, type IntentLang } from './intent-doc.js';
+
+export interface IntentDocVersion {
+  id: string;
+  lang: IntentLang;
+  contentHash: string;
+  contentSnapshot: string;
+  reason: string | null;
+  createdAt: string;
+}
+
+export interface IntentDocVersionStore {
+  saveVersion(input: { lang: IntentLang; content: string; reason?: string }): Promise<IntentDocVersion>;
+  listVersions(lang: IntentLang, limit?: number): Promise<IntentDocVersion[]>;
+  getVersion(id: string): Promise<IntentDocVersion | null>;
+  getLatest(lang: IntentLang): Promise<IntentDocVersion | null>;
+}
+
+const SECTION_KEYS = ['why', 'desiredOutcome', 'nonNegotiables', 'stopEscalation', 'currentStrategicFocus'] as const;
+
+export function computeVersionDiff(
+  oldContent: string,
+  newContent: string,
+): { section: string; changed: boolean }[] {
+  const oldSections = parseIntentDocSections(oldContent);
+  const newSections = parseIntentDocSections(newContent);
+  return SECTION_KEYS.map(key => ({
+    section: key,
+    changed: (oldSections[key] ?? '') !== (newSections[key] ?? ''),
+  }));
+}
+
+export function formatVersionSummary(
+  version: IntentDocVersion,
+  index: number,
+): { label: string; preview: string } {
+  const versionNumber = `v${index + 1}`;
+  const reason = version.reason ?? '无备注';
+  const label = `${versionNumber} · ${reason}`;
+  const previewText = version.contentSnapshot.replace(/##\s*\d+\.\s*[^\n]*/g, '').trim();
+  const preview = previewText.length > 80 ? previewText.slice(0, 77) + '...' : previewText;
+  return { label, preview };
+}

--- a/packages/principles-core/src/runtime-v2/intent/intent-doc-version.ts
+++ b/packages/principles-core/src/runtime-v2/intent/intent-doc-version.ts
@@ -35,7 +35,9 @@ export function formatVersionSummary(
   index: number,
 ): { label: string; preview: string } {
   const versionNumber = `v${index + 1}`;
-  const reason = version.reason ?? '无备注';
+  // Language-aware fallback for missing reason (CodeRabbit review):
+  // English versions should not show Chinese default text.
+  const reason = version.reason ?? (version.lang === 'en' ? '(no note)' : '无备注');
   const label = `${versionNumber} · ${reason}`;
   const previewText = version.contentSnapshot.replace(/##\s*\d+\.\s*[^\n]*/g, '').trim();
   const preview = previewText.length > 80 ? previewText.slice(0, 77) + '...' : previewText;

--- a/packages/principles-core/src/runtime-v2/intent/intent-doc.ts
+++ b/packages/principles-core/src/runtime-v2/intent/intent-doc.ts
@@ -58,3 +58,76 @@ When must the Agent stop and ask?
 
 What is the current strategic trade-off?
 `;
+
+export type IntentLang = 'zh-CN' | 'en';
+
+export function getIntentFilename(lang: IntentLang): string {
+  return `INTENT.${lang}.md`;
+}
+
+export const INTENT_DOC_TEMPLATE_ZH = `# INTENT.md
+
+## 1. Why
+
+这个项目 / 阶段为什么重要？
+它服务于什么长期目标？
+它不只是要完成什么任务，而是要解决什么真实问题？
+
+## 2. Desired Outcome
+
+完成后，世界应该发生什么可观察的变化？
+什么结果能说明我们更接近目标？
+避免写"让产品更好"这种不可比较描述。
+
+## 3. Non-negotiables
+
+为了达成目标，哪些东西不能被牺牲？
+例如：Owner 注意力、用户信任、MVP 速度、安全边界、可维护性、品牌调性。
+
+## 4. Stop / Escalation
+
+什么情况下 Agent 必须停下、询问或升级给 Owner？
+
+注意：这些是软升级条件；除非另行编码进 RuleHost，否则不构成硬拦截。
+
+## 5. Current Strategic Focus
+
+当前阶段最重要的战略取舍是什么？
+例如：验证痛点优先于架构完美；发布 MVP 优先于功能完整；保护 Owner 注意力优先于自动化覆盖率。
+`;
+
+export const INTENT_DOC_TEMPLATE_EN = `# INTENT.md
+
+## 1. Why
+
+Why does this project matter?
+What long-term goal does it serve?
+What real problem does it solve — beyond just completing tasks?
+
+## 2. Desired Outcome
+
+After completion, what observable change should happen in the world?
+What result would indicate we are closer to the goal?
+Avoid non-comparable descriptions like "make the product better".
+
+## 3. Non-negotiables
+
+To achieve the goal, what cannot be sacrificed?
+Examples: Owner attention, user trust, MVP speed, security boundaries, maintainability, brand voice.
+
+## 4. Stop / Escalation
+
+Under what circumstances must the Agent stop, ask, or escalate to Owner?
+
+Note: These are soft escalation conditions; unless separately encoded into RuleHost, they do not constitute hard blocks.
+
+## 5. Current Strategic Focus
+
+What is the most important strategic trade-off for the current phase?
+Examples: Validating pain points over architectural perfection; Shipping MVP over feature completeness; Protecting Owner attention over automation coverage.
+`;
+
+export function createIntentTemplate(lang: IntentLang): string {
+  if (lang === 'zh-CN') return INTENT_DOC_TEMPLATE_ZH;
+  return INTENT_DOC_TEMPLATE_EN;
+}

--- a/packages/principles-core/src/runtime-v2/store/intent/__tests__/sqlite-intent-doc-version-store.test.ts
+++ b/packages/principles-core/src/runtime-v2/store/intent/__tests__/sqlite-intent-doc-version-store.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SqliteIntentDocVersionStore tests (SPEC bilingual+lifecycle).
+ *
+ * Verifies saveVersion, listVersions (DESC order, lang isolation),
+ * getVersion (null for unknown), getLatest, and rc-2 type-guard mapRow.
+ *
+ * ERR checklist:
+ * - EP-01 / ERR-001, ERR-005: DB rows treated as unknown, mapped via guards
+ * - EP-03 / ERR-002: write failures throw (fail loud)
+ * - rc-2: no `as` bypass — all row fields validated element-wise
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import { SqliteConnection } from '../../sqlite-connection.js';
+import { SqliteIntentDocVersionStore } from '../sqlite-intent-doc-version-store.js';
+import { computeIntentContentHash } from '../../../intent/intent-doc.js';
+
+function createTestConnection(): SqliteConnection {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pd-test-intent-doc-version-'));
+  return new SqliteConnection(tmpDir);
+}
+
+describe('SqliteIntentDocVersionStore', () => {
+  let connection = null as unknown as SqliteConnection;
+  let store = null as unknown as SqliteIntentDocVersionStore;
+
+  beforeEach(() => {
+    connection = createTestConnection();
+    connection.getDb();
+    store = new SqliteIntentDocVersionStore(connection);
+  });
+
+  afterEach(() => {
+    connection?.close();
+  });
+
+  it('saveVersion inserts a record and returns it', async () => {
+    const content = '## 1. Why\ntest';
+    const version = await store.saveVersion({ lang: 'zh-CN', content });
+    expect(version.id).toBeTruthy();
+    expect(version.contentHash).toBe(computeIntentContentHash(content));
+    expect(version.contentSnapshot).toBe(content);
+    expect(version.lang).toBe('zh-CN');
+  });
+
+  it('saveVersion stores optional reason', async () => {
+    const version = await store.saveVersion({ lang: 'en', content: 'x', reason: 'first edit' });
+    expect(version.reason).toBe('first edit');
+  });
+
+  it('saveVersion stores null reason when not provided', async () => {
+    const version = await store.saveVersion({ lang: 'en', content: 'x' });
+    expect(version.reason).toBeNull();
+  });
+
+  it('listVersions returns versions in DESC order by createdAt', async () => {
+    await store.saveVersion({ lang: 'zh-CN', content: 'v1', reason: 'first' });
+    await store.saveVersion({ lang: 'zh-CN', content: 'v2', reason: 'second' });
+    const versions = await store.listVersions('zh-CN');
+    expect(versions).toHaveLength(2);
+    expect(versions[0]?.reason).toBe('second');
+    expect(versions[1]?.reason).toBe('first');
+  });
+
+  it('listVersions isolates by lang', async () => {
+    await store.saveVersion({ lang: 'zh-CN', content: 'zh' });
+    await store.saveVersion({ lang: 'en', content: 'en' });
+    expect(await store.listVersions('zh-CN')).toHaveLength(1);
+    expect(await store.listVersions('en')).toHaveLength(1);
+  });
+
+  it('getVersion returns null for unknown id', async () => {
+    expect(await store.getVersion('nonexistent')).toBeNull();
+  });
+
+  it('getLatest returns null on empty', async () => {
+    expect(await store.getLatest('zh-CN')).toBeNull();
+  });
+
+  it('getLatest returns most recent version', async () => {
+    await store.saveVersion({ lang: 'zh-CN', content: 'old' });
+    await store.saveVersion({ lang: 'zh-CN', content: 'new' });
+    const latest = await store.getLatest('zh-CN');
+    expect(latest?.contentSnapshot).toBe('new');
+  });
+
+  it('mapRow returns null for malformed row (rc-2 compliance)', async () => {
+    const db = connection.getDb();
+    db.exec(`INSERT INTO intent_doc_versions (id, lang, content_hash, content_snapshot, created_at) VALUES ('bad', 'not-a-lang', 'hash', 'snap', '2026-01-01')`);
+    const result = await store.getVersion('bad');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/store/intent/index.ts
+++ b/packages/principles-core/src/runtime-v2/store/intent/index.ts
@@ -1,5 +1,6 @@
 /**
- * Barrel for the IntentDecisionRecord SQLite store (PRI-470).
+ * Barrel for the IntentDecisionRecord and IntentDocVersion SQLite stores.
  */
 export { SqliteIntentDecisionStore } from './sqlite-intent-decision-store.js';
 export type { IntentDecisionStore } from '../../intent/intent-decision-record.js';
+export { SqliteIntentDocVersionStore } from './sqlite-intent-doc-version-store.js';

--- a/packages/principles-core/src/runtime-v2/store/intent/sqlite-intent-doc-version-store.ts
+++ b/packages/principles-core/src/runtime-v2/store/intent/sqlite-intent-doc-version-store.ts
@@ -1,0 +1,102 @@
+/**
+ * SqliteIntentDocVersionStore — SQLite implementation of IntentDocVersionStore.
+ *
+ * SPEC bilingual+lifecycle: stores immutable snapshots of INTENT.md content
+ * each time it changes, enabling version history and rollback. Mirrors the
+ * intent_decisions audit pattern (immutable snapshots, hash linkage).
+ *
+ * ERR checklist:
+ * - EP-01 / ERR-001, ERR-005: DB rows treated as unknown, mapped via guards
+ * - EP-03 / ERR-002: write failures throw (fail loud)
+ * - rc-2: no `as` bypass — all row fields validated element-wise via isIntentDocVersionRow
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { SqliteConnection } from '../sqlite-connection.js';
+import { computeIntentContentHash, type IntentLang } from '../../intent/intent-doc.js';
+import type { IntentDocVersion, IntentDocVersionStore } from '../../intent/intent-doc-version.js';
+
+function isIntentLang(value: unknown): value is IntentLang {
+  return value === 'zh-CN' || value === 'en';
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+interface IntentDocVersionRow {
+  id: string;
+  lang: IntentLang;
+  content_hash: string;
+  content_snapshot: string;
+  reason: string | null;
+  created_at: string;
+}
+
+function isIntentDocVersionRow(v: unknown): v is IntentDocVersionRow {
+  if (!isRecord(v)) return false;
+  if (typeof v.id !== 'string') return false;
+  if (!isIntentLang(v.lang)) return false;
+  if (typeof v.content_hash !== 'string') return false;
+  if (typeof v.content_snapshot !== 'string') return false;
+  if (v.reason !== null && typeof v.reason !== 'string') return false;
+  if (typeof v.created_at !== 'string') return false;
+  return true;
+}
+
+function mapRow(r: IntentDocVersionRow): IntentDocVersion {
+  return {
+    id: r.id,
+    lang: r.lang,
+    contentHash: r.content_hash,
+    contentSnapshot: r.content_snapshot,
+    reason: r.reason,
+    createdAt: r.created_at,
+  };
+}
+
+export class SqliteIntentDocVersionStore implements IntentDocVersionStore {
+  constructor(private readonly connection: SqliteConnection) {}
+
+  async saveVersion(input: { lang: IntentLang; content: string; reason?: string }): Promise<IntentDocVersion> {
+    const db = this.connection.getDb();
+    const id = randomUUID();
+    const contentHash = computeIntentContentHash(input.content);
+    const createdAt = new Date().toISOString();
+    const reason = input.reason ?? null;
+    db.prepare(
+      `INSERT INTO intent_doc_versions (id, lang, content_hash, content_snapshot, reason, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(id, input.lang, contentHash, input.content, reason, createdAt);
+    const row = db.prepare(`SELECT * FROM intent_doc_versions WHERE id = ?`).get(id);
+    if (!isIntentDocVersionRow(row)) {
+      throw new Error(`saveVersion: failed to read back inserted record ${id}`);
+    }
+    return mapRow(row);
+  }
+
+  async listVersions(lang: IntentLang, limit = 50): Promise<IntentDocVersion[]> {
+    const db = this.connection.getDb();
+    const rows = db.prepare(
+      `SELECT * FROM intent_doc_versions WHERE lang = ? ORDER BY created_at DESC, rowid DESC LIMIT ?`,
+    ).all(lang, limit);
+    return rows
+      .filter(isIntentDocVersionRow)
+      .map(mapRow);
+  }
+
+  async getVersion(id: string): Promise<IntentDocVersion | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare(`SELECT * FROM intent_doc_versions WHERE id = ?`).get(id);
+    if (!isIntentDocVersionRow(row)) return null;
+    return mapRow(row);
+  }
+
+  async getLatest(lang: IntentLang): Promise<IntentDocVersion | null> {
+    const db = this.connection.getDb();
+    const row = db.prepare(
+      `SELECT * FROM intent_doc_versions WHERE lang = ? ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+    ).get(lang);
+    if (!isIntentDocVersionRow(row)) return null;
+    return mapRow(row);
+  }
+}

--- a/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
+++ b/packages/principles-core/src/runtime-v2/store/sqlite-connection.ts
@@ -483,6 +483,21 @@ export class SqliteConnection {
         WHERE pain_id IS NOT NULL;
     `);
 
+    // INTENT.md doc version snapshots (SPEC bilingual+lifecycle).
+    // Mirrors the intent_decisions audit pattern: immutable snapshots, hash linkage.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS intent_doc_versions (
+        id TEXT PRIMARY KEY,
+        lang TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        content_snapshot TEXT NOT NULL,
+        reason TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_intent_doc_versions_lang
+        ON intent_doc_versions(lang, created_at DESC);
+    `);
+
     // P2-10: Minimal schema_version table for state.db migration tracking.
     // core cannot import plugin's MigrationRunner (dependency direction),
     // so this is a lightweight version that records schema version history.


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无（SPEC 驱动：`docs/superpowers/specs/2026-06-25-PD Intent Engineering MVP SPEC.md` 后续迭代）
- 解决的产品问题（一句话）: INTENT.md 双语支持（zh-CN / en）+ 版本历史可追溯，消除跨语言缓存污染与版本丢失风险
- emotional-value：降低 [失控感/重复纠正感] 创造 [沉淀感/掌控感]
  - 如无明确情绪价值，说明为何仍是必要的: N/A
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- 双语模板与语言工具：`INTENT.zh-CN.md` / `INTENT.en.md` 命名约定，`IntentLang` 类型，`getIntentFilename(lang)`、`createIntentTemplate(lang)`、`resolveIntentLang(workspaceDir)` 文件存在检测
- Core 纯逻辑层：`IntentDocVersion` 类型 + `SqliteIntentDocVersionStore`（`intent_doc_versions` 表：id/lang/content_hash/content_snapshot/reason/created_at）
- CLI 双语化：`pd intent init --lang <zh-CN|en>`、`pd intent show --lang <zh-CN|en>`，文件名按 lang 解析（无旧版兼容）
- Hooks 双语化：`prompt.ts` 与 `pain.ts` 通过 `resolveIntentLang()` 自动检测当前语言；缓存键 `${workspaceDir}:${lang}` 防污染
- Console UI：语言下拉选择器 + `GET /api/v1/intent/versions` 路由 + `IntentPage` 底部 `<details>` 版本历史面板（best-effort 写入，失败不阻塞保存）

### 影响范围
- [x] packages/principles-core
- [x] packages/openclaw-plugin
- [x] packages/pd-cli
- [x] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否
- [ ] 是（需 maintainer 批准，附理由）: ___

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 启用 `intent_engineering` flag（`.pd/config.yaml` 或 Console 切换）
- [ ] 动作 1: `pd intent init --lang en`
  - 观察: 工作区 `.principles/INTENT.en.md` 被创建；终端输出 `Created INTENT.en.md at ...`
- [ ] 动作 2: `pd intent show --lang en`
  - 观察: 终端打印英文模板内容
- [ ] 动作 3: 在 Console 打开 Intent 页面，从语言下拉切换到 "English"
  - 观察: 页面摘要/编辑器/版本历史全部基于 `INTENT.en.md`
- [ ] 动作 4: 在 Console 编辑并保存 INTENT 内容
  - 观察: 底部版本历史面板出现新条目，包含 reason、createdAt、contentHash 前 12 位
- 证据（截图/CLI 输出关键行）: 测试输出 53/53 通过

## 风险与可逆性（agent 填）
- 主要风险: 双语切换可能让 owner 困惑哪个文件是当前生效版本；通过 `resolveIntentLang()` 优先级（zh-CN > en > 默认 zh-CN）降低风险
- 回滚方式: [x] PR revert  [ ] feature flag  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否（沿用既有 `intent_engineering` flag，无新增 flag）
  - [ ] 是（名称: ___）
  - 规则引用: `mvp-q-3-how-disabled` —— 已有 `intent_engineering` flag 覆盖
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会。owner 是双语产品开发者，单语 INTENT.md 已造成实际摩擦
- `mvp-q-2-how-observed`: 如何观察它生效？CLI `--lang` flag + Console 语言下拉 + `INTENT.${lang}.md` 文件
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（无新文档需求；SPEC 文档丢失，靠既有 SPEC 与代码注释维持契约）
- [x] 无破坏性变更（或已标记为 breaking change）—— 文件名从 `INTENT.md` 改为 `INTENT.${lang}.md`，**仅影响启用 intent_engineering 的当前用户**，由于 owner 是当前唯一用户且明确要求无兼容，按预期
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：未删除源文件
- [x] Core 边界检查：本 PR 在 `packages/principles-core/src/runtime-v2/store/intent/` 新增了 `sqlite-intent-doc-version-store.ts`，但 store 目录已在白名单中（既有 `sqlite-intent-decision-store.ts` 同模式）；未新增 `fs`/`path` 到 core
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性 — 仅当修改 `packages/principles-core/src/**/sqlite-*-store.ts` 时填写）

- [x] N/A — 本 PR 新增 `sqlite-intent-doc-version-store.ts`（新文件，非契约修改）；既有 `sqlite-intent-decision-store.ts` 未修改

### ERR Checklist（必填）

- ERR-001 (parsed JSON as any): 本 PR 中 `routes/intent.ts` PUT/POST body 严格按 rc-1/rc-2 用 `typeof` + `Object.hasOwn` 校验，未用 `as` 绕过
- ERR-013 (in vs Object.hasOwn): `routes/intent.ts` 使用 `Object.hasOwn(bodyObj, 'content')` 而非 `in`
- ERR-002 (silent fallback): `IntentPageModel.recordVersion()` best-effort 失败时静默 catch，但**仅用于辅助版本记录**，主保存路径仍返回成功；`getVersions()` 失败时返回 `{ ok: false, reason, nextAction }` 不静默
- ERR-005 (array element validation): `validateIntentVersions` 校验 `Array.isArray(obj.versions)` 后整体断言；后续可补充元素字段校验

### Runtime Contract 自检（必填）

- [x] 本 PR 处理不可信数据
- [x] `rc-1-treat-as-unknown` — PUT/POST body 视为 `unknown`，先 JSON.parse 再 typeof 校验
- [x] `rc-2-no-as-bypass` — 仅在通过 typeof/Array.isArray/Object.hasOwn 后用 `as Record<string, unknown>` 做窄化
- [x] `rc-3-fail-loud-missing` — 缺 `content` 字段返回 400 + reason=missing_content
- [x] `rc-4-validate-array-elements` — `validateIntentVersions` 校验 versions 是数组
- [x] `rc-5-object-hasown-not-in` — 全程使用 Object.hasOwn
- [ ] `rc-6-lineage-consistency` — N/A 无血缘字段
- [ ] `rc-7-loop-state-freshness` — N/A 无重试循环
- [ ] `rc-8-safe-serialization` — N/A 无未知值序列化路径
- [x] `rc-9-no-silent-fallback` — `getVersions` 失败返回 reason+nextAction；`recordVersion` 静默仅为辅助路径，主路径仍发声
- 遵守方式说明: 见上

### CLI Gate 自检（条件性 — 仅当修改 `packages/pd-cli/src/commands/**` 时填写）

- [x] N/A — 本 PR 修改了 `packages/pd-cli/src/commands/intent.ts` 但 `pd intent init/show` **非 operator 命令**（无 --json、无 dry-run、无 state mutation），属于 owner 工具命令；CLI gate 主要约束 operator workflow 命令

### Feature Flag 注册检查（条件性 — 仅当引入新功能子系统/hook/writer/reader 时填写）

- [x] N/A — 本 PR 未引入新功能子系统，仅双语化既有 `intent_engineering` 子系统

### 反模式触发词检查

- [x] 无 `antipattern-future-extensibility`（"为未来铺路"）
- [x] 无 `antipattern-completeness`（"为完整性"）
- [x] 无 `antipattern-review-missing`（"review 时觉得缺失"）
- [x] 无 `antipattern-core-io`（"在 core 写 I/O 代码"）

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run test`: 通过（5790 passed / 3 skipped）
- [x] `cd packages/openclaw-plugin && npm run test`: 通过（1893 passed / 12 skipped）
- [x] `cd packages/pd-console && npm run test`: 通过（1674 passed / 1 expected fail）
- [x] `npm run lint`: 通过（0 errors / 31 warnings 全为预存 rc-5）
- [ ] `npm run verify:merge`: 未运行（rebase 后单包验证已通过）

## 相关 Issue
无对应 Linear issue（SPEC 驱动）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 意图文档现在支持中英文切换，可按语言查看、创建和保存对应内容。
  * 新增版本历史查看，用户可浏览意图文档的历史记录、备注和内容摘要。
  * 控制台与 CLI 的意图相关操作已支持语言参数，输出会显示对应语言文件名。

* **Bug 修复**
  * 提升了大文件读取保护，避免在文件变更过程中绕过大小限制。
  * 优化了缺失、超限或读取失败时的提示信息，更清晰地指引下一步操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->