### PR TITLE
test: add coverage for prompt-builder modules

### DIFF
--- a/packages/principles-core/src/prompt-builder/__tests__/attitude-directive.test.ts
+++ b/packages/principles-core/src/prompt-builder/__tests__/attitude-directive.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildAttitudeDirective } from '../attitude-directive.js';
+
+describe('attitude-directive', () => {
+  describe('buildAttitudeDirective', () => {
+    it('returns HUMBLE_RECOVERY mode when GFI >= 70', () => {
+      const result = buildAttitudeDirective(70);
+      expect(result).toContain('SYSTEM_MODE: HUMBLE_RECOVERY');
+      expect(result).toContain('Severe system friction');
+      expect(result).toContain('GFI: 70');
+      expect(result).toContain('HUMBLE_RECOVERY');
+    });
+
+    it('returns HUMBLE_RECOVERY mode for high GFI values', () => {
+      const result = buildAttitudeDirective(95);
+      expect(result).toContain('SYSTEM_MODE: HUMBLE_RECOVERY');
+      expect(result).toContain('GFI: 95');
+    });
+
+    it('returns CONCILIATORY mode when GFI >= 40 and < 70', () => {
+      const result = buildAttitudeDirective(40);
+      expect(result).toContain('SYSTEM_MODE: CONCILIATORY');
+      expect(result).toContain('Moderate friction');
+      expect(result).toContain('GFI: 40');
+    });
+
+    it('returns CONCILIATORY mode for mid-range GFI values', () => {
+      const result = buildAttitudeDirective(55);
+      expect(result).toContain('SYSTEM_MODE: CONCILIATORY');
+      expect(result).toContain('GFI: 55');
+    });
+
+    it('returns EFFICIENT mode when GFI < 40', () => {
+      const result = buildAttitudeDirective(39);
+      expect(result).toContain('SYSTEM_MODE: EFFICIENT');
+      expect(result).toContain('System healthy');
+      expect(result).toContain('GFI: 39');
+    });
+
+    it('returns EFFICIENT mode for low GFI values', () => {
+      const result = buildAttitudeDirective(0);
+      expect(result).toContain('SYSTEM_MODE: EFFICIENT');
+      expect(result).toContain('GFI: 0');
+    });
+
+    it('returns EFFICIENT mode for zero GFI', () => {
+      const result = buildAttitudeDirective(0);
+      expect(result).toContain('SYSTEM_MODE: EFFICIENT');
+    });
+
+    it('formats GFI as integer', () => {
+      const result = buildAttitudeDirective(42.5);
+      expect(result).toContain('GFI: 43');
+    });
+  });
+});

--- a/packages/principles-core/src/prompt-builder/__tests__/correction-cue.test.ts
+++ b/packages/principles-core/src/prompt-builder/__tests__/correction-cue.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { detectCorrectionCue } from '../correction-cue.js';
+
+describe('correction-cue detection', () => {
+  describe('detectCorrectionCue', () => {
+    it('detects Chinese correction cues', () => {
+      expect(detectCorrectionCue('不是这个')).toBe('不是这个');
+      expect(detectCorrectionCue('不对')).toBe('不对');
+      expect(detectCorrectionCue('错了')).toBe('错了');
+      expect(detectCorrectionCue('重新来')).toBe('重新来');
+      expect(detectCorrectionCue('再试一次')).toBe('再试一次');
+    });
+
+    it('detects English correction cues', () => {
+      expect(detectCorrectionCue('you are wrong')).toBe('you are wrong');
+      expect(detectCorrectionCue('wrong file')).toBe('wrong file');
+      expect(detectCorrectionCue('not this')).toBe('not this');
+      expect(detectCorrectionCue('redo')).toBe('redo');
+      expect(detectCorrectionCue('try again')).toBe('try again');
+      expect(detectCorrectionCue('again')).toBe('again');
+    });
+
+    it('normalizes whitespace and casing', () => {
+      expect(detectCorrectionCue('  不对  ')).toBe('不对');
+      expect(detectCorrectionCue('WRONG FILE')).toBe('wrong file');
+      expect(detectCorrectionCue('Try Again')).toBe('try again');
+    });
+
+    it('removes punctuation', () => {
+      expect(detectCorrectionCue('不对！')).toBe('不对');
+      expect(detectCorrectionCue('错了。')).toBe('错了');
+      expect(detectCorrectionCue('wrong file!')).toBe('wrong file');
+      expect(detectCorrectionCue('not this, please')).toBe('not this');
+      expect(detectCorrectionCue('redo.')).toBe('redo');
+    });
+
+    it('returns null for non-correction text', () => {
+      expect(detectCorrectionCue('好的')).toBeNull();
+      expect(detectCorrectionCue('可以')).toBeNull();
+      expect(detectCorrectionCue('继续')).toBeNull();
+      expect(detectCorrectionCue('OK')).toBeNull();
+      expect(detectCorrectionCue('yes')).toBeNull();
+      expect(detectCorrectionCue('correct answer')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(detectCorrectionCue('')).toBeNull();
+    });
+
+    it('returns null for whitespace-only string', () => {
+      expect(detectCorrectionCue('   ')).toBeNull();
+      expect(detectCorrectionCue('\t\n')).toBeNull();
+    });
+
+    it('matches first cue in array order when multiple cues overlap', () => {
+      expect(detectCorrectionCue('搞错了')).toBe('错了');
+      expect(detectCorrectionCue('理解错了')).toBe('错了');
+      expect(detectCorrectionCue('你理解错了')).toBe('错了');
+      expect(detectCorrectionCue('please redo')).toBe('redo');
+      expect(detectCorrectionCue('please try again')).toBe('try again');
+    });
+
+    it('detects cue within longer text', () => {
+      expect(detectCorrectionCue('我想说的不是这个，你搞错了')).toBe('不是这个');
+      expect(detectCorrectionCue('这个不对，请重新来')).toBe('不对');
+      expect(detectCorrectionCue('Please try again with different parameters')).toBe('try again');
+    });
+  });
+});

--- a/packages/principles-core/src/prompt-builder/__tests__/message-extraction.test.ts
+++ b/packages/principles-core/src/prompt-builder/__tests__/message-extraction.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { extractMessageContent } from '../message-extraction.js';
+
+describe('message-extraction', () => {
+  describe('extractMessageContent', () => {
+    it('returns string as-is', () => {
+      expect(extractMessageContent('hello world')).toBe('hello world');
+    });
+
+    it('returns empty string for null', () => {
+      expect(extractMessageContent(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+      expect(extractMessageContent(undefined)).toBe('');
+    });
+
+    it('returns empty string for non-object primitives', () => {
+      expect(extractMessageContent(123)).toBe('');
+      expect(extractMessageContent(true)).toBe('');
+      expect(extractMessageContent(Symbol('test'))).toBe('');
+    });
+
+    it('extracts string content from object', () => {
+      expect(extractMessageContent({ content: 'hello' })).toBe('hello');
+    });
+
+    it('returns empty string when content is missing', () => {
+      expect(extractMessageContent({})).toBe('');
+    });
+
+    it('returns empty string when content is not string', () => {
+      expect(extractMessageContent({ content: 123 })).toBe('');
+      expect(extractMessageContent({ content: null })).toBe('');
+      expect(extractMessageContent({ content: {} })).toBe('');
+    });
+
+    it('extracts text from array content with text parts', () => {
+      const message = {
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'text', text: 'world' },
+        ],
+      };
+      expect(extractMessageContent(message)).toBe('hello\nworld');
+    });
+
+    it('filters non-text parts from array content', () => {
+      const message = {
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'image', url: 'http://example.com' },
+          { type: 'text', text: 'world' },
+        ],
+      };
+      expect(extractMessageContent(message)).toBe('hello\nworld');
+    });
+
+    it('handles empty text in array parts', () => {
+      const message = {
+        content: [
+          { type: 'text', text: '' },
+          { type: 'text', text: 'hello' },
+        ],
+      };
+      expect(extractMessageContent(message)).toBe('hello');
+    });
+
+    it('handles missing text property in text parts', () => {
+      const message = {
+        content: [
+          { type: 'text' },
+          { type: 'text', text: 'hello' },
+        ],
+      };
+      expect(extractMessageContent(message)).toBe('hello');
+    });
+
+    it('trims result from array content', () => {
+      const message = {
+        content: [
+          { type: 'text', text: '  hello  ' },
+          { type: 'text', text: '  world  ' },
+        ],
+      };
+      expect(extractMessageContent(message)).toBe('hello  \n  world');
+    });
+
+    it('returns empty string for empty array content', () => {
+      expect(extractMessageContent({ content: [] })).toBe('');
+    });
+
+    it('returns empty string for array with no text parts', () => {
+      const message = {
+        content: [
+          { type: 'image', url: 'http://example.com' },
+          { type: 'file', name: 'test.txt' },
+        ],
+      };
+      expect(extractMessageContent(message)).toBe('');
+    });
+  });
+});

--- a/packages/principles-core/src/prompt-builder/__tests__/minimal-trigger.test.ts
+++ b/packages/principles-core/src/prompt-builder/__tests__/minimal-trigger.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { isMinimalTrigger } from '../minimal-trigger.js';
+
+describe('minimal-trigger', () => {
+  describe('isMinimalTrigger', () => {
+    it('returns true for heartbeat trigger', () => {
+      expect(isMinimalTrigger('heartbeat')).toBe(true);
+    });
+
+    it('returns true for cron trigger', () => {
+      expect(isMinimalTrigger('cron')).toBe(true);
+    });
+
+    it('returns true for subagent sessionId', () => {
+      expect(isMinimalTrigger('user', 'main:subagent:123')).toBe(true);
+    });
+
+    it('returns false for user trigger', () => {
+      expect(isMinimalTrigger('user')).toBe(false);
+    });
+
+    it('returns false for api trigger', () => {
+      expect(isMinimalTrigger('api')).toBe(false);
+    });
+
+    it('returns false for undefined trigger', () => {
+      expect(isMinimalTrigger(undefined)).toBe(false);
+    });
+
+    it('returns false for other triggers', () => {
+      expect(isMinimalTrigger('manual')).toBe(false);
+      expect(isMinimalTrigger('workflow')).toBe(false);
+      expect(isMinimalTrigger('test')).toBe(false);
+    });
+
+    it('returns false for non-subagent sessionId', () => {
+      expect(isMinimalTrigger('user', 'main:agent:123')).toBe(false);
+      expect(isMinimalTrigger('user', 'session-123')).toBe(false);
+      expect(isMinimalTrigger('user', 'main')).toBe(false);
+    });
+
+    it('returns false when sessionId is undefined', () => {
+      expect(isMinimalTrigger('user', undefined)).toBe(false);
+    });
+
+    it('returns false when sessionId is empty', () => {
+      expect(isMinimalTrigger('user', '')).toBe(false);
+    });
+
+    it('handles case sensitivity correctly', () => {
+      expect(isMinimalTrigger('HEARTBEAT')).toBe(false);
+      expect(isMinimalTrigger('Cron')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds test coverage for four uncovered modules in the prompt-builder package:

**Changes:**
- correction-cue.ts: Tests for Chinese/English correction cue detection, whitespace normalization, punctuation removal, and boundary conditions
- attitude-directive.ts: Tests for GFI-based attitude mode selection (HUMBLE_RECOVERY, CONCILIATORY, EFFICIENT)
- message-extraction.ts: Tests for message content extraction from various structures (string, object with content, array with text parts)
- minimal-trigger.ts: Tests for heartbeat/cron/subagent trigger detection

**Risk Coverage:**
- Correction cue detection prevents misidentification of user feedback
- Attitude directive ensures appropriate AI behavior based on system friction levels
- Message extraction handles diverse message formats safely
- Minimal trigger detection prevents unnecessary heavy context injection

All tests pass and follow existing project conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增提示构建相关测试，覆盖不同 GFI 阈值下的模式选择、数值格式化及输出内容。
  - 增加纠错提示识别测试，验证中英文匹配、大小写与空白处理、标点清理及优先匹配规则。
  - 增加消息内容提取测试，覆盖字符串、对象、数组内容及异常输入场景。
  - 增加最小触发条件测试，验证心跳、定时任务及子代理会话等触发规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->