### PR TITLE
fix(config): switch MVP default runtime to openclaw + disable correction_observer

### DIFF
--- a/packages/openclaw-plugin/tests/evolution-worker-slimming.test.ts
+++ b/packages/openclaw-plugin/tests/evolution-worker-slimming.test.ts
@@ -359,7 +359,7 @@ describe('PRI-294: Feature flag registry matches surface registry', () => {
   it('correction_observer flag exists in DEFAULT_FEATURE_FLAGS', () => {
     const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'correction_observer');
     expect(flag).toBeDefined();
-    expect(flag!.enabled).toBe(true);
+    expect(flag!.enabled).toBe(false); // MVP-Quiet: disabled by default
   });
 
   it('nocturnal and idle_trigger are gone flags', () => {

--- a/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-worker.correction-observer.test.ts
@@ -3,11 +3,11 @@ import { PLUGIN_SURFACE_REGISTRY } from '@principles/core/runtime-v2';
 import { DEFAULT_FEATURE_FLAGS, computeEffectiveFlags } from '@principles/core/runtime-v2';
 
 describe('Correction Observer Ownership — Feature Flag & Surface Registry Consistency (PRI-293, ERR-027)', () => {
-  it('correction_observer feature flag is registered as quiet with enabled:true (disableable runtime kill switch)', () => {
+  it('correction_observer feature flag is registered as quiet with enabled:false (MVP-Quiet, disableable runtime kill switch)', () => {
     const flag = DEFAULT_FEATURE_FLAGS.find(f => f.id === 'correction_observer');
     expect(flag).toBeDefined();
     expect(flag!.category).toBe('quiet');
-    expect(flag!.enabled).toBe(true);
+    expect(flag!.enabled).toBe(false);
   });
 
   it('correction_observer can be disabled via workspace config (P1 fix — runtime kill switch)', () => {

--- a/packages/pd-cli/src/commands/__tests__/runtime-probe-config.test.ts
+++ b/packages/pd-cli/src/commands/__tests__/runtime-probe-config.test.ts
@@ -420,9 +420,9 @@ describe('PRI-402: resolveRuntimeWithOverrides returns profile info', () => {
       const { resolveRuntimeWithOverrides } = await import('../../services/resolve-runtime-from-pd-config.js');
       const result = resolveRuntimeWithOverrides(workspace, {});
 
-      // Missing config → defaults, which use pd.default (pi-ai placeholder) as defaultRuntime
+      // Missing config → defaults, which use openclaw.default as defaultRuntime
       expect(result.configSource).toBe('.pd/config.yaml');
-      expect(result.runtimeProfileId).toBe('pd.default');
+      expect(result.runtimeProfileId).toBe('openclaw.default');
       expect(typeof result.runtimeProfileLabel).toBe('string');
     } finally {
       cleanupWorkspace(workspace);

--- a/packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts
+++ b/packages/pd-cli/tests/services/resolve-runtime-from-pd-config.test.ts
@@ -266,11 +266,11 @@ describe('resolveRuntimeFromPdConfig', () => {
     const tmp = mkTmpDir();
     try {
       const result = resolveRuntimeFromPdConfig(tmp);
-      // Default profile is pd.default (pi-ai with empty placeholder fields) →
-      // resolveRuntimeConfigFromPdConfig returns a needs_setup error.
-      expect(isRuntimeConfigError(result.result)).toBe(true);
+      // Default profile is openclaw.default (MVP default runtime) → resolves
+      // successfully without env var.
+      expect(isRuntimeConfigError(result.result)).toBe(false);
       expect(result.configSource).toBe('.pd/config.yaml');
-      expect(result.runtimeProfileId).toBe('pd.default');
+      expect(result.runtimeProfileId).toBe('openclaw.default');
       expect(typeof result.runtimeProfileLabel).toBe('string');
     } finally { rmTmpDir(tmp); }
   });

--- a/packages/pd-console/tests/server/routes/config.test.ts
+++ b/packages/pd-console/tests/server/routes/config.test.ts
@@ -205,8 +205,9 @@ describe('GET /api/v1/config/summary', () => {
       agents: { name: string; runtimeProfileId: string; runtimeProfileLabel: string }[];
     }>(res);
     expect(data.source).toBe('user_config');
-    // 3 user profiles + 1 default `pd.default` merged by computeEffectivePdConfig
-    expect(data.runtimeProfiles).toHaveLength(4);
+    // 3 user profiles; openclaw.default is already in VALID_CONFIG, so the MVP
+    // default profile is not merged again by computeEffectivePdConfig.
+    expect(data.runtimeProfiles).toHaveLength(3);
     expect(data.agents).toHaveLength(10); // all internal agents (incl. signalCollector)
   });
 
@@ -707,9 +708,9 @@ describe('GET /api/v1/config/readiness/:agentName', () => {
     expect(res.statusCode).toBe(200);
     const data = okEnvelope<{ agent: string; readiness: string }>(res);
     expect(data.agent).toBe('diagnostician');
-    // Default profile is pd.default (pi-ai placeholder) → needs_setup until
-    // user fills in provider/model/apiKeyEnv via web console (M9 + Plan C)
-    expect(data.readiness).toBe('needs_setup');
+    // Default profile is openclaw.default (MVP default runtime) → ready
+    // out of the box, no env var or user setup required.
+    expect(data.readiness).toBe('ready');
   });
 
   it('returns unknown readiness when config is malformed', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/resolve-runtime-config-from-pd-config.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/resolve-runtime-config-from-pd-config.test.ts
@@ -108,12 +108,12 @@ describe('resolveRuntimeConfigFromPdConfig', () => {
     if (isRuntimeConfigError(diagResult)) return;
     expect(diagResult.runtimeKind).toBe('pi-ai');
 
-    // default (no override) → pd.default (pi-ai placeholder), needs_setup without env var
+    // default (no override) → openclaw.default (MVP default runtime), resolves successfully
     const defaultEffective = computeEffectivePdConfig(null);
     const defaultResult = resolveRuntimeConfigFromPdConfig(defaultEffective, envWithoutKey);
-    expect(isRuntimeConfigError(defaultResult)).toBe(true);
-    if (!isRuntimeConfigError(defaultResult)) return;
-    expect(defaultResult.reason).toBe('needs_setup');
+    expect(isRuntimeConfigError(defaultResult)).toBe(false);
+    if (isRuntimeConfigError(defaultResult)) return;
+    expect(defaultResult.runtimeKind).toBe('openclaw-cli');
   });
 
   it('AC4: missing env var fails loud with reason + nextAction', () => {
@@ -128,13 +128,13 @@ describe('resolveRuntimeConfigFromPdConfig', () => {
     expect(result.nextAction).toBeTruthy();
   });
 
-  it('AC5: null config defaults to pi-ai placeholder, returns needs_setup without env var', () => {
+  it('AC5: null config defaults to openclaw runtime, resolves successfully without env var', () => {
     const effective = computeEffectivePdConfig(null);
     const result = resolveRuntimeConfigFromPdConfig(effective, envWithoutKey);
 
-    expect(isRuntimeConfigError(result)).toBe(true);
-    if (!isRuntimeConfigError(result)) return;
-    expect(result.reason).toBe('needs_setup');
+    expect(isRuntimeConfigError(result)).toBe(false);
+    if (isRuntimeConfigError(result)) return;
+    expect(result.runtimeKind).toBe('openclaw-cli');
   });
 
   it('returns error for disabled agent', () => {

--- a/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-agent-binding.test.ts
+++ b/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-agent-binding.test.ts
@@ -102,7 +102,7 @@ describe('resolveAgentRuntimeBinding', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.profileId).toBe(DEFAULT_RUNTIME_PROFILE_ID);
-    expect(result.profile.type).toBe('pi-ai');
+    expect(result.profile.type).toBe('openclaw');
     expect(result.source).toBe('default_runtime');
   });
 

--- a/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-contract.test.ts
+++ b/packages/principles-core/src/runtime-v2/config/__tests__/pd-config-contract.test.ts
@@ -109,14 +109,15 @@ describe('Scenario 1: Missing config → deterministic defaults', () => {
     expect(nn(effective.config.features.idle_trigger).category).toBe('gone');
   });
 
-  it('defaults include pd.default (pi-ai) and openclaw.default (openclaw) runtime profiles', () => {
+  it('defaults use openclaw.default while retaining pd.default as an explicit pi-ai option', () => {
     const effective = computeEffectivePdConfig(null);
-    // pd.default is the primary default profile (pi-ai type)
+    // The active MVP default works through the host OpenClaw runtime.
     expect(Object.hasOwn(effective.config.runtimeProfiles, DEFAULT_RUNTIME_PROFILE_ID)).toBe(true);
-    expect(nn(effective.config.runtimeProfiles[DEFAULT_RUNTIME_PROFILE_ID]).type).toBe('pi-ai');
-    // openclaw.default is retained as a fallback (openclaw type)
+    expect(nn(effective.config.runtimeProfiles[DEFAULT_RUNTIME_PROFILE_ID]).type).toBe('openclaw');
     expect(Object.hasOwn(effective.config.runtimeProfiles, 'openclaw.default')).toBe(true);
     expect(nn(effective.config.runtimeProfiles['openclaw.default']).type).toBe('openclaw');
+    // Direct pi-ai remains available only after the Owner explicitly configures it.
+    expect(nn(effective.config.runtimeProfiles['pd.default']).type).toBe('pi-ai');
   });
 
   it('defaults include all internal agents', () => {

--- a/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
+++ b/packages/principles-core/src/runtime-v2/config/pd-config-defaults.ts
@@ -32,15 +32,9 @@ for (const flag of CONTRACT_DEFAULTS) {
 
 // ── Default Runtime Profile ─────────────────────────────────────────────────
 //
-// M9 decision (2026-04-29, MEMORY.md L88): PiAiRuntimeAdapter is the default
-// Diagnostician Runtime. The default profile is therefore a pi-ai type profile
-// (`pd.default`). The legacy `openclaw.default` profile is retained as a
-// fallback so users can switch back via web console without editing yaml.
-//
-// The `pd.default` profile ships with empty placeholder fields
-// (provider/model/apiKeyEnv). Its static readiness is `needs_setup`. Users
-// must fill in real values via web console (Profile CRUD API) or by editing
-// `.pd/config.yaml`.
+// MVP installs must work with the OpenClaw runtime the plugin is already
+// running inside. The optional pi-ai profile remains available for explicit
+// configuration, but its empty placeholders must never be the active default.
 
 export const PI_AI_DEFAULT_PROFILE_ID = 'pd.default';
 
@@ -58,13 +52,9 @@ export const OPENCLAW_DEFAULT_PROFILE: OpenClawRuntimeProfile = {
   source: 'default',
 };
 
-// Backward-compatible aliases. Existing call sites that reference
-// DEFAULT_RUNTIME_PROFILE_ID / DEFAULT_RUNTIME_PROFILE now resolve to the
-// pi-ai default. Call sites that need the openclaw fallback should reference
-// OPENCLAW_DEFAULT_PROFILE_ID / OPENCLAW_DEFAULT_PROFILE explicitly.
-export const DEFAULT_RUNTIME_PROFILE_ID = PI_AI_DEFAULT_PROFILE_ID;
+export const DEFAULT_RUNTIME_PROFILE_ID = OPENCLAW_DEFAULT_PROFILE_ID;
 
-export const DEFAULT_RUNTIME_PROFILE: PdLocalRuntimeProfile = PI_AI_DEFAULT_PROFILE;
+export const DEFAULT_RUNTIME_PROFILE: OpenClawRuntimeProfile = OPENCLAW_DEFAULT_PROFILE;
 
 // ── Default Internal Agents ─────────────────────────────────────────────────
 

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -95,7 +95,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'prompt', category: 'core', enabled: true, since: '2026-05-24', description: 'Prompt injection for principle application' },
   { id: 'code_tool_hook', category: 'core', enabled: true, since: '2026-05-24', description: 'Code tool hook for rule host enforcement' },
   { id: 'defer_archive', category: 'core', enabled: true, since: '2026-05-24', description: 'Defer/archive activation writer' },
-  { id: 'correction_observer', category: 'quiet', enabled: true, since: '2026-06-02', description: 'Independent correction observer service for keyword self-correction (MVP-Core per ADR-0014 amendment, PRI-293; quiet flag to allow runtime disable)' },
+  { id: 'correction_observer', category: 'quiet', enabled: false, since: '2026-06-02', description: 'Optional LLM optimization service for correction keywords; synchronous correction detection remains active independently' },
   { id: 'signal_collector', category: 'quiet', enabled: false, since: '2026-06-30', description: 'Unified signal collection host (correction + empathy upstream merge). NOTE: keyword detection (high-precision phrases) runs regardless of this flag; this flag only gates the LLM deep-judgment path (ambiguous terms / missed keywords). Quiet flag: dogfood-only until validated.' },
   { id: 'internalization_auto_consumer', category: 'quiet', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381; quiet flag, default on, disableable via config)' },
   // PRI-408: Story A approval-completion orchestrator. Replaces the demo direct-writer


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无（评审发现的真实问题）
- 解决的产品问题（一句话）: MVP 安装后默认 runtime profile 是空 placeholder 的 pi-ai，导致 ready 状态为 needs_setup，安装即"坏"。
- emotional-value：降低 [失控感]（fresh install 显示 broken default profile）创造 [安心感]（default works out of the box）
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复

### 高层变更（3-5 条）
- `DEFAULT_RUNTIME_PROFILE_ID/PROFILE` 从 `pd.default`（pi-ai 空 placeholder）切回 `openclaw.default`（plugin 本身就跑在 OpenClaw runtime 里）
- `correction_observer` flag 从 `enabled: true` 改为 `enabled: false`（MVP-Quiet）；同步澄清 flag 描述，明确同步关键词检测独立于此 LLM 优化 flag 运行
- `pd.default` 仍保留为显式 pi-ai 选项，用户可在 config 中主动选择
- 测试断言跟随更新：[pd-config-contract.test.ts](packages/principles-core/src/runtime-v2/config/__tests__/pd-config-contract.test.ts) 验证 `openclaw.default` 为活动默认 + `pd.default` 仍可显式选择为 pi-ai

### 影响范围
- [x] packages/principles-core

### 是否触及产品边界
- [x] 是（默认 runtime profile 是 MVP-Core Story A' 起点，按 AGENTS.md "Adding a new feature to MVP-Core REQUIRES maintainer's explicit approval"。本 PR 是回退到 MVP 安装可用状态，而非新增能力，但请 maintainer 确认）

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 全新空 workspace
- [ ] 动作 1: `pd runtime-canary`
  - 观察: `runtime_health` 不再显示 `needs_setup`，profile type 为 `openclaw`
- [ ] 动作 2: 检查 `.pd/config.yaml` 中 `runtimeProfiles`
  - 观察: `openclaw.default` 是默认活动 profile；`pd.default` 仍存在作为显式 pi-ai 选项
- 证据: `cd packages/principles-core && npx vitest run src/runtime-v2/config/__tests__/pd-config-contract.test.ts` 全绿

## 风险与可逆性
- 主要风险: 已有用户曾显式配置 `pd.default` 为活动 profile 的情况下，本变更不影响其配置（仅改默认）。但若有调用点硬编码假设 default 是 pi-ai，可能出错。
- 回滚方式: [x] PR revert
- 是否需要 feature flag: 否（仅改默认值，用户配置覆盖优先级不变）

### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会被提起。fresh install broken default 是 P0 安装可用性问题
- `mvp-q-2-how-observed`: `pd runtime-canary` 显示 active profile type
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填）
- [x] 代码符合项目风格
- [x] 无破坏性变更（向后兼容：用户显式配置不受影响）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] Core 边界检查：本 PR 未在 `packages/principles-core/src/` 新增 fs/path 导入

### ERR Checklist
- ERR-002 (silent fallback): 旧的空 pi-ai default 实质是 silent fallback；本变更让真实 default 显式化
- ERR-013 (in operator): 测试使用 `Object.hasOwn` 而非 `in`
- ERR-089 (branch coverage): 测试覆盖 default 切换 + pd.default 仍可选两个分支

### Runtime Contract 自检
- [ ] 本 PR 处理不可信数据（否 — 仅改默认值常量，不接触 parsed JSON/LLM output）
- N/A — 本 PR 不处理不可信数据

### Feature Flag 注册检查
- [x] N/A — `correction_observer` 已注册，仅切换 enabled 状态

### BDD 影响评估
- [x] N/A — 本 PR 未修改 MVP-Core 用户旅程的可观察行为契约
  - `docs/specs/features/story-a/owner-approve-prompt.feature` 测试 prompt channel 流程，不直接断言 profile type
  - profile type 是后端默认值，不进入用户可见行为

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`
- [x] 无 `antipattern-completeness`
- [x] 无 `antipattern-review-missing`
- [x] 无 `antipattern-core-io`

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npx vitest run src/runtime-v2/config/__tests__/`: 通过
- [ ] `npm run lint`: 未运行（仅改默认值常量，不引入 lint 风险）
- [ ] `npm run verify:merge`: 未运行

## 相关 Issue
评审发现的真实问题：fresh MVP install 默认 runtime profile 是空 placeholder，安装即"坏"。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 默认运行时配置现优先使用 OpenClaw，提升开箱即用的兼容性。
  * Pi AI 配置仍可在明确配置后使用。

* **功能调整**
  * 默认关闭纠错优化服务；同步纠错检测仍保持启用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->