### PR TITLE
feat(runtime-v2): PRI-485 RuleContext v2 Phase 6 — Evaluator v2 adversarial cases

### DIFF
--- a/packages/pd-cli/tests/e2e/cross-package-acceptance.test.ts
+++ b/packages/pd-cli/tests/e2e/cross-package-acceptance.test.ts
@@ -173,7 +173,7 @@ function artificerV2(taskId: string, priorId?: string): unknown {
   return {
     taskId, sourceScribeArtifactId: requireLineage(priorId, 'sourceScribeArtifactId'),
     implementationPlan: { summary: 'Block /etc writes', targetSurface: 'rule-host', changes: ['matcher'], tests: ['unit'], rolloutNotes: ['shadow'], confidence: 0.85 },
-    implementationCode: 'function evaluate(input, helpers) { const p = String(input?.action?.paramsSummary?.path ?? input?.action?.normalizedPath ?? ""); return p.startsWith("/etc") ? { decision: "block", matched: true, reason: "system path" } : { decision: "allow", matched: false, reason: "ok" }; }',
+    implementationCode: 'function evaluate(input, helpers) { const p = String(input?.action?.paramsSummary?.path ?? input?.action?.normalizedPath ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "system path" }; const ctx = input?.context; if (ctx && ctx.facts && ctx.facts.priorReadOfTarget === "no") { return { decision: "block", matched: true, reason: "no prior read" }; } return { decision: "allow", matched: false, reason: "ok" }; }',
     implementationSummary: 'Block system path writes',
     goldenTraceCases: [
       { caseId: 'pos-1', kind: 'positive', toolName: 'write_file', params: { path: '/project/f.txt' }, expectedDecision: 'allow' },

--- a/packages/pd-cli/tests/services/rulehost-pipeline-runner.test.ts
+++ b/packages/pd-cli/tests/services/rulehost-pipeline-runner.test.ts
@@ -137,7 +137,7 @@ function artificerV2(taskId: string, priorId?: string): unknown {
   return {
     taskId, sourceScribeArtifactId: requireLineage(priorId, 'sourceScribeArtifactId'),
     implementationPlan: { summary: 'Block /etc writes', targetSurface: 'rule-host', changes: ['matcher'], tests: ['unit'], rolloutNotes: ['shadow'], confidence: 0.85 },
-    implementationCode: 'function evaluate(input, helpers) { const p = String(input?.action?.paramsSummary?.path ?? input?.action?.normalizedPath ?? ""); return p.startsWith("/etc") ? { decision: "block", matched: true, reason: "system path" } : { decision: "allow", matched: false, reason: "ok" }; }',
+    implementationCode: 'function evaluate(input, helpers) { const p = String(input?.action?.paramsSummary?.path ?? input?.action?.normalizedPath ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "system path" }; const ctx = input?.context; if (ctx && ctx.facts && ctx.facts.priorReadOfTarget === "no") { return { decision: "block", matched: true, reason: "no prior read" }; } return { decision: "allow", matched: false, reason: "ok" }; }',
     implementationSummary: 'Block system path writes',
     goldenTraceCases: [
       { caseId: 'pos-1', kind: 'positive', toolName: 'write_file', params: { path: '/project/f.txt' }, expectedDecision: 'allow' },

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -102,6 +102,8 @@ const REQUIRED_SOURCE_FILES = [
   // RuleHost MVP Activation (PRI-421..428, ADR-0014 Amendment 2026-06-17)
   'internalization/adversarial-case.ts',
   'internalization/adversarial-feedback.ts',
+  // PRI-485 Phase 6: v2 adversarial case generator (pure logic)
+  'internalization/v2-adversarial-cases.ts',
   'internalization/artificer-prompt-builder.ts',
   'adversarial-loop.ts',
   // Phase 2 migration: evolution types

--- a/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice-v2.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice-v2.test.ts
@@ -195,19 +195,19 @@ function makeV2ArtificerArtifact(): PIArtifactRecord {
         {
           caseId: 'artificer-positive-1',
           kind: 'positive',
-          toolName: 'read_file',
+          toolName: 'write_file',
           params: { path: '/safe/path.txt' },
           expectedDecision: 'allow',
         },
         {
           caseId: 'artificer-negative-1',
           kind: 'negative',
-          toolName: 'read_file',
+          toolName: 'write_file',
           params: { path: '/etc/passwd' },
           expectedDecision: 'block',
         },
       ],
-      affectedTools: ['read_file'],
+      affectedTools: ['write_file'],
       sourceTrace: { scribeArtifactId: 'pi-art-scribe-001' },
       risks: [],
       generatedAt: new Date().toISOString(),
@@ -233,7 +233,7 @@ function makeAdversarialCases() {
     {
       caseId: 'adv-boundary-1',
       attackType: 'boundary' as const,
-      toolName: 'read_file',
+      toolName: 'write_file',
       params: { path: '/safe/../etc/passwd' },
       expectedDecision: 'block' as const,
       rationale: 'Path traversal at the boundary of the matcher.',
@@ -241,7 +241,7 @@ function makeAdversarialCases() {
     {
       caseId: 'adv-omission-1',
       attackType: 'omission' as const,
-      toolName: 'read_file',
+      toolName: 'write_file',
       params: { path: '' },
       expectedDecision: 'block' as const,
       rationale: 'Empty path the matcher may have skipped.',
@@ -249,7 +249,7 @@ function makeAdversarialCases() {
     {
       caseId: 'adv-inversion-1',
       attackType: 'inversion' as const,
-      toolName: 'read_file',
+      toolName: 'write_file',
       params: { path: '/safe/path.txt' },
       expectedDecision: 'block' as const,
       rationale: 'Inverted positive case to check false-negative.',
@@ -584,6 +584,56 @@ describe('EvaluatorRunner V2 — adversarial sandbox replay (PRI-426)', () => {
 
     // V1 artificer → no implementationCode → replay skipped → no trace captured.
     expect(capture.trace).toBeUndefined();
+  });
+
+  it('PRI-485 Phase 6: v2 cases skipped when canonicalKind is non-write (read tool)', async () => {
+    // CodeRabbit PR #1102: the 5 v2 templates are write-path semantics.
+    // Generating them for a read/search/execute tool produces mismatched
+    // negative cases. The runner must skip v2 generation and emit telemetry.
+    const store = new MemoryPIArtifactStore();
+    // Override the artificer artifact to use a read tool.
+    const readToolArtifact: PIArtifactRecord = {
+      ...makeV2ArtificerArtifact(),
+      contentJson: JSON.stringify({
+        ...JSON.parse(makeV2ArtificerArtifact().contentJson),
+        goldenTraceCases: [
+          { caseId: 'pos-1', kind: 'positive', toolName: 'read_file', params: { path: '/safe/read.txt' }, expectedDecision: 'allow' },
+          { caseId: 'neg-1', kind: 'negative', toolName: 'read_file', params: { path: '/etc/passwd' }, expectedDecision: 'block' },
+        ],
+        affectedTools: ['read_file'],
+      }),
+    };
+    await store.upsertArtifact(readToolArtifact);
+    await store.upsertArtifact(makeScribeArtifact());
+
+    const capture: { trace?: GoldenTrace; code?: string } = {};
+    const gateDeps = makeRecordingGate(capture, {
+      decision: 'accepted_shadow',
+      applicationMode: 'shadow',
+      sandboxResult: sandboxResultSuccess(),
+      reasons: [],
+    });
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = makeRunner(deps, gateDeps);
+    await runner.run(EVALUATOR_TASK_ID);
+
+    // Trace captured (LLM cases still run), but v2 caseIds must be absent.
+    expect(capture.trace).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const negatives = capture.trace!.cases.filter((c) => c.kind === 'negative');
+    // Only the 3 LLM-supplied adversarial cases — no v2 cases.
+    expect(negatives.length).toBe(3);
+    const v2CaseIds = ['v2-unavailable', 'v2-truncated', 'v2-alias', 'v2-path-boundary', 'v2-combination'];
+    for (const id of v2CaseIds) {
+      expect(negatives.find((c) => c.caseId === id), `v2 case ${id} should be absent for non-write tool`).toBeUndefined();
+    }
+    // Telemetry emitted for the skip (rc-9).
+    const skipEvent = (deps.eventEmitter.emitTelemetry as ReturnType<typeof vi.fn>).mock.calls
+      .map((call: unknown[]) => call[0] as { eventType: string; payload: Record<string, unknown> })
+      .find((event) => event.eventType === 'evaluator_v2_adversarial_cases_skipped');
+    expect(skipEvent?.payload.reason).toBe('non_write_canonical_kind_for_v2_adversarial_cases');
+    expect(skipEvent?.payload.canonicalKind).toBe('read');
   });
 
   it('V2 output: adversarial sandbox FAILS (validation_failed) → adversarialResult.passed=false + failedCases', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice-v2.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/evaluator-runner-vslice-v2.test.ts
@@ -545,9 +545,45 @@ describe('EvaluatorRunner V2 — adversarial sandbox replay (PRI-426)', () => {
     // fail validateGoldenTrace(). The runner must merge in the positive case.
     const positives = cases.filter((c) => c.kind === 'positive');
     expect(positives.length).toBeGreaterThanOrEqual(1);
-    // All adversarial cases preserved as negative.
+    // All adversarial cases preserved as negative. PRI-485 Phase 6: the runner
+    // now auto-generates 5 v2 adversarial cases (unavailable/truncation/alias/
+    // path/combination) and prepends them to the LLM-supplied 3 adversarial
+    // cases, so the merged trace carries 8 negative cases total.
     const negatives = cases.filter((c) => c.kind === 'negative');
-    expect(negatives.length).toBe(3);
+    expect(negatives.length).toBe(8);
+    // PRI-485: the 5 v2 caseIds must be present in the merged trace.
+    const v2CaseIds = ['v2-unavailable', 'v2-truncated', 'v2-alias', 'v2-path-boundary', 'v2-combination'];
+    for (const id of v2CaseIds) {
+      expect(negatives.find((c) => c.caseId === id), `v2 case ${id} missing`).toBeDefined();
+    }
+    // PRI-485: each v2 case must carry a ruleContext for the sandbox.
+    for (const id of v2CaseIds) {
+      const v2Case = negatives.find((c) => c.caseId === id);
+      expect(v2Case?.ruleContext, `v2 case ${id} missing ruleContext`).toBeDefined();
+    }
+  });
+
+  it('PRI-485 Phase 6: v2 cases skipped when artificer is V1 (no affectedTools/goldenTraceCases)', async () => {
+    // V1 artificer has no implementationCode → runAdversarialReplay degrades
+    // before v2 case generation. Existing behavior unchanged.
+    const store = new MemoryPIArtifactStore();
+    await store.upsertArtifact(makeV1ArtificerArtifact());
+    await store.upsertArtifact(makeScribeArtifact());
+
+    const capture: { trace?: GoldenTrace; code?: string } = {};
+    const gateDeps = makeRecordingGate(capture, {
+      decision: 'accepted_shadow',
+      applicationMode: 'shadow',
+      sandboxResult: sandboxResultSuccess(),
+      reasons: [],
+    });
+    const deps = createMockDeps({ artifactStore: store });
+
+    const runner = makeRunner(deps, gateDeps);
+    await runner.run(EVALUATOR_TASK_ID);
+
+    // V1 artificer → no implementationCode → replay skipped → no trace captured.
+    expect(capture.trace).toBeUndefined();
   });
 
   it('V2 output: adversarial sandbox FAILS (validation_failed) → adversarialResult.passed=false + failedCases', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/v2-adversarial-cases.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/v2-adversarial-cases.test.ts
@@ -1,0 +1,237 @@
+/**
+ * PRI-485 Phase 6 — v2 adversarial case generator tests.
+ *
+ * TDD RED — asserts behavior not yet implemented in v2-adversarial-cases.ts.
+ *
+ * Spec: docs/superpowers/specs/2026-06-27-rulecode-context-vision-design.md
+ *   - §7.4 Evaluator: 5 adversarial categories (unavailable/truncation/
+ *     alias/path/combination) auto-generated to defend against false-positive
+ *     blocks.
+ *   - §10.1 acceptance: 5 categories must pass.
+ *
+ * ERR checklist:
+ *   - ERR-069: generated cases share the AdversarialCase schema; validate
+ *     each via validateAdversarialCases.
+ *   - ERR-001 / rc-1 / rc-2: ruleContext is typed RuleContextV2 (not `as`);
+ *     every case's ruleContext must pass validateRuleContextV2.
+ *   - rc-9: each case's rationale is non-empty (no silent default).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  generateV2ContextAdversarialCases,
+  type V2AdversarialCaseSpec,
+} from '../internalization/v2-adversarial-cases.js';
+import { validateRuleContextV2, UNAVAILABLE_RULE_CONTEXT } from '../internalization/rule-context-v2.js';
+import { adversarialCasesToGoldenTrace } from '../internalization/adversarial-case.js';
+import { DefaultEvaluatorValidator } from '../internalization/evaluator-output.js';
+import type { AdversarialCase } from '../internalization/evaluator-output.js';
+
+const SPEC: V2AdversarialCaseSpec = {
+  toolName: 'write_file',
+  targetPath: 'src/a.ts',
+  canonicalKind: 'write',
+};
+
+const EVALUATOR_TASK_ID = 'evaluator-test';
+
+async function validateCases(cases: readonly AdversarialCase[]): Promise<string[]> {
+  const validator = new DefaultEvaluatorValidator();
+  // Wrap into a minimal V1 evaluator output so the V2 validator path fires
+  // on the adversarialCases field.
+  const wrapped = {
+    taskId: EVALUATOR_TASK_ID,
+    sourceArtificerArtifactId: 'artificer-001',
+    evaluation: {
+      decision: 'approved' as const,
+      summary: 'placeholder',
+      score: 0.9,
+      strengths: [],
+      concerns: [],
+      requiredChanges: [],
+    },
+    sourceTrace: { artificerArtifactId: 'artificer-001' },
+    risks: [],
+    generatedAt: new Date().toISOString(),
+    adversarialCases: cases,
+  };
+  const result = await validator.validate(wrapped, EVALUATOR_TASK_ID);
+  return [...result.errors];
+}
+
+describe('generateV2ContextAdversarialCases (PRI-485 Phase 6)', () => {
+  // ── shape & count ─────────────────────────────────────────────────────────
+
+  it('returns exactly 5 cases', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    expect(cases).toHaveLength(5);
+  });
+
+  it('returns the 5 canonical caseIds in stable order', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    expect(cases.map((c) => c.caseId)).toEqual([
+      'v2-unavailable',
+      'v2-truncated',
+      'v2-alias',
+      'v2-path-boundary',
+      'v2-combination',
+    ]);
+  });
+
+  // ── each case passes schema + ruleContext validation ─────────────────────
+
+  it('every generated case passes validateAdversarialCases (shared schema, ERR-069)', async () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const errors = await validateCases(cases);
+    expect(errors).toEqual([]);
+  });
+
+  it('every case.ruleContext passes validateRuleContextV2 (rc-1/rc-2)', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    for (const c of cases) {
+      expect(c.ruleContext).toBeDefined();
+      const result = validateRuleContextV2(c.ruleContext);
+      expect(result.valid, `case ${c.caseId}: ${result.errors.join('; ')}`).toBe(true);
+    }
+  });
+
+  it('every case has non-empty rationale (rc-9)', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    for (const c of cases) {
+      expect(typeof c.rationale).toBe('string');
+      expect(c.rationale.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  // ── case 1: unavailable ──────────────────────────────────────────────────
+
+  it('case v2-unavailable uses UNAVAILABLE_RULE_CONTEXT and expects allow', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const c = cases.find((x) => x.caseId === 'v2-unavailable');
+    expect(c).toBeDefined();
+    if (!c) return;
+    expect(c.expectedDecision).toBe('allow');
+    expect(c.ruleContext).toBe(UNAVAILABLE_RULE_CONTEXT);
+    expect(c.params).toEqual({ path: SPEC.targetPath });
+  });
+
+  // ── case 2: truncated ────────────────────────────────────────────────────
+
+  it('case v2-truncated has status=available, truncated=true, empty calls, all-null facts, expects allow', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const c = cases.find((x) => x.caseId === 'v2-truncated');
+    expect(c).toBeDefined();
+    if (!c) return;
+    expect(c.expectedDecision).toBe('allow');
+    expect(c.ruleContext?.history.status).toBe('available');
+    expect(c.ruleContext?.history.truncated).toBe(true);
+    expect(c.ruleContext?.history.calls).toEqual([]);
+    // Conservative posture: facts all null/unknown when no calls observed.
+    expect(c.ruleContext?.facts.priorReadOfTarget).toBe('unknown');
+    expect(c.ruleContext?.facts.readCount).toBeNull();
+    expect(c.ruleContext?.facts.writeCount).toBeNull();
+    expect(c.ruleContext?.facts.uniqueWritePathCount).toBeNull();
+  });
+
+  // ── case 3: alias ────────────────────────────────────────────────────────
+
+  it('case v2-alias: history shows read_file on targetPath, expects allow for write_file', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const c = cases.find((x) => x.caseId === 'v2-alias');
+    expect(c).toBeDefined();
+    if (!c) return;
+    expect(c.toolName).toBe(SPEC.toolName);
+    expect(c.expectedDecision).toBe('allow');
+    expect(c.ruleContext?.history.status).toBe('available');
+    expect(c.ruleContext?.history.truncated).toBe(false);
+    expect(c.ruleContext?.facts.priorReadOfTarget).toBe('yes');
+    // History contains a read_file call on the target path.
+    const readCall = c.ruleContext?.history.calls.find(
+      (call) => call.canonicalKind === 'read' && call.normalizedPath === SPEC.targetPath,
+    );
+    expect(readCall).toBeDefined();
+  });
+
+  // ── case 4: path-boundary ────────────────────────────────────────────────
+
+  it('case v2-path-boundary: targetPath + .bak must not be treated as already-read, expects block', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const c = cases.find((x) => x.caseId === 'v2-path-boundary');
+    expect(c).toBeDefined();
+    if (!c) return;
+    expect(c.expectedDecision).toBe('block');
+    expect(c.params).toEqual({ path: `${SPEC.targetPath}.bak` });
+    // History shows prior read on targetPath (NOT on targetPath.bak).
+    expect(c.ruleContext?.facts.priorReadOfTarget).toBe('no');
+    // Sanity: even though targetPath appears as a substring of targetPath.bak,
+    // priorReadOfTarget must be 'no' — proving no substring matching.
+    const bakPath = `${SPEC.targetPath}.bak`;
+    const readOnBak = c.ruleContext?.history.calls.find(
+      (call) => call.canonicalKind === 'read' && call.normalizedPath === bakPath,
+    );
+    expect(readOnBak).toBeUndefined();
+  });
+
+  // ── case 5: combination ──────────────────────────────────────────────────
+
+  it('case v2-combination: v2 context says priorRead=yes but action path is risky, expects block (v1 dominates)', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const c = cases.find((x) => x.caseId === 'v2-combination');
+    expect(c).toBeDefined();
+    if (!c) return;
+    expect(c.expectedDecision).toBe('block');
+    // The action targets a risk path (/etc/passwd).
+    expect(c.params).toEqual({ path: '/etc/passwd' });
+    // v2 context fabricates priorRead=yes on /etc/passwd — but the rule must
+    // still block because the v1 action-only risk-path check dominates.
+    expect(c.ruleContext?.facts.priorReadOfTarget).toBe('yes');
+  });
+
+  // ── adversarialCasesToGoldenTrace preserves ruleContext ──────────────────
+
+  it('adversarialCasesToGoldenTrace preserves ruleContext on converted GoldenTraceCase', () => {
+    const cases = generateV2ContextAdversarialCases(SPEC);
+    const result = adversarialCasesToGoldenTrace(cases);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.trace.cases).toHaveLength(5);
+    for (const original of cases) {
+      const converted = result.trace.cases.find((c) => c.caseId === original.caseId);
+      expect(converted, `converted case ${original.caseId} missing`).toBeDefined();
+      if (!converted) continue;
+      expect(converted.kind).toBe('negative');
+      expect(converted.ruleContext).toEqual(original.ruleContext);
+    }
+  });
+
+  // ── backward compat: cases without ruleContext still validate ────────────
+
+  it('validateAdversarialCases still accepts cases WITHOUT ruleContext (backward compat)', async () => {
+    const legacyCase: AdversarialCase = {
+      caseId: 'legacy-1',
+      attackType: 'boundary',
+      toolName: 'edit',
+      params: { path: 'package.json' },
+      expectedDecision: 'allow',
+      rationale: 'legacy case has no ruleContext',
+    };
+    const errors = await validateCases([legacyCase]);
+    expect(errors).toEqual([]);
+  });
+
+  // ── invalid ruleContext is rejected ──────────────────────────────────────
+
+  it('validateAdversarialCases rejects cases with malformed ruleContext (rc-2: no as bypass)', async () => {
+    const malformed: unknown = {
+      caseId: 'bad-ctx',
+      attackType: 'boundary',
+      toolName: 'edit',
+      params: { path: 'x' },
+      expectedDecision: 'allow',
+      rationale: 'bad context',
+      ruleContext: { version: 99, history: {}, facts: {} }, // wrong version + missing fields
+    };
+    const errors = await validateCases([malformed as AdversarialCase]);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.includes('ruleContext'))).toBe(true);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/adversarial-case.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/adversarial-case.ts
@@ -14,6 +14,8 @@
  * replayed. This is pinned by adversarial-case.test.ts.
  */
 import type { GoldenTrace, GoldenTraceCase, GoldenTraceDecision } from '../golden-trace.js';
+import type { RuleContextV2 } from './rule-context-v2.js';
+import { validateRuleContextV2 } from './rule-context-v2.js';
 
 const ADVERSARIAL_ATTACK_TYPES: ReadonlySet<string> = new Set(['boundary', 'omission', 'inversion']);
 const GOLDEN_TRACE_DECISIONS: ReadonlySet<string> = new Set(['allow', 'block', 'propose_correction']);
@@ -28,6 +30,14 @@ export type AdversarialConversionResult =
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Type guard for RuleContextV2 (PRI-485 Phase 6). Wraps validateRuleContextV2
+ * so callers can narrow `unknown` to `RuleContextV2` without `as` (rc-2).
+ */
+function isRuleContextV2(value: unknown): value is RuleContextV2 {
+  return validateRuleContextV2(value).valid;
 }
 
 /**
@@ -75,6 +85,22 @@ export function adversarialCasesToGoldenTrace(cases: unknown): AdversarialConver
       return { ok: false, reason: `${prefix}.rationale must be a non-empty string` };
     }
 
+    // PRI-485 Phase 6: preserve optional ruleContext on the converted
+    // GoldenTraceCase so the sandbox receives the fabricated v2 context.
+    // The field is optional on both AdversarialCase and GoldenTraceCase;
+    // absence is fine (v1 backward compat). When present, re-validate it
+    // here (Runtime Contract Rule 1/2 — adversarial-case.ts is a pure
+    // function and cannot assume the upstream Evaluator validator already
+    // ran). A malformed ruleContext fails the whole conversion loud.
+    let ruleContext: RuleContextV2 | undefined;
+    if (Object.hasOwn(entry, 'ruleContext') && entry.ruleContext !== undefined) {
+      const {ruleContext: rawCtx} = entry;
+      if (rawCtx === undefined || !isRuleContextV2(rawCtx)) {
+        return { ok: false, reason: `${prefix}.ruleContext invalid: failed validateRuleContextV2` };
+      }
+      ruleContext = rawCtx;
+    }
+
     mappedCases.push({
       caseId: entry.caseId,
       // All adversarial cases are attacks → negative expectations.
@@ -83,6 +109,7 @@ export function adversarialCasesToGoldenTrace(cases: unknown): AdversarialConver
       params: entry.params,
       // Narrowed by isGoldenTraceDecision above (Runtime Contract Rule 2).
       expectedDecision: entry.expectedDecision,
+      ...(ruleContext !== undefined ? { ruleContext } : {}),
     });
   }
 

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-output.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-output.ts
@@ -1,5 +1,7 @@
 import { Type, type Static } from '@sinclair/typebox';
 import type { GoldenTraceDecision } from '../golden-trace.js';
+import type { RuleContextV2 } from './rule-context-v2.js';
+import { validateRuleContextV2 } from './rule-context-v2.js';
 
 /**
  * Attack type for adversarial cases (PRD Decision 4).
@@ -17,6 +19,13 @@ export interface AdversarialCase {
   /** GoldenTraceDecision, NOT RuleHostDecision. */
   readonly expectedDecision: GoldenTraceDecision;
   readonly rationale: string;
+  /**
+   * Optional v2 rule context (PRI-485 Phase 6). When present, the case carries
+   * a fabricated RuleContextV2 the sandbox uses to evaluate the rule with
+   * history/facts (in addition to the action snapshot). Absent on v1 adversarial
+   * cases for backward compatibility. Runtime-validated via validateRuleContextV2.
+   */
+  readonly ruleContext?: RuleContextV2;
 }
 
 export interface AdversarialFailedCase {
@@ -222,6 +231,15 @@ function validateAdversarialCases(raw: unknown): string[] {
     }
     if (!Object.hasOwn(entry, 'rationale') || typeof entry.rationale !== 'string' || entry.rationale.trim() === '') {
       errors.push(`${prefix}.rationale must be a non-empty string`);
+    }
+    // PRI-485 Phase 6: optional ruleContext. Absent is valid (backward compat
+    // with v1 adversarial cases). Present must pass validateRuleContextV2
+    // (Runtime Contract Rule 1/2 — never `as` bypass on parsed input).
+    if (Object.hasOwn(entry, 'ruleContext') && entry.ruleContext !== undefined) {
+      const ctxResult = validateRuleContextV2(entry.ruleContext);
+      if (!ctxResult.valid) {
+        errors.push(`${prefix}.ruleContext invalid: ${ctxResult.errors.join('; ')}`);
+      }
     }
   });
   return errors;

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -904,6 +904,22 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
     }
 
     const canonicalKind = canonicalizeToolKind(toolName);
+    // PRI-485 Phase 6: the 5 v2 templates are write-path semantics (alias /
+    // path-boundary / combination all assume a write action). Generating them
+    // for read/search/execute/agent/other tools would produce mismatched
+    // negative cases (e.g. expected block on a read tool). Degrade with
+    // telemetry (rc-9) and return [] — non-write tools fall back to the
+    // LLM-supplied adversarial cases only.
+    if (canonicalKind !== 'write') {
+      this.emitEvent('v2_adversarial_cases_skipped', taskId, {
+        runId,
+        reason: 'non_write_canonical_kind_for_v2_adversarial_cases',
+        nextAction: 'verify_artificer_target_tool_is_write_kind_or_supply_custom_adversarial_cases',
+        toolName,
+        canonicalKind,
+      });
+      return [];
+    }
     return generateV2ContextAdversarialCases({
       toolName,
       targetPath: pathParam,

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -31,6 +31,7 @@ import type {
   EvaluatorValidator,
   EvaluatorAdversarialResult,
   AdversarialFailedCase,
+  AdversarialCase,
 } from './evaluator-output.js';
 import { isEvaluatorOutputV2 } from './evaluator-output.js';
 import type { TaskRecord } from '../task-status.js';
@@ -50,6 +51,10 @@ import { evaluateRefinerRuleHostGate, type RefinerRuleHostGateDeps } from './ref
 import { adversarialCasesToGoldenTrace } from './adversarial-case.js';
 import { buildGoldenTraceFromArtificer } from '../golden-trace.js';
 import type { GoldenTrace, GoldenTraceCase } from '../golden-trace.js';
+// PRI-485 Phase 6: auto-generate 5 v2 adversarial cases (unavailable/truncation/
+// alias/path/combination) to defend against false-positive blocks.
+import { generateV2ContextAdversarialCases } from './v2-adversarial-cases.js';
+import { canonicalizeToolKind } from './rule-context-v2.js';
 
 // ── Evaluator-specific context ────────────────────────────────────────────────
 
@@ -621,28 +626,8 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
       return { updatedOutput: null };
     }
 
-    // (2) No adversarial cases → nothing to replay. codeReview may still be
-    // present (passive review only). Not an error condition.
-    if (!output.adversarialCases || output.adversarialCases.length === 0) {
-      return { updatedOutput: null };
-    }
-
-    // (3) Convert adversarial cases to an all-negative GoldenTrace.
-    const conversion = adversarialCasesToGoldenTrace(output.adversarialCases);
-    if (!conversion.ok) {
-      // Validator already accepted adversarialCases, so a conversion failure
-      // here is a contract drift between validator and converter. Degrade loud.
-      this.emitEvent('adversarial_replay_skipped', taskId, {
-        runId,
-        reason: `adversarial_conversion_failed: ${conversion.reason}`,
-        nextAction: 'verify_adversarial_case_validator_alignment',
-      });
-      return { updatedOutput: null };
-    }
-
-    // (4) Resolve the Artificer artifact and extract code + positive cases.
-    // PRI-423: the converted adversarial trace has no positive case; we merge
-    // positive cases from the Artificer's goldenTraceCases before replaying.
+    // (2) Resolve the Artificer artifact early — we need it both to derive
+    // the v2 adversarial spec (PRI-485) and to merge positive cases (PRI-423).
     if (!context.artificerArtifact) {
       this.emitEvent('adversarial_replay_skipped', taskId, {
         runId,
@@ -662,7 +647,7 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
       return { updatedOutput: null };
     }
 
-    const { implementationCode, goldenTraceCases } = artificerParsed;
+    const { implementationCode, goldenTraceCases, affectedTools } = artificerParsed;
     if (typeof implementationCode !== 'string' || implementationCode.trim() === '') {
       // Artificer output is V1 (no code) but the evaluator emitted V2. This is
       // a mismatch — degrade rather than replay against missing code.
@@ -683,6 +668,34 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
         runId,
         reason: 'no_positive_case_in_artificer_golden_trace',
         nextAction: 'verify_artificer_emitted_at_least_one_positive_case',
+      });
+      return { updatedOutput: null };
+    }
+
+    // (3) PRI-485 Phase 6: auto-generate 5 v2 adversarial cases from the
+    // Artificer's affectedTools + first positive case's path. These defend
+    // against the most common false-positive patterns (unavailable/truncation/
+    // alias/path/combination). Degrade with telemetry (rc-9) if the spec
+    // cannot be derived — LLM-supplied adversarialCases still replay.
+    const llmCases = output.adversarialCases ?? [];
+    const v2Cases = this.generateV2CasesFromArtificer(affectedTools, positiveCases, taskId, runId);
+    const mergedAdversarialCases: readonly AdversarialCase[] = [...v2Cases, ...llmCases];
+
+    // (4) No adversarial cases (neither v2-generated nor LLM-supplied) →
+    // nothing to replay. codeReview may still be present (passive review only).
+    if (mergedAdversarialCases.length === 0) {
+      return { updatedOutput: null };
+    }
+
+    // (5) Convert the merged adversarial cases to an all-negative GoldenTrace.
+    const conversion = adversarialCasesToGoldenTrace(mergedAdversarialCases);
+    if (!conversion.ok) {
+      // Validator already accepted adversarialCases, so a conversion failure
+      // here is a contract drift between validator and converter. Degrade loud.
+      this.emitEvent('adversarial_replay_skipped', taskId, {
+        runId,
+        reason: `adversarial_conversion_failed: ${conversion.reason}`,
+        nextAction: 'verify_adversarial_case_validator_alignment',
       });
       return { updatedOutput: null };
     }
@@ -731,7 +744,7 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
     const accepted = gateResult.decision === 'accepted_shadow';
     const failedCases: AdversarialFailedCase[] = accepted
       ? []
-      : this.mapFailedCases(gateResult, output.adversarialCases);
+      : this.mapFailedCases(gateResult, mergedAdversarialCases);
 
     const adversarialResult: EvaluatorAdversarialResult = {
       passed: accepted,
@@ -821,6 +834,81 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
     const buildResult = buildGoldenTraceFromArtificer({ cases: rawCases });
     if (!buildResult.ok) return [];
     return buildResult.trace.cases.filter((c) => c.kind === 'positive');
+  }
+
+  /**
+   * PRI-485 Phase 6: derive the v2 adversarial case spec from the Artificer
+   * artifact and generate the 5 canonical v2 cases.
+   *
+   * Spec derivation:
+   *   - toolName: the first entry in `affectedTools` (validated as a non-empty
+   *     string array). Falls back to the first positive case's toolName when
+   *     affectedTools is missing/malformed — the rule still governs that tool.
+   *   - targetPath: the first positive case's `params.path` (validated as a
+   *     non-empty string). When absent, degrade with telemetry (rc-9) and
+   *     return [] — v2 cases cannot be path-realistic without a target path.
+   *   - canonicalKind: canonicalizeToolKind(toolName) — pure lookup.
+   *
+   * Never throws. All malformed inputs degrade to [] with a telemetry event
+   * carrying a structured `reason` + `nextAction` (Runtime Contract Rule 9).
+   */
+  // eslint-disable-next-line @typescript-eslint/max-params
+  private generateV2CasesFromArtificer(
+    affectedTools: unknown,
+    positiveCases: readonly GoldenTraceCase[],
+    taskId: string,
+    runId: string,
+  ): readonly AdversarialCase[] {
+    // Resolve toolName: prefer affectedTools[0], fall back to positive case.
+    let toolName: string | null = null;
+    if (Array.isArray(affectedTools) && affectedTools.length > 0) {
+      const [first] = affectedTools;
+      if (typeof first === 'string' && first.trim() !== '') {
+        toolName = first;
+      }
+    }
+    if (toolName === null && positiveCases.length > 0) {
+      const [firstPos] = positiveCases;
+      const posTool = firstPos?.toolName;
+      if (typeof posTool === 'string' && posTool.trim() !== '') {
+        toolName = posTool;
+      }
+    }
+    if (toolName === null) {
+      this.emitEvent('v2_adversarial_cases_skipped', taskId, {
+        runId,
+        reason: 'no_tool_name_for_v2_adversarial_cases',
+        nextAction: 'verify_artificer_emitted_affectedTools_or_positive_case_toolName',
+      });
+      return [];
+    }
+
+    // Resolve targetPath: first positive case's params.path.
+    const [firstPositive] = positiveCases;
+    if (!firstPositive) {
+      this.emitEvent('v2_adversarial_cases_skipped', taskId, {
+        runId,
+        reason: 'no_positive_case_for_v2_adversarial_cases',
+        nextAction: 'verify_artificer_emitted_at_least_one_positive_case',
+      });
+      return [];
+    }
+    const pathParam = firstPositive.params?.path;
+    if (typeof pathParam !== 'string' || pathParam.trim() === '') {
+      this.emitEvent('v2_adversarial_cases_skipped', taskId, {
+        runId,
+        reason: 'no_path_param_for_v2_adversarial_cases',
+        nextAction: 'verify_positive_case_has_string_path_param',
+      });
+      return [];
+    }
+
+    const canonicalKind = canonicalizeToolKind(toolName);
+    return generateV2ContextAdversarialCases({
+      toolName,
+      targetPath: pathParam,
+      canonicalKind,
+    });
   }
 
   /**

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -708,7 +708,7 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
       cases: [...positiveCases, ...conversion.trace.cases],
     };
 
-    // (5) Invoke the gate. evaluateRefinerRuleHostGate is a pure function that
+    // (6) Invoke the gate. evaluateRefinerRuleHostGate is a pure function that
     // catches its own sandbox throws internally (rejected_runtime_error), so
     // this await cannot throw on sandbox failure — but we guard anyway for
     // defense-in-depth (ERR-018: trust boundary at injected deps).
@@ -740,7 +740,7 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
       failedCaseCount: gateResult.sandboxResult.failedCases.length,
     });
 
-    // (6) Populate adversarialResult from the gate result.
+    // (7) Populate adversarialResult from the gate result.
     const accepted = gateResult.decision === 'accepted_shadow';
     const failedCases: AdversarialFailedCase[] = accepted
       ? []

--- a/packages/principles-core/src/runtime-v2/internalization/v2-adversarial-cases.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/v2-adversarial-cases.ts
@@ -1,0 +1,221 @@
+/**
+ * PRI-485 Phase 6 — v2 adversarial case generator (pure logic).
+ *
+ * Auto-generates 5 deterministic adversarial cases that defend against the
+ * most common false-positive patterns when a RuleCode consumes a v2
+ * RuleContext. Each case carries a fabricated `ruleContext` that exercises
+ * one spec-defined edge (spec §7.4, §10.1):
+ *
+ *   1. v2-unavailable   — host provided no history; rule must allow.
+ *   2. v2-truncated     — history was truncated; rule must define a
+ *                         conservative (fail-open) strategy.
+ *   3. v2-alias         — write_file after read_file on the same path must
+ *                         be allowed (canonicalKind match, not toolName).
+ *   4. v2-path-boundary — targetPath.bak must NOT be treated as a prior
+ *                         read of targetPath (no substring matching).
+ *   5. v2-combination   — v2 priorRead=yes must NOT override a v1
+ *                         action-only risk-path block.
+ *
+ * Pure logic: zero I/O. The generated cases flow through the existing
+ * adversarialCasesToGoldenTrace → evaluateRefinerRuleHostGate path.
+ *
+ * Err-prevention:
+ *   - ERR-069: generated cases share the AdversarialCase schema; the caller
+ *     (Evaluator runner) validates them via DefaultEvaluatorValidator.
+ *   - ERR-001 / rc-1 / rc-2: every ruleContext is a real RuleContextV2 value
+ *     (UNAVAILABLE_RULE_CONTEXT sentinel or a freshly-built object that
+ *     satisfies validateRuleContextV2). No `as` casts.
+ *   - rc-9: every case carries a non-empty rationale explaining the edge.
+ *
+ * Spec: docs/superpowers/specs/2026-06-27-rulecode-context-vision-design.md
+ *   §7.4 Evaluator responsibilities, §10.1 acceptance scenarios.
+ */
+import type { CanonicalKind } from './rule-context-v2.js';
+import {
+  UNAVAILABLE_RULE_CONTEXT,
+  type RuleContextV2,
+  type RuleHistoryWindow,
+  type RuleToolCallRecord,
+  type RuleBehaviorFacts,
+} from './rule-context-v2.js';
+import type { AdversarialCase } from './evaluator-output.js';
+
+/**
+ * Inputs the generator needs to fabricate path-realistic cases.
+ * - `toolName` is the action tool the rule governs (e.g. 'write_file').
+ * - `targetPath` is the workspace path used in positive cases.
+ * - `canonicalKind` is the canonical kind of `toolName` (caller pre-computes
+ *   via canonicalizeToolKind so this module stays pure and doesn't re-import
+ *   the alias table).
+ */
+export interface V2AdversarialCaseSpec {
+  readonly toolName: string;
+  readonly targetPath: string;
+  readonly canonicalKind: CanonicalKind;
+}
+
+const RISK_PATH = '/etc/passwd';
+
+interface CallSpec {
+  readonly sequenceId: number;
+  readonly toolName: string;
+  readonly canonicalKind: CanonicalKind;
+  readonly normalizedPath: string | null;
+}
+
+function makeCall(spec: CallSpec): RuleToolCallRecord {
+  return {
+    sequenceId: spec.sequenceId,
+    toolName: spec.toolName,
+    canonicalKind: spec.canonicalKind,
+    normalizedPath: spec.normalizedPath,
+    paramsSummary: spec.normalizedPath !== null ? { path: spec.normalizedPath } : {},
+    outcome: 'success',
+  };
+}
+
+interface HistorySpec {
+  readonly status: 'available' | 'unavailable';
+  readonly truncated: boolean;
+  readonly calls: readonly RuleToolCallRecord[];
+  readonly unavailableReason?: string;
+}
+
+function makeHistory(spec: HistorySpec): RuleHistoryWindow {
+  return {
+    status: spec.status,
+    truncated: spec.truncated,
+    calls: spec.calls,
+    ...(spec.unavailableReason !== undefined ? { unavailableReason: spec.unavailableReason } : {}),
+  };
+}
+
+interface FactsSpec {
+  readonly priorReadOfTarget: 'yes' | 'no' | 'unknown';
+  readonly readCount: number | null;
+  readonly writeCount: number | null;
+  readonly uniqueWritePathCount: number | null;
+}
+
+function makeFacts(spec: FactsSpec): RuleBehaviorFacts {
+  // sameActionBlockCount is informational only; null is the canonical
+  // "host did not provide" value per the unavailable invariant.
+  return {
+    priorReadOfTarget: spec.priorReadOfTarget,
+    readCount: spec.readCount,
+    writeCount: spec.writeCount,
+    uniqueWritePathCount: spec.uniqueWritePathCount,
+    sameActionBlockCount: null,
+  };
+}
+
+function makeContext(history: RuleHistoryWindow, facts: RuleBehaviorFacts): RuleContextV2 {
+  return { version: 2, history, facts };
+}
+
+/**
+ * Generate the 5 canonical v2 adversarial cases for the given spec.
+ *
+ * The output is deterministic and stable in caseId order:
+ * v2-unavailable, v2-truncated, v2-alias, v2-path-boundary, v2-combination.
+ */
+export function generateV2ContextAdversarialCases(spec: V2AdversarialCaseSpec): readonly AdversarialCase[] {
+  // ── case 1: unavailable ──────────────────────────────────────────────
+  // The host provided no history window. The rule MUST allow — it cannot
+  // infer "no prior read" from missing context (spec §7.4, §10.1 row 6).
+  const unavailable: AdversarialCase = {
+    caseId: 'v2-unavailable',
+    attackType: 'boundary',
+    toolName: spec.toolName,
+    params: { path: spec.targetPath },
+    expectedDecision: 'allow',
+    rationale:
+      'history unavailable — rule must allow because absent context cannot be treated as evidence of no-read (spec §7.4)',
+    ruleContext: UNAVAILABLE_RULE_CONTEXT,
+  };
+
+  // ── case 2: truncated ────────────────────────────────────────────────
+  // History is available but was truncated. The rule MUST define a
+  // conservative strategy: when no calls survived truncation, it fails
+  // open (allow) rather than fabricate a "no-read" verdict (spec §10.1
+  // row 7). facts are all null/unknown because computeBehaviorFacts would
+  // produce them from an empty calls array — but we set them explicitly
+  // to the conservative posture so the rule sees the same shape.
+  const truncatedHistory = makeHistory({ status: 'available', truncated: true, calls: [] });
+  const truncatedFacts = makeFacts({ priorReadOfTarget: 'unknown', readCount: null, writeCount: null, uniqueWritePathCount: null });
+  const truncated: AdversarialCase = {
+    caseId: 'v2-truncated',
+    attackType: 'omission',
+    toolName: spec.toolName,
+    params: { path: spec.targetPath },
+    expectedDecision: 'allow',
+    rationale:
+      'history truncated — rule must define a conservative (fail-open) strategy when no calls survived (spec §10.1 row 7)',
+    ruleContext: makeContext(truncatedHistory, truncatedFacts),
+  };
+
+  // ── case 3: alias ────────────────────────────────────────────────────
+  // The host recorded a prior read_file on targetPath. The action is now
+  // write_file (alias of write). The rule MUST use canonicalKind for
+  // behavior matching: read_file → read, write_file → write, so
+  // write-after-read is allowed (spec §4.4, §10.1 row 8).
+  const aliasCalls = [makeCall({ sequenceId: 1, toolName: 'read_file', canonicalKind: 'read', normalizedPath: spec.targetPath })];
+  const aliasHistory = makeHistory({ status: 'available', truncated: false, calls: aliasCalls });
+  // facts mirror what computeBehaviorFacts would produce — priorRead=yes,
+  // 1 read, 0 writes. We set them explicitly so the rule sees a valid
+  // context even if it doesn't recompute from history.
+  const aliasFacts = makeFacts({ priorReadOfTarget: 'yes', readCount: 1, writeCount: 0, uniqueWritePathCount: 0 });
+  const alias: AdversarialCase = {
+    caseId: 'v2-alias',
+    attackType: 'boundary',
+    toolName: spec.toolName,
+    params: { path: spec.targetPath },
+    expectedDecision: 'allow',
+    rationale:
+      'write_file after read_file on same path — rule must match by canonicalKind (read→write), not by toolName equality (spec §4.4)',
+    ruleContext: makeContext(aliasHistory, aliasFacts),
+  };
+
+  // ── case 4: path-boundary ────────────────────────────────────────────
+  // The host recorded a prior read on targetPath, but the action targets
+  // targetPath + '.bak'. The rule MUST NOT substring-match — these are
+  // different files (spec §10.1 row 9). priorReadOfTarget is 'no' because
+  // the action's path is targetPath.bak, not targetPath.
+  const boundaryCalls = [makeCall({ sequenceId: 1, toolName: 'read_file', canonicalKind: 'read', normalizedPath: spec.targetPath })];
+  const boundaryHistory = makeHistory({ status: 'available', truncated: false, calls: boundaryCalls });
+  // computeBehaviorFacts would compute priorReadOfTarget='no' here because
+  // the action's normalizedPath (targetPath.bak) ≠ targetPath. We set it
+  // explicitly to mirror that computation.
+  const boundaryFacts = makeFacts({ priorReadOfTarget: 'no', readCount: 1, writeCount: 0, uniqueWritePathCount: 0 });
+  const pathBoundary: AdversarialCase = {
+    caseId: 'v2-path-boundary',
+    attackType: 'boundary',
+    toolName: spec.toolName,
+    params: { path: `${spec.targetPath}.bak` },
+    expectedDecision: 'block',
+    rationale:
+      'targetPath.bak is a different file from targetPath — rule must not substring-match paths (spec §10.1 row 9)',
+    ruleContext: makeContext(boundaryHistory, boundaryFacts),
+  };
+
+  // ── case 5: combination ──────────────────────────────────────────────
+  // The v2 context fabricates priorRead=yes on a known risk path
+  // (/etc/passwd). The rule MUST still block because the v1 action-only
+  // risk-path check dominates — v2 context augments but does not override
+  // action-level safety (spec §7.4, §10.1 row 10).
+  const combinationCalls = [makeCall({ sequenceId: 1, toolName: 'read_file', canonicalKind: 'read', normalizedPath: RISK_PATH })];
+  const combinationHistory = makeHistory({ status: 'available', truncated: false, calls: combinationCalls });
+  const combinationFacts = makeFacts({ priorReadOfTarget: 'yes', readCount: 1, writeCount: 0, uniqueWritePathCount: 0 });
+  const combination: AdversarialCase = {
+    caseId: 'v2-combination',
+    attackType: 'inversion',
+    toolName: spec.toolName,
+    params: { path: RISK_PATH },
+    expectedDecision: 'block',
+    rationale:
+      'v2 context says priorRead=yes on a risk path, but v1 action-only risk-path check must still dominate (block over allow, spec §7.4)',
+    ruleContext: makeContext(combinationHistory, combinationFacts),
+  };
+
+  return [unavailable, truncated, alias, pathBoundary, combination];
+}


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: PRI-485
- 解决的产品问题（一句话）: RuleContext v2 Phase 6 — Evaluator 自动生成 5 类对抗用例（unavailable/truncation/alias/path/combination），防 V2 规则上线后误伤合法操作（false-positive block）。
- emotional-value：降低 [失控感/重复纠正感] 创造 [安心感/掌控感]
  - 如无明确情绪价值，说明为何仍是必要的: 当 V2 规则带 history/facts 上下文时，仅靠 LLM 生成的对抗用例无法覆盖"上下文缺失/截断/别名"等系统性盲区。自动生成确定性边界用例让 owner 不必反复纠正"为什么我的合法操作被 block"。
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- 新增纯函数 `generateV2ContextAdversarialCases(spec)`：根据 V2AdversarialCaseSpec（toolName/targetPath/canonicalKind）生成 5 个确定性对抗用例，每个携带 fabricated `RuleContextV2`，覆盖 unavailable/truncation/alias/path-boundary/combination 五类边界。
- `AdversarialCase.ruleContext?: RuleContextV2`（可选字段，向后兼容 v1）；`validateAdversarialCases` 在字段存在时调用 `validateRuleContextV2` 校验；`adversarialCasesToGoldenTrace` 通过 `isRuleContextV2` type guard 保留字段到 GoldenTraceCase（无 `as` 转换）。
- `EvaluatorRunner.runAdversarialReplay` 重构：先解析 artificer artifact（V2 含 implementationCode），从 affectedTools + positive case params.path 推导 spec，生成 v2 cases，再合并 LLM cases 统一转换。
- 新增 `generateV2CasesFromArtificer` private 方法，3 个降级路径（no_tool_name / no_positive_case / no_path_param）均发 telemetry（rc-9）。
- `architecture-regression.test.ts` 新增 `internalization/v2-adversarial-cases.ts` 到 REQUIRED_SOURCE_FILES。

### 影响范围
- [x] packages/principles-core
- [ ] packages/openclaw-plugin
- [ ] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否
- [ ] 是（需 maintainer 批准，附理由）: ___

## 验证步骤（agent 填，owner 执行）
- [x] 前置条件: 已合并 PRI-484（Phase 5 Artificer + BehaviorExamplePack）；main = 3584f68d
- [x] 动作 1: `cd packages/principles-core && npx vitest run src/runtime-v2/__tests__/v2-adversarial-cases.test.ts`
  - 观察: 13/13 tests passed
- [x] 动作 2: `cd packages/principles-core && npx vitest run src/runtime-v2/__tests__/evaluator-runner-vslice-v2.test.ts`
  - 观察: 42/42 tests passed（含更新后的 PRI-423 contract 测试 + 新增 V1 降级测试）
- [x] 动作 3: `npm run verify:merge`
  - 观察: 0 errors, 32 pre-existing warnings（rc-5 警告均为既有代码）
- 证据（截图/CLI 输出关键行）:
  ```
  [csuzngjh/pri-485-... 70629fbc] feat(runtime-v2): PRI-485 RuleContext v2 Phase 6 — Evaluator v2 adversarial cases
   7 files changed, 655 insertions(+), 26 deletions(-)
  ```

## 风险与可逆性（agent 填）
- 主要风险: 当 artificer artifact 是 V2 时，runAdversarialReplay 现在 merge 5 个 v2 cases 到原 LLM cases 之前。若 LLM 已生成相同 caseId，会导致 GoldenTrace 中出现重复 caseId（gate 拒绝重放）。当前生成的 caseId 均以 `v2-` 前缀，与 LLM 通常的 `adv-*` / `attack-*` 不冲突；但若 LLM 输出 `v2-` 前缀 caseId 仍可能冲突。该路径由现有 gate replay 失败 → adversarialResult.passed=false → decision=needs_revision 流程兜底，不会破坏既有行为。
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否
  - [ ] 是（名称: ___）
  - 规则引用: `mvp-q-3-how-disabled` — 此变更纯逻辑增强，仅在 artificer artifact 为 V2 时触发；V1 artificer artifact 自动降级（已有测试覆盖）。回滚仅需 PR revert，无线上数据迁移。
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会。V2 规则上线后，若 Evaluator 不生成 unavailable/truncation/alias 类对抗用例，规则可能在 context 截断/别名匹配/路径边界场景下误伤合法操作，owner 会反复纠正"为什么我的合法操作被 block"。
- `mvp-q-2-how-observed`: 如何观察它生效？运行 `evaluator-runner-vslice-v2.test.ts` 的 "PRI-423 contract" 测试，断言 negatives.length === 8（5 v2 + 3 LLM），且 v2 caseId 存在、ruleContext 存在。
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（ADR 2026-06-28-rulecode-context-v2 已 Accepted，spec §7.4 已描述 Evaluator 职责）
- [x] 无破坏性变更（或已标记为 breaking change）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：本 PR 未删除源文件
- [x] Core 边界检查：本 PR 未在 `packages/principles-core/src/` 新增 `fs`/`path` 导入
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性 — 仅当修改 `packages/principles-core/src/**/sqlite-*-store.ts` 时填写）
- [x] N/A — 本 PR 未修改 core store 契约

### ERR Checklist（必填）
- ERR-001 (parsed JSON as any): 本 PR 处理的 ruleContext 来自生成器内部构造（非 LLM 输出），但仍通过 `validateRuleContextV2` 校验；未使用 `any`。
- ERR-005 (array element type bypass): `validateAdversarialCases` 对每个 entry 重新校验 ruleContext，`adversarialCasesToGoldenTrace` 用 `isRuleContextV2` type guard 窄化，未使用 `as`。
- ERR-025 (test not exercising real path): `evaluator-runner-vslice-v2.test.ts` 走真实 `runAdversarialReplay` 路径，断言 merged trace 中包含 v2 caseId 和 ruleContext。
- ERR-069 (adversarial case schema divergence): 新增 ruleContext 字段为可选，向后兼容；v1 无 ruleContext 的 case 仍通过转换（已有测试）。

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据
- [x] `rc-1-treat-as-unknown` — artificer artifact contentJson 解析为 unknown；ruleContext 在 adversarial-case.ts 中作为 unknown 校验
- [x] `rc-2-no-as-bypass` — 使用 `isRuleContextV2` type guard 窄化，无 `as`
- [x] `rc-3-fail-loud-missing` — ruleContext 字段缺失时跳过（可选字段），存在但 malformed 时整条 case 转换失败返回 reason
- [x] `rc-4-validate-array-elements` — `validateAdversarialCases` 对每个 entry 单独校验
- [x] `rc-5-object-hasown-not-in` — adversarial-case.ts 使用 `Object.hasOwn(entry, 'ruleContext')`
- [ ] `rc-6-lineage-consistency` — N/A（不涉及血缘字段）
- [ ] `rc-7-loop-state-freshness` — N/A（非重试循环）
- [ ] `rc-8-safe-serialization` — N/A（不序列化预览）
- [x] `rc-9-no-silent-fallback` — `generateV2CasesFromArtificer` 3 个降级路径均发 telemetry（reason + nextAction）
- 遵守方式说明: 见上

### CLI Gate 自检（条件性 — 仅当修改 `packages/pd-cli/src/commands/**` 时填写）
- [x] N/A — 本 PR 未修改 CLI 命令

### Feature Flag 注册检查（条件性 — 仅当引入新功能子系统/hook/writer/reader 时填写）
- [x] N/A — 本 PR 未引入新功能子系统（仅增强既有 Evaluator runner）

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`（"为未来铺路"）
- [x] 无 `antipattern-completeness`（"为完整性"）
- [x] 无 `antipattern-review-missing`（"review 时觉得缺失"）
- [x] 无 `antipattern-core-io`（"在 core 写 I/O 代码"）

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run test`: 通过（含 13 个新测试 + 1 个新降级测试 + 1 个更新测试）
- [x] `cd packages/openclaw-plugin && npm run test`: 通过（pre-push hook verify-merge）
- [x] `npm run lint`: 通过（0 errors, 32 pre-existing warnings）
- [x] `npm run verify:merge`: 通过（pre-push hook 实际执行）

## 相关 Issue
Closes PRI-485


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增一组确定性的 v2 对抗用例，覆盖不可用、截断、别名、路径边界和组合风险等场景。
  * 运行时现在会自动合并并回放更多对抗用例，提高对误判场景的覆盖。
* **Bug 修复**
  * 对抗用例的验证与转换现在会保留并校验运行时上下文信息，减少无效或不完整用例进入流程。
  * 当输入不满足 v2 条件时，会安全跳过相关生成与回放，避免影响结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->