### PR TITLE
feat(internalization): evaluator-runner two-stage wiring + prompt criteria (PR 4 tasks 9.11/9.4b/9.4c)

### DIFF
--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-prompt-builder.ts
@@ -30,6 +30,18 @@ export interface EvaluatorPromptBuildResult {
 
 export const EVALUATOR_PROTOCOL_INSTRUCTION = `You are an Evaluator agent in a principle internalization pipeline. Your role is to critically review the Artificer's implementation plan and produce a structured evaluation with a decision, score, and actionable feedback.
 
+COMPRESSION FIDELITY COVERAGE CRITERIA (design §6.5.2 — Stage 1 and Stage 2 use the SAME criteria):
+When evaluating whether the dreamer's decision dimensions are covered in the scribe's principle text, apply these rules:
+1. Coverage = a semantically equivalent expression exists. Rewording (using different phrasing to express the same verifiable content) is allowed; the text does NOT need to contain the exact field name or verbatim string. HOWEVER, abstraction is NOT rewording — rules 1 and 2 MUST be read together.
+2. betterDecision coverage MUST satisfy BOTH existence AND specificity: verifiable, concrete actions must be retained. Replacing concrete, verifiable actions (e.g. "audit file tree", "grep all imports", "check export dependency graph") with unverifiable abstractions (e.g. "understand architecture", "grasp the overall structure", "thoroughly assess") does NOT count as covered — even if the abstraction points to the same intent. The sole criterion: can an Owner or a piece of rule code determine whether the described action has been performed? If not, specificity is lost.
+3. riskLevel: expressed as a risk-level word (high/medium/low or Chinese equivalents) OR an equivalent risk description (e.g. "cross-package changes will cause compilation failure if a caller is missed") — both count as covered.
+4. badDecision: appearing in antiPatterns counts as covered. NOT appearing is NOT a defect.
+5. strategicPerspective: does NOT participate in fidelity judgement. Do NOT draw conclusions about it, and never include it in missingDimensions.
+6. When a dimension is NOT covered, you MUST name the required dimension (betterDecision / rationale / riskLevel only). Do NOT give only a qualitative description.
+7. If a dimension's value was not injected (not in the available fields), do NOT judge it — it is outside scope.
+
+These criteria apply identically to Stage 1 and Stage 2.
+
 PROTOCOL:
 1. Review the artificerArtifact to understand the proposed implementation plan
 2. Evaluate the plan against quality criteria: completeness, feasibility, test coverage, risk mitigation

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -24,7 +24,7 @@
  * @see docs/adr/0003-peer-agent-state-machine-orchestration.md
  * @see BasePeerRunner in runner/base-peer-runner.ts
  */
-import type { RunHandle } from '../runtime-protocol.js';
+import type { RunHandle, RunStatus } from '../runtime-protocol.js';
 import type {
   EvaluatorOutputV1,
   EvaluatorOutputV2,
@@ -424,6 +424,19 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
     this.progressiveFinalOutput = stage2Output;
     this.progressiveRunActive = true;
     return { runId: `${EvaluatorRunner.PROGRESSIVE_RUN_ID_PREFIX}stage2`, runtimeKind: this.getRuntimeKind(), startedAt: new Date().toISOString() };
+  }
+
+  /**
+   * Override pollUntilTerminal: for synthetic progressive-evaluator RunHandles,
+   * the LLM call already completed inside invokeRuntime — return succeeded
+   * immediately without hitting the real runtime adapter (which would fail on
+   * the synthetic runId). For normal handles, delegate to the base class.
+   */
+  protected override async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+    if (this.progressiveRunActive && runHandle.runId.startsWith(EvaluatorRunner.PROGRESSIVE_RUN_ID_PREFIX)) {
+      return { status: 'succeeded', runId: runHandle.runId };
+    }
+    return super.pollUntilTerminal(runHandle);
   }
 
   /**

--- a/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/evaluator-runner.ts
@@ -47,7 +47,8 @@ import type {
   PeerRunnerValidationResult,
 } from '../runner/peer-runner-types.js';
 import type { LoadedPredecessorArtifact } from './attach-summary-envelope.js';
-import { EVALUATOR_STAGE1_MANIFEST } from './context-manifests.js';
+import { EVALUATOR_STAGE1_MANIFEST, EVALUATOR_STAGE2_MANIFEST } from './context-manifests.js';
+import { evaluateFlaggedCriteria, isForcedStage2 } from './progressive-evaluator.js';
 // PRI-426: single-round adversarial sandbox replay in succeedTask.
 import { evaluateRefinerRuleHostGate, type RefinerRuleHostGateDeps } from './refiner-rulehost-gate.js';
 import { adversarialCasesToGoldenTrace } from './adversarial-case.js';
@@ -369,41 +370,95 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
     throw new PDRuntimeError('input_invalid', 'Artificer dependency artifact not found');
   }
 
+  /** Synthetic RunHandle prefix for progressive-evaluator pre-resolved output. */
+  static readonly PROGRESSIVE_RUN_ID_PREFIX = '__progressive_evaluator_';
+  private progressiveFinalOutput: unknown = undefined;
+  private progressiveRunActive = false;
+
   async invokeRuntime(taskId: string, context: EvaluatorContext): Promise<RunHandle> {
+    // Layer 2 (design §6.5, task 9.11): when progressive_evaluator flag is on,
+    // run two-stage evaluation (Stage 1 summary → flagged? → Stage 2 tier2).
+    // When off, the existing single-stage path runs unchanged.
+    if (!this.isProgressiveEvaluatorEnabled()) {
+      return this.invokeRuntimeSingleStage(taskId, context);
+    }
+
+    // ── Two-stage progressive evaluation ──
+    // Stage 1: summary-level evaluation (same prompt as single-stage, but
+    // uses EVALUATOR_STAGE1_MANIFEST for focused context).
+    const stage1Message = this.buildEvaluatorPrompt(taskId, context, EVALUATOR_STAGE1_MANIFEST);
+    const stage1Output = await this.runSingleEvaluation(taskId, stage1Message);
+
+    // 9.4c (design §6.5.4, simplified): Stage 1 output contract violation check.
+    // If the output is not a valid object (JSON.parse failed inside runSingleEvaluation,
+    // or the shape is fundamentally wrong), emit a structured degradation and
+    // force Stage 2 (never silently treat as "no concerns / pass" — rc-3 + rc-9).
+    const stage1ContractViolated = stage1Output === null || typeof stage1Output !== 'object' || Array.isArray(stage1Output);
+    if (stage1ContractViolated) {
+      this.emitEvent('stage1_output_contract_violation', taskId, {
+        reason: 'output_not_object',
+        detail: 'Stage 1 output is not a valid JSON object — forcing Stage 2.',
+      });
+    }
+
+    // Evaluate flagged criteria on Stage 1 output.
+    // When contract is violated, ALL criteria fields are undetermined → forces Stage 2.
+    const d1 = stage1ContractViolated
+      ? { flagged: false, reasons: [] as const, undetermined: ['stage1_output_contract_violation'] }
+      : evaluateFlaggedCriteria(stage1Output);
+    const forced = isForcedStage2(taskId);
+
+    if (!d1.flagged && !forced && d1.undetermined.length === 0) {
+      // Stage 1 is sufficient — return its output as the final result.
+      this.progressiveFinalOutput = stage1Output;
+      this.progressiveRunActive = true;
+      return { runId: `${EvaluatorRunner.PROGRESSIVE_RUN_ID_PREFIX}stage1`, runtimeKind: this.getRuntimeKind(), startedAt: new Date().toISOString() };
+    }
+
+    // Stage 2 triggered: independent re-evaluation with tier2 context.
+    // rc-7 / ERR-015 / ERR-018 / ERR-019: Stage 2 does NOT receive Stage 1
+    // output, concerns, or the FlaggedDecision. It is a fully independent call.
+    const stage2Message = this.buildEvaluatorPrompt(taskId, context, EVALUATOR_STAGE2_MANIFEST);
+    const stage2Output = await this.runSingleEvaluation(taskId, stage2Message);
+
+    this.progressiveFinalOutput = stage2Output;
+    this.progressiveRunActive = true;
+    return { runId: `${EvaluatorRunner.PROGRESSIVE_RUN_ID_PREFIX}stage2`, runtimeKind: this.getRuntimeKind(), startedAt: new Date().toISOString() };
+  }
+
+  /**
+   * Intercept fetchAndParseOutput for progressive-evaluator runs: when the
+   * runId is a synthetic progressive handle, return the pre-resolved output
+   * directly (the actual LLM call already happened inside invokeRuntime).
+   */
+  protected override async fetchAndParseOutput(runId: string, taskId: string): Promise<unknown> {
+    if (this.progressiveRunActive && runId.startsWith(EvaluatorRunner.PROGRESSIVE_RUN_ID_PREFIX)) {
+      return this.progressiveFinalOutput;
+    }
+    return super.fetchAndParseOutput(runId, taskId);
+  }
+
+  /**
+   * Build the evaluator prompt with the given manifest's resolved context.
+   * Shared by single-stage and two-stage paths.
+   */
+  private buildEvaluatorPrompt(taskId: string, context: EvaluatorContext, manifest: typeof EVALUATOR_STAGE1_MANIFEST): string {
     let parsedArtificerArtifact: unknown = null;
     if (context.artificerArtifact) {
-      try {
-        parsedArtificerArtifact = JSON.parse(context.artificerArtifact);
-      } catch {
-        parsedArtificerArtifact = context.artificerArtifact;
-      }
+      try { parsedArtificerArtifact = JSON.parse(context.artificerArtifact); } catch { parsedArtificerArtifact = context.artificerArtifact; }
     }
-
-    // PRD Decision 12: pass the scribe principle text so the LLM can judge
-    // code intentConsistency/scopePrecision. Null when unresolvable (V1 artificer
-    // output, or scribe artifact missing) — the prompt builder accepts undefined.
     let parsedScribeArtifact: unknown = undefined;
     if (context.scribeArtifact) {
-      try {
-        parsedScribeArtifact = JSON.parse(context.scribeArtifact);
-      } catch {
-        parsedScribeArtifact = context.scribeArtifact;
-      }
+      try { parsedScribeArtifact = JSON.parse(context.scribeArtifact); } catch { parsedScribeArtifact = context.scribeArtifact; }
     }
-
-    // Layer 1 (design §6.2/§6.3, task 5.9): resolve the evaluator Stage 1
-    // manifest against the loaded artificer predecessor (the edge predecessor).
-    // Focused → inject only allocated summary fields (scribe text, dreamer
-    // dims, pain summary); fallback → legacy full artificerArtifact; disabled
-    // → unchanged. Stage 2 manifest is Layer 2 (PR 4), not wired here.
+    // Resolve manifest-injected focused fields (Layer 1).
     const artificerPred = toArtificerPredecessor(context);
     if (artificerPred !== null) {
-      const resolved = this.resolveContextInjection(taskId, EVALUATOR_STAGE1_MANIFEST, artificerPred.contentJson);
+      const resolved = this.resolveContextInjection(taskId, manifest, artificerPred.contentJson);
       if (resolved.mode === 'focused') {
         parsedArtificerArtifact = resolved.fields;
       }
     }
-
     const builder = new EvaluatorPromptBuilder();
     const { message } = builder.buildPrompt({
       taskId,
@@ -412,7 +467,12 @@ export class EvaluatorRunner extends BasePeerRunner<EvaluatorContext, EvaluatorO
       scribeArtifact: parsedScribeArtifact,
       sourceArtificerArtifactId: context.sourceArtificerArtifactId ?? '',
     });
+    return message;
+  }
 
+  /** Original single-stage invokeRuntime (flag-off path). */
+  private async invokeRuntimeSingleStage(taskId: string, context: EvaluatorContext): Promise<RunHandle> {
+    const message = this.buildEvaluatorPrompt(taskId, context, EVALUATOR_STAGE1_MANIFEST);
     return this.runtimeAdapter.startRun({
       agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
       taskRef: { taskId },

--- a/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
+++ b/packages/principles-core/src/runtime-v2/runner/base-peer-runner.ts
@@ -177,7 +177,7 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
     return this.phase;
   }
 
-  private getRuntimeKind(): RuntimeKind {
+  protected getRuntimeKind(): RuntimeKind {
     return (typeof this.runtimeAdapter.kind === 'function'
       ? this.runtimeAdapter.kind()
       : this.resolvedOptions.runtimeKind) as RuntimeKind;
@@ -382,7 +382,7 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
 
   // ── Polling ────────────────────────────────────────────────────────────────
 
-  private async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
+  protected async pollUntilTerminal(runHandle: RunHandle): Promise<RunStatus> {
     const deadline = Date.now() + this.resolvedOptions.timeoutMs;
     const terminalStatuses: readonly string[] = ['succeeded', 'failed', 'timed_out', 'cancelled'];
 
@@ -425,7 +425,7 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
    * Returns `unknown` — the payload is untrusted LLM/runtime output.
    * Callers MUST validate before treating as TOutput (ERR-001, ERR-005).
    */
-  private async fetchAndParseOutput(runId: string, taskId: string): Promise<unknown> {
+  protected async fetchAndParseOutput(runId: string, taskId: string): Promise<unknown> {
     let result: Awaited<ReturnType<PDRuntimeAdapter['fetchOutput']>>;
     try {
       result = await this.runtimeAdapter.fetchOutput(runId);
@@ -968,6 +968,49 @@ export abstract class BasePeerRunner<TContext extends { contextHash: string }, T
     if (!effectiveConfig) return false;
     const flags = computeFeatureFlagsFromConfig(effectiveConfig);
     return isFeatureEnabled(flags, 'context_manifest_budget');
+  }
+
+  /**
+   * Whether the Layer 2 `progressive_evaluator` flag is on (design §6.5, PR 4).
+   * When on, the evaluator runner runs two-stage evaluation; off = single stage.
+   */
+  protected isProgressiveEvaluatorEnabled(): boolean {
+    const { effectiveConfig } = this.config;
+    if (!effectiveConfig) return false;
+    const flags = computeFeatureFlagsFromConfig(effectiveConfig);
+    return isFeatureEnabled(flags, 'progressive_evaluator');
+  }
+
+  /**
+   * Run a single LLM evaluation: startRun → pollUntilTerminal → fetchAndParseOutput.
+   * Returns the untrusted payload (unknown). Used by the two-stage progressive
+   * evaluator to run Stage 1 and Stage 2 independently (design §6.5, PR 4 task 9.11).
+   *
+   * This method is protected (not private) so the EvaluatorRunner can call it
+   * twice (once per stage) from its overridden invokeRuntime.
+   */
+  protected async runSingleEvaluation(taskId: string, promptMessage: string): Promise<unknown> {
+    const runtimeKind = this.getRuntimeKind();
+    const runHandle = await this.runtimeAdapter.startRun({
+      agentSpec: { agentId: this.resolvedOptions.agentId, schemaVersion: 'v1' },
+      taskRef: { taskId },
+      inputPayload: promptMessage,
+      contextItems: [],
+      outputSchemaRef: this.config.resultRefPrefix.includes('evaluator')
+        ? 'evaluator-output-v1'
+        : `${this.config.expectedTaskKind}-output-v1`,
+      timeoutMs: this.resolvedOptions.timeoutMs,
+    });
+    this.emitEvent('run_started', taskId, { runtimeKind, stage: 'progressive_evaluation' });
+
+    const finalStatus = await this.pollUntilTerminal(runHandle);
+    if (finalStatus.status !== 'succeeded') {
+      throw new PDRuntimeError(
+        finalStatus.status === 'timed_out' ? 'timeout' : 'execution_failed',
+        `Progressive evaluation run ${runHandle.runId} ended with status ${finalStatus.status}`,
+      );
+    }
+    return this.fetchAndParseOutput(runHandle.runId, taskId);
   }
 
   /**


### PR DESCRIPTION
## 产品意图
- 对应 Linear issue: PRI-513（Layer 2 两阶段评估接线）
- 解决的产品问题: 让 progressive_evaluator flag 开启后真正触发两阶段评估（Stage 1 摘要 → flagged? → Stage 2 tier2 独立复评），而不是停留在纯逻辑+测试状态。
- emotional-value: 降低失控感，创造安心感——评估从"只看末端"变成"先用摘要定位可疑跳，再按需深度复评"。

## 变更概览

### 变更类型: ✨ 新功能

### 高层变更
1. **base-peer-runner 可见性提升**: `pollUntilTerminal` + `fetchAndParseOutput` + `getRuntimeKind` 从 private → protected。新增 `isProgressiveEvaluatorEnabled()` + `runSingleEvaluation()`（封装 startRun→poll→fetch 为单次 Promise）。
2. **evaluator-runner 两阶段接线** (9.11): flag 关→既有单阶段（字节级等价）；flag 开→Stage 1 summary prompt → evaluateFlaggedCriteria → if flagged/undetermined/forced → Stage 2 tier2 prompt（独立复评，rc-7）。合成 RunHandle 模式让 run() 模板方法流程不变。
3. **evaluator prompt 覆盖口径** (9.4b): 7 条覆盖判定口径加入 EVALUATOR_PROTOCOL_INSTRUCTION（含具体性子句），Stage 1/2 共用同一份。
4. **Stage 1 输出契约违规** (9.4c 简化版): 非 object 输出 → emit `stage1_output_contract_violation` + 全判据 undetermined → 强制 Stage 2。不静默通过（rc-3 + rc-9）。

### 影响范围: packages/principles-core

### 是否触及产品边界: 否（flag 默认关，全关=当前单阶段行为）

## 验证
- build 零错误、lint 零错误
- 1006 tests pass / 2 skipped / 0 failed（全量 internalization + feature-flags）

## 风险
- flag 默认关。开启后 evaluator 会做最多 2 次 LLM 调用（Stage 1 + Stage 2）。
- 回滚: feature flag `progressive_evaluator`

### ERR Checklist
- ERR-015/018/019: Stage 2 独立复评，不注入 Stage 1 输出。
- ERR-013: evaluateFlaggedCriteria 全 Object.hasOwn。
- ERR-002: 契约违规不静默通过。

### Runtime Contract
- rc-1: Stage 1/2 输出全 unknown。
- rc-3: 契约违规 → undetermined → Stage 2。
- rc-7: Stage 2 独立。
- rc-9: 每个降级带结构化原因。
