### PR TITLE
fix(publish): revert package name to principles-disciple (no scope) — npm registry has no @csuzngjh scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: npm run build --workspace=@principles/core
 
       - name: Build plugin dependency
-        run: npm run build --workspace=@csuzngjh/principles-disciple
+        run: npm run build --workspace=principles-disciple
 
       - name: Build and test
         working-directory: packages/pd-cli
@@ -243,8 +243,8 @@ jobs:
       - name: Build dependencies
         run: |
           npm run build --workspace=@principles/core
-          npm run build:bundle --workspace=@csuzngjh/principles-disciple
-          npm run build --workspace=@csuzngjh/principles-disciple
+          npm run build:bundle --workspace=principles-disciple
+          npm run build --workspace=principles-disciple
           npm run build --workspace=@principles/pd-cli
           npm run build --workspace=@principles/pd-console
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,10 +6,10 @@ on:
       package:
         description: 'Package to publish'
         required: true
-        default: '@csuzngjh/principles-disciple'
+        default: 'principles-disciple'
         type: choice
         options:
-          - '@csuzngjh/principles-disciple'
+          - principles-disciple
           - '@principles/core'
           - '@principles/pd-cli'
           - create-principles-disciple
@@ -52,8 +52,8 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             INPUT="${{ github.event.inputs.package }}"
             case "$INPUT" in
-              "@csuzngjh/principles-disciple")
-                echo 'matrix=[{"pkg_dir":"openclaw-plugin","npm_name":"@csuzngjh/principles-disciple"}]' >> $GITHUB_OUTPUT
+              "principles-disciple")
+                echo 'matrix=[{"pkg_dir":"openclaw-plugin","npm_name":"principles-disciple"}]' >> $GITHUB_OUTPUT
                 ;;
               "@principles/core")
                 echo 'matrix=[{"pkg_dir":"principles-core","npm_name":"@principles/core"}]' >> $GITHUB_OUTPUT
@@ -102,7 +102,7 @@ jobs:
           }
 
           check_and_add "principles-core" "@principles/core"
-          check_and_add "openclaw-plugin" "@csuzngjh/principles-disciple"
+          check_and_add "openclaw-plugin" "principles-disciple"
           check_and_add "pd-cli" "@principles/pd-cli"
           check_and_add "create-principles-disciple" "create-principles-disciple"
 
@@ -183,11 +183,11 @@ jobs:
         run: |
           PKG_DIR="${{ matrix.pkg_dir }}"
           if [ "$PKG_DIR" = "openclaw-plugin" ]; then
-            npm run build --workspace=@csuzngjh/principles-disciple
+            npm run build --workspace=principles-disciple
           elif [ "$PKG_DIR" = "pd-cli" ]; then
             npm run build --workspace=@principles/pd-cli
           elif [ "$PKG_DIR" = "create-principles-disciple" ]; then
-            npm run build --workspace=@csuzngjh/principles-disciple
+            npm run build --workspace=principles-disciple
             npm run build --workspace=@principles/pd-cli
             npm run build --workspace=@principles/pd-console
             cd packages/create-principles-disciple && npm ci && npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,10 +1596,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@csuzngjh/principles-disciple": {
-      "resolved": "packages/openclaw-plugin",
-      "link": true
-    },
     "node_modules/@cucumber/gherkin": {
       "version": "31.0.0",
       "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
@@ -15520,6 +15516,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/principles-disciple": {
+      "resolved": "packages/openclaw-plugin",
+      "link": true
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -19844,7 +19844,7 @@
       }
     },
     "packages/openclaw-plugin": {
-      "name": "@csuzngjh/principles-disciple",
+      "name": "principles-disciple",
       "version": "1.74.1",
       "license": "MIT",
       "dependencies": {
@@ -19917,11 +19917,11 @@
       "version": "1.74.1",
       "license": "MIT",
       "dependencies": {
-        "@csuzngjh/principles-disciple": "^1.74.1",
         "@principles/core": "^1.74.1",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.0.0",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.1",
+        "principles-disciple": "^1.74.1"
       },
       "bin": {
         "pd": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspace=@principles/core && npm run build --workspace=@csuzngjh/principles-disciple",
+    "build": "npm run build --workspace=@principles/core && npm run build --workspace=principles-disciple",
     "lint": "npm run build --workspace=@principles/core && npx eslint packages/**/*.ts --ignore-pattern **/*.test.ts --ignore-pattern **/*.spec.ts --ignore-pattern **/*.d.ts",
     "lint:fix": "npm run build --workspace=@principles/core && npx eslint packages/**/*.ts --ignore-pattern **/*.test.ts --ignore-pattern **/*.spec.ts --ignore-pattern **/*.d.ts --fix",
     "typecheck:openclaw-plugin": "cd packages/openclaw-plugin && npx tsc --noEmit",

--- a/packages/create-principles-disciple/pd-cli/package.json
+++ b/packages/create-principles-disciple/pd-cli/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@principles/core": "file:../core",
-    "@csuzngjh/principles-disciple": "file:../plugin",
+    "principles-disciple": "file:../plugin",
     "better-sqlite3": "^12.9.0",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.1"

--- a/packages/create-principles-disciple/scripts/bundle-plugin.mjs
+++ b/packages/create-principles-disciple/scripts/bundle-plugin.mjs
@@ -200,12 +200,12 @@ function rewriteBundledDependency(pkgPath, label, depName, replacement) {
 rewriteBundledDependency(join(PLUGIN_DEST, 'package.json'), 'plugin', '@principles/core', 'file:./core');
 rewriteBundledDependency(join(PD_CLI_DEST, 'package.json'), 'pd-cli', '@principles/core', 'file:../core');
 rewriteBundledDependency(join(CONSOLE_DEST, 'package.json'), 'console', '@principles/core', 'file:../core');
-// pd-cli also depends on @csuzngjh/principles-disciple (the plugin package). Rewrite to a local
+// pd-cli also depends on principles-disciple (the plugin package). Rewrite to a local
 // file reference so the bundled package is self-contained. The installer's syncPdCli()
-// creates a node_modules/@csuzngjh/principles-disciple symlink to the installed plugin directory.
+// creates a node_modules/principles-disciple symlink to the installed plugin directory.
 // Without this rewrite + symlink, `pd runtime init` crashes with ERR_MODULE_NOT_FOUND
 // because pd-cli statically imports initTrajectorySchema/initWorkflowSchema from it.
-rewriteBundledDependency(join(PD_CLI_DEST, 'package.json'), 'pd-cli', '@csuzngjh/principles-disciple', 'file:../plugin');
+rewriteBundledDependency(join(PD_CLI_DEST, 'package.json'), 'pd-cli', 'principles-disciple', 'file:../plugin');
 
 console.log('\n🔍 Verifying hook activation contract...');
 

--- a/packages/create-principles-disciple/src/installer.ts
+++ b/packages/create-principles-disciple/src/installer.ts
@@ -601,15 +601,15 @@ function syncPdCli(pluginDir: string): boolean {
     }
   }
 
-  // Create node_modules/@csuzngjh/principles-disciple symlink so pd-cli can resolve
-  // its @csuzngjh/principles-disciple dependency (the plugin package, rewritten to
+  // Create node_modules/principles-disciple symlink so pd-cli can resolve
+  // its principles-disciple dependency (the plugin package, rewritten to
   // "file:../plugin" by bundle-plugin.mjs). The plugin is installed at the
   // extension dir root (getPluginExtDir()), so the symlink target is the
-  // ext dir itself — Node resolves `import '@csuzngjh/principles-disciple'` via the
+  // ext dir itself — Node resolves `import 'principles-disciple'` via the
   // plugin's package.json exports field.
   // Without this, `pd runtime init` crashes with ERR_MODULE_NOT_FOUND
   // because runtime-init.ts statically imports initTrajectorySchema/initWorkflowSchema.
-  const pdLinkDir = path.join(installedPdCliDir, 'node_modules', '@csuzngjh');
+  const pdLinkDir = path.join(installedPdCliDir, 'node_modules');
   const pdLinkTarget = getPluginExtDir();
   mkdirSync(pdLinkDir, { recursive: true });
   const pdLinkPath = path.join(pdLinkDir, 'principles-disciple');
@@ -617,9 +617,9 @@ function syncPdCli(pluginDir: string): boolean {
     if (isWindows()) {
       symlinkSync(pdLinkTarget, pdLinkPath, 'junction');
     } else {
-      // Relative from <ext>/pd-cli/node_modules/@csuzngjh/ to <ext>/: go up three
-      // times (@csuzngjh → node_modules → pd-cli → ext)
-      symlinkSync('../../../', pdLinkPath, 'dir');
+      // Relative from <ext>/pd-cli/node_modules/ to <ext>/: go up twice
+      // (node_modules → pd-cli → ext)
+      symlinkSync('../../', pdLinkPath, 'dir');
     }
   }
 

--- a/packages/create-principles-disciple/tests/mvp-config.test.ts
+++ b/packages/create-principles-disciple/tests/mvp-config.test.ts
@@ -1861,13 +1861,13 @@ describe('validateConfigYamlFull catches incomplete config', () => {
   });
 });
 
-// ── PRI-442 P0: @csuzngjh/principles-disciple dependency rewrite + symlink (Bug-B-001/002/003/004) ──
-// Root cause: bundle-plugin.mjs only rewrote @principles/core, not @csuzngjh/principles-disciple.
-// installer.ts syncPdCli() only created @principles/core symlink, not @csuzngjh/principles-disciple.
+// ── PRI-442 P0: principles-disciple dependency rewrite + symlink (Bug-B-001/002/003/004) ──
+// Root cause: bundle-plugin.mjs only rewrote @principles/core, not principles-disciple.
+// installer.ts syncPdCli() only created @principles/core symlink, not principles-disciple.
 // Result: `pd runtime init` crashed with ERR_MODULE_NOT_FOUND because runtime-init.ts
-// statically imports initTrajectorySchema/initWorkflowSchema from @csuzngjh/principles-disciple.
+// statically imports initTrajectorySchema/initWorkflowSchema from principles-disciple.
 
-describe('PRI-442 P0: @csuzngjh/principles-disciple dependency rewrite in bundle-plugin.mjs (Bug-B-002)', () => {
+describe('PRI-442 P0: principles-disciple dependency rewrite in bundle-plugin.mjs (Bug-B-002)', () => {
   const scriptPath = path.resolve(__dirname, '..', 'scripts', 'bundle-plugin.mjs');
   const content = fs.readFileSync(scriptPath, 'utf-8');
 
@@ -1881,12 +1881,12 @@ describe('PRI-442 P0: @csuzngjh/principles-disciple dependency rewrite in bundle
     expect(content).toMatch(/rewriteBundledDependency\(.*depName.*replacement/);
   });
 
-  it('bundle-plugin.mjs rewrites @csuzngjh/principles-disciple dependency in pd-cli to file:../plugin', () => {
-    // Must rewrite @csuzngjh/principles-disciple → file:../plugin for pd-cli (the only consumer)
-    expect(content).toContain("'@csuzngjh/principles-disciple'");
+  it('bundle-plugin.mjs rewrites principles-disciple dependency in pd-cli to file:../plugin', () => {
+    // Must rewrite principles-disciple → file:../plugin for pd-cli (the only consumer)
+    expect(content).toContain("'principles-disciple'");
     expect(content).toContain("'file:../plugin'");
     // The rewrite call must target PD_CLI_DEST
-    const rewriteCallIdx = content.indexOf("'@csuzngjh/principles-disciple', 'file:../plugin'");
+    const rewriteCallIdx = content.indexOf("'principles-disciple', 'file:../plugin'");
     const pdCliDestIdx = content.indexOf('PD_CLI_DEST');
     expect(rewriteCallIdx).toBeGreaterThan(0);
     expect(pdCliDestIdx).toBeGreaterThan(0);
@@ -1899,13 +1899,13 @@ describe('PRI-442 P0: @csuzngjh/principles-disciple dependency rewrite in bundle
   });
 });
 
-describe('PRI-442 P0: @csuzngjh/principles-disciple symlink in installer.ts syncPdCli (Bug-B-004)', () => {
+describe('PRI-442 P0: principles-disciple symlink in installer.ts syncPdCli (Bug-B-004)', () => {
   const installerPath = path.resolve(__dirname, '..', 'src', 'installer.ts');
   const content = fs.readFileSync(installerPath, 'utf-8');
 
-  it('syncPdCli creates node_modules/@csuzngjh/principles-disciple symlink', () => {
-    // Must create a @csuzngjh/principles-disciple symlink in pd-cli's node_modules
-    expect(content).toContain("'@csuzngjh'");
+  it('syncPdCli creates node_modules/principles-disciple symlink', () => {
+    // Must create a principles-disciple symlink in pd-cli's node_modules
+    expect(content).toContain("'principles-disciple'");
     // The symlink path must be under node_modules
     const pdLinkIdx = content.indexOf("pdLinkPath");
     expect(pdLinkIdx).toBeGreaterThan(0);
@@ -1914,8 +1914,8 @@ describe('PRI-442 P0: @csuzngjh/principles-disciple symlink in installer.ts sync
     expect(symlinkSection).toContain('symlinkSync');
   });
 
-  it('@csuzngjh/principles-disciple symlink target is getPluginExtDir() (the installed plugin root)', () => {
-    // The plugin (@csuzngjh/principles-disciple package) is installed at <ext-dir>/ root
+  it('principles-disciple symlink target is getPluginExtDir() (the installed plugin root)', () => {
+    // The plugin (principles-disciple package) is installed at <ext-dir>/ root
     const pdLinkTargetIdx = content.indexOf('pdLinkTarget');
     expect(pdLinkTargetIdx).toBeGreaterThan(0);
     const targetSection = content.substring(pdLinkTargetIdx, pdLinkTargetIdx + 200);
@@ -1933,13 +1933,13 @@ describe('PRI-442 P0: @csuzngjh/principles-disciple symlink in installer.ts sync
     expect(pdLinkSection).toContain("'junction'");
   });
 
-  it('syncPdCli creates symlink on Unix using relative path ../../../', () => {
-    // Unix must use relative symlink for portability (3 levels up: @csuzngjh → node_modules → pd-cli → ext)
+  it('syncPdCli creates symlink on Unix using relative path ../../', () => {
+    // Unix must use relative symlink for portability (2 levels up: node_modules → pd-cli → ext)
     const pdLinkStart = content.indexOf('const pdLinkDir');
     const upgradeCallIdx = content.indexOf('tryUpgradePdCliFromNpm(installedPdCliDir)', pdLinkStart);
     expect(upgradeCallIdx).toBeGreaterThan(pdLinkStart);
     const pdLinkSection = content.substring(pdLinkStart, upgradeCallIdx);
-    expect(pdLinkSection).toContain("'../../../'");
+    expect(pdLinkSection).toContain("'../../'");
   });
 
   it('syncPdCli still creates @principles/core symlink (regression guard)', () => {
@@ -1954,15 +1954,15 @@ describe('PRI-442 P0: runtime-init.ts import resolves via symlink (Bug-B-001)', 
   const rootDir = path.resolve(__dirname, '..', '..', '..');
   const runtimeInitPath = path.join(rootDir, 'packages', 'pd-cli', 'src', 'commands', 'runtime-init.ts');
 
-  it('runtime-init.ts imports from @csuzngjh/principles-disciple (the plugin package)', () => {
+  it('runtime-init.ts imports from principles-disciple (the plugin package)', () => {
     // This import is the crash point — it must resolve via the symlink created by syncPdCli
     const content = fs.readFileSync(runtimeInitPath, 'utf-8');
-    expect(content).toContain("from '@csuzngjh/principles-disciple'");
+    expect(content).toContain("from 'principles-disciple'");
     expect(content).toContain('initTrajectorySchema');
     expect(content).toContain('initWorkflowSchema');
   });
 
-  it('@csuzngjh/principles-disciple (openclaw-plugin) exports initTrajectorySchema and initWorkflowSchema', () => {
+  it('principles-disciple (openclaw-plugin) exports initTrajectorySchema and initWorkflowSchema', () => {
     // The plugin's index.ts must export these functions so the import resolves
     const pluginIndexPath = path.join(rootDir, 'packages', 'openclaw-plugin', 'src', 'index.ts');
     const content = fs.readFileSync(pluginIndexPath, 'utf-8');

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@csuzngjh/principles-disciple",
+  "name": "principles-disciple",
   "version": "1.74.1",
   "description": "Teach your AI once. PD turns your corrections into reviewable behavior principles — so the AI never repeats the same mistake.",
   "type": "module",

--- a/packages/pd-cli/package.json
+++ b/packages/pd-cli/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@principles/core": "^1.74.1",
-    "@csuzngjh/principles-disciple": "^1.74.1",
+    "principles-disciple": "^1.74.1",
     "better-sqlite3": "^12.9.0",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.1"

--- a/packages/pd-cli/src/commands/runtime-init.ts
+++ b/packages/pd-cli/src/commands/runtime-init.ts
@@ -20,7 +20,7 @@
 import * as path from 'path';
 import { SqliteConnection } from '@principles/core/runtime-v2';
 import { SchemaConformanceReadModel } from '@principles/core/runtime-v2';
-import { initTrajectorySchema, initWorkflowSchema } from '@csuzngjh/principles-disciple';
+import { initTrajectorySchema, initWorkflowSchema } from 'principles-disciple';
 import { resolveWorkspaceDir } from '../resolve-workspace.js';
 import { emitResult, emitFlagConflict, emitError } from '../services/cli-output.js';
 

--- a/packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts
+++ b/packages/pd-cli/src/commands/runtime-internalization-run-rulehost.ts
@@ -472,13 +472,13 @@ export async function handleRunRuleHost(opts: RunRuleHostOptions): Promise<void>
         return;
       }
       if (opts.confirm) {
-        // Lazy import: avoids loading `@csuzngjh/principles-disciple` at module init time.
+        // Lazy import: avoids loading `principles-disciple` at module init time.
         // `pd --version` (and the create-principles-disciple smoke test) loads
         // this file statically via index.ts. If we used a static import, the
         // module would fail with MODULE_NOT_FOUND in bundled environments where
-        // `@csuzngjh/principles-disciple` is not resolvable from pd-cli's node_modules.
+        // `principles-disciple` is not resolvable from pd-cli's node_modules.
         // The import only executes when `--confirm` is actually used.
-        const { BehaviorExamplePackAssembler, RuleHostEvidenceRegistry } = await import('@csuzngjh/principles-disciple/rulehost-evidence');
+        const { BehaviorExamplePackAssembler, RuleHostEvidenceRegistry } = await import('principles-disciple/rulehost-evidence');
         try {
           const assembler = new BehaviorExamplePackAssembler({ workspaceDir, stateDir: path.join(workspaceDir, '.state') });
           behaviorExamplePack = assembler.assemble({

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -325,7 +325,7 @@ runtimeCmd
   });
 
 // pd runtime init — Initialize all PD SQLite databases for a workspace.
-// Lazy import: avoids loading `@csuzngjh/principles-disciple` at module init time, which
+// Lazy import: avoids loading `principles-disciple` at module init time, which
 // would crash `pd --version` in packaged installs where the plugin's transitive
 // deps are not resolvable from pd-cli's node_modules. The import only executes
 // when `pd runtime init` is actually invoked.

--- a/packages/pd-cli/tests/commands/runtime-init.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-init.test.ts
@@ -35,7 +35,7 @@ const mockState = vi.hoisted(() => {
   };
 });
 
-vi.mock('@csuzngjh/principles-disciple', () => ({
+vi.mock('principles-disciple', () => ({
   initTrajectorySchema: mockState.initTrajectorySchema,
   initWorkflowSchema: mockState.initWorkflowSchema,
 }));


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无
- 解决的产品问题（一句话）: PR #1191 + #1192 合并后 GA `publish-npm.yml` 仍失败（EOTP），根因是 commit `0d5aebee` 把包名从 `principles-disciple` 误改为 `@csuzngjh/principles-disciple`——但 npm registry 上从未存在 `@csuzngjh` scope
- emotional-value：降低 [失控感/疲惫感] 创造 [掌控感]
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）

### 变更类型
- [x] 🐛 Bug 修复
- [x] ♻️ 重构（package name revert）

### 高层变更
1. **根因修复**: 把 `packages/openclaw-plugin/package.json` 的 `name` 从 `@csuzngjh/principles-disciple` 改回 `principles-disciple`（无 scope）
   - 根因：commit `0d5aebee` (PR #1182) 把包名改为 `@csuzngjh/principles-disciple`，但 npm registry 上从未存在 `@csuzngjh` scope（实际 npm 用户是 `principles-disciple`，已发布 `principles-disciple@1.174.0`）
   - 现象：GA `publish-npm.yml` 失败 EOTP（npm 对 PUT 到不存在 scope 返回 OTP 挑战，是反探测行为，不是干净的 403）
   - 旁证：同 workflow、同 `NPM_TOKEN` 发布 `@principles/core` 8 小时前成功无 OTP——证明 token 工作正常，只是 scope 错

2. **联动修改（14 处）**：
   - `package.json`（root + openclaw-plugin + pd-cli + create-principles-disciple/pd-cli）4 个
   - `.github/workflows/{ci,publish-npm}.yml`（`--workspace=` 引用 + `npm_name`）2 个
   - `packages/pd-cli/src/commands/runtime-init.ts`（import）+ `runtime-internalization-run-rulehost.ts`（dynamic import + 注释）+ `index.ts`（注释）
   - `packages/pd-cli/tests/commands/runtime-init.test.ts`（`vi.mock` target）
   - `packages/create-principles-disciple/scripts/bundle-plugin.mjs`（`rewriteBundledDependency` depName）
   - `packages/create-principles-disciple/src/installer.ts`（symlink 路径：删除 `@csuzngjh/` 子目录，直接挂到 `node_modules/principles-disciple`；Unix 相对路径 `../../../` → `../../`）
   - `packages/create-principles-disciple/tests/mvp-config.test.ts`（断言 + 注释，217 tests 全绿）
   - `package-lock.json`（npm install 自动重写）

### 影响范围
- [x] packages/openclaw-plugin/package.json（核心修复）
- [x] packages/pd-cli/**（import 联动）
- [x] packages/create-principles-disciple/**（bundling 联动）
- [x] .github/workflows/**（CI 联动）
- [x] root package.json + package-lock.json

### 是否触及产品边界
- [x] 否——纯包名回滚，无产品行为变更

## 验证步骤（agent 填，owner 执行）
- [ ] 动作 1: 合并本 PR 后，等 GitHub Actions `publish-npm.yml` 跑完
  - 观察: Actions 应该成功；`npm view principles-disciple version` 应返回 `1.74.1` 或更高
- [ ] 动作 2: 验证 ClawHub 首次发布
  - 执行: `clawhub package publish packages/openclaw-plugin`
  - 观察: 应该 PASS

## 风险与可逆性
- 主要风险: 无（这是恢复到 commit `0d5aebee` 之前的正确状态）
- 回滚方式: [x] PR revert
- 是否需要 feature flag: 否

### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？**会**——不修则 `principles-disciple` 永远无法发布新版本到 npm，ClawHub 发布也无法进行
- `mvp-q-2-how-observed`: `npm view principles-disciple version` 返回新版本号
- `mvp-q-4-emotional-value`: 已填写

## 技术自检

### ERR Checklist
- ERR-090 (`package.json` entry point): N/A——本 PR 未改 entry point
- ERR-068 (source-of-truth drift): 包名是源 of truth，本次直接修改源，无 drift 风险；所有引用通过 grep `@csuzngjh/principles-disciple` 确认已全部清理（仅 ERROR_EXPERIENCE_HANDBOOK.md 历史记录保留）
- ERR-040 (test reality gap): 通过实际跑 217 + 14 tests 验证

### Runtime Contract 自检
- [x] N/A — 本 PR 不处理不可信数据

### CLI Gate 自检
- [x] N/A — 本 PR 未修改 CLI 命令

### 反模式检查
- [x] 无 `antipattern-*` 触发词

### BDD 影响评估
- [x] 本 PR 是否修改了 MVP-Core 用户旅程? 否
- [x] 本 PR 是否新增/修改了 CLI 命令? 否
- [x] 本 PR 是否触发了 ERR 类? 是（ERR-068 source-of-truth drift 的反向修复——把 drift 修回正确状态）
- [x] 本 PR 是否删除了 `.feature` 文件? 否

## 测试结果
- [x] `npm run build --workspace=@principles/core`: 通过
- [x] `npm run build --workspace=principles-disciple`: 通过
- [x] `npm run build --workspace=@principles/pd-cli`: 通过
- [x] `npx vitest run tests/mvp-config.test.ts` (create-principles-disciple): 217/217 通过
- [x] `npx vitest run tests/commands/runtime-init.test.ts` (pd-cli): 14/14 通过
- [x] pre-push hook: gitleaks + verify-merge + protect-main 全绿

## 相关 Issue
- 修复 PR #1191 + #1192 合并后发现的根因 regression
- Blocks: ClawHub 首次发布（合并本 PR 后即可执行 `clawhub package publish`）

## 历史背景
- npm 上 PD 4 个包（`principles-disciple`、`create-principles-disciple`、`@principles/core`、`@principles/pd-cli`）都是 npm 用户 `principles-disciple` 发布的
- `csuzngjh` 是 GitHub 用户名 + ClawHub owner，但不是 npm 账号
- commit `0d5aebee` (PR #1182) 误改包名引入 `@csuzngjh` scope，本次 PR 完全回滚
