### PR TITLE
fix(ci): build principles-core before regression e2e tests

### DIFF
--- a/.github/workflows/regression-e2e.yml
+++ b/.github/workflows/regression-e2e.yml
@@ -21,6 +21,9 @@ jobs:
         working-directory: packages/openclaw-plugin
         run: npm install
 
+      - name: Build principles-core
+        run: npm run build --workspace=@principles/core
+
       - name: Run regression tests
         working-directory: packages/openclaw-plugin
         run: npx vitest run tests/core/regression-v1-9-1.test.ts --reporter=verbose


### PR DESCRIPTION
## Problem

The E2E Regression Test workflow (regression-e2e.yml) has been failing on every main push since #1175 was merged. The error:



Error: Cannot find package '@principles/core/runtime-v2' imported from packages/openclaw-plugin/src/core/system-logger.ts
Serialized Error: { code: 'ERR_MODULE_NOT_FOUND' }



## Root Cause

PR #1175 introduced an import of @principles/core/runtime-v2 in system-logger.ts (guardWorkspaceLeak). The regression-e2e.yml workflow runs npm install in packages/openclaw-plugin but never builds principles-core. Since dist/ is gitignored, the @principles/core/runtime-v2 export target (dist/runtime-v2/index.js) does not exist, causing ERR_MODULE_NOT_FOUND.

## Fix

Add a Build principles-core step after install, matching the pattern used by pd-console-e2e.yml (which runs npm run build at the root before e2e tests).



## ERR Considerations

- This is a CI infrastructure fix, not a runtime change.
- No ERR class directly applies (no code logic changed).
- The fix follows the established pattern from pd-console-e2e.yml.