### PR TITLE
fix(diagnostician): make SplitDiagnosticianRunner parent terminal-state writes fail loud (PRI-520)

### DIFF
--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts
@@ -457,7 +457,14 @@ describe('SplitDiagnosticianRunner terminal-state persistence', () => {
       errorCategory: 'storage_unavailable',
     });
     expect(result.failureReason).toContain('failed to persist parent task failure');
+    // ERR-088: assert the injected persistence error is surfaced, not just a
+    // generic banner — a future refactor that drops the persist error message
+    // must fail this test.
+    expect(result.failureReason).toContain('database write failed');
+    // ERR-015/ERR-088: the original stage outcome must be preserved in the
+    // reason so operators can see why the stage failed AND why it stuck.
     expect(result.failureReason).toContain('Root-cause output was invalid');
+    expect(result.failureReason).toContain('Original stage outcome: output_invalid');
   });
 
   it('does not report success when it cannot persist a succeeded parent terminal state', async () => {
@@ -484,5 +491,7 @@ describe('SplitDiagnosticianRunner terminal-state persistence', () => {
       errorCategory: 'storage_unavailable',
     });
     expect(result.failureReason).toContain('failed to persist parent task success');
+    // ERR-088: assert the injected persistence error is surfaced.
+    expect(result.failureReason).toContain('database write failed');
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts
@@ -417,3 +417,72 @@ describe('Bug-N: SplitDiagnosticianRunner parent task lease acquisition', () => 
     expect(stateManager.markTaskFailed).toHaveBeenCalledWith(PARENT_TASK_ID, expect.any(String));
   });
 });
+
+// ── Terminal-state persistence must fail loud ─────────────────────────────
+//
+// ERR entries considered:
+//   - ERR-002: never silently degrade when a required state transition fails
+//   - ERR-015/ERR-018/ERR-019: report the current terminal-state failure, not
+//     the earlier stage result, so callers do not mistake a leased task for a
+//     completed one
+//   - ERR-025: exercise the runner's RuntimeStateManager boundary directly
+//   - ERR-088: assert the specific storage failure rather than only `failed`
+
+describe('SplitDiagnosticianRunner terminal-state persistence', () => {
+  it('reports storage_unavailable when it cannot persist a failed parent terminal state', async () => {
+    const tasks: Record<string, TaskRecord> = {
+      [PARENT_TASK_ID]: makeTask(PARENT_TASK_ID, { taskKind: 'diagnostician', status: 'pending' }),
+    };
+    const stateManager = makeMockStateManager(tasks);
+    stateManager.markTaskFailed = vi.fn().mockRejectedValue(new Error('database write failed'));
+    const rootCauseRunner = makeMockRunner<DiagRootCauseOutputV1>();
+    rootCauseRunner.run.mockResolvedValue(
+      makeFailedResult<DiagRootCauseOutputV1>(STAGE_A_TASK_ID, 'Root-cause output was invalid'),
+    );
+
+    const runner = new SplitDiagnosticianRunner({
+      rootCauseRunner: rootCauseRunner as never,
+      distillerRunner: makeMockRunner<DiagDistillerOutputV1>() as never,
+      routerRunner: makeMockRunner<DiagnosticianOutputV1>() as never,
+      stateManager: stateManager as never,
+      committer: makeMockCommitter(),
+      perStageTimeoutMs: 30_000,
+    });
+
+    const result = await runner.run(PARENT_TASK_ID);
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      taskId: PARENT_TASK_ID,
+      errorCategory: 'storage_unavailable',
+    });
+    expect(result.failureReason).toContain('failed to persist parent task failure');
+    expect(result.failureReason).toContain('Root-cause output was invalid');
+  });
+
+  it('does not report success when it cannot persist a succeeded parent terminal state', async () => {
+    const tasks: Record<string, TaskRecord> = {
+      [PARENT_TASK_ID]: makeTask(PARENT_TASK_ID, { taskKind: 'diagnostician', status: 'pending' }),
+    };
+    const stateManager = makeMockStateManager(tasks);
+    stateManager.markTaskSucceeded = vi.fn().mockRejectedValue(new Error('database write failed'));
+
+    const runner = new SplitDiagnosticianRunner({
+      rootCauseRunner: makeMockRunner<DiagRootCauseOutputV1>() as never,
+      distillerRunner: makeMockRunner<DiagDistillerOutputV1>() as never,
+      routerRunner: makeMockRunner<DiagnosticianOutputV1>() as never,
+      stateManager: stateManager as never,
+      committer: makeMockCommitter(),
+      perStageTimeoutMs: 30_000,
+    });
+
+    const result = await runner.run(PARENT_TASK_ID);
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      taskId: PARENT_TASK_ID,
+      errorCategory: 'storage_unavailable',
+    });
+    expect(result.failureReason).toContain('failed to persist parent task success');
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/split-diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/split-diagnostician-runner.ts
@@ -204,7 +204,23 @@ export class SplitDiagnosticianRunner {
     const parentResultRef = resultC.resultRef ?? `split-pipeline://${parentTaskId}`;
     try {
       await this.stateManager.markTaskSucceeded(parentTaskId, parentResultRef);
-    } catch { /* best-effort — return success regardless */ }
+    } catch (error) {
+      // rc-3/rc-9 fail-loud (PRI-520): never report success before the parent
+      // terminal transition is durable. If markTaskSucceeded cannot persist,
+      // the parent task stays leased/running in storage while we would claim
+      // succeeded — the most damaging "it said it finished, but the state says
+      // otherwise" failure (ERR-002/ERR-015/ERR-088). Surface a structured
+      // storage_unavailable result so operators see the persistence failure,
+      // not a false success.
+      const persistErrorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        status: 'failed',
+        taskId: parentTaskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `failed to persist parent task success for ${parentTaskId}. Persistence error: ${persistErrorMessage}`,
+        attemptCount: resultC.attemptCount,
+      };
+    }
 
     const stageA = await this.stateManager.getTask(stageATaskId);
     const stageB = await this.stateManager.getTask(stageBTaskId);
@@ -362,14 +378,31 @@ export class SplitDiagnosticianRunner {
     parentTaskId: string,
     stageResult: PeerRunnerResult<unknown>,
   ): Promise<RunnerResult> {
+    const stageErrorCategory = stageResult.errorCategory;
+    const stageFailureReason = stageResult.failureReason ?? `Stage failed for parent task ${parentTaskId}`;
     try {
-      await this.stateManager.markTaskFailed(parentTaskId, stageResult.errorCategory ?? 'execution_failed');
-    } catch { /* best-effort — return failure regardless */ }
+      await this.stateManager.markTaskFailed(parentTaskId, stageErrorCategory ?? 'execution_failed');
+    } catch (error) {
+      // rc-3/rc-9 fail-loud (PRI-520): if markTaskFailed cannot persist, the
+      // parent task stays leased/running while we report the earlier stage
+      // category. That hides the persistence failure behind the stage failure
+      // (ERR-002/ERR-015/ERR-088). Surface storage_unavailable as the primary
+      // category, but preserve the original stage outcome in failureReason so
+      // operators can see both the why-it-failed and why-it-stuck.
+      const persistErrorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        status: 'failed',
+        taskId: parentTaskId,
+        errorCategory: 'storage_unavailable',
+        failureReason: `failed to persist parent task failure for ${parentTaskId}. Persistence error: ${persistErrorMessage}. Original stage outcome: ${stageErrorCategory ?? 'execution_failed'} — ${stageFailureReason}`,
+        attemptCount: stageResult.attemptCount,
+      };
+    }
     return {
       status: stageResult.status === 'retried' ? 'failed' : stageResult.status,
       taskId: parentTaskId,
-      errorCategory: stageResult.errorCategory,
-      failureReason: stageResult.failureReason ?? `Stage failed for parent task ${parentTaskId}`,
+      errorCategory: stageErrorCategory,
+      failureReason: stageFailureReason,
       attemptCount: stageResult.attemptCount,
     };
   }


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: [PRI-520](https://linear.app/principlesdisciple/issue/PRI-520/bug-make-splitdiagnosticianrunner-parent-terminal-state-writes-fail)
- 解决的产品问题（一句话）: `SplitDiagnosticianRunner` 在父任务终态写入失败时静默吞错，调用方收到 `succeeded` 或旧的 stage 错误，但持久层父任务仍停在 `leased`/`running`——即"它说完成了，状态却没落地"。
- emotional-value：降低 失控感 / 不信任感（"系统收到了却没有下文"），创造 清醒感（持久化失败现在以结构化 `storage_unavailable` 显式暴露，可观测、可处理）。
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复

### 高层变更（3-5 条，非逐文件 diff）
- 成功路径：`markTaskSucceeded` 抛错时不再返回 `succeeded`，改为返回 `status=failed` + `errorCategory=storage_unavailable` + 持久化错误信息。
- 失败路径（`failParent`）：`markTaskFailed` 抛错时不再返回旧的 stage category（掩盖持久化失败），改为返回 `errorCategory=storage_unavailable` 作为主类别，**同时把原始 stage 结果（category + reason）保留在 `failureReason`**，让 operator 能同时看到"为什么 stage 失败"和"为什么任务卡住"。
- 新增 2 个回归测试，通过在 `RuntimeStateManager` 真实 seam 处注入存储错误，断言精确的 `storage_unavailable` 类别与 reason 子串。
- 修复范围严格限定为现有终态报告的 fail-loud 行为；不引入新子系统/flag/队列/诊断架构。

### 影响范围
- [x] packages/principles-core
- [ ] packages/openclaw-plugin
- [ ] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- 其他: 无

### 是否触及产品边界
- [x] 否
  - 仅修复现有主链的终态可观测性缺陷，不扩张 MVP-Core 范围，不新增功能或激活路径。

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: `cd packages/principles-core`，已在 main 分支拉取本 PR。
- [ ] 动作 1: `npx vitest run src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts`
  - 观察: `SplitDiagnosticianRunner terminal-state persistence` 两个测试通过，其余 10 个 ERR-067/Bug-N 测试仍通过，共 12/12。
- [ ] 动作 2: `npx vitest run src/runtime-v2/internalization/__tests__/diag-chain-e2e.test.ts`
  - 观察: 15/15 通过，无回归。
- [ ] 动作 3: `npm run build`（在该 package 下）
  - 观察: tsc 无报错。
- 证据（截图/CLI 输出关键行）:
  - 回归测试此前为红灯（`received output_invalid` / `received status=succeeded`），修复后转绿并断言 `errorCategory=storage_unavailable`。

## 风险与可逆性（agent 填）
- 主要风险: 行为变更——以前在持久化失败时返回成功/旧 stage 错误的 caller，现在会收到 `storage_unavailable`。但 caller（`PainSignalBridge`/runtime-factory）原本就按 `result.status !== 'succeeded'` / `errorCategory` 处理失败分支，不会因新增的失败而崩。
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否
  - 这是窄范围的终态报告 bug 修复，非新运行时子系统；现有恢复/重试路径不变，可经 PR revert 回滚。
  - 规则引用: `mvp-q-3-how-disabled`

### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会。持久化失败被掩盖时，调用方收到完成信号但父任务停在 `leased`/`running`，Owner 会反复看到"无解释的卡住任务"并重复纠正——与 PRI-518 历史现象一致。
- `mvp-q-2-how-observed`: 如何观察它生效？注入 `markTaskFailed`/`markTaskSucceeded` 存储错误并断言返回的 `storage_unavailable` 类别与 reason；正常 SQLite 诊断链集成测试保持绿。
- `mvp-q-4-emotional-value`: 已在产品意图段填写（降低失控/不信任，创造清醒）。

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（PR + Linear 评论即文档；源码注释标注 `rc-3/rc-9`、`PRI-520`、相关 ERR）
- [x] 无破坏性变更（仅在原先吞错的分支上新增结构化失败结果，正常路径行为不变）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）——遵循 fail-loud 与状态新鲜度规则
- [x] 迁移删除检查：N/A（未删除源文件）
- [x] Core 边界检查：未在 `packages/principles-core/src/` 新增 `fs`/`path` 导入（纯逻辑变更）
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计
- [x] N/A — 本 PR 未修改 core store 契约（仅修改 `SplitDiagnosticianRunner` 对 `RuntimeStateManager` 已有方法的调用错误处理，未改 store 方法签名/未加 throw/未加 precondition）

## ERR 防复发清单（rule: Error Handbook Gate）
- **rc-3 / rc-9（ERR-002 / ERR-009 / ERR-010）**: 两处原先 `catch { /* best-effort */ }` 全部改为返回结构化 `storage_unavailable` 结果（含 category + reason）。无吞错。
- **ERR-015 / ERR-018 / ERR-019（loop state freshness）**: 报告*当前*终态写入失败，而非早期 stage 状态；成功路径不再在终态写入失败时报告 `succeeded`。
- **ERR-088（test reality gap）**: 回归测试断言精确的 `errorCategory='storage_unavailable'` 与精确 reason 子串（`failed to persist parent task failure` / `failed to persist parent task success`），而非仅断言 `status='failed'`。成功路径测试能唯一区分意图失败（从 succeeded stage 产生 `status=failed` 只能由持久化失败路径解释）。

## PR 评论处理
- 本 PR 基于上次会话留下的诊断结论与红灯测试。在创建本 PR 前没有外部评审评论需要处理。

## 测试运行
- `npx vitest run src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts` → 12/12 pass
- `npx vitest run src/runtime-v2/internalization/__tests__/diag-chain-e2e.test.ts` → 15/15 pass
- pain-signal-bridge 全套（`bridge-retried`/`bridge-result-shaping`/`bridge-short-circuit`/`unification`/`observability`）→ 47/47 pass
- `src/runtime-v2/__tests__/architecture-regression.test.ts` → 516/516 pass
- `src/runtime-v2/internalization/` 全套 → 684/684 pass
- `npm run build`（tsc）→ clean
- eslint 改动文件 → clean
- `npm run check:error-handbook` → OK（仅有既存大小警告，非本 PR 引入）

## BDD 影响评估
- 本 PR 是否修改了 MVP-Core 用户旅程？否。仅修复 `SplitDiagnosticianRunner` 终态报告的内部 fail-loud 行为，不改变 Story A' 任何 `.feature` 行为契约的对外可观察结果（owner 看到的是失败被诚实暴露而非被掩盖，属改善而非契约变更）。
- 本 PR 是否新增/修改了 CLI 命令？否。`cli-1~cli-7` N/A。
- 本 PR 是否触发了 ERR 类？是（修复 ERR-002/ERR-015/ERR-088 类），已新增回归 `.feature` 等价的单元回归测试（在 split-diagnostician-runner-retry.test.ts 中，断言精确 storage_unavailable 行为）。
- 本 PR 是否删除了 `.feature` 文件？否。

## 与 PRI-518 的关系（重要）
本修复是 PRI-518 "task 不再无解释停留 leased" 验收项的**一部分**——它关闭了"持久化失败被掩盖"这一机制。但**不能证明** PRI-518 历史卡住任务仅由这一路径造成（其它候选：进程被中断/恢复扫尾未执行、历史 parent-lease 所有权冲突仍待排除）。PRI-518 该验收项的完全解决仍需一次带唯一 marker 的真实 OpenClaw campaign 重跑来确认。其余 PRI-518 验收项（送达 Owner 纠正、产出 candidate、`lineage-map.json`、lineage 一致性）不受本 PR 影响，仍是 PRI-518 的独立阻塞项。

## 剩余风险
- 行为变更：原本在持久化失败时收到"成功"的 caller 现在会收到 `storage_unavailable` 失败。这是预期且必要的，但若上游有依赖"即使持久化失败也按成功处理"的隐式假设（已排查 PainSignalBridge/runtime-factory 未发现），需关注。
- 未覆盖：本修复未触及 `diag_rootcause` / `diag_distiller` / `diag_router` 子 stage 自己的终态写入；如这些 runner 内部也存在同类吞错，需另开工单（不在本 PR 范围）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复任务状态持久化失败时仍显示成功的问题。
  - 当父任务成功或失败状态无法保存时，运行结果会明确标记为失败，并提示存储不可用。
  - 保留并展示原始阶段失败原因，避免关键错误信息丢失。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->