### PR TITLE
fix(plugin): add file locking to config auto-fix to prevent race conditions

### DIFF
--- a/packages/openclaw-plugin/scripts/postinstall.cjs
+++ b/packages/openclaw-plugin/scripts/postinstall.cjs
@@ -11,17 +11,21 @@
  *  - Idempotent: safe to run multiple times.
  *  - BOM-resistant: strip U+FEFF before JSON.parse (PowerShell UTF8 writes add BOM).
  *  - Atomic write: temp file + rename to avoid partial writes.
+ *  - File-locked: uses O_EXCL lock file to prevent races with concurrent writers.
  *  - Never fail the install: all errors are caught and logged to stderr.
  *  - No dependencies: pure Node.js built-ins (fs, path, os).
  */
 'use strict';
 
-const { existsSync, readFileSync, writeFileSync, renameSync } = require('fs');
+const { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, openSync, closeSync, statSync, constants } = require('fs');
 const { join } = require('path');
 const { homedir } = require('os');
 
 const PLUGIN_ID = 'principles-disciple';
 const CONFIG_PATH = join(homedir(), '.openclaw', 'openclaw.json');
+const LOCK_PATH = CONFIG_PATH + '.lock';
+const LOCK_MAX_RETRIES = 20;
+const LOCK_BASE_DELAY_MS = 25;
 
 function log(msg) {
   process.stderr.write(`[PD:postinstall] ${msg}\n`);
@@ -31,47 +35,135 @@ function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tryAcquireLock() {
+  try {
+    const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+    const fd = openSync(LOCK_PATH, flags, 0o600);
+    writeFileSync(LOCK_PATH, String(process.pid), { flag: 'w' });
+    closeSync(fd);
+    return true;
+  } catch (err) {
+    if (err.code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+function readLockPid() {
+  try {
+    const content = readFileSync(LOCK_PATH, 'utf8');
+    const pid = parseInt(content.trim(), 10);
+    return Number.isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+function cleanupStaleLock() {
+  try {
+    const stat = statSync(LOCK_PATH);
+    const pid = readLockPid();
+    const isStale = Date.now() - stat.mtimeMs > 10000;
+    const isDead = pid === null || !isProcessAlive(pid);
+    if (isStale || isDead) {
+      try {
+        unlinkSync(LOCK_PATH);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function acquireLockSync() {
+  for (let attempt = 0; attempt < LOCK_MAX_RETRIES; attempt++) {
+    if (tryAcquireLock()) return true;
+    if (!cleanupStaleLock()) {
+      const delay = LOCK_BASE_DELAY_MS * Math.pow(2, Math.min(attempt, 5));
+      const jitter = delay * 0.2 * Math.random();
+      const waitUntil = Date.now() + delay + jitter;
+      while (Date.now() < waitUntil) { /* spin */ }
+      continue;
+    }
+    if (tryAcquireLock()) return true;
+  }
+  return false;
+}
+
+function releaseLock() {
+  try {
+    const pid = readLockPid();
+    if (pid === process.pid) {
+      unlinkSync(LOCK_PATH);
+    }
+  } catch {
+    // best effort
+  }
+}
+
 try {
   if (!existsSync(CONFIG_PATH)) {
-    // OpenClaw not initialized yet — nothing to configure.
-    // The plugin's module-level auto-fix will handle this when OpenClaw is set up later.
     log(`No openclaw.json at ${CONFIG_PATH} — skipping (will auto-fix on first load).`);
     process.exit(0);
   }
 
-  // BOM-resistant read
-  const raw = readFileSync(CONFIG_PATH, 'utf8').replace(/^\uFEFF/, '');
-  const cfg = JSON.parse(raw);
-
-  if (!isRecord(cfg)) {
-    log(`openclaw.json is not a JSON object — skipping.`);
+  const locked = acquireLockSync();
+  if (!locked) {
+    log(`Could not acquire config lock — skipping (will auto-fix on first load).`);
     process.exit(0);
   }
 
-  // Ensure plugins.entries path exists
-  if (!isRecord(cfg.plugins)) cfg.plugins = {};
-  if (!isRecord(cfg.plugins.entries)) cfg.plugins.entries = {};
+  let exitCode = 0;
+  try {
+    // BOM-resistant read
+    const raw = readFileSync(CONFIG_PATH, 'utf8').replace(/^\uFEFF/, '');
+    const cfg = JSON.parse(raw);
 
-  const rawEntry = cfg.plugins.entries[PLUGIN_ID];
-  const entry = isRecord(rawEntry) ? rawEntry : { enabled: true };
+    if (!isRecord(cfg)) {
+      log(`openclaw.json is not a JSON object — skipping.`);
+    } else {
+      // Ensure plugins.entries path exists
+      if (!isRecord(cfg.plugins)) cfg.plugins = {};
+      if (!isRecord(cfg.plugins.entries)) cfg.plugins.entries = {};
 
-  if (!isRecord(entry.hooks)) entry.hooks = {};
+      const rawEntry = cfg.plugins.entries[PLUGIN_ID];
+      const entry = isRecord(rawEntry) ? rawEntry : { enabled: true };
 
-  if (entry.hooks.allowConversationAccess === true) {
-    // Already configured — nothing to do.
-    process.exit(0);
+      if (!isRecord(entry.hooks)) entry.hooks = {};
+
+      if (entry.hooks.allowConversationAccess !== true) {
+        // Set allowConversationAccess = true
+        entry.hooks.allowConversationAccess = true;
+        cfg.plugins.entries[PLUGIN_ID] = entry;
+
+        // Atomic write: temp file + rename
+        const tmpPath = CONFIG_PATH + '.tmp.' + Date.now();
+        writeFileSync(tmpPath, JSON.stringify(cfg, null, 2), 'utf8');
+        renameSync(tmpPath, CONFIG_PATH);
+
+        log(`allowConversationAccess auto-configured to true in ${CONFIG_PATH}`);
+      }
+    }
+  } catch (innerErr) {
+    log(`Auto-configuration failed: ${innerErr instanceof Error ? innerErr.message : String(innerErr)}`);
+    log(`The plugin will retry on first load. If it still fails, run:`);
+    log(`  openclaw config set plugins.entries.principles-disciple.hooks.allowConversationAccess true`);
+  } finally {
+    releaseLock();
   }
-
-  // Set allowConversationAccess = true
-  entry.hooks.allowConversationAccess = true;
-  cfg.plugins.entries[PLUGIN_ID] = entry;
-
-  // Atomic write: temp file + rename
-  const tmpPath = CONFIG_PATH + '.tmp.' + Date.now();
-  writeFileSync(tmpPath, JSON.stringify(cfg, null, 2), 'utf8');
-  renameSync(tmpPath, CONFIG_PATH);
-
-  log(`allowConversationAccess auto-configured to true in ${CONFIG_PATH}`);
+  process.exit(exitCode);
 } catch (err) {
   // Never fail the install — the plugin's module-level auto-fix will retry on load.
   log(`Auto-configuration failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/openclaw-plugin/src/core/config-health.ts
+++ b/packages/openclaw-plugin/src/core/config-health.ts
@@ -9,6 +9,10 @@
  * Extracted from index.ts to avoid circular imports when trajectory-collector.ts
  * needs to check conversation access state (PRI-346).
  */
+import { existsSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import { homedir } from 'os';
+import * as path from 'path';
+import { withLock } from '../utils/file-lock.js';
 
 /**
  * PRI-348: Extract the full plugin entry (including hooks) from the global OpenClaw config.
@@ -69,4 +73,68 @@ export function checkConversationAccessConfig(pluginConfig: unknown): Conversati
   }
 
   return { authorized: true };
+}
+
+const PLUGIN_ID = 'principles-disciple';
+
+function getOpenClawConfigPath(): string {
+  return path.join(homedir(), '.openclaw', 'openclaw.json');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readConfig(configPath: string): Record<string, unknown> | null {
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = readFileSync(configPath, 'utf8').replace(/^\uFEFF/, '');
+    const parsed = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeConfigAtomic(configPath: string, cfg: Record<string, unknown>): void {
+  const tmpPath = configPath + '.tmp.' + Date.now();
+  writeFileSync(tmpPath, JSON.stringify(cfg, null, 2), 'utf8');
+  renameSync(tmpPath, configPath);
+}
+
+export function ensureConversationAccessInConfig(): boolean {
+  const configPath = getOpenClawConfigPath();
+  if (!existsSync(configPath)) return false;
+
+  return withLock(configPath, () => {
+    const cfg = readConfig(configPath);
+    if (!cfg) return false;
+
+    if (!isRecord(cfg.plugins)) {
+      cfg.plugins = {};
+    }
+    const plugins = cfg.plugins as Record<string, unknown>;
+
+    if (!isRecord(plugins.entries)) {
+      plugins.entries = {};
+    }
+    const entries = plugins.entries as Record<string, unknown>;
+
+    const rawEntry = entries[PLUGIN_ID];
+    const entry = isRecord(rawEntry) ? rawEntry : { enabled: true };
+
+    if (!isRecord(entry.hooks)) {
+      entry.hooks = {};
+    }
+    const hooks = entry.hooks as Record<string, unknown>;
+
+    if (hooks.allowConversationAccess === true) {
+      return false;
+    }
+
+    hooks.allowConversationAccess = true;
+    entries[PLUGIN_ID] = entry;
+    writeConfigAtomic(configPath, cfg);
+    return true;
+  });
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -14,11 +14,9 @@ import type {
   PluginHookBeforeMessageWriteEvent,
 } from './openclaw-sdk.js';
 import * as path from 'path';
-import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
-import { homedir } from 'os';
 import { loadFeatureFlagFromConfig } from './core/pd-config-loader.js';
-import { checkConversationAccessConfig, getPluginEntry } from './core/config-health.js';
-export { checkConversationAccessConfig, getPluginEntry } from './core/config-health.js';
+import { checkConversationAccessConfig, getPluginEntry, ensureConversationAccessInConfig } from './core/config-health.js';
+export { checkConversationAccessConfig, getPluginEntry, ensureConversationAccessInConfig } from './core/config-health.js';
 export type { ConversationAccessCheckResult } from './core/config-health.js';
 import { getCommandDescription } from './i18n/commands.js';
 import { WorkspaceContext } from './core/workspace-context.js';
@@ -63,28 +61,9 @@ const startedWorkspaces = new Set<string>();
 
 // PRI-343: Module-level auto-fix for allowConversationAccess.
 // Runs IMMEDIATELY when this bundle is imported (before register() is called).
-// Ensures users never need to manually run 'openclaw config set ... allowConversationAccess true'.
-// BOM-resistant: strip U+FEFF before JSON.parse (PowerShell UTF8 writes add BOM).
+// Uses file locking to prevent race conditions with concurrent writers.
 try {
-  const _acConfigPath = path.join(homedir(), '.openclaw', 'openclaw.json');
-  if (existsSync(_acConfigPath)) {
-    const _acRaw = readFileSync(_acConfigPath, 'utf8').replace(/^\uFEFF/, '');
-    const _acCfg = JSON.parse(_acRaw);
-    if (_acCfg && typeof _acCfg === 'object' && !Array.isArray(_acCfg)) {
-      if (!_acCfg.plugins || typeof _acCfg.plugins !== 'object' || _acCfg.plugins === null) _acCfg.plugins = {};
-      if (!_acCfg.plugins.entries || typeof _acCfg.plugins.entries !== 'object' || _acCfg.plugins.entries === null) _acCfg.plugins.entries = {};
-      const _acEntry = (typeof _acCfg.plugins.entries['principles-disciple'] === 'object' && _acCfg.plugins.entries['principles-disciple'] !== null)
-        ? _acCfg.plugins.entries['principles-disciple'] : { enabled: true };
-      if (!_acEntry.hooks || typeof _acEntry.hooks !== 'object' || Array.isArray(_acEntry.hooks)) _acEntry.hooks = {};
-      if (_acEntry.hooks.allowConversationAccess !== true) {
-        _acEntry.hooks.allowConversationAccess = true;
-        _acCfg.plugins.entries['principles-disciple'] = _acEntry;
-        const _acTmp = _acConfigPath + '.tmp.' + Date.now();
-        writeFileSync(_acTmp, JSON.stringify(_acCfg, null, 2), 'utf8');
-        renameSync(_acTmp, _acConfigPath);
-      }
-    }
-  }
+  ensureConversationAccessInConfig();
 } catch {
   // Best-effort — register() will retry with logging.
 }
@@ -211,31 +190,12 @@ const plugin = {
       }
 
       // PRI-343: Check allowConversationAccess — auto-fix if missing/false, warn if fix fails.
-      // BOM-resistant: strip U+FEFF before JSON.parse.
+      // Uses file locking to prevent race conditions with concurrent writers.
       const accessCheck = checkConversationAccessConfig(getPluginEntry(api.config, api.id));
       if (!accessCheck.authorized) {
         let fixed = false;
         try {
-          const configPath = path.join(homedir(), '.openclaw', 'openclaw.json');
-          if (existsSync(configPath)) {
-            const raw = readFileSync(configPath, 'utf8').replace(/^\uFEFF/, '');
-            const cfg = JSON.parse(raw);
-            if (cfg && typeof cfg === 'object' && !Array.isArray(cfg)) {
-              if (!cfg.plugins) cfg.plugins = {};
-              if (typeof cfg.plugins !== 'object' || cfg.plugins === null) cfg.plugins = {};
-              if (!cfg.plugins.entries) cfg.plugins.entries = {};
-              if (typeof cfg.plugins.entries !== 'object' || cfg.plugins.entries === null) cfg.plugins.entries = {};
-              const entry = (typeof cfg.plugins.entries['principles-disciple'] === 'object' && cfg.plugins.entries['principles-disciple'] !== null)
-                ? cfg.plugins.entries['principles-disciple'] : { enabled: true };
-              if (!entry.hooks || typeof entry.hooks !== 'object' || Array.isArray(entry.hooks)) entry.hooks = {};
-              entry.hooks.allowConversationAccess = true;
-              cfg.plugins.entries['principles-disciple'] = entry;
-              const tmp = configPath + '.tmp.' + Date.now();
-              writeFileSync(tmp, JSON.stringify(cfg, null, 2), 'utf8');
-              renameSync(tmp, configPath);
-              fixed = true;
-            }
-          }
+          fixed = ensureConversationAccessInConfig();
         } catch (err) {
           api.logger.warn(
             `[PD:health] auto-fix for allowConversationAccess failed: ${String(err instanceof Error ? err.message : err)}`,

--- a/packages/openclaw-plugin/tests/core/config-health.test.ts
+++ b/packages/openclaw-plugin/tests/core/config-health.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import * as os from 'os';
+import {
+  checkConversationAccessConfig,
+  getPluginEntry,
+  ensureConversationAccessInConfig,
+} from '../../src/core/config-health.js';
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: vi.fn(),
+  };
+});
+
+describe('config-health', () => {
+  describe('checkConversationAccessConfig', () => {
+    it('returns authorized when hooks.allowConversationAccess is true', () => {
+      const result = checkConversationAccessConfig({
+        hooks: { allowConversationAccess: true },
+      });
+      expect(result.authorized).toBe(true);
+    });
+
+    it('returns unauthorized when pluginConfig is null', () => {
+      const result = checkConversationAccessConfig(null);
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toContain('missing or invalid');
+    });
+
+    it('returns unauthorized when hooks is missing', () => {
+      const result = checkConversationAccessConfig({});
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toContain('allowConversationAccess');
+    });
+
+    it('returns unauthorized when allowConversationAccess is false', () => {
+      const result = checkConversationAccessConfig({
+        hooks: { allowConversationAccess: false },
+      });
+      expect(result.authorized).toBe(false);
+    });
+
+    it('returns unauthorized when hooks is an array', () => {
+      const result = checkConversationAccessConfig({
+        hooks: [],
+      });
+      expect(result.authorized).toBe(false);
+    });
+  });
+
+  describe('getPluginEntry', () => {
+    it('returns the plugin entry when it exists', () => {
+      const config = {
+        plugins: {
+          entries: {
+            'principles-disciple': { enabled: true, hooks: {} },
+          },
+        },
+      };
+      const entry = getPluginEntry(config, 'principles-disciple');
+      expect(entry).toEqual({ enabled: true, hooks: {} });
+    });
+
+    it('returns undefined when config is invalid', () => {
+      expect(getPluginEntry(null, 'test')).toBeUndefined();
+      expect(getPluginEntry([], 'test')).toBeUndefined();
+      expect(getPluginEntry('string', 'test')).toBeUndefined();
+    });
+
+    it('returns undefined when plugins.entries path is missing', () => {
+      expect(getPluginEntry({}, 'test')).toBeUndefined();
+      expect(getPluginEntry({ plugins: {} }, 'test')).toBeUndefined();
+      expect(getPluginEntry({ plugins: { entries: {} } }, 'test')).toBeUndefined();
+    });
+  });
+});
+
+describe('ensureConversationAccessInConfig', () => {
+  const testHome = join('/tmp', 'pd-test-config-health-' + Date.now());
+  const configDir = join(testHome, '.openclaw');
+  const configPath = join(configDir, 'openclaw.json');
+  const lockPath = configPath + '.lock';
+
+  beforeEach(() => {
+    vi.mocked(os.homedir).mockReturnValue(testHome);
+    mkdirSync(configDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testHome, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('returns false when config file does not exist', () => {
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(false);
+  });
+
+  it('returns false when config is valid JSON but not an object', () => {
+    writeFileSync(configPath, '[]', 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(false);
+  });
+
+  it('returns false when allowConversationAccess is already true', () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          'principles-disciple': {
+            hooks: { allowConversationAccess: true },
+          },
+        },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(cfg), 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(false);
+  });
+
+  it('sets allowConversationAccess to true when missing', () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          'principles-disciple': { enabled: true },
+        },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(cfg), 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(true);
+
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.plugins.entries['principles-disciple'].hooks.allowConversationAccess).toBe(true);
+  });
+
+  it('creates plugins.entries path if missing', () => {
+    writeFileSync(configPath, '{}', 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(true);
+
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.plugins.entries['principles-disciple'].hooks.allowConversationAccess).toBe(true);
+  });
+
+  it('creates plugin entry with enabled: true if missing', () => {
+    const cfg = {
+      plugins: {
+        entries: {},
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(cfg), 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(true);
+
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.plugins.entries['principles-disciple'].enabled).toBe(true);
+    expect(updated.plugins.entries['principles-disciple'].hooks.allowConversationAccess).toBe(true);
+  });
+
+  it('preserves other config fields when updating', () => {
+    const cfg = {
+      someTopLevelSetting: 'value',
+      plugins: {
+        entries: {
+          'other-plugin': { enabled: true },
+          'principles-disciple': { enabled: true, config: { language: 'zh' } },
+        },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(cfg), 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(true);
+
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.someTopLevelSetting).toBe('value');
+    expect(updated.plugins.entries['other-plugin'].enabled).toBe(true);
+    expect(updated.plugins.entries['principles-disciple'].config.language).toBe('zh');
+    expect(updated.plugins.entries['principles-disciple'].hooks.allowConversationAccess).toBe(true);
+  });
+
+  it('cleans up lock file after successful write', () => {
+    writeFileSync(configPath, '{}', 'utf8');
+    ensureConversationAccessInConfig();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('handles BOM in config file', () => {
+    const cfg = { plugins: { entries: { 'principles-disciple': { enabled: true } } } };
+    writeFileSync(configPath, '\uFEFF' + JSON.stringify(cfg), 'utf8');
+    const result = ensureConversationAccessInConfig();
+    expect(result).toBe(true);
+
+    const updated = JSON.parse(readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
+    expect(updated.plugins.entries['principles-disciple'].hooks.allowConversationAccess).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug Summary

The `allowConversationAccess` auto-fix (introduced in commit b155afa8) writes to `~/.openclaw/openclaw.json` from **three separate code paths** without any file locking:

1. `postinstall.cjs` - runs during npm install
2. Module-level auto-fix in `index.ts` - runs at import time
3. Register-level health check auto-fix in `index.ts` - runs 1s after register

## Impact: Data Loss / Config Corruption

**Trigger scenario:**
- User changes an OpenClaw setting while the PD plugin postinstall script runs
- Both writers read the config file, modify it, and write back atomically via rename
- Last writer wins, silently discarding the other writer's changes

This can cause user-configured settings to be lost without any error or warning.

## Fix

- Extract shared `ensureConversationAccessInConfig()` helper in `config-health.ts`
- Use existing `withLock()` utility from `file-lock.ts` for all in-process writes
- Add inline O_EXCL file locking to `postinstall.cjs` (no-dependency constraint)
- All three write paths now coordinate via the same `.lock` file mechanism
- Lock uses PID-based stale detection with exponential backoff retry

## Tests

- 17 new tests for `config-health` module covering:
  - `checkConversationAccessConfig` edge cases
  - `getPluginEntry` invalid input handling
  - `ensureConversationAccessInConfig` write path (missing config, BOM, field preservation)
  - Lock file cleanup after successful writes

All 1685 existing unit tests pass. TypeScript typecheck passes cleanly.