### PR TITLE
fix(ci): run tsc + esbuild for plugin when building installer

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -212,7 +212,7 @@ jobs:
           elif [ "$PKG_DIR" = "pd-cli" ]; then
             npm run build --workspace=@principles/pd-cli
           elif [ "$PKG_DIR" = "create-principles-disciple" ]; then
-            npm run build:production --workspace=principles-disciple
+            npm run build --workspace=principles-disciple && npm run build:production --workspace=principles-disciple
             npm run build --workspace=@principles/pd-cli
             npm run build --workspace=@principles/pd-console
             cd packages/create-principles-disciple && npm run build


### PR DESCRIPTION
tsc produces .d.ts type declarations (needed by pd-cli imports). esbuild produces dist/bundle.js (needed by bundle-plugin.mjs). Both are required — previous fix only ran esbuild.