### PR TITLE
fix(ci): restore NODE_AUTH_TOKEN on Publish to npm step + user-friendly plugin description (P0)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -320,6 +320,8 @@ jobs:
       - name: Publish to npm
         working-directory: packages/${{ matrix.pkg_dir }}
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Git tag and push
         if: matrix.pkg_dir == 'openclaw-plugin'

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "principles-disciple",
   "name": "Principles Disciple",
-  "description": "Evolutionary programming agent framework with strategic guardrails and reflection loops.",
+  "description": "Teach your AI once. PD turns your corrections into reviewable behavior principles — so the AI never repeats the same mistake.",
   "version": "1.74.1",
   "activation": {
     "onCapabilities": [

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@csuzngjh/principles-disciple",
   "version": "1.74.1",
-  "description": "Native OpenClaw plugin for Principles Disciple",
+  "description": "Teach your AI once. PD turns your corrections into reviewable behavior principles — so the AI never repeats the same mistake.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无
- 解决的产品问题（一句话）: PR #1191 合并后 GA publish-npm.yml 发布 `@csuzngjh/principles-disciple` 失败（npm 404），阻塞 ClawHub 首次发布
- emotional-value：降低 [失控感/疲惫感] 创造 [掌控感]
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复
- [x] 📝 文案优化

### 高层变更
1. **P0 修复**: [publish-npm.yml](file:///d:/Code/principles/.github/workflows/publish-npm.yml) 的 `Publish to npm` step 缺少 `env: NODE_AUTH_TOKEN`，导致 `npm publish` 时无认证 token，npm registry 返回 404（npm 对未认证 PUT 返回 404 而非 401，是反探测行为）
   - 根因：commit `e22e1c68` "ci: migrate to npm Trusted Publishing (OIDC)" 误以为 `--provenance` 替代了 token auth，删除了 env。实际上 `--provenance` 只生成 provenance statement（通过 OIDC），publish 操作本身仍需要 NODE_AUTH_TOKEN 认证
   - 这个 bug 一直没被发现，因为 `@csuzngjh/...` scope 从未成功发布过；之前发布的 `@principles/core` 等是另一个 scope，且时间在 e22e1c68 之前

2. **插件描述优化**: [package.json](file:///d:/Code/principles/packages/openclaw-plugin/package.json) 和 [openclaw.plugin.json](file:///d:/Code/principles/packages/openclaw-plugin/openclaw.plugin.json) 的 description 字段从技术黑话改为通俗易懂版：
   - 旧: "Evolutionary programming agent framework with strategic guardrails and reflection loops."（太抽象，"Evolutionary programming"有歧义）
   - 新: "Teach your AI once. PD turns your corrections into reviewable behavior principles — so the AI never repeats the same mistake."
   - 依据: PRODUCT_IDENTITY.md（PD 是 owner-governed behavior internalization system）+ emotional-value.md（把重复纠正感转化为沉淀感）

### 影响范围
- [x] .github/workflows/publish-npm.yml
- [x] packages/openclaw-plugin/package.json
- [x] packages/openclaw-plugin/openclaw.plugin.json

### 是否触及产品边界
- [x] 否

## 验证步骤（agent 填，owner 执行）
- [ ] 动作 1: 合并本 PR 后，等 GitHub Actions `publish-npm.yml` 跑完
  - 观察: Actions 应该成功（之前失败在 Publish to npm step）；`npm view @csuzngjh/principles-disciple version` 返回 `1.74.1`
- [ ] 动作 2: 在 ClawHub 网站搜索 `principles-disciple`
  - 观察: 卡片描述应为 "Teach your AI once. PD turns your corrections into reviewable behavior principles..."

## 风险与可逆性
- 主要风险: 无（修复加回被误删的 env，是恢复到 commit e22e1c68 之前的正确状态）
- 回滚方式: [x] PR revert
- 是否需要 feature flag: 否（CI 修复，无运行时行为变更）

### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？**会**——不修则 `@csuzngjh/principles-disciple` 永远无法发布到 npm，ClawHub 发布也无法进行
- `mvp-q-2-how-observed`: `npm view @csuzngjh/principles-disciple version` 返回版本号
- `mvp-q-4-emotional-value`: 已填写

## 技术自检

### ERR Checklist
- ERR-090 (`package.json` entry point): N/A——本 PR 未改 entry point
- ERR-068 (source-of-truth drift): description 字段是源 of truth，本次直接修改源，无 drift 风险
- ERR-040 (test reality gap): CI 修复将通过 GA 实际发布验证，不依赖单元测试断言

### Runtime Contract 自检
- [x] N/A — 本 PR 不处理不可信数据

### CLI Gate 自检
- [x] N/A — 本 PR 未修改 CLI 命令

### 反模式检查
- [x] 无 `antipattern-*` 触发词

## 测试结果
- [x] `npm run verify:merge`: 通过（lefthook pre-push hook 全绿）
- [x] `npm run lint`: 通过
- [x] 无运行时代码改动，无需跑 package tests

## 相关 Issue
- 修复 PR #1191 合并后发现的 P0 regression
- Blocks: ClawHub 首次发布（合并本 PR 后即可执行 `clawhub package publish`）
