### PR TITLE
fix(ci): use build:production for plugin when bundling installer

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -212,7 +212,7 @@ jobs:
           elif [ "$PKG_DIR" = "pd-cli" ]; then
             npm run build --workspace=@principles/pd-cli
           elif [ "$PKG_DIR" = "create-principles-disciple" ]; then
-            npm run build --workspace=principles-disciple
+            npm run build:production --workspace=principles-disciple
             npm run build --workspace=@principles/pd-cli
             npm run build --workspace=@principles/pd-console
             cd packages/create-principles-disciple && npm run build


### PR DESCRIPTION
bundle-plugin.mjs requires dist/bundle.js which is produced by esbuild (build:production), not tsc (build). Previous workflow only ran tsc, so bundle.js was missing.