### PR TITLE
fix(pri-442): wire effectiveConfig + sourcePainId + artificer prompt consistency

### DIFF
--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -41,6 +41,7 @@ import { loadPdConfig, computeFlagsFromLoadResult } from '../services/pd-config-
 import { isFeatureEnabled, SPLIT_PIPELINE_TOTAL_TIMEOUT_MS } from '@principles/core/runtime-v2';
 import { resolveRuntimeAdapterFromConfig, ConfigResolutionError } from '../services/runtime-adapter-resolver.js';
 import { checkAdmissionGate } from './admission-gate.js';
+import { resolveSourcePainIdFromDiagnostician } from './candidate.js';
 import * as path from 'path';
 
 function validateStalledThreshold(val: unknown): number | undefined {
@@ -358,6 +359,11 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     const featureFlags = computeFlagsFromLoadResult(configLoadResult);
     const isSplitPipeline = isFeatureEnabled(featureFlags, 'diagnostician_split_pipeline');
     const pipelineTimeoutMs = isSplitPipeline ? SPLIT_PIPELINE_TOTAL_TIMEOUT_MS : 300_000;
+    // BUG-1 (PRI-442): extract effectiveConfig so ADR-0019 LLM rate-limit
+    // degradation (isDegradationEnabled in base-peer-runner) can read the
+    // diagnostician_llm_degradation feature flag. Without this, the runners
+    // receive no effectiveConfig and degradation silently never fires.
+    const effectiveConfig = configLoadResult.ok ? configLoadResult.effective : configLoadResult.defaults;
 
     let runner: DiagnosticianRunnerLike;
     if (isSplitPipeline) {
@@ -365,15 +371,15 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
       const perStageTimeoutMs = pipelineTimeoutMs / 3;
       const rootCauseRunner = new DiagRootCauseRunner(
         { stateManager, runtimeAdapter, eventEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDiagRootCauseValidator(), contextAssembler },
-        { owner: 'pd-cli-diagnose', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs },
+        { owner: 'pd-cli-diagnose', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs, effectiveConfig },
       );
       const distillerRunner = new DiagDistillerRunner(
         { stateManager, runtimeAdapter, eventEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDiagDistillerValidator() },
-        { owner: 'pd-cli-diagnose', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs },
+        { owner: 'pd-cli-diagnose', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs, effectiveConfig },
       );
       const routerRunner = new DiagRouterRunner(
         { stateManager, runtimeAdapter, eventEmitter, artifactStore: stateManager.piArtifactStore, committer },
-        { owner: 'pd-cli-diagnose', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs },
+        { owner: 'pd-cli-diagnose', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs, effectiveConfig },
       );
 
       runner = new SplitDiagnosticianRunner({
@@ -522,10 +528,12 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
           if (!route) continue;
           const channel = ROUTE_CHANNEL_MAP[route];
           const ready = !!channel && MVP_ENABLED_CHANNELS.has(channel);
-          // sourcePainId is unavailable in CLI context (opts.taskId is the
-          // diagnostician task ID, not a pain ID). Passing undefined is safe —
-          // buildDreamerSeedFromCandidate omits the field when blank.
-          const seed = buildDreamerSeedFromCandidate(candidate, { route, ready, sourcePainId: undefined });
+          // BUG-2 (PRI-442): resolve sourcePainId from the diagnostician task
+          // chain (rc-6 lineage consistency). The candidate itself doesn't carry
+          // sourcePainId; it must be resolved from the diagnostician task's
+          // diagnosticJson. ERR-004: never invent lineage.
+          const sourcePainId = await resolveSourcePainIdFromDiagnostician(stateManager, candidate);
+          const seed = buildDreamerSeedFromCandidate(candidate, { route, ready, sourcePainId: sourcePainId ?? undefined });
           // eslint-disable-next-line no-restricted-syntax -- 'in' required for discriminated union narrowing (BridgeTaskSeed | BridgeDecision)
           if ('decision' in seed) continue; // not_internalizable or invalid — skip
           const existingTask = await stateManager.getTask(seed.taskId);

--- a/packages/pd-cli/src/commands/diagnose.ts
+++ b/packages/pd-cli/src/commands/diagnose.ts
@@ -363,6 +363,16 @@ export async function handleDiagnoseRun(opts: DiagnoseRunOptions): Promise<void>
     // degradation (isDegradationEnabled in base-peer-runner) can read the
     // diagnostician_llm_degradation feature flag. Without this, the runners
     // receive no effectiveConfig and degradation silently never fires.
+    // CR-1 (CodeRabbit P2, rc-9): warn when config load failed so the
+    // fallback to defaults is observable — no silent degradation.
+    if (!configLoadResult.ok) {
+      const errSummary = configLoadResult.errors
+        .map((e) => `${e.path}: ${e.reason}`)
+        .join('; ');
+      console.warn(
+        `[pd diagnose] .pd/config.yaml at ${configLoadResult.configPath} is malformed — falling back to default feature flags. Errors: ${errSummary}. Next action: ${configLoadResult.errors[0]?.nextAction ?? 'fix config errors and retry'}`,
+      );
+    }
     const effectiveConfig = configLoadResult.ok ? configLoadResult.effective : configLoadResult.defaults;
 
     let runner: DiagnosticianRunnerLike;

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -385,6 +385,16 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
     // degradation (isDegradationEnabled in base-peer-runner) can read the
     // diagnostician_llm_degradation feature flag. Without this, the runners
     // receive no effectiveConfig and degradation silently never fires.
+    // CR-1 (CodeRabbit P2, rc-9): warn when config load failed so the
+    // fallback to defaults is observable — no silent degradation.
+    if (!configLoadResult.ok) {
+      const errSummary = configLoadResult.errors
+        .map((e) => `${e.path}: ${e.reason}`)
+        .join('; ');
+      console.warn(
+        `[pd pain retry] .pd/config.yaml at ${configLoadResult.configPath} is malformed — falling back to default feature flags. Errors: ${errSummary}. Next action: ${configLoadResult.errors[0]?.nextAction ?? 'fix config errors and retry'}`,
+      );
+    }
     const effectiveConfig = configLoadResult.ok ? configLoadResult.effective : configLoadResult.defaults;
 
     let runner: DiagnosticianRunnerLike;

--- a/packages/pd-cli/src/commands/pain-retry.ts
+++ b/packages/pd-cli/src/commands/pain-retry.ts
@@ -381,21 +381,27 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
     const featureFlags = computeFlagsFromLoadResult(configLoadResult);
     const isSplitPipeline = isFeatureEnabled(featureFlags, 'diagnostician_split_pipeline');
     const pipelineTimeoutMs = isSplitPipeline ? SPLIT_PIPELINE_TOTAL_TIMEOUT_MS : 300_000;
+    // BUG-1 (PRI-442): extract effectiveConfig so ADR-0019 LLM rate-limit
+    // degradation (isDegradationEnabled in base-peer-runner) can read the
+    // diagnostician_llm_degradation feature flag. Without this, the runners
+    // receive no effectiveConfig and degradation silently never fires.
+    const effectiveConfig = configLoadResult.ok ? configLoadResult.effective : configLoadResult.defaults;
 
     let runner: DiagnosticianRunnerLike;
     if (isSplitPipeline) {
       const resolvedKind = typeof runtimeAdapter.kind === 'function' ? runtimeAdapter.kind() : runtimeKind;
+      const perStageTimeoutMs = pipelineTimeoutMs / 3;
       const rootCauseRunner = new DiagRootCauseRunner(
         { stateManager, runtimeAdapter, eventEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDiagRootCauseValidator(), contextAssembler },
-        { owner: 'pd-cli-pain-retry', runtimeKind: resolvedKind, outputLanguage },
+        { owner: 'pd-cli-pain-retry', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs, effectiveConfig },
       );
       const distillerRunner = new DiagDistillerRunner(
         { stateManager, runtimeAdapter, eventEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDiagDistillerValidator() },
-        { owner: 'pd-cli-pain-retry', runtimeKind: resolvedKind, outputLanguage },
+        { owner: 'pd-cli-pain-retry', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs, effectiveConfig },
       );
       const routerRunner = new DiagRouterRunner(
         { stateManager, runtimeAdapter, eventEmitter, artifactStore: stateManager.piArtifactStore, committer },
-        { owner: 'pd-cli-pain-retry', runtimeKind: resolvedKind, outputLanguage },
+        { owner: 'pd-cli-pain-retry', runtimeKind: resolvedKind, outputLanguage, timeoutMs: perStageTimeoutMs, effectiveConfig },
       );
 
       runner = new SplitDiagnosticianRunner({
@@ -404,7 +410,7 @@ export async function handlePainRetry(opts: PainRetryOptions): Promise<void> {
         routerRunner,
         stateManager,
         committer,
-        perStageTimeoutMs: pipelineTimeoutMs / 3,
+        perStageTimeoutMs,
       });
     } else {
       runner = new DisabledDiagnosticianRunner();

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -66,6 +66,21 @@ const { mockResolveRuntimeFromPdConfig } = vi.hoisted(() => {
   return { mockResolveRuntimeFromPdConfig };
 });
 
+// BUG-1: capture runner constructor args to verify effectiveConfig wiring
+const { diagRootCauseRunnerCtor, diagDistillerRunnerCtor, diagRouterRunnerCtor } = vi.hoisted(() => {
+  const diagRootCauseRunnerCtor = vi.fn().mockImplementation(function () { return {}; });
+  const diagDistillerRunnerCtor = vi.fn().mockImplementation(function () { return {}; });
+  const diagRouterRunnerCtor = vi.fn().mockImplementation(function () { return {}; });
+  return { diagRootCauseRunnerCtor, diagDistillerRunnerCtor, diagRouterRunnerCtor };
+});
+
+// BUG-2: capture buildDreamerSeedFromCandidate sourcePainId arg + mock resolver
+const { buildDreamerSeedCalls, mockResolveSourcePainId } = vi.hoisted(() => {
+  const buildDreamerSeedCalls: Array<{ candidateId: string; sourcePainId?: string }> = [];
+  const mockResolveSourcePainId = vi.fn().mockResolvedValue('pain_test-source-1');
+  return { buildDreamerSeedCalls, mockResolveSourcePainId };
+});
+
 vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
 }));
@@ -83,9 +98,9 @@ vi.mock('@principles/core/runtime-v2', () => {
     StoreEventEmitter: vi.fn().mockImplementation(function () { return {}; }),
     storeEmitter: { emitTelemetry: vi.fn() },
     SplitDiagnosticianRunner: vi.fn().mockImplementation(function () { return {}; }),
-    DiagRootCauseRunner: vi.fn().mockImplementation(function () { return {}; }),
-    DiagDistillerRunner: vi.fn().mockImplementation(function () { return {}; }),
-    DiagRouterRunner: vi.fn().mockImplementation(function () { return {}; }),
+    DiagRootCauseRunner: diagRootCauseRunnerCtor,
+    DiagDistillerRunner: diagDistillerRunnerCtor,
+    DiagRouterRunner: diagRouterRunnerCtor,
     DefaultDiagRootCauseValidator: vi.fn().mockImplementation(function () { return {}; }),
     DefaultDiagDistillerValidator: vi.fn().mockImplementation(function () { return {}; }),
     DisabledDiagnosticianRunner: vi.fn().mockImplementation(function () { return {}; }),
@@ -142,15 +157,19 @@ vi.mock('@principles/core/runtime-v2', () => {
     status: vi.fn(),
     PrincipleTreeLedgerAdapter: MockPrincipleTreeLedgerAdapter,
     // Defect-004 dreamer seed mocks — minimal stubs that mirror real behavior
-    buildDreamerSeedFromCandidate: vi.fn().mockImplementation((candidate: { candidateId: string }, _opts: { route: string; ready: boolean; sourcePainId?: string }) => ({
-      taskId: `dreamer-${candidate.candidateId}`,
-      taskKind: 'dreamer' as const,
-      channel: 'prompt' as const,
-      diagnosticJson: JSON.stringify({ candidateId: candidate.candidateId }),
-      status: 'pending' as const,
-      attemptCount: 0,
-      maxAttempts: 3,
-    })),
+    // BUG-2: capture sourcePainId arg to verify lineage wiring
+    buildDreamerSeedFromCandidate: vi.fn().mockImplementation((candidate: { candidateId: string }, opts: { route: string; ready: boolean; sourcePainId?: string }) => {
+      buildDreamerSeedCalls.push({ candidateId: candidate.candidateId, sourcePainId: opts?.sourcePainId });
+      return {
+        taskId: `dreamer-${candidate.candidateId}`,
+        taskKind: 'dreamer' as const,
+        channel: 'prompt' as const,
+        diagnosticJson: JSON.stringify({ candidateId: candidate.candidateId }),
+        status: 'pending' as const,
+        attemptCount: 0,
+        maxAttempts: 3,
+      };
+    }),
     CANDIDATE_KIND_TO_ROUTE: {
       principle: 'principle-candidate',
       rule: 'rule-candidate',
@@ -170,12 +189,21 @@ vi.mock('../../src/config-reader.js', () => ({
 }));
 
 vi.mock('../../src/services/pd-config-loader.js', () => ({
-  loadPdConfig: vi.fn().mockReturnValue({ ok: true, effective: { config: {}, source: 'defaults', warnings: [] } }),
+  loadPdConfig: vi.fn().mockReturnValue({
+    ok: true,
+    effective: { config: { featureFlags: { diagnostician_llm_degradation: true } }, source: 'file', warnings: [] },
+    defaults: { config: {}, source: 'defaults', warnings: [] },
+  }),
   computeFlagsFromLoadResult: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock('../../src/services/resolve-runtime-from-pd-config.js', () => ({
   resolveRuntimeFromPdConfig: mockResolveRuntimeFromPdConfig,
+}));
+
+// BUG-2: mock resolveSourcePainIdFromDiagnostician imported by diagnose.ts from candidate.js
+vi.mock('../../src/commands/candidate.js', () => ({
+  resolveSourcePainIdFromDiagnostician: mockResolveSourcePainId,
 }));
 
 import { handleDiagnoseRun, handleDiagnoseStatus, type DiagnoseRunOptions } from '../../src/commands/diagnose.js';
@@ -1289,6 +1317,110 @@ describe('Defect-004: pd diagnose run — dreamer seed after intake', () => {
     const seedResult = parsed.intake.candidates.find((c: { candidateId: string; status: string }) => c.candidateId === 'cand-1' && c.status === 'dreamer_seed_failed');
     expect(seedResult).toBeDefined();
     expect(seedResult.error).toContain('DB write failed');
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+// BUG-1 (PRI-442): effectiveConfig must be passed to split-pipeline runners
+// so that ADR-0019 LLM rate-limit degradation (isDegradationEnabled) can fire.
+// Without this wiring, isDegradationEnabled() always returns false because
+// this.config.effectiveConfig is undefined. EP-02: production path wiring.
+describe('BUG-1 (PRI-442): effectiveConfig wiring to split-pipeline runners', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { run } = await import('@principles/core/runtime-v2');
+    vi.mocked(run).mockResolvedValue(SUCCEEDED_RESULT);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockIntake.mockReset();
+  });
+
+  it('passes effectiveConfig to DiagRootCauseRunner when split pipeline is enabled', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    expect(diagRootCauseRunnerCtor).toHaveBeenCalled();
+    const optionsArg = diagRootCauseRunnerCtor.mock.calls[0]?.[1];
+    expect(optionsArg?.effectiveConfig).toBeDefined();
+    expect(optionsArg?.effectiveConfig).toEqual(
+      expect.objectContaining({ config: expect.anything(), source: 'file' }),
+    );
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('passes effectiveConfig to DiagDistillerRunner and DiagRouterRunner', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    const distillerOptions = diagDistillerRunnerCtor.mock.calls[0]?.[1];
+    expect(distillerOptions?.effectiveConfig).toBeDefined();
+
+    const routerOptions = diagRouterRunnerCtor.mock.calls[0]?.[1];
+    expect(routerOptions?.effectiveConfig).toBeDefined();
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+// BUG-2 (PRI-442): sourcePainId must be resolved from the diagnostician task
+// chain and passed to buildDreamerSeedFromCandidate. Without this, the dreamer
+// task's diagnosticJson omits sourcePainId, breaking run-rulehost lineage.
+// rc-6: lineage consistency. ERR-004: never invent lineage.
+describe('BUG-2 (PRI-442): sourcePainId resolution for dreamer seed', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    buildDreamerSeedCalls.length = 0;
+    const { run } = await import('@principles/core/runtime-v2');
+    vi.mocked(run).mockResolvedValue(SUCCEEDED_RESULT);
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockCreateTask.mockResolvedValue(undefined);
+    mockGetTask.mockResolvedValue(null);
+    mockIntake.mockReset();
+    mockIntake.mockResolvedValue({ id: 'ledger-1', title: 'P1', status: 'probation' });
+    mockResolveSourcePainId.mockResolvedValue('pain_test-source-1');
+  });
+
+  it('passes resolved sourcePainId to buildDreamerSeedFromCandidate (lineage consistency)', async () => {
+    const candidates = [
+      { candidateId: 'cand-1', artifactId: 'art-1', taskId: 'test-task-1', status: 'pending', recommendationKind: 'principle' },
+    ];
+    mockGetCandidatesByTaskId.mockResolvedValue(candidates);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    // resolveSourcePainIdFromDiagnostician should have been called
+    expect(mockResolveSourcePainId).toHaveBeenCalled();
+    // buildDreamerSeedFromCandidate should have received the resolved sourcePainId
+    expect(buildDreamerSeedCalls.length).toBeGreaterThan(0);
+    expect(buildDreamerSeedCalls[0].sourcePainId).toBe('pain_test-source-1');
 
     consoleSpy.mockRestore();
     exitSpy.mockRestore();

--- a/packages/pd-cli/tests/commands/diagnose.test.ts
+++ b/packages/pd-cli/tests/commands/diagnose.test.ts
@@ -1379,6 +1379,57 @@ describe('BUG-1 (PRI-442): effectiveConfig wiring to split-pipeline runners', ()
     consoleSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  // CR-2 (CodeRabbit P2): loadPdConfig mock only covered ok:true. The
+  // ok:false fallback branch (effectiveConfig = defaults) was untested.
+  // This test locks in the fallback behavior + asserts rc-9 observability.
+  it('warns and falls back to defaults when configLoadResult.ok is false', async () => {
+    // Override the module-level mock for this test only
+    const { loadPdConfig } = await import('../../src/services/pd-config-loader.js');
+    vi.mocked(loadPdConfig).mockReturnValueOnce({
+      ok: false,
+      source: 'malformed',
+      configPath: '/tmp/fake-workspace/.pd/config.yaml',
+      errors: [
+        { path: 'featureFlags.diagnostician_llm_degradation', reason: 'expected boolean, got string', nextAction: 'Fix the value to be a boolean' },
+      ],
+      defaults: { config: {}, source: 'defaults', warnings: [] },
+      warnings: [],
+      legacyFilesDetected: [],
+      legacyFileNextActions: [],
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handleDiagnoseRun({
+      taskId: 'test-task-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    } as DiagnoseRunOptions);
+
+    // Assert warning was emitted (rc-9: no silent fallback)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[pd diagnose]'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed'),
+    );
+
+    // Assert runners still received effectiveConfig (the defaults-based one)
+    expect(diagRootCauseRunnerCtor).toHaveBeenCalled();
+    const optionsArg = diagRootCauseRunnerCtor.mock.calls[0]?.[1];
+    expect(optionsArg?.effectiveConfig).toBeDefined();
+    expect(optionsArg?.effectiveConfig).toEqual(
+      expect.objectContaining({ source: 'defaults' }),
+    );
+
+    warnSpy.mockRestore();
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 });
 
 // BUG-2 (PRI-442): sourcePainId must be resolved from the diagnostician task

--- a/packages/pd-cli/tests/commands/pain-retry.test.ts
+++ b/packages/pd-cli/tests/commands/pain-retry.test.ts
@@ -90,6 +90,23 @@ vi.mock('../../src/resolve-workspace.js', () => ({
   resolveWorkspaceDir: vi.fn().mockReturnValue('/tmp/fake-workspace'),
 }));
 
+// BUG-1 (PRI-442): capture runner constructor args to verify effectiveConfig wiring
+const { diagRootCauseRunnerCtor, diagDistillerRunnerCtor, diagRouterRunnerCtor } = vi.hoisted(() => {
+  const diagRootCauseRunnerCtor = vi.fn().mockImplementation(function () { return {}; });
+  const diagDistillerRunnerCtor = vi.fn().mockImplementation(function () { return {}; });
+  const diagRouterRunnerCtor = vi.fn().mockImplementation(function () { return {}; });
+  return { diagRootCauseRunnerCtor, diagDistillerRunnerCtor, diagRouterRunnerCtor };
+});
+
+vi.mock('../../src/services/pd-config-loader.js', () => ({
+  loadPdConfig: vi.fn().mockReturnValue({
+    ok: true,
+    effective: { config: { featureFlags: { diagnostician_llm_degradation: true } }, source: 'file', warnings: [] },
+    defaults: { config: {}, source: 'defaults', warnings: [] },
+  }),
+  computeFlagsFromLoadResult: vi.fn().mockReturnValue({}),
+}));
+
 vi.mock('@principles/core/runtime-v2', () => {
   return {
     RuntimeStateManager: vi.fn().mockImplementation(function () {
@@ -103,9 +120,9 @@ vi.mock('@principles/core/runtime-v2', () => {
     StoreEventEmitter: vi.fn().mockImplementation(function () { return {}; }),
     storeEmitter: { emitTelemetry: vi.fn() },
     SplitDiagnosticianRunner: vi.fn().mockImplementation(function () { return {}; }),
-    DiagRootCauseRunner: vi.fn().mockImplementation(function () { return {}; }),
-    DiagDistillerRunner: vi.fn().mockImplementation(function () { return {}; }),
-    DiagRouterRunner: vi.fn().mockImplementation(function () { return {}; }),
+    DiagRootCauseRunner: diagRootCauseRunnerCtor,
+    DiagDistillerRunner: diagDistillerRunnerCtor,
+    DiagRouterRunner: diagRouterRunnerCtor,
     DefaultDiagRootCauseValidator: vi.fn().mockImplementation(function () { return {}; }),
     DefaultDiagDistillerValidator: vi.fn().mockImplementation(function () { return {}; }),
     DisabledDiagnosticianRunner: vi.fn().mockImplementation(function () { return {}; }),
@@ -964,5 +981,54 @@ describe('Commander wiring for pd pain retry', () => {
     const { program, capturedOpts } = createPainRetryProgram();
     await program.parseAsync(['node', 'pd', 'pain', 'retry', '--pain-id', 'abc', '--openclaw-gateway']);
     expect(capturedOpts.openclawGateway).toBe(true);
+  });
+});
+
+// BUG-1 (PRI-442): effectiveConfig must be passed to split-pipeline runners
+// so that ADR-0019 LLM rate-limit degradation (isDegradationEnabled) can fire.
+// EP-02: production path wiring.
+describe('BUG-1 (PRI-442): pain retry — effectiveConfig wiring to split-pipeline runners', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCandidatesByTaskId.mockResolvedValue([]);
+    mockUpdateCandidateStatus.mockResolvedValue(undefined);
+    mockGetRunsByTask.mockResolvedValue([]);
+    mockIntake.mockReset();
+    mockRun.mockResolvedValue({
+      status: 'succeeded',
+      taskId: 'diagnosis_test-pain-1',
+      runId: 'run-retry-1',
+      contextHash: 'abc123',
+    });
+  });
+
+  it('passes effectiveConfig to all three runners when split pipeline is enabled', async () => {
+    mockGetTask.mockResolvedValue(RETRY_WAIT_TASK);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+
+    await handlePainRetry({
+      painId: 'test-pain-1',
+      workspace: '/tmp/fake-workspace',
+      runtime: 'test-double',
+      json: true,
+    });
+
+    expect(diagRootCauseRunnerCtor).toHaveBeenCalled();
+    const rootOptions = diagRootCauseRunnerCtor.mock.calls[0]?.[1];
+    expect(rootOptions?.effectiveConfig).toBeDefined();
+    expect(rootOptions?.effectiveConfig).toEqual(
+      expect.objectContaining({ config: expect.anything(), source: 'file' }),
+    );
+
+    const distillerOptions = diagDistillerRunnerCtor.mock.calls[0]?.[1];
+    expect(distillerOptions?.effectiveConfig).toBeDefined();
+
+    const routerOptions = diagRouterRunnerCtor.mock.calls[0]?.[1];
+    expect(routerOptions?.effectiveConfig).toBeDefined();
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/artificer-prompt-builder.test.ts
@@ -180,3 +180,50 @@ describe('PRI-484 Artificer prompt context modes', () => {
     expect(ARTIFICER_PROTOCOL_INSTRUCTION).toContain('RETRY');
   });
 });
+
+describe('BUG-3 (PRI-442): artificer prompt propose_correction consistency', () => {
+  const builder = new ArtificerPromptBuilder();
+
+  it('shared CONSTRAINTS must not mention propose_correction as an expected negative case', () => {
+    // The shared CONSTRAINTS section (ARTIFICER_PROTOCOL_INSTRUCTION) must NOT
+    // tell the LLM to emit propose_correction — it contradicts the V2 ban and
+    // causes schema validation failures (ERR-009).
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).not.toMatch(/negative block\/propose_correction case/);
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).not.toMatch(/propose_correction cases MUST include/);
+  });
+
+  it('shared CONSTRAINTS forbids propose_correction, requireApproval, and auto_correct', () => {
+    // The "only allow/block" constraint must appear in the shared section so
+    // both v1 and v2 prompts are consistent.
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toMatch(/expectedDecision MUST be only.*allow.*block/i);
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toMatch(/do not.*propose_correction/i);
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toMatch(/do not.*requireApproval/i);
+    expect(ARTIFICER_PROTOCOL_INSTRUCTION).toMatch(/do not.*auto_correct/i);
+  });
+
+  it('v1 prompt forbids propose_correction (no contradiction with v2)', () => {
+    const result = builder.buildPrompt({
+      contextMode: 'v1',
+      taskId: 'bug3-v1',
+      contextHash: 'ctx-bug3',
+      sourceScribeArtifactId: 'scribe-bug3',
+      scribeArtifact: {},
+    });
+    expect(result.promptInput.artificerInstruction).toMatch(/do not.*propose_correction/i);
+    expect(result.promptInput.artificerInstruction).not.toMatch(/negative block\/propose_correction case/);
+  });
+
+  it('v2 prompt still forbids propose_correction (constraint preserved after move)', () => {
+    const result = builder.buildPrompt({
+      contextMode: 'v2',
+      taskId: 'bug3-v2',
+      contextHash: 'ctx-bug3',
+      sourceScribeArtifactId: 'scribe-bug3',
+      scribeArtifact: {},
+      behaviorExamplePack: validBehaviorExamplePack,
+    });
+    expect(result.promptInput.artificerInstruction).toMatch(/do not.*propose_correction/i);
+    expect(result.promptInput.artificerInstruction).toMatch(/do not.*requireApproval/i);
+    expect(result.promptInput.artificerInstruction).toMatch(/do not.*auto_correct/i);
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/artificer-prompt-builder.ts
@@ -82,8 +82,8 @@ CONSTRAINTS:
 - BAD:  return { decision: 'allow', matched: true } — missing reason, will be rejected
 - input.action contains toolName, normalizedPath, and paramsSummary
 - implementationCode MUST be deterministic and self-contained: no imports, require, eval, Function, I/O, network, timers, Date.now, or randomness
-- goldenTraceCases MUST contain 2-10 cases with at least one positive allow case and one negative block/propose_correction case
-- propose_correction cases MUST include expectedProposedParams and expectedApplicationMode (shadow or live)
+- goldenTraceCases MUST contain 2-10 cases with at least one positive allow case and one negative block case
+- goldenTraceCases expectedDecision MUST be only "allow" or "block" — do NOT emit "propose_correction", "requireApproval", or "auto_correct" (seed-user MVP only supports allow/block; all other action types are rejected by the schema validator)
 - affectedTools MUST contain the non-empty tool names the rule can match
 
 PRIOR ADVERSARIAL FAILURES (when \`adversarialFeedback\` is present):
@@ -107,7 +107,6 @@ CONTEXT MODE: v2 (Owner-labelled evidence is present)
 - You may inspect input.context. When it is undefined or context.history.status is unavailable, MUST return { decision: "allow", matched: false, reason: "context unavailable" }.
 - Prefer deterministic context.facts and canonicalKind over raw context.history.calls.
 - An empty or truncated history is insufficient evidence; do not infer "not done" from it.
-- SEED RULE CONSTRAINT: goldenTraceCases expectedDecision MUST be only "allow" or "block". Do NOT emit "propose_correction", "requireApproval", or "auto_correct" — seed-user MVP only supports allow/block decisions; all other action types are rejected by the schema validator.
 - You MUST copy evidenceRefs exactly from the behaviorExamplePack into your output. Do not omit, reorder, or rewrite any evidenceRef string.
 `;
 


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: PRI-442
- 解决的产品问题（一句话）: 修复内部验收测试第二轮发现的 3 个 Bug（effectiveConfig 未传递、sourcePainId 丢失、artificer prompt 矛盾），使六步闭环可达到 GO 状态。
- emotional-value：降低 [重复纠正感/失控感] 创造 [掌控感/安心感]
  - 如无明确情绪价值，说明为何仍是必要的: 三个 Bug 均阻塞六步闭环，修复后 Owner 可观察到诊断降级正常触发、dreamer 血缘完整、artificer 输出不再因矛盾 prompt 失败。
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复

### 高层变更（3-5 条，非逐文件 diff）
- Bug #1: `diagnose.ts` 和 `pain-retry.ts` 从 `configLoadResult` 提取 `effectiveConfig` 并传递给 3 个 split-pipeline runner，使 ADR-0019 LLM 限流降级 (`isDegradationEnabled`) 可正常读取 `diagnostician_llm_degradation` feature flag。
- Bug #2: `diagnose.ts` 在 seed dreamer task 前调用 `resolveSourcePainIdFromDiagnostician(stateManager, candidate)` 解析 sourcePainId，恢复 candidate → dreamer 血缘链（rc-6）。
- Bug #3: `artificer-prompt-builder.ts` 将 "expectedDecision MUST be only allow or block" 约束从 V2-only 提升到 shared CONSTRAINTS，删除 shared 中提及 propose_correction 的矛盾指引，消除 LLM 困惑导致的 schema validation 失败。
- `pain-retry.ts` 额外补齐缺失的 `timeoutMs: perStageTimeoutMs`（与 diagnose.ts 一致性修复）。

### 影响范围
- [x] packages/principles-core
- [ ] packages/openclaw-plugin
- [x] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 工作区已配置 `.pd/config.yaml` 含 `diagnostician_llm_degradation: true` 和 `diagnostician_split_pipeline: true`。
- [ ] 动作 1: `pd diagnose run --task-id <diagnostician-task-id> --runtime pi-ai ...` 触发诊断（或 mock 429 场景）
  - 观察: 当 LLM 返回 429 时，诊断器降级路径触发（日志/事件含 degradation 标记），而非硬失败。
- [ ] 动作 2: `pd diagnose run` 成功后查询 dreamer task 的 `diagnosticJson`
  - 观察: `diagnosticJson` 含 `sourcePainId` 字段，值与原始 pain 信号一致。
- [ ] 动作 3: 触发 artificer runner（candidate → dreamer → artificer 链路），检查 artificer LLM 输出
  - 观察: goldenTraceCases 的 expectedDecision 仅含 allow/block，不再出现 propose_correction，schema validation 通过。
- 证据（截图/CLI 输出关键行）: TDD 测试覆盖以上 3 个场景，测试结果见下方"测试结果"段。

## 风险与可逆性（agent 填）
- 主要风险: Bug #3 将 V1 prompt 也改为禁止 propose_correction（V1 validator 仍接受）。这是安全方向——prompt 比 validator 更严格，LLM 不会 emit，validator 的 accept 路径不被触发。V2 validator 本就拒绝 propose_correction，无影响。
- 回滚方式: [x] PR revert
- 是否需要 feature flag:
  - [x] 否
  - 规则引用: `mvp-q-3-how-disabled` —— 本 PR 是 bug 修复（wiring + prompt 文本），不引入新功能子系统，PR revert 即可回滚，无需 feature flag。
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会——这 3 个 Bug 阻塞六步闭环，不修复则内部验收无法达到 GO，seed customer 交付受阻。
- `mvp-q-2-how-observed`: 如何观察它生效？Bug #1: 429 时降级日志；Bug #2: dreamer task diagnosticJson 含 sourcePainId；Bug #3: artificer 输出不再含 propose_correction。
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（无需——bug 修复，无 API/行为契约变化）
- [x] 无破坏性变更（或已标记为 breaking change）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：N/A——未删除源文件
- [x] Core 边界检查：本 PR 未在 `packages/principles-core/src/` 新增 `fs`/`path` 导入。Bug #3 仅修改 prompt 文本字符串，无新 I/O。
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性）
- [x] N/A — 本 PR 未修改 core store 契约

### ERR Checklist（必填）
- ERR-002 (silent fallback): Bug #1 是 silent-failure 变体——degradation 静默不触发。修复使 wiring 显式化，`isDegradationEnabled()` 可读取 flag。
- ERR-004 (lineage inconsistency): Bug #2 丢失 sourcePainId，破坏 candidate → dreamer 血缘。修复恢复 `resolveSourcePainIdFromDiagnostician` 调用，血缘同源。
- ERR-009 (fail loud missing): Bug #1 使限流降级路径静默失效；Bug #3 矛盾 prompt 静默产生 invalid output。修复使约束明确，fail-loud 路径可执行。
- EP-02 (production path wiring): Bug #1 是教科书 EP-02——组件有隔离测试，但真实 CLI 路径未传递 config。
- EP-03 (fail loud and observable degradation): Bug #1 破坏降级可观测性契约。

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据（Bug #2 调用 `resolveSourcePainIdFromDiagnostician` 解析 diagnosticJson 中的 sourcePainId；Bug #3 修改处理 LLM 输出的 prompt）
- [x] `rc-1-treat-as-unknown` — `resolveSourcePainIdFromDiagnostician` 内部已用 typeof/Object.hasOwn 校验 diagnosticJson（未修改该函数，仅调用）。
- [x] `rc-2-no-as-bypass` — 未使用 as 绕过校验。
- [ ] `rc-3-fail-loud-missing` — N/A（未新增必填字段校验）
- [ ] `rc-4-validate-array-elements` — N/A
- [ ] `rc-5-object-hasown-not-in` — N/A（未新增 key 检查）
- [x] `rc-6-lineage-consistency` — Bug #2 恢复 sourcePainId 血缘同源（candidate → diagnostician → pain）。
- [ ] `rc-7-loop-state-freshness` — N/A
- [ ] `rc-8-safe-serialization` — N/A
- [x] `rc-9-no-silent-fallback` — Bug #1 修复 silent degradation；Bug #3 修复 silent invalid output。
- 遵守方式说明: Bug #2 调用已存在的 `resolveSourcePainIdFromDiagnostician`（该函数内部遵循 rc-1/rc-5），返回 `string | null`，null 时传 undefined 保留 `buildDreamerSeedFromCandidate` 的 omit-when-blank 行为，不发明血缘。

### CLI Gate 自检（条件性 — 本 PR 修改了 `packages/pd-cli/src/commands/**`）
- [x] `cli-1-strict-json` — N/A（未修改 JSON 输出格式）
- [x] `cli-2-exit-stops` — N/A（未修改 exit 路径）
- [ ] `cli-3-negated-flags-parser-tests` — N/A（未新增 --no-* flag）
- [ ] `cli-4-dry-run-confirm-mutex` — N/A
- [x] `cli-5-failure-no-mutation` — Bug #1/#2 修改的是 runner 构造和 dreamer seed 构造，均在诊断成功路径；失败路径（refuseExit）不触发这些代码，无新增 mutation。
- [x] `cli-6-output-next-action` — N/A（未修改降级/拒绝输出）
- [x] `cli-7-test-wiring` — TDD 测试通过 `vi.hoisted` 捕获 runner 构造参数和 `buildDreamerSeedFromCandidate` 调用参数，验证真实 wiring。

### Feature Flag 注册检查（条件性）
- [x] N/A — 本 PR 未引入新功能子系统（Bug #1 wiring 现有 flag，Bug #2 调用现有函数，Bug #3 修改 prompt 文本）

### BDD 影响评估（条件性）
- [x] N/A — 本 PR 未触及 BDD 行为契约
  - 理由: Bug #1/#2 是 wiring 修复（使现有行为契约可执行），Bug #3 是 prompt 文本修复（使现有 validator 契约不被矛盾 prompt 绕过）。无 .feature 文件需更新。

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`
- [x] 无 `antipattern-completeness`
- [x] 无 `antipattern-review-missing`
- [x] 无 `antipattern-core-io`

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run test`: 通过（6194 passed | 3 skipped | 3 todo）
- [x] `cd packages/pd-cli && npm run test`: 通过（1334 passed | 2 skipped）
- [x] `npm run lint`: 通过（0 errors, 1 pre-existing warning in openclaw-plugin/prompt.ts）
- [x] `npm run verify:merge`: 通过

TDD 测试明细:
- `diagnose.test.ts`: 3 new tests (BUG-1 effectiveConfig × 2, BUG-2 sourcePainId × 1)
- `pain-retry.test.ts`: 1 new test (BUG-1 effectiveConfig)
- `artificer-prompt-builder.test.ts`: 4 new tests (BUG-3 prompt consistency)

## 相关 Issue
- Closes PRI-442 (内部验收测试 Bug 修复)
- Bug #4（prompt-channel dreamer 不被 openclaw runtime 支持）将另建独立 issue。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 改进 `pd-cli diagnose` 和 `pain-retry` 在拆分流程中的配置传递，确保诊断相关步骤使用一致的有效配置。
  - 修复候选项种子生成的来源信息，提升诊断链路的一致性与可追踪性。
  - 调整内化提示规则，统一限制允许的决策类型，避免不一致的提示行为。

- **Tests**
  - 新增回归测试，覆盖有效配置透传和种子来源解析等关键场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->