### PR TITLE
chore(deps-dev): bump @cucumber/gherkin from 31.0.0 to 42.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.0",
-        "@cucumber/gherkin": "^31.0.0",
+        "@cucumber/gherkin": "^42.0.0",
         "@cucumber/messages": "^27.2.0",
         "@eslint/js": "^10.0.1",
         "@semantic-release/changelog": "^6.0.3",
@@ -1597,42 +1597,21 @@
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
-      "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
+      "version": "42.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-42.0.0.tgz",
+      "integrity": "sha512-kBcv+NV4FGQYX6NIsSCjsjaX8MsRdEH559BQ9xEFPgkLQX/Z//JZrY94fpjxW6quo4V5kxlzFiiVC5xouF9Akg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <=26"
+        "@cucumber/messages": ">=34.0.0 <35"
       }
     },
     "node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
-      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
+      "version": "34.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-34.2.0.tgz",
+      "integrity": "sha512-6X6T1TApmbQNqxC0Oh3GcnLU+gfE5fp+cEXE/ml6+Ldx76Q6BDmkgM5vagSSDXP+vetPV2Fb0kWVeP7QIR6+Aw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "10.0.0",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "10.0.0"
-      }
-    },
-    "node_modules/@cucumber/gherkin/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+      "license": "MIT"
     },
     "node_modules/@cucumber/messages": {
       "version": "27.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
-    "@cucumber/gherkin": "^31.0.0",
+    "@cucumber/gherkin": "^42.0.0",
     "@cucumber/messages": "^27.2.0",
     "@eslint/js": "^10.0.1",
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
Pure dependency bump extracted from #1243.

## Why separate
#1243 mixed this bump with an unrelated PRI-517 console e2e commit that fails CI. The cucumber/gherkin upgrade itself is clean — verified by 1891 unit tests passing (only an unrelated flaky perf/e2e test failed on the mixed branch).

## Scope
- `@cucumber/gherkin`: 31.0.0 → 42.0.0 (package.json + lockfile only)
- No source/test changes

## Verification
CI on this pure branch will confirm gherkin 42 has no parsing breakage across all BDD tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **维护**
  * 更新 Gherkin 解析组件至较新版本，提升开发环境的兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->