### PR TITLE
fix(prompt): align correction detection gating with isUserInteraction

### DIFF
--- a/packages/openclaw-plugin/src/core/signal-collector-host.ts
+++ b/packages/openclaw-plugin/src/core/signal-collector-host.ts
@@ -4,7 +4,7 @@
  * 把 core 的纯逻辑 (collectSync / mapLlmResultToOutput) 接进 openclaw 运行时。
  *
  * 同步路径 (prompt.ts before_prompt_build 钩子调用,绝不阻塞):
- *   - trigger 门控 (仅 user)
+ *   - trigger 门控 (user/api/undefined 视为用户交互,其余跳过)
  *   - Stage1 关键词快扫 (零成本)
  *   - 写 user_turns (复用 recordUserTurn)
  *   - 高精度短语命中 (high) → 直接走 STRONG 分流 (同步,纯内存)
@@ -51,6 +51,17 @@ export const DEFAULT_SIGNAL_CONFIG: SignalCollectorConfig = {
   strongPainScore: 70,
   strongRateLimitPerHour: 5,
 };
+
+/**
+ * 判定 trigger 是否代表真实用户交互。
+ *
+ * `user` / `api` / `undefined` 均视为用户交互(prompt.ts 与 detectSync 共享同一判定,
+ * 避免两处门控不一致导致 api/undefined 触发的纠正信号丢失)。
+ * `heartbeat` / `cron` / `subagent` 等系统触发不视为用户交互。
+ */
+export function isUserInteractionTrigger(trigger: string | undefined): boolean {
+  return trigger === 'user' || trigger === 'api' || trigger === undefined;
+}
 
 export function buildDefaultKeywordStore(): UnifiedKeywordStore {
   const terms: UnifiedKeywordStore['terms'] = {
@@ -136,8 +147,10 @@ export class SignalCollectorHost {
     trigger: string,
     options?: { referencesAssistantTurnId?: number | null; turnIndex?: number },
   ): void {
-    // 1. trigger 门控 (保留现有 trigger 门控,仅处理真实用户消息)
-    if (trigger !== 'user') {
+    // 1. trigger 门控:仅处理真实用户交互(user/api/undefined)。
+    //    与 prompt.ts 共享 isUserInteractionTrigger,避免两处门控不一致导致
+    //    api/undefined 触发的纠正信号在 detectSync 内部被静默丢弃。
+    if (!isUserInteractionTrigger(trigger)) {
       return;
     }
 

--- a/packages/openclaw-plugin/src/hooks/prompt.ts
+++ b/packages/openclaw-plugin/src/hooks/prompt.ts
@@ -30,7 +30,7 @@ import {
   formatEvolutionPrinciples,
   assembleAppendSystemContext,
 } from './prompt-helpers.js';
-import { SignalCollectorHost, createSignalLlmClassifierFromConfig } from '../core/signal-collector-host.js';
+import { SignalCollectorHost, createSignalLlmClassifierFromConfig, isUserInteractionTrigger } from '../core/signal-collector-host.js';
 import type { CachedFile, PromptHookApi } from './prompt-types.js';
 
 // ---------------------------------------------------------------------------
@@ -204,6 +204,7 @@ export async function handleBeforePromptBuild(
 
   const wctx = WorkspaceContext.fromHookContext(ctx);
   const { runId, sessionKey, trigger, sessionId } = ctx;
+  const isUserInteraction = isUserInteractionTrigger(trigger);
   const api = ctx.api;
   if (sessionId) {
     wctx.trajectory?.recordSession?.({ sessionId });
@@ -212,7 +213,7 @@ export async function handleBeforePromptBuild(
   // OpenClaw sends the current model-visible user input in event.prompt. event.messages
   // contains prepared history and must only be used for lineage and turn indexing.
   let correctionReferencesAssistantTurnId: number | null = null;
-  if (sessionId && trigger === 'user' && event.messages.some((message) => hasMessageRole(message, 'assistant'))) {
+  if (sessionId && isUserInteraction && event.messages.some((message) => hasMessageRole(message, 'assistant'))) {
     const turns = wctx.trajectory?.listAssistantTurns?.(sessionId) ?? [];
     const lastAssistant = turns[turns.length - 1];
     correctionReferencesAssistantTurnId = lastAssistant?.id ?? null;
@@ -256,8 +257,6 @@ export async function handleBeforePromptBuild(
   const { message: currentUserMessage, isAgentToAgent } =
     extractUserMessageFromPrompt(event.prompt, sessionId);
 
-  const isUserInteraction = trigger === 'user' || trigger === 'api' || !trigger;
-
   // Track if we should inject behavioral constraints (will be added to appendSystemContext later)
   // 注:原 empathy 检测门控(empathyEnabled)已移除,检测职责由 SignalCollectorHost 接管。
   // behavioral 约束注入是独立职责,保留门控。
@@ -268,15 +267,17 @@ export async function handleBeforePromptBuild(
 
   // SignalCollectorHost 统一接管 correction + empathy 检测(spec §3.3 决策1)。
   // 在 isAgentToAgent 解析之后调用,避免 agent-to-agent 流量被误当用户纠正(CodeRabbit #7)。
-  if (currentUserMessage && sessionId && trigger === 'user' && !isAgentToAgent) {
+  if (currentUserMessage && sessionId && isUserInteraction && !isAgentToAgent) {
     if (runId && hasClaimedSignalRun(wctx.workspaceDir, sessionKey ?? sessionId, runId)) {
       logger?.info?.(`[PD:Prompt] duplicate signal run skipped: runId=${runId}, sessionId=${sessionId.substring(0, 20)}`);
     } else {
       if (!runId) {
         logger?.warn?.(`[PD:Prompt] runId missing; signal collection cannot be deduplicated: sessionId=${sessionId.substring(0, 20)}`);
       }
+      // trigger ?? 'api':detectSync 的 trigger 参数必须为具体值(host 内部用
+      // isUserInteractionTrigger 判定,undefined 会被接受但下游日志/标签需要具体值)。
       getSignalCollectorHost(wctx, logger).detectSync(
-        currentUserMessage, sessionId, trigger,
+        currentUserMessage, sessionId, trigger ?? 'api',
         {
           referencesAssistantTurnId: correctionReferencesAssistantTurnId,
           turnIndex: nextUserTurnIndex(wctx, sessionId, event.messages),

--- a/packages/openclaw-plugin/tests/core/signal-collector-host.test.ts
+++ b/packages/openclaw-plugin/tests/core/signal-collector-host.test.ts
@@ -66,11 +66,23 @@ function flushAsync(ms = 50): Promise<void> {
 describe('SignalCollectorHost.detectSync', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('skips when trigger !== user', () => {
+  it('skips when trigger is a non-user system trigger (heartbeat)', () => {
     const wctx = makeMockWctx();
     const host = makeHost(wctx, { keywordStore: testStore, config: testConfig });
     host.detectSync('这是错的', 'sess1', 'heartbeat');
     expect(wctx.trajectory.recordUserTurn).not.toHaveBeenCalled();
+  });
+
+  it('accepts api trigger as user interaction (regression: previously rejected by trigger !== user gate)', () => {
+    // P1 regression: detectSync 内部曾用 `if (trigger !== 'user') return;` 静默丢弃
+    // api/undefined 触发的纠正信号。现在改用 isUserInteractionTrigger,user/api/undefined
+    // 均被视为用户交互。prompt.ts 调用时已将 undefined 转为 'api',所以这里测 'api'。
+    const wctx = makeMockWctx();
+    const host = makeHost(wctx, { keywordStore: testStore, config: testConfig });
+    host.detectSync('这是错的', 'sess-api', 'api');
+    expect(wctx.trajectory.recordUserTurn).toHaveBeenCalledWith(expect.objectContaining({
+      correctionDetected: true,
+    }));
   });
 
   it('high-precision correction → writes user_turns with correctionDetected=true', () => {

--- a/packages/openclaw-plugin/tests/hooks/prompt-characterization.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/prompt-characterization.test.ts
@@ -97,6 +97,8 @@ vi.mock('../../src/core/signal-collector-host.js', () => ({
     detectSync = mockDetectSync;
   },
   createSignalLlmClassifierFromConfig: vi.fn().mockReturnValue(null),
+  isUserInteractionTrigger: (trigger: string | undefined) =>
+    trigger === 'user' || trigger === 'api' || trigger === undefined,
 }));
 
 // ─── Mutable session mock ────────────────────────────────────────────────────

--- a/packages/openclaw-plugin/tests/hooks/prompt-user-interaction-trigger.test.ts
+++ b/packages/openclaw-plugin/tests/hooks/prompt-user-interaction-trigger.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { isUserInteractionTrigger } from '../../src/core/signal-collector-host.js';
+
+describe('prompt user interaction trigger classification', () => {
+  it.each(['user', 'api', undefined])('accepts user entry trigger %s', (trigger) => {
+    expect(isUserInteractionTrigger(trigger)).toBe(true);
+  });
+
+  it.each(['heartbeat', 'cron', 'subagent'])('rejects non-user trigger %s', (trigger) => {
+    expect(isUserInteractionTrigger(trigger)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无（评审发现的真实 bug）
- 解决的产品问题（一句话）: prompt.ts 的 `isUserInteraction` 定义与下游两处门控 `trigger === 'user'` 不一致，且 SignalCollectorHost.detectSync 内部还有一道 `if (trigger !== 'user') return` 硬门控——三层门控不一致导致 `api`/`undefined` 触发的纠正信号在 detectSync 内部被静默丢弃（调用方门控已放宽但 host 内部仍拒绝）
- emotional-value：降低 [信息过载]（丢失的纠正信号会让 Owner 反复纠正相同行为）创造 [沉淀感]（每一次纠正都被正确捕获）
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复

### 高层变更
- **提取 `isUserInteractionTrigger(trigger)` 到 `signal-collector-host.ts`**（单一真相源）：`user`/`api`/`undefined` → true；`heartbeat`/`cron`/`subagent`/其他 → false
- **`signal-collector-host.ts` detectSync P1 修复**：将 `if (trigger !== 'user') return` 改为 `if (!isUserInteractionTrigger(trigger)) return`。这是本 PR 的核心修复——原 PR 只放宽了 prompt.ts 的调用门控，但 detectSync 内部仍用硬编码 `trigger !== 'user'` 拒绝 api/undefined，导致修复无效
- `prompt.ts`：import `isUserInteractionTrigger`；将内联 `isUserInteraction` 定义替换为共享 helper；将 `isUserInteraction` 计算上移，使其同时门控 correctionReferencesAssistantTurnId 块和 detectSync 调用块；detectSync 调用传 `trigger ?? 'api'` 保证 host 总收到具体值
- Manual Pain Clearance（`trigger === 'user'`）**有意保留**：仅真实用户操作触发 friction reset，不扩展到 api/undefined
- 新增 `prompt-user-interaction-trigger.test.ts`：6 个测试覆盖 accept (user/api/undefined) 和 reject (heartbeat/cron/subagent)
- `signal-collector-host.test.ts`：新增 `api` trigger 回归测试（证明 detectSync 不再拒绝 api）；重命名 "skips when trigger !== user" → "skips when trigger is a non-user system trigger (heartbeat)"

### 评审历史
- 初版（commit `2b43dd16`）: 仅放宽 prompt.ts 两处 `trigger === 'user'` 门控为 `isUserInteraction`，但**遗漏了 detectSync 内部的 `trigger !== 'user'` 硬门控**——修复无效（P1）。且分支基线过期导致全仓库 add/add 冲突（P0 dirty conflict）
- 修订版（commit `51bf35e1`, force-push）: cherry-pick 到当前 main 重建分支；提取 `isUserInteractionTrigger` 到 signal-collector-host.ts 作为单一真相源；修复 detectSync 内部门控（P1）；补 mock 修复

### 影响范围
- [x] packages/openclaw-plugin

### 是否触及产品边界
- [ ] 否（修复门控一致性，不改变 correction 检测的产品行为契约，仅修复漏触发的 bug）

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 构建依赖 `npm run build`
- [ ] 动作 1: `cd packages/openclaw-plugin && npx vitest run tests/hooks/prompt-user-interaction-trigger.test.ts tests/core/signal-collector-host.test.ts`
  - 观察: 41 个测试全绿，含 `accepts api trigger as user interaction` 回归测试
- [ ] 动作 2: 在 API 触发的 prompt 中输入纠正文本（如 "不要这样做"）
  - 观察: trajectory DB 的 `user_turns` 表中应有该次纠正记录；之前 bug 模式下不会被记录
- 证据: 单元测试输出 + CI

## 风险与可逆性
- 主要风险: `trigger ?? 'api'` 引入新语义——当 trigger 为 undefined 时，detectSync 现在收到 `'api'` 而非 `undefined`。已确认：detectSync 内部用 `isUserInteractionTrigger` 判定（接受 api），下游日志/标签仅作展示用
- 回滚方式: [x] PR revert
- 是否需要 feature flag: 否（仅修复门控不一致，未引入新功能）

### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后会被提起。`api`/`undefined` 触发的纠正信号丢失是数据完整性 bug
- `mvp-q-2-how-observed`: 单元测试 + trajectory DB user_turns 表记录
- `mvp-q-3-how-disabled`: PR revert
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填）
- [x] 代码符合项目风格
- [x] 无破坏性变更（`'user'` 触发路径行为不变；`api`/`undefined` 路径从"静默丢弃"变为"正常处理"是 bug 修复）
- [x] Core 边界检查：未改 core；`isUserInteractionTrigger` 放在 openclaw-plugin/src/core/（plugin 层，非 @principles/core 包）

### ERR Checklist
- ERR-002 (silent fallback): 原 detectSync 内部 `trigger !== 'user'` 静默丢弃 api/undefined 纠正——典型的 silent fallback。已通过共享 `isUserInteractionTrigger` 修复
- ERR-015/018/019 (stale loop state): `isUserInteraction` 在函数顶部计算一次，下游不重复计算
- ERR-089 (branch coverage): 新增测试覆盖 3 个 accept + 3 个 reject 触发值 + detectSync 级 api 回归测试

### Runtime Contract 自检
- [ ] 本 PR 处理不可信数据（否 — trigger 是 ctx 上的 string，不是 parsed JSON/LLM output）
- rc-5 (Object.hasOwn): N/A — 无不可信对象键访问
- rc-1/rc-2: N/A — trigger 是 string，不是 unknown；无 `as` bypass 引入

### CLI 自检
- N/A — 未修改 packages/pd-cli/src/commands/** 或 CLI 注册

### BDD 影响评估
- [x] N/A — 本 PR 未修改 MVP-Core 用户旅程的可观察行为契约。`docs/specs/features/story-a/owner-approve-prompt.feature` 测试 prompt channel 完整流程，不直接断言 trigger 值。修复扩展了触发范围（api/undefined 现在也走 correction 检测），但 `.feature` 的可观察行为（pain → candidate → activation）不变

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`
- [x] 无 `antipattern-completeness`
- [x] 无 `antipattern-review-missing`
- [x] 无 `antipattern-core-io`

## 测试结果（agent 填）
- [x] `npx vitest run tests/hooks/prompt-user-interaction-trigger.test.ts tests/core/signal-collector-host.test.ts`: 通过（41 tests，含 api 回归测试）
- [x] `npx tsc --noEmit` (openclaw-plugin): 通过
- [ ] `npm run lint`: 未本地运行（CI lint job 会跑）
- [ ] `npm run verify:merge`: 未本地运行（CI verify-merge job 会跑）

## 相关 Issue
评审发现的真实 bug：`isUserInteraction` 定义与下游门控不一致，导致 api/undefined 触发时 correction 检测漏触发；且 detectSync 内部硬门控使原 PR 修复无效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 统一用户交互触发器的识别逻辑，支持来自用户消息和 API 的有效触发。
  - API 触发的消息现在可正常执行信号检测与纠正处理，避免相关信号被静默忽略。
  - 心跳、定时任务及子代理等系统触发仍会被正确跳过。

- **测试**
  - 增加并更新触发器分类及 API 触发场景的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->