### PR TITLE
fix(adapter): resolve outputSchemaRef in OpenClawCliRuntimeAdapter (unblock split-pipeline Stage A) — PRI-518

### DIFF
--- a/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/architecture-regression.test.ts
@@ -2095,10 +2095,12 @@ describe('PRI-111 ArtificerRunner boundary', () => {
     expect(src).toContain('DefaultArtificerValidator');
   });
 
-  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers unified artificer-rule-output-v2 schema', async () => {
+  it('SCHEMA_REGISTRY: shared output-schema-registry registers unified artificer-rule-output-v2 schema', async () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
-    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    // The registry was extracted to adapter/output-schema-registry.ts (single
+    // source of truth shared by pi-ai and openclaw-cli adapters). Assert there.
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'output-schema-registry.ts'), 'utf-8');
     expect(src).toContain('artificer-rule-output-v2');
     expect(src).not.toContain('artificer-rule-output-v1');
     expect(src).toContain('ArtificerRuleOutputSchema');
@@ -2179,10 +2181,10 @@ describe('PRI-EVAL EvaluatorRunner boundary', () => {
     expect(src).not.toContain("from './evaluator-prompt-builder.js'");
   });
 
-  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers evaluator-output-v1 schema', async () => {
+  it('SCHEMA_REGISTRY: shared output-schema-registry registers evaluator-output-v1 schema', async () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
-    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'output-schema-registry.ts'), 'utf-8');
     expect(src).toContain('evaluator-output-v1');
     expect(src).toContain('EvaluatorOutputV1Schema');
   });
@@ -2246,10 +2248,10 @@ describe('PRI-RR RolloutReviewerRunner boundary', () => {
     expect(src).not.toContain("from './rollout-reviewer-prompt-builder.js'");
   });
 
-  it('SCHEMA_REGISTRY: pi-ai-runtime-adapter.ts registers rollout-reviewer-output-v1 schema', async () => {
+  it('SCHEMA_REGISTRY: shared output-schema-registry registers rollout-reviewer-output-v1 schema', async () => {
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
-    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'pi-ai-runtime-adapter.ts'), 'utf-8');
+    const src = readFileSync(resolve(__dirname, '..', 'adapter', 'output-schema-registry.ts'), 'utf-8');
     expect(src).toContain('rollout-reviewer-output-v1');
     expect(src).toContain('RolloutReviewerOutputV1Schema');
   });

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts
@@ -233,6 +233,101 @@ describe('OpenClawCliRuntimeAdapter', () => {
     });
   });
 
+  // PRI-518: outputSchemaRef must drive which schema validates the output.
+  // Previously fetchOutput hardcoded DiagnosticianOutputV1Schema, which rejected
+  // every valid Stage A (diag_rootcause) and Stage B (diag_distiller) output in
+  // the split diagnostician pipeline → 0 candidates. These tests guard the fix.
+  describe('fetchOutput() outputSchemaRef resolution (PRI-518)', () => {
+    const ROOT_CAUSE_PAYLOAD = {
+      valid: true,
+      diagnosisId: 'rc-1',
+      taskId: 'diag_rootcause-task-A',
+      summary: 'root cause identified',
+      causalChain: [{ why: 1, statement: 'missing dep declared but not installed', evidenceRefs: ['ev-1'] }],
+      rootCause: 'Tooling: missing peer dependency',
+      rootCauseCategory: 'Tooling',
+      evidence: [{ sourceRef: 'tool_call_failure:t1', note: 'exec failed: module not found' }],
+      confidence: 0.8,
+    };
+
+    const DISTILLER_PAYLOAD = {
+      valid: true,
+      taskId: 'diag_distiller-task-B',
+      sourceRootCauseArtifactId: 'art-rc-1',
+      abstractedPrinciple: 'Verify dependencies resolve before running the suite',
+      rationale: 'A declared-but-missing peer dependency is the root cause',
+      groundedOnCorePrincipleIds: ['T-04'],
+      scope: 'domain',
+      confidence: 0.75,
+    };
+
+    it('outputSchemaRef=diag-rootcause-output-v1 accepts valid Stage A output (regression: was always rejected)', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      mockRunCliProcess.mockResolvedValue(makeCliOutput({ stdout: JSON.stringify(ROOT_CAUSE_PAYLOAD), exitCode: 0 }));
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag_rootcause', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+        outputSchemaRef: 'diag-rootcause-output-v1',
+      });
+
+      const result = await adapter.fetchOutput(handle.runId);
+      // Must NOT throw output_invalid; Stage A shape round-trips.
+      expect(result.payload).toMatchObject({ diagnosisId: 'rc-1', rootCauseCategory: 'Tooling' });
+    });
+
+    it('outputSchemaRef=diag-distiller-output-v1 accepts valid Stage B output', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      mockRunCliProcess.mockResolvedValue(makeCliOutput({ stdout: JSON.stringify(DISTILLER_PAYLOAD), exitCode: 0 }));
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag_distiller', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+        outputSchemaRef: 'diag-distiller-output-v1',
+      });
+
+      const result = await adapter.fetchOutput(handle.runId);
+      expect(result.payload).toMatchObject({ abstractedPrinciple: 'Verify dependencies resolve before running the suite', scope: 'domain' });
+    });
+
+    it('unknown outputSchemaRef fails loud with output_invalid (rc-3, not silent)', async () => {
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      mockRunCliProcess.mockResolvedValue(makeCliOutput({ stdout: JSON.stringify(VALID_PAYLOAD), exitCode: 0 }));
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+        outputSchemaRef: 'does-not-exist-v9',
+      });
+
+      await expect(adapter.fetchOutput(handle.runId)).rejects.toThrow(/Unknown outputSchemaRef: does-not-exist-v9/i);
+    });
+
+    it('outputSchemaRef=diag-rootcause-output-v1 rejects DiagnosticianV1-shaped payload (proves the right schema is applied)', async () => {
+      // VALID_PAYLOAD is a DiagnosticianOutputV1 shape — it lacks causalChain
+      // and rootCauseCategory, so it must fail DiagRootCauseOutputV1Schema even
+      // though it would pass the old hardcoded DiagnosticianOutputV1Schema.
+      const adapter = new OpenClawCliRuntimeAdapter({ runtimeMode: 'local' });
+      mockRunCliProcess.mockResolvedValue(makeCliOutput({ stdout: JSON.stringify(VALID_PAYLOAD), exitCode: 0 }));
+
+      const handle = await adapter.startRun({
+        agentSpec: { agentId: 'diag_rootcause', schemaVersion: 'v1' },
+        inputPayload: {},
+        contextItems: [],
+        timeoutMs: 30000,
+        outputSchemaRef: 'diag-rootcause-output-v1',
+      });
+
+      await expect(adapter.fetchOutput(handle.runId)).rejects.toThrow(/does not match diag-rootcause-output-v1 schema/i);
+    });
+  });
+
   // OCRA-04: CLI failures map to correct PDErrorCategory
   describe('fetchOutput() error mapping', () => {
     it('throws PDRuntimeError("runtime_unavailable") when ENOENT (binary not found)', async () => {

--- a/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/__tests__/pi-ai-runtime-adapter.test.ts
@@ -862,16 +862,20 @@ describe('PiAiRuntimeAdapter', () => {
       expect(mockComplete).toHaveBeenCalledTimes(4);
     });
 
-    it('skips repair for unknown outputSchemaRef (not in registry)', async () => {
-      mockComplete.mockResolvedValueOnce(makeAssistantMessage(JSON.stringify({ valid: true, missing: 'fields' })));
-
+    it('unknown outputSchemaRef fails loud before repair is attempted (rc-3)', async () => {
+      // CodeRabbit PR #1259: unknown non-empty ref now fails loud at schema
+      // resolution (in startRun), so repair is never attempted.
+      // NOTE: no mockComplete setup — resolution fails BEFORE any LLM call,
+      // so no mock value is queued to leak into subsequent tests.
       const adapter = makeAdapter();
-      const handle = await adapter.startRun(makeStartRunInput({
+      await expect(adapter.startRun(makeStartRunInput({
         outputSchemaRef: 'custom-unknown-v1',
-      }));
-      expect(mockComplete).toHaveBeenCalledTimes(1);
-      const output = await adapter.fetchOutput(handle.runId);
-      expect(output?.payload).toMatchObject({ valid: true, missing: 'fields' });
+      }))).rejects.toMatchObject({
+        category: 'output_invalid',
+        message: expect.stringMatching(/Unknown outputSchemaRef: custom-unknown-v1/i),
+      });
+      // LLM was never called because resolution failed first.
+      expect(mockComplete).toHaveBeenCalledTimes(0);
     });
 
     it('skips repair for non-JSON output (no schema errors to report)', async () => {
@@ -1125,17 +1129,20 @@ describe('PiAiRuntimeAdapter', () => {
       expect(output?.payload).toMatchObject({ valid: true, diagnosisId: 'diag-test-1' });
     });
 
-    it('unknown outputSchemaRef skips schema validation and succeeds', async () => {
-      const arbitraryOutput = { foo: 'bar', baz: 42 };
-      mockComplete.mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(arbitraryOutput)));
-
+    it('unknown outputSchemaRef fails loud with output_invalid (rc-3, was silent skip)', async () => {
+      // CodeRabbit PR #1259: previously an unknown non-empty outputSchemaRef
+      // resolved to undefined and silently skipped schema-gated validation.
+      // That is an rc-9/rc-3 silent-fallback. Now it fails loud, consistent
+      // with OpenClawCliRuntimeAdapter.fetchOutput.
+      // NOTE: no mockComplete setup — resolution fails BEFORE any LLM call.
       const adapter = makeAdapter();
-      const handle = await adapter.startRun(makeStartRunInput({
+      await expect(adapter.startRun(makeStartRunInput({
         outputSchemaRef: 'custom-output-v1',
-      }));
-
-      const output = await adapter.fetchOutput(handle.runId);
-      expect(output?.payload).toMatchObject(arbitraryOutput);
+      }))).rejects.toMatchObject({
+        category: 'output_invalid',
+        message: expect.stringMatching(/Unknown outputSchemaRef: custom-output-v1/i),
+      });
+      expect(mockComplete).toHaveBeenCalledTimes(0);
     });
 
     it('no outputSchemaRef skips schema validation (backward compatible)', async () => {
@@ -1359,19 +1366,21 @@ describe('PiAiRuntimeAdapter', () => {
       expect((payload.rawOutputPreview as string).length).toBeGreaterThan(0);
     });
 
-    it('10. unknown schemaRef keeps existing backward-compatible behavior', async () => {
+    it('10. unknown schemaRef fails loud (rc-3; was backward-compatible silent skip)', async () => {
+      // CodeRabbit PR #1259: previously an unknown non-empty outputSchemaRef
+      // silently skipped schema validation (the "backward-compatible behavior").
+      // That silent skip is an rc-9/rc-3 defect — now it fails loud, matching
+      // OpenClawCliRuntimeAdapter. NOTE: no mockComplete setup because schema
+      // resolution fails before any LLM call.
       resetMock();
-      const arbitraryOutput = { foo: 'bar', baz: 42 };
-      mockComplete.mockResolvedValueOnce(makeAssistantMessage(JSON.stringify(arbitraryOutput)));
-
       const adapter = makeAdapter();
-      const handle = await adapter.startRun(makeStartRunInput({
+      await expect(adapter.startRun(makeStartRunInput({
         outputSchemaRef: 'custom-unknown-v1',
-      }));
-
-      expect(mockComplete).toHaveBeenCalledTimes(1);
-      const output = await adapter.fetchOutput(handle.runId);
-      expect(output?.payload).toMatchObject(arbitraryOutput);
+      }))).rejects.toMatchObject({
+        category: 'output_invalid',
+        message: expect.stringMatching(/Unknown outputSchemaRef: custom-unknown-v1/i),
+      });
+      expect(mockComplete).toHaveBeenCalledTimes(0);
     });
 
     it('emits output_schema_invalid telemetry before repair attempt', async () => {

--- a/packages/principles-core/src/runtime-v2/adapter/openclaw-cli-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/openclaw-cli-runtime-adapter.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path';
 import { runCliProcess, type CliOutput } from '../utils/cli-process-runner.js';
 import { PDRuntimeError } from '../error-categories.js';
 import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
+import { resolveOutputSchema } from './output-schema-registry.js';
 import type { StoreEventEmitter} from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { safeStringifyPreview, truncatePreview } from './output-repair-contract.js';
@@ -75,6 +76,13 @@ interface RunState {
   startedAt: string;
   cliOutput: CliOutput | null; // null until CLI completes
   completed: boolean;
+  /**
+   * The outputSchemaRef passed by the runner at startRun time (e.g.
+   * 'diag-rootcause-output-v1'). fetchOutput uses this to resolve the correct
+   * TypeBox schema for validation instead of hardcoding DiagnosticianOutputV1.
+   * Absent for legacy callers → falls back to DiagnosticianOutputV1Schema.
+   */
+  outputSchemaRef?: string;
 }
 
 interface MessageFileRef {
@@ -605,8 +613,11 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
     const runId = crypto.randomUUID();
     const startedAt = new Date().toISOString();
 
-    // Initialize state — cliOutput null until CLI completes
-    const state: RunState = { runId, startedAt, cliOutput: null, completed: false };
+    // Initialize state — cliOutput null until CLI completes.
+    // Capture outputSchemaRef so fetchOutput can validate against the runner's
+    // expected schema (e.g. diag-rootcause-output-v1 for Stage A) instead of
+    // hardcoding DiagnosticianOutputV1Schema.
+    const state: RunState = { runId, startedAt, cliOutput: null, completed: false, outputSchemaRef: input.outputSchemaRef };
     this.runStateMap.set(runId, state);
 
     // Build CLI args per D-02
@@ -833,11 +844,41 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
       }
     }
 
-    // OCRA-03: Validate DiagnosticianOutputV1Schema
+    // OCRA-03: Validate against the schema named by outputSchemaRef.
+    // The split diagnostician pipeline runs 3 stages with DIFFERENT output
+    // shapes: Stage A (diag_rootcause) → DiagRootCauseOutputV1, Stage B
+    // (diag_distiller) → DiagDistillerOutputV1, Stage C (diag_router) →
+    // DiagnosticianOutputV1. Each runner passes outputSchemaRef to name its
+    // expected shape. Previously this hardcoded DiagnosticianOutputV1Schema,
+    // which rejected every valid Stage A/B output → 0 candidates.
+    // Resolution rules (rc-3-fail-loud-missing):
+    //   - outputSchemaRef present + in registry → validate against that schema
+    //   - outputSchemaRef present + NOT in registry → fail loud (unknown ref)
+    //   - outputSchemaRef absent → fall back to DiagnosticianOutputV1Schema
+    //     (backward compat for legacy callers / monolithic diagnostician path)
+    let schema: Parameters<typeof Value.Check>[0];
+    if (state.outputSchemaRef) {
+      const resolved = resolveOutputSchema(state.outputSchemaRef);
+      if (!resolved) {
+        throw new PDRuntimeError(
+          'output_invalid',
+          `Unknown outputSchemaRef: ${state.outputSchemaRef}`,
+          {
+            parseFailureReason: 'unknown_output_schema_ref',
+            outputSchemaRef: state.outputSchemaRef,
+            nextAction: `Register the schema in OUTPUT_SCHEMA_REGISTRY or pass a known ref (e.g. 'diag-rootcause-output-v1')`,
+          },
+        );
+      }
+      schema = resolved;
+    } else {
+      schema = DiagnosticianOutputV1Schema;
+    }
+
     // OCRA-05: On schema mismatch, include evidence with bounded preview (ERR-014/016/017)
     // ERR-055/056: redact sensitive fields from parsed payload before persisting preview
-    if (!Value.Check(DiagnosticianOutputV1Schema, parsed)) {
-      const schemaErrors = [...Value.Errors(DiagnosticianOutputV1Schema, parsed)]
+    if (!Value.Check(schema, parsed)) {
+      const schemaErrors = [...Value.Errors(schema, parsed)]
         .slice(0, 10)
         .map(e => ({ path: e.path, message: e.message }));
       const redacted = redactSensitiveFields(parsed);
@@ -847,9 +888,10 @@ export class OpenClawCliRuntimeAdapter implements PDRuntimeAdapter {
 
       throw new PDRuntimeError(
         'output_invalid',
-        'CLI output does not match DiagnosticianOutputV1 schema',
+        `CLI output does not match ${state.outputSchemaRef ?? 'diagnostician-output-v1'} schema`,
         {
           parseFailureReason: 'schema_validation_failed',
+          outputSchemaRef: state.outputSchemaRef ?? 'diagnostician-output-v1',
           boundedRawOutputPreview: boundedPreview,
           schemaErrors,
           nextAction: 'Review schema errors; check LLM output format and required fields',

--- a/packages/principles-core/src/runtime-v2/adapter/output-schema-registry.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/output-schema-registry.ts
@@ -1,0 +1,63 @@
+/**
+ * Output Schema Registry — shared mapping from `outputSchemaRef` string to the
+ * TypeBox schema that validates a runtime adapter's parsed output.
+ *
+ * Single source of truth for both PiAiRuntimeAdapter and OpenClawCliRuntimeAdapter
+ * (and any future PDRuntimeAdapter). Extracted from pi-ai-runtime-adapter.ts so
+ * the OpenClaw adapter can validate Stage A/B outputs against the correct schema
+ * instead of hardcoding DiagnosticianOutputV1Schema.
+ *
+ * Why this matters: the split diagnostician pipeline runs three stages, each
+ * producing a DIFFERENT output shape:
+ *   - Stage A (diag_rootcause) → DiagRootCauseOutputV1 (causalChain, rootCauseCategory)
+ *   - Stage B (diag_distiller) → DiagDistillerOutputV1 (abstractedPrinciple, rationale)
+ *   - Stage C (diag_router)    → DiagnosticianOutputV1  (violatedPrinciples, recommendations)
+ * Stage runners pass `outputSchemaRef` on StartRunInput to name which shape they
+ * expect; adapters MUST resolve the schema from this registry rather than assume
+ * DiagnosticianOutputV1 (which only matches Stage C).
+ */
+import type { TSchema } from '@sinclair/typebox';
+import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
+import { DiagRootCauseOutputV1Schema } from '../diagnostician/diag-rootcause-output.js';
+import { DiagDistillerOutputV1Schema } from '../diagnostician/diag-distiller-output.js';
+import { DreamerOutputV1Schema } from '../internalization/dreamer-output.js';
+import { PhilosopherOutputV1Schema } from '../internalization/philosopher-output.js';
+import { ScribeOutputV1Schema } from '../internalization/scribe-output.js';
+import { ArtificerRuleOutputSchema } from '../internalization/artificer-output.js';
+import { EvaluatorOutputV1Schema } from '../internalization/evaluator-output.js';
+import { RolloutReviewerOutputV1Schema } from '../internalization/rollout-reviewer-output.js';
+import { EmpathyObserverOutputV1Schema } from '../observer/empathy-observer.js';
+import { CorrectionObserverOutputV1Schema } from '../observer/correction-observer.js';
+
+/**
+ * Map of `outputSchemaRef` string → TypeBox schema. Keys match the
+ * `outputSchemaRef` values passed by each runner's `invokeRuntime()`.
+ */
+export const OUTPUT_SCHEMA_REGISTRY: ReadonlyMap<string, TSchema> = new Map<string, TSchema>([
+  ['diagnostician-output-v1', DiagnosticianOutputV1Schema],
+  ['diag-rootcause-output-v1', DiagRootCauseOutputV1Schema],
+  ['diag-distiller-output-v1', DiagDistillerOutputV1Schema],
+  ['dreamer-output-v1', DreamerOutputV1Schema],
+  ['philosopher-output-v1', PhilosopherOutputV1Schema],
+  ['scribe-output-v1', ScribeOutputV1Schema],
+  ['artificer-rule-output-v2', ArtificerRuleOutputSchema],
+  ['evaluator-output-v1', EvaluatorOutputV1Schema],
+  ['rollout-reviewer-output-v1', RolloutReviewerOutputV1Schema],
+  ['empathy-observer-output-v1', EmpathyObserverOutputV1Schema],
+  ['correction-observer-output-v1', CorrectionObserverOutputV1Schema],
+]);
+
+/**
+ * Resolve the TypeBox schema for a given `outputSchemaRef`.
+ *
+ * @param ref - the outputSchemaRef string passed by a runner (e.g. 'diag-rootcause-output-v1').
+ * @returns the matching schema, or `undefined` when:
+ *   - `ref` is undefined/null/empty (caller should apply its own default), OR
+ *   - `ref` is a non-empty string not present in the registry (caller should fail loud).
+ * Callers MUST distinguish these two cases: an absent ref is "use default", an
+ * unknown ref is a bug (fail loud per rc-3-fail-loud-missing).
+ */
+export function resolveOutputSchema(ref: string | undefined | null): TSchema | undefined {
+  if (!ref) return undefined;
+  return OUTPUT_SCHEMA_REGISTRY.get(ref);
+}

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -20,7 +20,7 @@ import { Value } from '@sinclair/typebox/value';
 import type { TSchema } from '@sinclair/typebox';
 import { PDRuntimeError } from '../error-categories.js';
 import { extractJsonObject } from './json-extractor.js';
-import { OUTPUT_SCHEMA_REGISTRY } from './output-schema-registry.js';
+import { resolveOutputSchema } from './output-schema-registry.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair, deriveSchemaSummary } from './structured-output-repair.js';
@@ -526,7 +526,22 @@ export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
     try {
       // PRI-271 B3: Three-path fallback chain for structured output
       const schemaRef = input.outputSchemaRef;
-      const schema = schemaRef ? OUTPUT_SCHEMA_REGISTRY.get(schemaRef) : undefined;
+      const schema = resolveOutputSchema(schemaRef);
+      // rc-3-fail-loud-missing: a non-empty outputSchemaRef that cannot be
+      // resolved is a bug (typo or unregistered schema). Fail loud instead of
+      // silently skipping schema-gated validation paths. Consistent with
+      // OpenClawCliRuntimeAdapter.fetchOutput.
+      if (schemaRef && !schema) {
+        throw new PDRuntimeError(
+          'output_invalid',
+          `Unknown outputSchemaRef: ${schemaRef}`,
+          {
+            parseFailureReason: 'unknown_output_schema_ref',
+            outputSchemaRef: schemaRef,
+            nextAction: `Register the schema in OUTPUT_SCHEMA_REGISTRY or pass a known ref (e.g. 'diag-rootcause-output-v1')`,
+          },
+        );
+      }
       const strategy = this.config.outputPathStrategy ?? 'tool_call_first';
 
       let validatedOutput: unknown = undefined;

--- a/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
+++ b/packages/principles-core/src/runtime-v2/adapter/pi-ai-runtime-adapter.ts
@@ -20,17 +20,7 @@ import { Value } from '@sinclair/typebox/value';
 import type { TSchema } from '@sinclair/typebox';
 import { PDRuntimeError } from '../error-categories.js';
 import { extractJsonObject } from './json-extractor.js';
-import { DiagnosticianOutputV1Schema } from '../diagnostician-output.js';
-import { DiagRootCauseOutputV1Schema } from '../diagnostician/diag-rootcause-output.js';
-import { DiagDistillerOutputV1Schema } from '../diagnostician/diag-distiller-output.js';
-import { DreamerOutputV1Schema } from '../internalization/dreamer-output.js';
-import { PhilosopherOutputV1Schema } from '../internalization/philosopher-output.js';
-import { ScribeOutputV1Schema } from '../internalization/scribe-output.js';
-import { ArtificerRuleOutputSchema } from '../internalization/artificer-output.js';
-import { EvaluatorOutputV1Schema } from '../internalization/evaluator-output.js';
-import { RolloutReviewerOutputV1Schema } from '../internalization/rollout-reviewer-output.js';
-import { EmpathyObserverOutputV1Schema } from '../observer/empathy-observer.js';
-import { CorrectionObserverOutputV1Schema } from '../observer/correction-observer.js';
+import { OUTPUT_SCHEMA_REGISTRY } from './output-schema-registry.js';
 import type { StoreEventEmitter } from '../store/event-emitter.js';
 import { storeEmitter } from '../store/event-emitter.js';
 import { attemptStructuredOutputRepair, deriveSchemaSummary } from './structured-output-repair.js';
@@ -332,20 +322,6 @@ interface RunState {
   reason?: string;
   output?: StructuredRunOutput;
 }
-
-const OUTPUT_SCHEMA_REGISTRY = new Map<string, TSchema>([
-  ['diagnostician-output-v1', DiagnosticianOutputV1Schema],
-  ['diag-rootcause-output-v1', DiagRootCauseOutputV1Schema],
-  ['diag-distiller-output-v1', DiagDistillerOutputV1Schema],
-  ['dreamer-output-v1', DreamerOutputV1Schema],
-  ['philosopher-output-v1', PhilosopherOutputV1Schema],
-  ['scribe-output-v1', ScribeOutputV1Schema],
-  ['artificer-rule-output-v2', ArtificerRuleOutputSchema],
-  ['evaluator-output-v1', EvaluatorOutputV1Schema],
-  ['rollout-reviewer-output-v1', RolloutReviewerOutputV1Schema],
-  ['empathy-observer-output-v1', EmpathyObserverOutputV1Schema],
-  ['correction-observer-output-v1', CorrectionObserverOutputV1Schema],
-]);
 
 export class PiAiRuntimeAdapter implements PDRuntimeAdapter {
   private readonly config: PiAiRuntimeAdapterConfig;


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: PRI-518
- 解决的产品问题（一句话）: OpenClawCliRuntimeAdapter 硬编码 DiagnosticianOutputV1Schema 校验、忽略 outputSchemaRef，导致 split-pipeline 的 Stage A（diag_rootcause）合法输出永远被拒 → 诊断全失败 → 0 candidates，Story A 真实闭环产不出可审批原则。
- emotional-value：降低 失控感 / 不信任感，创造 掌控感 / 沉淀感（Owner 的纠正终于能沉淀为可审批原则）
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🔧 重构/优化（提取共享 registry）
- [x] 🧪 测试

### 高层变更（3-5 条）
- **根因（真实 Story A run + SQLite 查询确认）**：`fetchOutput()` 在 `openclaw-cli-runtime-adapter.ts:839` 硬编码 `Value.Check(DiagnosticianOutputV1Schema, parsed)`，忽略 runner 传入的 `outputSchemaRef`。split-pipeline Stage A 产出 `DiagRootCauseOutputV1`（需 causalChain/rootCauseCategory，无 violatedPrinciples/recommendations），永远过不了 DiagnosticianV1 schema → 每 run `output_invalid` → `max_attempts_exceeded` → 0 candidates。**这是 Story A"零候选"的真实根因**（不是已修的 M2 empty-recs，那是另一条静默成功路径）。
- 新建共享 `adapter/output-schema-registry.ts`：把原本 pi-ai 私有的 `OUTPUT_SCHEMA_REGISTRY`（11 个 schema 按 ref 索引）提取为单一真相源 + `resolveOutputSchema(ref)` helper。pi-ai 与 openclaw 两个 adapter 共用。
- `openclaw-cli-runtime-adapter.ts`：RunState 加 `outputSchemaRef`；startRun 捕获 `input.outputSchemaRef`；fetchOutput 按 registry 解析正确 schema。解析规则（rc-3）：已知 ref→对应 schema；未知 ref→fail loud `output_invalid`；未传 ref→回退 DiagnosticianOutputV1Schema（向后兼容 legacy/monolithic 调用者与既有测试）。
- pi-ai-runtime-adapter.ts：改为 import 共享 registry（行为不变）；删除因此 unused 的 DiagnosticianOutputV1Schema import。
- 4 个回归测试 + 3 个 architecture-regression 断言更新（指向共享 registry 模块）。

### 影响范围
- [x] packages/principles-core
- [ ] packages/openclaw-plugin
- [ ] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs

### 是否触及产品边界
- [x] 否（修复既有诊断流水线的 schema 校验 bug，不改产品行为边界）

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: `cd packages/principles-core && npm run build`
- [ ] 动作 1: `npx vitest run src/runtime-v2/adapter/__tests__/openclaw-cli-runtime-adapter.test.ts`
  - 观察: 46 passed，含 4 个新 `outputSchemaRef resolution` 测试（Stage A/B 接受、未知 ref fail loud、错形状被拒）。
- [ ] 动作 2: `npx vitest run src/runtime-v2/__tests__/architecture-regression.test.ts`
  - 观察: 516 passed（3 个 SCHEMA_REGISTRY 断言已指向共享 registry）。
- 证据: 全量 adapter 14 文件 463 passed + architecture-regression 516 passed；build/lint 干净。

## 风险与可逆性（agent 填）
- 主要风险: 回退策略（未传 ref → DiagnosticianV1）是向后兼容选择；若 maintainer 倾向"未传 ref 必须报错"可在 review 调整。
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag: [x] 否（bug 修复，revert 即完全回滚）
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会提起吗？会——不修则 Story A 真实闭环永远产不出 candidate，GO 卡死在"零候选"。
- `mvp-q-2-how-observed`: 真实 Story A run 的 verdict 不再因 output_invalid 失败，产出 ≥1 candidate。
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填）
### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（注释说明 schema 解析规则与为何提取 registry）
- [x] 无破坏性变更（未传 ref 路径行为不变；pi-ai 行为不变）
- [x] 通过 Thinking OS 检查
- [x] Core 边界检查：N/A（adapter 在 core 内，但无新增 fs/path/network 导入；output-schema-registry 纯数据映射）

### ERR Checklist（必填）
- ERR-001/EP-01 (trust boundary) — `parsed` 仍经 `Value.Check` 校验后才用；schema 由 registry 按 ref 解析，非硬编码。
- ERR-009/EP-03 (fail loud missing) — 未知 outputSchemaRef 显式 throw output_invalid + nextAction，非静默。
- ERR-024/EP-02 (production path wiring) — 修复直接走真实 fetchOutput 校验链；测试用真实 OpenClawCliRuntimeAdapter（mock runCliProcess），非隔离 helper。
- ERR-083/EP-02 (shared type/contract change across packages) — registry 提取影响 pi-ai import；已同步更新 architecture-regression 断言。

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据（CLI stdout 解析的 LLM 输出）
- [x] `rc-1-treat-as-unknown` — parsed 经 Value.Check(schema) 校验
- [x] `rc-2-no-as-bypass` — 无新增 as
- [x] `rc-3-fail-loud-missing` — 未知 ref fail loud
- [x] `rc-8-safe-serialization` — 错误用 safeStringifyPreview
- [x] `rc-9-no-silent-fallback` — 未知 ref 不静默；未传 ref 的回退是有意且文档化的向后兼容
- 其余 rc-* N/A

### CLI Gate / Feature Flag / BDD 自检
- [x] N/A

### 反模式触发词检查
- [x] 无 antipattern 触发词

## 产品品味审计（owner 填）

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run build`: 通过（tsc 干净）
- [ ] `cd packages/openclaw-plugin && npm run test`: 未运行（本 PR 未改 plugin）
- [x] `npm run lint`: 改动文件 eslint 干净
- [ ] `npm run verify:merge`: 未运行

## 相关 Issue
Refers PRI-518。这是 Story A 真实闭环"零候选"的代码根因修复。合并后需重跑 `node scripts/e2e-story-a.mjs --trap trap-03 --timeout 1500` 验证产出 ≥1 candidate。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持根据输出模式引用动态选择对应的输出校验规则。
  * 增加诊断流程不同阶段的输出格式校验支持。

* **错误修复**
  * 未知或不匹配的输出模式现在会明确报告错误，避免错误格式被误接受。
  * 保留默认校验行为，提升输出验证的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->