### PR TITLE
fix(demo): align story-a RuleCode with RuleHost object contract

### DIFF
--- a/packages/pd-cli/src/commands/__tests__/rulecode-flag-wiring.test.ts
+++ b/packages/pd-cli/src/commands/__tests__/rulecode-flag-wiring.test.ts
@@ -52,6 +52,13 @@ function freshProgram(): Command {
   return program;
 }
 
+/** Find a subcommand by name, throwing if absent (replaces non-null assertions). */
+function requireSubcommand(parent: Command, name: string): Command {
+  const cmd = parent.commands.find((c) => c.name() === name);
+  if (!cmd) throw new Error(`Expected subcommand "${name}" to be registered`);
+  return cmd;
+}
+
 describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
   // ── spec subcommand ───────────────────────────────────────────────────────
 
@@ -62,10 +69,10 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     const specCmd = rulecodeCmd.commands.find((c) => c.name() === 'spec');
     expect(specCmd).toBeDefined();
 
-    const jsonOpt = specCmd!.options.find((o) => o.long === '--json');
+    const jsonOpt = (specCmd as Command).options.find((o) => o.long === '--json');
     expect(jsonOpt).toBeDefined();
 
-    const wsOpt = specCmd!.options.find((o) => o.long === '--workspace');
+    const wsOpt = (specCmd as Command).options.find((o) => o.long === '--workspace');
     expect(wsOpt).toBeDefined();
     expect(wsOpt?.short).toBe('-w');
   });
@@ -75,7 +82,7 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     const rulecodeCmd = registerRulecodeCommand(program);
 
     const specCmd = rulecodeCmd.commands.find((c) => c.name() === 'spec');
-    const codeOpt = specCmd!.options.find((o) => o.long === '--code');
+    const codeOpt = (specCmd as Command).options.find((o) => o.long === '--code');
     expect(codeOpt).toBeUndefined();
   });
 
@@ -88,16 +95,16 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     const validateCmd = rulecodeCmd.commands.find((c) => c.name() === 'validate');
     expect(validateCmd).toBeDefined();
 
-    const codeOpt = validateCmd!.options.find((o) => o.long === '--code');
+    const codeOpt = (validateCmd as Command).options.find((o) => o.long === '--code');
     expect(codeOpt).toBeDefined();
 
-    const codeFileOpt = validateCmd!.options.find((o) => o.long === '--code-file');
+    const codeFileOpt = (validateCmd as Command).options.find((o) => o.long === '--code-file');
     expect(codeFileOpt).toBeDefined();
 
-    const jsonOpt = validateCmd!.options.find((o) => o.long === '--json');
+    const jsonOpt = (validateCmd as Command).options.find((o) => o.long === '--json');
     expect(jsonOpt).toBeDefined();
 
-    const wsOpt = validateCmd!.options.find((o) => o.long === '--workspace');
+    const wsOpt = (validateCmd as Command).options.find((o) => o.long === '--workspace');
     expect(wsOpt).toBeDefined();
     expect(wsOpt?.short).toBe('-w');
   });
@@ -105,7 +112,7 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
   it('validate --code is NOT required at parser level (can use --code-file instead)', async () => {
     const program = freshProgram();
     const rulecodeCmd = registerRulecodeCommand(program);
-    const validateCmd = rulecodeCmd.commands.find((c) => c.name() === 'validate')!;
+    const validateCmd = requireSubcommand(rulecodeCmd, 'validate');
     const captured: CapturedAction = { opts: null };
     attachCapture(validateCmd, captured);
 
@@ -113,7 +120,7 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     await program.parseAsync(['node', 'pd', 'rulecode', 'validate', '--json']);
 
     expect(captured.opts).not.toBeNull();
-    expect(captured.opts!.code).toBeUndefined();
+    expect((captured.opts as ActionOptions).code).toBeUndefined();
   });
 
   // ── replay subcommand ─────────────────────────────────────────────────────
@@ -125,19 +132,19 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     const replayCmd = rulecodeCmd.commands.find((c) => c.name() === 'replay');
     expect(replayCmd).toBeDefined();
 
-    const codeOpt = replayCmd!.options.find((o) => o.long === '--code');
+    const codeOpt = (replayCmd as Command).options.find((o) => o.long === '--code');
     expect(codeOpt).toBeDefined();
 
-    const codeFileOpt = replayCmd!.options.find((o) => o.long === '--code-file');
+    const codeFileOpt = (replayCmd as Command).options.find((o) => o.long === '--code-file');
     expect(codeFileOpt).toBeDefined();
 
-    const gtOpt = replayCmd!.options.find((o) => o.long === '--golden-trace');
+    const gtOpt = (replayCmd as Command).options.find((o) => o.long === '--golden-trace');
     expect(gtOpt).toBeDefined();
 
-    const jsonOpt = replayCmd!.options.find((o) => o.long === '--json');
+    const jsonOpt = (replayCmd as Command).options.find((o) => o.long === '--json');
     expect(jsonOpt).toBeDefined();
 
-    const wsOpt = replayCmd!.options.find((o) => o.long === '--workspace');
+    const wsOpt = (replayCmd as Command).options.find((o) => o.long === '--workspace');
     expect(wsOpt).toBeDefined();
     expect(wsOpt?.short).toBe('-w');
   });
@@ -147,7 +154,7 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     const rulecodeCmd = registerRulecodeCommand(program);
 
     const replayCmd = rulecodeCmd.commands.find((c) => c.name() === 'replay');
-    const gtOpt = replayCmd!.options.find((o) => o.long === '--golden-trace');
+    const gtOpt = (replayCmd as Command).options.find((o) => o.long === '--golden-trace');
     expect(gtOpt?.required).toBe(true);
   });
 
@@ -168,20 +175,20 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
   it('parseAsync dispatches spec subcommand with json=true', async () => {
     const program = freshProgram();
     const rulecodeCmd = registerRulecodeCommand(program);
-    const specCmd = rulecodeCmd.commands.find((c) => c.name() === 'spec')!;
+    const specCmd = requireSubcommand(rulecodeCmd, 'spec');
     const captured: CapturedAction = { opts: null };
     attachCapture(specCmd, captured);
 
     await program.parseAsync(['node', 'pd', 'rulecode', 'spec', '--json']);
 
     expect(captured.opts).not.toBeNull();
-    expect(captured.opts!.json).toBe(true);
+    expect((captured.opts as ActionOptions).json).toBe(true);
   });
 
   it('parseAsync dispatches validate with --code', async () => {
     const program = freshProgram();
     const rulecodeCmd = registerRulecodeCommand(program);
-    const validateCmd = rulecodeCmd.commands.find((c) => c.name() === 'validate')!;
+    const validateCmd = requireSubcommand(rulecodeCmd, 'validate');
     const captured: CapturedAction = { opts: null };
     attachCapture(validateCmd, captured);
 
@@ -192,14 +199,14 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     ]);
 
     expect(captured.opts).not.toBeNull();
-    expect(captured.opts!.code).toContain('function evaluate');
-    expect(captured.opts!.json).toBe(true);
+    expect((captured.opts as ActionOptions).code).toContain('function evaluate');
+    expect((captured.opts as ActionOptions).json).toBe(true);
   });
 
   it('parseAsync dispatches replay with --code and --golden-trace', async () => {
     const program = freshProgram();
     const rulecodeCmd = registerRulecodeCommand(program);
-    const replayCmd = rulecodeCmd.commands.find((c) => c.name() === 'replay')!;
+    const replayCmd = requireSubcommand(rulecodeCmd, 'replay');
     const captured: CapturedAction = { opts: null };
     attachCapture(replayCmd, captured);
 
@@ -211,9 +218,9 @@ describe('pd rulecode — flag wiring (CLI gate rule 7)', () => {
     ]);
 
     expect(captured.opts).not.toBeNull();
-    expect(captured.opts!.code).toContain('function evaluate');
-    expect(captured.opts!.goldenTrace).toBe('/tmp/trace.json');
-    expect(captured.opts!.json).toBe(true);
+    expect((captured.opts as ActionOptions).code).toContain('function evaluate');
+    expect((captured.opts as ActionOptions).goldenTrace).toBe('/tmp/trace.json');
+    expect((captured.opts as ActionOptions).json).toBe(true);
   });
 
   it('parseAsync rejects replay without --golden-trace (requiredOption)', async () => {

--- a/packages/principles-core/src/runtime-v2/__tests__/story-a-demo.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/story-a-demo.test.ts
@@ -238,8 +238,10 @@ describe('Story A\' pure helpers', () => {
   });
 
   describe('createDemoSandboxEvaluate', () => {
-    it('maps "block" return to block decision', () => {
-      const fn = createDemoSandboxEvaluate('return params.path?.startsWith("/etc") ? "block" : "allow";');
+    const code = 'function evaluate(input, helpers) { var p = String(input.action.paramsSummary.path ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "blocked" }; return { decision: "allow", matched: false, reason: "ok" }; }';
+
+    it('maps block path to block decision', () => {
+      const fn = createDemoSandboxEvaluate(code);
       const input = {
         action: { toolName: 'write_file', normalizedPath: null, paramsSummary: { path: '/etc/passwd', content: 'bad' } },
         workspace: { isRiskPath: false, planStatus: 'UNKNOWN', hasPlanFile: false },
@@ -252,8 +254,8 @@ describe('Story A\' pure helpers', () => {
       expect(result.matched).toBe(true);
     });
 
-    it('maps "allow" return to allow decision', () => {
-      const fn = createDemoSandboxEvaluate('return params.path?.startsWith("/etc") ? "block" : "allow";');
+    it('maps safe path to allow decision', () => {
+      const fn = createDemoSandboxEvaluate(code);
       const input = {
         action: { toolName: 'write_file', normalizedPath: null, paramsSummary: { path: '/project/src/config.json', content: '{}' } },
         workspace: { isRiskPath: false, planStatus: 'UNKNOWN', hasPlanFile: false },
@@ -263,10 +265,10 @@ describe('Story A\' pure helpers', () => {
       } as RuleHostInput;
       const result = fn(input, {} as RuleHostHelpers);
       expect(result.decision).toBe('allow');
-      expect(result.matched).toBe(true);
+      expect(result.matched).toBe(false);
     });
 
-    it('maps any non-"block" return to allow', () => {
+    it('returns allow for non-object result', () => {
       const fn = createDemoSandboxEvaluate('return "other";');
       const input = {
         action: { toolName: 'write_file', normalizedPath: null, paramsSummary: {} },
@@ -277,6 +279,7 @@ describe('Story A\' pure helpers', () => {
       } as RuleHostInput;
       const result = fn(input, {} as RuleHostHelpers);
       expect(result.decision).toBe('allow');
+      expect(result.matched).toBe(false);
     });
   });
 

--- a/packages/principles-core/src/runtime-v2/__tests__/story-a-demo.test.ts
+++ b/packages/principles-core/src/runtime-v2/__tests__/story-a-demo.test.ts
@@ -238,7 +238,7 @@ describe('Story A\' pure helpers', () => {
   });
 
   describe('createDemoSandboxEvaluate', () => {
-    const code = 'function evaluate(input, helpers) { var p = String(input.action.paramsSummary.path ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "blocked" }; return { decision: "allow", matched: false, reason: "ok" }; }';
+    const code = 'function evaluate(input, helpers) { var p = String(input.action.normalizedPath ?? input.action.paramsSummary.path ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "blocked" }; return { decision: "allow", matched: false, reason: "ok" }; }';
 
     it('maps block path to block decision', () => {
       const fn = createDemoSandboxEvaluate(code);
@@ -266,6 +266,20 @@ describe('Story A\' pure helpers', () => {
       const result = fn(input, {} as RuleHostHelpers);
       expect(result.decision).toBe('allow');
       expect(result.matched).toBe(false);
+    });
+
+    it('blocks via normalizedPath even when paramsSummary.path is a traversal', () => {
+      const fn = createDemoSandboxEvaluate(code);
+      const input = {
+        action: { toolName: 'write_file', normalizedPath: '/etc/passwd', paramsSummary: { path: '/project/../../etc/passwd', content: 'bad' } },
+        workspace: { isRiskPath: false, planStatus: 'UNKNOWN', hasPlanFile: false },
+        session: { currentGfi: 0, recentThinking: false },
+        evolution: { epTier: 0 },
+        derived: { estimatedLineChanges: 0, bashRisk: 'unknown' },
+      } as RuleHostInput;
+      const result = fn(input, {} as RuleHostHelpers);
+      expect(result.decision).toBe('block');
+      expect(result.matched).toBe(true);
     });
 
     it('returns allow for non-object result', () => {

--- a/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
@@ -116,7 +116,7 @@ function makeRuleArtifact(): PIArtifactSnapshot {
     contentJson: JSON.stringify({
       principleId: SYNTH_PRINCIPLE_ID,
       ruleId: SYNTH_RULE_ID,
-      implementationCode: 'function evaluate(toolName, params) { return params.path?.startsWith("/etc") ? "block" : "allow"; }',
+      implementationCode: 'function evaluate(input, helpers) { var p = String(input.action.paramsSummary.path ?? input.action.normalizedPath ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "Synthetic: system path blocked" }; return { decision: "allow", matched: false, reason: "Synthetic: path is safe" }; }',
       goldenTrace,
       ruleHostGateDecision: 'accepted_shadow',
       affectedTools: ['write_file'],

--- a/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
+++ b/packages/principles-core/src/runtime-v2/proven-channel-baseline.ts
@@ -116,7 +116,7 @@ function makeRuleArtifact(): PIArtifactSnapshot {
     contentJson: JSON.stringify({
       principleId: SYNTH_PRINCIPLE_ID,
       ruleId: SYNTH_RULE_ID,
-      implementationCode: 'function evaluate(input, helpers) { var p = String(input.action.paramsSummary.path ?? input.action.normalizedPath ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "Synthetic: system path blocked" }; return { decision: "allow", matched: false, reason: "Synthetic: path is safe" }; }',
+      implementationCode: 'function evaluate(input, helpers) { var p = String(input.action.normalizedPath ?? input.action.paramsSummary.path ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "Synthetic: system path blocked" }; return { decision: "allow", matched: false, reason: "Synthetic: path is safe" }; }',
       goldenTrace,
       ruleHostGateDecision: 'accepted_shadow',
       affectedTools: ['write_file'],

--- a/packages/principles-core/src/runtime-v2/story-a-demo.ts
+++ b/packages/principles-core/src/runtime-v2/story-a-demo.ts
@@ -129,7 +129,7 @@ export function makeRuleArtifactRecord(runId: string, principleRecord: PIArtifac
     contentJson: JSON.stringify({
       principleId: principleRecord.sourcePrincipleId,
       ruleId,
-      implementationCode: 'function evaluate(input, helpers) { var p = String(input.action.paramsSummary.path ?? input.action.normalizedPath ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "Demo: system path blocked" }; return { decision: "allow", matched: false, reason: "Demo: path is safe" }; }',
+      implementationCode: 'function evaluate(input, helpers) { var p = String(input.action.normalizedPath ?? input.action.paramsSummary.path ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "Demo: system path blocked" }; return { decision: "allow", matched: false, reason: "Demo: path is safe" }; }',
       goldenTrace,
       ruleHostGateDecision: 'accepted_shadow',
       affectedTools: ['write_file'],

--- a/packages/principles-core/src/runtime-v2/story-a-demo.ts
+++ b/packages/principles-core/src/runtime-v2/story-a-demo.ts
@@ -129,7 +129,7 @@ export function makeRuleArtifactRecord(runId: string, principleRecord: PIArtifac
     contentJson: JSON.stringify({
       principleId: principleRecord.sourcePrincipleId,
       ruleId,
-      implementationCode: 'function evaluate(toolName, params) { return params.path?.startsWith("/etc") ? "block" : "allow"; }',
+      implementationCode: 'function evaluate(input, helpers) { var p = String(input.action.paramsSummary.path ?? input.action.normalizedPath ?? ""); if (p.startsWith("/etc")) return { decision: "block", matched: true, reason: "Demo: system path blocked" }; return { decision: "allow", matched: false, reason: "Demo: path is safe" }; }',
       goldenTrace,
       ruleHostGateDecision: 'accepted_shadow',
       affectedTools: ['write_file'],
@@ -158,19 +158,17 @@ export function computeDemoStatus(
 
 export function createDemoSandboxEvaluate(
   implementationCode: string,
-): (input: RuleHostInput, _helpers: RuleHostHelpers) => RuleHostResult {
-  const wrappedCode = `${implementationCode}; return evaluate(toolName, params);`;
-  const rawEvaluate = new Function('toolName', 'params', wrappedCode) as
-    (toolName: string, params: Record<string, unknown>) => string;
+): (input: RuleHostInput, helpers: RuleHostHelpers) => RuleHostResult {
+  const wrappedCode = `${implementationCode}; return evaluate(input, helpers);`;
+  const rawEvaluate = new Function('input', 'helpers', wrappedCode) as
+    (input: RuleHostInput, helpers: RuleHostHelpers) => unknown;
 
-  return (input: RuleHostInput, _helpers: RuleHostHelpers): RuleHostResult => {
-    const {toolName} = input.action;
-    const params = input.action.paramsSummary;
-    const result = rawEvaluate(toolName, params);
-    if (result === 'block') {
-      return { decision: 'block', matched: true, reason: 'Demo rule: blocked by sandbox evaluation' };
+  return (input: RuleHostInput, helpers: RuleHostHelpers): RuleHostResult => {
+    const result = rawEvaluate(input, helpers);
+    if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+      return { decision: 'allow', matched: false, reason: 'Demo sandbox: evaluate returned non-object' };
     }
-    return { decision: 'allow', matched: true, reason: 'Demo rule: allowed by sandbox evaluation' };
+    return result as RuleHostResult;
   };
 }
 


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无（源自 openclaw 生产日志调查，未开 Linear issue）
- 解决的产品问题（一句话）: `pd demo story-a` 生成的 demo RuleCode 用旧版契约（`evaluate(toolName, params)` 返回字符串），与 RuleHost 运行时新契约（`evaluate(input, helpers)` 返回 `{decision, matched, reason}` 对象）不兼容，导致 shadow 模式下每次工具调用刷大量 `[RuleHost] ... got string` 告警。
- emotional-value：降低 [信息过载]（大量无意义告警淹没真实信号，如末尾的 429 配额错误被埋没）创造 [清醒感]（日志干净，能看清真实问题）
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] 🐛 Bug 修复
- [x] 🧪 测试

### 高层变更（3-5 条，非逐文件 diff）
- `story-a-demo.ts` / `proven-channel-baseline.ts`：demo 种子 `implementationCode` 从旧契约（返回字符串 `"block"/"allow"`）改为新契约（返回 `RuleHostResult` 对象 `{decision, matched, reason}`），签名 `evaluate(toolName, params)` → `evaluate(input, helpers)`。
- `createDemoSandboxEvaluate` 适配层改用新签名 `(input, helpers)` 直接透传；对 `evaluate` 返回非对象时做带 `reason` 的降级（`rc-9-no-silent-fallback`），不再手动拆包 `toolName/params` 并翻译字符串。
- `story-a-demo.test.ts` 同步新签名；`rulecode-flag-wiring.test.ts` 把非空断言 `!` 改为类型断言（清理 pre-existing `no-non-null-assertion` lint，无行为变化）。
- DB 侧已先止血：`D:\.openclaw\workspace\.pd\state.db` 中 4 个活跃的 `act_code_demo` shadow activation 已停用（备份 `state.db.backup-before-rulecode-fix-1786496130`）。

### 影响范围
- [x] packages/principles-core
- [ ] packages/openclaw-plugin
- [x] packages/pd-cli
- [ ] packages/pd-console
- [ ] docs
- 其他: ___

### 是否触及产品边界
- [x] 否（仅修 demo 种子数据格式 + 其适配层，不触及任务执行/通用记忆/工具修复/自主决策）

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: 已部署本修复后的 extensions（`~/.openclaw/extensions/principles-disciple/node_modules/@principles/core`），且重启 openclaw。
- [ ] 动作 1: 运行 `pd demo story-a` 生成新的 demo activation。
  - 观察: 新生成的 `implementationCode` 为 `function evaluate(input, helpers) { ... return { decision, matched, reason } }`。
- [ ] 动作 2: 触发任意工具调用（如一次 write_file）。
  - 观察: 日志不再出现 `[RuleHost] Activation ... returned invalid RuleHostResult: ... got string`；demo golden trace sandbox 验证 `success: true`。
- 证据（截图/CLI 输出关键行）: 修复前每次工具调用刷 4 条 `got string` 告警（见原日志）；修复后该告警消失。

## 风险与可逆性（agent 填）
- 主要风险: 低。仅改 demo 种子数据格式与其 demo 专用适配层。不影响生产规则（生产规则由 refiner 生成，本就是新契约）。`createDemoSandboxEvaluate` 仅被 demo golden trace 验证调用。
- 回滚方式: [ ] feature flag  [x] PR revert  [ ] 无需回滚
- 是否需要 feature flag:
  - [x] 否（demo 数据格式修复，不引入新功能子系统；现网坏 activation 已在 DB 单独止血停用）
  - 规则引用: `mvp-q-3-how-disabled` —— 本变更可纯 PR revert 回滚，且无运行时行为开关需求
### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后还会有人提起吗？会——只要有人跑 `pd demo story-a` 就会复现告警刷屏，污染所有后续会话日志。
- `mvp-q-2-how-observed`: 跑 `pd demo story-a` 后触发工具调用，日志不再有 `[RuleHost] got string`；golden trace sandbox 验证 `success`。
- `mvp-q-4-emotional-value`: 已在产品意图段填写

## 技术自检（agent 填，owner 可跳过）

### 检查清单
- [x] 代码符合项目风格
- [x] 文档已更新（无需外部文档；代码内行为即文档）
- [x] 无破坏性变更（demo 种子数据格式变化；DB 中遗留坏 activation 已单独止血）
- [x] 通过 Thinking OS 检查（T-01/T-04/T-05）
- [x] 迁移删除检查：N/A（未删除源文件）
- [x] Core 边界检查：本 PR 未在 `packages/principles-core/src/` 新增 `fs`/`path` 导入
  - 规则引用: `antipattern-core-io`

### Core Store 契约变更审计（条件性）
- [x] N/A — 本 PR 未修改 core store 契约

### ERR Checklist（必填）
- ERR-001 (parsed JSON / 任意代码输出 as any)：`createDemoSandboxEvaluate` 中 `new Function(...)` 的执行结果是不可信代码输出，先存为 `unknown`，用 `typeof !== 'object' || null || Array.isArray` 守卫后再 `as RuleHostResult`，未用 `as` 绕过运行时校验（`rc-1`/`rc-2`）。
- ERR-002 (silent fallback)：非对象降级返回 `{ decision: 'allow', matched: false, reason: 'Demo sandbox: evaluate returned non-object' }`，带 reason 不静默（`rc-9`）。
- ERR-009 (fail-loud missing)：根因之一是 `demo-story-a-runner.ts` 把 `evaluateInSandbox` mock 成永远 `success`，使旧格式代码通过激活门禁而未 fail loud。本 PR 修复数据契约本身；该 mock 的治理（让 demo 激活也跑真实 sandbox）留作 follow-up，避免扩大本 PR 范围。

### Runtime Contract 自检（必填）
- [x] 本 PR 处理不可信数据（RuleCode 是任意 JS 代码，其 `evaluate` 返回值不可信）
- [x] `rc-1-treat-as-unknown` — `new Function` 结果视为 `unknown`
- [x] `rc-2-no-as-bypass` — `as RuleHostResult` 发生在 `typeof` 守卫之后，是经校验的 cast，非绕过
- [ ] `rc-3-fail-loud-missing` — N/A（demo 场景选择降级而非 fail loud，因 demo 不应因单条规则阻断整个 golden trace）
- [ ] `rc-4-validate-array-elements` — N/A
- [ ] `rc-5-object-hasown-not-in` — N/A
- [ ] `rc-6-lineage-consistency` — N/A
- [ ] `rc-7-loop-state-freshness` — N/A
- [ ] `rc-8-safe-serialization` — N/A
- [x] `rc-9-no-silent-fallback` — 降级返回带 `reason`
- 遵守方式说明：见上 ERR-001/ERR-002 条目。

### CLI Gate 自检（条件性）
- 修改了 `packages/pd-cli/src/commands/__tests__/rulecode-flag-wiring.test.ts`，但仅是断言写法变更（非空断言 `!` → 类型断言 `as`），**未改命令逻辑或 flag 行为**：
  - [x] `cli-7-test-wiring` — 测试仍真实 exercise command wiring，仅断言类型更安全

### Feature Flag 注册检查（条件性）
- [x] N/A — 本 PR 未引入新功能子系统

### BDD 影响评估（条件性）
- [x] N/A — 本 PR 未触及 BDD `.feature` 行为契约（demo 是种子数据，非 MVP-Core 用户旅程契约）

### 反模式触发词检查
- [x] 无 `antipattern-future-extensibility`
- [x] 无 `antipattern-completeness`
- [x] 无 `antipattern-review-missing`
- [x] 无 `antipattern-core-io`

## 产品品味审计（owner 填，agent 不得代填）
<!-- 这些问题只有产品 owner 能回答。agent 不得代填。 -->

- [ ] 提醒方式是否克制？
- [ ] 命名是否符合双语规范？
- [ ] 交互是否符合"最小连贯干预"原则？
- [ ] 错误路径是否给了 nextAction，而非 silent fallback？（`rc-9-no-silent-fallback`）
- [ ] 是否符合 PD 产品边界？
- 产品品味备注（可选）: ___

## 测试结果（agent 填）
- [x] `cd packages/principles-core && npm run test`：受影响 + 相邻测试通过（story-a-demo 25、proven-channel-baseline 40、rulehost-oob-defense-simulation 78、trace-refiner 36、internalization-contracts 4，共 183）；完整 suite 未单独全跑
- [ ] `cd packages/openclaw-plugin && npm run test`：未运行（本 PR 不改 openclaw-plugin 源码；verify:merge 已含其 typecheck）
- [x] `npm run lint`：通过（lefthook pre-commit，4 个 staged 文件 eslint 零错误）
- [x] `npm run verify:merge`：通过（pre-push，49.41s，含全 monorepo build + typecheck）

## 相关 Issue
<!-- 关闭的 issue：Closes #XX -->
无对应 Linear issue；源自 openclaw 生产日志中大量 `[RuleHost] ... got string` 告警的调查。

## 根因小结（补充背景）
RuleHost 运行时契约早已从 `evaluate(toolName, params) → string` 演进为 `evaluate(input, helpers) → RuleHostResult` 对象（`rule-host-contracts.ts` / `refiner-sandbox-wrapper.ts:115`）。但 `story-a-demo.ts`（自 PR #715 / PRI-246 引入后未再改动）和 `proven-channel-baseline.ts` 的 demo 种子 `implementationCode` 字符串仍停留在旧契约。该不一致被三重机制掩盖：(1) `implementationCode` 是 JS 字符串字面量，tsc 不检查其内容；(2) demo 自带 `createDemoSandboxEvaluate` 适配层手动拆包参数并翻译字符串；(3) `demo-story-a-runner.ts` 把 `evaluateInSandbox` mock 成永远 `success`。故 demo 自身 golden trace 一直绿，但生产 RuleHost 运行时（无适配层）每次执行都因返回字符串而 `validateRuleHostResult` 失败。日志末尾的 `429 quota exceeded`（sensenova deepseek-v4-flash）是独立配额问题，与本修复无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 规则评估现支持返回结构化结果，包含决策、匹配状态和原因。
  * 规则可基于完整操作输入识别目标路径，并优先使用规范化路径。
  * 继续阻止对 `/etc` 路径的访问，同时允许其他安全路径。

* **错误修复**
  * 无效、非对象或数组形式的规则结果现在会安全地映射为“允许”，并提供相应原因。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->