### PR TITLE
feat(update): single update button + what's new changelog

### DIFF
--- a/packages/pd-console/src/server/routes/update.ts
+++ b/packages/pd-console/src/server/routes/update.ts
@@ -237,26 +237,39 @@ async function doCheckForUpdates(currentVersion: string) {
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const rawData: unknown = await response.json();
-      if (typeof rawData !== 'object' || rawData === null) throw new Error('Invalid registry response');
-      const data = rawData as Record<string, unknown>;
-      if (typeof data.version !== 'string') throw new Error('Invalid registry response: missing version');
-      latestVersion = data.version;
+      if (!isRecord(rawData)) throw new Error('Invalid registry response');
+      if (typeof rawData.version !== 'string') throw new Error('Invalid registry response: missing version');
+      latestVersion = rawData.version;
     } finally {
       clearTimeout(timeoutId);
     }
+
+    // Fetch release notes from GitHub for the latest version (best-effort,
+    // non-blocking — if it fails, the UI still shows version info without notes).
+    let changelog = '';
+    try {
+      const ghResponse = await fetch(
+        `https://api.github.com/repos/csuzngjh/principles/releases/tags/v${latestVersion}`,
+        { signal: AbortSignal.timeout(5000), headers: { Accept: 'application/vnd.github.v3+json' } },
+      );
+      if (ghResponse.ok) {
+        const ghData: unknown = await ghResponse.json();
+        if (isRecord(ghData) && typeof ghData.body === 'string') {
+          changelog = ghData.body;
+        }
+      }
+    } catch { /* best-effort — changelog is optional */ }
+
     return {
       hasUpdate: semver.gt(latestVersion, currentVersion),
       currentVersion,
       latestVersion,
+      changelog,
     };
   } catch (error) {
     return {
       hasUpdate: false,
       currentVersion,
-      // Contract with the UI (UpdatePage.tsx) requires latestVersion to be a
-      // string. When the registry check fails we don't know the latest version,
-      // so emit an empty string to keep the response shape stable and let the
-      // UI surface `error` instead of crashing the whole page.
       latestVersion: '',
       error: error instanceof Error ? error.message : 'Unknown error',
     };

--- a/packages/pd-console/src/ui/i18n/en.json
+++ b/packages/pd-console/src/ui/i18n/en.json
@@ -863,9 +863,10 @@
       "applyFullUpdate": "Full Update",
       "fullUpdating": "Full update in progress…",
       "fullUpdateSuccess": "Full update completed.",
-      "confirmFullUpdateTitle": "Confirm Full Update",
+      "confirmFullUpdateTitle": "Confirm Update",
       "confirmFullUpdateDesc": "Downloads and updates all PD packages (plugin, console, core, CLI). Usually takes just a few seconds. Your custom files (AGENTS.md etc.) are not affected. You will need to restart the console after completion.",
-      "fullUpdateRestartPrompt": "Full update complete. Please restart the console to load the new version: press Ctrl+C, then run pd console again."
+      "fullUpdateRestartPrompt": "Update complete. Please restart the console to load the new version: press Ctrl+C, then run pd console again.",
+      "whatsNew": "What's New"
     },
     "intent": {
       "eyebrow": "Owner Intent",

--- a/packages/pd-console/src/ui/i18n/zh-CN.json
+++ b/packages/pd-console/src/ui/i18n/zh-CN.json
@@ -863,9 +863,10 @@
       "applyFullUpdate": "全量更新",
       "fullUpdating": "全量更新中…",
       "fullUpdateSuccess": "全量更新完成。",
-      "confirmFullUpdateTitle": "确认全量更新",
+      "confirmFullUpdateTitle": "确认更新",
       "confirmFullUpdateDesc": "将下载并更新全部 PD 代码包（插件、控制台、核心、CLI）。通常只需几秒钟。你自定义的文件（AGENTS.md 等）不受影响。更新完成后需要重启控制台。",
-      "fullUpdateRestartPrompt": "全量更新已完成。请重启控制台以加载新版本：按 Ctrl+C 停止，然后重新运行 pd console。"
+      "fullUpdateRestartPrompt": "更新已完成。请重启控制台以加载新版本：按 Ctrl+C 停止，然后重新运行 pd console。",
+      "whatsNew": "更新内容"
     },
     "intent": {
       "eyebrow": "拥有者意图",

--- a/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
@@ -328,12 +328,24 @@ export function UpdatePage() {
             </div>
           )}
 
-          {/* Check button — secondary style (tool page, lower visual weight) */}
+          {/* What's new — changelog from GitHub Release */}
+          {statusData?.changelog && statusData.hasUpdate && (
+            <div className="mt-4 p-4 rounded-[4px] border border-line bg-surface/50">
+              <p className="text-[12px] font-mono text-ink-3 uppercase tracking-wide mb-2">
+                {t("pages.update.whatsNew")}
+              </p>
+              <div className="text-[13px] text-ink-2 leading-relaxed max-h-[200px] overflow-y-auto whitespace-pre-wrap">
+                {statusData.changelog.split("---")[0]}
+              </div>
+            </div>
+          )}
+
+          {/* Buttons — one check + one update */}
           <div className="mt-5 pt-4 border-t border-line flex items-center gap-3 flex-wrap">
             <button
               type="button"
               onClick={handleCheckForUpdates}
-              disabled={checking || updating || fullUpdating}
+              disabled={checking || fullUpdating}
               className="border border-line bg-surface text-ink rounded-[3px] px-[14px] py-[6px] text-[12.5px] hover:border-line-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
             >
               {checking ? t("pages.update.checking") : t("pages.update.checkForUpdates")}
@@ -341,11 +353,11 @@ export function UpdatePage() {
             {!isUpToDate && (
               <button
                 type="button"
-                onClick={() => setShowUpdateDialog(true)}
-                disabled={updating || checking || fullUpdating}
+                onClick={() => setShowFullUpdateDialog(true)}
+                disabled={checking || fullUpdating}
                 className="bg-gov text-white rounded-[3px] px-[14px] py-[6px] text-[12.5px] hover:bg-gov/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
               >
-                {updating ? (
+                {fullUpdating ? (
                   <span className="flex items-center gap-1.5">
                     <Loader2 className="h-3.5 w-3.5 animate-spin" />
                     {t("pages.update.updating")}
@@ -355,22 +367,6 @@ export function UpdatePage() {
                 )}
               </button>
             )}
-            {/* Full update — always available; covers all packages via the installer */}
-            <button
-              type="button"
-              onClick={() => setShowFullUpdateDialog(true)}
-              disabled={updating || checking || fullUpdating}
-              className="border border-line bg-surface text-ink rounded-[3px] px-[14px] py-[6px] text-[12.5px] hover:border-line-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-gov focus-visible:outline-offset-2"
-            >
-              {fullUpdating ? (
-                <span className="flex items-center gap-1.5">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  {t("pages.update.fullUpdating")}
-                </span>
-              ) : (
-                t("pages.update.applyFullUpdate")
-              )}
-            </button>
           </div>
 
           {/* Update result message — enhanced card */}
@@ -508,24 +504,6 @@ export function UpdatePage() {
       </div>
 
       {/* Update confirmation dialog */}
-      <AlertDialog open={showUpdateDialog} onOpenChange={setShowUpdateDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("pages.update.confirmUpdateTitle")}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("pages.update.confirmUpdateDesc", { version: statusData?.latestVersion ?? "latest" })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleApplyUpdate}>
-              {t("pages.update.applyUpdate")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Full update confirmation dialog */}
       <AlertDialog open={showFullUpdateDialog} onOpenChange={setShowFullUpdateDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
+++ b/packages/pd-console/src/ui/pages/settings/UpdatePage.tsx
@@ -334,8 +334,8 @@ export function UpdatePage() {
               <p className="text-[12px] font-mono text-ink-3 uppercase tracking-wide mb-2">
                 {t("pages.update.whatsNew")}
               </p>
-              <div className="text-[13px] text-ink-2 leading-relaxed max-h-[200px] overflow-y-auto whitespace-pre-wrap">
-                {statusData.changelog.split("---")[0]}
+              <div className="text-[13px] text-ink-2 leading-relaxed max-h-[300px] overflow-y-auto whitespace-pre-wrap">
+                {statusData.changelog}
               </div>
             </div>
           )}

--- a/packages/pd-console/src/ui/utils/validators.ts
+++ b/packages/pd-console/src/ui/utils/validators.ts
@@ -834,6 +834,8 @@ export interface UpdateStatusData {
   error?: string;
   /** True when Codex host is also installed (triggers a warning banner). */
   codexInstalled?: boolean;
+  /** Release notes for the latest version (markdown, from GitHub Releases). */
+  changelog?: string;
 }
 
 export function validateUpdateStatus(v: unknown): UpdateStatusData | null {
@@ -846,13 +848,14 @@ export function validateUpdateStatus(v: unknown): UpdateStatusData | null {
     latestVersion: v.latestVersion,
     hasUpdate: v.hasUpdate,
   };
-  // Optional error field (present when registry check fails)
   if (Object.hasOwn(v, 'error') && isString(v.error)) {
     result.error = v.error;
   }
-  // Optional codexInstalled field (present when Codex host is detected)
   if (Object.hasOwn(v, 'codexInstalled') && typeof v.codexInstalled === 'boolean') {
     result.codexInstalled = v.codexInstalled;
+  }
+  if (Object.hasOwn(v, 'changelog') && isString(v.changelog)) {
+    result.changelog = v.changelog;
   }
   return result;
 }

--- a/packages/pd-console/tests/server/routes/update.test.ts
+++ b/packages/pd-console/tests/server/routes/update.test.ts
@@ -145,6 +145,33 @@ describe('handleUpdateRoute', () => {
       expect(body.data.latestVersion).toBe('2.0.0');
     });
 
+    it('should include changelog from GitHub Release when update is available', async () => {
+      vi.mocked(fetch).mockImplementation(((url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url.toString();
+        if (urlStr.startsWith('https://registry.npmjs.org/')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ version: '2.0.0' }),
+          } as Response);
+        }
+        if (urlStr.startsWith('https://api.github.com/')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ body: '## V2.0.0 — Bug fixes\n\n- Fixed update EPERM' }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: false, status: 404 } as Response);
+      }) as unknown as typeof fetch);
+
+      const req = createMockRequest('GET');
+      const res = createMockResponse();
+
+      await handleUpdateRoute(req, res, workspaceDir, '/check');
+
+      const body = parseResponseBody<{ data: { changelog?: string } }>(res);
+      expect(body.data.changelog).toContain('Bug fixes');
+    });
+
     it('should return hasUpdate false when current is latest', async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: true,

--- a/packages/pd-console/tests/ui/cr10-api-validators.test.ts
+++ b/packages/pd-console/tests/ui/cr10-api-validators.test.ts
@@ -533,6 +533,12 @@ describe('validateUpdateStatus', () => {
   it('rejects wrong types', () => {
     expect(validateUpdateStatus({ ...validStatus, hasUpdate: 'yes' })).toBeNull();
   });
+
+  it('accepts optional changelog field', () => {
+    const result = validateUpdateStatus({ ...validStatus, changelog: '## What\'s new\n- Bug fix' });
+    expect(result).not.toBeNull();
+    expect(result!.changelog).toBe('## What\'s new\n- Bug fix');
+  });
 });
 
 // ── validateConfigSummary ─────────────────────────────────────────────────────


### PR DESCRIPTION
## 解决的用户困惑

### 1. 合并两个按钮为一个
- **之前**：两个按钮（立即更新 + 全量更新），用户不知道区别
- **之后**：一个"更新"按钮，更新全部代码包，秒级完成

### 2. 显示更新内容
- **之前**：用户只看到版本号，不知道更新了什么
- **之后**：检查更新时自动获取 GitHub Release 的更新说明，显示"更新内容"面板

### 3. 简化文案
- 移除了"全量"、"轻量"等开发术语
- 对话框标题从"确认全量更新"改为"确认更新"

## 改动文件
- `update.ts`: /check 新增 changelog 获取（GitHub Releases API，best-effort）
- `UpdatePage.tsx`: 合并按钮 + 新增"更新内容"面板
- `validators.ts`: UpdateStatusData 新增 changelog 字段
- i18n: 新增 whatsNew key，简化文案

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 检查更新时显示最新版本的发布说明，帮助了解更新内容。
  * 仅在检测到新版本时显示更新按钮和相关说明。

* **改进**
  * 更新流程统一为完整更新确认，界面更加简洁。
  * 优化中英文更新页面文案，并完善更新信息校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->