### PR TITLE
feat(internalization): auto-consumer advances full dreamer→evaluator chain (PRI-419 amendment)

### DIFF
--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -190,10 +190,10 @@ export async function runConsumerCycle(
         wakeResult = candidate;
         break;
       }
+      // Keep decision/reason paired across iterations so the final SKIP log
+      // never reports a stale reason from an earlier kind (EP-03 observability).
       lastSkipDecision = candidate.decision;
-      if (candidate.decision === 'no_ready_tasks') {
-        lastSkipReason = candidate.reason;
-      }
+      lastSkipReason = candidate.decision === 'no_ready_tasks' ? candidate.reason : undefined;
     }
 
     if (!wakeResult) {

--- a/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
+++ b/packages/openclaw-plugin/src/service/internalization-auto-consumer-service.ts
@@ -3,7 +3,15 @@ import {
   createRuntimeStateHandle,
   InternalizationOrchestrator,
   DreamerRunner,
+  PhilosopherRunner,
+  ScribeRunner,
+  ArtificerRunner,
+  EvaluatorRunner,
   DefaultDreamerValidator,
+  DefaultPhilosopherValidator,
+  DefaultScribeValidator,
+  DefaultArtificerValidator,
+  DefaultEvaluatorValidator,
   PiAiRuntimeAdapter,
   L2AgentLoopAdapter,
   buildL2PrincipleReaderFromLedger,
@@ -12,9 +20,12 @@ import {
   resolveRuntimeConfigFromPdConfig,
   isRuntimeConfigError,
   computeConsumerDecision,
+  FULL_CHAIN_CONSUMER_RUNNER_KINDS,
+  DEFAULT_CONSUMER_RUNNER_KINDS,
   InternalizationQueueReadModel,
   MVP_CORE_TASK_KINDS,
   type PDRuntimeAdapter,
+  type WakeOnceResult,
 } from '@principles/core/runtime-v2';
 import { loadLedger } from '@principles/core/principle-tree-ledger';
 import { loadPdConfigForPlugin, loadFeatureFlagFromConfig } from '../core/pd-config-loader.js';
@@ -137,9 +148,18 @@ export async function runConsumerCycle(
       logger.warn(`[PD:AutoConsumer] Backlog detected: ${snapshot.readyTasks.length} tasks ready. Processing only one task.`);
     }
 
+    // PRI-419 amendment: when internalization_full_chain is ON (default), the
+    // auto-consumer advances the full dreamer→…→evaluator chain so artifacts
+    // reach validation_status='validated'. flag-off reverts to dreamer-only.
+    const fullChainFlag = loadFeatureFlagFromConfig(workspaceDir, 'internalization_full_chain');
+    const consumerRunnerKinds = fullChainFlag.enabled
+      ? FULL_CHAIN_CONSUMER_RUNNER_KINDS
+      : DEFAULT_CONSUMER_RUNNER_KINDS;
+
     const decision = computeConsumerDecision({
       autoConsumerEnabled: true,
       readyTaskCount: snapshot.readyTasks.length,
+      runnerKinds: consumerRunnerKinds,
     });
 
     if (!decision.shouldConsume) {
@@ -157,25 +177,41 @@ export async function runConsumerCycle(
       { owner: 'auto-consumer', runtimeKind, dryRun: true },
     );
 
-    const wakeResult = await orchestrator.wakeOnce('dreamer');
+    // Advance the configured runner kinds in priority order (dreamer first,
+    // then philosopher→…→evaluator under full-chain scope). Lease the first
+    // ready task whose dependencies are satisfied. rollout_reviewer is never
+    // in the auto-consume set — it stays a manual Owner gate.
+    let wakeResult: Extract<WakeOnceResult, { decision: 'would_lease' }> | null = null;
+    let lastSkipDecision = 'no_ready_tasks';
+    let lastSkipReason: string | undefined;
+    for (const kind of decision.runnerKinds) {
+      const candidate = await orchestrator.wakeOnce(kind);
+      if (candidate.decision === 'would_lease') {
+        wakeResult = candidate;
+        break;
+      }
+      lastSkipDecision = candidate.decision;
+      if (candidate.decision === 'no_ready_tasks') {
+        lastSkipReason = candidate.reason;
+      }
+    }
 
-    if (wakeResult.decision !== 'would_lease') {
-      const skipPayload: Record<string, unknown> = {
-        decision: wakeResult.decision,
-      };
-      if (wakeResult.decision === 'no_ready_tasks') {
-        skipPayload.reason = wakeResult.reason;
+    if (!wakeResult) {
+      const skipPayload: Record<string, unknown> = { decision: lastSkipDecision };
+      if (lastSkipReason) {
+        skipPayload.reason = lastSkipReason;
       }
       SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify(skipPayload));
-      logger.info(`[PD:AutoConsumer] No task to consume: ${wakeResult.decision}`);
+      logger.info(`[PD:AutoConsumer] No task to consume: ${lastSkipDecision}`);
       return;
     }
 
     let adapter: PDRuntimeAdapter;
     if (runtimeKind === 'pi-ai') {
-      // PRI-419: when l2_dreamer flag is on, route through the L2 multi-turn agent loop.
+      // PRI-419: when l2_dreamer flag is on AND this is a dreamer task, route
+      // through the L2 multi-turn agent loop. Non-dreamer runners always use PiAi.
       const l2Flag = loadFeatureFlagFromConfig(workspaceDir, 'l2_dreamer');
-      if (l2Flag.enabled) {
+      if (l2Flag.enabled && wakeResult.taskKind === 'dreamer') {
         const stateDir = `${workspaceDir}/.state`;
         const principleReader = buildL2PrincipleReaderFromLedger(loadLedger(stateDir), {
           logger: { warn: (msg) => logger.warn(msg) },
@@ -225,29 +261,60 @@ export async function runConsumerCycle(
       throw new Error(`Unsupported runtime kind resolved for auto-consumer: ${runtimeKind}`);
     }
 
-    const validator = new DefaultDreamerValidator();
-    const runner = new DreamerRunner(
-      {
-        stateManager,
-        runtimeAdapter: adapter,
-        eventEmitter: storeEmitter,
-        artifactStore: stateManager.piArtifactStore,
-        validator,
-        // Layer 0 (design §6.1): inject sha256-hex so the dreamer writer can
-        // attach a predecessorSummary.contentHash for staleness detection.
-        contentHashFn,
-      },
-      {
-        owner: 'auto-consumer',
-        runtimeKind,
-      },
-    );
-
     const taskId = wakeResult.taskId;
-    logger.info(`[PD:AutoConsumer] Running dreamer task: ${taskId}`);
+    const taskKind = wakeResult.taskKind;
+    const runnerOptions = { owner: 'auto-consumer' as const, runtimeKind };
+
+    // Dispatch by leased task kind. rollout_reviewer and diagnostician stages
+    // are never auto-consumed (excluded from FULL_CHAIN_CONSUMER_RUNNER_KINDS),
+    // so they should not reach the default branch — fail loud if they do (EP-03).
+    let runner: DreamerRunner | PhilosopherRunner | ScribeRunner | ArtificerRunner | EvaluatorRunner;
+    switch (taskKind) {
+      case 'dreamer':
+        runner = new DreamerRunner(
+          { stateManager, runtimeAdapter: adapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultDreamerValidator(), contentHashFn },
+          runnerOptions,
+        );
+        break;
+      case 'philosopher':
+        runner = new PhilosopherRunner(
+          { stateManager, runtimeAdapter: adapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultPhilosopherValidator(), contentHashFn },
+          runnerOptions,
+        );
+        break;
+      case 'scribe':
+        runner = new ScribeRunner(
+          { stateManager, runtimeAdapter: adapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultScribeValidator(), contentHashFn },
+          runnerOptions,
+        );
+        break;
+      case 'artificer':
+        runner = new ArtificerRunner(
+          { stateManager, runtimeAdapter: adapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultArtificerValidator(), contentHashFn },
+          runnerOptions,
+        );
+        break;
+      case 'evaluator':
+        // Base construction — the PRI-509 repair loop is intentionally NOT
+        // wired here; it stays opt-in via the separate evaluator_artificer_repair_loop
+        // flag (quiet, default off). When omitted, evaluator follows the legacy
+        // needs_revision path (no repair task seeded), which is sufficient for
+        // artifacts to reach validation_status='validated' on approved candidates.
+        runner = new EvaluatorRunner(
+          { stateManager, runtimeAdapter: adapter, eventEmitter: storeEmitter, artifactStore: stateManager.piArtifactStore, validator: new DefaultEvaluatorValidator() },
+          runnerOptions,
+        );
+        break;
+      default:
+        SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_SKIP', JSON.stringify({ decision: 'no_runner_for_kind', taskKind }));
+        logger.warn(`[PD:AutoConsumer] No auto-consumer runner for task kind '${taskKind}'; skipping. Advance manually: pd runtime internalization run-once --runner ${taskKind}`);
+        return;
+    }
+
+    logger.info(`[PD:AutoConsumer] Running ${taskKind} task: ${taskId}`);
     SystemLogger.log(workspaceDir, 'INTERNALIZATION_CONSUMER_RUN', JSON.stringify({
       taskId,
-      taskKind: 'dreamer',
+      taskKind,
     }));
 
     let runResult;

--- a/packages/openclaw-plugin/tests/internalization-auto-consumer-service.test.ts
+++ b/packages/openclaw-plugin/tests/internalization-auto-consumer-service.test.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as yaml from 'js-yaml';
 import Database from 'better-sqlite3';
 import { runConsumerCycle } from '../src/service/internalization-auto-consumer-service.js';
-import { DreamerRunner, OpenClawCliRuntimeAdapter, PiAiRuntimeAdapter } from '@principles/core/runtime-v2';
+import { DreamerRunner, PhilosopherRunner, OpenClawCliRuntimeAdapter, PiAiRuntimeAdapter } from '@principles/core/runtime-v2';
 
 // We mock the dictionary service to prevent unwanted DB lookups
 vi.mock('../src/core/dictionary-service.js', () => ({
@@ -215,5 +215,76 @@ describe('Auto-Consumer Unhandled Runner Crash Recovery', () => {
     // The captured adapter should be an instance of OpenClawCliRuntimeAdapter, not PiAiRuntimeAdapter
     expect(capturedAdapter).toBeInstanceOf(OpenClawCliRuntimeAdapter);
     expect(capturedAdapter).not.toBeInstanceOf(PiAiRuntimeAdapter);
+  });
+
+  it('dispatches PhilosopherRunner (not DreamerRunner) when a philosopher task is ready under full-chain scope', async () => {
+    // internalization_full_chain is a core flag (default ON) — the auto-consumer
+    // must advance past dreamer to philosopher when a philosopher task's
+    // dependencies are satisfied. EP-02: proves the new dispatch path actually
+    // reaches PhilosopherRunner (not just dreamer).
+    const db = new Database(dbPath);
+    const now = new Date().toISOString();
+    const dreamerDiag = JSON.stringify({ pi_metadata: { dependencyTaskIds: [], channel: 'prompt', timeoutMs: 300000, inputArtifactRefs: [], outputArtifactRefs: [] } });
+    const philDiag = JSON.stringify({ pi_metadata: { dependencyTaskIds: ['dreamer-dep-1'], channel: 'prompt', timeoutMs: 300000, inputArtifactRefs: [], outputArtifactRefs: [] } });
+    db.prepare(`INSERT INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json, created_at, updated_at, result_ref) VALUES (?, 'dreamer', 'succeeded', 1, 3, ?, ?, ?, 'dreamer://run_dreamer-dep-1_1')`)
+      .run('dreamer-dep-1', dreamerDiag, now, now);
+    db.prepare(`INSERT INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json, created_at, updated_at) VALUES (?, 'philosopher', 'pending', 0, 3, ?, ?, ?)`)
+      .run('philosopher-task-1', philDiag, now, now);
+    db.close();
+
+    let philosopherRunCalled = false;
+    vi.spyOn(PhilosopherRunner.prototype, 'run').mockImplementation(async () => {
+      philosopherRunCalled = true;
+      return { status: 'succeeded', runId: 'mock-phil', artifactId: 'mock-phil-art', resultRef: 'philosopher://mock' };
+    });
+    vi.spyOn(DreamerRunner.prototype, 'run').mockImplementation(async () => {
+      throw new Error('DreamerRunner must not run when only a philosopher task is ready');
+    });
+
+    const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    // commitNextTaskProposal may throw on the sparse fixture (mock artifactId not
+    // in pi_artifacts); we assert the dispatch signal, not the commit side-effect.
+    try { await runConsumerCycle(workspaceDir, mockLogger); } catch { /* see comment above */ }
+
+    expect(philosopherRunCalled).toBe(true);
+  });
+
+  it('does NOT advance past dreamer when internalization_full_chain is disabled (flag-off rollback)', async () => {
+    // Rewrite config to explicitly disable the core flag — auto-consumer must
+    // revert to dreamer-only scope (DEFAULT_CONSUMER_RUNNER_KINDS), so a ready
+    // philosopher task is never dispatched. EP-03: rollback path is observable.
+    const configPath = path.join(workspaceDir, '.pd', 'config.yaml');
+    const config = {
+      version: 1,
+      features: {
+        internalization_auto_consumer: { category: 'quiet', enabled: true },
+        internalization_full_chain: { category: 'core', enabled: false },
+      },
+      runtimeProfiles: { 'openclaw.default': { type: 'openclaw', source: 'default' } },
+      internalAgents: { defaultRuntime: 'openclaw.default', agents: { dreamer: { enabled: true } } },
+    };
+    fs.writeFileSync(configPath, yaml.dump(config, { schema: yaml.JSON_SCHEMA }), 'utf8');
+
+    const db = new Database(dbPath);
+    const now = new Date().toISOString();
+    const dreamerDiag = JSON.stringify({ pi_metadata: { dependencyTaskIds: [], channel: 'prompt', timeoutMs: 300000, inputArtifactRefs: [], outputArtifactRefs: [] } });
+    const philDiag = JSON.stringify({ pi_metadata: { dependencyTaskIds: ['dreamer-dep-2'], channel: 'prompt', timeoutMs: 300000, inputArtifactRefs: [], outputArtifactRefs: [] } });
+    db.prepare(`INSERT INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json, created_at, updated_at, result_ref) VALUES (?, 'dreamer', 'succeeded', 1, 3, ?, ?, ?, 'dreamer://run_dreamer-dep-2_1')`)
+      .run('dreamer-dep-2', dreamerDiag, now, now);
+    db.prepare(`INSERT INTO tasks (task_id, task_kind, status, attempt_count, max_attempts, diagnostic_json, created_at, updated_at) VALUES (?, 'philosopher', 'pending', 0, 3, ?, ?, ?)`)
+      .run('philosopher-task-2', philDiag, now, now);
+    db.close();
+
+    let philosopherRunCalled = false;
+    vi.spyOn(PhilosopherRunner.prototype, 'run').mockImplementation(async () => {
+      philosopherRunCalled = true;
+      return { status: 'succeeded', runId: 'mock-phil', artifactId: 'mock-phil-art', resultRef: 'philosopher://mock' };
+    });
+
+    const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    try { await runConsumerCycle(workspaceDir, mockLogger); } catch { /* sparse fixture */ }
+
+    // flag-off → runnerKinds = ['dreamer'] only → philosopher never dispatched
+    expect(philosopherRunCalled).toBe(false);
   });
 });

--- a/packages/pd-cli/src/index.ts
+++ b/packages/pd-cli/src/index.ts
@@ -539,7 +539,7 @@ runtimeHealthCmd
   });
 
 const internalizationCmd = runtimeCmd
-  .command('internalization', { hidden: true })
+  .command('internalization')
   .description('Internalization Engine operator visibility');
 
 internalizationCmd

--- a/packages/pd-cli/tests/commands/cli-help-snapshot.test.ts
+++ b/packages/pd-cli/tests/commands/cli-help-snapshot.test.ts
@@ -86,7 +86,6 @@ describe('PRI-455: pd runtime --help shows only MVP owner subcommands', () => {
     'canary',
     'synthetic',
     'uat',
-    'internalization',
     'recovery',
     'pruning',
     'diagnostics',

--- a/packages/pd-cli/tests/commands/runtime-internalization.test.ts
+++ b/packages/pd-cli/tests/commands/runtime-internalization.test.ts
@@ -46,8 +46,8 @@ describe('CLI command tree: pd runtime internalization', () => {
     expect(output).toContain('--json');
   });
 
-  it('runtime subcommand list does NOT include internalization (PRI-455: hidden from --help)', () => {
+  it('runtime subcommand list includes internalization (PRI-419 amendment: un-hidden for operator visibility)', () => {
     const output = runPdHelp(['runtime', '--help']);
-    expect(output).not.toMatch(/internalization\s/);
+    expect(output).toMatch(/internalization\s/);
   });
 });

--- a/packages/pd-console/src/ui/utils/agent-metadata.ts
+++ b/packages/pd-console/src/ui/utils/agent-metadata.ts
@@ -305,25 +305,25 @@ export const AGENT_METADATA: Record<InternalAgentName, AgentMeta> = {
     roleZh: '原则生效前的最后一道审查',
     roleEn: 'Final review before a principle goes live',
     detailZh:
-      '评估员通过后，上线评审员做最终把关——评估上线风险、安全检查，决定是否真的推向 rollout。\n\n它本就是 MVP-Quiet 默认关闭的，关掉不影响任何功能。',
+      '评估员通过后，上线评审员做最终把关——评估上线风险、安全检查，决定是否真的推向 rollout。\n\n它在 MVP_CORE_TASK_KINDS 白名单中（队列可见），但 auto-consumer 不会自动推进它——作为原则进入 approval 队列前的最后一道人工关，由 Owner 手动触发。',
     detailEn:
-      'After the Evaluator passes, the Rollout Reviewer does the final gate — assessing rollout risks and safety checks, deciding whether to actually push to rollout.\n\nIt is already MVP-Quiet (off by default); disabling does not affect any functionality.',
+      'After the Evaluator passes, the Rollout Reviewer does the final gate — assessing rollout risks and safety checks, deciding whether to actually push to rollout.\n\nIt is in the MVP_CORE_TASK_KINDS whitelist (visible in the queue), but the auto-consumer does NOT advance it — it is the last manual Owner gate before the approval queue, triggered by hand.',
     impactLevel: 'green',
-    impactZh: '无影响。本就是 MVP-Quiet 默认关闭。',
-    impactEn: 'No impact. Already MVP-Quiet (off by default).',
+    impactZh: '手动触发的最后关。不被 auto-consumer 自动消费。',
+    impactEn: 'Manual last gate. Not auto-consumed by the auto-consumer.',
     techDetailZh: {
-      'MVP 状态': 'MVP-Quiet。不在 `MVP_CORE_TASK_KINDS` 白名单中。',
+      'MVP 状态': 'MVP-Core（手动）。在 `MVP_CORE_TASK_KINDS` 中，但不被 auto-consumer 自动推进——由 Owner 手动触发（`pd runtime internalization run-once --runner rollout_reviewer`）。',
       '输出': '`RolloutReviewerOutputV1` · approve_rollout / needs_revision / reject + rolloutRisks + safetyChecks',
       '实现': '唯一不继承 `BasePeerRunner` 的 peer runner',
     },
     techDetailEn: {
-      'MVP status': 'MVP-Quiet. Not in the `MVP_CORE_TASK_KINDS` whitelist.',
+      'MVP status': 'MVP-Core (manual). In `MVP_CORE_TASK_KINDS`, but NOT auto-advanced — triggered by hand (pd runtime internalization run-once --runner rollout_reviewer).',
       'Output': '`RolloutReviewerOutputV1` · approve_rollout / needs_revision / reject + rolloutRisks + safetyChecks',
       'Implementation': 'The only peer runner that does not extend `BasePeerRunner`',
     },
-    isCore: false,
-    mvpNoteZh: 'MVP-Quiet。不在 MVP_CORE_TASK_KINDS 白名单中。',
-    mvpNoteEn: 'MVP-Quiet. Not in the MVP_CORE_TASK_KINDS whitelist.',
+    isCore: true,
+    mvpNoteZh: 'MVP-Core（手动触发）。在白名单中但不被 auto-consumer 自动消费。',
+    mvpNoteEn: 'MVP-Core (manual trigger). In the whitelist but not auto-consumed.',
   },
 
   correctionObserver: {

--- a/packages/pd-console/tests/ui/agent-metadata.test.ts
+++ b/packages/pd-console/tests/ui/agent-metadata.test.ts
@@ -103,6 +103,7 @@ describe("AGENT_METADATA: isCore assignment", () => {
       "scribe",
       "artificer",
       "evaluator",
+      "rolloutReviewer",
       "correctionObserver",
       "empathyObserver",
     ];
@@ -112,7 +113,7 @@ describe("AGENT_METADATA: isCore assignment", () => {
   });
 
   it("isCore=false for optional agents (MVP-Quiet, direct toggle)", () => {
-    const optionalAgents = ["philosopher", "rolloutReviewer"];
+    const optionalAgents = ["philosopher"];
     for (const name of optionalAgents) {
       expect(AGENT_METADATA[name].isCore).toBe(false);
     }

--- a/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
+++ b/packages/principles-core/src/runtime-v2/feature-flags/feature-flag-contract.ts
@@ -98,6 +98,18 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlagDefinition[] = [
   { id: 'correction_observer', category: 'quiet', enabled: false, since: '2026-06-02', description: 'Optional LLM optimization service for correction keywords; synchronous correction detection remains active independently' },
   { id: 'signal_collector', category: 'quiet', enabled: false, since: '2026-06-30', description: 'Unified signal collection host (correction + empathy upstream merge). NOTE: keyword detection (high-precision phrases) runs regardless of this flag; this flag only gates the LLM deep-judgment path (ambiguous terms / missed keywords). Quiet flag: dogfood-only until validated.' },
   { id: 'internalization_auto_consumer', category: 'quiet', enabled: true, since: '2026-06-13', description: 'Bounded auto-consumer for dreamer internalization tasks — prevents ready tasks from pending forever (PRI-381; quiet flag, default on, disableable via config)' },
+  // PRI-419 amendment: internalization auto-consumer full-chain scope.
+  // Extends auto-consumer advancement from dreamer-only to the full peer-runner
+  // chain (dreamer→philosopher→scribe→artificer→evaluator) so artifacts reach
+  // validation_status='validated' unattended. rollout_reviewer is deliberately
+  // EXCLUDED — it stays a manual Owner gate before the approval queue
+  // (advanced via `pd runtime internalization run-once --runner rollout_reviewer`).
+  // Maintainer-approved MVP-Core (2026-08-12): default ON. Roll back = set
+  // enabled: false in .pd/config.yaml → auto-consumer reverts to dreamer-only
+  // (DEFAULT_CONSUMER_RUNNER_KINDS). The scope sets are independent: see
+  // FULL_CHAIN_CONSUMER_RUNNER_KINDS vs DEFAULT_CONSUMER_RUNNER_KINDS in
+  // internalization-consumer-decision.ts.
+  { id: 'internalization_full_chain', category: 'core', enabled: true, since: '2026-08-12', description: 'PRI-419 amendment: auto-consumer advances dreamer→…→evaluator (full chain) so artifacts reach validated. rollout_reviewer stays manual. Default ON; flag-off = dreamer-only.' },
   // PRI-408: Story A approval-completion orchestrator. Replaces the demo direct-writer
   // activation path with a formal ApprovalCompletionService that validates approval state,
   // enforces idempotency, and dispatches via ActivationDispatcher with rolloutDecision='approved'.

--- a/packages/principles-core/src/runtime-v2/index.ts
+++ b/packages/principles-core/src/runtime-v2/index.ts
@@ -1084,6 +1084,7 @@ export {
   computeConsumerDecision,
   DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE,
   DEFAULT_CONSUMER_RUNNER_KINDS,
+  FULL_CHAIN_CONSUMER_RUNNER_KINDS,
 } from './internalization/internalization-consumer-decision.js';
 export type {
   ConsumerDecision,

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/c2-live-runner-chain.test.ts
@@ -385,22 +385,32 @@ describe('PRI-457 C2-P0: Live MVP runner chain pinning test', () => {
     expect(agents.agents.rolloutReviewer.enabled).toBe(false);
   });
 
-  // ── MVP_CORE_TASK_KINDS excludes rollout_reviewer ─────────────────────────
+  // ── MVP_CORE_TASK_KINDS includes rollout_reviewer (manual-gate kind) ────────
 
-  it('MVP_CORE_TASK_KINDS excludes rollout_reviewer', async () => {
+  it('MVP_CORE_TASK_KINDS includes all 6 peer-runner kinds (rollout_reviewer = manual gate)', async () => {
     const { MVP_CORE_TASK_KINDS } = await import('../queue-actionability.js');
     expect(MVP_CORE_TASK_KINDS).toContain('dreamer');
     expect(MVP_CORE_TASK_KINDS).toContain('philosopher');
     expect(MVP_CORE_TASK_KINDS).toContain('scribe');
     expect(MVP_CORE_TASK_KINDS).toContain('artificer');
     expect(MVP_CORE_TASK_KINDS).toContain('evaluator');
-    expect(MVP_CORE_TASK_KINDS).not.toContain('rollout_reviewer');
+    expect(MVP_CORE_TASK_KINDS).toContain('rollout_reviewer');
   });
 
-  // ── DEFAULT_CONSUMER_RUNNER_KINDS is dreamer-only ────────────────────────
+  // ── DEFAULT_CONSUMER_RUNNER_KINDS is dreamer-only (flag-off rollback) ──────
 
-  it('DEFAULT_CONSUMER_RUNNER_KINDS is dreamer-only', async () => {
+  it('DEFAULT_CONSUMER_RUNNER_KINDS is dreamer-only (flag-off rollback default)', async () => {
     const { DEFAULT_CONSUMER_RUNNER_KINDS } = await import('../internalization-consumer-decision.js');
     expect(DEFAULT_CONSUMER_RUNNER_KINDS).toEqual(['dreamer']);
+  });
+
+  // ── FULL_CHAIN_CONSUMER_RUNNER_KINDS (flag-on scope) excludes rollout_reviewer ─
+
+  it('FULL_CHAIN_CONSUMER_RUNNER_KINDS advances dreamer→…→evaluator and excludes rollout_reviewer', async () => {
+    const { FULL_CHAIN_CONSUMER_RUNNER_KINDS } = await import('../internalization-consumer-decision.js');
+    expect(FULL_CHAIN_CONSUMER_RUNNER_KINDS).toEqual([
+      'dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator',
+    ]);
+    expect(FULL_CHAIN_CONSUMER_RUNNER_KINDS).not.toContain('rollout_reviewer');
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-consumer-decision.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/internalization-consumer-decision.test.ts
@@ -3,6 +3,7 @@ import {
   computeConsumerDecision,
   DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE,
   DEFAULT_CONSUMER_RUNNER_KINDS,
+  FULL_CHAIN_CONSUMER_RUNNER_KINDS,
 } from '../internalization-consumer-decision.js';
 
 describe('computeConsumerDecision', () => {
@@ -261,5 +262,34 @@ describe('computeConsumerDecision — boundary conditions', () => {
       maxTasksPerCycle: 5,
     });
     expect(equal.maxTasksPerCycle).toBe(5);
+  });
+
+  it('honors explicit runnerKinds override (full-chain scope)', () => {
+    // The auto-consumer service passes FULL_CHAIN_CONSUMER_RUNNER_KINDS when
+    // internalization_full_chain is ON; the decision echoes it back so the
+    // wake-loop advances dreamer→…→evaluator instead of dreamer-only.
+    const fullChain = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 3,
+      runnerKinds: FULL_CHAIN_CONSUMER_RUNNER_KINDS,
+    });
+    expect(fullChain.shouldConsume).toBe(true);
+    expect(fullChain.runnerKinds).toEqual(FULL_CHAIN_CONSUMER_RUNNER_KINDS);
+    expect(fullChain.runnerKinds).not.toContain('rollout_reviewer');
+
+    // No-ready-tasks path also echoes the override (used in SKIP telemetry).
+    const noTasks = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 0,
+      runnerKinds: FULL_CHAIN_CONSUMER_RUNNER_KINDS,
+    });
+    expect(noTasks.runnerKinds).toEqual(FULL_CHAIN_CONSUMER_RUNNER_KINDS);
+
+    // Omitting runnerKinds falls back to dreamer-only (flag-off rollback).
+    const defaulted = computeConsumerDecision({
+      autoConsumerEnabled: true,
+      readyTaskCount: 3,
+    });
+    expect(defaulted.runnerKinds).toEqual(['dreamer']);
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/__tests__/queue-actionability.test.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/__tests__/queue-actionability.test.ts
@@ -11,6 +11,15 @@ describe('classifyTaskActionability', () => {
     enabledChannels: new Set(['prompt', 'code_tool_hook', 'defer_archive']),
     actionableTaskKinds: new Set(MVP_CORE_TASK_KINDS),
   };
+  // Policy that deliberately excludes rollout_reviewer. Used to exercise the
+  // task_kind_not_mvp_actionable suppression PATH independently of the
+  // MVP_CORE_TASK_KINDS constant contents (rollout_reviewer was promoted into
+  // the constant as a manual-gate kind; the suppression logic itself is
+  // unchanged and must still be covered by a test).
+  const rolloutExcludedPolicy: ActionabilityPolicyInput = {
+    enabledChannels: new Set(['prompt', 'code_tool_hook', 'defer_archive']),
+    actionableTaskKinds: new Set(['dreamer', 'philosopher', 'scribe', 'artificer', 'evaluator']),
+  };
 
   it('classifies enabled-channel MVP-Core dreamer as actionable', () => {
     const result = classifyTaskActionability(
@@ -49,10 +58,10 @@ describe('classifyTaskActionability', () => {
     expect(result.diagnostic.channel).toBe('skill');
   });
 
-  it('suppresses rollout_reviewer task with task_kind_not_mvp_actionable reason', () => {
+  it('suppresses a kind excluded from actionableTaskKinds with task_kind_not_mvp_actionable reason', () => {
     const result = classifyTaskActionability(
       { taskId: 'rollout-abc-prompt', taskKind: 'rollout_reviewer', channel: 'prompt' },
-      defaultPolicy,
+      rolloutExcludedPolicy,
     );
     expect(result.actionable).toBe(false);
     if (result.actionable) throw new Error('expected not actionable');
@@ -90,7 +99,7 @@ describe('classifyTaskActionability', () => {
   it('preserves taskId, taskKind, channel, status in suppressed diagnostic', () => {
     const result = classifyTaskActionability(
       { taskId: 'rr-abc-prompt', taskKind: 'rollout_reviewer', channel: 'prompt' },
-      defaultPolicy,
+      rolloutExcludedPolicy,
     );
     if (result.actionable) throw new Error('expected not actionable');
     const d: SuppressedDiagnostic = result.diagnostic;
@@ -110,7 +119,7 @@ describe('MVP_CORE_TASK_KINDS constant', () => {
     expect(MVP_CORE_TASK_KINDS).toContain('evaluator');
   });
 
-  it('does not include post-MVP runners', () => {
-    expect(MVP_CORE_TASK_KINDS).not.toContain('rollout_reviewer');
+  it('includes rollout_reviewer (manual-gate kind — visible in queue, not auto-consumed)', () => {
+    expect(MVP_CORE_TASK_KINDS).toContain('rollout_reviewer');
   });
 });

--- a/packages/principles-core/src/runtime-v2/internalization/internalization-consumer-decision.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/internalization-consumer-decision.ts
@@ -1,7 +1,31 @@
 import type { RunnerKind } from './peer-runner-contracts.js';
 
 export const DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE = 1;
+
+/**
+ * Auto-consume scope when the `internalization_full_chain` flag is OFF.
+ * Dreamer-only (PRI-419 original scope). Kept as the rollback default so
+ * disabling the flag immediately restores the prior behavior.
+ */
 export const DEFAULT_CONSUMER_RUNNER_KINDS: readonly RunnerKind[] = ['dreamer'] as const;
+
+/**
+ * Auto-consume scope when the `internalization_full_chain` flag is ON.
+ * Advances dreamer → philosopher → scribe → artificer → evaluator so artifacts
+ * reach `validation_status='validated'` unattended.
+ *
+ * `rollout_reviewer` is deliberately EXCLUDED: it stays a manual Owner trigger
+ * (the last human gate before a principle enters the approval queue). Manual
+ * advancement via `pd runtime internalization run-once --runner rollout_reviewer`
+ * is unaffected (run-once bypasses actionability).
+ */
+export const FULL_CHAIN_CONSUMER_RUNNER_KINDS: readonly RunnerKind[] = [
+  'dreamer',
+  'philosopher',
+  'scribe',
+  'artificer',
+  'evaluator',
+] as const;
 
 export interface ConsumerDecision {
   shouldConsume: boolean;
@@ -15,10 +39,19 @@ export interface ConsumerDecisionInput {
   autoConsumerEnabled: boolean;
   readyTaskCount: number;
   maxTasksPerCycle?: number;
+  /**
+   * Override the auto-consume runner-kind scope. When omitted, falls back to
+   * DEFAULT_CONSUMER_RUNNER_KINDS (dreamer-only). The auto-consumer service
+   * resolves this from the `internalization_full_chain` flag:
+   *   flag ON  → FULL_CHAIN_CONSUMER_RUNNER_KINDS
+   *   flag OFF → DEFAULT_CONSUMER_RUNNER_KINDS
+   */
+  runnerKinds?: readonly RunnerKind[];
 }
 
 export function computeConsumerDecision(input: ConsumerDecisionInput): ConsumerDecision {
   const maxTasks = input.maxTasksPerCycle ?? DEFAULT_CONSUMER_MAX_TASKS_PER_CYCLE;
+  const runnerKinds = input.runnerKinds ?? DEFAULT_CONSUMER_RUNNER_KINDS;
 
   if (!input.autoConsumerEnabled) {
     return {
@@ -35,7 +68,7 @@ export function computeConsumerDecision(input: ConsumerDecisionInput): ConsumerD
     return {
       shouldConsume: false,
       maxTasksPerCycle: maxTasks,
-      runnerKinds: DEFAULT_CONSUMER_RUNNER_KINDS,
+      runnerKinds,
       reason: 'no_ready_tasks',
     };
   }
@@ -43,6 +76,6 @@ export function computeConsumerDecision(input: ConsumerDecisionInput): ConsumerD
   return {
     shouldConsume: true,
     maxTasksPerCycle: Math.min(maxTasks, input.readyTaskCount),
-    runnerKinds: DEFAULT_CONSUMER_RUNNER_KINDS,
+    runnerKinds,
   };
 }

--- a/packages/principles-core/src/runtime-v2/internalization/queue-actionability.ts
+++ b/packages/principles-core/src/runtime-v2/internalization/queue-actionability.ts
@@ -14,12 +14,24 @@ import type { RunnerKind, PeerRunnerKind, InternalizationChannel } from './peer-
 
 // ── MVP-Core task kinds ──────────────────────────────────────────────────────
 
+/**
+ * Task kinds considered operator-actionable: visible as `ready` (not
+ * `suppressed`) in the queue snapshot and counted toward `readyTaskCount`.
+ *
+ * `rollout_reviewer` is included so operators can see pending rollout-review
+ * tasks and advance them manually (`pd runtime internalization run-once
+ * --runner rollout_reviewer`). It is NOT auto-consumed — the auto-consumer's
+ * execution scope is governed independently by FULL_CHAIN_CONSUMER_RUNNER_KINDS
+ * (internalization-consumer-decision.ts), which deliberately excludes it,
+ * keeping rollout review as the last manual Owner gate before approval.
+ */
 export const MVP_CORE_TASK_KINDS: readonly PeerRunnerKind[] = [
   'dreamer',
   'philosopher',
   'scribe',
   'artificer',
   'evaluator',
+  'rollout_reviewer',
 ] as const;
 
 // ── Types ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 产品意图（agent 填，owner 确认）
- 对应 Linear issue: 无（owner-direct；建议 follow-up 开 Linear 跟踪 PRI-419 amendment）
- 解决的产品问题（一句话）: internalization 链冻结在 dreamer 之后，真实原则永远到不了激活，PD 核心价值（行为内化）事实失效
- emotional-value：降低【失控感/不信任感】（"原则怎么永远不生效"），创造【掌控感/沉淀感】（链自动跑到 evaluator，rollout_reviewer 留给我把关）
  - 规则引用: `mvp-q-4-emotional-value`

## 变更概览（agent 填）
### 变更类型
- [x] ✨ 新功能

### 高层变更
- auto-consumer 从 dreamer-only 扩到 dreamer→evaluator 全链（新 flag `internalization_full_chain`, core/default-on）
- `rollout_reviewer` 进入 `MVP_CORE_TASK_KINDS`（队列可见），但仍排除在自动消费外（`FULL_CHAIN_CONSUMER_RUNNER_KINDS` 不含它）——保留为"进 approval 队列前的手动关"
- auto-consumer dispatch 按租到的 taskKind 分发（dreamer/philosopher/scribe/artificer/evaluator）；evaluator 用基础构造（repair loop 仍由 PRI-509 独立 quiet flag 控制，作为 follow-up）
- `pd runtime internalization` 命令树取消 `hidden`（operator 可见）

### 影响范围
- [x] packages/principles-core
- [x] packages/openclaw-plugin
- [x] packages/pd-cli
- [x] packages/pd-console

### 是否触及产品边界
- [x] 是（MVP-Core 扩展：auto-consumer 范围 + rollout_reviewer 入 MVP_CORE + core/default-on flag）。maintainer 已批准（owner 选"渐进"方案 + "默认开启 + 划拨 MVP"）

## 验证步骤（agent 填，owner 执行）
- [ ] 前置条件: PR 合并后，重新构建 openclaw plugin 并同步到 `~/.openclaw/extensions/principles-disciple/`，重启 openclaw
- [ ] 动作 1: 在 openclaw 对话触发一个 pain（`pd pain record ...`）
  - 观察: SYSTEM 日志依次出现 `INTERNALIZATION_CONSUMER_RUN` 的 taskKind = dreamer→philosopher→scribe→artificer→evaluator（每 ~2min 一步），`pi_artifacts` 出现新 `validation_status='validated'`
- [ ] 动作 2: `pd runtime internalization queue -w <ws>`
  - 观察: rollout_reviewer 任务显示在 ready（不再 `suppressed`/`task_kind_not_mvp_actionable`）
- [ ] 动作 3: `pd runtime internalization run-once --runner rollout_reviewer`（手动推进最后关）
  - 观察: 任务进入 approval queue（`pd approval list` 可见）
- 证据: 实测把卡住的 9189466b 链 philosopher→evaluator 全跑通；历史数据证明 validated→approved→activated→rolled-back 闭环

## 风险与可逆性（agent 填）
- 主要风险: (1) SenseNova 配额——每个 pain 触发最多 5 次 LLM（dreamer→evaluator）×重试；(2) 原则产出速度增加（evaluator 质量门 needs_revision 是天然闸门）
- 回滚方式: [x] feature flag —— `.pd/config.yaml` 设 `internalization_full_chain: { enabled: false }` 立即回 dreamer-only
- 是否需要 feature flag: [x] 是（名称: `internalization_full_chain`）。规则引用: `mvp-q-3-how-disabled`

### MVP 三问自答
- `mvp-q-1-what-if-skip`: 30 天后 Owner 会再次抱怨"原则没生效"——链冻结是反复出现的痛点
- `mvp-q-2-how-observed`: SYSTEM 日志 INTERNALIZATION_CONSUMER_RUN 的 taskKind + pi_artifacts.validation_status + pd runtime internalization queue
- `mvp-q-4-emotional-value`: 见产品意图

## 技术自检（agent 填）
- [x] 代码符合项目风格
- [x] 无破坏性变更（flag-off 行为回退到 dreamer-only）
- [x] Core 边界检查: 本 PR 未在 `principles-core/src/` 新增 `fs`/`path` 导入（consumer-decision / queue-actionability / feature-flag-contract 都是纯逻辑/常量）。规则引用: `antipattern-core-io` —— N/A
- [x] Core Store 契约变更审计: N/A（未修改 `sqlite-*-store.ts`）

### ERR 考量
- **EP-02（production path wiring）**: auto-consumer dispatch mirror `run-once.ts` 的 runner 构造；新增 dispatch 测试证明 full-chain on→PhilosopherRunner 调用、off→不调用。新 core flag default-on，受影响测试（queue-actionability / c2-live-runner-chain）已更新断言
- **EP-03（fail loud）**: dispatch switch 的 default 分支显式 log `no_runner_for_kind` + return（不静默）；循环 wakeOnce 失败走既有 `INTERNALIZATION_CONSUMER_TASK_FAILED` 日志
- **EP-04（CLI）**: 去 hidden 是可见性改动（不改行为/flag），用 live help 验证（`runtime --help` 现显示 internalization）。internalization 命令在 index.ts 内联注册（无 helper），未抽 helper 做单测（超范围）
- **EP-07（runtime state source）**: runnerKinds 单一来源（flag→service→decision），不混线
- **EP-10（flag-flip re-route）: 新 flag default-on，受影响测试已更新；runtime-v2 单独 285 文件 0 error**

## 测试
- principles-core: 全量 7115 passed（runtime-v2 单独 6235 passed / 0 error；全量 2 个 worker-exit error 经验证来自 runtime-v2 之外、非本 PR 引起——符合 ERR-078 验证要求）
- openclaw-plugin: 全量 2280 passed（含新增 dispatch 测试 4 case）
- 受影响测试: queue-actionability(11) / c2-live-runner-chain(9) / internalization-consumer-decision(19) / internalization-queue-read-model(24) / auto-consumer-service(4)
- lint: 改动文件 eslint exit 0
- build: core / openclaw-plugin / pd-cli / pd-console 全 tsc 通过

## 自评修正（实现中发现并修正的计划缺口）
- 计划原写 evaluator 用 `createEvaluatorRunnerDeps`、scribe 用 `readOutputLanguageFromWorkspace`——核实发现两者都是 **pd-cli 专属**，openclaw-plugin 无法导入。修正：evaluator 改用基础 `EvaluatorRunner` 构造（repair loop 字段可选，走 legacy path，repair loop 由 PRI-509 独立 flag 作为 follow-up）；scribe 不传 outputLanguage（live config 未设该字段，与 run-once 行为一致）

## 部署 follow-up（PR 合并后）
1. `cd packages/openclaw-plugin && npm run build`
2. 同步 dist 到 `~/.openclaw/extensions/principles-disciple/`（或重装 plugin）
3. （可选）live `.pd/config.yaml` 显式注册 `internalization_full_chain: { category: core, enabled: true }`（不注册也靠默认 on 生效；注册便于 operator 可见/可关）
4. 重启 openclaw，观察 SYSTEM 日志确认全链推进

## BDD 影响评估
- [ ] 本 PR 未修改 MVP-Core 用户旅程的可观察结果（链路行为是"从冻结变为自动推进"，无 .feature 契约断言"dreamer-only"或"rollout_reviewer suppressed"；queue-actionability 单测已更新）
- [ ] 未删除任何 .feature 文件
