### PR TITLE
test: add coverage for pd-task-reconciler, evolution-dedup, and internalization-auto-consumer-service

### DIFF
--- a/packages/openclaw-plugin/tests/core/pd-task-reconciler.test.ts
+++ b/packages/openclaw-plugin/tests/core/pd-task-reconciler.test.ts
@@ -10,8 +10,24 @@ import {
 } from '../../src/core/pd-task-reconciler.js';
 import { readTasks, writeTasks } from '../../src/core/pd-task-store.js';
 
+// Hoisted mutable array so individual tests can control BUILTIN_PD_TASKS.
+// Without this, BUILTIN_PD_TASKS defaults to [] and reconcilePDTasks' diff()
+// never sees any declared task — making CREATE/DISABLE/SKIP paths untestable.
+const { builtinTasks } = vi.hoisted(() => ({
+  builtinTasks: [] as PDTaskSpec[],
+}));
+
 vi.mock('fs');
 vi.mock('../../src/core/pd-task-store.js');
+vi.mock('../../src/core/pd-task-types.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return { ...actual, BUILTIN_PD_TASKS: builtinTasks };
+});
+// writeCronStore uses withLockAsync which acquires a real fs lock; under the
+// fs mock the lock path hangs. Bypass the lock and just run the callback.
+vi.mock('../../src/utils/file-lock.js', () => ({
+  withLockAsync: vi.fn(async (_filePath: string, fn: () => Promise<unknown>) => fn()),
+}));
 
 describe('PDTaskReconciler', () => {
   const tmpDir = path.join(os.tmpdir(), `pd-task-reconciler-test-${Date.now()}`);
@@ -37,6 +53,7 @@ describe('PDTaskReconciler', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    builtinTasks.length = 0; // reset declared tasks between tests
     vi.mocked(fs.existsSync).mockImplementation((p) => {
       if (p.toString().startsWith(tmpDir)) return true;
       if (p.toString() === cronStorePath) return true;
@@ -52,8 +69,15 @@ describe('PDTaskReconciler', () => {
   });
 
   describe('reconcilePDTasks', () => {
-    it('should create new tasks', async () => {
-      vi.mocked(readTasks).mockReturnValue([]);
+    it('should create new jobs for declared builtin tasks with no existing cron job', async () => {
+      builtinTasks.push(testTask);
+      const result = await reconcilePDTasks(tmpDir, { dryRun: false });
+      expect(result.created).toHaveLength(1);
+      expect(result.created[0]).toBe('PD Test Task');
+    });
+
+    it('should return empty created list when no builtin tasks are declared', async () => {
+      // BUILTIN_PD_TASKS is empty (no declared tasks) → diff() has nothing to process
       const result = await reconcilePDTasks(tmpDir, { dryRun: true });
       expect(result.created).toHaveLength(0);
     });
@@ -108,16 +132,33 @@ describe('PDTaskReconciler', () => {
       expect(result.orphaned).toHaveLength(0);
     });
 
-    it('should skip CREATE for disabled task', async () => {
-      vi.mocked(readTasks).mockReturnValue([disabledTask]);
+    it('should disable existing job when declared task is disabled', async () => {
+      // disabledTask must be a declared builtin AND have an existing cron job
+      // for diff() to reach the DISABLE branch (task.enabled === false, job exists).
+      builtinTasks.push(disabledTask);
+      const existingJob: CronJob = {
+        id: 'pd-disabled-1',
+        name: 'PD Disabled Task',
+        enabled: true,
+        createdAtMs: 123,
+        updatedAtMs: 123,
+        schedule: { kind: 'every', everyMs: 3600000 },
+        sessionTarget: 'isolated',
+        wakeMode: 'now',
+        payload: { kind: 'agentTurn', message: 'A disabled task' },
+        state: { nextRunAtMs: 123456 },
+        metadata: { pdVersion: '1.0.0', pdTaskId: 'disabled-task' },
+      };
       vi.mocked(fs.readFileSync).mockImplementation((p) => {
         if (p.toString() === cronStorePath) {
-          return JSON.stringify({ version: 1, jobs: [] });
+          return JSON.stringify({ version: 1, jobs: [existingJob] });
         }
         return '[]';
       });
-      const result = await reconcilePDTasks(tmpDir, { dryRun: true });
+      const logger = { info: vi.fn(), warn: vi.fn() };
+      const result = await reconcilePDTasks(tmpDir, { dryRun: false, logger });
       expect(result.created).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith('[PD:Reconciler] Disabled job: PD Disabled Task');
     });
 
     it('should handle malformed cron store gracefully', async () => {
@@ -160,6 +201,15 @@ describe('PDTaskReconciler', () => {
       const result = await trigger('test-task', tmpDir);
       expect(result.ok).toBe(false);
       expect(result.error).toBe('Task is auto-disabled. Use force=true to override.');
+    });
+
+    it('should trigger an existing enabled task successfully', async () => {
+      vi.mocked(readTasks).mockReturnValue([testTask]);
+      const result = await trigger('test-task', tmpDir);
+      expect(result.ok).toBe(true);
+      expect(result.error).toBeUndefined();
+      // A successful trigger persists the updated task meta (lastTriggeredAtMs).
+      expect(writeTasks).toHaveBeenCalledWith(tmpDir, expect.arrayContaining([expect.objectContaining({ id: 'test-task' })]));
     });
   });
 });

--- a/packages/openclaw-plugin/tests/core/pd-task-reconciler.test.ts
+++ b/packages/openclaw-plugin/tests/core/pd-task-reconciler.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  reconcilePDTasks,
+  trigger,
+  type PDTaskSpec,
+  type CronJob,
+} from '../../src/core/pd-task-reconciler.js';
+import { readTasks, writeTasks } from '../../src/core/pd-task-store.js';
+
+vi.mock('fs');
+vi.mock('../../src/core/pd-task-store.js');
+
+describe('PDTaskReconciler', () => {
+  const tmpDir = path.join(os.tmpdir(), `pd-task-reconciler-test-${Date.now()}`);
+  const cronStorePath = path.join(os.homedir(), '.openclaw', 'cron', 'jobs.json');
+
+  const testTask: PDTaskSpec = {
+    id: 'test-task',
+    name: 'PD Test Task',
+    description: 'A test task',
+    enabled: true,
+    version: '1.0.0',
+    schedule: { kind: 'every', everyMs: 3600000 },
+    execution: { promptTemplate: 'test', timeoutSeconds: 60 },
+    delivery: { mode: 'none' },
+  };
+
+  const disabledTask: PDTaskSpec = {
+    ...testTask,
+    id: 'disabled-task',
+    name: 'PD Disabled Task',
+    enabled: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      if (p.toString().startsWith(tmpDir)) return true;
+      if (p.toString() === cronStorePath) return true;
+      return false;
+    });
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p.toString() === cronStorePath) {
+        return JSON.stringify({ version: 1, jobs: [] });
+      }
+      return '[]';
+    });
+    vi.mocked(readTasks).mockReturnValue([]);
+  });
+
+  describe('reconcilePDTasks', () => {
+    it('should create new tasks', async () => {
+      vi.mocked(readTasks).mockReturnValue([]);
+      const result = await reconcilePDTasks(tmpDir, { dryRun: true });
+      expect(result.created).toHaveLength(0);
+    });
+
+    it('should log orphaned jobs', async () => {
+      const orphanJob: CronJob = {
+        id: 'pd-orphan-123',
+        name: 'PD Orphan Task',
+        enabled: true,
+        createdAtMs: 123,
+        updatedAtMs: 123,
+        schedule: { kind: 'every', everyMs: 3600000 },
+        sessionTarget: 'isolated',
+        wakeMode: 'now',
+        payload: { kind: 'agentTurn', message: 'An orphan task' },
+        state: { nextRunAtMs: 123456 },
+        metadata: { pdVersion: '1.0.0', pdTaskId: 'orphan-task' },
+      };
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (p.toString() === cronStorePath) {
+          return JSON.stringify({ version: 1, jobs: [orphanJob] });
+        }
+        return '[]';
+      });
+      const logger = { info: vi.fn(), warn: vi.fn() };
+      const result = await reconcilePDTasks(tmpDir, { dryRun: true, logger });
+      expect(result.orphaned).toHaveLength(1);
+      expect(result.orphaned[0]).toBe('PD Orphan Task');
+      expect(logger.warn).toHaveBeenCalledWith('[PD:Reconciler] Orphaned job (no declaration): PD Orphan Task');
+    });
+
+    it('should not mark non-PD jobs as orphan', async () => {
+      const nonPdJob: CronJob = {
+        id: 'external-job-123',
+        name: 'External Task',
+        enabled: true,
+        createdAtMs: 123,
+        updatedAtMs: 123,
+        schedule: { kind: 'every', everyMs: 3600000 },
+        sessionTarget: 'isolated',
+        wakeMode: 'now',
+        payload: { kind: 'agentTurn', message: 'An external task' },
+        state: { nextRunAtMs: 123456 },
+      };
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (p.toString() === cronStorePath) {
+          return JSON.stringify({ version: 1, jobs: [nonPdJob] });
+        }
+        return '[]';
+      });
+      const result = await reconcilePDTasks(tmpDir, { dryRun: true });
+      expect(result.orphaned).toHaveLength(0);
+    });
+
+    it('should skip CREATE for disabled task', async () => {
+      vi.mocked(readTasks).mockReturnValue([disabledTask]);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (p.toString() === cronStorePath) {
+          return JSON.stringify({ version: 1, jobs: [] });
+        }
+        return '[]';
+      });
+      const result = await reconcilePDTasks(tmpDir, { dryRun: true });
+      expect(result.created).toHaveLength(0);
+    });
+
+    it('should handle malformed cron store gracefully', async () => {
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (p.toString() === cronStorePath) {
+          return 'not valid json';
+        }
+        return '[]';
+      });
+      const logger = { info: vi.fn(), warn: vi.fn() };
+      const result = await reconcilePDTasks(tmpDir, { dryRun: true, logger });
+      expect(result.created).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to parse cron/jobs.json'));
+    });
+
+    it('should handle missing cron store', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => '[]');
+      const logger = { info: vi.fn(), warn: vi.fn() };
+      const result = await reconcilePDTasks(tmpDir, { dryRun: true, logger });
+      expect(result.created).toHaveLength(0);
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('cron/jobs.json not found'));
+    });
+  });
+
+  describe('trigger', () => {
+    it('should return error when task not found', async () => {
+      vi.mocked(readTasks).mockReturnValue([]);
+      const result = await trigger('non-existent', tmpDir);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("Task 'non-existent' not found");
+    });
+
+    it('should return error when task is auto-disabled without force', async () => {
+      const disabledTaskWithMeta: PDTaskSpec = {
+        ...testTask,
+        meta: { autoDisabled: true, autoDisabledAt: Date.now() },
+      };
+      vi.mocked(readTasks).mockReturnValue([disabledTaskWithMeta]);
+      const result = await trigger('test-task', tmpDir);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('Task is auto-disabled. Use force=true to override.');
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/service/evolution-dedup.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-dedup.test.ts
@@ -93,11 +93,18 @@ describe('EvolutionDedup', () => {
 
     it('should truncate long source and preview strings', () => {
       const now = Date.now();
-      const longString = 'a'.repeat(500);
+      // Two strings that share the same first 200 chars (the truncation
+      // threshold MAX_DEDUP_KEY_COMPONENT_LENGTH) but differ afterward.
+      // If truncation works, they normalize to the same dedup key and match.
+      // If truncation did NOT work, they would differ and not match — so this
+      // test actually verifies the truncation logic, not just string equality.
+      const prefix = 'a'.repeat(200);
+      const queueString = prefix + 'QUEUE_TAIL';
+      const lookupString = prefix + 'LOOKUP_TAIL';
       const queue: EvolutionQueueItem[] = [
-        createQueueItem(longString, longString, now - 1000),
+        createQueueItem(queueString, queueString, now - 1000),
       ];
-      const duplicate = findRecentDuplicateTask(queue, longString, longString, now);
+      const duplicate = findRecentDuplicateTask(queue, lookupString, lookupString, now);
       expect(duplicate).toBeDefined();
     });
 

--- a/packages/openclaw-plugin/tests/service/evolution-dedup.test.ts
+++ b/packages/openclaw-plugin/tests/service/evolution-dedup.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  findRecentDuplicateTask,
+  hasRecentDuplicateTask,
+  hasEquivalentPromotedRule,
+  PAIN_QUEUE_DEDUP_WINDOW_MS,
+} from '../../src/service/evolution-dedup.js';
+import type { EvolutionQueueItem } from '../../src/core/evolution-types.js';
+
+describe('EvolutionDedup', () => {
+  const createQueueItem = (
+    source: string,
+    preview: string,
+    enqueuedAt: number,
+    status: 'pending' | 'completed' = 'pending',
+    reason?: string,
+  ): EvolutionQueueItem => ({
+    id: `task-${Date.now()}-${Math.random()}`,
+    source,
+    trigger_text_preview: preview,
+    enqueued_at: new Date(enqueuedAt).toISOString(),
+    timestamp: new Date(enqueuedAt).toISOString(),
+    status,
+    ...(reason ? { reason } : {}),
+  } as EvolutionQueueItem);
+
+  describe('findRecentDuplicateTask', () => {
+    it('should find duplicate task within dedup window', () => {
+      const now = Date.now();
+      const source = 'code_review';
+      const preview = 'fix bug in auth';
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem(source, preview, now - 1000),
+      ];
+      const duplicate = findRecentDuplicateTask(queue, source, preview, now);
+      expect(duplicate).toBeDefined();
+      expect(duplicate?.source).toBe(source);
+      expect(duplicate?.trigger_text_preview).toBe(preview);
+    });
+
+    it('should not find duplicate task outside dedup window', () => {
+      const now = Date.now();
+      const source = 'code_review';
+      const preview = 'fix bug in auth';
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem(source, preview, now - PAIN_QUEUE_DEDUP_WINDOW_MS - 1000),
+      ];
+      const duplicate = findRecentDuplicateTask(queue, source, preview, now);
+      expect(duplicate).toBeUndefined();
+    });
+
+    it('should not match completed tasks', () => {
+      const now = Date.now();
+      const source = 'code_review';
+      const preview = 'fix bug in auth';
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem(source, preview, now - 1000, 'completed'),
+      ];
+      const duplicate = findRecentDuplicateTask(queue, source, preview, now);
+      expect(duplicate).toBeUndefined();
+    });
+
+    it('should match tasks with different casing', () => {
+      const now = Date.now();
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem('CODE_REVIEW', 'FIX BUG IN AUTH', now - 1000),
+      ];
+      const duplicate = findRecentDuplicateTask(queue, 'code_review', 'fix bug in auth', now);
+      expect(duplicate).toBeDefined();
+    });
+
+    it('should ignore extra whitespace when matching', () => {
+      const now = Date.now();
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem(' code_review ', '  fix bug in auth  ', now - 1000),
+      ];
+      const duplicate = findRecentDuplicateTask(queue, 'code_review', 'fix bug in auth', now);
+      expect(duplicate).toBeDefined();
+    });
+
+    it('should consider reason in deduplication', () => {
+      const now = Date.now();
+      const source = 'code_review';
+      const preview = 'fix bug in auth';
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem(source, preview, now - 1000, 'pending', 'manual'),
+      ];
+      const duplicateWithSameReason = findRecentDuplicateTask(queue, source, preview, now, 'manual');
+      const duplicateWithDifferentReason = findRecentDuplicateTask(queue, source, preview, now, 'auto');
+      expect(duplicateWithSameReason).toBeDefined();
+      expect(duplicateWithDifferentReason).toBeUndefined();
+    });
+
+    it('should truncate long source and preview strings', () => {
+      const now = Date.now();
+      const longString = 'a'.repeat(500);
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem(longString, longString, now - 1000),
+      ];
+      const duplicate = findRecentDuplicateTask(queue, longString, longString, now);
+      expect(duplicate).toBeDefined();
+    });
+
+    it('should handle tasks with missing enqueued_at', () => {
+      const now = Date.now();
+      const source = 'code_review';
+      const preview = 'fix bug';
+      const queue: EvolutionQueueItem[] = [
+        {
+          ...createQueueItem(source, preview, now - 1000),
+          enqueued_at: undefined,
+        } as EvolutionQueueItem,
+      ];
+      const duplicate = findRecentDuplicateTask(queue, source, preview, now);
+      expect(duplicate).toBeDefined();
+    });
+  });
+
+  describe('hasRecentDuplicateTask', () => {
+    it('should return true when duplicate exists', () => {
+      const now = Date.now();
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem('code_review', 'fix bug', now - 1000),
+      ];
+      const result = hasRecentDuplicateTask(queue, 'code_review', 'fix bug', now);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when no duplicate exists', () => {
+      const now = Date.now();
+      const queue: EvolutionQueueItem[] = [
+        createQueueItem('code_review', 'different task', now - 1000),
+      ];
+      const result = hasRecentDuplicateTask(queue, 'code_review', 'fix bug', now);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('hasEquivalentPromotedRule', () => {
+    const createMockDictionary = (rules: Record<string, { type: string; phrases?: string[]; pattern?: string; status: string }>) => ({
+      getAllRules: () => rules,
+    });
+
+    it('should match exact phrase rule', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'exact_match', phrases: ['fix bug', 'update config'], status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(true);
+    });
+
+    it('should not match inactive rule', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'exact_match', phrases: ['fix bug'], status: 'disabled' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(false);
+    });
+
+    it('should match exact phrase with different casing', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'exact_match', phrases: ['FIX BUG'], status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(true);
+    });
+
+    it('should not match non-existent phrase', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'exact_match', phrases: ['update config'], status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(false);
+    });
+
+    it('should match regex pattern rule', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'regex', pattern: '/fix.*/', status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, '/fix.*/');
+      expect(result).toBe(true);
+    });
+
+    it('should not match when pattern format differs', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'regex', pattern: '/fix.*/', status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix.*');
+      expect(result).toBe(false);
+    });
+
+    it('should handle empty phrases array', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'exact_match', phrases: [], status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(false);
+    });
+
+    it('should handle missing phrases for exact_match rule', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'exact_match', status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(false);
+    });
+
+    it('should handle missing pattern for regex rule', () => {
+      const dictionary = createMockDictionary({
+        rule1: { type: 'regex', status: 'active' },
+      });
+      const result = hasEquivalentPromotedRule(dictionary, 'fix bug');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/service/internalization-auto-consumer-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/internalization-auto-consumer-service.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../../src/service/internalization-auto-consumer-service.js';
 import { loadFeatureFlagFromConfig, loadPdConfigForPlugin } from '../../src/core/pd-config-loader.js';
 import { SystemLogger } from '../../src/core/system-logger.js';
+import type { OpenClawPluginServiceContext } from '../../src/openclaw-sdk.js';
 
 vi.mock('../../src/core/pd-config-loader.js');
 vi.mock('../../src/core/system-logger.js');
@@ -34,28 +35,28 @@ describe('InternalizationAutoConsumerService', () => {
     });
   });
 
-  describe('InternalizationAutoConsumerService', () => {
+  describe('start / stop', () => {
     it('should log warning when workspaceDir is missing', () => {
-      const ctx = { logger } as any;
+      const ctx = { logger } as OpenClawPluginServiceContext;
       InternalizationAutoConsumerService.start(ctx);
       expect(logger.warn).toHaveBeenCalledWith('[PD:AutoConsumer] No workspace directory, not starting.');
     });
 
     it('should skip start when feature flag is disabled', () => {
       vi.mocked(loadFeatureFlagFromConfig).mockReturnValue({ enabled: false, source: 'default' });
-      const ctx = { workspaceDir, logger } as any;
+      const ctx = { workspaceDir, logger } as OpenClawPluginServiceContext;
       InternalizationAutoConsumerService.start(ctx);
       expect(SystemLogger.log).toHaveBeenCalledWith(workspaceDir, 'INTERNALIZATION_CONSUMER_DISABLED', expect.any(String));
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('NOT started for workspace'));
     });
 
     it('should stop gracefully without workspaceDir', () => {
-      const ctx = {} as any;
+      const ctx = {} as OpenClawPluginServiceContext;
       InternalizationAutoConsumerService.stop(ctx);
     });
 
     it('should stop gracefully with workspaceDir', () => {
-      const ctx = { workspaceDir, logger } as any;
+      const ctx = { workspaceDir, logger } as OpenClawPluginServiceContext;
       InternalizationAutoConsumerService.stop(ctx);
     });
   });

--- a/packages/openclaw-plugin/tests/service/internalization-auto-consumer-service.test.ts
+++ b/packages/openclaw-plugin/tests/service/internalization-auto-consumer-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  runConsumerCycle,
+  InternalizationAutoConsumerService,
+} from '../../src/service/internalization-auto-consumer-service.js';
+import { loadFeatureFlagFromConfig, loadPdConfigForPlugin } from '../../src/core/pd-config-loader.js';
+import { SystemLogger } from '../../src/core/system-logger.js';
+
+vi.mock('../../src/core/pd-config-loader.js');
+vi.mock('../../src/core/system-logger.js');
+
+describe('InternalizationAutoConsumerService', () => {
+  const workspaceDir = '/mock/workspace';
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('runConsumerCycle', () => {
+    it('should skip when feature flag is disabled', async () => {
+      vi.mocked(loadFeatureFlagFromConfig).mockReturnValue({ enabled: false, source: 'default' });
+      await runConsumerCycle(workspaceDir, logger);
+      expect(SystemLogger.log).toHaveBeenCalledWith(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', expect.stringContaining('internalization_auto_consumer_disabled'));
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Cycle skipped: auto-consumer disabled'));
+    });
+
+    it('should skip when config is malformed', async () => {
+      vi.mocked(loadFeatureFlagFromConfig).mockReturnValue({ enabled: true, source: 'default' });
+      vi.mocked(loadPdConfigForPlugin).mockReturnValue({ ok: false, errors: [{ reason: 'invalid yaml', nextAction: 'Fix config' }] });
+      await runConsumerCycle(workspaceDir, logger);
+      expect(SystemLogger.log).toHaveBeenCalledWith(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', expect.stringContaining('config_malformed'));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Config malformed, skipping cycle'));
+    });
+  });
+
+  describe('InternalizationAutoConsumerService', () => {
+    it('should log warning when workspaceDir is missing', () => {
+      const ctx = { logger } as any;
+      InternalizationAutoConsumerService.start(ctx);
+      expect(logger.warn).toHaveBeenCalledWith('[PD:AutoConsumer] No workspace directory, not starting.');
+    });
+
+    it('should skip start when feature flag is disabled', () => {
+      vi.mocked(loadFeatureFlagFromConfig).mockReturnValue({ enabled: false, source: 'default' });
+      const ctx = { workspaceDir, logger } as any;
+      InternalizationAutoConsumerService.start(ctx);
+      expect(SystemLogger.log).toHaveBeenCalledWith(workspaceDir, 'INTERNALIZATION_CONSUMER_DISABLED', expect.any(String));
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('NOT started for workspace'));
+    });
+
+    it('should stop gracefully without workspaceDir', () => {
+      const ctx = {} as any;
+      InternalizationAutoConsumerService.stop(ctx);
+    });
+
+    it('should stop gracefully with workspaceDir', () => {
+      const ctx = { workspaceDir, logger } as any;
+      InternalizationAutoConsumerService.stop(ctx);
+    });
+  });
+});


### PR DESCRIPTION
Added comprehensive unit tests for three previously untested modules:

**1. pd-task-reconciler.test.ts (8 tests)**
- Orphan job detection and logging
- Non-PD job filtering  
- Disabled task handling
- Malformed cron store graceful handling
- Missing cron store handling
- Task trigger validation (not found, auto-disabled)

**2. evolution-dedup.test.ts (19 tests)**
- Duplicate task detection within dedup window
- Timeout-based duplicate filtering
- Completed task exclusion
- Case-insensitive matching
- Whitespace normalization
- Reason-based deduplication
- Long string truncation
- Equivalent promoted rule detection
- Edge cases (empty phrases, missing fields)

**3. internalization-auto-consumer-service.test.ts (6 tests)**
- Feature flag disabled skip behavior
- Malformed config skip behavior
- Missing workspace directory handling
- Service start/stop lifecycle

**Risk Reduction:**
These tests reduce regression risk by covering:
- Core scheduling and task management logic
- Queue deduplication preventing duplicate processing
- Auto-consumer service lifecycle and error handling

**Verification:**
- All 33 new tests pass
- Full unit test suite passes (except one pre-existing flaky performance test)
- No lint errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 新增 PD 任务协调与触发流程测试：覆盖孤儿任务告警、禁用任务处理、异常/缺失存储容错，以及触发失败与强制触发提示。
  * 新增任务去重测试：覆盖时间窗口、状态过滤、文本/原因匹配规则、长文本截断一致性，以及规则等价判断的多种边界情况。
  * 新增自动消费者服务测试：覆盖功能开关关闭、配置解析/校验失败跳过、以及启动/停止在缺失工作区目录等场景下的行为与日志。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->