### PR TITLE
fix(rulehost): PRI-489 shadow-first activation + CLI approve flag wiring

### DIFF
--- a/packages/openclaw-plugin/src/core/rule-host.ts
+++ b/packages/openclaw-plugin/src/core/rule-host.ts
@@ -339,18 +339,19 @@ export class RuleHost {
           continue;
         }
         if (activationMode === 'shadow') {
-          // CodeRabbit PR #1121: shadow activations are observation-only and do
-          // NOT enter mergeDecisions (no block / requireApproval). Historical
-          // owner-approved records persisted with action=code_tool_hook_shadow_activate
-          // (before RuleHostWriter was fixed to write code_tool_hook_live_activate)
-          // silently lost execution after the dual-mode change. Surface a
+          // PRI-489 (seed-MVP readiness): shadow activations are
+          // observation-only and do NOT enter mergeDecisions (no block /
+          // requireApproval). Owner approval creates a shadow activation
+          // first; the only shadow -> live transition is `pd activation
+          // promote --activation-id ... --confirm` (atomic action rewrite
+          // in SqliteActivationStateStore.promoteActivation). Surface a
           // structured reason + nextAction so the degradation is observable
-          // (rc-9-no-silent-fallback), not silent. Fires once per fingerprint
-          // change (cached), not per evaluation.
+          // (rc-9-no-silent-fallback), not silent. Fires once per
+          // fingerprint change (cached), not per evaluation.
           this.logger.warn?.(
             `[RuleHost] Activation ${activationId}: loaded in shadow (observation-only) mode; ` +
             'it will NOT block or require approval (shadowDecisions only). ' +
-            `nextAction=run \`pd runtime activation promote --activation-id ${activationId} --confirm\` to enable live blocking, ` +
+            `nextAction=run \`pd activation promote --activation-id ${activationId} --confirm\` to enable live blocking, ` +
             'or leave as-is for shadow observation.',
           );
         }

--- a/packages/pd-cli/src/commands/runtime-activation.ts
+++ b/packages/pd-cli/src/commands/runtime-activation.ts
@@ -224,7 +224,7 @@ export async function handleRuntimeActivationDeactivate(opts: ActivationDeactiva
       ok: false,
       activationId: '',
       reason: 'activation_id_required',
-      nextAction: 'Provide --activation-id <id> from `pd runtime activation list`',
+      nextAction: 'Provide --activation-id <id> from `pd activation list`',
     };
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -254,7 +254,7 @@ export async function handleRuntimeActivationDeactivate(opts: ActivationDeactiva
           ok: false,
           activationId: opts.activationId,
           reason: 'not_found_or_already_deactivated',
-          nextAction: 'Check activation ID with `pd runtime activation list`, or it may already be deactivated',
+          nextAction: 'Check activation ID with `pd activation list`, or it may already be deactivated',
         };
 
     if (opts.json) {
@@ -871,13 +871,26 @@ export async function handleActivationApprove(opts: ActivationApproveOptions): P
         return rec ? toSnapshot(rec) : null;
       },
     };
+    // PRI-489: inject the real workspace `rulecode_context_v2` feature flag
+    // probe into the approve path's RuleHostWriter — same wiring as the
+    // dispatch path (handleRuntimeActivationDispatch) and the Console model
+    // (ApprovalsConsoleModel.dispatchActivationAfterApproval). Previously
+    // this path constructed RuleHostWriter without the probe, so a v2
+    // artifact in a flag-off workspace would pass canActivate here while
+    // being rejected by dispatch/Console — an inconsistent contract that
+    // violated ERR-024 (validator wired in one enforcement path but not
+    // another) and ERR-089 (sibling approval path diverged from dispatch).
+    const featureFlags = computeFlagsFromLoadResult(loadPdConfig(workspaceDir));
     const dispatcher = new ActivationDispatcher(
       artifactReadModel,
       activationStateStore,
       {
         writers: [
           new PromptWriter(),
-          new RuleHostWriter({ gateDeps: createProductionGateDeps() }),
+          new RuleHostWriter({
+            gateDeps: createProductionGateDeps(),
+            featureFlagProbe: (flagId) => featureFlags.flags[flagId]?.enabled === true,
+          }),
           new DeferArchiveWriter(),
         ],
         approvalQueueStore,

--- a/packages/pd-cli/src/services/rulehost-pipeline-runner.ts
+++ b/packages/pd-cli/src/services/rulehost-pipeline-runner.ts
@@ -413,7 +413,7 @@ export async function runRuleHostPipeline(opts: RuleHostPipelineOptions): Promis
         // Enqueue failed — the candidate artifact exists but is not in the
         // approval queue. Degrade gracefully with a structured reason (ERR-002).
         const enqueueErr = err instanceof Error ? err.message : String(err);
-        const degradeReason = `candidate_approved_but_enqueue_failed: ${enqueueErr}. Manual enqueue required: pd runtime activation dispatch --artifact-id ${loopResult.ruleArtifactId} --channel ${channel}`;
+        const degradeReason = `candidate_approved_but_enqueue_failed: ${enqueueErr}. Manual enqueue required: pd activation dispatch --artifact-id ${loopResult.ruleArtifactId} --channel ${channel}`;
         return {
           decision: pipelineDecision,
           painId: opts.painId,

--- a/packages/pd-cli/tests/commands/runtime-activation.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-activation.test.ts
@@ -839,6 +839,7 @@ describe('handleActivationApprove', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRuleHostWriterConfigs.length = 0;
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockGetArtifactById.mockResolvedValue(makeArtifact());
@@ -1076,5 +1077,42 @@ describe('handleActivationApprove', () => {
     expect(captured.decidedBy).toBe('alice');
     expect(captured.note).toBe('lgtm');
     expect(captured.json).toBe(true);
+  });
+
+  // PRI-489 AP-08: The approve path must inject the real workspace
+  // `rulecode_context_v2` feature flag probe into RuleHostWriter — same
+  // wiring as the dispatch path (tested at line 136-146) and the Console
+  // model (ApprovalsConsoleModel.dispatchActivationAfterApproval).
+  // Previously this path constructed RuleHostWriter without the probe, so a
+  // v2 artifact in a flag-off workspace would pass canActivate here while
+  // being rejected by dispatch/Console — an inconsistent contract that
+  // violated ERR-024 (validator wired in one enforcement path but not
+  // another) and ERR-089 (sibling approval path diverged from dispatch).
+  it('AP-08: wires the effective workspace feature flags into RuleHostWriter (ERR-024/ERR-089)', async () => {
+    mockApprovalApprove.mockResolvedValue({
+      ok: true,
+      record: { approvalId: 'appr-001', artifactId: 'art-001', status: 'approved' },
+    });
+    mockCompletionComplete.mockResolvedValue({
+      ok: true,
+      activationId: 'act-001',
+      decision: { decision: 'activated', activationId: 'act-001', action: 'prompt', targetRef: 'P_001' },
+    });
+
+    await handleActivationApprove({
+      workspace: WS,
+      approvalId: 'appr-001',
+      decidedBy: 'test-owner',
+      json: true,
+    });
+
+    // The RuleHostWriter mock captures its constructor config — verify the
+    // featureFlagProbe was injected and reflects the mocked feature flags
+    // (rulecode_context_v2: enabled=true, see mockFeatureFlags at top).
+    expect(mockRuleHostWriterConfigs).toHaveLength(1);
+    expect(mockRuleHostWriterConfigs[0]?.featureFlagProbe).toBeDefined();
+    expect(mockRuleHostWriterConfigs[0]?.featureFlagProbe?.('rulecode_context_v2')).toBe(true);
+    // Unknown flags must not be reported as enabled (rc-2-no-as-bypass).
+    expect(mockRuleHostWriterConfigs[0]?.featureFlagProbe?.('nonexistent_flag')).toBe(false);
   });
 });

--- a/packages/pd-cli/tests/e2e/cross-package-acceptance.test.ts
+++ b/packages/pd-cli/tests/e2e/cross-package-acceptance.test.ts
@@ -426,8 +426,15 @@ describe('Cross-Package Acceptance Test (PRI-408 P1/P2 fixes) — unsplippable c
       { warn: () => {} },
       { workspaceDir: tmpDir },
     );
-    // Shadow activation must NOT block — evaluate returns undefined.
-    expect(shadowRuleHost.evaluate(makeRuleHostInput('/etc/passwd'))).toBeUndefined();
+    try {
+      const report = shadowRuleHost.evaluateDetailed(makeRuleHostInput('/etc/passwd'));
+      expect(report.liveDecision).toBeUndefined();
+      expect(report.shadowDecisions).toContainEqual(
+        expect.objectContaining({ activationId: activationRecord!.activationId }),
+      );
+    } finally {
+      shadowRuleHost.dispose();
+    }
 
     // ── Step 7b: Promote shadow → live (PRI-489) ──────────────────────────
     // `pd activation promote --activation-id ... --confirm` is the ONLY

--- a/packages/pd-cli/tests/e2e/cross-package-acceptance.test.ts
+++ b/packages/pd-cli/tests/e2e/cross-package-acceptance.test.ts
@@ -397,21 +397,23 @@ describe('Cross-Package Acceptance Test (PRI-408 P1/P2 fixes) — unsplippable c
     expect(activationRecord!.artifactId).toBe(revisedArtifactId);
     expect(activationRecord!.channel).toBe('code_tool_hook');
     expect(activationRecord!.deactivatedAt).toBeNull();
+    // PRI-489: Owner approval creates a SHADOW activation first (not live).
+    // Shadow activations are observation-only — they record would-block into
+    // shadowDecisions but never actually block the tool call. The only
+    // shadow -> live transition is `pd activation promote --confirm`.
+    expect(activationRecord!.action).toBe('code_tool_hook_shadow_activate');
 
     // Verify via listCodeToolHookActivations (P2 #5: default excludes deactivated)
     const activeActivations = await stateStore.listCodeToolHookActivations();
     const ourActivation = activeActivations.find(a => a.artifactId === revisedArtifactId);
     expect(ourActivation).toBeDefined();
     expect(ourActivation!.deactivatedAt).toBeNull();
+    expect(ourActivation!.action).toBe('code_tool_hook_shadow_activate');
 
-    // ── Step 7b: Verify the rule actually affects behavior via the gate (P1 #4)
-    // The production RuleHost gate loads all active rules, compiles their code,
-    // and calls evaluate() on each tool call. This step simulates that:
-    // 1. Load active rules from the activation state store
-    // 2. Compile the rule code in the production vm sandbox
-    // 3. Call evaluate() with system-path and normal-path inputs
-    // 4. Verify the rule blocks system paths and allows normal paths
-
+    // ── Step 7a: Verify shadow activation does NOT block (PRI-489) ────────
+    // Shadow mode is observation-only. The RuleHost loads the activation but
+    // records shadowDecisions instead of blocking. evaluate() must return
+    // undefined (no block) for shadow activations, even for /etc/passwd.
     const makeRuleHostInput = (targetPath: string): RuleHostInput => ({
       action: { toolName: 'write_file', normalizedPath: targetPath, paramsSummary: { path: targetPath } },
       workspace: { isRiskPath: targetPath.startsWith('/etc'), planStatus: 'NONE', hasPlanFile: false },
@@ -419,6 +421,36 @@ describe('Cross-Package Acceptance Test (PRI-408 P1/P2 fixes) — unsplippable c
       evolution: { epTier: 0 },
       derived: { estimatedLineChanges: 1, bashRisk: 'safe' },
     });
+    const shadowRuleHost = new RuleHost(
+      path.join(tmpDir, '.state'),
+      { warn: () => {} },
+      { workspaceDir: tmpDir },
+    );
+    // Shadow activation must NOT block — evaluate returns undefined.
+    expect(shadowRuleHost.evaluate(makeRuleHostInput('/etc/passwd'))).toBeUndefined();
+
+    // ── Step 7b: Promote shadow → live (PRI-489) ──────────────────────────
+    // `pd activation promote --activation-id ... --confirm` is the ONLY
+    // shadow → live entry. SqliteActivationStateStore.promoteActivation
+    // atomically rewrites action to `code_tool_hook_live_activate` inside a
+    // BEGIN IMMEDIATE transaction.
+    const activationId = activationRecord!.activationId;
+    const promoteResult = await stateStore.promoteActivation(activationId, new Date().toISOString());
+    expect(promoteResult).toBe(true);
+
+    // Verify the action is now live
+    const liveActivationRecord = await stateStore.getActivationStatus(idempotencyKey);
+    expect(liveActivationRecord).not.toBeNull();
+    expect(liveActivationRecord!.action).toBe('code_tool_hook_live_activate');
+    expect(liveActivationRecord!.promotedAt).not.toBeNull();
+
+    // ── Step 7c: Verify the rule actually blocks in live mode (P1 #4) ────
+    // The production RuleHost gate loads all active rules, compiles their code,
+    // and calls evaluate() on each tool call. This step simulates that:
+    // 1. Load active rules from the activation state store
+    // 2. Compile the rule code in the production vm sandbox
+    // 3. Call evaluate() with system-path and normal-path inputs
+    // 4. Verify the rule blocks system paths and allows normal paths
     const ruleHost = new RuleHost(
       path.join(tmpDir, '.state'),
       { warn: () => {} },
@@ -431,7 +463,6 @@ describe('Cross-Package Acceptance Test (PRI-408 P1/P2 fixes) — unsplippable c
     expect(ruleHost.evaluate(makeRuleHostInput('/project/src/main.ts'))).toBeUndefined();
 
     // ── Step 8: Owner deactivates (rollback) ───────────────────────────────
-    const activationId = activationRecord!.activationId;
     const deactivateResult = await stateStore.deactivateActivation(activationId, new Date().toISOString());
     expect(deactivateResult).toBe(true);
 

--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -2375,12 +2375,16 @@ describe('PRI-146: RuleHostWriter shadow activation boundary', () => {
     expect(src).not.toContain('new Function');
   });
 
-  it('LIVE_AFTER_APPROVAL: rule-host-writer.ts uses live action for owner-approved activations', async () => {
+  it('SHADOW_AFTER_APPROVAL: rule-host-writer.ts uses shadow action for owner-approved activations (PRI-489)', async () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const src = readFileSync(resolve(__dirname, '..', 'activation', 'writers', 'rule-host-writer.ts'), 'utf-8');
-    expect(src).toContain('code_tool_hook_live_activate');
-    expect(src).not.toContain('code_tool_hook_shadow_activate');
+    // PRI-489: Owner approval creates a SHADOW activation first. The only
+    // shadow -> live transition is `pd activation promote` (atomic action
+    // rewrite in SqliteActivationStateStore.promoteActivation). Live action
+    // must never appear as a return value from activate(), only in comments
+    // documenting the promote path.
+    expect(src).toContain("action: 'code_tool_hook_shadow_activate'");
     expect(src).toContain('accepted_shadow');
   });
 

--- a/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/__tests__/rule-host-writer.test.ts
@@ -144,22 +144,30 @@ describe('RuleHostWriter', () => {
     expect(result.reason).toContain('gate_decision_not_accepted_shadow');
   });
 
-  it('returns live activation action after owner approval', async () => {
+  // PRI-489: Owner approval creates a SHADOW activation first. The only
+  // shadow -> live transition is `pd activation promote --activation-id ...
+  // --confirm` (SqliteActivationStateStore.promoteActivation). Live blocking
+  // must never happen immediately after approval — that was the seed-MVP
+  // release blocker this test now guards against.
+  it('returns shadow activation action after owner approval (shadow-first)', async () => {
     const { RuleHostWriter } = await importWriter();
     const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
     const artifact = makeRuleArtifact();
     const result = await writer.activate(makeWriterInput(), artifact);
-    expect(result.action).toBe('code_tool_hook_live_activate');
+    expect(result.action).toBe('code_tool_hook_shadow_activate');
     expect(result.targetRef).toContain('R_001');
   });
 
-  it('never returns shadow activation action for owner-approved rules', async () => {
+  it('never returns live activation action directly after owner approval', async () => {
     const { RuleHostWriter } = await importWriter();
     const writer = new RuleHostWriter({ gateDeps: makeGateDeps() });
     const artifact = makeRuleArtifact();
     const result = await writer.activate(makeWriterInput(), artifact);
-    expect(result.action).not.toContain('shadow');
-    expect(result.action).toContain('live');
+    // Shadow-first: live must only appear after an explicit promote, never
+    // straight from the writer. This assertion uniquely identifies the
+    // shadow-first contract (ERR-088: assert the specific action value).
+    expect(result.action).not.toContain('live');
+    expect(result.action).toContain('shadow');
   });
 
   it('returns correct activationId format', async () => {

--- a/packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts
+++ b/packages/principles-core/src/runtime-v2/activation/writers/rule-host-writer.ts
@@ -196,9 +196,23 @@ export class RuleHostWriter implements ChannelWriter {
       ? artifact.sourceRuleId.trim()
       : input.principleId;
 
+    // PRI-489 (seed-MVP readiness): Owner approval creates a SHADOW
+    // activation first. Shadow activations are observation-only — the
+    // runtime RuleHost (rule-host.ts) records would-block/would-allow into
+    // `shadowDecisions` but never blocks or modifies the tool call. The
+    // only shadow -> live transition is `pd activation promote
+    // --activation-id ... --confirm`, which atomically rewrites the action
+    // to `code_tool_hook_live_activate` inside a BEGIN IMMEDIATE
+    // transaction (SqliteActivationStateStore.promoteActivation).
+    //
+    // Returning `code_tool_hook_live_activate` here was the seed-MVP
+    // release blocker: a newly approved rule would immediately block
+    // production tool calls with no observation window. Shadow-first
+    // gives the owner a reversible observation phase before any live
+    // enforcement.
     return {
       activationId: `act_code_${ruleId}`,
-      action: 'code_tool_hook_live_activate',
+      action: 'code_tool_hook_shadow_activate',
       targetRef: `impl://${ruleId}`,
     };
   }

--- a/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
@@ -528,7 +528,7 @@ export function generateContinuityMatrix(): ContinuityMatrixEntry[] {
     {
       channel: 'code_tool_hook',
       entryPoint: 'ActivationDispatcher.dispatch → RuleHostWriter.canActivate → evaluateRefinerRuleHostGate → RuleHostWriter.activate',
-      expectedObservable: 'decision=would_activate|queued_for_approval, activationId=act_code_{ruleId}, action=code_tool_hook_live_activate, targetRef=impl://{ruleId}',
+      expectedObservable: 'decision=would_activate|queued_for_approval, activationId=act_code_{ruleId}, action=code_tool_hook_shadow_activate, targetRef=impl://{ruleId}',
       testCommand: 'npx vitest run packages/principles-core/src/runtime-v2/__tests__/proven-channel-baseline.test.ts',
       dependsOnPluginDiscovery: false,
       pri119ReuseEvidence: 'ActivationDispatcher.dispatch → RuleHostWriter gate decision contract; goldenTrace validation path',


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: PRI-489
- 解决的产品问题（一句话）: Owner 审批 RuleHost 规则后立即进入 shadow 观察期，不再直接 live 阻断生产工具调用；CLI approve 路径补齐 `rulecode_context_v2` feature flag probe 接线。
- emotional-value：降低 [失控感] 创造 [安心感/掌控感]
  - 如无明确情绪价值，说明为何仍是必要的: 种子用户首次体验 RuleHost 时，最怕"一审批就阻断"。shadow-first 给 owner 一个可逆的观察窗口，promote 是显式动作。这是 seed-MVP release blocker。
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🔧 重构/优化
- [ ] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- `RuleHostWriter.activate()` 返回 `code_tool_hook_shadow_activate`（原 `code_tool_hook_live_activate`）。Owner 审批后进入 shadow 观察期，不阻断。
- CLI `pd activation approve` 路径注入真实 workspace `rulecode_context_v2` feature flag probe，与 dispatch 路径和 Console 模型一致（修复 ERR-024/ERR-089）。
- 修复 4 处 stale `pd runtime activation list/promote/dispatch` → `pd activation list/promote/dispatch`（runtime-activation.ts ×2、rulehost-pipeline-runner.ts ×1、rule-host.ts ×1）。
- 更新 architecture-regression / proven-channel-baseline / writer 测试 / E2E 测试以反映 shadow-first 契约；新增 AP-08 测试验证 approve 路径 flag probe 接线。

### 影响范围
- [x] packages/principles-core
- [x] packages/openclaw-plugin
- [x] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否
- [ ] 是（需 maintainer 批准，附理由）: ___

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 工作区已有 RuleHost 候选 artifact（可通过 `pd run-rulehost` 生成）。
- [ ] 动作 1: `pd activation approve --approval-id <id> --confirm`
  - 观察: `decision=activated`，但 `pd activation list --channel code_tool_hook` 显示 `action=code_tool_hook_shadow_activate`，且生产工具调用不被阻断。
- [ ] 动作 2: `pd activation promote --activation-id <id> --confirm`
  - 观察: `pd activation list` 显示 `action=code_tool_hook_live_activate`，`promotedAt` 非空；此时规则才真正阻断。
- [ ] 动作 3: `pd activation deactivate --activation-id <id>`
  - 观察: shadow 和 live 都立即失效（`deactivatedAt` 非空）。
- 证据（截图/CLI 输出关键行）: E2E 测试 `cross-package-acceptance.test.ts` Step 7-8 已验证 shadow→promote→live→deactivate 全链路。

## 风险与可逆性（agent 填）
- 主要风险: 历史已 approved 的 v1 activation 不受影响（v1 走原路径）；新审批的 v2/v1 activation 现在默认 shadow，owner 需显式 promote 才能 live 阻断——这是预期行为，但 owner 若不知道需要 promote 可能误以为"审批了没生效"。
- 回滚方式: [x] PR revert  [ ] feature flag  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否（shadow-first 是契约修正，不是新功能；v2 仍由 `rulecode_context_v2` flag gate）
  - [ ] 是（名称: ___）
  - 规则引用: `mvp-q-3-how-disabled` —— 任何需 PR revert 的变更必须带 flag
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会——seed-MVP release blocker，不修则种子用户首次审批即 live 阻断，无观察窗口。
- `mvp-q-2-how-observed`: 如何观察它生效？`pd activation list --channel code_tool_hook` 显示 `action=code_tool_hook_shadow_activate`；promote 后变 `code_tool_hook_live_activate`。
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（注释更新）
- [x] 无破坏性变更（或已标记为 breaking change）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：如果删除了源文件，确认 barrel (`index.ts`) 和 compile test (`exports-compile.ts`) 已同步清理
- [x] Core 边界检查：本 PR 是否在 `packages/principles-core/src/` 新增了 `fs`/`path` 导入？如果是，是否更新了 `architecture-regression.test.ts` 的白名单和 `eslint.config.js` 的豁免列表？
  - 规则引用: `antipattern-core-io` — 无新增 I/O 导入

### Core Store 契约变更审计（条件性 — 仅当修改 `packages/principles-core/src/**/sqlite-*-store.ts` 时填写）
- [x] N/A — 本 PR 未修改 core store 契约

### ERR Checklist（必填）
- ERR-024 (validator 只在一条路径接入): 本 PR 修复点 — approve 路径现在注入 featureFlagProbe，与 dispatch 路径和 Console 模型一致。
- ERR-089 (兄弟路径契约分叉): approve 路径现与 dispatch 一致；Console 模型仍有 stale `pd runtime activation dispatch` warning 字符串（P2，不阻塞合并，建议 follow-up）。
- ERR-025 (生产接线缺失): approve 路径现在有生产接线 `loadPdConfig` + `computeFlagsFromLoadResult`。
- ERR-053 (测试断言 X 生产做 Y): 测试断言具体值 `code_tool_hook_shadow_activate`，非 truthy。
- ERR-088 (断言具体值非 truthy): writer 测试 `expect(result.action).not.toContain('live')` + `toContain('shadow')` 双向断言。

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据（featureFlags 来自 `loadPdConfig` 解析的 config）
- [x] `rc-1-treat-as-unknown` — `featureFlags` 来自已类型化的 `FeatureFlagsResult`，非 `any`
- [x] `rc-2-no-as-bypass` — 探针 `(flagId) => featureFlags.flags[flagId]?.enabled === true` 用方括号+可选链，无 `as`
- [x] `rc-3-fail-loud-missing` — flag off 时 `canActivate` 返回 `rulecode_context_v2_disabled`（既有代码）
- [ ] `rc-4-validate-array-elements` — N/A
- [x] `rc-5-object-hasown-not-in` — 探针用 `flags[flagId]`（方括号访问），既有 `canActivate` 已用 `Object.hasOwn`
- [ ] `rc-6-lineage-consistency` — N/A
- [ ] `rc-7-loop-state-freshness` — N/A
- [ ] `rc-8-safe-serialization` — N/A
- [x] `rc-9-no-silent-fallback` — rule-host.ts shadow 模式 warn 含 reason + nextAction；approve 路径外层 catch 含 reason + nextAction

### CLI Gate 自检（条件性 — 仅当修改 `packages/pd-cli/src/commands/**` 时填写）
- [x] `cli-1-strict-json` — approve 路径 `console.log(JSON.stringify(result, null, 2))` 输出单一对象；AP-05 已验证
- [x] `cli-2-exit-stops` — 用 `process.exitCode = 1; return;` 模式
- [ ] `cli-3-negated-flags-parser-tests` — N/A（无 `--no-*`）
- [ ] `cli-4-dry-run-confirm-mutex` — N/A（approve 无 dry-run/confirm）
- [x] `cli-5-failure-no-mutation` — 失败路径回滚 approval（919-921、948-951）
- [x] `cli-6-output-next-action` — 所有 degraded/refused 结果含 reason + nextAction；stale nextAction 已修
- [x] `cli-7-test-wiring` — AP-08 通过 `mockRuleHostWriterConfigs` 捕获构造配置测试真实接线；AP-07 测试 parser flags

### Feature Flag 注册检查（条件性 — 仅当引入新功能子系统/hook/writer/reader 时填写）
- [x] N/A — 本 PR 未引入新功能子系统（仅修正既有 writer 行为）

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`
- [x] 无 `antipattern-completeness`
- [x] 无 `antipattern-review-missing`
- [x] 无 `antipattern-core-io`

## 产品品味审计（owner 填，agent 不得代填）
- [ ] 提醒方式是否克制？（非大声通知，精巧视觉）
- [ ] 命名是否符合双语规范？
- [ ] 交互是否符合"最小连贯干预"原则？
- [ ] 错误路径是否给了 nextAction，而非 silent fallback？（`rc-9-no-silent-fallback`）
- [ ] 是否符合 PD 产品边界？（非任务执行/通用记忆/工具修复/自主价值决策）
- 产品品味备注（可选）: ___

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run test`: 通过（5990 passed | 3 skipped | 3 todo）
- [x] `cd packages/openclaw-plugin && npm run test`: 通过（1904 passed | 12 skipped）
- [x] `cd packages/pd-cli && npm run test`: 通过（1232 passed | 2 skipped）
- [x] `npm run lint`: 通过
- [x] `npm run verify:merge`: 通过

### Skipped/warnings 说明
- core: 3 skipped + 3 todo 是既有未启用测试，与本 PR 无关
- openclaw-plugin: 12 skipped 是既有 Windows 平台跳过测试
- pd-cli: 2 skipped 是既有未启用测试
- eslint: 2 warnings 是 test 文件被 ignore 的正常警告（非错误）

## 剩余风险
- Console 模型 `ApprovalsConsoleModel.ts:194` 仍有 stale `pd runtime activation dispatch` warning 字符串（P2，不阻塞合并，建议 follow-up issue）
- 历史已 approved 的 activation 若 action 是 `code_tool_hook_live_activate`（旧 writer 写入），仍会 live 阻断——这是预期行为，不影响新审批

## 相关 Issue
- Linear: PRI-489
- Parent: PRI-478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 激活审批后改为先生成“观察模式”激活，再通过显式提升进入生效状态，增强了上线前的可观测性。
  * 相关流程现在支持先验证观察模式行为，再切换到正式拦截或放行。

* **Bug 修复**
  * 统一更新了若干激活相关提示与命令路径，避免用户看到过时的操作说明。
  * 修正了审批后特性开关的判定方式，确保激活行为一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->