### PR TITLE
fix(core/runtime-v2): guard evidence iteration + Stage C cache JSON parse

### DIFF
--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/split-diagnostician-runner-retry.test.ts
@@ -495,3 +495,119 @@ describe('SplitDiagnosticianRunner terminal-state persistence', () => {
     expect(result.failureReason).toContain('database write failed');
   });
 });
+
+// ── Stage C cache fallback on corrupt JSON ────────────────────────────────
+//
+// ERR entries considered:
+//   - ERR-001 / rc-1: no unguarded `JSON.parse` on trusted-boundary-crossing
+//     data (runs.outputPayload is persisted DB content, not TypeScript-guarded)
+//   - ERR-002 / PRI-520: never leave parent task leased because of an
+//     unhandled native SyntaxError
+//   - EP-01 / rc-2: treat persisted content as unknown — defensively parse
+
+describe('SplitDiagnosticianRunner Stage C corrupt outputPayload', () => {
+  it('falls through to re-run Stage C when cached outputPayload is corrupt JSON', async () => {
+    const tasks: Record<string, TaskRecord> = {
+      [PARENT_TASK_ID]: makeTask(PARENT_TASK_ID, { taskKind: 'diagnostician', status: 'pending' }),
+      [STAGE_C_TASK_ID]: makeTask(STAGE_C_TASK_ID, {
+        taskKind: 'diag_router',
+        status: 'succeeded',
+        attemptCount: 2,
+      }),
+    };
+    const stateManager = makeMockStateManager(tasks);
+    // Return a succeeded run whose outputPayload is NOT valid JSON.
+    // Previously this threw SyntaxError uncaught through run() → bridge,
+    // leaving the parent task leased (stuck, consistent with PRI-518/520).
+    // With the fix, cache is declared unusable and Stage C is re-run.
+    stateManager.getRunsByTask = vi.fn().mockResolvedValue([
+      {
+        runId: 'run-sc-corrupt',
+        executionStatus: 'succeeded',
+        outputPayload: '{ this is not: [valid json, }',
+      },
+    ]);
+
+    const validOutput: DiagnosticianOutputV1 = {
+      valid: true,
+      diagnosisId: 'fallback-diag',
+      summary: 'Fallback diagnosis after cache unreadable',
+      rootCause: 'Fallback: corrupt cache',
+      violatedPrinciples: [],
+      evidence: [{ sourceRef: 'rerun', note: 'Rerun produced valid output' }],
+      recommendations: [{ kind: 'defer', description: 'Cache was corrupt; reran Stage C' }],
+      confidence: 0.8,
+    };
+    const routerRunner = makeMockRunner<DiagnosticianOutputV1>();
+    routerRunner.run.mockResolvedValue({
+      status: 'succeeded',
+      taskId: STAGE_C_TASK_ID,
+      attemptCount: 1,
+      contextHash: 'ctx-rerun',
+      output: validOutput,
+    });
+
+    const runner = new SplitDiagnosticianRunner({
+      rootCauseRunner: makeMockRunner<DiagRootCauseOutputV1>() as never,
+      distillerRunner: makeMockRunner<DiagDistillerOutputV1>() as never,
+      routerRunner: routerRunner as never,
+      stateManager: stateManager as never,
+      committer: makeMockCommitter(),
+      perStageTimeoutMs: 30_000,
+    });
+
+    // run() must resolve with succeeded — not throw SyntaxError.
+    await expect(runner.run(PARENT_TASK_ID)).resolves.toBeDefined();
+    // Because cache was unusable, routerRunner.run must have been invoked
+    // (Stage C re-run path). Previously the test would throw before reaching
+    // this assertion.
+    expect(routerRunner.run).toHaveBeenCalledWith(STAGE_C_TASK_ID);
+  });
+
+  it('uses cached succeeded output when outputPayload is valid JSON', async () => {
+    // Positive counterpart: valid JSON cache is used and Stage C is NOT rerun.
+    const tasks: Record<string, TaskRecord> = {
+      [PARENT_TASK_ID]: makeTask(PARENT_TASK_ID, { taskKind: 'diagnostician', status: 'pending' }),
+      [STAGE_C_TASK_ID]: makeTask(STAGE_C_TASK_ID, {
+        taskKind: 'diag_router',
+        status: 'succeeded',
+        attemptCount: 1,
+      }),
+    };
+    const stateManager = makeMockStateManager(tasks);
+    const cachedOutput: DiagnosticianOutputV1 = {
+      valid: true,
+      diagnosisId: 'cached-001',
+      summary: 'Cached diagnosis',
+      rootCause: 'From previous successful run',
+      violatedPrinciples: [],
+      evidence: [],
+      recommendations: [{ kind: 'defer', description: 'Cached: no action' }],
+      confidence: 0.9,
+    };
+    stateManager.getRunsByTask = vi.fn().mockResolvedValue([
+      {
+        runId: 'run-sc-ok',
+        executionStatus: 'succeeded',
+        outputPayload: JSON.stringify(cachedOutput),
+      },
+    ]);
+
+    const routerRunner = makeMockRunner<DiagnosticianOutputV1>();
+
+    const runner = new SplitDiagnosticianRunner({
+      rootCauseRunner: makeMockRunner<DiagRootCauseOutputV1>() as never,
+      distillerRunner: makeMockRunner<DiagDistillerOutputV1>() as never,
+      routerRunner: routerRunner as never,
+      stateManager: stateManager as never,
+      committer: makeMockCommitter(),
+      perStageTimeoutMs: 30_000,
+    });
+
+    const result = await runner.run(PARENT_TASK_ID);
+
+    expect(result.status).toBe('succeeded');
+    // Stage C was cached — routerRunner.run should NOT be invoked
+    expect(routerRunner.run).not.toHaveBeenCalled();
+  });
+});

--- a/packages/principles-core/src/runtime-v2/internalization/split-diagnostician-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/split-diagnostician-runner.ts
@@ -177,14 +177,40 @@ export class SplitDiagnosticianRunner {
       const runs = await this.stateManager.getRunsByTask(stageCTaskId);
       const succeededRun = runs.find((r) => r.executionStatus === 'succeeded');
       const outputPayload = succeededRun?.outputPayload;
-      const output = outputPayload ? JSON.parse(outputPayload) : undefined;
-      resultC = {
-        status: 'succeeded',
-        taskId: stageCTaskId,
-        attemptCount: stageCTask.attemptCount,
-        contextHash: '',
-        output,
-      };
+      // EP-01 / rc-1: JSON.parse of persisted DB content is a trust boundary —
+      // outputPayload may be corrupt/malformed (e.g. partial write, DB
+      // corruption). Without this guard, JSON.parse on corrupt data throws an
+      // unhandled SyntaxError that propagates through run() to the bridge —
+      // the parent task stays leased/running (stuck task, consistent with
+      // PRI-518/PRI-520 observations). Fail safe: if parse fails, treat the
+      // cache as unusable and fall through to re-run Stage C normally so the
+      // standard retry/failure path produces a structured result.
+      let parsedOutput: unknown;
+      let cacheUsable = true;
+      if (outputPayload !== undefined && outputPayload !== null) {
+        try {
+          parsedOutput = JSON.parse(outputPayload);
+        } catch {
+          cacheUsable = false;
+        }
+      } else {
+        parsedOutput = undefined;
+      }
+      if (cacheUsable) {
+        resultC = {
+          status: 'succeeded',
+          taskId: stageCTaskId,
+          attemptCount: stageCTask.attemptCount,
+          contextHash: '',
+          output: parsedOutput as DiagnosticianOutputV1,
+        };
+      } else {
+        resultC = await this.runStageWithRetry({
+          taskId: stageCTaskId,
+          runFn: (id) => this.routerRunner.run(id),
+          stageLabel: 'C (router)',
+        });
+      }
     } else {
       resultC = await this.runStageWithRetry({
         taskId: stageCTaskId,

--- a/packages/principles-core/src/runtime-v2/runner/__tests__/default-validator.test.ts
+++ b/packages/principles-core/src/runtime-v2/runner/__tests__/default-validator.test.ts
@@ -207,6 +207,50 @@ describe('evidence array', () => {
     assertInvalid(result, 'output_invalid', 1);
     expect(result.errors.some((e) => e.includes('note'))).toBe(true);
   });
+
+  it('evidence is undefined fails in standard mode without throwing (regression: for...of undefined)', async () => {
+    // Parity with recommendations guard (commit 2d866209): evidence iteration
+    // used to throw `output.evidence is not iterable` when evidence was a
+    // non-array. Must return output_invalid with a structured error instead
+    // of throwing a native TypeError — otherwise base-peer-runner classifies
+    // it as execution_failed (retryable) and wastes quota, rather than
+    // output_invalid (permanent).
+    const validator = new DefaultDiagnosticianValidator();
+    const output = { ...makeValidOutput(), evidence: undefined } as unknown as DiagnosticianOutputV1;
+    const result = await validator.validate(output, 'task-001');
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('evidence must be an array'))).toBe(true);
+  });
+
+  it('evidence is a non-array string fails in standard mode without throwing', async () => {
+    const validator = new DefaultDiagnosticianValidator();
+    const output = { ...makeValidOutput(), evidence: 'none provided' } as unknown as DiagnosticianOutputV1;
+    const result = await validator.validate(output, 'task-001');
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('evidence must be an array'))).toBe(true);
+  });
+
+  it('evidence is null fails in verbose mode without throwing (regression: for...of null)', async () => {
+    // verbose mode: guard must be present on BOTH evidence loops (the 2e
+    // shape loop AND the 2g sourceRef existence loop) — otherwise either
+    // `for (const ev of null)` or `for (const ev of undefined)` throws.
+    const validator = new DefaultDiagnosticianValidator();
+    const output = { ...makeValidOutput(), evidence: null } as unknown as DiagnosticianOutputV1;
+    const result = await validator.validate(output, 'task-001', { verbose: true, sourceRefs: ['task-001'] });
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('evidence must be an array'))).toBe(true);
+  });
+
+  it('evidence is an object (non-array) fails in verbose mode and 2g loop does not throw', async () => {
+    // 2g verbose sourceRef existence loop also iterates evidence — confirm it
+    // uses the same Array.isArray guard so a non-array evidence value cannot
+    // trigger `for...of` TypeError even when sourceRefs are provided.
+    const validator = new DefaultDiagnosticianValidator();
+    const output = { ...makeValidOutput(), evidence: { 0: 'fake' } } as unknown as DiagnosticianOutputV1;
+    const result = await validator.validate(output, 'task-001', { verbose: true, sourceRefs: ['ref-a'] });
+    assertInvalid(result, 'output_invalid', 1);
+    expect(result.errors.some((e) => e.includes('evidence must be an array'))).toBe(true);
+  });
 });
 
 // ── REQ-2.3e: Recommendations shape ─────────────────────────────────────────

--- a/packages/principles-core/src/runtime-v2/runner/default-validator.ts
+++ b/packages/principles-core/src/runtime-v2/runner/default-validator.ts
@@ -96,7 +96,18 @@ export class DefaultDiagnosticianValidator implements DiagnosticianValidator {
     }
 
     // 2e: Evidence array shape
-    for (const ev of output.evidence) {
+    // Guard: record a structural error when evidence is not an array (e.g. LLM
+    // returned a string "none"), then iterate only over a real array. Without
+    // this guard, malformed output would throw `X is not iterable` at the
+    // for...of below instead of returning a categorized output_invalid result.
+    // (Parity with recommendations: commit 2d866209 fixed the same pattern for
+    // recommendations but missed evidence.)
+    if (!Array.isArray(output.evidence)) {
+      const msg = 'evidence must be an array';
+      if (!isVerbose) return buildResult(false, '1 field invalid: evidence', [msg]);
+      detailErrors.push(msg);
+    }
+    for (const ev of Array.isArray(output.evidence) ? output.evidence : []) {
       if (!ev.sourceRef || ev.sourceRef.trim() === '') {
         const msg = 'evidence[].sourceRef must be a non-empty string';
         if (!isVerbose) return buildResult(false, '1 field invalid: evidence', [msg]);
@@ -167,7 +178,8 @@ export class DefaultDiagnosticianValidator implements DiagnosticianValidator {
     // 2g: Evidence sourceRef existence check (verbose mode only)
     if (isVerbose && options?.sourceRefs) {
       const refSet = new Set(options.sourceRefs);
-      for (const ev of output.evidence) {
+      // Guard: iterate only over a real array — same pattern as 2e above.
+      for (const ev of Array.isArray(output.evidence) ? output.evidence : []) {
         if (ev.sourceRef && !refSet.has(ev.sourceRef)) {
           const msg = `evidence[].sourceRef "${ev.sourceRef}" not found in context sourceRefs`;
           detailErrors.push(msg);


### PR DESCRIPTION
## Summary

Post-commit correctness audit identified two high-impact defects in recent commits that would cause task failures and stuck leases in production.

## Trigger Scenarios & Impact

### 1. Validator: Non-array `evidence` throws native TypeError (PRI-518 class)

**Trigger**: LLM returns malformed `DiagnosticianOutputV1` where `evidence` is a non-array (e.g. `undefined`, `null`, string `"none"`, plain object `{}`).

**Before fix**: Two `for...of output.evidence` loops (2e shape validation, 2g verbose sourceRef check) throw native `TypeError: output.evidence is not iterable`. This propagates uncaught through `base-peer-runner`, which classifies the error as `execution_failed` (retryable) instead of `output_invalid` (permanent). Result: wasted LLM quota on retries that will never succeed, plus obscured failure category in telemetry.

**Note**: Commit `2d866209` previously applied the same Array.isArray guard to `output.recommendations` — `evidence` was missed.

### 2. Split Runner: Corrupt Stage C `outputPayload` throws SyntaxError (PRI-520 class)

**Trigger**: A previously succeeded Stage C (router) task has a persisted `runs.outputPayload` that is not valid JSON — e.g. partial DB write, DB corruption, or a future schema migration that partially rewrites rows.

**Before fix**: `JSON.parse(outputPayload)` on line 192 throws native `SyntaxError`. Unlike structured `PeerRunnerResult` failures, a native throw propagates through `SplitDiagnosticianRunner.run()` → `InternalizationOrchestrator` → bridge. **The parent task is never transitioned out of `leased`/`running`** because the terminal state persistence block never runs. Result: stuck (orphaned) leased task, matching production observations tagged PRI-518 / PRI-520.

## Fixes

### `default-validator.ts` — Parity with recommendations guard
- Added `Array.isArray(output.evidence)` check **before** the 2e shape loop and 2g sourceRef existence loop.
- When evidence is not an array: records a structured `"evidence must be an array"` error and returns `output_invalid` (permanent, no retries) instead of throwing.
- Both loops iterate only over `Array.isArray(output.evidence) ? output.evidence : []`.

### `split-diagnostician-runner.ts` — Fail-safe cache recovery
- Wrapped `JSON.parse(outputPayload)` in explicit `try/catch` (trust boundary: `outputPayload` comes from the SQLite runs table, not TypeScript-guarded memory).
- Introduced `cacheUsable` flag: if parse fails → `cacheUsable = false`.
- On unusable cache: fall through to `runStageWithRetry` for Stage C, so the standard retry/failure path produces a categorized `PeerRunnerResult` (succeeded / retried / failed) instead of a native throw. Parent task deterministically reaches a persisted terminal state.
- Null/undefined payload: preserved existing behavior (treat as no cached output, normal run).

## Tests Added

### default-validator (4 regression tests)
- `evidence is undefined` — standard mode: returns `output_invalid` without throwing.
- `evidence is string "none provided"` — standard mode: returns `output_invalid` without throwing.
- `evidence is null` — verbose mode: both 2e and 2g loops are guarded; no TypeError.
- `evidence is object {0: "fake"}` — verbose mode with sourceRefs: 2g sourceRef existence loop is guarded against for...of on non-array object.

### split-diagnostician-runner (2 tests)
- **corrupt JSON cache**: Stage C task is `succeeded` but `outputPayload` is `'{ this is not: [valid json, }'`. Assertion: `run()` resolves (does not throw SyntaxError), and `routerRunner.run` IS called (Stage C is re-run).
- **valid JSON cache (positive)**: Stage C task is `succeeded` with valid JSON payload. Assertion: `run()` returns `succeeded`, and `routerRunner.run` is NOT called (cache hit, no unnecessary re-execution).

## Verification

- ✅ All 81 affected tests pass:
  - `default-validator.test.ts`: 67 tests pass
  - `split-diagnostician-runner-retry.test.ts`: 14 tests pass
- ✅ Broader regression suite: 906 tests across 19 runtime-v2 test files pass
  - Includes `architecture-regression.test.ts` (516 tests), `internalization-*` contract tests, `diagnostician-committer.test.ts`
- ✅ ESLint on 4 modified files: 0 errors
- ✅ Architectural boundaries respected: All changes are inside `@principles/core` (Core Layer), no cross-layer imports added