### PR TITLE
fix(ci): remove redundant npm ci that breaks workspace symlinks in create-principles-disciple build

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -215,7 +215,7 @@ jobs:
             npm run build --workspace=principles-disciple
             npm run build --workspace=@principles/pd-cli
             npm run build --workspace=@principles/pd-console
-            cd packages/create-principles-disciple && npm ci && npm run build
+            cd packages/create-principles-disciple && npm run build
           fi
 
       - name: Verify package dry-run


### PR DESCRIPTION
## Root Cause

Running `npm ci` inside `packages/create-principles-disciple/` destroys the root `node_modules/@principles/core` workspace symlink. Without the symlink, `tsc` cannot resolve `@principles/core/host` exports → TS2307 build failure on every `create-principles-disciple` publish since PR #1298 (Codex host adapter).

## Fix

Removed the redundant `npm ci` from the subdirectory build step. The root-level `npm ci --ignore-scripts` (line 200) already installs all workspace dependencies and creates the symlinks.

## Verification

Reproduced locally: `npm ci` inside the subdirectory → symlink destroyed → `tsc` fails. Without it → `tsc` succeeds (exit 0).

## Impact

This has been blocking ALL `create-principles-disciple` publishes since the Codex host adapter was merged. Fixing it unblocks the full update feature distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **构建与发布**
  * 优化发布流程，构建指定软件包时不再重复安装依赖，改为直接执行构建命令。
  * 提升发布流程的执行效率与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->