### PR TITLE
fix(website): pull Git LFS assets in Cloudflare Pages deploy CI

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,8 +11,22 @@ jobs:
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (with Git LFS)
         uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Verify LFS assets pulled
+        run: |
+          # Fail fast if mp4/webp are still LFS pointers (130 bytes) instead of real content
+          for f in packages/website/public/promo.mp4 packages/website/public/promo-en.mp4; do
+            size=$(stat -c%s "$f" 2>/dev/null || echo 0)
+            if [ "$size" -lt 1024 ]; then
+              echo "::error::$f is $size bytes — Git LFS pull failed (expected real video content >1KB)"
+              exit 1
+            fi
+            echo "[ok] $f: $size bytes"
+          done
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: N/A（CI 修复）
- 解决的产品问题: 防止 LFS 迁移后 Cloudflare Pages 部署的 website 视频播放失效
- emotional价值：降低 [失控感] 创造 [安心感]
  - 如无明确情绪价值，说明为何仍是必要的: CI 修复是 LFS 迁移的前置条件，不做会导致 website 部署收到 130 字节的 LFS 指针而非真实 mp4
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复

### 高层变更
- `deploy-website.yml` 的 checkout 步骤加 `lfs: true`，确保 Cloudflare Pages 部署 CI 拉取真实 mp4/webp 内容
- 新增"Verify LFS assets pulled"步骤：build 前验证 mp4 文件 >1KB，若 LFS pull 失败立即 fail loud（`rc-3-fail-loud-missing`）

### 影响范围
- [ ] packages/principles-core
- [ ] packages/openclaw-plugin
- [ ] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- [x] 其他: `.github/workflows/deploy-website.yml`（CI 配置）

### 是否触及产品边界
- [x] 否

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 无（CI 修复，PR 合并后自动触发部署）
- [ ] 动作 1: 合并 PR，观察 Deploy Website workflow
  - 观察: "Verify LFS assets pulled" 步骤打印 `[ok] packages/website/public/promo.mp4: 5767168 bytes`
- [ ] 动作 2: 部署完成后访问 https://principles-website.pages.dev/（或自定义域名）
  - 观察: HeroSection 视频可正常播放
- 证据: CI 日志 + 浏览器 DevTools Network 显示 `/promo.mp4` Content-Type: video/mp4

## 风险与可逆性（agent 填）
- 主要风险: 极低。`lfs: true` 是 GitHub 官方支持，未装 LFS 的仓库该参数无副作用
- 回滚方式: [x] PR revert
- 是否需要 feature flag: [x] 否
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后会有人提起——LFS 迁移一旦完成，website 视频立即失效
- `mvp-q-2-how-observed`: CI workflow 的 "Verify LFS assets pulled" 步骤 + 浏览器视频播放
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填）

### 检查清单
- [x] 代码符合项目风格
- [x] 无破坏性变更
- [x] 通过 Thinking OS 检查
- [x] Core 边界检查: N/A（未改 core）

### ERR Checklist
- ERR-009 (silent fallback): 新增的 "Verify LFS assets" 步骤用 `exit 1` fail loud，避免静默部署 LFS 指针
- ERR-002 (graceful degradation without reason): 失败时打印 `::error::` 明确原因 + 建议动作
- ERR-014 (safe serialization): N/A —— 无序列化

### Runtime Contract 自检
- [x] N/A — 本 PR 不处理不可信数据（CI 配置）

### CLI Gate 自检
- [x] N/A — 本 PR 未修改 CLI 命令

### Feature Flag 注册检查
- [x] N/A — 未引入新功能子系统

### BDD 影响评估
- [x] N/A — 未触及 BDD 行为契约

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`
- [x] 无 `antipattern-completeness`
- [x] 无 `antipattern-review-missing`
- [x] 无 `antipattern-core-io`

## 测试结果（agent 填）
- [ ] `npm run verify:merge`: 待 CI 验证（pre-push 已通过本地 verify:merge）

## 相关 Issue
N/A —— 仓库维护任务的前置修复

## 上下文

这是 PD 仓库瘦身收尾计划（v2）的 Phase A 延伸修复。PR #1156 已配置 Git LFS 跟踪 mp4/webp，但 Cloudflare Pages 部署 CI 的 `actions/checkout@v6` 默认不拉取 LFS 内容。一旦 Phase B-C 完成 LFS 历史迁移，部署 CI 会把 130 字节的 LFS 指针当成 mp4 部署，导致 website 视频播放失效。

本 PR 修复：
1. checkout 加 `lfs: true`
2. build 前验证 mp4 文件 >1KB（fail loud，避免静默部署坏文件）
